### PR TITLE
Mark the `test_deadlock` test as flaky

### DIFF
--- a/postgres/tests/test_deadlock.py
+++ b/postgres/tests/test_deadlock.py
@@ -8,6 +8,7 @@ import time
 
 import psycopg2
 import pytest
+from flaky import flaky
 
 from .common import DB_NAME, HOST, PORT, POSTGRES_VERSION
 
@@ -32,6 +33,7 @@ def wait_on_result(cursor=None, sql=None, binds=None, expected_value=None):
     POSTGRES_VERSION is None or float(POSTGRES_VERSION) < 9.2,
     reason='Deadlock test requires version 9.2 or higher (make sure POSTGRES_VERSION is set)',
 )
+@flaky(max_runs=5)
 def test_deadlock(aggregator, dd_run_check, integration_check, pg_instance):
     '''
     This test creates a deadlock by having two connections update the same two rows in opposite order.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Mark the `test_deadlock` test as flaky

### Motivation
<!-- What inspired you to submit this pull request? -->

This test is flaky: https://github.com/DataDog/integrations-core/actions/runs/7584228469/job/20657565448

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Created https://datadoghq.atlassian.net/browse/DBMON-3437

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
