### PR TITLE
[DBMON-3435] fix mariadb 10.10 docker startup issue

### DIFF
--- a/mysql/hatch.toml
+++ b/mysql/hatch.toml
@@ -33,7 +33,7 @@ version = [
   "10.5",  # EOL 24 June 2025
   "10.8",
   "10.9",
-  "10.10.7-debian-11-r2", # EOL 17 November 2023
+  "10.10", # EOL 17 November 2023
 ]
 
 [envs.default.overrides]

--- a/mysql/tests/compose/mariadb.yaml
+++ b/mysql/tests/compose/mariadb.yaml
@@ -11,6 +11,7 @@ services:
       - MARIADB_USER=my_user
       - MARIADB_PASSWORD=my_password
       - MARIADB_DATABASE=my_database
+      - DB_REPLICATION_SLAVE_DUMP=false
     ports:
       - "${MYSQL_PORT}:3306"
     volumes:
@@ -29,6 +30,7 @@ services:
       - MARIADB_REPLICATION_PASSWORD=my_repl_password
       - MARIADB_MASTER_HOST=mysql-master
       - MARIADB_MASTER_PORT_NUMBER=3306
+      - DB_REPLICATION_SLAVE_DUMP=false
     ports:
       - "${MYSQL_SLAVE_PORT}:3306"
     depends_on:


### PR DESCRIPTION
### What does this PR do?
This PR fixes mariadb 10.10 docker startup issue.

### Motivation
`bitnami/mariadb` pushed an update on 10.10 which causes CI to fail

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
