### PR TITLE
Take into account all the checks when bumping or freezing the dependencies

### DIFF
--- a/ddev/changelog.d/16537.fixed
+++ b/ddev/changelog.d/16537.fixed
@@ -1,0 +1,1 @@
+ Take into account all the checks when bumping or freezing the dependencies

--- a/ddev/src/ddev/cli/dep.py
+++ b/ddev/src/ddev/cli/dep.py
@@ -323,8 +323,7 @@ def read_check_dependencies(repo, integrations=None):
     if isinstance(integrations, list):
         integrations = [repo.integrations.get(integration) for integration in integrations]
     elif integrations is None:
-        integrations = list(repo.integrations.iter_agent_checks('all'))
-        integrations.append(repo.integrations.get('datadog_checks_base'))
+        integrations = list(repo.integrations.iter_shippable('all'))
     else:
         integrations = [repo.integrations.get(integrations)]
 

--- a/ddev/tests/cli/test_dep.py
+++ b/ddev/tests/cli/test_dep.py
@@ -64,6 +64,7 @@ def test_sync(ddev, fake_repo):
     create_integration(fake_repo, 'foo', ['dep-a==1.0.0', 'dep-b==3.1.4'])
     create_integration(fake_repo, 'bar', ['dep-a==1.0.0'])
     create_integration(fake_repo, 'datadog_checks_base', ['dep-a==1.0.0'])
+    create_integration(fake_repo, 'datadog_checks_downloader', ['dep-a==1.0.0'])
 
     requirements = """
 dep-a==1.1.1
@@ -76,10 +77,11 @@ dep-b==3.1.4
     result = ddev('dep', 'sync')
 
     assert result.exit_code == 0
-    assert result.output == 'Files updated: 3\n'
+    assert result.output == 'Files updated: 4\n'
 
     assert_dependencies(fake_repo, 'foo', ['dep-a==1.1.1', 'dep-b==3.1.4'])
     assert_dependencies(fake_repo, 'bar', ['dep-a==1.1.1'])
+    assert_dependencies(fake_repo, 'datadog_checks_base', ['dep-a==1.1.1'])
     assert_dependencies(fake_repo, 'datadog_checks_base', ['dep-a==1.1.1'])
 
 
@@ -138,6 +140,7 @@ dep-a can be updated to version 1.2.3 on py2 and py3
         self.add_integration('foo', ['dep-a==1.0.0', 'dep-b==3.1.4'])
         self.add_integration('bar', ['dep-a==1.0.0'])
         self.add_integration('datadog_checks_base', ['dep-a==1.0.0', 'dep-b==3.1.4'])
+        self.add_integration('datadog_checks_downloader', ['dep-a==1.0.0', 'dep-b==3.1.4'])
         self.write_requirements()
 
         self.add_pypi_entry(
@@ -154,7 +157,7 @@ dep-a can be updated to version 1.2.3 on py2 and py3
         assert result.exit_code == 0
         assert (
             result.output
-            == '''Files updated: 3
+            == '''Files updated: 4
 Updated 1 dependencies
 '''
         )
@@ -162,6 +165,7 @@ Updated 1 dependencies
         assert_dependencies(self.repo, 'foo', ['dep-a==1.2.3', 'dep-b==3.1.4'])
         assert_dependencies(self.repo, 'bar', ['dep-a==1.2.3'])
         assert_dependencies(self.repo, 'datadog_checks_base', ['dep-a==1.2.3', 'dep-b==3.1.4'])
+        assert_dependencies(self.repo, 'datadog_checks_downloader', ['dep-a==1.2.3', 'dep-b==3.1.4'])
 
         requirements = self.requirements_path.read_text()
         expected = """


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Take into account all the checks when bumping or freezing the dependencies (reminder: checks = integrations that are shipped with the agent)

### Motivation
<!-- What inspired you to submit this pull request? -->

The `dep` commands do not take into account all the checks that are shipped, namely the downloader in my case. [This PR](https://github.com/DataDog/integrations-core/pull/16365) was not enough

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
