### PR TITLE
Bump the `datadog-checks-dev` minimum version to 29.0.1

### DIFF
--- a/ddev/changelog.d/16506.fixed
+++ b/ddev/changelog.d/16506.fixed
@@ -1,0 +1,1 @@
+Bump the `datadog-checks-dev` minimum version to 29.0.1

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "click~=8.1.6",
     "coverage",
     "datadog-api-client==2.20.0",
-    "datadog-checks-dev[cli]~=29.0",
+    "datadog-checks-dev[cli]>=29.0.1,<=30",
     "hatch>=1.8.1",
     "httpx",
     "jsonpointer",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump the datadog-checks-dev minimum version to 29.0.1

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/integrations-core/pull/16505

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
