### PR TITLE
[Tooling] Pin dev container python to 3.11

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,6 +11,10 @@
 	// To run docker in docker
 	"privileged": true,
 	"features": {
+		// We pin the Python version both in the base Dockerfile and in the devcontainer specification.
+		// If the version is not provided in the devcontainer.json, it will be overriden with `latest`.
+		// When updating it, modify both the base Dockerfile and the devcontainer.json reference.
+		// Ref: https://github.com/devcontainers/features/blob/562305d37b97d47331d96306ffc2a0a3cce55e64/src/python/install.sh#L10
 		"ghcr.io/devcontainers/features/python:1": {
 			"version": "3.11"
 		}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,9 @@
 	// To run docker in docker
 	"privileged": true,
 	"features": {
-		"ghcr.io/devcontainers/features/python:1": {}
+		"ghcr.io/devcontainers/features/python:1": {
+			"version": "3.11"
+		}
 	},
 
 	// Install the local ddev cli at creation time and set the location of the integrations-core folder


### PR DESCRIPTION
### What does this PR do?
* Changes the dev container Python version from system-provided to 3.11, current target version the repo
<img width="733" alt="image" src="https://github.com/DataDog/integrations-core/assets/97530782/bf35a039-6f4e-47d1-9ded-1af215ac4122">

### Motivation
* Some ddev features require 3.10+ and Python version from the container should simply be aligned with the target, itself aligned with the Agent
### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
