### PR TITLE
Set the Python version back to 3.9 in the templates

### DIFF
--- a/datadog_checks_dev/changelog.d/16504.fixed
+++ b/datadog_checks_dev/changelog.d/16504.fixed
@@ -1,0 +1,1 @@
+Set the Python version back to 3.9 in the templates

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/pyproject.toml
@@ -9,7 +9,7 @@ name = "datadog-{project_name}"
 description = "The {integration_name} check"
 readme = "README.md"
 license = "BSD-3-Clause"
-requires-python = ">=3.11"
+requires-python = ">=3.9"
 keywords = [
     "datadog",
     "datadog agent",

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/pyproject.toml
@@ -11,7 +11,7 @@ name = "datadog-{project_name}"
 description = "The {integration_name} check"
 readme = "README.md"
 license = "BSD-3-Clause"
-requires-python = ">=3.11"
+requires-python = ">=3.9"
 keywords = [
     "datadog",
     "datadog agent",

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
@@ -11,7 +11,7 @@ name = "datadog-{project_name}"
 description = "The {integration_name} check"
 readme = "README.md"
 license = "BSD-3-Clause"
-requires-python = ">=3.11"
+requires-python = ">=3.9"
 keywords = [
     "datadog",
     "datadog agent",


### PR DESCRIPTION
### What does this PR do?

Set the Python version back to 3.9 in the templates 

### Motivation

Agent 7.51 that is shipped with Python 3.11 is not out yet so the integrations that are created right now can't be installed on the current Agent. 

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
