### PR TITLE
Bump `pycryptodomex` version to 3.19.1

### DIFF
--- a/datadog_checks_base/changelog.d/16560.added
+++ b/datadog_checks_base/changelog.d/16560.added
@@ -1,0 +1,1 @@
+Bump `pycryptodomex` version to 3.19.1

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -62,7 +62,7 @@ psycopg-pool==3.2.0; python_version > '3.0'
 psycopg2-binary==2.9.9; python_version > '3.0'
 psycopg[binary]==3.1.16; python_version > '3.0'
 pyasn1==0.4.6
-pycryptodomex==3.10.1
+pycryptodomex==3.19.1
 pydantic==2.0.2; python_version > '3.0'
 pyjwt==1.7.1; python_version < '3.0'
 pyjwt==2.8.0; python_version > '3.0'

--- a/snmp/changelog.d/16560.added
+++ b/snmp/changelog.d/16560.added
@@ -1,0 +1,1 @@
+Bump `pycryptodomex` version to 3.19.1

--- a/snmp/pyproject.toml
+++ b/snmp/pyproject.toml
@@ -44,7 +44,7 @@ deps = [
     "ipaddress==1.0.23; python_version < '3.0'",
     "ply==3.11",
     "pyasn1==0.4.6",
-    "pycryptodomex==3.10.1",
+    "pycryptodomex==3.19.1",
     "pysmi==0.3.4",
     "pysnmp-mibs==0.1.6",
     "pysnmp==4.4.9",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump `pycryptodomex` version to 3.19.1

### Motivation
<!-- What inspired you to submit this pull request? -->

We [do not bump pycryptodomex with ddev](https://github.com/DataDog/integrations-core/blob/4df0799a10ce2ce651675d44f6af8f99cd5a0c66/ddev/src/ddev/cli/dep.py#L24), but seems like it is now working. I'll drop it from ddev in a follow-up PR

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
