### PR TITLE
Use Airflow version to determine health endpoint

### DIFF
--- a/airflow/changelog.d/16646.added
+++ b/airflow/changelog.d/16646.added
@@ -1,0 +1,1 @@
+Use Airflow version to determine health endpoint

--- a/airflow/datadog_checks/airflow/airflow.py
+++ b/airflow/datadog_checks/airflow/airflow.py
@@ -31,7 +31,7 @@ class AirflowCheck(AgentCheck):
         can_connect_status = AgentCheck.OK
 
         # Choose which version of Airflow to use
-        if self._get_version(url_stable_version) is None:
+        if not self._get_version(url_stable_version):
             # Airflow version 1
             target_url = url_experimental
             submit_metrics = self._submit_healthy_metrics_experimental
@@ -58,9 +58,9 @@ class AirflowCheck(AgentCheck):
         except Exception as e:
             self.log.debug("Couldn't collect version from URL: %s with exception: %s", url, e)
         else:
-            version = resp_payload.get('version', None)
+            version = resp_payload.get('version')
             if version:
-                self.log.info("Airflow version: %s", version)
+                self.log.debug("Airflow version: %s", version)
             return version
 
     def _submit_healthy_metrics_experimental(self, resp, tags):

--- a/airflow/tests/test_unit.py
+++ b/airflow/tests/test_unit.py
@@ -30,8 +30,7 @@ def test_service_checks_healthy_exp(aggregator, json_resp, expected_healthy_stat
     instance = common.FULL_CONFIG['instances'][0]
     check = AirflowCheck('airflow', common.FULL_CONFIG, [instance])
 
-    with mock.patch('datadog_checks.airflow.airflow.AirflowCheck._get_version') as get_version:
-        get_version.return_value = None
+    with mock.patch('datadog_checks.airflow.airflow.AirflowCheck._get_version', return_value=None):
 
         with mock.patch('datadog_checks.base.utils.http.requests') as req:
             mock_resp = mock.MagicMock(status_code=200)
@@ -60,8 +59,7 @@ def test_service_checks_healthy_stable(
     instance = common.FULL_CONFIG['instances'][0]
     check = AirflowCheck('airflow', common.FULL_CONFIG, [instance])
 
-    with mock.patch('datadog_checks.airflow.airflow.AirflowCheck._get_version') as get_version:
-        get_version.return_value = '2.6.2'
+    with mock.patch('datadog_checks.airflow.airflow.AirflowCheck._get_version', return_value='2.6.2'):
 
         with mock.patch('datadog_checks.base.utils.http.requests') as req:
             mock_resp = mock.MagicMock(status_code=200)

--- a/airflow/tests/test_unit.py
+++ b/airflow/tests/test_unit.py
@@ -30,12 +30,15 @@ def test_service_checks_healthy_exp(aggregator, json_resp, expected_healthy_stat
     instance = common.FULL_CONFIG['instances'][0]
     check = AirflowCheck('airflow', common.FULL_CONFIG, [instance])
 
-    with mock.patch('datadog_checks.base.utils.http.requests') as req:
-        mock_resp = mock.MagicMock(status_code=200)
-        mock_resp.json.side_effect = [None, json_resp]
-        req.get.return_value = mock_resp
+    with mock.patch('datadog_checks.airflow.airflow.AirflowCheck._get_version') as get_version:
+        get_version.return_value = None
 
-        check.check(None)
+        with mock.patch('datadog_checks.base.utils.http.requests') as req:
+            mock_resp = mock.MagicMock(status_code=200)
+            mock_resp.json.side_effect = [json_resp]
+            req.get.return_value = mock_resp
+
+            check.check(None)
 
     tags = ['key:my-tag', 'url:http://localhost:8080']
 
@@ -53,7 +56,7 @@ def test_service_checks_healthy_exp(aggregator, json_resp, expected_healthy_stat
 )
 def test_service_checks_healthy_stable(
     aggregator, metadb_status, scheduler_status, expected_healthy_status, expected_healthy_value
-):
+):  # Stable is only defined in the context of Airflow 2
     instance = common.FULL_CONFIG['instances'][0]
     check = AirflowCheck('airflow', common.FULL_CONFIG, [instance])
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Uses Airflow's stable API to get version and determines which health endpoint needs to be hit for our service check.

### Motivation
<!-- What inspired you to submit this pull request? -->
https://datadoghq.atlassian.net/browse/FRAGENT-2003

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
