### PR TITLE
Mark the `test_wal_stats` as flaky

### DIFF
--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -7,6 +7,7 @@ import time
 import mock
 import psycopg2
 import pytest
+from flaky import flaky
 
 from datadog_checks.base.errors import ConfigurationError
 from datadog_checks.postgres import PostgreSql
@@ -545,6 +546,7 @@ def test_state_clears_on_connection_error(integration_check, pg_instance):
     'is_aurora',
     [True, False],
 )
+@flaky(max_runs=5)
 def test_wal_stats(aggregator, integration_check, pg_instance, is_aurora):
     conn = _get_superconn(pg_instance)
     with conn.cursor() as cur:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Mark the `test_wal_stats` as flaky.

### Motivation
<!-- What inspired you to submit this pull request? -->

This PR is a suggestion more than anything else. I'm trying to get our CI. I noticed this test seems to be flaky (failure on master [here](https://github.com/DataDog/integrations-core/actions/runs/7572167556/job/20621539708)). My idea is to mark these tests as flaky and re-run them when they fail, hoping they will eventually be green. 

I know this is not ideal and it's a short-term solution. When we merge this kind of PR, we should open a card in our respective backlog to eventually fix this test and get rid of the `@flaky`.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
