### PR TITLE
Bump `psutil` version to 5.9.7

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -61,7 +61,7 @@ prometheus-client,PyPI,Apache-2.0,Copyright 2015 Brian Brazil
 prometheus-client,PyPI,Apache-2.0,Copyright 2015 The Prometheus Authors
 protobuf,PyPI,BSD-3-Clause,Copyright 2008 Google Inc.
 protobuf,PyPI,BSD-3-Clause,Copyright 2008 Google Inc.  All rights reserved.
-psutil,PyPI,BSD-3-Clause,"Copyright (c) 2009, Jay Loden, Dave Daeschler, Giampaolo Rodola'"
+psutil,PyPI,BSD-3-Clause,"Copyright (c) 2009, Jay Loden, Dave Daeschler, Giampaolo Rodola"
 psycopg2-binary,PyPI,BSD-3-Clause,Copyright 2013 Federico Di Gregorio
 psycopg2-binary,PyPI,LGPL-3.0-only,Copyright (C) 2013 Federico Di Gregorio
 pyasn1,PyPI,BSD-3-Clause,"Copyright (c) 2005-2019, Ilya Etingof <etingof@gmail.com>"

--- a/btrfs/changelog.d/16547.added
+++ b/btrfs/changelog.d/16547.added
@@ -1,0 +1,1 @@
+Bump `psutil` version to 5.9.7

--- a/btrfs/pyproject.toml
+++ b/btrfs/pyproject.toml
@@ -40,7 +40,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "psutil==5.9.0",
+    "psutil==5.9.7",
 ]
 
 [project.urls]

--- a/datadog_checks_base/changelog.d/16547.added
+++ b/datadog_checks_base/changelog.d/16547.added
@@ -1,0 +1,1 @@
+Bump `psutil` version to 5.9.7

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -57,7 +57,7 @@ prometheus-client==0.12.0; python_version < '3.0'
 prometheus-client==0.19.0; python_version > '3.0'
 protobuf==3.17.3; python_version < '3.0'
 protobuf==3.20.2; python_version > '3.0'
-psutil==5.9.0
+psutil==5.9.7
 psycopg2-binary==2.9.9; python_version > '3.0'
 pyasn1==0.4.6
 pycryptodomex==3.10.1

--- a/disk/changelog.d/16547.added
+++ b/disk/changelog.d/16547.added
@@ -1,0 +1,1 @@
+Bump `psutil` version to 5.9.7

--- a/disk/pyproject.toml
+++ b/disk/pyproject.toml
@@ -41,7 +41,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "psutil==5.9.0",
+    "psutil==5.9.7",
 ]
 
 [project.urls]

--- a/gunicorn/changelog.d/16547.added
+++ b/gunicorn/changelog.d/16547.added
@@ -1,0 +1,1 @@
+Bump `psutil` version to 5.9.7

--- a/gunicorn/pyproject.toml
+++ b/gunicorn/pyproject.toml
@@ -40,7 +40,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "psutil==5.9.0",
+    "psutil==5.9.7",
 ]
 
 [project.urls]

--- a/ibm_mq/changelog.d/16547.added
+++ b/ibm_mq/changelog.d/16547.added
@@ -1,0 +1,1 @@
+Bump `psutil` version to 5.9.7

--- a/ibm_mq/pyproject.toml
+++ b/ibm_mq/pyproject.toml
@@ -37,7 +37,7 @@ requires-python = ">=3.9"
 
 [project.optional-dependencies]
 deps = [
-    "psutil==5.9.0",
+    "psutil==5.9.7",
     "pymqi==1.12.10; (sys_platform != 'darwin' or platform_machine != 'arm64') and python_version > '3.0'",
 ]
 

--- a/network/changelog.d/16547.added
+++ b/network/changelog.d/16547.added
@@ -1,0 +1,1 @@
+Bump `psutil` version to 5.9.7

--- a/network/pyproject.toml
+++ b/network/pyproject.toml
@@ -40,7 +40,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "psutil==5.9.0",
+    "psutil==5.9.7",
 ]
 
 [project.urls]

--- a/process/changelog.d/16547.added
+++ b/process/changelog.d/16547.added
@@ -1,0 +1,1 @@
+Bump `psutil` version to 5.9.7

--- a/process/pyproject.toml
+++ b/process/pyproject.toml
@@ -40,7 +40,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "psutil==5.9.0",
+    "psutil==5.9.7",
 ]
 
 [project.urls]

--- a/system_core/changelog.d/16547.added
+++ b/system_core/changelog.d/16547.added
@@ -1,0 +1,1 @@
+Bump `psutil` version to 5.9.7

--- a/system_core/pyproject.toml
+++ b/system_core/pyproject.toml
@@ -40,7 +40,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "psutil==5.9.0",
+    "psutil==5.9.7",
 ]
 
 [project.urls]

--- a/system_swap/changelog.d/16547.added
+++ b/system_swap/changelog.d/16547.added
@@ -1,0 +1,1 @@
+Bump `psutil` version to 5.9.7

--- a/system_swap/pyproject.toml
+++ b/system_swap/pyproject.toml
@@ -40,7 +40,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "psutil==5.9.0",
+    "psutil==5.9.7",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump `psutil` version to 5.9.7

### Motivation
<!-- What inspired you to submit this pull request? -->

[One version broke our tests](https://github.com/DataDog/integrations-core/blame/master/ddev/src/ddev/cli/dep.py#L27) but it's not the case anymore. I'll drop it from the `dep` command in a follow-up PR

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
