### PR TITLE
Autogenerate source_type_id when running ddev create

### DIFF
--- a/datadog_checks_dev/changelog.d/16544.added
+++ b/datadog_checks_dev/changelog.d/16544.added
@@ -1,0 +1,1 @@
+Autogenerate source_type_id in 'manifest.json' when running 'ddev create'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -2,8 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
-from uuid import uuid4
 from datetime import datetime
+from uuid import uuid4
 
 from ..fs import (
     create_file,
@@ -127,7 +127,7 @@ To install the {integration_name} check on your host:
         'support_type': support_type,
         'integration_links': integration_links,
         # Source Type IDs are unique-per-integration integers
-        # This uses the current timestamp with the subtraction to start the IDs at around a few million, allowing room to grow.
+        # Based on current timestamp with subtraction to start the IDs at around a few million, allowing room to grow.
         "source_type_id": int(datetime.utcnow().timestamp()) - 1700000000,
     }
     config.update(kwargs)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 from uuid import uuid4
+from datetime import datetime
 
 from ..fs import (
     create_file,
@@ -125,6 +126,9 @@ To install the {integration_name} check on your host:
         'repo_name': REPO_CHOICES.get(repo_choice, ''),
         'support_type': support_type,
         'integration_links': integration_links,
+        # Source Type IDs are unique-per-integration integers
+        # This uses the current timestamp with the subtraction to start the IDs at around a few million, allowing room to grow.
+        "source_type_id": int(datetime.utcnow().timestamp()) - 1700000000,
     }
     config.update(kwargs)
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/manifest.json
@@ -23,6 +23,7 @@
   }},
   "assets": {{
     "integration": {{
+      "source_type_id": {source_type_id},
       "source_type_name": "{integration_name}",
       "configuration": {{
         "spec": "assets/configuration/spec.yaml"

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/manifest.json
@@ -19,6 +19,7 @@
   }},
   "assets": {{
     "integration": {{
+      "source_type_id": {source_type_id},
       "source_type_name": "{integration_name}",
       "configuration": {{
         "spec": "assets/configuration/spec.yaml"

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/manifest.json
@@ -20,6 +20,7 @@
   }},
   "assets": {{
     "integration": {{
+      "source_type_id": {source_type_id},
       "source_type_name": "{integration_name}",
       "configuration": {{
         "spec": "assets/configuration/spec.yaml"

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/metrics_pull/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/metrics_pull/{check_name}/manifest.json
@@ -18,6 +18,7 @@
   "assets": {{
     "integration": {{
       "auto_install": false,
+      "source_type_id": {source_type_id},
       "source_type_name": "{integration_name}",
       "events": {{
         "creates_events": false

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/snmp_tile/snmp_{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/snmp_tile/snmp_{check_name}/manifest.json
@@ -22,6 +22,7 @@
   }},
   "assets": {{
     "integration": {{
+      "source_type_id": {source_type_id},
       "source_type_name": "{integration_name}",
       "configuration": {{
         "spec": "assets/configuration/spec.yaml"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds an auto-generation of "source_type_id" and put it in the `manifest.json` file during `ddev create`.

### Motivation
<!-- What inspired you to submit this pull request? -->
This is a field that already exists for all current integrations and followup work will backport the current IDs into the existing manifests. 

Otherwise, the rationale can be found here - https://datadoghq.atlassian.net/wiki/spaces/MKT/pages/3306327909/2023-11-27+APW+Integration+Source+Type+ID+Generation

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I was able to test this by running `ddev -x create test_integration`. Then the resulting `test_integration/manifest.json` contained the following:

```
...
  "assets": {
    "integration": {
      "source_type_id": 4526851,
      "source_type_name": "test_integration",
      "configuration": {
        "spec": "assets/configuration/spec.yaml"
      },
...
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
