### PR TITLE
Add external_metrics_updated in DCA telemetry to check when we last received data from backend for it

### DIFF
--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
@@ -43,6 +43,7 @@ DEFAULT_METRICS = {
     'external_metrics_datadog_metrics': 'external_metrics.datadog_metrics',
     'external_metrics_delay_seconds': 'external_metrics.delay_seconds',
     'external_metrics_processed_value': 'external_metrics.processed_value',
+    'external_metrics_updated': 'external_metrics.updated',
     'go_goroutines': 'go.goroutines',
     'go_memstats_alloc_bytes': 'go.memstats.alloc_bytes',
     'go_threads': 'go.threads',

--- a/datadog_cluster_agent/metadata.csv
+++ b/datadog_cluster_agent/metadata.csv
@@ -45,6 +45,7 @@ datadog.cluster_agent.external_metrics.api_requests,gauge,,,,Count of API Reques
 datadog.cluster_agent.external_metrics.datadog_metrics,gauge,,,,"The label valid is true if the DatadogMetric CR is valid, false otherwise",0,datadog_cluster_agent,external metrics datadog metrics,
 datadog.cluster_agent.external_metrics.delay_seconds,gauge,,second,,Freshness of the metric evaluated from querying Datadog,0,datadog_cluster_agent,external metrics delay,
 datadog.cluster_agent.external_metrics.processed_value,gauge,,,,Value processed from querying Datadog by metric,0,datadog_cluster_agent,external metrics processed,
+datadog.cluster_agent.external_metrics.updated,gauge,,,,Counter increased everytime a new value is received for a query,external metrics updated,
 datadog.cluster_agent.go.goroutines,gauge,,,,Number of goroutines that currently exist,0,datadog_cluster_agent,go goroutines,
 datadog.cluster_agent.go.memstats.alloc_bytes,gauge,,byte,,Number of bytes allocated and still in use,0,datadog_cluster_agent,go memstats alloc bytes,
 datadog.cluster_agent.go.threads,gauge,,thread,,Number of OS threads created,0,datadog_cluster_agent,go threads,


### PR DESCRIPTION
### What does this PR do?

Add mapping for new metric in https://github.com/DataDog/datadog-agent/pull/22103

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
