### PR TITLE
[DBMON-3299] edge case handling when partitioned table has no activity

### DIFF
--- a/postgres/changelog.d/16517.fixed
+++ b/postgres/changelog.d/16517.fixed
@@ -1,0 +1,1 @@
+[DBMON-3299] Improve edge case handling on partitioned table activity query  when a partitioned table has no children (partitioned sub-tables)

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -362,7 +362,7 @@ class PostgresMetadata(DBMAsyncJob):
                 # get activity
                 cursor.execute(PARTITION_ACTIVITY_QUERY.format(parent_oid=info['id']))
                 row = cursor.fetchone()
-                return row['total_activity']
+                return row.get('total_activity', 0) if row else 0
 
         # if relation metrics are enabled, sorted based on last activity information
         table_info = sorted(table_info, key=sort_tables, reverse=True)

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -196,7 +196,7 @@ def check_db_count(aggregator, expected_tags, count=1):
         table_count = 9
     # And PG >= 14 will also report the parent table
     if float(POSTGRES_VERSION) >= 14.0:
-        table_count = 10
+        table_count = 11
     aggregator.assert_metric(
         'postgresql.table.count',
         value=table_count,

--- a/postgres/tests/compose/resources/03_load_data.sh
+++ b/postgres/tests/compose/resources/03_load_data.sh
@@ -39,6 +39,7 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" datadog_test <<-EOSQL
     INSERT INTO test_part (filler) SELECT * FROM generate_series(1, 2000);
     INSERT INTO test_part (filler) SELECT array_to_string(ARRAY(SELECT chr((65 + round(random() * 50)) :: integer) FROM generate_series(1,3000)), '');
     VACUUM ANALYZE test_part;
+    CREATE TABLE test_part_no_children (id SERIAL PRIMARY KEY, filler text) PARTITION BY RANGE (id);
 EOSQL
 fi
 

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -115,40 +115,6 @@ def test_collect_schemas(integration_check, dbm_instance, aggregator):
     assert_not_fields(tables_got, tables_not_reported_set)
 
 
-# @pytest.mark.integration
-# def test_collect_schemas_partitioned(integration_check, dbm_instance, aggregator):
-#     dbm_instance["collect_schemas"] = {'enabled': True, 'collection_interval': 0.5}
-#     dbm_instance['relations'] = [{'relation_regex': ".*"}]
-#     dbm_instance["database_autodiscovery"] = {"enabled": True, "include": ["datadog"]}
-#     del dbm_instance['dbname']
-#     check = integration_check(dbm_instance)
-
-#     admin_conn = psycopg2.connect(host=HOST, dbname=DB_NAME, user=USER_ADMIN, password=PASSWORD_ADMIN)
-#     with admin_conn.cursor() as cursor:
-#         cursor.execute("DROP TABLE IF EXISTS test_part_no_children CASCADE")
-#         cursor.execute("CREATE TABLE test_part_no_children (id int, name varchar(40)) PARTITION BY RANGE (id)")
-#         # DO NOT create any partitions, we want to test that we can still collect the schema
-#         # even if the partitioned table has no children
-#     admin_conn.close()
-
-#     run_one_check(check, dbm_instance)
-#     dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
-#     schema_event = next(e for e in dbm_metadata if e['kind'] == 'pg_databases')
-
-#     database_metadata = schema_event['metadata']
-#     assert len(database_metadata) == 1
-
-#     schemas = database_metadata[0]['schemas']
-#     public = next(s for s in schemas if s['name'] == 'public')
-#     assert public is not None
-#     assert len(public['tables']) > 0
-#     print(database_metadata)
-#     test_part_no_children = next(t for t in public['tables'] if t['name'] == 'test_part_no_children')
-#     print(test_part_no_children)
-#     raise Exception('test')
-#     assert test_part_no_children is not None
-
-
 def assert_fields(keys: List[str], fields: List[str]):
     for field in fields:
         assert field in keys

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -33,7 +33,6 @@ def stop_orphaned_threads():
     DBMAsyncJob.executor = ThreadPoolExecutor()
 
 
-@pytest.mark.integration
 def test_collect_metadata(integration_check, dbm_instance, aggregator):
     check = integration_check(dbm_instance)
     check.check(dbm_instance)
@@ -46,7 +45,6 @@ def test_collect_metadata(integration_check, dbm_instance, aggregator):
     assert len(event["metadata"]) > 0
 
 
-@pytest.mark.integration
 def test_collect_schemas(integration_check, dbm_instance, aggregator):
     dbm_instance["collect_schemas"] = {'enabled': True, 'collection_interval': 0.5}
     dbm_instance['relations'] = [{'relation_regex': ".*"}]


### PR DESCRIPTION
### What does this PR do?
This PR handles an edge case on Postgres schema collection for partitioned table. The integration relies on table activity (sequence scan & index scan) as the sort key of collected table, that way we can prioritize collecting schemas for tables with high activity. 
The current implementation fails for an edge case when a partitioned table has no children (partitioned sub-tables). This edge case will result in no returned rows for the `PARTITION_ACTIVITY_QUERY`, due to the join with `pg_inherits`. 

### Motivation
Customer reported issues on collecting schema https://datadoghq.atlassian.net/browse/SDBM-776

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
