### PR TITLE
Fix a flaky test

### DIFF
--- a/rabbitmq/tests/conftest.py
+++ b/rabbitmq/tests/conftest.py
@@ -23,16 +23,12 @@ def dd_environment():
     up.
     """
 
-    env = {}
-
     if 'RABBITMQ_VERSION' not in os.environ:
         pytest.exit('RABBITMQ_VERSION not available')
 
     compose_file = os.path.join(HERE, 'compose', 'docker-compose.yaml')
 
-    with docker_run(
-        compose_file, log_patterns='Server startup complete', env_vars=env, conditions=[setup_rabbitmq], sleep=5
-    ):
+    with docker_run(compose_file, log_patterns='Server startup complete', conditions=[setup_rabbitmq], sleep=5):
         if RABBITMQ_METRICS_PLUGIN == "prometheus":
             yield OPENMETRICS_CONFIG
         else:

--- a/rabbitmq/tests/metrics.py
+++ b/rabbitmq/tests/metrics.py
@@ -386,13 +386,9 @@ def assert_metric_covered(aggregator):
         aggregator.assert_metric_has_tag_prefix(mname, 'rabbitmq_node', count=1)
 
     aggregator.assert_metric('rabbitmq.node.partitions', value=0, count=1)
-    aggregator.assert_metric('rabbitmq.connections', tags=['rabbitmq_vhost:/', "tag1:1", "tag2"], value=0, count=1)
-    aggregator.assert_metric(
-        'rabbitmq.connections', tags=['rabbitmq_vhost:myvhost', "tag1:1", "tag2"], value=0, count=1
-    )
-    aggregator.assert_metric(
-        'rabbitmq.connections', tags=['rabbitmq_vhost:myothervhost', "tag1:1", "tag2"], value=0, count=1
-    )
+    aggregator.assert_metric('rabbitmq.connections', tags=['rabbitmq_vhost:/', "tag1:1", "tag2"], count=1)
+    aggregator.assert_metric('rabbitmq.connections', tags=['rabbitmq_vhost:myvhost', "tag1:1", "tag2"], count=1)
+    aggregator.assert_metric('rabbitmq.connections', tags=['rabbitmq_vhost:myothervhost', "tag1:1", "tag2"], count=1)
 
     # Queue attributes, should be only one queue fetched
     for mname in Q_METRICS:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix a flaky test

### Motivation
<!-- What inspired you to submit this pull request? -->

We sometimes get a connection in the e2e env and we do not really care about the value in the e2e tests, only in the unit tests: 

```
=================================== FAILURES ===================================
_________________________ test_rabbitmq_e2e_management _________________________
tests/test_e2e.py:22: in test_rabbitmq_e2e_management
    assert_metric_covered(aggregator)
tests/metrics.py:389: in assert_metric_covered
    aggregator.assert_metric('rabbitmq.connections', tags=['rabbitmq_vhost:/', "tag1:1", "tag2"], value=0, count=1)
../datadog_checks_base/datadog_checks/base/stubs/aggregator.py:368: in assert_metric
    self._assert(condition, msg=msg, expected_stub=expected_metric, submitted_elements=self._metrics)
../datadog_checks_base/datadog_checks/base/stubs/aggregator.py:410: in _assert
    assert condition, new_msg
E   AssertionError: Needed exactly 1 candidates for 'rabbitmq.connections', got 0
E   Expected:
E           MetricStub(name='rabbitmq.connections', type=None, value=0, tags=['rabbitmq_vhost:/', 'tag1:1', 'tag2'], hostname=None, device=None, flush_first_value=None)
E   Similar submitted:
E   Score   Most similar
E   0.98    MetricStub(name='rabbitmq.connections', type=0, value=0, tags=['rabbitmq_vhost:myvhost', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
E   0.97    MetricStub(name='rabbitmq.connections', type=0, value=0, tags=['rabbitmq_vhost:myothervhost', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
E   0.80    MetricStub(name='rabbitmq.connections', type=0, value=1, tags=['rabbitmq_vhost:/', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
E   0.78    MetricStub(name='rabbitmq.node.partitions', type=0, value=0, tags=['rabbitmq_node:rabbit@b4b3b797bdfe', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
E   0.73    MetricStub(name='rabbitmq.overview.object_totals.connections', type=0, value=0, tags=['rabbitmq_cluster:rabbitmqtest', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
E   0.70    MetricStub(name='rabbitmq.node.disk_alarm', type=0, value=0, tags=['rabbitmq_node:rabbit@b4b3b797bdfe', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
E   0.69    MetricStub(name='rabbitmq.queue.consumers', type=0, value=0, tags=['rabbitmq_node:rabbit@b4b3b797bdfe', 'rabbitmq_queue:test1', 'rabbitmq_vhost:/', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
E   0.68    MetricStub(name='rabbitmq.connections.state', type=0, value=1, tags=['rabbitmq_conn_state:direct', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
E   0.68    MetricStub(name='rabbitmq.node.run_queue', type=0, value=0, tags=['rabbitmq_node:rabbit@b4b3b797bdfe', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
E   0.65    MetricStub(name='rabbitmq.overview.object_totals.channels', type=0, value=0, tags=['rabbitmq_cluster:rabbitmqtest', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
E   0.65    MetricStub(name='rabbitmq.node.mem_alarm', type=0, value=0, tags=['rabbitmq_node:rabbit@b4b3b797bdfe', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
E   0.63    MetricStub(name='rabbitmq.overview.object_totals.consumers', type=0, value=0, tags=['rabbitmq_cluster:rabbitmqtest', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
E   0.62    MetricStub(name='rabbitmq.overview.messages.confirm.rate', type=0, value=0, tags=['rabbitmq_cluster:rabbitmqtest', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
E   0.62    MetricStub(name='rabbitmq.overview.queue_totals.messages.rate', type=0, value=0, tags=['rabbitmq_cluster:rabbitmqtest', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
E   0.61    MetricStub(name='rabbitmq.exchange.messages.confirm.rate', type=0, value=0, tags=['rabbitmq_exchange:test1', 'rabbitmq_vhost:/', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
- generated xml file: /home/runner/work/integrations-core/integrations-core/rabbitmq/.junit/test-e2e-py3.9-3.5$TOX_ENV_NAME.xml -
=========================== short test summary info ============================
FAILED tests/test_e2e.py::test_rabbitmq_e2e_management - AssertionError: Needed exactly 1 candidates for 'rabbitmq.connections', got 0
Expected:
        MetricStub(name='rabbitmq.connections', type=None, value=0, tags=['rabbitmq_vhost:/', 'tag1:1', 'tag2'], hostname=None, device=None, flush_first_value=None)
Similar submitted:
Score   Most similar
0.98    MetricStub(name='rabbitmq.connections', type=0, value=0, tags=['rabbitmq_vhost:myvhost', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
0.97    MetricStub(name='rabbitmq.connections', type=0, value=0, tags=['rabbitmq_vhost:myothervhost', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
0.80    MetricStub(name='rabbitmq.connections', type=0, value=1, tags=['rabbitmq_vhost:/', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
0.78    MetricStub(name='rabbitmq.node.partitions', type=0, value=0, tags=['rabbitmq_node:rabbit@b4b3b797bdfe', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
0.73    MetricStub(name='rabbitmq.overview.object_totals.connections', type=0, value=0, tags=['rabbitmq_cluster:rabbitmqtest', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
0.70    MetricStub(name='rabbitmq.node.disk_alarm', type=0, value=0, tags=['rabbitmq_node:rabbit@b4b3b797bdfe', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
0.69    MetricStub(name='rabbitmq.queue.consumers', type=0, value=0, tags=['rabbitmq_node:rabbit@b4b3b797bdfe', 'rabbitmq_queue:test1', 'rabbitmq_vhost:/', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
0.68    MetricStub(name='rabbitmq.connections.state', type=0, value=1, tags=['rabbitmq_conn_state:direct', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
0.68    MetricStub(name='rabbitmq.node.run_queue', type=0, value=0, tags=['rabbitmq_node:rabbit@b4b3b797bdfe', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
0.65    MetricStub(name='rabbitmq.overview.object_totals.channels', type=0, value=0, tags=['rabbitmq_cluster:rabbitmqtest', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
0.65    MetricStub(name='rabbitmq.node.mem_alarm', type=0, value=0, tags=['rabbitmq_node:rabbit@b4b3b797bdfe', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
0.63    MetricStub(name='rabbitmq.overview.object_totals.consumers', type=0, value=0, tags=['rabbitmq_cluster:rabbitmqtest', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
0.62    MetricStub(name='rabbitmq.overview.messages.confirm.rate', type=0, value=0, tags=['rabbitmq_cluster:rabbitmqtest', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
0.62    MetricStub(name='rabbitmq.overview.queue_totals.messages.rate', type=0, value=0, tags=['rabbitmq_cluster:rabbitmqtest', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
0.61    MetricStub(name='rabbitmq.exchange.messages.confirm.rate', type=0, value=0, tags=['rabbitmq_exchange:test1', 'rabbitmq_vhost:/', 'tag1:1', 'tag2'], hostname='fv-az450-760', device=None, flush_first_value=False)
================= 1 failed, 1 skipped, 20 deselected in 3.43s ==================
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

https://datadoghq.atlassian.net/browse/AI-3437

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
