### PR TITLE
Fix vacuum age computation

### DIFF
--- a/postgres/changelog.d/16581.fixed
+++ b/postgres/changelog.d/16581.fixed
@@ -1,0 +1,1 @@
+Fix vacuum age computation

--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -78,10 +78,16 @@ REL_METRICS = {
         'autovacuum_count': ('postgresql.autovacuumed', AgentCheck.monotonic_count),
         'analyze_count': ('postgresql.analyzed', AgentCheck.monotonic_count),
         'autoanalyze_count': ('postgresql.autoanalyzed', AgentCheck.monotonic_count),
-        'EXTRACT(EPOCH FROM -age(last_vacuum))': ('postgresql.last_vacuum_age', AgentCheck.gauge),
-        'EXTRACT(EPOCH FROM -age(last_autovacuum))': ('postgresql.last_autovacuum_age', AgentCheck.gauge),
-        'EXTRACT(EPOCH FROM -age(last_analyze))': ('postgresql.last_analyze_age', AgentCheck.gauge),
-        'EXTRACT(EPOCH FROM -age(last_autoanalyze))': ('postgresql.last_autoanalyze_age', AgentCheck.gauge),
+        'EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, last_vacuum))': ('postgresql.last_vacuum_age', AgentCheck.gauge),
+        'EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, last_autovacuum))': (
+            'postgresql.last_autovacuum_age',
+            AgentCheck.gauge,
+        ),
+        'EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, last_analyze))': ('postgresql.last_analyze_age', AgentCheck.gauge),
+        'EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, last_autoanalyze))': (
+            'postgresql.last_autoanalyze_age',
+            AgentCheck.gauge,
+        ),
     },
     'query': """
 SELECT relname,schemaname,{metrics_columns}

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -7,7 +7,7 @@ import pytest
 from datadog_checks.base import ConfigurationError
 from datadog_checks.postgres.relationsmanager import QUERY_PG_CLASS, RelationsManager
 
-from .common import DB_NAME, HOST, PORT, _get_expected_tags, _iterate_metric_name
+from .common import DB_NAME, HOST, PORT, _get_expected_tags, _iterate_metric_name, assert_metric_at_least
 from .utils import _get_superconn, _wait_for_value, requires_over_11
 
 RELATION_METRICS = [
@@ -213,7 +213,14 @@ def test_vacuum_age(aggregator, integration_check, pg_instance):
 
     expected_tags = _get_expected_tags(check, pg_instance, db='datadog_test', table='persons', schema='public')
     for name in ['postgresql.last_vacuum_age', 'postgresql.last_analyze_age']:
-        aggregator.assert_metric(name, count=1, tags=expected_tags)
+        assert_metric_at_least(
+            aggregator,
+            name,
+            lower_bound=0,
+            higher_bound=100,
+            tags=expected_tags,
+            count=1,
+        )
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### What does this PR do?
Fix age of vacuum events

### Motivation
`age(t1)` will yield `t1 - current_date at midgnight` which is incorrect for our usage.
We want the number of seconds since the last vacuum event. We will use age(t1, t2) which yield `t1 - t2` using the start of the statement time as t1 and the vacuum event as t2.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
