### PR TITLE
When host auto discovery is enabled, do nothing and emit OK for check status

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -8,7 +8,6 @@ files:
   - template: instances
     options:
     - name: host
-      required: true
       description: |
         The hostname to connect to.
         NOTE: Even if the server name is `localhost`, the Agent connects to PostgreSQL using TCP/IP unless you also
@@ -22,7 +21,6 @@ files:
         type: integer
         example: 5432
     - name: username
-      required: true
       description: The Datadog username created to connect to PostgreSQL.
       value:
           type: string

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -13,7 +13,6 @@ files:
         NOTE: Even if the server name is `localhost`, the Agent connects to PostgreSQL using TCP/IP unless you also
         provide a value for the sock key.
       value:
-        example: localhost
         type: string
     - name: port
       description: The port to use when connecting to PostgreSQL.
@@ -24,7 +23,6 @@ files:
       description: The Datadog username created to connect to PostgreSQL.
       value:
           type: string
-          example: datadog
     - name: password
       description: The password associated with the Datadog user.
       value:

--- a/postgres/changelog.d/16540.added
+++ b/postgres/changelog.d/16540.added
@@ -1,0 +1,1 @@
+When host auto discovery is enabled, do nothing and emit OK for check status

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -24,15 +24,17 @@ class PostgresConfig:
     GAUGE = AgentCheck.gauge
     MONOTONIC = AgentCheck.monotonic_count
 
-    def __init__(self, instance):
+    def __init__(self, init_config, instance):
+        autodiscover_config = init_config.get('autodiscover_hosts', {})
+        self.host_autodiscovery_enabled = is_affirmative(autodiscover_config.get('enabled', False))
         self.host = instance.get('host', '')
-        if not self.host:
+        if not self.host and not self.host_autodiscovery_enabled:
             raise ConfigurationError('Specify a Postgres host to connect to.')
         self.port = instance.get('port', '')
         if self.port != '':
             self.port = int(self.port)
         self.user = instance.get('username', '')
-        if not self.user:
+        if not self.user and not self.host_autodiscovery_enabled:
             raise ConfigurationError('Please specify a user to connect to Postgres.')
         self.password = instance.get('password', '')
         self.dbname = instance.get('dbname', 'postgres')

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -72,6 +72,10 @@ def instance_empty_default_hostname():
     return False
 
 
+def instance_host():
+    return 'localhost'
+
+
 def instance_idle_connection_timeout():
     return 60000
 
@@ -122,3 +126,7 @@ def instance_table_count_limit():
 
 def instance_tag_replication_role():
     return False
+
+
+def instance_username():
+    return 'datadog'

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -72,10 +72,6 @@ def instance_empty_default_hostname():
     return False
 
 
-def instance_host():
-    return 'localhost'
-
-
 def instance_idle_connection_timeout():
     return 60000
 
@@ -126,7 +122,3 @@ def instance_table_count_limit():
 
 def instance_tag_replication_role():
     return False
-
-
-def instance_username():
-    return 'datadog'

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -214,7 +214,7 @@ class InstanceConfig(BaseModel):
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
     gcp: Optional[Gcp] = None
-    host: str
+    host: Optional[str] = None
     idle_connection_timeout: Optional[int] = None
     ignore_databases: Optional[tuple[str, ...]] = None
     log_unobfuscated_plans: Optional[bool] = None
@@ -243,7 +243,7 @@ class InstanceConfig(BaseModel):
     table_count_limit: Optional[int] = None
     tag_replication_role: Optional[bool] = None
     tags: Optional[tuple[str, ...]] = None
-    username: str
+    username: Optional[str] = None
 
     @model_validator(mode='before')
     def _initial_validation(cls, values):

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -13,22 +13,23 @@ init_config:
 #
 instances:
 
-    ## @param host - string - required
+  -
+    ## @param host - string - optional - default: localhost
     ## The hostname to connect to.
     ## NOTE: Even if the server name is `localhost`, the Agent connects to PostgreSQL using TCP/IP unless you also
     ## provide a value for the sock key.
     #
-  - host: localhost
+    # host: localhost
 
     ## @param port - integer - optional - default: 5432
     ## The port to use when connecting to PostgreSQL.
     #
     # port: 5432
 
-    ## @param username - string - required
+    ## @param username - string - optional - default: datadog
     ## The Datadog username created to connect to PostgreSQL.
     #
-    username: datadog
+    # username: datadog
 
     ## @param password - string - optional
     ## The password associated with the Datadog user.

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -14,22 +14,22 @@ init_config:
 instances:
 
   -
-    ## @param host - string - optional - default: localhost
+    ## @param host - string - optional
     ## The hostname to connect to.
     ## NOTE: Even if the server name is `localhost`, the Agent connects to PostgreSQL using TCP/IP unless you also
     ## provide a value for the sock key.
     #
-    # host: localhost
+    # host: <HOST>
 
     ## @param port - integer - optional - default: 5432
     ## The port to use when connecting to PostgreSQL.
     #
     # port: 5432
 
-    ## @param username - string - optional - default: datadog
+    ## @param username - string - optional
     ## The Datadog username created to connect to PostgreSQL.
     #
-    # username: datadog
+    # username: <USERNAME>
 
     ## @param password - string - optional
     ## The password associated with the Datadog user.

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -123,7 +123,11 @@ class PostgreSql(AgentCheck):
         self._clean_state()
         self.check_initializations.append(lambda: RelationsManager.validate_relations_config(self._config.relations))
         self.check_initializations.append(self.set_resolved_hostname_metadata)
-        if self._config.host_autodiscovery_enabled and self._config.host:
+        # initialize connections if host autodiscovery is disabled or if host autodiscovery is enabled but the host
+        # is set in the config
+        if not self._config.host_autodiscovery_enabled or (
+                self._config.host_autodiscovery_enabled and self._config.host
+        ):
             self.check_initializations.append(self._connect)
             self.check_initializations.append(self.load_version)
             self.check_initializations.append(self.initialize_is_aurora)

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -123,9 +123,10 @@ class PostgreSql(AgentCheck):
         self._clean_state()
         self.check_initializations.append(lambda: RelationsManager.validate_relations_config(self._config.relations))
         self.check_initializations.append(self.set_resolved_hostname_metadata)
-        self.check_initializations.append(self._connect)
-        self.check_initializations.append(self.load_version)
-        self.check_initializations.append(self.initialize_is_aurora)
+        if self._config.host_autodiscovery_enabled and self._config.host:
+            self.check_initializations.append(self._connect)
+            self.check_initializations.append(self.load_version)
+            self.check_initializations.append(self.initialize_is_aurora)
         self.tags_without_db = [t for t in copy.copy(self.tags) if not t.startswith("db:")]
         self.autodiscovery = self._build_autodiscovery()
         self._dynamic_queries = []

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -126,7 +126,7 @@ class PostgreSql(AgentCheck):
         # initialize connections if host autodiscovery is disabled or if host autodiscovery is enabled but the host
         # is set in the config
         if not self._config.host_autodiscovery_enabled or (
-                self._config.host_autodiscovery_enabled and self._config.host
+            self._config.host_autodiscovery_enabled and self._config.host
         ):
             self.check_initializations.append(self._connect)
             self.check_initializations.append(self.load_version)

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -1029,3 +1029,16 @@ def assert_state_set(check):
     if POSTGRES_VERSION != '9.3':
         assert check.metrics_cache.archiver_metrics
     assert check.metrics_cache.replication_metrics
+
+
+def test_host_autodiscover_init_config(aggregator, pg_instance):
+    init = {
+        'autodiscover_hosts': {
+            'enabled': True,
+        }
+    }
+    check_with_init = PostgreSql('test_instance', init, {})
+    assert check_with_init._config.autodiscovery_enabled is True
+    check_with_init.check({})
+    # assert that the service check is OK
+    aggregator.assert_service_check('postgres.can_connect', count=1, status=PostgreSql.OK)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This fixes an issue where we do not allow people to not set `host` and `username` fields in the config, which breaks the host auto discovery feature for postgres users. This results in the following error in the status output
```
  Loading Errors
  ==============
    postgres
    --------
      Core Check Loader:
        Check postgres not found in Catalog

      JMX Check Loader:
        check is not a jmx check, or unable to determine if it's so

      Python Check Loader:
        could not configure check instance for python check postgres: could not invoke 'postgres' python check constructor. New constructor API returned:
Traceback (most recent call last):
  File "/opt/datadog-agent/embedded/lib/python3.9/site-packages/datadog_checks/postgres/postgres.py", line 95, in __init__
    self._config = PostgresConfig(self.instance)
  File "/opt/datadog-agent/embedded/lib/python3.9/site-packages/datadog_checks/postgres/config.py", line 30, in __init__
    raise ConfigurationError('Specify a Postgres host to connect to.')
datadog_checks.base.errors.ConfigurationError: Specify a Postgres host to connect to.
Deprecated constructor API returned:
__init__() got an unexpected keyword argument 'agentConfig'
```

... this prevents us from sending agent integration metadata to our backend, which is necessary for the host auto discovery feature to work. With this fix the status output turns green:

```
    postgres (15.3.1)
    -----------------
      Instance ID: postgres:45f57430416e4e37 [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/postgres.d/conf.yaml
      Total Runs: 1
      Metric Samples: Last Run: 0, Total: 0
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 1
      Average Execution Time : 304ms
      Last Execution Date : 2024-01-09 14:30:01 UTC (1704810601000)
      Last Successful Execution Date : 2024-01-09 14:30:01 UTC (1704810601000)
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
