### PR TITLE
[Postgres] - Allow configuration of ignored patterns for settings

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -507,7 +507,8 @@ files:
             example: 600
         - name: ignore_prefixes
           description: |
-            A list of setting prefixes to ignore. Any setting key matching one of the value in this list will not be collected.
+            A list of setting prefixes to ignore. Any setting key matching one of the value in this list will 
+            not be collected.
           value:
               type: array
               items:

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -505,7 +505,7 @@ files:
           value:
             type: number
             example: 600
-        - name: ignored_setting_patterns
+        - name: ignored_settings_patterns
           description: |
             A list of setting patterns to ignore. Any setting key matching one of the value in this list will 
             not be collected. This uses the traditional LIKE pattern-matching approach.

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -505,18 +505,18 @@ files:
           value:
             type: number
             example: 600
-        - name: ignored_prefixes
+        - name: ignored_setting_patterns
           description: |
-            A list of setting prefixes to ignore. Any setting key matching one of the value in this list will 
-            not be collected.
+            A list of setting patterns to ignore. Any setting key matching one of the value in this list will 
+            not be collected. This uses the traditional LIKE pattern-matching approach.
           value:
               type: array
               items:
                 type: string
               example:
-                - plpgsql
+                - plpgsql%
               default:
-                - plpgsql
+                - plpgsql%
     - name: collect_schemas
       description: |
         Enable collection of database schemas. In order to collect schemas from all user databases,

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -137,9 +137,9 @@ files:
       hidden: true
       description: |
         Sets the upper bound limit on the number of concurrent connections the Agent can have on the database server.
-        The Agent needs to open additional connections to collect explain plans across databases. 
-        Idle connections are cached, but pruned over time to balance the performance impact of opening connections and the cost of having many open connections. 
-        Raising the default value should only be needed on workloads with >50 databases. 
+        The Agent needs to open additional connections to collect explain plans across databases.
+        Idle connections are cached, but pruned over time to balance the performance impact of opening connections and the cost of having many open connections.
+        Raising the default value should only be needed on workloads with >50 databases.
         Lowering the default value can reduce the number of explain plans collected and is not recommended in most cases.
       value:
         type: integer
@@ -301,18 +301,18 @@ files:
                   type: <COLUMNS_2_TYPE>
               tags:
                 - <TAG_KEY>:<TAG_VALUE>
-    - name: database_autodiscovery 
+    - name: database_autodiscovery
       description: |
         Define the configuration for database autodiscovery.
         Complete this section if you want to auto-discover databases on this host
-        instead of specifying each using dbname. 
+        instead of specifying each using dbname.
       options:
         - name: enabled
           description: Enable database autodiscovery.
           value:
             type: boolean
             example: false
-            display_default: false 
+            display_default: false
         - name: max_databases
           description: The maximum number of databases this host should monitor.
           value:
@@ -321,14 +321,14 @@ files:
             display_default: 100
         - name: include
           description: |
-            Regular expression for database names to include as part of 
+            Regular expression for database names to include as part of
             database autodiscovery.
-            Will report metrics for databases that are found in this instance, 
+            Will report metrics for databases that are found in this instance,
             ignores databases listed but not found.
-            Character casing is ignored. The regular expressions start matching from 
+            Character casing is ignored. The regular expressions start matching from
             the beginning, so to match anywhere, prepend `.*`. For exact matches append `$`.
             Defaults to `.*` to include everything.
-          value: 
+          value:
             type: array
             items:
               type: string
@@ -505,11 +505,21 @@ files:
           value:
             type: number
             example: 600
-
+        - name: ignore_prefixes
+          description: |
+            A list of setting prefixes to ignore. Any setting key matching one of the value in this list will not be collected.
+          value:
+              type: array
+              items:
+                type: string
+              example:
+                - plpgsql
+              default:
+                - plpgsql
     - name: collect_schemas
       description: |
-        Enable collection of database schemas. In order to collect schemas from all user databases, 
-        enable `database_autodiscovery`. To collect from a single database, set `dbname` to collect 
+        Enable collection of database schemas. In order to collect schemas from all user databases,
+        enable `database_autodiscovery`. To collect from a single database, set `dbname` to collect
         the schema for that database.
         Relation metrics must be enabled for schema collection.
       options:
@@ -542,27 +552,27 @@ files:
 
     - name: aws
       description: |
-        This block defines the configuration for AWS RDS and Aurora instances. 
-        
-        Complete this section if you have installed the Datadog AWS Integration 
-        (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances 
+        This block defines the configuration for AWS RDS and Aurora instances.
+
+        Complete this section if you have installed the Datadog AWS Integration
+        (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances
         with Postgres integration telemetry.
-        
+
         These values are only applied when `dbm: true` option is set.
       options:
         - name: instance_endpoint
           description: |
-            Equal to the Endpoint.Address of the instance the agent is connecting to. 
+            Equal to the Endpoint.Address of the instance the agent is connecting to.
             This value is optional if the value of `host` is already configured to the instance endpoint.
-            
-            For more information on instance endpoints, 
+
+            For more information on instance endpoints,
             see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
           value:
             type: string
             example: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
         - name: region
           description: |
-            Equal to the region of the instance the agent is connecting to. 
+            Equal to the region of the instance the agent is connecting to.
             This value is used to configure IAM authentication.
           value:
             type: string
@@ -575,7 +585,7 @@ files:
 
             For more information on configuration, see
             https://docs.datadoghq.com/database_monitoring/guide/managed_authentication
-            
+
             For more information on RDS IAM Authentication, see the AWS docs
             https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Connecting.html
 
@@ -592,17 +602,17 @@ files:
     - name: gcp
       description: |
         This block defines the configuration for Google Cloud SQL instances.
-        
-        Complete this section if you have installed the Datadog GCP Integration 
-        (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances 
+
+        Complete this section if you have installed the Datadog GCP Integration
+        (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances
         with Postgres integration telemetry.
-        
+
         These values are only applied when `dbm: true` option is set.
       options:
         - name: project_id
           description: |
             Equal to the GCP resource's project ID.
-            
+
             For more information on project IDs,
             See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
           value:
@@ -611,7 +621,7 @@ files:
         - name: instance_id
           description: |
             Equal to the GCP resource's instance ID.
-            
+
             For more information on instance IDs,
             See the GCP docs https://cloud.google.com/sql/docs/postgres/instance-settings#instance-id-2ndgen
           value:
@@ -621,22 +631,22 @@ files:
     - name: azure
       description: |
         This block defines the configuration for Azure Database for PostgreSQL.
-        
-        Complete this section if you have installed the Datadog Azure Integration 
-        (https://docs.datadoghq.com/integrations/azure) to enrich instances 
+
+        Complete this section if you have installed the Datadog Azure Integration
+        (https://docs.datadoghq.com/integrations/azure) to enrich instances
         with Postgres integration telemetry.
         These values are only applied when `dbm: true` option is set.
       options:
         - name: deployment_type
           description: |
-            Equal to the deployment type for the managed database. 
-            
+            Equal to the deployment type for the managed database.
+
             Acceptable values are:
-              - `flexible_server` 
+              - `flexible_server`
               - `single_server`
               - `virtual_machine`
-            
-            For more information on deployment types, 
+
+            For more information on deployment types,
             see the Azure docs https://docs.microsoft.com/en-us/azure/postgresql/overview-postgres-choose-server-options
           value:
             type: string
@@ -644,7 +654,7 @@ files:
         - name: fully_qualified_domain_name
           description: |
             Equal to the full qualified domain name of the Azure PostgreSQL database.
-            
+
             This value is optional if the value of `host` is already configured to the fully qualified domain name.
           value:
             type: string
@@ -652,12 +662,12 @@ files:
         - name: managed_authentication
           description: |
             Configuration section used for Azure AD Authentication.
-        
+
             This supports using System or User assigned managed identities.
 
             For more information on configuration, see
             https://docs.datadoghq.com/database_monitoring/guide/managed_authentication
-            
+
             For more information on Managed Identities, see the Azure docs
             https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
 
@@ -684,10 +694,10 @@ files:
         DEPRECATED: Please use `azure.managed_authentication` instead.
 
         Configuration section used for Azure AD Authentication.
-        
+
         This supports using System or User assigned managed identities.
         If this section is set, then the `username` and `password` fields will be ignored.
-        
+
         For more information on Managed Identities, see the Azure docs
         https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
       options:
@@ -700,7 +710,7 @@ files:
           description: |
             The permission scope from where to access the identity token. This value is optional if using the default
             identity scope for Azure managed databases.
-            
+
             For more information on scopes, see the Azure docs
             https://learn.microsoft.com/en-us/azure/active-directory/develop/scopes-oidc
           value:
@@ -843,7 +853,7 @@ files:
       hidden: true
       description: |
         Set the database instance collection interval (in seconds). The database instance collection sends
-        basic information about the database instance along with a signal that it still exists. 
+        basic information about the database instance along with a signal that it still exists.
         This collection does not involve any additional queries to the database.
       value:
         type: number

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -505,7 +505,7 @@ files:
           value:
             type: number
             example: 600
-        - name: ignore_prefixes
+        - name: ignored_prefixes
           description: |
             A list of setting prefixes to ignore. Any setting key matching one of the value in this list will 
             not be collected.

--- a/postgres/changelog.d/16634.added
+++ b/postgres/changelog.d/16634.added
@@ -1,0 +1,1 @@
+[Postgres] - Allow configuration of ignored_prefixes for settings.

--- a/postgres/changelog.d/16634.added
+++ b/postgres/changelog.d/16634.added
@@ -1,1 +1,1 @@
-[Postgres] - Allow configuration of ignored_prefixes for settings.
+[Postgres] - Allow configuration of ignored patterns for settings collection.

--- a/postgres/changelog.d/16634.added
+++ b/postgres/changelog.d/16634.added
@@ -1,1 +1,1 @@
-[Postgres] - Allow configuration of ignored patterns for settings collection.
+[Postgres] - Allow configuration of ignored patterns for settings collection, under the `ignored_setting_patterns` key

--- a/postgres/changelog.d/16634.added
+++ b/postgres/changelog.d/16634.added
@@ -1,1 +1,1 @@
-[Postgres] - Allow configuration of ignored patterns for settings collection, under the `ignored_setting_patterns` key
+[Postgres] - Allow configuration of ignored patterns for settings collection, under the `ignored_settings_patterns` key

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -76,7 +76,7 @@ class CollectSettings(BaseModel):
     )
     collection_interval: Optional[float] = None
     enabled: Optional[bool] = None
-    ignored_prefixes: Optional[tuple[str, ...]] = None
+    ignored_setting_patterns: Optional[tuple[str, ...]] = None
 
 
 class DatabaseAutodiscovery(BaseModel):

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -76,6 +76,7 @@ class CollectSettings(BaseModel):
     )
     collection_interval: Optional[float] = None
     enabled: Optional[bool] = None
+    ignore_prefixes: Optional[tuple[str, ...]] = None
 
 
 class DatabaseAutodiscovery(BaseModel):

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -76,7 +76,7 @@ class CollectSettings(BaseModel):
     )
     collection_interval: Optional[float] = None
     enabled: Optional[bool] = None
-    ignore_prefixes: Optional[tuple[str, ...]] = None
+    ignored_prefixes: Optional[tuple[str, ...]] = None
 
 
 class DatabaseAutodiscovery(BaseModel):

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -76,7 +76,7 @@ class CollectSettings(BaseModel):
     )
     collection_interval: Optional[float] = None
     enabled: Optional[bool] = None
-    ignored_setting_patterns: Optional[tuple[str, ...]] = None
+    ignored_settings_patterns: Optional[tuple[str, ...]] = None
 
 
 class DatabaseAutodiscovery(BaseModel):

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -409,11 +409,11 @@ instances:
         #
         # collection_interval: 600
 
-        ## @param ignored_setting_patterns - list of strings - optional
+        ## @param ignored_settings_patterns - list of strings - optional
         ## A list of setting patterns to ignore. Any setting key matching one of the value in this list will 
         ## not be collected. This uses the traditional LIKE pattern-matching approach.
         #
-        # ignored_setting_patterns:
+        # ignored_settings_patterns:
         #   - plpgsql%
 
     ## Enable collection of database schemas. In order to collect schemas from all user databases,

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -409,11 +409,11 @@ instances:
         #
         # collection_interval: 600
 
-        ## @param ignore_prefixes - list of strings - optional
+        ## @param ignored_prefixes - list of strings - optional
         ## A list of setting prefixes to ignore. Any setting key matching one of the value in this list will 
         ## not be collected.
         #
-        # ignore_prefixes:
+        # ignored_prefixes:
         #   - plpgsql
 
     ## Enable collection of database schemas. In order to collect schemas from all user databases,

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -409,12 +409,12 @@ instances:
         #
         # collection_interval: 600
 
-        ## @param ignored_prefixes - list of strings - optional
-        ## A list of setting prefixes to ignore. Any setting key matching one of the value in this list will 
-        ## not be collected.
+        ## @param ignored_setting_patterns - list of strings - optional
+        ## A list of setting patterns to ignore. Any setting key matching one of the value in this list will 
+        ## not be collected. This uses the traditional LIKE pattern-matching approach.
         #
-        # ignored_prefixes:
-        #   - plpgsql
+        # ignored_setting_patterns:
+        #   - plpgsql%
 
     ## Enable collection of database schemas. In order to collect schemas from all user databases,
     ## enable `database_autodiscovery`. To collect from a single database, set `dbname` to collect

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -243,7 +243,7 @@ instances:
 
     ## Define the configuration for database autodiscovery.
     ## Complete this section if you want to auto-discover databases on this host
-    ## instead of specifying each using dbname. 
+    ## instead of specifying each using dbname.
     #
     # database_autodiscovery:
 
@@ -258,11 +258,11 @@ instances:
         # max_databases: 100
 
         ## @param include - list of strings - optional - default: ['.*']
-        ## Regular expression for database names to include as part of 
+        ## Regular expression for database names to include as part of
         ## database autodiscovery.
-        ## Will report metrics for databases that are found in this instance, 
+        ## Will report metrics for databases that are found in this instance,
         ## ignores databases listed but not found.
-        ## Character casing is ignored. The regular expressions start matching from 
+        ## Character casing is ignored. The regular expressions start matching from
         ## the beginning, so to match anywhere, prepend `.*`. For exact matches append `$`.
         ## Defaults to `.*` to include everything.
         #
@@ -409,8 +409,15 @@ instances:
         #
         # collection_interval: 600
 
-    ## Enable collection of database schemas. In order to collect schemas from all user databases, 
-    ## enable `database_autodiscovery`. To collect from a single database, set `dbname` to collect 
+        ## @param ignore_prefixes - list of strings - optional
+        ## A list of setting prefixes to ignore. Any setting key matching one of the value in this list will 
+        ## not be collected.
+        #
+        # ignore_prefixes:
+        #   - plpgsql
+
+    ## Enable collection of database schemas. In order to collect schemas from all user databases,
+    ## enable `database_autodiscovery`. To collect from a single database, set `dbname` to collect
     ## the schema for that database.
     ## Relation metrics must be enabled for schema collection.
     #
@@ -436,10 +443,10 @@ instances:
         #
         # collection_interval: 600
 
-    ## This block defines the configuration for AWS RDS and Aurora instances. 
+    ## This block defines the configuration for AWS RDS and Aurora instances.
     ##
-    ## Complete this section if you have installed the Datadog AWS Integration 
-    ## (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances 
+    ## Complete this section if you have installed the Datadog AWS Integration
+    ## (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances
     ## with Postgres integration telemetry.
     ##
     ## These values are only applied when `dbm: true` option is set.
@@ -447,16 +454,16 @@ instances:
     # aws:
 
         ## @param instance_endpoint - string - optional - default: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
-        ## Equal to the Endpoint.Address of the instance the agent is connecting to. 
+        ## Equal to the Endpoint.Address of the instance the agent is connecting to.
         ## This value is optional if the value of `host` is already configured to the instance endpoint.
         ##
-        ## For more information on instance endpoints, 
+        ## For more information on instance endpoints,
         ## see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
         #
         # instance_endpoint: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
 
         ## @param region - string - optional - default: us-east-1
-        ## Equal to the region of the instance the agent is connecting to. 
+        ## Equal to the region of the instance the agent is connecting to.
         ## This value is used to configure IAM authentication.
         #
         # region: us-east-1
@@ -480,8 +487,8 @@ instances:
 
     ## This block defines the configuration for Google Cloud SQL instances.
     ##
-    ## Complete this section if you have installed the Datadog GCP Integration 
-    ## (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances 
+    ## Complete this section if you have installed the Datadog GCP Integration
+    ## (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances
     ## with Postgres integration telemetry.
     ##
     ## These values are only applied when `dbm: true` option is set.
@@ -506,22 +513,22 @@ instances:
 
     ## This block defines the configuration for Azure Database for PostgreSQL.
     ##
-    ## Complete this section if you have installed the Datadog Azure Integration 
-    ## (https://docs.datadoghq.com/integrations/azure) to enrich instances 
+    ## Complete this section if you have installed the Datadog Azure Integration
+    ## (https://docs.datadoghq.com/integrations/azure) to enrich instances
     ## with Postgres integration telemetry.
     ## These values are only applied when `dbm: true` option is set.
     #
     # azure:
 
         ## @param deployment_type - string - optional - default: flexible_server
-        ## Equal to the deployment type for the managed database. 
+        ## Equal to the deployment type for the managed database.
         ##
         ## Acceptable values are:
-        ##   - `flexible_server` 
+        ##   - `flexible_server`
         ##   - `single_server`
         ##   - `virtual_machine`
         ##
-        ## For more information on deployment types, 
+        ## For more information on deployment types,
         ## see the Azure docs https://docs.microsoft.com/en-us/azure/postgresql/overview-postgres-choose-server-options
         #
         # deployment_type: flexible_server

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -472,10 +472,10 @@ class PostgresMetadata(DBMAsyncJob):
         with self._check._get_main_db() as conn:
             with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
                 if self.pg_settings_ignored_patterns:
-                    query = PG_SETTINGS_QUERY + " WHERE name NOT LIKE ANY(%s)"
+                    query = PG_SETTINGS_QUERY + " WHERE name NOT LIKE ALL(%s)"
                 else:
                     query = PG_SETTINGS_QUERY
-                self._log.debug("Running query [%s]", query)
+                self._log.debug("Running query [%s] and patterns are %s", query, self.pg_settings_ignored_patterns)
                 self._time_since_last_settings_query = time.time()
                 cursor.execute(query, (self.pg_settings_ignored_patterns,))
                 rows = cursor.fetchall()

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -472,14 +472,12 @@ class PostgresMetadata(DBMAsyncJob):
         with self._check._get_main_db() as conn:
             with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
                 if self.pg_settings_ignored_patterns:
-                    query = PG_SETTINGS_QUERY + " WHERE name NOT LIKE ANY(array{})".format(
-                        self.pg_settings_ignored_patterns
-                    )
+                    query = PG_SETTINGS_QUERY + " WHERE name NOT LIKE ANY(ARRAY%s)"
                 else:
                     query = PG_SETTINGS_QUERY
-                self._log.warning("Running query [%s]", query)
+                self._log.debug("Running query [%s]", query)
                 self._time_since_last_settings_query = time.time()
-                cursor.execute(query)
+                cursor.execute(query, (self.pg_settings_ignored_patterns,))
                 rows = cursor.fetchall()
                 self._log.debug("Loaded %s rows from pg_settings", len(rows))
                 return [dict(row) for row in rows]

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -23,7 +23,7 @@ from .version_utils import VersionUtils
 DEFAULT_SETTINGS_COLLECTION_INTERVAL = 600
 DEFAULT_SCHEMAS_COLLECTION_INTERVAL = 600
 DEFAULT_RESOURCES_COLLECTION_INTERVAL = 300
-DEFAULT_SETTINGS_IGNORED_PREFIXES = ('plpgsql',)
+DEFAULT_SETTINGS_IGNORED_PATTERNS = ['plpgsql%']
 
 PG_SETTINGS_QUERY = """
 SELECT name, setting FROM pg_settings
@@ -165,8 +165,8 @@ class PostgresMetadata(DBMAsyncJob):
         self.pg_settings_collection_interval = config.settings_metadata_config.get(
             'collection_interval', DEFAULT_SETTINGS_COLLECTION_INTERVAL
         )
-        self.pg_settings_ignored_prefixes = config.settings_metadata_config.get(
-            'ignored_prefixes', DEFAULT_SETTINGS_IGNORED_PREFIXES
+        self.pg_settings_ignored_patterns = config.settings_metadata_config.get(
+            'ignored_patterns', DEFAULT_SETTINGS_IGNORED_PATTERNS
         )
         self.schemas_collection_interval = config.schemas_metadata_config.get(
             'collection_interval', DEFAULT_SCHEMAS_COLLECTION_INTERVAL
@@ -471,15 +471,15 @@ class PostgresMetadata(DBMAsyncJob):
     def _collect_postgres_settings(self):
         with self._check._get_main_db() as conn:
             with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
-                self._log.debug("Running query [%s]", PG_SETTINGS_QUERY)
+                if self.pg_settings_ignored_patterns:
+                    query = PG_SETTINGS_QUERY + " WHERE name NOT LIKE ANY(array{})".format(
+                        self.pg_settings_ignored_patterns
+                    )
+                else:
+                    query = PG_SETTINGS_QUERY
+                self._log.warning("Running query [%s]", query)
                 self._time_since_last_settings_query = time.time()
-                cursor.execute(PG_SETTINGS_QUERY)
+                cursor.execute(query)
                 rows = cursor.fetchall()
                 self._log.debug("Loaded %s rows from pg_settings", len(rows))
-                return [dict(row) for row in rows if not self._is_ignored_setting(row)]
-
-    def _is_ignored_setting(self, row):
-        for prefix in self.pg_settings_ignored_prefixes:
-            if row['name'].startswith(prefix):
-                return True
-        return False
+                return [dict(row) for row in rows]

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -472,7 +472,7 @@ class PostgresMetadata(DBMAsyncJob):
         with self._check._get_main_db() as conn:
             with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
                 if self.pg_settings_ignored_patterns:
-                    query = PG_SETTINGS_QUERY + " WHERE name NOT LIKE ANY(ARRAY%s)"
+                    query = PG_SETTINGS_QUERY + " WHERE name NOT LIKE ANY(%s)"
                 else:
                     query = PG_SETTINGS_QUERY
                 self._log.debug("Running query [%s]", query)

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -166,7 +166,7 @@ class PostgresMetadata(DBMAsyncJob):
             'collection_interval', DEFAULT_SETTINGS_COLLECTION_INTERVAL
         )
         self.pg_settings_ignored_patterns = config.settings_metadata_config.get(
-            'ignored_patterns', DEFAULT_SETTINGS_IGNORED_PATTERNS
+            'ignored_settings_patterns', DEFAULT_SETTINGS_IGNORED_PATTERNS
         )
         self.schemas_collection_interval = config.schemas_metadata_config.get(
             'collection_interval', DEFAULT_SCHEMAS_COLLECTION_INTERVAL

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -34,7 +34,7 @@ def stop_orphaned_threads():
 
 
 def test_collect_metadata(integration_check, dbm_instance, aggregator):
-    dbm_instance["collect_settings"]['ignored_prefixes'] = ['max_wal']
+    dbm_instance["collect_settings"]['ignored_patterns'] = ['max_wal%']
     check = integration_check(dbm_instance)
     check.check(dbm_instance)
     dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -34,7 +34,7 @@ def stop_orphaned_threads():
 
 
 def test_collect_metadata(integration_check, dbm_instance, aggregator):
-    dbm_instance["collect_settings"]['ignored_patterns'] = ['max_wal%']
+    dbm_instance["collect_settings"]['ignored_settings_patterns'] = ['max_wal%']
     check = integration_check(dbm_instance)
     check.check(dbm_instance)
     dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -34,6 +34,7 @@ def stop_orphaned_threads():
 
 
 def test_collect_metadata(integration_check, dbm_instance, aggregator):
+    dbm_instance["collect_settings"]['ignored_prefixes'] = ['max_wal']
     check = integration_check(dbm_instance)
     check.check(dbm_instance)
     dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
@@ -43,6 +44,7 @@ def test_collect_metadata(integration_check, dbm_instance, aggregator):
     assert event['dbms'] == "postgres"
     assert event['kind'] == "pg_settings"
     assert len(event["metadata"]) > 0
+    assert all(not k['name'].startswith('max_wal') for k in event['metadata'])
 
 
 def test_collect_schemas(integration_check, dbm_instance, aggregator):


### PR DESCRIPTION
### What does this PR do?

- Adds the `ignored_settings_patterns` configuration under `collect_settings`. This allows users to define a list of setting patterns that the agent should NOT collect.

### Motivation

- Some settings are set on a per-connection level, and with connection reuse, our agent sometimes picks up on these per-connection settings as changes. With the addition of change tracking, this creates unnecessary noise. We set the default to be `['plpgsql%']`. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
