### PR TITLE
Pin the `pytest-asyncio` version

### DIFF
--- a/datadog_checks_base/datadog_checks/__init__.py
+++ b/datadog_checks_base/datadog_checks/__init__.py
@@ -1,5 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/datadog_checks_base/datadog_checks/__init__.py
+++ b/datadog_checks_base/datadog_checks/__init__.py
@@ -1,4 +1,5 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/datadog_checks_dev/changelog.d/16507.fixed
+++ b/datadog_checks_dev/changelog.d/16507.fixed
@@ -1,0 +1,1 @@
+Pin the `pytest-asyncio` version to 0.23.2

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "psutil",
     "py>=1.8.2; python_version < '3.0'",  # https://github.com/ionelmc/pytest-benchmark/issues/226
     "pytest",
-    "pytest-asyncio>=0.20.3; python_version > '3.0'",
+    "pytest-asyncio==0.23.2; python_version > '3.0'",
     "pytest-benchmark[histogram]<4.0.0; python_version < '3.0'",
     "pytest-benchmark[histogram]>=4.0.0; python_version > '3.0'",
     "pytest-cov>=2.6.1",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Pin the pytest-asyncio version to 0.23.2

### Motivation
<!-- What inspired you to submit this pull request? -->

Something [broke the base check's tests](https://github.com/DataDog/integrations-core/actions/runs/7384236138/job/20086796772) with the latest version related to https://github.com/pytest-dev/pytest-asyncio/issues/729, pinning it for now until it's resolved

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Green job [here](https://github.com/DataDog/integrations-core/actions/runs/7384477100/job/20087538171?pr=16507)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
