### PR TITLE
[PLINT-265] Update pyvmomi to 8.0.2.0.1

### DIFF
--- a/datadog_checks_base/changelog.d/16542.added
+++ b/datadog_checks_base/changelog.d/16542.added
@@ -1,0 +1,1 @@
+Update pyvmomi to 8.0.2.0.1

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -79,7 +79,7 @@ python-binary-memcached==0.26.1; sys_platform != 'win32' and python_version < '3
 python-binary-memcached==0.31.2; sys_platform != 'win32' and python_version > '3.0'
 python-dateutil==2.8.2
 python3-gearman==0.1.0; sys_platform != 'win32' and python_version > '3.0'
-pyvmomi==7.0.3
+pyvmomi==8.0.2.0.1
 pywin32==228; sys_platform == 'win32' and python_version < '3.0'
 pywin32==306; sys_platform == 'win32' and python_version > '3.0'
 pyyaml==5.4.1; python_version < '3.0'

--- a/vsphere/changelog.d/16542.added
+++ b/vsphere/changelog.d/16542.added
@@ -1,0 +1,1 @@
+Update pyvmomi to 8.0.2.0.1

--- a/vsphere/datadog_checks/vsphere/api.py
+++ b/vsphere/datadog_checks/vsphere/api.py
@@ -7,7 +7,7 @@ import ssl
 from typing import Any, Callable, List, TypeVar, cast  # noqa: F401
 
 from pyVim import connect
-from pyVmomi import SoapAdapter, vim, vmodl
+from pyVmomi import vim, vmodl
 from six import itervalues
 
 from datadog_checks.base.log import CheckLoggingAdapter  # noqa: F401
@@ -332,7 +332,7 @@ class VSphereAPI(object):
         query_filter.type = ALLOWED_EVENTS
         try:
             events = event_manager.QueryEvents(query_filter)
-        except SoapAdapter.ParserError as e:
+        except TypeError as e:
             self.log.debug("Error parsing bulk events: %s", e)
 
             if self.config.use_collect_events_fallback:
@@ -361,7 +361,7 @@ class VSphereAPI(object):
         while True:
             try:
                 collected_events = event_collector.ReadNextEvents(1)  # Read with page_size=1
-            except SoapAdapter.ParserError as e:
+            except TypeError as e:
                 self.log.debug("Cannot parse event, skipped: %s", e)
                 continue
             if len(collected_events) == 0:

--- a/vsphere/datadog_checks/vsphere/api.py
+++ b/vsphere/datadog_checks/vsphere/api.py
@@ -332,7 +332,7 @@ class VSphereAPI(object):
         query_filter.type = ALLOWED_EVENTS
         try:
             events = event_manager.QueryEvents(query_filter)
-        except TypeError as e:
+        except KeyError as e:
             self.log.debug("Error parsing bulk events: %s", e)
 
             if self.config.use_collect_events_fallback:
@@ -361,7 +361,7 @@ class VSphereAPI(object):
         while True:
             try:
                 collected_events = event_collector.ReadNextEvents(1)  # Read with page_size=1
-            except TypeError as e:
+            except KeyError as e:
                 self.log.debug("Cannot parse event, skipped: %s", e)
                 continue
             if len(collected_events) == 0:

--- a/vsphere/pyproject.toml
+++ b/vsphere/pyproject.toml
@@ -40,7 +40,7 @@ license = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "futures==3.4.0; python_version < '3.0'",
-    "pyvmomi==7.0.3",
+    "pyvmomi==8.0.2.0.1",
 ]
 
 [project.urls]

--- a/vsphere/tests/test_api.py
+++ b/vsphere/tests/test_api.py
@@ -6,7 +6,7 @@ import ssl
 
 import pytest
 from mock import ANY, MagicMock, patch
-from pyVmomi import SoapAdapter, vim, vmodl
+from pyVmomi import vim, vmodl
 
 from datadog_checks.vsphere.api import APIConnectionError, VSphereAPI
 from datadog_checks.vsphere.config import VSphereConfig
@@ -183,9 +183,9 @@ def test_get_new_events_failure_without_fallback(realtime_instance):
         config = VSphereConfig(realtime_instance, {}, MagicMock())
         api = VSphereAPI(config, MagicMock())
 
-        api._conn.content.eventManager.QueryEvents.side_effect = SoapAdapter.ParserError("some parse error")
+        api._conn.content.eventManager.QueryEvents.side_effect = TypeError("some parse error")
 
-        with pytest.raises(SoapAdapter.ParserError):
+        with pytest.raises(TypeError):
             api.get_new_events(start_time=dt.datetime.now())
 
 
@@ -200,16 +200,16 @@ def test_get_new_events_with_fallback(realtime_instance):
         event3 = vim.event.Event(key=3)
         event_collector = MagicMock()
         api._conn.content.eventManager.QueryEvents.side_effect = [
-            SoapAdapter.ParserError("some parse error"),
+            TypeError("some parse error"),
             [event1],
-            SoapAdapter.ParserError("event parse error"),
+            TypeError("event parse error"),
             [event3],
         ]
         api._conn.content.eventManager.CreateCollectorForEvents.return_value = event_collector
 
         event_collector.ReadNextEvents.side_effect = [
             [event1],
-            SoapAdapter.ParserError("event parse error"),
+            TypeError("event parse error"),
             [event3],
             [],
         ]

--- a/vsphere/tests/test_api.py
+++ b/vsphere/tests/test_api.py
@@ -183,9 +183,9 @@ def test_get_new_events_failure_without_fallback(realtime_instance):
         config = VSphereConfig(realtime_instance, {}, MagicMock())
         api = VSphereAPI(config, MagicMock())
 
-        api._conn.content.eventManager.QueryEvents.side_effect = TypeError("some parse error")
+        api._conn.content.eventManager.QueryEvents.side_effect = KeyError("some parse error")
 
-        with pytest.raises(TypeError):
+        with pytest.raises(KeyError):
             api.get_new_events(start_time=dt.datetime.now())
 
 
@@ -200,16 +200,16 @@ def test_get_new_events_with_fallback(realtime_instance):
         event3 = vim.event.Event(key=3)
         event_collector = MagicMock()
         api._conn.content.eventManager.QueryEvents.side_effect = [
-            TypeError("some parse error"),
+            KeyError("some parse error"),
             [event1],
-            TypeError("event parse error"),
+            KeyError("event parse error"),
             [event3],
         ]
         api._conn.content.eventManager.CreateCollectorForEvents.return_value = event_collector
 
         event_collector.ReadNextEvents.side_effect = [
             [event1],
-            TypeError("event parse error"),
+            KeyError("event parse error"),
             [event3],
             [],
         ]


### PR DESCRIPTION
### What does this PR do?
Updates pyvmomi to the next major version and newest release

### Motivation
Support for new API parameters added in recent releases and eventual support for vSphere 8

### Additional Notes
 the major upgrade to 8.x (https://github.com/vmware/pyvmomi/commit/a90023fedfeda48cb1824200dc4530084215f99e#diff-5a4a25310fcd77c939492db13158e8639be94c33532b071817930805a7be554b) includes removal of the `ParserError` class. Handling this error was added in https://github.com/DataDog/integrations-core/pull/6658 to account for this [issue](https://github.com/vmware/pyvmomi/issues/190). 

`ParserError` was used as a catch-all parsing excepting in `ParseData`, which was removed from `Deserialize` in the new version of the library

```
def Deserialize(data, resultType=object, stub=None):
   parser = ParserCreate(namespace_separator=NS_SEP)
   ds = SoapDeserializer(stub)
   ds.Deserialize(parser, resultType)
   ParseData(parser, data)
   return ds.GetResult()
```
-->
```
def Deserialize(data, resultType=object, stub=None):
    parser = ParserCreate(namespace_separator=NS_SEP)
    ds = SoapDeserializer(stub)
    ds.Deserialize(parser, resultType)
    if isinstance(data, six.binary_type) or isinstance(data, six.text_type):
        parser.Parse(data)
    else:
        parser.ParseFile(data)
    return ds.GetResult()
```

This issue seems like the equivalent error thrown in pyvmomi 8.x: https://github.com/vmware/pyvmomi/issues/1016. This comment from the older issue https://github.com/vmware/pyvmomi/issues/190#issuecomment-341864180 references the `KeyError` thrown by `GuessWsdlType`, which is the resulting error thrown in issue 1016. This is why I've changed our error handling to catch `KeyError`s instead.

### Review checklist (to be filled by reviewers)


- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
