### PR TITLE
Remove the direct dependency to `protobuf`

### DIFF
--- a/gitlab/changelog.d/16572.fixed
+++ b/gitlab/changelog.d/16572.fixed
@@ -1,0 +1,1 @@
+Remove the direct dependency to `protobuf`

--- a/gitlab/pyproject.toml
+++ b/gitlab/pyproject.toml
@@ -38,10 +38,7 @@ dynamic = [
 license = "BSD-3-Clause"
 
 [project.optional-dependencies]
-deps = [
-    "protobuf==3.17.3; python_version < '3.0'",
-    "protobuf==3.20.2; python_version > '3.0'",
-]
+deps = []
 
 [project.urls]
 Source = "https://github.com/DataDog/integrations-core"

--- a/gitlab_runner/changelog.d/16572.fixed
+++ b/gitlab_runner/changelog.d/16572.fixed
@@ -1,0 +1,1 @@
+Remove the direct dependency to `protobuf`

--- a/gitlab_runner/pyproject.toml
+++ b/gitlab_runner/pyproject.toml
@@ -38,10 +38,7 @@ dynamic = [
 license = "BSD-3-Clause"
 
 [project.optional-dependencies]
-deps = [
-    "protobuf==3.17.3; python_version < '3.0'",
-    "protobuf==3.20.2; python_version > '3.0'",
-]
+deps = []
 
 [project.urls]
 Source = "https://github.com/DataDog/integrations-core"

--- a/kube_dns/changelog.d/16572.fixed
+++ b/kube_dns/changelog.d/16572.fixed
@@ -1,0 +1,1 @@
+Remove the direct dependency to `protobuf`

--- a/kube_dns/pyproject.toml
+++ b/kube_dns/pyproject.toml
@@ -38,10 +38,7 @@ dynamic = [
 license = "BSD-3-Clause"
 
 [project.optional-dependencies]
-deps = [
-    "protobuf==3.17.3; python_version < '3.0'",
-    "protobuf==3.20.2; python_version > '3.0'",
-]
+deps = []
 
 [project.urls]
 Source = "https://github.com/DataDog/integrations-core"

--- a/kubernetes_state/changelog.d/16572.fixed
+++ b/kubernetes_state/changelog.d/16572.fixed
@@ -1,0 +1,1 @@
+Remove the direct dependency to `protobuf`

--- a/kubernetes_state/pyproject.toml
+++ b/kubernetes_state/pyproject.toml
@@ -38,10 +38,7 @@ dynamic = [
 license = "BSD-3-Clause"
 
 [project.optional-dependencies]
-deps = [
-    "protobuf==3.17.3; python_version < '3.0'",
-    "protobuf==3.20.2; python_version > '3.0'",
-]
+deps = []
 
 [project.urls]
 Source = "https://github.com/DataDog/integrations-core"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove the direct dependency to `protobuf`

### Motivation
<!-- What inspired you to submit this pull request? -->

`protobuf` is used for the [prometheus check](https://github.com/DataDog/integrations-core/blob/b7c15a6882af399c6f477b7c751c7b0dac23a0ce/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py#L25-L31) and thus should be declared [in the base check only](https://github.com/DataDog/integrations-core/blob/645175ff5709e5295367489b7a3c3d2b073cda78/datadog_checks_base/pyproject.toml#L56-L57). There's no need to duplicate the  dependency in other integrations since they depend on the base check.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I found this trying to bump `protobuf`, I'll do that in a follow-up PR. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
