### PR TITLE
Add openstack config tests

### DIFF
--- a/openstack/tests/test_openstack.py
+++ b/openstack/tests/test_openstack.py
@@ -300,3 +300,55 @@ def test_cache_between_runs(self, *args):
 
     assert 'server-1' not in cached_servers
     assert 'server_newly_added' in cached_servers
+
+
+@pytest.mark.parametrize(
+    'init_config, instances, exception',
+    [
+        pytest.param(
+            {
+                'keystone_server_url': 'http://10.0.2.15:5000',
+                'ssl_verify': False,
+            },
+            [{}],
+            r'datadog_checks.base.errors.ConfigurationError: Detected 2 errors',
+            id="empty instance",
+        ),
+        pytest.param(
+            {
+                'keystone_server_url': 'http://10.0.2.15:5000',
+                'ssl_verify': False,
+            },
+            [{'name': 'test'}],
+            r'datadog_checks.base.errors.ConfigurationError: Detected 1 error',
+            id="no user",
+        ),
+        pytest.param(
+            {
+                'keystone_server_url': 'http://10.0.2.15:5000',
+                'ssl_verify': False,
+            },
+            [{'user': {'name': 'test'}}],
+            r'datadog_checks.base.errors.ConfigurationError: Detected 1 error',
+            id="no name",
+        ),
+        pytest.param(
+            {
+                'keystone_server_url': 'http://10.0.2.15:5000',
+                'ssl_verify': False,
+            },
+            [{'user': {'name': 'test', 'password': 'pass', 'domain': {'id': 'test'}}, 'name': 'test'}],
+            None,
+            id="valid",
+        ),
+    ],
+)
+def test_config(dd_run_check, init_config, instances, exception, caplog):
+    check = OpenStackCheck("test", init_config, instances)
+
+    if exception is not None:
+        with pytest.raises(Exception, match=exception):
+            dd_run_check(check)
+    else:
+        dd_run_check(check)
+        assert "The agent could not contact the specified identity server" in caplog.text

--- a/openstack/tests/test_openstack.py
+++ b/openstack/tests/test_openstack.py
@@ -10,6 +10,7 @@ import pytest
 from six import iteritems
 
 from datadog_checks.base import AgentCheck
+from datadog_checks.dev.testing import requires_py3
 from datadog_checks.openstack.openstack import (
     IncompleteAuthScope,
     IncompleteConfig,
@@ -302,6 +303,7 @@ def test_cache_between_runs(self, *args):
     assert 'server_newly_added' in cached_servers
 
 
+@requires_py3
 @pytest.mark.parametrize(
     'init_config, instances, exception',
     [


### PR DESCRIPTION
### What does this PR do?
Adds tests for config validation 
### Motivation
QA for https://github.com/DataDog/integrations-core/pull/16299; we did not have any tests for openstack that ran check initializations using `dd_run_check`
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
