### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@ conf.yaml.example     @DataDog/documentation @DataDog/agent-integrations
 conf.yaml.default     @DataDog/documentation @DataDog/agent-integrations @DataDog/agent-metrics-logs
 auto_conf.yaml        @DataDog/documentation @DataDog/agent-integrations @DataDog/container-integrations
 manifest.json         @DataDog/documentation @DataDog/agent-integrations
-assets/               @DataDog/documentation @DataDog/agent-integrations
+**/assets             @DataDog/documentation @DataDog/agent-integrations
 
 # Checks base
 /datadog_checks_base/                                          @DataDog/agent-integrations


### PR DESCRIPTION
### What does this PR do?
Change the CodeOwners so that documentation team is added to any changes in files located under the /assets/ folder of an integration.

### Motivation
<!-- A brief description of the change being made with this pull request. -->
Ideally the Documentation team is added as reviewers for any integration asset changes (Dashboards and Monitors), which are usually located in `<integration>/assets/monitors/file.json`. Some PRs have not added Documentation as expected [[example](https://github.com/DataDog/integrations-core/pull/16501)].

Reviewed the [Github CodeOwners examples](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file), and I think this might work better for our use case:
```
# In this example, @octocat owns any file in a `/logs` directory such as
# `/build/logs`, `/scripts/logs`, and `/deeply/nested/logs`. Any changes
# in a `/logs` directory will require approval from @octocat.
**/logs @octocat
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
