### PR TITLE
[DBMON-3300] collect function & count metrics for auto discovered databases

### DIFF
--- a/postgres/changelog.d/16530.added
+++ b/postgres/changelog.d/16530.added
@@ -1,0 +1,1 @@
+[DBMON-3300] collect function & count metrics for auto discovered databases

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -589,7 +589,7 @@ class PostgreSql(AgentCheck):
 
         self.metrics_cache.table_activity_metrics[db][tablename][metric_name] = value
 
-    def _collect_relations_autodiscovery(self, instance_tags, relations_scopes):
+    def _collect_metric_autodiscovery(self, instance_tags, scopes, scope_type):
         if not self.autodiscovery:
             return
 
@@ -598,11 +598,11 @@ class PostgreSql(AgentCheck):
         for db in databases:
             with self.db_pool.get_connection(db, self._config.idle_connection_timeout) as conn:
                 with conn.cursor() as cursor:
-                    for scope in relations_scopes:
+                    for scope in scopes:
                         self._query_scope(cursor, scope, instance_tags, False, db)
         elapsed_ms = (time() - start_time) * 1000
         self.histogram(
-            "dd.postgres._collect_relations_autodiscovery.time",
+            f"dd.postgres.{scope_type}.time",
             elapsed_ms,
             tags=self.tags + self._get_debug_tags(),
             hostname=self.resolved_hostname,
@@ -642,11 +642,14 @@ class PostgreSql(AgentCheck):
         archiver_instance_metrics = self.metrics_cache.get_archiver_metrics(self.version)
 
         metric_scope = [CONNECTION_METRICS]
+        per_database_metric_scope = []
 
         if self._config.collect_function_metrics:
-            metric_scope.append(FUNCTION_METRICS)
+            # Function metrics are collected from all databases discovered
+            per_database_metric_scope.append(FUNCTION_METRICS)
         if self._config.collect_count_metrics:
-            metric_scope.append(self.metrics_cache.get_count_metrics())
+            # Count metrics are collected from all databases discovered
+            per_database_metric_scope.append(self.metrics_cache.get_count_metrics())
         if self.version >= V13:
             metric_scope.append(SLRU_METRICS)
 
@@ -659,7 +662,11 @@ class PostgreSql(AgentCheck):
 
             # If autodiscovery is enabled, get relation metrics from all databases found
             if self.autodiscovery:
-                self._collect_relations_autodiscovery(instance_tags, relations_scopes)
+                self._collect_metric_autodiscovery(
+                    instance_tags,
+                    scopes=relations_scopes,
+                    scope_type='_collect_relations_autodiscovery',
+                )
             # otherwise, continue just with dbname
             else:
                 metric_scope.extend(relations_scopes)
@@ -694,6 +701,18 @@ class PostgreSql(AgentCheck):
                 activity_metrics = self.metrics_cache.get_activity_metrics(self.version)
                 with conn.cursor() as cursor:
                     self._query_scope(cursor, activity_metrics, instance_tags, False)
+
+            if per_database_metric_scope:
+                # if autodiscovery is enabled, get per-database metrics from all databases found
+                if self.autodiscovery:
+                    self._collect_metric_autodiscovery(
+                        instance_tags,
+                        scopes=per_database_metric_scope,
+                        scope_type='_collect_stat_autodiscovery',
+                    )
+                else:
+                    # otherwise, continue just with dbname
+                    metric_scope.extend(per_database_metric_scope)
 
             for scope in list(metric_scope):
                 with conn.cursor() as cursor:

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -609,6 +609,7 @@ SELECT s.schemaname,
     ON o.funcname = s.funcname;
 """,
     'relation': False,
+    'use_global_db_tag': True,
     'name': 'function_metrics',
 }
 

--- a/postgres/tests/compose/etc/postgresql/postgresql.conf
+++ b/postgres/tests/compose/etc/postgresql/postgresql.conf
@@ -3,6 +3,7 @@ shared_preload_libraries=pg_stat_statements
 pg_stat_statements.max=10000
 pg_stat_statements.track=all
 track_io_timing=on
+track_functions=pl
 
 wal_level = logical
 max_wal_senders = 10

--- a/postgres/tests/compose/etc/postgresql_logical_replica/postgresql.conf
+++ b/postgres/tests/compose/etc/postgresql_logical_replica/postgresql.conf
@@ -4,3 +4,4 @@ shared_preload_libraries=pg_stat_statements
 pg_stat_statements.max=100
 pg_stat_statements.track=all
 track_io_timing=on
+track_functions=pl

--- a/postgres/tests/compose/etc/postgresql_replica/postgresql.conf
+++ b/postgres/tests/compose/etc/postgresql_replica/postgresql.conf
@@ -4,6 +4,7 @@ shared_preload_libraries=pg_stat_statements
 pg_stat_statements.max=10000
 pg_stat_statements.track=all
 track_io_timing=on
+track_functions=pl
 
 hot_standby = on
 hot_standby_feedback = on

--- a/postgres/tests/compose/etc/postgresql_replica2/postgresql.conf
+++ b/postgres/tests/compose/etc/postgresql_replica2/postgresql.conf
@@ -4,6 +4,7 @@ shared_preload_libraries=pg_stat_statements
 pg_stat_statements.max=100
 pg_stat_statements.track=all
 track_io_timing=on
+track_functions=pl
 
 hot_standby = on
 hot_standby_feedback = off

--- a/postgres/tests/compose/resources/02_setup.sh
+++ b/postgres/tests/compose/resources/02_setup.sh
@@ -85,8 +85,19 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" "$DBNAME" <<-'EOSQL'
     RETURNS NULL ON NULL INPUT
     SECURITY DEFINER;
     ALTER FUNCTION datadog.explain_statement_noaccess(l_query TEXT, OUT explain JSON) OWNER TO datadog;
-EOSQL
 
+    -- create dummy function to be executed to populate function metrics
+    CREATE OR REPLACE FUNCTION dummy_function()
+    RETURNS text AS
+    $$
+    BEGIN
+        RETURN 'Hello, world!';
+    END;
+    $$
+    LANGUAGE 'plpgsql'
+    SECURITY DEFINER;
+    ALTER FUNCTION dummy_function() OWNER TO datadog;
+EOSQL
 done
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" dogs_nofunc <<-'EOSQL'


### PR DESCRIPTION
### What does this PR do?
Postgres integration will start collecting function & count metrics for auto discovered databases.

### Motivation
Function & count metrics are database specific, but they were not being properly collected for auto discovered databases. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
