### PR TITLE
Fix disk usage widget color formula in dashboard

### DIFF
--- a/vsphere/assets/dashboards/vsphere_overview.json
+++ b/vsphere/assets/dashboards/vsphere_overview.json
@@ -385,7 +385,7 @@
           {
             "q": "top(avg:vsphere.disk.used.latest{$vcenter_server,$vcenter_datacenter,vsphere_type:datastore} by {vsphere_datastore}/avg:vsphere.disk.capacity.latest{$vcenter_server,$vcenter_datacenter,vsphere_type:datastore} by {vsphere_datastore}*100,10,'mean','desc')",
             "conditional_formats": [
-              { "comparator": "<=", "value": 270, "palette": "white_on_green" },
+              { "comparator": "<=", "value": 70, "palette": "white_on_green" },
               { "comparator": "<=", "value": 90, "palette": "white_on_yellow" },
               { "comparator": ">", "value": 90, "palette": "white_on_red" }
             ]


### PR DESCRIPTION
### What does this PR do?
Fixes the disk usage color formula in the OOTB dashboard; currently, it only ever colors the bars green
### Motivation
support case
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
