### PR TITLE
Fix airflow taks logs path in readme

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -243,7 +243,7 @@ _Available for Agent versions >6.0_
       ```yaml
       logs:
         - type: file
-          path: "<PATH_TO_AIRFLOW>/logs/!(scheduler)/*/*.log"
+          path: "<PATH_TO_AIRFLOW>/logs/*/*/*/*.log"
           source: airflow
           log_processing_rules:
             - type: multi_line


### PR DESCRIPTION
### What does this PR do?

This is updating the airflow integration doc to fix the tasks logs path.

### Motivation

The airflow tasks logs path in the doc has two issues
- the logs are 1 folder deeper, the structure is `{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log` documented just below in the same doc
- the `!(scheduler)` pattern is not regonized by the datadog agent

### Additional Notes

Datadog agent status before addressing 2nd bullet point:
```
- Type: file
      Path: /opt/airflow/logs/!(scheduler)/*/*/*.log
      Source: airflow
      Status: Error: could not find any file matching pattern /opt/airflow/logs/!(scheduler)/*/*/*.log, check thatall its subdirectories are executable
```

Datadog agent status after:
```
- Type: file
      Path: /opt/airflow/logs/*/*/*/*.log
      Source: airflow
      Status: OK
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
