### PR TITLE
Add Python 2 to Windows

### DIFF
--- a/.builders/images/linux-x86_64/Dockerfile
+++ b/.builders/images/linux-x86_64/Dockerfile
@@ -165,6 +165,10 @@ RUN curl "https://www.unixodbc.org/unixODBC-${ODBC_VERSION}.tar.gz" -Lo /tmp/uni
 ENV OPENSSL_LIB_DIR="/usr/local/lib64"
 ENV OPENSSL_INCLUDE_DIR="/usr/local/include"
 
+# Set up runner
+COPY runner_dependencies.txt /runner_dependencies.txt
+RUN python3 -m pip install --no-warn-script-location -r /runner_dependencies.txt
+
 # Set up extra build information
 ENV PIP_CONSTRAINT="/pip_constraints.txt"
 ENV PIP_CONSTRAINT_FILE="${PIP_CONSTRAINT}"

--- a/.builders/images/runner_dependencies.txt
+++ b/.builders/images/runner_dependencies.txt
@@ -1,0 +1,3 @@
+urllib3==2.1.0
+auditwheel==5.4.0; sys_platform == 'linux'
+delvewheel==1.5.2; sys_platform == 'win32'

--- a/.builders/images/windows-x86_64/Dockerfile
+++ b/.builders/images/windows-x86_64/Dockerfile
@@ -79,6 +79,24 @@ RUN Get-RemoteFile `
     & 'C:\Program Files\Python311\python.exe' -m virtualenv 'C:\py3'; `
     Add-ToPath -Append 'C:\Program Files\Python311'
 
+# Install Python 2
+ENV PYTHON_VERSION="2.7.18"
+RUN Get-RemoteFile `
+      -Uri https://www.python.org/ftp/python/$Env:PYTHON_VERSION/python-$Env:PYTHON_VERSION.amd64.msi `
+      -Path python-$Env:PYTHON_VERSION.amd64.msi `
+      -Hash 'b74a3afa1e0bf2a6fc566a7b70d15c9bfabba3756fb077797d16fffa27800c05'; `
+    Start-Process -Wait -FilePath msiexec -ArgumentList '/i', python-$Env:PYTHON_VERSION.amd64.msi, '/quiet', '/norestart', 'InstallAllUsers=1'; `
+    Remove-Item python-$Env:PYTHON_VERSION.amd64.msi; `
+    & 'C:\Python27\python.exe' -m pip install --no-warn-script-location --upgrade pip; `
+    & 'C:\Python27\python.exe' -m pip install --no-python-version-warning --no-warn-script-location virtualenv; `
+    & 'C:\Python27\python.exe' -m virtualenv 'C:\py2'
+RUN Get-RemoteFile `
+      -Uri https://s3.amazonaws.com/dd-agent-omnibus/VCForPython27.msi `
+      -Path VCForPython27.msi `
+      -Hash '070474db76a2e625513a5835df4595df9324d820f9cc97eab2a596dcbc2f5cbf'; `
+    Start-Process -Wait -FilePath msiexec -ArgumentList '/i', VCForPython27.msi, '/quiet'; `
+    Remove-Item VCForPython27.msi
+
 # Install IBM MQ
 ENV IBM_MQ_VERSION="9.2.4.0"
 RUN Get-RemoteFile `
@@ -88,6 +106,10 @@ RUN Get-RemoteFile `
     7z x $Env:IBM_MQ_VERSION-IBM-MQC-Redist-Win64.zip -oC:\ibm_mq; `
     Remove-Item $Env:IBM_MQ_VERSION-IBM-MQC-Redist-Win64.zip; `
     setx /M MQ_FILE_PATH 'C:\ibm_mq'
+
+# Set up runner
+COPY runner_dependencies.txt C:\runner_dependencies.txt
+RUN python -m pip install --no-warn-script-location -r C:\runner_dependencies.txt
 
 # Restore the default Windows shell for correct batch processing.
 SHELL ["cmd", "/S", "/C"]

--- a/.builders/scripts/build_wheels.py
+++ b/.builders/scripts/build_wheels.py
@@ -98,7 +98,7 @@ def main():
 
         # Repair wheels
         check_process([
-            str(python_path), '-u', str(MOUNT_DIR / 'scripts' / 'repair_wheels.py'),
+            sys.executable, '-u', str(MOUNT_DIR / 'scripts' / 'repair_wheels.py'),
             '--source-dir', str(staged_wheel_dir),
             '--output-dir', str(wheels_dir),
         ])

--- a/.builders/scripts/build_wheels.py
+++ b/.builders/scripts/build_wheels.py
@@ -51,7 +51,7 @@ def check_process(*args, **kwargs) -> subprocess.CompletedProcess:
 
 def main():
     parser = argparse.ArgumentParser(prog='wheel-builder', allow_abbrev=False)
-    parser.add_argument('--python', default='3')
+    parser.add_argument('--python', required=True)
     args = parser.parse_args()
 
     python_version = args.python

--- a/.deps/build_dependencies.txt
+++ b/.deps/build_dependencies.txt
@@ -1,4 +1,3 @@
-# Required for building all dependent Python packages
 hatchling==1.21.0; python_version > '3.0'
 hatchling==0.25.1; python_version < '3.0'
 setuptools==66.1.1; python_version > '3.0'
@@ -11,9 +10,4 @@ setuptools-rust>=1.7.0; python_version > '3.0'
 maturin; python_version > '3.0'
 cffi>=1.12
 cython<3.0.0
-tomli>=2.0.1
-
-# Required for tooling
-urllib3
-auditwheel==5.4.0; sys_platform == 'linux'
-delvewheel==1.5.2; sys_platform == 'win32'
+tomli>=2.0.1; python_version > '3.0'


### PR DESCRIPTION
### Additional Notes

- Made the Python version argument required for the inner build script.
- Changed the logic for the runner component: the runner now must be the Python 3 executable that is outside/parent of the virtual environment. As such, this Python is only one that should ever be on PATH.
- Python 2 on Windows does not yet work for IBM MQ but we should get this merged to unblock the Linux side