### PR TITLE
make backend_only field mandatory

### DIFF
--- a/activemq/assets/logs/activemq.yaml
+++ b/activemq/assets/logs/activemq.yaml
@@ -1,5 +1,6 @@
 id: activemq
 metric_id: activemq
+backend_only: false
 facets:
   - name: URL Host
     source: log

--- a/aerospike/assets/logs/aerospike.yaml
+++ b/aerospike/assets/logs/aerospike.yaml
@@ -1,5 +1,6 @@
 id: aerospike
 metric_id: aerospike
+backend_only: false
 pipeline:
   type: pipeline
   name: Aerospike

--- a/airflow/assets/logs/airflow.yaml
+++ b/airflow/assets/logs/airflow.yaml
@@ -1,12 +1,12 @@
 id: airflow
 metric_id: airflow
+backend_only: false
 facets:
   - name: Filename
     source: log
     path: filename
     groups:
       - Source Code
-
 pipeline:
   type: pipeline
   name: Airflow

--- a/ambari/assets/logs/ambari.yaml
+++ b/ambari/assets/logs/ambari.yaml
@@ -1,5 +1,6 @@
 id: ambari
 metric_id: ambari
+backend_only: false
 facets:
   - name: Thread Name
     source: log

--- a/apache/assets/logs/apache.yaml
+++ b/apache/assets/logs/apache.yaml
@@ -1,5 +1,6 @@
 id: apache
 metric_id: apache
+backend_only: false
 facets:
   - name: Method
     source: log

--- a/arangodb/assets/logs/arangodb.yaml
+++ b/arangodb/assets/logs/arangodb.yaml
@@ -1,7 +1,7 @@
 id: arangodb
 metric_id: arangodb
+backend_only: false
 facets:
-
 pipeline:
   type: pipeline
   name: ArangoDB

--- a/argocd/assets/logs/argocd.yaml
+++ b/argocd/assets/logs/argocd.yaml
@@ -1,5 +1,6 @@
 id: argocd
 metric_id: argocd
+backend_only: false
 facets:
   - name: GRPC Service
     source: log
@@ -28,8 +29,8 @@ pipeline:
       enabled: true
       source: message
       samples:
-        - "time=\"2022-12-16T19:15:50Z\" level=info msg=\"finished unary call with code OK\" grpc.code=OK grpc.method=Check grpc.service=grpc.health.v1.Health grpc.start_time=\"2022-12-16T19:14:50Z\" grpc.time_ms=0.03 span.kind=server system=grpc"
-        - "time=\"2022-12-16T22:27:42Z\" level=info msg=\"Alloc=10469 TotalAlloc=9306163 Sys=29009 NumGC=4180 Goroutines=18\""
+        - time="2022-12-16T19:15:50Z" level=info msg="finished unary call with code OK" grpc.code=OK grpc.method=Check grpc.service=grpc.health.v1.Health grpc.start_time="2022-12-16T19:14:50Z" grpc.time_ms=0.03 span.kind=server system=grpc
+        - time="2022-12-16T22:27:42Z" level=info msg="Alloc=10469 TotalAlloc=9306163 Sys=29009 NumGC=4180 Goroutines=18"
         - 'redis: 2022/12/10 21:54:44 pubsub.go:159: redis: discarding bad PubSub connection: write tcp 10.20.1.6:38344->10.12.46.46:6379: write: broken pipe'
         - 'Trace[79767753]: ---"Objects listed" error:Get "https://10.12.32.1:443/apis/argoproj.io/v1alpha1/namespaces/default/applications?resourceVersion=26616507": dial tcp 10.12.32.1:443: i/o timeout 30001ms (01:19:41.462)'
         - 'E1219 01:18:53.299220       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.24.2/tools/cache/reflector.go:167: Failed to watch *v1.ConfigMap: failed to list *v1.ConfigMap: Get "https://10.12.32.1:443/api/v1/namespaces/default/configmaps?labelSelector=app.kubernetes.io%2Fpart-of%3Dargocd&resourceVersion=26616193": dial tcp 10.12.32.1:443: i/o timeout'

--- a/azure_active_directory/assets/logs/azure.activedirectory.yaml
+++ b/azure_active_directory/assets/logs/azure.activedirectory.yaml
@@ -1,5 +1,6 @@
 id: azure.activedirectory
 metric_id: azure-active-directory
+backend_only: false
 facets:
   - name: Duration
     source: log

--- a/azure_iot_edge/assets/logs/azure.iot_edge.yaml
+++ b/azure_iot_edge/assets/logs/azure.iot_edge.yaml
@@ -1,5 +1,6 @@
 id: azure.iot_edge
 metric_id: azure-iot-edge
+backend_only: false
 facets:
   - name: Duration
     source: log

--- a/cacti/assets/logs/cacti.yaml
+++ b/cacti/assets/logs/cacti.yaml
@@ -1,5 +1,6 @@
 id: cacti
 metric_id: cacti
+backend_only: false
 facets:
   - name: Thread Name
     source: log

--- a/cassandra/assets/logs/cassandra.yaml
+++ b/cassandra/assets/logs/cassandra.yaml
@@ -1,5 +1,6 @@
 id: cassandra
 metric_id: cassandra
+backend_only: false
 facets:
   - name: Operation Type
     source: log

--- a/ceph/assets/logs/ceph.yaml
+++ b/ceph/assets/logs/ceph.yaml
@@ -1,5 +1,6 @@
 id: ceph
 metric_id: ceph
+backend_only: false
 facets:
   - name: Thread Name
     source: log

--- a/citrix_hypervisor/assets/logs/citrix_hypervisor.yaml
+++ b/citrix_hypervisor/assets/logs/citrix_hypervisor.yaml
@@ -1,5 +1,6 @@
 id: citrix_hypervisor
 metric_id: citrix-hypervisor
+backend_only: false
 pipeline:
   type: pipeline
   name: Citrix Hypervisor

--- a/clickhouse/assets/logs/clickhouse.yaml
+++ b/clickhouse/assets/logs/clickhouse.yaml
@@ -1,5 +1,6 @@
 id: clickhouse
 metric_id: clickhouse
+backend_only: false
 facets:
   - name: ClickHouse Service Name
     source: log
@@ -34,8 +35,8 @@ pipeline:
         matchRules: |
           clickhouse %{_date} \[ %{_pid} \] \{%{_uuid}\} <%{_level}> (%{_service_common}( %{_app})?|%{_service_verbose}): %{data:message}
       samples:
-        - "2019.11.06 05:19:07.473780 [ 7 ] {} <Trace> default.tableau (ReplicatedMergeTreeQueue): Loaded queue"
-        - "2019.11.06 05:19:07.489819 [ 32 ] {a05c4495-ebdb-4f1d-894a-523a8d3a1d5f} <Debug> executeQuery: (from 127.0.0.1:43218) INSERT INTO tableau VALUES"
+        - '2019.11.06 05:19:07.473780 [ 7 ] {} <Trace> default.tableau (ReplicatedMergeTreeQueue): Loaded queue'
+        - '2019.11.06 05:19:07.489819 [ 32 ] {a05c4495-ebdb-4f1d-894a-523a8d3a1d5f} <Debug> executeQuery: (from 127.0.0.1:43218) INSERT INTO tableau VALUES'
     - type: date-remapper
       name: Define `timestamp` as the official date of the log
       enabled: true

--- a/cockroachdb/assets/logs/cockroachdb.yaml
+++ b/cockroachdb/assets/logs/cockroachdb.yaml
@@ -1,5 +1,6 @@
 id: cockroachdb
 metric_id: cockroachdb
+backend_only: false
 facets:
 pipeline:
   type: pipeline

--- a/confluent_platform/assets/logs/confluent_platform.yaml
+++ b/confluent_platform/assets/logs/confluent_platform.yaml
@@ -1,5 +1,6 @@
 id: confluent_platform
 metric_id: confluent-platform
+backend_only: false
 facets:
   - name: Logger Name
     source: log

--- a/consul/assets/logs/consul.yaml
+++ b/consul/assets/logs/consul.yaml
@@ -1,5 +1,6 @@
 id: consul
 metric_id: consul
+backend_only: false
 facets:
 pipeline:
   type: pipeline

--- a/coredns/assets/logs/coredns.yaml
+++ b/coredns/assets/logs/coredns.yaml
@@ -1,5 +1,6 @@
 id: coredns
 metric_id: coredns
+backend_only: false
 facets:
   - name: Answer Size
     source: log

--- a/couch/assets/logs/couchdb.yaml
+++ b/couch/assets/logs/couchdb.yaml
@@ -1,5 +1,6 @@
 id: couchdb
 metric_id: couchdb
+backend_only: false
 facets:
   - name: Method
     source: log

--- a/datadog_cluster_agent/assets/logs/agent.yaml
+++ b/datadog_cluster_agent/assets/logs/agent.yaml
@@ -1,5 +1,6 @@
 id: agent
 metric_id: datadog-cluster-agent # Only one official integration for the agent for now
+backend_only: false
 installation_sources:
   - agent
   - datadog-agent

--- a/docker_daemon/assets/logs/docker.yaml
+++ b/docker_daemon/assets/logs/docker.yaml
@@ -1,5 +1,6 @@
 id: docker
 metric_id: docker
+backend_only: false
 facets:
 pipeline:
   type: pipeline

--- a/druid/assets/logs/druid.yaml
+++ b/druid/assets/logs/druid.yaml
@@ -1,5 +1,6 @@
 id: druid
 metric_id: druid
+backend_only: false
 facets:
   - name: Logger Name
     source: log

--- a/elastic/assets/logs/elasticsearch.yaml
+++ b/elastic/assets/logs/elasticsearch.yaml
@@ -1,5 +1,6 @@
 id: elasticsearch
 metric_id: elasticsearch
+backend_only: false
 facets:
   - name: Duration
     source: log

--- a/envoy/assets/logs/envoy.yaml
+++ b/envoy/assets/logs/envoy.yaml
@@ -1,5 +1,6 @@
 id: envoy
 metric_id: envoy
+backend_only: false
 facets:
   - name: Duration
     source: log

--- a/etcd/assets/logs/etcd.yaml
+++ b/etcd/assets/logs/etcd.yaml
@@ -1,5 +1,6 @@
 id: etcd
 metric_id: etcd
+backend_only: false
 facets:
   - name: Package
     source: log

--- a/exchange_server/assets/logs/exchange-server.yaml
+++ b/exchange_server/assets/logs/exchange-server.yaml
@@ -1,5 +1,6 @@
 id: exchange-server
 metric_id: exchange-server
+backend_only: false
 facets:
   - name: Event ID
     source: log

--- a/flink/assets/logs/flink.yaml
+++ b/flink/assets/logs/flink.yaml
@@ -1,5 +1,6 @@
 id: flink
 metric_id: flink
+backend_only: false
 facets:
   - name: Logger Name
     source: log

--- a/foundationdb/assets/logs/foundationdb.yaml
+++ b/foundationdb/assets/logs/foundationdb.yaml
@@ -1,4 +1,5 @@
 id: foundationdb
+backend_only: false
 facets:
   - name: Event Name
     source: log
@@ -109,4 +110,4 @@ pipeline:
           _machine_ip_and_port %{ip:machine.ip}:%{port:machine.port}
         supportRules: ''
       samples:
-        - "127.0.0.1:4500"
+        - 127.0.0.1:4500

--- a/gearmand/assets/logs/gearman.yaml
+++ b/gearmand/assets/logs/gearman.yaml
@@ -1,5 +1,6 @@
 id: gearman
 metric_id: gearman
+backend_only: false
 facets:
   - name: Thread Name
     source: log

--- a/gitlab/assets/logs/gitlab.yaml
+++ b/gitlab/assets/logs/gitlab.yaml
@@ -1,5 +1,6 @@
 id: gitlab
 metric_id: gitlab
+backend_only: false
 facets:
   - name: Duration
     source: log
@@ -183,7 +184,7 @@ pipeline:
           sidekiq.start_format %{_gitlab_date} %{_sidekiq_date} %{_sidekiq_pid} TID-%{_sidekiq_thread_id} %{_sidekiq_class} JID-%{_sidekiq_jobid} %{_sidekiq_level}: start
           sidekiq.finish_format %{_gitlab_date} %{_sidekiq_date} %{_sidekiq_pid} TID-%{_sidekiq_thread_id} %{_sidekiq_class} JID-%{_sidekiq_jobid} %{_sidekiq_level}: done: %{_sidekiq_duration} sec
           sidekiq.fallback_format %{_gitlab_date} %{_sidekiq_date} %{_sidekiq_pid} TID-%{_sidekiq_thread_id} %{_sidekiq_level}:.*
-          
+
           sidekiq.format_2 %{_sidekiq_date} pid=%{_sidekiq_pid} (tid=%{_sidekiq_thread_id} class=%{_sidekiq_class} )?jid=%{_sidekiq_jobid} (elapsed=%{_sidekiq_duration} )?%{_sidekiq_level}:.*
 
           # Extra gitlab-rails/sidekiq.log samples:

--- a/gitlab_runner/assets/logs/gitlab-runner.yaml
+++ b/gitlab_runner/assets/logs/gitlab-runner.yaml
@@ -1,5 +1,6 @@
 id: gitlab-runner
 metric_id: gitlab-runner
+backend_only: false
 facets:
   - name: Job Outcome
     source: log
@@ -16,7 +17,6 @@ facets:
     path: job.runner
     groups:
       - Event
-
 pipeline:
   type: pipeline
   name: Gitlab Runner
@@ -48,8 +48,8 @@ pipeline:
           gitlab_runner_check Checking for jobs... %{word:job.outcome}\s+%{_color}\s+job%{_color}=%{integer:job.id} repo_url%{_color}=%{notSpace:url} runner%{_color}=%{word:job.runner}
           gitlab_runner_level %{word:level}: %{data:message}
       samples:
-        - 'Checking for jobs... received                       job=141847259 repo_url=https://gitlab.ddbuild.io/DataDog/k8s-nodegroups.git runner=nXySy2Hv'
-        - 'Job succeeded                    duration=24.383583446s job=2154106 project=141 runner=cxxE2HUr'
+        - Checking for jobs... received                       job=141847259 repo_url=https://gitlab.ddbuild.io/DataDog/k8s-nodegroups.git runner=nXySy2Hv
+        - Job succeeded                    duration=24.383583446s job=2154106 project=141 runner=cxxE2HUr
     - type: grok-parser
       name: Parsing JSON Gitlab Runner logs
       enabled: true

--- a/glusterfs/assets/logs/glusterfs.yaml
+++ b/glusterfs/assets/logs/glusterfs.yaml
@@ -1,5 +1,6 @@
 id: glusterfs
 metric_id: glusterfs
+backend_only: false
 facets:
   - name: GlusterFS Domain
     source: log

--- a/gunicorn/assets/logs/gunicorn.yaml
+++ b/gunicorn/assets/logs/gunicorn.yaml
@@ -1,5 +1,6 @@
 id: gunicorn
 metric_id: gunicorn
+backend_only: false
 facets:
   - name: Method
     source: log

--- a/haproxy/assets/logs/haproxy.yaml
+++ b/haproxy/assets/logs/haproxy.yaml
@@ -1,5 +1,6 @@
 id: haproxy
 metric_id: haproxy
+backend_only: false
 facets:
   - name: Duration
     source: log

--- a/harbor/assets/logs/harbor.yaml
+++ b/harbor/assets/logs/harbor.yaml
@@ -1,5 +1,6 @@
 id: harbor
 metric_id: harbor
+backend_only: false
 facets:
   - name: Database
     source: log

--- a/hazelcast/assets/logs/hazelcast.yaml
+++ b/hazelcast/assets/logs/hazelcast.yaml
@@ -1,5 +1,6 @@
 id: hazelcast
 metric_id: hazelcast
+backend_only: false
 facets:
   - name: Logger Name
     source: log

--- a/hdfs_datanode/assets/logs/hdfs_datanode.yaml
+++ b/hdfs_datanode/assets/logs/hdfs_datanode.yaml
@@ -1,5 +1,6 @@
 id: hdfs_datanode
 metric_id: hdfs-datanode
+backend_only: false
 facets:
   - name: Logger Name
     source: log

--- a/hdfs_namenode/assets/logs/hdfs_namenode.yaml
+++ b/hdfs_namenode/assets/logs/hdfs_namenode.yaml
@@ -1,5 +1,6 @@
 id: hdfs_namenode
 metric_id: hdfs-namenode
+backend_only: false
 facets:
   - name: Logger Name
     source: log

--- a/hive/assets/logs/hive.yaml
+++ b/hive/assets/logs/hive.yaml
@@ -1,5 +1,6 @@
 id: hive
 metric_id: hive
+backend_only: false
 facets:
   - name: Operation Type
     source: log

--- a/hivemq/assets/logs/hivemq.yaml
+++ b/hivemq/assets/logs/hivemq.yaml
@@ -1,5 +1,6 @@
 id: hivemq
 metric_id: hivemq
+backend_only: false
 facets:
   - name: HiveMQ Node Name
     source: log

--- a/hudi/assets/logs/hudi.yaml
+++ b/hudi/assets/logs/hudi.yaml
@@ -1,5 +1,6 @@
 id: hudi
 metric_id: hudi
+backend_only: false
 facets:
   - name: Logger Name
     source: log

--- a/ibm_ace/assets/logs/ibm_ace.yaml
+++ b/ibm_ace/assets/logs/ibm_ace.yaml
@@ -1,5 +1,6 @@
 id: ibm_ace
 metric_id: ibm-ace
+backend_only: false
 facets:
   - name: Logger Name
     source: log

--- a/ibm_db2/assets/logs/ibm_db2.yaml
+++ b/ibm_db2/assets/logs/ibm_db2.yaml
@@ -1,5 +1,6 @@
 id: ibm_db2
 metric_id: ibm-db2
+backend_only: false
 facets:
   - name: Database
     source: log
@@ -36,7 +37,7 @@ pipeline:
   name: IBM Db2
   enabled: true
   meta:
-    description: "[Documentation on AWS IBM Db2 logs](https://www.ibm.com/support/knowledgecenter/en/SSEPGG_9.7.0/com.ibm.db2.luw.admin.trb.doc/doc/c0020815.html)"
+    description: '[Documentation on AWS IBM Db2 logs](https://www.ibm.com/support/knowledgecenter/en/SSEPGG_9.7.0/com.ibm.db2.luw.admin.trb.doc/doc/c0020815.html)'
   filter:
     query: source:ibm_db2
   processors:

--- a/ibm_mq/assets/logs/ibm_mq.yaml
+++ b/ibm_mq/assets/logs/ibm_mq.yaml
@@ -1,5 +1,6 @@
 id: ibm_mq
 metric_id: ibm-mq
+backend_only: false
 facets:
   - name: User
     source: log

--- a/ibm_was/assets/logs/ibm_was.yaml
+++ b/ibm_was/assets/logs/ibm_was.yaml
@@ -1,5 +1,6 @@
 id: ibm_was
 metric_id: ibm-was
+backend_only: false
 facets:
   - name: Thread Name
     source: log

--- a/ignite/assets/logs/ignite.yaml
+++ b/ignite/assets/logs/ignite.yaml
@@ -1,5 +1,6 @@
 id: ignite
 metric_id: ignite
+backend_only: false
 facets:
   - name: Logger Name
     source: log

--- a/iis/assets/logs/iis.yaml
+++ b/iis/assets/logs/iis.yaml
@@ -1,5 +1,6 @@
 id: iis
 metric_id: iis
+backend_only: false
 facets:
   - name: Duration
     source: log

--- a/impala/assets/logs/impala.yaml
+++ b/impala/assets/logs/impala.yaml
@@ -1,5 +1,6 @@
 id: impala
 metric_id: impala
+backend_only: false
 facets:
   - name: Thread Name
     source: log
@@ -48,10 +49,10 @@ pipeline:
       enabled: true
       source: message
       samples:
-        - "I0909 12:54:20.375062     1 HiveMetaStoreClient.java:251] HMS client filtering is enabled."
+        - I0909 12:54:20.375062     1 HiveMetaStoreClient.java:251] HMS client filtering is enabled.
         - "I0722 08:49:07.843855     1 thrift-server.cc:456] ThriftServer 'hiveserver2-http-frontend' started on port: 28000"
-        - "I0722 08:49:04.990258    64 TAcceptQueueServer.cpp:340] New connection to server CatalogService from client <Host: 172.26.0.5 Port: 58642>"
-        - "I0722 08:49:08.039357    34 statestore.cc:278] Preparing initial impala-membership topic update for impalad@172.26.0.5:27000. Size = 148.00 B"
+        - 'I0722 08:49:04.990258    64 TAcceptQueueServer.cpp:340] New connection to server CatalogService from client <Host: 172.26.0.5 Port: 58642>'
+        - I0722 08:49:08.039357    34 statestore.cc:278] Preparing initial impala-membership topic update for impalad@172.26.0.5:27000. Size = 148.00 B
         - 'I0906 08:11:07.063410   591 cluster-membership-mgr.cc:287] Adding backend 5f45a790bd0dc864:ea6f64dd0bdfaab7 to group name: \"default\"\nmin_size: 1'
       grok:
         supportRules: |
@@ -61,7 +62,7 @@ pipeline:
           _file_name %{notSpace:file.name}
           _file_line %{integer:file.line}
           _query_id %{notSpace:query.id}
-          
+
           _log_message (%{_thrift_server_started_message}|%{_new_connection_message}|%{_new_membership_message}|%{_preparing_topic}|%{_message})
           _thrift_server_started_message ThriftServer '%{notSpace:network.destination.name}' started on port: %{port:network.destination.port}
           _new_connection_message New connection to server %{notSpace:network.destination.name} from client <Host: %{ip:network.destination.ip} Port: %{port:network.destination.port}>

--- a/istio/assets/logs/istio.yaml
+++ b/istio/assets/logs/istio.yaml
@@ -1,5 +1,6 @@
 id: istio
 metric_id: istio
+backend_only: false
 facets:
   - name: Duration
     source: log

--- a/jboss_wildfly/assets/logs/jboss_wildfly.yaml
+++ b/jboss_wildfly/assets/logs/jboss_wildfly.yaml
@@ -1,5 +1,6 @@
 id: jboss_wildfly
 metric_id: jboss-wildfly
+backend_only: false
 facets:
   - name: Method
     source: log

--- a/jmeter/assets/logs/jmeter.yaml
+++ b/jmeter/assets/logs/jmeter.yaml
@@ -1,5 +1,6 @@
 id: jmeter
 metric_id: jmeter
+backend_only: false
 facets:
   - name: Method
     source: log

--- a/kafka/assets/logs/kafka.yaml
+++ b/kafka/assets/logs/kafka.yaml
@@ -1,5 +1,6 @@
 id: kafka
 metric_id: kafka
+backend_only: false
 facets:
   - name: Logger Name
     source: log

--- a/karpenter/assets/logs/karpenter.yaml
+++ b/karpenter/assets/logs/karpenter.yaml
@@ -1,0 +1,46 @@
+id: karpenter
+metric_id: karpenter
+backend_only: false
+facets:
+  - name: Logger Name
+    source: log
+    path: logger.name
+    groups:
+      - Source Code
+pipeline:
+  type: pipeline
+  name: Karpenter
+  enabled: true
+  filter:
+    query: source:karpenter
+  processors:
+    - type: grok-parser
+      name: Parsing Karpenter date to timestamp
+      enabled: true
+      source: time
+      samples:
+        - '2023-11-28T17:42:02.909Z'
+      grok:
+        matchRules: |
+          timestamp_parser %{date("yyyy-MM-dd'T'HH:mm:ss.SSSZ"):timestamp}
+        supportRules: ''
+    - type: date-remapper
+      name: Define `timestamp` as the official date of the log
+      enabled: true
+      sources:
+        - timestamp
+    - type: status-remapper
+      name: Define `level` as the official status of the log
+      enabled: true
+      sources:
+        - level
+    - type: attribute-remapper
+      name: Map `logger` to `logger.name`
+      enabled: true
+      sources:
+        - logger
+      target: logger.name
+      preserveSource: false
+      overrideOnConflict: false
+      sourceType: attribute
+      targetType: attribute

--- a/karpenter/assets/logs/karpenter_tests.yaml
+++ b/karpenter/assets/logs/karpenter_tests.yaml
@@ -1,0 +1,94 @@
+id: "karpenter"
+tests:
+ -
+  sample: |-
+    {
+      "level" : "DEBUG",
+      "logger" : "controller",
+      "cluster-endpoint" : "https://D326AC16637B9DBA283767977E6F46D3.sk1.ca-central-1.eks.amazonaws.com",
+      "commit" : "3a61217",
+      "time" : "2023-11-28T16:49:41.858Z",
+      "message" : "discovered cluster endpoint"
+    }
+  result:
+    custom:
+      cluster-endpoint: "https://D326AC16637B9DBA283767977E6F46D3.sk1.ca-central-1.eks.amazonaws.com"
+      commit: "3a61217"
+      level: "DEBUG"
+      logger:
+        name: "controller"
+      time: "2023-11-28T16:49:41.858Z"
+      timestamp: 1701190181858
+    message: "discovered cluster endpoint"
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1701190181858
+ -
+  sample: |-
+    {
+      "level" : "DEBUG",
+      "logger" : "controller",
+      "commit" : "3a61217",
+      "time" : "2023-11-28T16:49:41.683Z",
+      "message" : "retrieving region from IMDS"
+    }
+  result:
+    custom:
+      commit: "3a61217"
+      level: "DEBUG"
+      logger:
+        name: "controller"
+      time: "2023-11-28T16:49:41.683Z"
+      timestamp: 1701190181683
+    message: "retrieving region from IMDS"
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1701190181683
+ -
+  sample: |-
+    {
+      "controller" : "nodeclaim.tagging",
+      "level" : "INFO",
+      "logger" : "controller",
+      "commit" : "3a61217",
+      "controllerGroup" : "karpenter.sh",
+      "time" : "2023-11-28T17:42:02.908Z",
+      "message" : "Starting Controller",
+      "controllerKind" : "NodeClaim"
+    }
+  result:
+    custom:
+      commit: "3a61217"
+      controller: "nodeclaim.tagging"
+      controllerGroup: "karpenter.sh"
+      controllerKind: "NodeClaim"
+      level: "INFO"
+      logger:
+        name: "controller"
+      time: "2023-11-28T17:42:02.908Z"
+      timestamp: 1701193322908
+    message: "Starting Controller"
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1701193322908
+ -
+  sample: |-
+    {
+      "level" : "ERROR",
+      "logger" : "controller.interruption",
+      "commit" : "3a61217",
+      "time" : "2023-11-28T17:42:02.908Z",
+      "message" : "getting messages from queue, discovering queue url, fetching queue url, AWS.SimpleQueueService.NonExistentQueue: The specified queue does not exist for this wsdl version.\n\tstatus code: 400, request id: ae70a985-8d67-5d68-8513-f441f2c7e8c7"
+    }
+  result:
+    custom:
+      commit: "3a61217"
+      level: "ERROR"
+      logger:
+        name: "controller.interruption"
+      time: "2023-11-28T17:42:02.908Z"
+      timestamp: 1701193322908
+    message: "getting messages from queue, discovering queue url, fetching queue url, AWS.SimpleQueueService.NonExistentQueue: The specified queue does not exist for this wsdl version.\n\tstatus code: 400, request id: ae70a985-8d67-5d68-8513-f441f2c7e8c7"
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1701193322908

--- a/kong/assets/logs/kong.yaml
+++ b/kong/assets/logs/kong.yaml
@@ -1,5 +1,6 @@
 id: kong
 metric_id: kong
+backend_only: false
 facets:
   - name: Method
     source: log

--- a/kube_scheduler/assets/logs/kube_scheduler.yaml
+++ b/kube_scheduler/assets/logs/kube_scheduler.yaml
@@ -1,5 +1,6 @@
 id: kube_scheduler
 metric_id: kube-scheduler
+backend_only: false
 installation_sources:
   - kube_scheduler
   - kube-scheduler

--- a/kyototycoon/assets/logs/kyototycoon.yaml
+++ b/kyototycoon/assets/logs/kyototycoon.yaml
@@ -1,5 +1,6 @@
 id: kyototycoon
 metric_id: kyoto-tycoon
+backend_only: false
 facets:
   - name: Method
     source: log

--- a/lighttpd/assets/logs/lighttpd.yaml
+++ b/lighttpd/assets/logs/lighttpd.yaml
@@ -1,5 +1,6 @@
 id: lighttpd
 metric_id: lighttpd
+backend_only: false
 facets:
   - name: Method
     source: log

--- a/mapr/assets/logs/mapr.yaml
+++ b/mapr/assets/logs/mapr.yaml
@@ -1,5 +1,6 @@
 id: mapr
 metric_id: mapr
+backend_only: false
 facets:
   - name: Logger Name
     source: log

--- a/mapreduce/assets/logs/mapreduce.yaml
+++ b/mapreduce/assets/logs/mapreduce.yaml
@@ -1,18 +1,17 @@
 id: mapreduce
 metric_id: mapreduce
+backend_only: false
 facets:
   - name: Logger Name
     source: log
     path: logger.name
     groups:
       - Source Code
-
   - name: MapReduce ApplicationID
     source: log
     path: mapreduce.application.app_id
     groups:
       - MapReduce
-
   - name: MapReduce Application State
     source: log
     path: mapreduce.application.state
@@ -28,25 +27,21 @@ facets:
     path: mapreduce.attempt.attempt_id
     groups:
       - MapReduce
-
   - name: MapReduce ApplicationAttempt State
     source: log
     path: mapreduce.attempt.state
     groups:
       - MapReduce
-
   - name: MapReduce TaskID
     source: log
     path: mapreduce.task.task_id
     groups:
       - MapReduce
-
   - name: MapReduce Task State
     source: log
     path: mapreduce.task.state
     groups:
       - MapReduce
-
 pipeline:
   type: pipeline
   name: mapreduce
@@ -91,9 +86,9 @@ pipeline:
           app_ids_with_container_second %{data}(%{_app_id}|%{_attempt_id}|%{_task_id})%{data}%{_container_id}%{data}
           app_ids_solo %{data}(%{_app_id}|%{_attempt_id}|%{_task_id})%{data}
       samples:
-        - 'Could not delete hdfs://namenode:9000/user/root/grep-temp-312857601/_temporary/1/_temporary/attempt_1597861183743_0001_m_000012_0'
-        - 'KILLING attempt_1597851676689_0007_r_000000_0'
-        - 'attempt_1597861183743_0008_r_000000_0 TaskAttempt Transitioned from SUCCESS_FINISHING_CONTAINER to SUCCEEDED'
+        - Could not delete hdfs://namenode:9000/user/root/grep-temp-312857601/_temporary/1/_temporary/attempt_1597861183743_0001_m_000012_0
+        - KILLING attempt_1597851676689_0007_r_000000_0
+        - attempt_1597861183743_0008_r_000000_0 TaskAttempt Transitioned from SUCCESS_FINISHING_CONTAINER to SUCCEEDED
     - type: grok-parser
       name: Parse state per activity type
       enabled: true

--- a/marathon/assets/logs/marathon.yaml
+++ b/marathon/assets/logs/marathon.yaml
@@ -1,5 +1,6 @@
 id: marathon
 metric_id: marathon
+backend_only: false
 facets:
   - name: Logger Name
     source: log

--- a/marklogic/assets/logs/marklogic.yaml
+++ b/marklogic/assets/logs/marklogic.yaml
@@ -1,5 +1,6 @@
 id: marklogic
 metric_id: marklogic
+backend_only: false
 facets:
   - name: Operation Type
     source: log

--- a/mcache/assets/logs/memcached.yaml
+++ b/mcache/assets/logs/memcached.yaml
@@ -1,5 +1,6 @@
 id: memcached
 metric_id: memcached
+backend_only: false
 facets:
   - name: Direction
     source: log

--- a/mesos_slave/assets/logs/mesos.yaml
+++ b/mesos_slave/assets/logs/mesos.yaml
@@ -1,5 +1,6 @@
 id: mesos
 metric_id: mesos
+backend_only: false
 facets:
   - name: Method
     source: log

--- a/mongo/assets/logs/mongodb.yaml
+++ b/mongo/assets/logs/mongodb.yaml
@@ -1,5 +1,6 @@
 id: mongodb
 metric_id: mongodb
+backend_only: false
 facets:
   - name: Database
     source: log

--- a/mysql/assets/logs/mysql.yaml
+++ b/mysql/assets/logs/mysql.yaml
@@ -1,5 +1,6 @@
 id: mysql
 metric_id: mysql
+backend_only: false
 facets:
 
   - name: Operation Type

--- a/nagios/assets/logs/nagios.yaml
+++ b/nagios/assets/logs/nagios.yaml
@@ -1,5 +1,6 @@
 id: nagios
 metric_id: nagios
+backend_only: false
 pipeline:
   type: pipeline
   name: Nagios

--- a/nginx/assets/logs/nginx.yaml
+++ b/nginx/assets/logs/nginx.yaml
@@ -1,5 +1,6 @@
 id: nginx
 metric_id: nginx
+backend_only: false
 facets:
   - name: Method
     source: log

--- a/nginx_ingress_controller/assets/logs/nginx-ingress-controller.yaml
+++ b/nginx_ingress_controller/assets/logs/nginx-ingress-controller.yaml
@@ -1,5 +1,6 @@
 id: nginx-ingress-controller
 metric_id: nginx-ingress-controller
+backend_only: false
 facets:
   - name: Duration
     source: log

--- a/nginx_ingress_controller/assets/logs/weave-kube.yaml
+++ b/nginx_ingress_controller/assets/logs/weave-kube.yaml
@@ -1,5 +1,6 @@
 id: weave-kube
 metric_id: nginx-ingress-controller
+backend_only: false
 facets:
   - name: Client IP
     source: log
@@ -26,25 +27,21 @@ facets:
     path: network.client.mac
     groups:
       - Network
-
   - name: Client Name
     source: log
     path: network.client.name
     groups:
       - Network
-
   - name: Destination MAC
     source: log
     path: network.destination.mac
     groups:
       - Network
-
   - name: Destination Name
     source: log
     path: network.destination.name
     groups:
       - Web Access
-
 pipeline:
   type: pipeline
   name: Weave Kube

--- a/nginx_ingress_controller/assets/logs/weave-npc.yaml
+++ b/nginx_ingress_controller/assets/logs/weave-npc.yaml
@@ -1,5 +1,6 @@
 id: weave-npc
 metric_id: nginx-ingress-controller
+backend_only: false
 facets:
   - name: Client IP
     source: log

--- a/nvidia_triton/assets/logs/nvidia_triton.yaml
+++ b/nvidia_triton/assets/logs/nvidia_triton.yaml
@@ -1,5 +1,6 @@
 id: nvidia_triton
 metric_id: nvidia-triton
+backend_only: false
 facets:
 pipeline:
   type: pipeline
@@ -14,7 +15,7 @@ pipeline:
       source: message
       samples:
         - "I1011 13:21:57.174321 1 cache_manager.cc:174] Creating TritonCache with name: 'local', libpath: '/opt/tritonserver/caches/local/libtritoncache_local.so', cache_config: '{\"size\":\"1048576\"}'"
-        - "2023-10-11 13:21:57.768609: I tensorflow/core/util/port.cc:110] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`."
+        - '2023-10-11 13:21:57.768609: I tensorflow/core/util/port.cc:110] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.'
         - "2023-10-1113:21:57 I 1 cache_manager.cc:174] Creating TritonCache with name: 'local', libpath: '/opt/tritonserver/caches/local/libtritoncache_local.so', cache_config: '{\"size\":\"1048576\"}'"
       grok:
         matchRules: |

--- a/openldap/assets/logs/openldap.yaml
+++ b/openldap/assets/logs/openldap.yaml
@@ -1,5 +1,6 @@
 id: openldap
 metric_id: openldap
+backend_only: false
 facets:
   - name: Logger Name
     source: log

--- a/openstack/assets/logs/openstack.yaml
+++ b/openstack/assets/logs/openstack.yaml
@@ -1,6 +1,6 @@
 id: openstack
 metric_id: openstack
-
+backend_only: false
 facets:
   - name: Method
     source: log

--- a/pan_firewall/assets/logs/pan.firewall.yaml
+++ b/pan_firewall/assets/logs/pan.firewall.yaml
@@ -1,5 +1,6 @@
 id: pan.firewall
 metric_id: pan-firewall
+backend_only: false
 facets:
   - name: Event Name
     source: log

--- a/pgbouncer/assets/logs/pgbouncer.yaml
+++ b/pgbouncer/assets/logs/pgbouncer.yaml
@@ -1,5 +1,6 @@
 id: pgbouncer
 metric_id: pgbouncer
+backend_only: false
 facets:
   - name: Database
     source: log

--- a/postfix/assets/logs/postfix.yaml
+++ b/postfix/assets/logs/postfix.yaml
@@ -1,5 +1,6 @@
 id: postfix
 metric_id: postfix
+backend_only: false
 facets:
   - name: Client ID
     source: log

--- a/postgres/assets/logs/postgresql.yaml
+++ b/postgres/assets/logs/postgresql.yaml
@@ -1,5 +1,6 @@
 id: postgresql
 metric_id: postgres
+backend_only: false
 facets:
   - name: Database
     source: log

--- a/powerdns_recursor/assets/logs/powerdns.yaml
+++ b/powerdns_recursor/assets/logs/powerdns.yaml
@@ -1,6 +1,6 @@
 id: powerdns
 metric_id: powerdns
-
+backend_only: false
 pipeline:
   type: pipeline
   name: Powerdns Recursor

--- a/presto/assets/logs/presto.yaml
+++ b/presto/assets/logs/presto.yaml
@@ -1,5 +1,6 @@
 id: presto
 metric_id: presto
+backend_only: false
 facets:
   - name: Duration
     source: log

--- a/proxysql/assets/logs/proxysql.yaml
+++ b/proxysql/assets/logs/proxysql.yaml
@@ -1,5 +1,6 @@
 id: proxysql
 metric_id: proxysql
+backend_only: false
 facets:
   - name: Database
     source: log
@@ -62,8 +63,8 @@ pipeline:
           stdout %{data:proxysql_service}\s+%{_revision}\s+--\s+%{notSpace:logger.name}\s+--\s+%{_textDate}
       samples:
         - "2020-04-06 08:59:07 MySQL_Monitor.cpp:960:monitor_read_only_thread(): [ERROR] Timeout on read_only check for db:3306 after 2ms. Unable to create a connection. If the server is overload, increase mysql-monitor_connect_timeout. Error: timeout on creating new connection: Can't connect to MySQL server on 'db' (115)."
-        - '2020-04-06 08:59:08 [INFO] New mysql_aws_aurora_hostgroups table'
-        - "Standard MySQL Authentication rev. 0.2.0902 -- MySQL_Authentication.cpp -- Tue Oct 15 17:03:55 2019"
+        - 2020-04-06 08:59:08 [INFO] New mysql_aws_aurora_hostgroups table
+        - Standard MySQL Authentication rev. 0.2.0902 -- MySQL_Authentication.cpp -- Tue Oct 15 17:03:55 2019
     - type: grok-parser
       # Audit logs have a duration field that specify a unit
       name: '[audit log] Format duration field unit and move into duration_us'
@@ -107,7 +108,7 @@ pipeline:
           logger %{notSpace:logger.name}\:%{number:logger.line_number}\:%{notSpace:logger.method_name}
         supportRules: ''
       samples:
-        -  MySQL_Thread.cpp:2652:~MySQL_Thread()
+        - MySQL_Thread.cpp:2652:~MySQL_Thread()
     - type: attribute-remapper
       name: Map `schemaname` to `db.instance`
       enabled: true

--- a/pulsar/assets/logs/pulsar.yaml
+++ b/pulsar/assets/logs/pulsar.yaml
@@ -1,5 +1,6 @@
 id: pulsar
 metric_id: pulsar
+backend_only: false
 facets:
   - name: Method
     source: log

--- a/rabbitmq/assets/logs/rabbitmq.yaml
+++ b/rabbitmq/assets/logs/rabbitmq.yaml
@@ -1,5 +1,6 @@
 id: rabbitmq
 metric_id: rabbitmq
+backend_only: false
 facets:
 pipeline:
   type: pipeline

--- a/ray/assets/logs/ray.yaml
+++ b/ray/assets/logs/ray.yaml
@@ -1,4 +1,5 @@
 id: ray
+backend_only: false
 facets:
   - name: Thread Name
     source: log

--- a/redisdb/assets/logs/redis.yaml
+++ b/redisdb/assets/logs/redis.yaml
@@ -1,5 +1,6 @@
 id: redis
 metric_id: redis
+backend_only: false
 facets:
   - name: Redis PID
     source: log

--- a/rethinkdb/assets/logs/rethinkdb.yaml
+++ b/rethinkdb/assets/logs/rethinkdb.yaml
@@ -1,5 +1,6 @@
 id: rethinkdb
 metric_id: rethinkdb
+backend_only: false
 facets:
   - name: Table
     source: log
@@ -16,7 +17,6 @@ facets:
       name: second
     groups:
       - Measure
-
 pipeline:
   type: pipeline
   name: RethinkDB
@@ -50,10 +50,10 @@ pipeline:
           table_default Table %{notSpace:db.table}: .*
         supportRules: ''
       samples:
-        - 'Server ready, "server0" c79e1284-c542-429d-babf-627447e86318'
-        - 'Connected to proxy proxy-1e80aed3-898c-49d0-8774-8fb95f773c42'
+        - Server ready, "server0" c79e1284-c542-429d-babf-627447e86318
+        - Connected to proxy proxy-1e80aed3-898c-49d0-8774-8fb95f773c42
         - 'Table de8766a5-5147-4e64-b624-862028cb5572: Added replica on this server.'
-        - 'Connected to server "server1" 03bd7126-5d09-48ed-8074-d0a7101dc58c'
+        - Connected to server "server1" 03bd7126-5d09-48ed-8074-d0a7101dc58c
     - type: date-remapper
       name: Define `timestamp` as the official date of the log
       enabled: true

--- a/riak/assets/logs/riak.yaml
+++ b/riak/assets/logs/riak.yaml
@@ -1,5 +1,6 @@
 id: riak
 metric_id: riak
+backend_only: false
 facets:
   - name: Thread Name
     source: log

--- a/scylla/assets/logs/scylla.yaml
+++ b/scylla/assets/logs/scylla.yaml
@@ -1,5 +1,6 @@
 id: scylla
 metric_id: scylla
+backend_only: false
 facets:
   - name: Database
     source: log

--- a/sidekiq/assets/logs/sidekiq.yaml
+++ b/sidekiq/assets/logs/sidekiq.yaml
@@ -1,5 +1,6 @@
 id: sidekiq
 metric_id: sidekiq
+backend_only: false
 facets:
   - name: Duration
     source: log

--- a/singlestore/assets/logs/singlestore.yaml
+++ b/singlestore/assets/logs/singlestore.yaml
@@ -1,5 +1,6 @@
 id: singlestore
 metric_id: singlestore
+backend_only: false
 facets:
 pipeline:
   type: pipeline

--- a/solr/assets/logs/solr.yaml
+++ b/solr/assets/logs/solr.yaml
@@ -1,5 +1,6 @@
 id: solr
 metric_id: solr
+backend_only: false
 facets:
   - name: Logger Name
     source: log
@@ -11,7 +12,6 @@ facets:
     path: logger.thread_name
     groups:
       - Source Code
-
 pipeline:
   type: pipeline
   name: Solr

--- a/sonarqube/assets/logs/sonarqube.yaml
+++ b/sonarqube/assets/logs/sonarqube.yaml
@@ -1,5 +1,6 @@
 id: sonarqube
 metric_id: sonarqube
+backend_only: false
 facets:
   - name: Method
     source: log

--- a/spark/assets/logs/spark.yaml
+++ b/spark/assets/logs/spark.yaml
@@ -1,5 +1,6 @@
 id: spark
 metric_id: spark
+backend_only: false
 facets:
   - name: Logger Name
     source: log

--- a/sqlserver/assets/logs/sqlserver.yaml
+++ b/sqlserver/assets/logs/sqlserver.yaml
@@ -1,5 +1,6 @@
 id: sqlserver
 metric_id: sql-server
+backend_only: false
 facets:
   - name: Thread Name
     source: log

--- a/squid/assets/logs/squid.yaml
+++ b/squid/assets/logs/squid.yaml
@@ -1,5 +1,6 @@
 id: squid
 metric_id: squid
+backend_only: false
 facets:
   - name: Method
     source: log

--- a/ssh_check/assets/logs/sshd.yaml
+++ b/ssh_check/assets/logs/sshd.yaml
@@ -1,5 +1,6 @@
 id: sshd
 metric_id: ssh
+backend_only: false
 facets:
   - name: Client IP
     source: log

--- a/statsd/assets/logs/statsd.yaml
+++ b/statsd/assets/logs/statsd.yaml
@@ -1,5 +1,6 @@
 id: statsd
 metric_id: statsd
+backend_only: false
 pipeline:
   type: pipeline
   name: Statsd

--- a/strimzi/assets/logs/strimzi.yaml
+++ b/strimzi/assets/logs/strimzi.yaml
@@ -1,5 +1,6 @@
 id: strimzi
 metric_id: strimzi
+backend_only: false
 facets:
 pipeline:
   type: pipeline
@@ -13,11 +14,11 @@ pipeline:
       enabled: true
       source: message
       samples:
-        - "2023-09-21T08:25:27.244309295Z stdout F 2023-09-21 08:25:27 INFO  AbstractOperator:510 - Reconciliation #55(timer) Kafka(kafka/my-cluster): reconciled"
-        - "2023-04-27 09:46:39 INFO  Main:79 - ClusterOperator 0.34.0 is starting"
-        - "2023-09-26 18:38:08,49502 WARN  [vertx-blocked-thread-checker] BlockedThreadChecker: - Thread Thread[blocking-startup-ops-0,5,main] has been blocked for 323364 ms, time limit is 60000 ms"
-        - "2023-04-27 09:47:41,48424 INFO  [main] Main:38 - TopicOperator 0.34.0 is starting"
-        - "2023-09-26 18:38:26,499 INFO Committing global session 0x1001486b1980009 (org.apache.zookeeper.server.quorum.LeaderSessionTracker) [CommitProcessor:1]"
+        - '2023-09-21T08:25:27.244309295Z stdout F 2023-09-21 08:25:27 INFO  AbstractOperator:510 - Reconciliation #55(timer) Kafka(kafka/my-cluster): reconciled'
+        - 2023-04-27 09:46:39 INFO  Main:79 - ClusterOperator 0.34.0 is starting
+        - '2023-09-26 18:38:08,49502 WARN  [vertx-blocked-thread-checker] BlockedThreadChecker: - Thread Thread[blocking-startup-ops-0,5,main] has been blocked for 323364 ms, time limit is 60000 ms'
+        - 2023-04-27 09:47:41,48424 INFO  [main] Main:38 - TopicOperator 0.34.0 is starting
+        - 2023-09-26 18:38:26,499 INFO Committing global session 0x1001486b1980009 (org.apache.zookeeper.server.quorum.LeaderSessionTracker) [CommitProcessor:1]
       grok:
         matchRules: |
           strimzi_raw_log %{_date} %{_stream_type} %{_entry_type} %{strimzi_k8s}

--- a/supervisord/assets/logs/supervisord.yaml
+++ b/supervisord/assets/logs/supervisord.yaml
@@ -1,5 +1,6 @@
 id: supervisord
 metric_id: supervisord
+backend_only: false
 facets:
 pipeline:
   type: pipeline

--- a/teamcity/assets/logs/teamcity.yaml
+++ b/teamcity/assets/logs/teamcity.yaml
@@ -1,5 +1,6 @@
 id: teamcity
 metric_id: teamcity
+backend_only: false
 facets:
   - name: Logger Name
     source: log

--- a/temporal/assets/logs/temporal.yaml
+++ b/temporal/assets/logs/temporal.yaml
@@ -1,5 +1,6 @@
 id: temporal
 metric_id: temporal
+backend_only: false
 facets:
   - name: Namespace
     source: log

--- a/tenable/assets/logs/tenable.yaml
+++ b/tenable/assets/logs/tenable.yaml
@@ -1,5 +1,6 @@
 id: tenable
 metric_id: tenable
+backend_only: false
 facets:
   - name: Event Name
     source: log

--- a/tomcat/assets/logs/tomcat.yaml
+++ b/tomcat/assets/logs/tomcat.yaml
@@ -1,5 +1,6 @@
 id: tomcat
 metric_id: tomcat
+backend_only: false
 facets:
   - name: Duration
     source: log
@@ -66,13 +67,11 @@ facets:
     path: gc.action
     groups:
       - Garbage Collector
-
   - name: GC Phase
     source: log
     path: gc.phase
     groups:
       - Garbage Collector
-
   - name: Memory Freed
     source: log
     path: gc.memory_freed
@@ -83,7 +82,6 @@ facets:
       name: mebibyte
     groups:
       - Garbage Collector
-
 pipeline:
   type: pipeline
   name: Tomcat

--- a/torchserve/assets/logs/torchserve.yaml
+++ b/torchserve/assets/logs/torchserve.yaml
@@ -1,5 +1,6 @@
 id: torchserve
 metric_id: torchserve
+backend_only: false
 facets:
   - name: Method
     source: log

--- a/traffic_server/assets/logs/traffic_server.yaml
+++ b/traffic_server/assets/logs/traffic_server.yaml
@@ -1,5 +1,6 @@
 id: traffic_server
 metric_id: traffic-server
+backend_only: false
 facets:
   - name: Error Type
     source: log

--- a/twemproxy/assets/logs/twemproxy.yaml
+++ b/twemproxy/assets/logs/twemproxy.yaml
@@ -1,5 +1,6 @@
 id: twemproxy
 metric_id: twemproxy
+backend_only: false
 facets:
   - name: Host
     source: log
@@ -11,7 +12,6 @@ facets:
     path: port
     groups:
       - Twemproxy
-
 pipeline:
   type: pipeline
   name: Twemproxy

--- a/twistlock/assets/logs/twistlock.yaml
+++ b/twistlock/assets/logs/twistlock.yaml
@@ -1,5 +1,6 @@
 id: twistlock
 metric_id: twistlock
+backend_only: false
 facets:
   - name: Package
     source: log
@@ -47,8 +48,8 @@ pipeline:
         matchRules: |
           keyvalue_rule %{data:vulnerability:keyvalue}
       samples:
-        - 'time="2018-12-17T23:04:53.405061747Z" type="registry_scan" log_type="vulnerability" vulnerability_id="46" description="Image contains vulnerable OS packages" cve="CVE-2017-13727" severity="low" package="tiff (used in libtiff5)" package_version="4.0.3-7ubuntu0.4" vendor_status="fixed in 4.0.3-7ubuntu0.8" rule="Default - alert all components" host="demo-jeremy-p-twistlock-com" image_id="sha256:abce18594030284839329484737358538983838383838383838383838383838a" image_name="registry.infra.svc.cluster.local:5000/infoslack/dvwa:latest"'
-        - 'time="2018-12-17T23:04:53.405061747Z" type="registry_scan" log_type="vulnerability" vulnerability_id="46" description="Image contains vulnerable OS packages" cve="CVE-2017-13727" severity="low" package="tiff (used in libtiff5)" package_version="4.0.3-7ubuntu0.4" vendor_status="fixed in 4.0.3-7ubuntu0.8" rule="Default - alert all components" host="demo-jeremy-p-twistlock-com" image_id="sha256:abce18594030284839329484737358538983838383838383838383838383838a" image_name="registry.infra.svc.cluster.local:5000/infoslack/dvwa:latest"'
+        - time="2018-12-17T23:04:53.405061747Z" type="registry_scan" log_type="vulnerability" vulnerability_id="46" description="Image contains vulnerable OS packages" cve="CVE-2017-13727" severity="low" package="tiff (used in libtiff5)" package_version="4.0.3-7ubuntu0.4" vendor_status="fixed in 4.0.3-7ubuntu0.8" rule="Default - alert all components" host="demo-jeremy-p-twistlock-com" image_id="sha256:abce18594030284839329484737358538983838383838383838383838383838a" image_name="registry.infra.svc.cluster.local:5000/infoslack/dvwa:latest"
+        - time="2018-12-17T23:04:53.405061747Z" type="registry_scan" log_type="vulnerability" vulnerability_id="46" description="Image contains vulnerable OS packages" cve="CVE-2017-13727" severity="low" package="tiff (used in libtiff5)" package_version="4.0.3-7ubuntu0.4" vendor_status="fixed in 4.0.3-7ubuntu0.8" rule="Default - alert all components" host="demo-jeremy-p-twistlock-com" image_id="sha256:abce18594030284839329484737358538983838383838383838383838383838a" image_name="registry.infra.svc.cluster.local:5000/infoslack/dvwa:latest"
     - type: attribute-remapper
       name: Map `vulnerability.vulnerability_id` to `vulnerability.id`
       enabled: true

--- a/varnish/assets/logs/varnish.yaml
+++ b/varnish/assets/logs/varnish.yaml
@@ -1,5 +1,6 @@
 id: varnish
 metric_id: varnish
+backend_only: false
 facets:
   - name: Method
     source: log

--- a/vault/assets/logs/vault.yaml
+++ b/vault/assets/logs/vault.yaml
@@ -1,5 +1,6 @@
 id: vault
 metric_id: vault
+backend_only: false
 facets:
   - name: Method
     source: log

--- a/vertica/assets/logs/vertica.yaml
+++ b/vertica/assets/logs/vertica.yaml
@@ -1,5 +1,6 @@
 id: vertica
 metric_id: vertica
+backend_only: false
 facets:
   - name: Logger Name
     source: log

--- a/voltdb/assets/logs/voltdb.yaml
+++ b/voltdb/assets/logs/voltdb.yaml
@@ -1,12 +1,12 @@
 id: voltdb
 metric_id: voltdb
+backend_only: false
 facets:
   - name: Logger Name
     source: log
     path: logger.name
     groups:
       - Source Code
-
 pipeline:
   type: pipeline
   name: VoltDB

--- a/weblogic/assets/logs/weblogic.yaml
+++ b/weblogic/assets/logs/weblogic.yaml
@@ -1,5 +1,6 @@
 id: weblogic
 metric_id: weblogic
+backend_only: false
 facets:
   - name: Status Code
     source: log

--- a/yarn/assets/logs/yarn.yaml
+++ b/yarn/assets/logs/yarn.yaml
@@ -1,31 +1,27 @@
 id: yarn
 metric_id: yarn
+backend_only: false
 facets:
   - name: Logger Name
     source: log
     path: logger.name
     groups:
       - Source Code
-
   - name: MapReduce ApplicationID
     source: log
     path: mapreduce.application.app_id
     groups:
       - MapReduce
-
   - name: MapReduce Application State
     source: log
     path: mapreduce.application.state
     groups:
       - MapReduce
-
   - name: MapReduce ApplicationAttemptID
     source: log
     path: mapreduce.attempt.attempt_id
     groups:
       - MapReduce
-
-
 pipeline:
   type: pipeline
   name: YARN
@@ -68,8 +64,8 @@ pipeline:
         matchRules: |
           app_ids %{data}(%{_app_id}|%{_attempt_id})%{data}
       samples:
-        - 'application_1595271076848_0001 State change from KILLING to FINAL_SAVING'
-        - 'appattempt_1595271076848_0001_000001 State change from SCHEDULED to FINAL_SAVING'
+        - application_1595271076848_0001 State change from KILLING to FINAL_SAVING
+        - appattempt_1595271076848_0001_000001 State change from SCHEDULED to FINAL_SAVING
     - type: grok-parser
       name: Parse state per activity type
       enabled: true
@@ -86,8 +82,8 @@ pipeline:
           attempt_state_change %{_attempt_id} State change from %{word} to %{_attempt_state}
           final_state %{data} finalState=%{_app_state}
       samples:
-        - 'application_1595271076848_0001 State change from KILLING to FINAL_SAVING'
-        - 'appattempt_1595271076848_0001_000001 State change from SCHEDULED to FINAL_SAVING'
+        - application_1595271076848_0001 State change from KILLING to FINAL_SAVING
+        - appattempt_1595271076848_0001_000001 State change from SCHEDULED to FINAL_SAVING
     - type: date-remapper
       name: Define `timestamp` as the official date of the log
       enabled: true

--- a/zk/assets/logs/zookeeper.yaml
+++ b/zk/assets/logs/zookeeper.yaml
@@ -1,5 +1,6 @@
 id: zookeeper
 metric_id: zookeeper
+backend_only: false
 facets:
   - name: Logger Name
     source: log


### PR DESCRIPTION
### What does this PR do?
This adds the backend_only field, which will be mandatory going forward, to yaml files in integrations core

### Motivation
The changes to logs core have already been made, now syncing
https://datadoghq.atlassian.net/browse/LOGSC-749

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
