### PR TITLE
Update the cloudflare instances to fail only if the certificates are going to expire the next day

### DIFF
--- a/tls/tests/conftest.py
+++ b/tls/tests/conftest.py
@@ -161,12 +161,18 @@ def instance_e2e():
 
 @pytest.fixture
 def instance_remote_ok_ip():
-    return {'server': '1.1.1.1', 'tls_validate_hostname': False}
+    return {'server': '1.1.1.1', 'tls_validate_hostname': False, 'days_warning': 1, 'days_critical': 1}
 
 
 @pytest.fixture
 def instance_remote_ok_udp():
-    return {'server': '1.1.1.1', 'transport': 'udp', 'tls_validate_hostname': False}
+    return {
+        'server': '1.1.1.1',
+        'transport': 'udp',
+        'tls_validate_hostname': False,
+        'days_warning': 1,
+        'days_critical': 1,
+    }
 
 
 @pytest.fixture


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update the cloudflare instances to fail only if the certificates are going to expire the next day

### Motivation
<!-- What inspired you to submit this pull request? -->

Their certificates are going to expire in 9 days so our check emits a warning (set to 14 days by default). 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I know it's not perfect, we're highly dependant on an external resources we do not control

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
