### PR TITLE
Do not run the `pr-check` workflow on PRs that do not target master

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   run:
     uses: ./.github/workflows/pr-quick-check.yml
+    if: ${{ github.base_ref == 'master' }}
     with:
       repo: core
     secrets: inherit


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Do not run the pr-check workflow on PRs that do not target master

### Motivation
<!-- What inspired you to submit this pull request? -->

It failed [here](https://github.com/DataDog/integrations-core/pull/16519) but it's ok, intermediate PRs do not need this

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
