### PR TITLE
(DOCS-7017) Add site information

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -34,7 +34,7 @@ The Datadog Terraform provider is available through the [Terraform Registry][1].
 **Note**: If you are not using the Datadog US1 site, you must set the `api_url` [optional parameter][7] with your [Datadog site][6]. Ensure the documentation site selector on the right of the page is set to your correct Datadog site, then use the following URL as the value of the `api_url` parameter:
 
 ```
-api.{{< region-param key="dd_site" code="true" >}}
+https://api.{{< region-param key="dd_site" code="true" >}}/
 ```
 
 4. Run `terraform init`. This initializes the directory for use with Terraform and pulls the Datadog provider.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -31,12 +31,11 @@ The Datadog Terraform provider is available through the [Terraform Registry][1].
     }
     ```
 
-**Note**: If you are not using the Datadog US1 site, you must set the `api_url` [optional parameter][7] with your [Datadog site][6]. Ensure the documentation site selector on the right of the page is set to your correct Datadog site, then use the following URL as the value of the `api_url` parameter:
+    **Note**: If you are not using the Datadog US1 site, you must set the `api_url` [optional parameter][7] with your [Datadog site][6]. Ensure the documentation site selector on the right of the page is set to your correct Datadog site, then use the following URL as the value of the `api_url` parameter:
 
-```
-https://api.{{< region-param key="dd_site" code="true" >}}/
-```
-
+    ```
+    https://api.{{< region-param key="dd_site" code="true" >}}/
+    ```
 4. Run `terraform init`. This initializes the directory for use with Terraform and pulls the Datadog provider.
 5. Create any `.tf` file in the `terraform_config/` directory and start creating Datadog resources. 
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -12,8 +12,8 @@ The Datadog Terraform provider is available through the [Terraform Registry][1].
 
 ### Configuration
 
-1. [Install Terraform][2]
-2. Create a directory to contain the Terraform configuration files, for example: `terraform_config/`
+1. [Install Terraform][2].
+2. Create a directory to contain the Terraform configuration files, for example: `terraform_config/`.
 3. Create a `main.tf` file in the `terraform_config/` directory with the following content:
     ```
     terraform {
@@ -30,6 +30,12 @@ The Datadog Terraform provider is available through the [Terraform Registry][1].
       app_key = var.datadog_app_key
     }
     ```
+
+**Note**: If you are not using the Datadog US1 site, you must set the `api_url` [optional parameter][7] with your [Datadog site][6]. Ensure the documentation site selector on the right of the page is set to your correct Datadog site, then use the following URL as the value of the `api_url` parameter:
+
+```
+api.{{< region-param key="dd_site" code="true" >}}
+```
 
 4. Run `terraform init`. This initializes the directory for use with Terraform and pulls the Datadog provider.
 5. Create any `.tf` file in the `terraform_config/` directory and start creating Datadog resources. 
@@ -103,3 +109,5 @@ Need help? Contact [Datadog support][3].
 [3]: https://docs.datadoghq.com/help/
 [4]: https://github.com/DataDog/datadogpy
 [5]: https://docs.datadoghq.com/monitors/types/process/
+[6]: https://docs.datadoghq.com/getting_started/site/
+[7]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs#optional


### PR DESCRIPTION
### What does this PR do?
Add information about setting the `api_url` parameter for users not using the Datadog US1 site

### Motivation
DOCS-7017

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
