### PR TITLE
[DBMON-3302] emit correct error message when explain parameterized query fails

### DIFF
--- a/postgres/changelog.d/16516.fixed
+++ b/postgres/changelog.d/16516.fixed
@@ -1,0 +1,1 @@
+[DBMON-3302] emit correct error message when explain parameterized query fails

--- a/postgres/datadog_checks/postgres/explain_parameterized_queries.py
+++ b/postgres/datadog_checks/postgres/explain_parameterized_queries.py
@@ -66,9 +66,10 @@ class ExplainParameterizedQueries:
                 Returns: (plan)
     '''
 
-    def __init__(self, check, config):
+    def __init__(self, check, config, explain_function):
         self._check = check
         self._config = config
+        self._explain_function = explain_function
 
     @tracked_method(agent_check_getter=agent_check_getter)
     def explain_statement(self, dbname, statement, obfuscated_statement):
@@ -100,7 +101,7 @@ class ExplainParameterizedQueries:
                 logger.debug(
                     "Unable to explain parameterized query. "
                     "The explain function %s was executed but no plan was returned",
-                    self._config.statement_samples_config.get('explain_function', 'datadog.explain_statement'),
+                    self._explain_function,
                 )
                 return None, DBExplainError.no_plan_returned_with_prepared_statement, None
         except Exception as e:
@@ -149,9 +150,7 @@ class ExplainParameterizedQueries:
             return self._execute_query_and_fetch_rows(
                 dbname,
                 EXPLAIN_QUERY.format(
-                    explain_function=self._config.statement_samples_config.get(
-                        'explain_function', 'datadog.explain_statement'
-                    ),
+                    explain_function=self._explain_function,
                     statement=execute_prepared_statement_query,
                 ),
             )

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -31,7 +31,7 @@ from datadog_checks.base.utils.time import get_timestamp
 from datadog_checks.base.utils.tracking import tracked_method
 from datadog_checks.postgres.explain_parameterized_queries import ExplainParameterizedQueries
 
-from .util import DatabaseConfigurationError, warning_with_tags
+from .util import DatabaseConfigurationError, DBExplainError, warning_with_tags
 from .version_utils import V9_6, V10
 
 # according to https://unicodebook.readthedocs.io/unicode_encodings.html, the max supported size of a UTF-8 encoded
@@ -117,47 +117,6 @@ class StatementTruncationState(Enum):
     truncated = 'truncated'
     not_truncated = 'not_truncated'
     unknown = 'unknown'
-
-
-class DBExplainError(Enum):
-    """
-    Denotes the various reasons a query may not have an explain statement.
-    """
-
-    # may be due to a misconfiguration of the database during setup or the Agent is
-    # not able to access the required function
-    database_error = 'database_error'
-
-    # datatype mismatch occurs when return type is not json, for instance when multiple queries are explained
-    datatype_mismatch = 'datatype_mismatch'
-
-    # this could be the result of a missing EXPLAIN function
-    invalid_schema = 'invalid_schema'
-
-    # a value retrieved from the EXPLAIN function could be invalid
-    invalid_result = 'invalid_result'
-
-    # some statements cannot be explained i.e AUTOVACUUM
-    no_plans_possible = 'no_plans_possible'
-
-    # there could be a problem with the EXPLAIN function (missing, invalid permissions, or an incorrect definition)
-    failed_function = 'failed_function'
-
-    # a truncated statement can't be explained
-    query_truncated = "query_truncated"
-
-    # connection error may be due to a misconfiguration during setup
-    connection_error = 'connection_error'
-
-    # clients using the extended query protocol or prepared statements can't be explained due to
-    # the separation of the parsed query and raw bind parameters
-    parameterized_query = 'parameterized_query'
-
-    # search path may be different when the client executed a query from where we executed it.
-    undefined_table = 'undefined_table'
-
-    # the statement was explained with the prepared statement workaround
-    explained_with_prepared_statement = 'explained_with_prepared_statement'
 
 
 DEFAULT_COLLECTION_INTERVAL = 1
@@ -654,11 +613,9 @@ class PostgresStatementSamples(DBMAsyncJob):
             # instead of trying to explain it then failing
             if self._explain_parameterized_queries._is_parameterized_query(statement):
                 if is_affirmative(self._config.statement_samples_config.get('explain_parameterized_queries', True)):
-                    plan = self._explain_parameterized_queries.explain_statement(
+                    return self._explain_parameterized_queries.explain_statement(
                         dbname, statement, obfuscated_statement
                     )
-                    if plan:
-                        return plan, DBExplainError.explained_with_prepared_statement, None
                 e = psycopg2.errors.UndefinedParameter("Unable to explain parameterized query")
                 self._log.debug(
                     "Unable to collect execution plan, clients using the extended query protocol or prepared statements"

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -169,7 +169,7 @@ class PostgresStatementSamples(DBMAsyncJob):
         self._activity_last_query_start = None
         # The value is loaded when connecting to the main database
         self._explain_function = config.statement_samples_config.get('explain_function', 'datadog.explain_statement')
-        self._explain_parameterized_queries = ExplainParameterizedQueries(check, config)
+        self._explain_parameterized_queries = ExplainParameterizedQueries(check, config, self._explain_function)
         self._obfuscate_options = to_native_string(json.dumps(self._config.obfuscator_options))
 
         self._collection_strategy_cache = TTLCache(

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -36,6 +36,53 @@ class DatabaseConfigurationError(Enum):
     autodiscovered_metrics_exceeds_collection_interval = "autodiscovered-metrics-exceeds-collection-interval"
 
 
+class DBExplainError(Enum):
+    """
+    Denotes the various reasons a query may not have an explain statement.
+    """
+
+    # may be due to a misconfiguration of the database during setup or the Agent is
+    # not able to access the required function
+    database_error = 'database_error'
+
+    # datatype mismatch occurs when return type is not json, for instance when multiple queries are explained
+    datatype_mismatch = 'datatype_mismatch'
+
+    # this could be the result of a missing EXPLAIN function
+    invalid_schema = 'invalid_schema'
+
+    # a value retrieved from the EXPLAIN function could be invalid
+    invalid_result = 'invalid_result'
+
+    # some statements cannot be explained i.e AUTOVACUUM
+    no_plans_possible = 'no_plans_possible'
+
+    # there could be a problem with the EXPLAIN function (missing, invalid permissions, or an incorrect definition)
+    failed_function = 'failed_function'
+
+    # a truncated statement can't be explained
+    query_truncated = "query_truncated"
+
+    # connection error may be due to a misconfiguration during setup
+    connection_error = 'connection_error'
+
+    # clients using the extended query protocol or prepared statements can't be explained due to
+    # the separation of the parsed query and raw bind parameters
+    parameterized_query = 'parameterized_query'
+
+    # search path may be different when the client executed a query from where we executed it.
+    undefined_table = 'undefined_table'
+
+    # the statement was explained with the prepared statement workaround
+    explained_with_prepared_statement = 'explained_with_prepared_statement'
+
+    # the statement was tried to be explained with the prepared statement workaround but failedd
+    failed_to_explain_with_prepared_statement = 'failed_to_explain_with_prepared_statement'
+
+    # the statement was tried to be explained with the prepared statement workaround but no plan was returned
+    no_plan_returned_with_prepared_statement = 'no_plan_returned_with_prepared_statement'
+
+
 def warning_with_tags(warning_message, *args, **kwargs):
     if args:
         warning_message = warning_message % args

--- a/postgres/tests/test_explain_parameterized_queries.py
+++ b/postgres/tests/test_explain_parameterized_queries.py
@@ -2,10 +2,13 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+from unittest import mock
+
+import psycopg2
 import pytest
 
 from datadog_checks.base.utils.db.sql import compute_sql_signature
-from datadog_checks.postgres.statement_samples import DBExplainError
+from datadog_checks.postgres.util import DBExplainError
 from datadog_checks.postgres.version_utils import V12
 
 from .common import DB_NAME
@@ -28,6 +31,7 @@ def dbm_instance(pg_instance):
     return pg_instance
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize(
     "query,expected_explain_err_code",
     [
@@ -63,6 +67,7 @@ def test_explain_parameterized_queries(integration_check, dbm_instance, query, e
     assert len(rows) == 0
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize(
     "query,expected_generic_values",
     [
@@ -85,12 +90,129 @@ def test_explain_parameterized_queries_generic_params(integration_check, dbm_ins
     query_signature = compute_sql_signature(query)
 
     explain_param_queries = check.statement_samples._explain_parameterized_queries
-    assert explain_param_queries._create_prepared_statement(DB_NAME, query, query, query_signature) is True
+    explain_param_queries._create_prepared_statement(DB_NAME, query, query, query_signature)
     assert expected_generic_values == explain_param_queries._get_number_of_parameters_for_prepared_statement(
         DB_NAME, query_signature
     )
 
 
+@pytest.mark.integration
+def test_explain_parameterized_queries_version_below_12(integration_check, dbm_instance):
+    '''
+    For postgres versions below 12, we do not support explaining parameterized queries,
+    because plan_cache_mode is not supported. We should return proper error.
+    '''
+    check = integration_check(dbm_instance)
+    check._connect()
+
+    check.check(dbm_instance)
+    if check.version >= V12:
+        # this test is for versions below 12 to make sure we return proper error for unsupported versions
+        return
+
+    plan_dict, explain_err_code, err = check.statement_samples._run_and_track_explain(
+        DB_NAME, "SELECT * FROM pg_settings WHERE name = $1", "SELECT * FROM pg_settings WHERE name = $1", ""
+    )
+    assert plan_dict is None
+    assert explain_err_code == DBExplainError.parameterized_query
+    assert err is not None
+    assert err == "<class 'psycopg2.errors.UndefinedParameter'>"
+
+
+@pytest.mark.integration
+def test_explain_parameterized_queries_create_prepared_statement_exception(integration_check, dbm_instance):
+    check = integration_check(dbm_instance)
+    check._connect()
+
+    check.check(dbm_instance)
+    if check.version < V12:
+        return
+
+    with mock.patch(
+        'datadog_checks.postgres.explain_parameterized_queries.ExplainParameterizedQueries._create_prepared_statement',
+        side_effect=psycopg2.errors.DatabaseError("unexpected exception"),
+    ):
+        plan_dict, explain_err_code, err = check.statement_samples._run_and_track_explain(
+            DB_NAME, "SELECT * FROM pg_settings WHERE name = $1", "SELECT * FROM pg_settings WHERE name = $1", ""
+        )
+        assert plan_dict is None
+        assert explain_err_code == DBExplainError.failed_to_explain_with_prepared_statement
+        assert err is not None
+        assert err == "<class 'psycopg2.DatabaseError'>"
+
+
+@pytest.mark.integration
+def test_explain_parameterized_queries_explain_prepared_statement_exception(integration_check, dbm_instance):
+    check = integration_check(dbm_instance)
+    check._connect()
+
+    check.check(dbm_instance)
+    if check.version < V12:
+        return
+
+    with mock.patch(
+        'datadog_checks.postgres.explain_parameterized_queries.ExplainParameterizedQueries._explain_prepared_statement',
+        side_effect=psycopg2.errors.DatabaseError("unexpected exception"),
+    ):
+        query = "SELECT * FROM pg_settings WHERE name = $1"
+        plan_dict, explain_err_code, err = check.statement_samples._run_and_track_explain(DB_NAME, query, query, "")
+        assert plan_dict is None
+        assert explain_err_code == DBExplainError.failed_to_explain_with_prepared_statement
+        assert err is not None
+        assert err == "<class 'psycopg2.DatabaseError'>"
+        # check that we deallocated the prepared statement after explaining
+        rows = check.statement_samples._explain_parameterized_queries._execute_query_and_fetch_rows(
+            DB_NAME,
+            "SELECT * FROM pg_prepared_statements WHERE name = 'dd_{query_signature}'".format(
+                query_signature=compute_sql_signature(query)
+            ),
+        )
+        assert len(rows) == 0
+
+
+@pytest.mark.integration
+def test_explain_parameterized_queries_explain_prepared_statement_no_plan_returned(integration_check, dbm_instance):
+    check = integration_check(dbm_instance)
+    check._connect()
+
+    check.check(dbm_instance)
+    if check.version < V12:
+        return
+
+    with mock.patch(
+        'datadog_checks.postgres.explain_parameterized_queries.ExplainParameterizedQueries._execute_query_and_fetch_rows',
+        return_value=None,
+    ):
+        plan_dict, explain_err_code, err = check.statement_samples._run_and_track_explain(
+            DB_NAME, "SELECT * FROM pg_settings WHERE name = $1", "SELECT * FROM pg_settings WHERE name = $1", ""
+        )
+        assert plan_dict is None
+        assert explain_err_code == DBExplainError.no_plan_returned_with_prepared_statement
+        assert err is None
+
+
+@pytest.mark.integration
+def test_create_prepared_statement_exception(integration_check, dbm_instance):
+    check = integration_check(dbm_instance)
+    check._connect()
+
+    check.check(dbm_instance)
+    if check.version < V12:
+        return
+
+    query = "SELECT * FROM pg_settings WHERE name = $1"
+    query_signature = compute_sql_signature(query)
+    with mock.patch(
+        'datadog_checks.postgres.explain_parameterized_queries.ExplainParameterizedQueries._execute_query',
+        side_effect=Exception,
+    ):
+        with pytest.raises(Exception):
+            check.statement_samples._explain_parameterized_queries._create_prepared_statement(
+                DB_NAME, query, query, query_signature
+            )
+
+
+@pytest.mark.integration
 @pytest.mark.parametrize(
     "query,statement_is_parameterized_query",
     [


### PR DESCRIPTION
### What does this PR do?
This PR adds proper error handling and emit correct error message when explain parameterized query fails. 

### Motivation
Prior to the fix, when `explain_parameterized_queries` is enabled but the integration fails to explain the parameterized query, an incorrect error `DBExplainError.parameterized_query` will be set by the agent. 
This is often very confusing to the user as DBM will display below error message on the UI. User might wonder whether `explain_parameterized_queries` is actually enabled or not. But in reality, `explain_parameterized_queries` is often properly set in the config but other exceptions are raised when explain parameterized query. 
![image](https://github.com/DataDog/integrations-core/assets/4964070/0748991f-e598-437d-9589-09f4af529738)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
