### PR TITLE
[7.51.x] Fix the trigger-agent build script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -262,12 +262,12 @@ validate-log-intgs-builder:
 validate-agent-build-builder:
   stage: build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:18.03.1
-  only:
-    changes:
-      - .gitlab/validate-agent-build/**/*
-      - .gitlab-ci.yml
-    refs:
-      - master
+#  only:
+#    changes:
+#      - .gitlab/validate-agent-build/**/*
+#      - .gitlab-ci.yml
+#    refs:
+#      - master
   script:
     - cd .gitlab/validate-agent-build/
     - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/Datadog/devtools.git --depth 1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -262,12 +262,12 @@ validate-log-intgs-builder:
 validate-agent-build-builder:
   stage: build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:18.03.1
-#  only:
-#    changes:
-#      - .gitlab/validate-agent-build/**/*
-#      - .gitlab-ci.yml
-#    refs:
-#      - master
+  only:
+    changes:
+      - .gitlab/validate-agent-build/**/*
+      - .gitlab-ci.yml
+    refs:
+      - master
   script:
     - cd .gitlab/validate-agent-build/
     - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/Datadog/devtools.git --depth 1

--- a/.gitlab/validate-agent-build/trigger_agent_build.py
+++ b/.gitlab/validate-agent-build/trigger_agent_build.py
@@ -28,6 +28,7 @@ def trigger_pipeline():
             "BUCKET_BRANCH": "none",
             "INTEGRATIONS_CORE_VERSION": os.environ['CI_COMMIT_REF_NAME'],
             "RUN_KITCHEN_TESTS": "false",
+            # TODO Remove `RUN_E2E_TESTS` once the agent CI is fixed.
             "RUN_E2E_TESTS": "true",
         }
     }

--- a/.gitlab/validate-agent-build/trigger_agent_build.py
+++ b/.gitlab/validate-agent-build/trigger_agent_build.py
@@ -28,6 +28,7 @@ def trigger_pipeline():
             "BUCKET_BRANCH": "none",
             "INTEGRATIONS_CORE_VERSION": os.environ['CI_COMMIT_REF_NAME'],
             "RUN_KITCHEN_TESTS": "false",
+            "RUN_E2E_TESTS": "true",
         }
     }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix the trigger-agent build script

### Motivation
<!-- What inspired you to submit this pull request? -->

There's a bug in the Agent CI, the quick fix is to set the `RUN_E2E_TESTS` variable to true. We will drop it as soon as they fix the pipeline on their side

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I pushed a new version of the docker image using this branch, see the commit history if needed

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
