### PR TITLE
[ECOS-1127] Set explicit auto_install value based on the integration type.

### DIFF
--- a/datadog_checks_dev/changelog.d/16647.added
+++ b/datadog_checks_dev/changelog.d/16647.added
@@ -1,0 +1,1 @@
+Set auto_install in 'manifest.json' when running 'ddev create'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -111,6 +111,7 @@ To install the {integration_name} check on your host:
 
     config = {
         'author': author,
+        'auto_install': 'false' if repo_choice == 'marketplace' or integration_type == 'metrics_pull' else 'true',
         'check_class': f"{''.join(part.capitalize() for part in normalized_integration_name.split('_'))}Check",
         'check_name': check_name,
         'project_name': normalize_project_name(normalized_integration_name),

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/manifest.json
@@ -23,6 +23,7 @@
   }},
   "assets": {{
     "integration": {{
+      "auto_install": true,
       "source_type_id": {source_type_id},
       "source_type_name": "{integration_name}",
       "configuration": {{

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/manifest.json
@@ -23,7 +23,7 @@
   }},
   "assets": {{
     "integration": {{
-      "auto_install": true,
+      "auto_install": {auto_install},
       "source_type_id": {source_type_id},
       "source_type_name": "{integration_name}",
       "configuration": {{

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/manifest.json
@@ -19,6 +19,7 @@
   }},
   "assets": {{
     "integration": {{
+      "auto_install": true,
       "source_type_id": {source_type_id},
       "source_type_name": "{integration_name}",
       "configuration": {{

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/manifest.json
@@ -19,7 +19,7 @@
   }},
   "assets": {{
     "integration": {{
-      "auto_install": true,
+      "auto_install": {auto_install},
       "source_type_id": {source_type_id},
       "source_type_name": "{integration_name}",
       "configuration": {{

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/manifest.json
@@ -20,7 +20,7 @@
   }},
   "assets": {{
     "integration": {{
-      "auto_install": true,
+      "auto_install": {auto_install},
       "source_type_id": {source_type_id},
       "source_type_name": "{integration_name}",
       "configuration": {{

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/manifest.json
@@ -20,6 +20,7 @@
   }},
   "assets": {{
     "integration": {{
+      "auto_install": true,
       "source_type_id": {source_type_id},
       "source_type_name": "{integration_name}",
       "configuration": {{

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/metrics_pull/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/metrics_pull/{check_name}/manifest.json
@@ -17,7 +17,7 @@
   }},
   "assets": {{
     "integration": {{
-      "auto_install": false,
+      "auto_install": {auto_install},
       "source_type_id": {source_type_id},
       "source_type_name": "{integration_name}",
       "events": {{

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/snmp_tile/snmp_{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/snmp_tile/snmp_{check_name}/manifest.json
@@ -22,7 +22,7 @@
   }},
   "assets": {{
     "integration": {{
-      "auto_install": true,
+      "auto_install": {auto_install},
       "source_type_id": {source_type_id},
       "source_type_name": "{integration_name}",
       "configuration": {{

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/snmp_tile/snmp_{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/snmp_tile/snmp_{check_name}/manifest.json
@@ -22,6 +22,7 @@
   }},
   "assets": {{
     "integration": {{
+      "auto_install": true,
       "source_type_id": {source_type_id},
       "source_type_name": "{integration_name}",
       "configuration": {{


### PR DESCRIPTION
### What does this PR do?
This will make `ddev create` always include an explicit `auto_install` flag so we can get rid of the `integration sync` logic that tries to infer it from the repo.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
