### PR TITLE
Update the template for logs integrations to not require a specific Python and base check version

### DIFF
--- a/datadog_checks_dev/changelog.d/16528.fixed
+++ b/datadog_checks_dev/changelog.d/16528.fixed
@@ -1,0 +1,1 @@
+Update the template for logs integrations to not require a specific Python and base check version

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
@@ -9,7 +9,6 @@ name = "datadog-{project_name}"
 description = "The {integration_name} check"
 readme = "README.md"
 license = "BSD-3-Clause"
-requires-python = ">=3.9"
 keywords = [
     "datadog",
     "datadog agent",
@@ -29,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=32.6.0",
+    "datadog-checks-base>=4.2.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update the template for logs integrations to not require a specific Python and base check version

### Motivation
<!-- What inspired you to submit this pull request? -->

- https://github.com/DataDog/integrations-core/pull/16499#discussion_r1441653005
- We don't really need to ensure this for logs integrations since they are not checks

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
