### PR TITLE
Fix autovacuum metrics for postgres >= 10

### DIFF
--- a/postgres/changelog.d/16612.fixed
+++ b/postgres/changelog.d/16612.fixed
@@ -1,0 +1,1 @@
+Fix autovacuum metrics for postgres >= 10

--- a/postgres/datadog_checks/postgres/metrics_cache.py
+++ b/postgres/datadog_checks/postgres/metrics_cache.py
@@ -229,7 +229,7 @@ class PostgresMetricsCache:
 
             if version >= V10:
                 metrics_query = ACTIVITY_METRICS_10
-            if version >= V9_6:
+            elif version >= V9_6:
                 metrics_query = ACTIVITY_METRICS_9_6
             elif version >= V9_2:
                 metrics_query = ACTIVITY_METRICS_9_2


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix autovacuum metrics for postgres >= 10

### Motivation
<!-- What inspired you to submit this pull request? -->

Missed in https://github.com/DataDog/integrations-core/pull/16290

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
