### PR TITLE
[Tooling] Add container integrations team as devcontainer codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -219,4 +219,4 @@ docs/developer/process/integration-release.md                         @DataDog/s
 /.gitlab-ci.yml                                                       @DataDog/agent-integrations @trishankatdatadog
 
 # Dev container
-/.devcontainer                                                        @DataDog/agent-integrations @DataDog/container-integrations
+/.devcontainer/                                                        @DataDog/agent-integrations @DataDog/container-integrations

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -217,3 +217,6 @@ docs/developer/process/integration-release.md                         @DataDog/s
 # As well as the pipelines.
 /.github/workflows/                                                   @DataDog/agent-integrations
 /.gitlab-ci.yml                                                       @DataDog/agent-integrations @trishankatdatadog
+
+# Dev container
+/.devcontainer                                                        @DataDog/agent-integrations @DataDog/container-integrations


### PR DESCRIPTION
### What does this PR do?
* Adds container integrations team as codeowner of the integrations-core dev container
### Motivation

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
