### PR TITLE
Remove setuptools depedency for jmx and logs integration templates

### DIFF
--- a/datadog_checks_dev/changelog.d/16527.fixed
+++ b/datadog_checks_dev/changelog.d/16527.fixed
@@ -1,0 +1,1 @@
+Remove setuptools depedency for jmx and logs integrations. Make them consistent with the `check` template.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.13.0",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.13.0",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Make those consistent with the `check` template. We don't need `setuptools` anymore.

Detected while reviewing https://github.com/DataDog/integrations-core/pull/16499

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
