### PR TITLE
Add the possibility to send specific values in the `generate_metrics` script

### DIFF
--- a/ddev/changelog.d/16672.added
+++ b/ddev/changelog.d/16672.added
@@ -1,0 +1,1 @@
+Add the possibility to send specific values in the `generate_metrics` script

--- a/ddev/src/ddev/cli/meta/scripts/generate_metrics.py
+++ b/ddev/src/ddev/cli/meta/scripts/generate_metrics.py
@@ -50,13 +50,23 @@ def generate_metrics(app: Application, integration: str, api_url: str, api_key: 
     configuration.server_index = 1
     configuration.server_variables["name"] = api_url
 
+    # Update this map to avoid generating random values for a given metric
+    overriden_values = {
+        'ray.worker.register_time.sum': [10, 9, 8],
+    }
+
     with ApiClient(configuration) as api_client:
         api_instance = MetricsApi(api_client)
+        loop = 0
 
         while True:
             series = []
             for metric in intg.metrics:
-                value = random.randint(0, 100)
+                value = (
+                    overriden_values[metric.metric_name][loop % len(overriden_values[metric.metric_name])]
+                    if metric.metric_name in overriden_values
+                    else random.randint(0, 100)
+                )
                 type = (
                     MetricIntakeType.GAUGE
                     if metric.metric_type == 'gauge'
@@ -90,3 +100,4 @@ def generate_metrics(app: Application, integration: str, api_url: str, api_key: 
 
             app.display_info("Sleeping for 10 seconds...")
             sleep(10)
+            loop += 1


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add the possibility to send specific values in the `generate_metrics` script

### Motivation
<!-- What inspired you to submit this pull request? -->

Right now the values are all random. We sometimes need to provide the value ourselves.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
