### PR TITLE
Fix ironic nodes pagination logic

### DIFF
--- a/openstack_controller/changelog.d/16566.fixed
+++ b/openstack_controller/changelog.d/16566.fixed
@@ -1,0 +1,1 @@
+Fix ironic nodes pagination logic

--- a/openstack_controller/datadog_checks/openstack_controller/api/api_rest.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api/api_rest.py
@@ -314,7 +314,7 @@ class ApiRest(Api):
             resources = response_json.get(resource_name, [])
             if len(resources) > 0:
                 last_item = resources[-1]
-                next = last_item.get('next')
+                next = response_json.get('next')
                 item_list.extend(resources)
                 if next is None:
                     break

--- a/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail/limit=1/marker=9d72cf53-19c8-4942-9314-005fa5d2a6a0/response-1.80.json
+++ b/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail/limit=1/marker=9d72cf53-19c8-4942-9314-005fa5d2a6a0/response-1.80.json
@@ -138,9 +138,9 @@
             "href": "http://34.141.226.224/baremetal/nodes/bd7a61bb-5fe0-4c93-9628-55e312f9ef0e/volume",
             "rel": "bookmark"
           }
-        ],
-        "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=bd7a61bb-5fe0-4c93-9628-55e312f9ef0e"
+        ]
       }
-    ]
+    ],
+    "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=bd7a61bb-5fe0-4c93-9628-55e312f9ef0e"
   }
   

--- a/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail/limit=1/marker=9d72cf53-19c8-4942-9314-005fa5d2a6a0/response.json
+++ b/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail/limit=1/marker=9d72cf53-19c8-4942-9314-005fa5d2a6a0/response.json
@@ -52,9 +52,9 @@
             "href": "http://34.141.226.224/baremetal/nodes/bd7a61bb-5fe0-4c93-9628-55e312f9ef0e/ports",
             "rel": "bookmark"
           }
-        ],
-        "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=bd7a61bb-5fe0-4c93-9628-55e312f9ef0e"
+        ]
       }
-    ]
+    ],
+    "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=bd7a61bb-5fe0-4c93-9628-55e312f9ef0e"
   }
   

--- a/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail/limit=1/marker=bd7a61bb-5fe0-4c93-9628-55e312f9ef0e/response-1.80.json
+++ b/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail/limit=1/marker=bd7a61bb-5fe0-4c93-9628-55e312f9ef0e/response-1.80.json
@@ -138,9 +138,9 @@
             "href": "http://34.141.226.224/baremetal/nodes/54855e59-83ca-46f8-a78f-55d3370e0656/volume",
             "rel": "bookmark"
           }
-        ],
-        "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=54855e59-83ca-46f8-a78f-55d3370e0656"
+        ]
       }
-    ]
+    ],
+    "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=54855e59-83ca-46f8-a78f-55d3370e0656"
   }
   

--- a/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail/limit=1/marker=bd7a61bb-5fe0-4c93-9628-55e312f9ef0e/response.json
+++ b/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail/limit=1/marker=bd7a61bb-5fe0-4c93-9628-55e312f9ef0e/response.json
@@ -52,9 +52,9 @@
             "href": "http://34.141.226.224/baremetal/nodes/54855e59-83ca-46f8-a78f-55d3370e0656/ports",
             "rel": "bookmark"
           }
-        ],
-        "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=54855e59-83ca-46f8-a78f-55d3370e0656"
+        ]
       }
-    ]
+    ],
+    "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=54855e59-83ca-46f8-a78f-55d3370e0656"
   }
   

--- a/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail/limit=1/response-1.80.json
+++ b/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail/limit=1/response-1.80.json
@@ -138,9 +138,9 @@
             "href": "http://34.141.226.224/baremetal/nodes/9d72cf53-19c8-4942-9314-005fa5d2a6a0/volume",
             "rel": "bookmark"
           }
-        ],
-        "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=9d72cf53-19c8-4942-9314-005fa5d2a6a0"
+        ]
       }
-    ]
+    ],
+    "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=9d72cf53-19c8-4942-9314-005fa5d2a6a0"
   }
   

--- a/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail/limit=1/response.json
+++ b/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail/limit=1/response.json
@@ -52,9 +52,9 @@
             "href": "http://34.141.226.224/baremetal/nodes/9d72cf53-19c8-4942-9314-005fa5d2a6a0/ports",
             "rel": "bookmark"
           }
-        ],
-        "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=9d72cf53-19c8-4942-9314-005fa5d2a6a0"
+        ]
       }
-    ]
+    ],
+    "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=9d72cf53-19c8-4942-9314-005fa5d2a6a0"
   }
   

--- a/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail=True/limit=1/marker=9d72cf53-19c8-4942-9314-005fa5d2a6a0/response-1.80.json
+++ b/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail=True/limit=1/marker=9d72cf53-19c8-4942-9314-005fa5d2a6a0/response-1.80.json
@@ -138,8 +138,8 @@
                     "href": "http://34.141.226.224/baremetal/nodes/bd7a61bb-5fe0-4c93-9628-55e312f9ef0e/volume",
                     "rel": "bookmark"
                 }
-            ],
-            "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=bd7a61bb-5fe0-4c93-9628-55e312f9ef0e"
+            ]
         }
-    ]
+    ],
+    "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=bd7a61bb-5fe0-4c93-9628-55e312f9ef0e"
 }

--- a/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail=True/limit=1/marker=9d72cf53-19c8-4942-9314-005fa5d2a6a0/response.json
+++ b/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail=True/limit=1/marker=9d72cf53-19c8-4942-9314-005fa5d2a6a0/response.json
@@ -52,9 +52,9 @@
                 "href": "http://34.141.226.224/baremetal/nodes/bd7a61bb-5fe0-4c93-9628-55e312f9ef0e/ports",
                 "rel": "bookmark"
               }
-            ],
-            "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=bd7a61bb-5fe0-4c93-9628-55e312f9ef0e"
+            ]
         }
-    ]
+    ],
+    "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=bd7a61bb-5fe0-4c93-9628-55e312f9ef0e"
   }
   

--- a/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail=True/limit=1/marker=bd7a61bb-5fe0-4c93-9628-55e312f9ef0e/response-1.80.json
+++ b/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail=True/limit=1/marker=bd7a61bb-5fe0-4c93-9628-55e312f9ef0e/response-1.80.json
@@ -138,9 +138,9 @@
             "href": "http://34.141.226.224/baremetal/nodes/54855e59-83ca-46f8-a78f-55d3370e0656/volume",
             "rel": "bookmark"
           }
-        ],
-        "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=54855e59-83ca-46f8-a78f-55d3370e0656"
+        ]
       }
-    ]
+    ],
+    "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=54855e59-83ca-46f8-a78f-55d3370e0656"
   }
   

--- a/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail=True/limit=1/marker=bd7a61bb-5fe0-4c93-9628-55e312f9ef0e/response.json
+++ b/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail=True/limit=1/marker=bd7a61bb-5fe0-4c93-9628-55e312f9ef0e/response.json
@@ -52,9 +52,9 @@
             "href": "http://34.141.226.224/baremetal/nodes/54855e59-83ca-46f8-a78f-55d3370e0656/ports",
             "rel": "bookmark"
           }
-        ],
-        "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=54855e59-83ca-46f8-a78f-55d3370e0656"
+        ]
       }
-    ]
+    ],
+    "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=54855e59-83ca-46f8-a78f-55d3370e0656"
   }
   

--- a/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail=True/limit=1/response-1.80.json
+++ b/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail=True/limit=1/response-1.80.json
@@ -138,9 +138,9 @@
             "href": "http://34.141.226.224/baremetal/nodes/9d72cf53-19c8-4942-9314-005fa5d2a6a0/volume",
             "rel": "bookmark"
           }
-        ],
-        "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=9d72cf53-19c8-4942-9314-005fa5d2a6a0"
+        ]
       }
-    ]
+    ],
+    "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=9d72cf53-19c8-4942-9314-005fa5d2a6a0"
   }
   

--- a/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail=True/limit=1/response.json
+++ b/openstack_controller/tests/fixtures/GET/baremetal/v1/nodes/detail=True/limit=1/response.json
@@ -138,9 +138,9 @@
             "href": "http://34.141.226.224/baremetal/nodes/9d72cf53-19c8-4942-9314-005fa5d2a6a0/volume",
             "rel": "bookmark"
           }
-        ],
-        "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=9d72cf53-19c8-4942-9314-005fa5d2a6a0"
+        ]
       }
-    ]
+    ],
+    "next": "http://34.141.226.224/baremetal/v1/nodes/detail?sort_key=id&sort_dir=asc&limit=1&marker=9d72cf53-19c8-4942-9314-005fa5d2a6a0"
   }
   


### PR DESCRIPTION
### What does this PR do?
Fixes pagination logic for ironic nodes endpoint- 'next' signifier is not in the `nodes` list, it is a top-level attribute
### Motivation
QA for https://github.com/DataDog/integrations-core/pull/16400
### Additional Notes
ironic nodes API documentation: https://docs.openstack.org/api-ref/baremetal/#list-nodes-detailed
overall pagination docs https://docs.openstack.org/api-guide/compute/paginated_collections.html
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
