### PR TITLE
Fix a bug that prevents to run e2e tests in a non-default repository

### DIFF
--- a/ddev/changelog.d/16671.fixed
+++ b/ddev/changelog.d/16671.fixed
@@ -1,0 +1,1 @@
+Fix a bug that prevents to run e2e tests in a non-default repository

--- a/ddev/src/ddev/cli/env/test.py
+++ b/ddev/src/ddev/cli/env/test.py
@@ -68,6 +68,7 @@ def test_command(
     from ddev.cli.env.start import start
     from ddev.cli.env.stop import stop
     from ddev.cli.test import test
+    from ddev.config.constants import AppEnvVars
     from ddev.e2e.config import EnvDataStorage
     from ddev.e2e.constants import E2EMetadata
     from ddev.utils.ci import running_in_ci
@@ -129,7 +130,10 @@ def test_command(
         env_data = storage.get(integration.name, env_name)
         metadata = env_data.read_metadata()
         try:
-            with EnvVars(metadata.get(E2EMetadata.ENV_VARS, {})):
+            env_vars = metadata.get(E2EMetadata.ENV_VARS, {})
+            env_vars[AppEnvVars.REPO] = app.repo.name
+
+            with EnvVars(env_vars):
                 ctx.invoke(
                     test, target_spec=f'{intg_name}:{env_name}', args=args, junit=junit, hide_header=True, e2e=True
                 )

--- a/ddev/tests/cli/env/test_test.py
+++ b/ddev/tests/cli/env/test_test.py
@@ -1,0 +1,22 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import mock
+
+
+class MockEnvVars:
+    def __init__(self, env_vars=None):
+        assert env_vars['DDEV_REPO'] == 'core'
+
+    def __enter__(*_args, **_kwargs):
+        pass
+
+    def __exit__(*_args, **_kwargs):
+        pass
+
+
+def test_env_vars_repo(ddev, helpers, data_dir, write_result_file, mocker):
+    mocker.patch('subprocess.run', side_effect=write_result_file({'metadata': {}, 'config': {}}))
+    with mock.patch('ddev.utils.structures.EnvVars', side_effect=MockEnvVars):
+        result = ddev('env', 'test', 'postgres', 'py3.12')
+        assert result.exit_code == 0, result.output


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix a bug that prevents to run e2e tests in a non-default repository (for instance if you run `ddev -e env test <something>` when you are using `core` by default in your config)

### Motivation
<!-- What inspired you to submit this pull request? -->

- In the plugin we call the agent with [this](https://github.com/DataDog/integrations-core/blob/ae3fdeef335839272136b75aa7b2dd5fd327d88c/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py#L190)
- As you can see, it does not forward the `-e`, because it does not really know about it.
- The idea is to leverage [this](https://github.com/DataDog/integrations-core/blob/ae3fdeef335839272136b75aa7b2dd5fd327d88c/ddev/src/ddev/cli/application.py#L73-L74) and set the env variable before we run the tests

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
