### PR TITLE
DOCS-7069 - state that fargate doesn't support npm

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -2,7 +2,8 @@
 
 ## Overview
 
-**Note**: This page describes the ECS Fargate integration. For EKS Fargate, see the documentation for Datadog's [EKS Fargate integration][1].
+<div class="alert alert-warning"> This page describes the ECS Fargate integration. For EKS Fargate, see the documentation for Datadog's <a href="http://docs.datadoghq.com/integrations/eks_fargate">EKS Fargate integration</a>.
+</div>
 
 Get metrics from all your containers running in ECS Fargate:
 
@@ -16,6 +17,8 @@ The Datadog Agent retrieves metrics for the task definition's containers with th
 The Task Metadata endpoint is only available from within the task definition itself, which is why the Datadog Agent needs to be run as an additional container within each task definition to be monitored.
 
 The only configuration required to enable this metrics collection is to set an environment variable `ECS_FARGATE` to `"true"` in the task definition.
+
+**Note**: Network Process Monitoring (NPM) is not supported for EKS Fargate.
 
 ## Setup
 

--- a/eks_fargate/README.md
+++ b/eks_fargate/README.md
@@ -2,9 +2,12 @@
 
 ## Overview
 
-**Note**: This page describes the EKS Fargate integration. For ECS Fargate, see the documentation for Datadog's [ECS Fargate integration][1].
+<div class="alert alert-warning"> This page describes the EKS Fargate integration. For ECS Fargate, see the documentation for Datadog's <a href="http://docs.datadoghq.com/integrations/ecs_fargate">ECS Fargate integration</a>.
+</div>
 
 Amazon EKS on AWS Fargate is a managed Kubernetes service that automates certain aspects of deployment and maintenance for any standard Kubernetes environment. Kubernetes nodes are managed by AWS Fargate and abstracted away from the user.
+
+**Note**: Network Process Monitoring (NPM) is not supported for EKS Fargate.
 
 ## Setup
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds notes on the ECS Fargate and EKS Fargate readmes that NPM is not supported.

### Motivation
DOCS-7069

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
