### PR TITLE
Fix incompatibility issues with Python 3.9 and lower

### DIFF
--- a/postgres/changelog.d/16608.fixed
+++ b/postgres/changelog.d/16608.fixed
@@ -1,0 +1,1 @@
+Fix incompatibility issues with Python 3.9 and lower

--- a/postgres/datadog_checks/postgres/metrics_cache.py
+++ b/postgres/datadog_checks/postgres/metrics_cache.py
@@ -242,7 +242,7 @@ class PostgresMetricsCache:
                 if '{dd__user}' in q:
                     metrics_query[i] = q.format(dd__user=self.config.user)
 
-            metrics = dict(zip(metrics_query, ACTIVITY_DD_METRICS, strict=False))
+            metrics = dict(zip(metrics_query, ACTIVITY_DD_METRICS))
 
             self.activity_metrics = (metrics, query, descriptors)
         else:

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -542,7 +542,7 @@ class PostgreSql(AgentCheck):
             column_values = row[len(descriptors) :]
 
             # build a map of descriptors and their values
-            desc_map = {name: value for (_, name), value in zip(descriptors, descriptor_values, strict=False)}
+            desc_map = {name: value for (_, name), value in zip(descriptors, descriptor_values)}
 
             # Build tags.
 
@@ -564,7 +564,7 @@ class PostgreSql(AgentCheck):
             tags += [("%s:%s" % (k, v)) for (k, v) in iteritems(desc_map)]
 
             # Submit metrics to the Agent.
-            for column, value in zip(cols, column_values, strict=False):
+            for column, value in zip(cols, column_values):
                 name, submit_metric = scope['metrics'][column]
                 submit_metric(self, name, value, tags=set(tags), hostname=self.resolved_hostname)
 
@@ -869,7 +869,7 @@ class PostgreSql(AgentCheck):
                         query_tags = list(custom_query.get('tags', []))
                         query_tags.extend(tags)
 
-                        for column, value in zip(columns, row, strict=False):
+                        for column, value in zip(columns, row):
                             # Columns can be ignored via configuration.
                             if not column:
                                 continue

--- a/teradata/changelog.d/16608.fixed
+++ b/teradata/changelog.d/16608.fixed
@@ -1,0 +1,1 @@
+Fix incompatibility issues with Python 3.9 and lower

--- a/teradata/datadog_checks/teradata/utils.py
+++ b/teradata/datadog_checks/teradata/utils.py
@@ -112,8 +112,7 @@ def submit_version(check, row):
     try:
         teradata_version = row[0]
         version_parts = {
-            name: part
-            for name, part in zip(('major', 'minor', 'maintenance', 'patch'), teradata_version.split('.'), strict=False)
+            name: part for name, part in zip(('major', 'minor', 'maintenance', 'patch'), teradata_version.split('.'))
         }
         check.set_metadata('version', teradata_version, scheme='parts', final_scheme='semver', part_map=version_parts)
     except Exception as e:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix incompatibility issues with Python 3.9 and lower

### Motivation
<!-- What inspired you to submit this pull request? -->

The `strict` param was added in Python 3.10. The default value is `false`. A customer is trying to install the 16.0.0 wjheel on 7.50.2 and it's not working because of this

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
