### PR TITLE
Mark the `test_common_logical_replica_metrics` test as flaky

### DIFF
--- a/postgres/tests/test_logical_replication.py
+++ b/postgres/tests/test_logical_replication.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
+from flaky import flaky
 
 from datadog_checks.postgres.util import STAT_SUBSCRIPTION_METRICS
 
@@ -42,6 +43,7 @@ def _get_connection_string(instance):
 
 
 @requires_over_11
+@flaky(max_runs=5)
 def test_common_logical_replica_metrics(aggregator, integration_check, pg_replica_logical):
     check = integration_check(pg_replica_logical)
     check._connect()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Mark the `test_common_logical_replica_metrics` test as flaky

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/integrations-core/actions/runs/7607378517/job/20714699481?pr=16672#step:13:4129

### Additional Notes
<!-- Anything else we should know when reviewing? -->

https://datadoghq.atlassian.net/browse/DBMON-3441

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
