### PR TITLE
Fix a bug that prevents the `validate dep` command to fail if extra deps are found in the Agent file

### DIFF
--- a/.github/workflows/run-validations.yml
+++ b/.github/workflows/run-validations.yml
@@ -161,7 +161,7 @@ jobs:
 
     - name: Validate dependencies
       if: inputs.dep
-      run: ddev validate dep $TARGET
+      run: ddev validate dep
 
     - name: Validate EULA files
       if: inputs.eula

--- a/datadog_checks_dev/changelog.d/16541.fixed
+++ b/datadog_checks_dev/changelog.d/16541.fixed
@@ -1,0 +1,1 @@
+Fix a bug that prevents the `validate dep` command to fail if extra deps are found in the Agent file

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
@@ -224,7 +224,7 @@ def dep(check, require_base_check_version, min_base_check_version):
 
         # Check that this dependency defined on the agent requirements is actually used
         # This only makes sense when we take all check dependencies into account
-        if checks is None and name not in check_dependencies:
+        if check is None and name not in check_dependencies:
             failed = True
             message = f'Stale dependency needs to be removed by syncing: {name}'
             echo_failure(message)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- Fix a bug that prevents the validate dep command to fail if extra deps are found in the Agent file
- Also run the full validation on PRs to spot this kind of issues

### Motivation
<!-- What inspired you to submit this pull request? -->

- Comes from this [refacto](https://github.com/DataDog/integrations-core/pull/15416) where we lost the `s`
- Spotted thanks to this https://github.com/DataDog/integrations-core/pull/15859
- It should have failed

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- I know, there's no tests. I'll add them when we'll move this to the new `ddev`
- To be merged after https://github.com/DataDog/integrations-core/pull/16538, that's why the CI is red

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
