### PR TITLE
Add kerberos support to confluent-kafka

### DIFF
--- a/.builders/images/linux-x86_64/Dockerfile
+++ b/.builders/images/linux-x86_64/Dockerfile
@@ -29,7 +29,7 @@ RUN yum install -y perl-IPC-Cmd && \
  SHA256="f93c9e8edde5e9166119de31755fc87b4aa34863662f67ddfcba14d0b6b69b61" \
  RELATIVE_PATH="openssl-{{version}}" \
  # no-module prevents the creation of dynamically loaded modules that would be problematic to bundle into Python wheels
- CONFIGURE_SCRIPT="config" \
+ CONFIGURE_SCRIPT="./config" \
  CONFIGURE_ARGS="-Wl,-Bsymbolic-functions -fPIC shared no-module no-comp no-idea no-mdc2 no-rc5 no-ssl3 no-gost" \
  bash install-from-source.sh \
  -fPIC shared \
@@ -131,6 +131,31 @@ RUN \
  RELATIVE_PATH=unixODBC-{{version}} \
  bash install-from-source.sh --disable-readline --with-included-ltdl --enable-ltdl-install
 
+# Dependencies needed to build librdkafka (and thus, confluent-kafka) with kerberos support
+# Note that we don't ship these but rely on the Agent providing a working cyrus-sasl installation
+# with kerberos support, therefore we only need to watch out for the version of cyrus-sasl being
+# compatible with that in the Agent, the rest shouldn't matter much
+RUN \
+ DOWNLOAD_URL="https://github.com/LMDB/lmdb/archive/LMDB_{{version}}.tar.gz" \
+ VERSION="0.9.29" \
+ SHA256="22054926b426c66d8f2bc22071365df6e35f3aacf19ad943bc6167d4cae3bebb" \
+ RELATIVE_PATH="lmdb-LMDB_{{version}}/libraries/liblmdb" \
+ # No ./configure, use a NOOP
+ CONFIGURE_SCRIPT="true" \
+ bash install-from-source.sh
+RUN \
+ DOWNLOAD_URL="https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v{{version}}/e2fsprogs-{{version}}.tar.gz" \
+ VERSION="1.47.0" \
+ SHA256="0b4fe723d779b0927fb83c9ae709bc7b40f66d7df36433bef143e41c54257084" \
+ RELATIVE_PATH="e2fsprogs-{{version}}" \
+ bash install-from-source.sh --enable-elf-shlibs
+RUN \
+ DOWNLOAD_URL="https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-{{version}}/cyrus-sasl-{{version}}.tar.gz" \
+ VERSION="2.1.28" \
+ SHA256="7ccfc6abd01ed67c1a0924b353e526f1b766b21f42d4562ee635a8ebfc5bb38c" \
+ RELATIVE_PATH="cyrus-sasl-{{version}}" \
+ bash install-from-source.sh --with-dblib=lmdb --enable-gssapi=/usr/local
+
 # Environment variables to help openssl crate find OpenSSL
 ENV OPENSSL_LIB_DIR="/usr/local/lib64"
 ENV OPENSSL_INCLUDE_DIR="/usr/local/include"
@@ -148,3 +173,4 @@ COPY build_script.sh /build_script.sh
 ENV DD_BUILD_COMMAND="bash /build_script.sh"
 
 ENTRYPOINT ["python3", "/home/scripts/build_wheels.py"]
+

--- a/.builders/images/linux-x86_64/Dockerfile
+++ b/.builders/images/linux-x86_64/Dockerfile
@@ -112,14 +112,6 @@ RUN \
  --without-debugger \
  --disable-static
 
-# librdkafka for confluent-kafka
-RUN \
- DOWNLOAD_URL="https://github.com/confluentinc/librdkafka/archive/refs/tags/v{{version}}.tar.gz" \
- VERSION="2.3.0" \
- SHA256="2d49c35c77eeb3d42fa61c43757fcbb6a206daa560247154e60642bcdcc14d12" \
- RELATIVE_PATH="librdkafka-{{version}}" \
- bash install-from-source.sh
-
 # libpq and pg_config as needed by psycopg2
 RUN \
  DOWNLOAD_URL="https://ftp.postgresql.org/pub/source/v{{version}}/postgresql-{{version}}.tar.bz2" \

--- a/.builders/images/linux-x86_64/Dockerfile
+++ b/.builders/images/linux-x86_64/Dockerfile
@@ -1,73 +1,50 @@
 ARG BASE_IMAGE=quay.io/pypa/manylinux2010_x86_64
 FROM ${BASE_IMAGE}
 
-ENV IBM_MQ_VERSION="9.2.4.0"
-ENV IBM_MQ_SHA256="d0d583eba72daf20b3762976f8831c2e23150ace90509520e12f8cda5b5bdb49"
-ENV KRB5_VERSION="1.20.1"
-ENV KRB5_SHA256="704aed49b19eb5a7178b34b2873620ec299db08752d6a8574f95d41879ab8851"
-ENV OPENSSL_VERSION="3.0.12"
-ENV OPENSSL_SHA256="f93c9e8edde5e9166119de31755fc87b4aa34863662f67ddfcba14d0b6b69b61"
-ENV LIBXML2_VERSION="2.10.3"
-ENV LIBXML2_SHA256="5d2cc3d78bec3dbe212a9d7fa629ada25a7da928af432c93060ff5c17ee28a9c"
-ENV LIBXSLT_VERSION="1.1.37"
-ENV LIBXSLT_SHA256="3a4b27dc8027ccd6146725950336f1ec520928f320f144eb5fa7990ae6123ab4"
-ENV RUST_VERSION="nightly-2022-05-15"
-ENV RUSTC_SHA256="3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338"
-ENV RUSTUP_VERSION="1.24.3"
-ENV RUSTUP_SHA256="3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338"
+# Script for the common task of fetching a source tarball, compiling and installing it
+COPY install-from-source.sh /
 
-# Compile and install Python 2
-ENV PYTHON2_VERSION=2.7.18
-ENV PYTHON2_SHA256="da3080e3b488f648a3d7a4560ddee895284c3380b11d6de75edb986526b9a814"
 # For Python 2, we get openssl(1) via yum just to get the necessary headers,
 # and we remove the package after compilation to prevent it from interfering
 # with the use of openssl3 everywhere else
-RUN yum install -y openssl-devel \
- && curl "https://python.org/ftp/python/${PYTHON2_VERSION}/Python-${PYTHON2_VERSION}.tgz" -Lo /tmp/python.tar.gz \
- && echo "${PYTHON2_SHA256}  /tmp/python.tar.gz" | sha256sum --check \
- && tar -C /tmp -xf /tmp/python.tar.gz \
- && cd /tmp/Python-${PYTHON2_VERSION} \
- && ./configure --prefix=/opt/python/${PYTHON2_VERSION} --with-ensurepip=yes --enable-shared --enable-ipv6 --enable-unicode=ucs4 \
- && make \
- && make install \
- && rm -rf /tmp/Python-${PYTHON2_VERSION} \
- && rm -rf /tmp/python.tar.gz \
+ENV PYTHON2_VERSION=2.7.18
+RUN yum install -y openssl-devel && \
+ DOWNLOAD_URL="https://python.org/ftp/python/${PYTHON2_VERSION}/Python-${PYTHON2_VERSION}.tgz" \
+ VERSION="${PYTHON2_VERSION}" \
+ SHA256="da3080e3b488f648a3d7a4560ddee895284c3380b11d6de75edb986526b9a814" \
+ RELATIVE_PATH=Python-{{version}} \
+ bash install-from-source.sh \
+ --prefix=/opt/python/${PYTHON2_VERSION} --with-ensurepip=yes --enable-shared --enable-ipv6 --enable-unicode=ucs4 \
  && yum remove -y openssl-devel
+
 ENV LD_LIBRARY_PATH="/opt/python/${PYTHON2_VERSION}/lib:${LD_LIBRARY_PATH}"
 # Set up virtual environment for Python 2
 RUN /opt/python/${PYTHON2_VERSION}/bin/python -m pip install --no-warn-script-location virtualenv \
  && /opt/python/${PYTHON2_VERSION}/bin/python -m virtualenv /py2
 
 # openssl
-RUN yum install -y perl-IPC-Cmd
-RUN curl "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz" -o /tmp/openssl.tar.gz \
- && echo "${OPENSSL_SHA256}  /tmp/openssl.tar.gz" | sha256sum --check \
- && tar -C /tmp -xf /tmp/openssl.tar.gz \
- && cd /tmp/openssl-${OPENSSL_VERSION} \
- && ./config -Wl,-Bsymbolic-functions \
- -fPIC \
- shared \
+RUN yum install -y perl-IPC-Cmd && \
+ DOWNLOAD_URL="https://www.openssl.org/source/openssl-{{version}}.tar.gz" \
+ VERSION="3.0.12" \
+ SHA256="f93c9e8edde5e9166119de31755fc87b4aa34863662f67ddfcba14d0b6b69b61" \
+ RELATIVE_PATH="openssl-{{version}}" \
+ # no-module prevents the creation of dynamically loaded modules that would be problematic to bundle into Python wheels
+ CONFIGURE_SCRIPT="config" \
+ CONFIGURE_ARGS="-Wl,-Bsymbolic-functions -fPIC shared no-module no-comp no-idea no-mdc2 no-rc5 no-ssl3 no-gost" \
+ bash install-from-source.sh \
+ -fPIC shared \
  # This prevents the creation of dynamically loaded modules that would be problematic to bundle into Python wheels
  no-module \
- no-comp no-idea no-mdc2 no-rc5 no-ssl3 no-gost \
- && make \
- && make install \
- && rm -rf /tmp/openssl-${OPENSSL_VERSION} \
- && rm -rf /tmp/openssl.tar.gz
+ no-comp no-idea no-mdc2 no-rc5 no-ssl3 no-gost
 
 # Compile and install Python 3
-ENV PYTHON_VERSION=3.11.5
-ENV PYTHON_SHA256="a12a0a013a30b846c786c010f2c19dd36b7298d888f7c4bd1581d90ce18b5e58"
-RUN yum install -y libffi-devel
-RUN curl "https://python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz" -Lo /tmp/python.tar.gz \
- && echo "${PYTHON_SHA256}  /tmp/python.tar.gz" | sha256sum --check \
- && tar -C /tmp -xf /tmp/python.tar.gz \
- && cd /tmp/Python-${PYTHON_VERSION} \
- && ./configure --prefix=/opt/python/${PYTHON_VERSION} --with-ensurepip=yes --enable-shared --enable-ipv6 --with-dbmliborder= \
- && make \
- && make install \
- && rm -rf /tmp/Python-${PYTHON_VERSION} \
- && rm -rf /tmp/python.tar.gz
+ENV PYTHON3_VERSION=3.11.5
+RUN yum install -y libffi-devel && \
+ DOWNLOAD_URL="https://python.org/ftp/python/{{version}}/Python-{{version}}.tgz" \
+ VERSION="${PYTHON3_VERSION}" \
+ SHA256="a12a0a013a30b846c786c010f2c19dd36b7298d888f7c4bd1581d90ce18b5e58" \
+ RELATIVE_PATH="Python-{{version}}" \
+ bash install-from-source.sh --prefix=/opt/python/${PYTHON_VERSION} --with-ensurepip=yes --enable-shared --enable-ipv6 --with-dbmliborder=
 ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/python/${PYTHON_VERSION}/lib:${LD_LIBRARY_PATH}"
 # Set up virtual environment for Python 3
@@ -76,6 +53,10 @@ RUN /opt/python/${PYTHON_VERSION}/bin/python3 -m pip install --no-warn-script-lo
  && /opt/python/${PYTHON_VERSION}/bin/python3 -m virtualenv /py3
 
 # Rust toolchain
+ENV RUST_VERSION="nightly-2022-05-15"
+ENV RUSTC_SHA256="3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338"
+ENV RUSTUP_VERSION="1.24.3"
+ENV RUSTUP_SHA256="3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338"
 RUN curl -sSL -o rustup-init "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init" \
  && echo "${RUSTUP_SHA256}  rustup-init" | sha256sum --check \
  && chmod +x ./rustup-init \
@@ -85,6 +66,8 @@ RUN curl -sSL -o rustup-init "https://static.rust-lang.org/rustup/archive/${RUST
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # MQ Client library required by pymqi
+ENV IBM_MQ_VERSION="9.2.4.0"
+ENV IBM_MQ_SHA256="d0d583eba72daf20b3762976f8831c2e23150ace90509520e12f8cda5b5bdb49"
 RUN mkdir -p /opt/mqm \
  && curl "https://s3.amazonaws.com/dd-agent-omnibus/ibm-mq-backup/${IBM_MQ_VERSION}-IBM-MQC-Redist-LinuxX64.tar.gz" -o /tmp/mq_client.tar.gz \
  && echo "${IBM_MQ_SHA256}  /tmp/mq_client.tar.gz" | sha256sum --check \
@@ -92,22 +75,20 @@ RUN mkdir -p /opt/mqm \
  && rm -rf /tmp/mq_client.tar.gz
 
 # krb5 for dependencies that require kerberos support
-RUN curl "https://kerberos.org/dist/krb5/1.20/krb5-${KRB5_VERSION}.tar.gz" -o /tmp/krb5.tar.gz \
- && echo "${KRB5_SHA256}  /tmp/krb5.tar.gz" | sha256sum --check \
- && tar -C /tmp -xf /tmp/krb5.tar.gz \
- && cd /tmp/krb5-${KRB5_VERSION}/src \
- && ./configure --without-keyutils --without-system-verto --without-libedit --disable-static \
- && make \
- && make install \
- && rm -rf /tmp/krb5-${KRB5_VERSION}/src \
- && rm -rf /tmp/krb5.tar.gz
+RUN \
+ DOWNLOAD_URL="https://kerberos.org/dist/krb5/1.20/krb5-{{version}}.tar.gz" \
+ VERSION="1.20.1" \
+ SHA256="704aed49b19eb5a7178b34b2873620ec299db08752d6a8574f95d41879ab8851" \
+ RELATIVE_PATH="krb5-{{version}}/src" \
+ bash install-from-source.sh --without-keyutils --without-system-verto --without-libedit --disable-static
 
 # libxml & libxslt for lxml
-RUN curl "https://download.gnome.org/sources/libxml2/2.10/libxml2-${LIBXML2_VERSION}.tar.xz" -Lo /tmp/libxml2.tar.xz \
- && echo "${LIBXML2_SHA256}  /tmp/libxml2.tar.xz" | sha256sum --check \
- && tar -C /tmp -xf /tmp/libxml2.tar.xz \
- && cd /tmp/libxml2-${LIBXML2_VERSION} \
- && ./configure \
+RUN \
+ DOWNLOAD_URL="https://download.gnome.org/sources/libxml2/2.10/libxml2-{{version}}.tar.xz" \
+ VERSION="2.10.3" \
+ SHA256="5d2cc3d78bec3dbe212a9d7fa629ada25a7da928af432c93060ff5c17ee28a9c" \
+ RELATIVE_PATH="libxml2-{{version}}" \
+ bash install-from-source.sh \
  --without-iconv \
  --without-python \
  --without-icu \
@@ -117,73 +98,46 @@ RUN curl "https://download.gnome.org/sources/libxml2/2.10/libxml2-${LIBXML2_VERS
  --without-legacy \
  --without-catalog \
  --without-docbook \
- --disable-static \
- && make \
- && make install \
- && rm -rf /tmp/libxml2-${LIBXML2_VERSION} \
- && rm -rf /tmp/libxml2.tar.xz
-RUN curl "https://download.gnome.org/sources/libxslt/1.1/libxslt-${LIBXSLT_VERSION}.tar.xz" -Lo /tmp/libxslt.tar.xz \
- && echo "${LIBXSLT_SHA256}  /tmp/libxslt.tar.xz" | sha256sum --check \
- && tar -C /tmp -xf /tmp/libxslt.tar.xz \
- && cd /tmp/libxslt-${LIBXSLT_VERSION} \
- && ./configure \
+ --disable-static
+
+RUN \
+ DOWNLOAD_URL="https://download.gnome.org/sources/libxslt/1.1/libxslt-{{version}}.tar.xz" \
+ VERSION="1.1.37" \
+ SHA256="3a4b27dc8027ccd6146725950336f1ec520928f320f144eb5fa7990ae6123ab4" \
+ RELATIVE_PATH="libxslt-{{version}}" \
+ bash install-from-source.sh \
  --without-python \
  --without-crypto \
  --without-profiler \
  --without-debugger \
- --disable-static \
- && make \
- && make install \
- && rm -rf /tmp/libxslt-${LIBXSLT_VERSION} \
- && rm -rf /tmp/libxslt.tar.xz
+ --disable-static
 
 # librdkafka for confluent-kafka
-ENV LIBRDKAFKA_VERSION="2.3.0"
-ENV LIBRDKAFKA_SHA256="2d49c35c77eeb3d42fa61c43757fcbb6a206daa560247154e60642bcdcc14d12"
-RUN curl "https://github.com/confluentinc/librdkafka/archive/refs/tags/v${LIBRDKAFKA_VERSION}.tar.gz" -Lo /tmp/librdkafka.tar.gz \
- && echo "${LIBRDKAFKA_SHA256}  /tmp/librdkafka.tar.gz" | sha256sum --check \
- && tar -C /tmp -xf /tmp/librdkafka.tar.gz \
- && cd /tmp/librdkafka-${LIBRDKAFKA_VERSION} \
- && ./configure \
- && make \
- && make install \
- && rm -rf /tmp/librdkafka-${LIBRDKAFKA_VERSION} \
- && rm -rf /tmp/librdkafka.tar.gz
+RUN \
+ DOWNLOAD_URL="https://github.com/confluentinc/librdkafka/archive/refs/tags/v{{version}}.tar.gz" \
+ VERSION="2.3.0" \
+ SHA256="2d49c35c77eeb3d42fa61c43757fcbb6a206daa560247154e60642bcdcc14d12" \
+ RELATIVE_PATH="librdkafka-{{version}}" \
+ bash install-from-source.sh
 
 # libpq and pg_config as needed by psycopg2
-ENV POSTGRESQL_VERSION="16.0"
-ENV POSTGRESQL_SHA256="df9e823eb22330444e1d48e52cc65135a652a6fdb3ce325e3f08549339f51b99"
-RUN curl "https://ftp.postgresql.org/pub/source/v${POSTGRESQL_VERSION}/postgresql-${POSTGRESQL_VERSION}.tar.bz2" -Lo /tmp/postgresql.tar.bz2 \
- && echo "${POSTGRESQL_SHA256}  /tmp/postgresql.tar.bz2" | sha256sum --check \
- && tar -C /tmp -xf /tmp/postgresql.tar.bz2 \
- && cd /tmp/postgresql-${POSTGRESQL_VERSION} \
- && ./configure \
- --without-readline \
- --with-openssl \
- --without-icu \
- && make \
- && make install \
- && rm -rf /tmp/postgresql-${POSTGRESQL_VERSION} \
- && rm -rf /tmp/postgres.tar.bz2
+RUN \
+ DOWNLOAD_URL="https://ftp.postgresql.org/pub/source/v{{version}}/postgresql-{{version}}.tar.bz2" \
+ VERSION="16.0" \
+ SHA256="df9e823eb22330444e1d48e52cc65135a652a6fdb3ce325e3f08549339f51b99" \
+ RELATIVE_PATH="postgresql-{{version}}" \
+ bash install-from-source.sh --without-readline --with-openssl --without-icu
 # Add paths to pg_config and to the library
 ENV PATH="/usr/local/pgsql/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/usr/local/pgsql/lib/:${LD_LIBRARY_PATH}"
 
 # odbc for pyodbc
-ENV ODBC_VERSION="2.3.9"
-ENV ODBC_SHA256="52833eac3d681c8b0c9a5a65f2ebd745b3a964f208fc748f977e44015a31b207"
-RUN curl "https://www.unixodbc.org/unixODBC-${ODBC_VERSION}.tar.gz" -Lo /tmp/unixodbc.tar.gz \
- && echo "${ODBC_SHA256}  /tmp/unixodbc.tar.gz" | sha256sum --check \
- && tar -C /tmp -xf /tmp/unixodbc.tar.gz \
- && cd /tmp/unixODBC-${ODBC_VERSION} \
- && ./configure \
- --disable-readline \
- --with-included-ltdl \
- --enable-ltdl-install \
- && make \
- && make install \
- && rm -rf /tmp/unixODBC-${ODBC_VERSION} \
- && rm -rf /tmp/unixobdc.tar.gz
+RUN \
+ DOWNLOAD_URL="https://www.unixodbc.org/unixODBC-{{version}}.tar.gz" \
+ VERSION="2.3.9" \
+ SHA256="52833eac3d681c8b0c9a5a65f2ebd745b3a964f208fc748f977e44015a31b207" \
+ RELATIVE_PATH=unixODBC-{{version}} \
+ bash install-from-source.sh --disable-readline --with-included-ltdl --enable-ltdl-install
 
 # Environment variables to help openssl crate find OpenSSL
 ENV OPENSSL_LIB_DIR="/usr/local/lib64"

--- a/.builders/images/linux-x86_64/build_script.sh
+++ b/.builders/images/linux-x86_64/build_script.sh
@@ -10,12 +10,24 @@ build_wheels() {
 echo "bcrypt < 4.1.0" >> "${PIP_CONSTRAINT_FILE}"
 
 if [[ "${DD_BUILD_PYTHON_VERSION}" == "3" ]]; then
+    # confluent-kafka
+    # confluent-kafka and librdkafka need to be compiled from source to get kerberos support
+    # The librdkafka version needs to stay in sync with the confluent-kafka version,
+    # thus we extract the version from the requirements file.
+    kafka_version=$(grep 'confluent-kafka==' /home/requirements.in | sed -E 's/^.*([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+).*$/\1/')
+    DOWNLOAD_URL="https://github.com/confluentinc/librdkafka/archive/refs/tags/v{{version}}.tar.gz" \
+      VERSION="${kafka_version}" \
+      SHA256="2d49c35c77eeb3d42fa61c43757fcbb6a206daa560247154e60642bcdcc14d12" \
+      RELATIVE_PATH="librdkafka-{{version}}" \
+      bash install-from-source.sh
+
     # pydantic-core
     pydantic_core_version="2.1.2"
     curl -L "https://github.com/pydantic/pydantic-core/archive/refs/tags/v${pydantic_core_version}.tar.gz" \
         | tar -C /tmp -xzf -
-    cd "/tmp/pydantic-core-${pydantic_core_version}"
+    pushd "/tmp/pydantic-core-${pydantic_core_version}"
     patch -p1 -i "${DD_MOUNT_DIR}/patches/pydantic-core-for-manylinux1.patch"
     build_wheels --no-deps .
     echo "pydantic-core == ${pydantic_core_version}" >> "${PIP_CONSTRAINT_FILE}"
+    popd
 fi

--- a/.builders/images/linux-x86_64/build_script.sh
+++ b/.builders/images/linux-x86_64/build_script.sh
@@ -10,7 +10,6 @@ build_wheels() {
 echo "bcrypt < 4.1.0" >> "${PIP_CONSTRAINT_FILE}"
 
 if [[ "${DD_BUILD_PYTHON_VERSION}" == "3" ]]; then
-    # confluent-kafka
     # confluent-kafka and librdkafka need to be compiled from source to get kerberos support
     # The librdkafka version needs to stay in sync with the confluent-kafka version,
     # thus we extract the version from the requirements file.
@@ -19,7 +18,7 @@ if [[ "${DD_BUILD_PYTHON_VERSION}" == "3" ]]; then
       VERSION="${kafka_version}" \
       SHA256="2d49c35c77eeb3d42fa61c43757fcbb6a206daa560247154e60642bcdcc14d12" \
       RELATIVE_PATH="librdkafka-{{version}}" \
-      bash install-from-source.sh
+      bash install-from-source.sh --enable-sasl
 
     # pydantic-core
     pydantic_core_version="2.1.2"

--- a/.builders/images/linux-x86_64/install-from-source.sh
+++ b/.builders/images/linux-x86_64/install-from-source.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Download, unzip, compile and install a package.
+# Arguments to this script are passed directly to the configure script
+# Required env variables:
+# - DOWNLOAD_URL. Use `{{version}}` as a placeholder to be replaced by the actual version
+# - VERSION
+# - SHA256
+# - RELATIVE_PATH. Set to the relative path in the archive where the source needs to built from.
+#    Can also use the `{{version}}` placeholder for replacemnet.
+# Optional:
+# - CONFIGURE_SCRIPT: Alternative to the default ./configure
+
+
+set -exu
+
+url=${DOWNLOAD_URL//'{{version}}'/${VERSION}}
+relative_path=${RELATIVE_PATH//'{{version}}'/${VERSION}}
+archive_name="$(basename ${url})"
+workdir="/tmp/build-${archive_name}"
+mkdir -p "${workdir}"
+
+curl "${url}" -Lo "${workdir}/${archive_name}"
+echo "${SHA256}  ${workdir}/${archive_name}" | sha256sum --check
+tar -C "${workdir}" -xf "${workdir}/${archive_name}"
+pushd "${workdir}/${relative_path}"
+./${CONFIGURE_SCRIPT:-configure} "$@"
+make -j $(nproc)
+make install
+popd
+rm -rf "${workdir}"

--- a/.builders/images/linux-x86_64/install-from-source.sh
+++ b/.builders/images/linux-x86_64/install-from-source.sh
@@ -23,7 +23,7 @@ curl "${url}" -Lo "${workdir}/${archive_name}"
 echo "${SHA256}  ${workdir}/${archive_name}" | sha256sum --check
 tar -C "${workdir}" -xf "${workdir}/${archive_name}"
 pushd "${workdir}/${relative_path}"
-./${CONFIGURE_SCRIPT:-configure} "$@"
+${CONFIGURE_SCRIPT:-./configure} "$@"
 make -j $(nproc)
 make install
 popd

--- a/.builders/scripts/build_wheels.py
+++ b/.builders/scripts/build_wheels.py
@@ -76,10 +76,10 @@ def main():
         env_vars['PIP_WHEEL_DIR'] = str(staged_wheel_dir)
         env_vars['DD_BUILD_PYTHON_VERSION'] = python_version
         env_vars['DD_MOUNT_DIR'] = str(MOUNT_DIR)
-        env_vars['PIP_NO_BINARY'] = ' '.join(PACKAGES_FORCE_BUILD)
 
         # Off is on, see: https://github.com/pypa/pip/issues/5735
         env_vars['PIP_NO_BUILD_ISOLATION'] = '0'
+        env_vars['PIP_NO_BINARY'] = ' '.join(PACKAGES_FORCE_BUILD)
 
         # Spaces are used to separate multiple values which means paths themselves cannot contain spaces, see:
         # https://github.com/pypa/pip/issues/10114#issuecomment-1880125475

--- a/.builders/scripts/build_wheels.py
+++ b/.builders/scripts/build_wheels.py
@@ -14,6 +14,7 @@ if sys.platform == 'win32':
     PY3_PATH = Path('C:\\py3\\Scripts\\python.exe')
     PY2_PATH = Path('C:\\py2\\Scripts\\python.exe')
     MOUNT_DIR = Path('C:\\mnt')
+    PACKAGES_FORCE_BUILD = []
 
     def join_command_args(args: list[str]) -> str:
         return subprocess.list2cmdline(args)
@@ -27,6 +28,7 @@ else:
     PY3_PATH = Path('/py3/bin/python')
     PY2_PATH = Path('/py2/bin/python')
     MOUNT_DIR = Path('/home')
+    PACKAGES_FORCE_BUILD = ['confluent-kafka']
 
     def join_command_args(args: list[str]) -> str:
         return shlex.join(args)
@@ -74,6 +76,7 @@ def main():
         env_vars['PIP_WHEEL_DIR'] = str(staged_wheel_dir)
         env_vars['DD_BUILD_PYTHON_VERSION'] = python_version
         env_vars['DD_MOUNT_DIR'] = str(MOUNT_DIR)
+        env_vars['PIP_NO_BINARY'] = ' '.join(PACKAGES_FORCE_BUILD)
 
         # Off is on, see: https://github.com/pypa/pip/issues/5735
         env_vars['PIP_NO_BUILD_ISOLATION'] = '0'

--- a/.builders/scripts/repair_wheels.py
+++ b/.builders/scripts/repair_wheels.py
@@ -59,6 +59,10 @@ def repair_linux(source_dir: str, output_dir: str) -> None:
     exclusions = [
         # pymqi
         'libmqic_r.so',
+        # confluent_kafka
+        # We leave cyrus-sasl out of the wheel because of the complexity involved in bundling it portably.
+        # This means the confluent-kafka wheel will have a runtime dependency on this library
+        'libsasl2.so.3',
     ]
 
     # Hardcoded policy to the minimum we need to currently support


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes

Creating a wheel for confluent-kafka such that it's actually self contained is way too hard to be worth it, due to how `cyrus-sasl` works. Instead, we're linking dynamically against `cyrus-sasl` but not including it in the wheel, such that the resulting wheel will rely on the Agent having that library properly installed and convigured.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
