### PR TITLE
Remove deprecated `tomcat.cache` metrics

### DIFF
--- a/tomcat/changelog.d/16650.removed
+++ b/tomcat/changelog.d/16650.removed
@@ -1,0 +1,1 @@
+Remove deprecated `tomcat.cache` metrics

--- a/tomcat/datadog_checks/tomcat/data/metrics.yaml
+++ b/tomcat/datadog_checks/tomcat/data/metrics.yaml
@@ -61,18 +61,6 @@ jmx_metrics:
             alias: tomcat.servlet.min_time
             metric_type: gauge
     - include:
-        # Deprecated metric available in Tomcat 7
-        # https://github.com/apache/tomcat/blob/7.0.x/java/org/apache/catalina/core/StandardContext.java#L5293-L5297
-        domain_regex: Catalina|Tomcat
-        type: Cache
-        attribute:
-          accessCount:
-            alias: tomcat.cache.access_count
-            metric_type: counter
-          hitsCounts:
-            alias: tomcat.cache.hits_count
-            metric_type: counter
-    - include:
         domain_regex: Catalina|Tomcat
         type: StringCache
         attribute:

--- a/tomcat/metadata.csv
+++ b/tomcat/metadata.csv
@@ -13,8 +13,6 @@ tomcat.processing_time,gauge,10,,,The sum of request processing times across all
 tomcat.servlet.processing_time,gauge,10,,,The sum of request processing times across all requests to the servlet (in milliseconds) per second.,0,tomcat,servlet proc time,
 tomcat.servlet.error_count,gauge,10,error,second,The number of erroneous requests received by the servlet per second.,-1,tomcat,servlet err count,
 tomcat.servlet.request_count,gauge,10,request,second,The number of requests received by the servlet per second.,0,tomcat,servlet requests,
-tomcat.cache.access_count,gauge,10,get,second,The number of accesses to the cache per second.,0,tomcat,cache accesses,
-tomcat.cache.hits_count,gauge,10,hit,second,The number of cache hits per second.,0,tomcat,cache hits,
 tomcat.servlet.max_time,gauge,10,millisecond,,The maximum processing time of a request,0,tomcat,servlet max time,
 tomcat.servlet.min_time,gauge,10,millisecond,,The minimum processing time of a request,0,tomcat,servlet min time,
 tomcat.string_cache.access_count,gauge,10,get,second,The number of accesses to the string cache per second.,0,tomcat,string cache accesses,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove deprecated `tomcat.cache` metrics

### Motivation
<!-- What inspired you to submit this pull request? -->

Tomcat 7 EOLed 3 years ago and we do not have these metrics anymore.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

They are not tested anymore

[datadoghq.atlassian.net/browse/AI-3731](https://datadoghq.atlassian.net/browse/AI-3731)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
