### PR TITLE
Fix for empty "/image" instances for Twistlock

### DIFF
--- a/twistlock/changelog.d/16680.fixed
+++ b/twistlock/changelog.d/16680.fixed
@@ -1,0 +1,1 @@
+Skip over "/image" endpoint instances with no images

--- a/twistlock/datadog_checks/twistlock/twistlock.py
+++ b/twistlock/datadog_checks/twistlock/twistlock.py
@@ -142,6 +142,8 @@ class TwistlockCheck(AgentCheck):
                 continue
 
             instances = image.get('instances')
+            if len(instances) == 0:
+                continue
             instance = instances[0]
             image_name = instance.get('image')
             if not image_name:

--- a/twistlock/datadog_checks/twistlock/twistlock.py
+++ b/twistlock/datadog_checks/twistlock/twistlock.py
@@ -142,7 +142,7 @@ class TwistlockCheck(AgentCheck):
                 continue
 
             instances = image.get('instances')
-            if len(instances) == 0:
+            if not instances:
                 continue
             instance = instances[0]
             image_name = instance.get('image')

--- a/twistlock/tests/fixtures/empty_images.json
+++ b/twistlock/tests/fixtures/empty_images.json
@@ -1,0 +1,1135 @@
+[
+    {
+        "_id": "sha256:823f14d29ccab07123f98a8e52459477703d23412572d15beceaaa84ec80b2b0",
+        "hostname": "",
+        "scanTime": "2019-02-14T16:14:15.843Z",
+        "info": {
+            "image": {
+                "created": "0001-01-01T00:00:00Z"
+            },
+            "history": [
+                {
+                    "created": 1536704390,
+                    "instruction": "ADD file:25c10b1d1b41d46a1827ad0b0d2389c24df6d31430005ff4e9a2d84ea23ebd42 in / ",
+                    "sizeBytes": 4413370,
+                    "id": "<missing>"
+                },
+                {
+                    "created": 1536704390,
+                    "instruction": "CMD [\"/bin/sh\"]",
+                    "id": "<missing>"
+                },
+                {
+                    "created": 1544662549,
+                    "instruction": "RUN apk update && apk add ca-certificates mongodb>='3.6.5-r0' mongodb-tools 'musl>=1.1.19-r10' 'busybox>=1.28.4-r0' &&     apk del apk-tools && rm -rf /var/cache/apk/*",
+                    "sizeBytes": 251558986,
+                    "id": "<missing>"
+                },
+                {
+                    "created": 1544662549,
+                    "instruction": "RUN mkdir -p /app/www",
+                    "id": "<missing>"
+                },
+                {
+                    "created": 1544662549,
+                    "instruction": "WORKDIR /app",
+                    "id": "<missing>"
+                },
+                {
+                    "created": 1544662553,
+                    "instruction": "COPY dir:936eda1f437fa005793c38c23a73ecce6b6a54f79db3278dc9e6596081e00f72 in /app/www/ ",
+                    "sizeBytes": 329096314,
+                    "id": "<missing>"
+                },
+                {
+                    "created": 1544662553,
+                    "instruction": "COPY multi:b1752b29bbe76be06672121a042a683c5401b1bce7bff0bc9f6b0a4ba577e0f6 in /var/lib/twistlock/scripts/ ",
+                    "sizeBytes": 50365,
+                    "id": "<missing>"
+                },
+                {
+                    "created": 1544662556,
+                    "instruction": "RUN mv /app/www/server /app/ &&     mkdir /data /images; mv /app/www/twistlock_defender_windows.zip /app/www/twistlock_defender.tar.gz /app/www/twistlock_defender_server.tar.gz /images/ &&     mv /app/www/libtw_serverless.so /app/www/serverless.node /app/www/twistcli /app/www/openscap.tar.gz /app/www/cve-descriptions.json /app/www/cve.json /app/www/cve-windows.json /app/www/stats.json /data/ &&     rm -rf /etc/profile /etc/profile.d &&     find /usr/bin/mongo* -type f -not -name \"mongo\" -not -name \"mongod\" -not -name \"mongodump\" -not -name \"mongorestore\" -delete &&     adduser -D -H twistlock -u 2674 &&     chown -R twistlock /data/ &&     chmod u+xrw -R /data/",
+                    "sizeBytes": 263305585,
+                    "id": "<missing>"
+                },
+                {
+                    "created": 1544662556,
+                    "instruction": "COPY file:282f603db17d0f0daaa08478826f16213c103a8fbd8f467ecbc418029692808d in /data/twistlock-console.service ",
+                    "sizeBytes": 366,
+                    "id": "<missing>"
+                },
+                {
+                    "created": 1544662556,
+                    "instruction": "EXPOSE 8081",
+                    "id": "<missing>"
+                },
+                {
+                    "created": 1544662556,
+                    "instruction": "VOLUME [/var/run /tmp /var/log /var/lib/twistlock /data/]",
+                    "id": "<missing>"
+                },
+                {
+                    "created": 1544662557,
+                    "instruction": "HEALTHCHECK &{[\"CMD-SHELL\" \"/app/server healthcheck\"] \"20m0s\" \"10s\" \"0s\" '\\x03'}",
+                    "id": "<missing>"
+                },
+                {
+                    "created": 1544662557,
+                    "instruction": "LABEL twistlock.model.name=twistlock",
+                    "id": "<missing>"
+                },
+                {
+                    "tags": [
+                        "twistlock/private:console_18_11_103"
+                    ],
+                    "created": 1544662557,
+                    "instruction": "ENTRYPOINT [\"/app/server\"]",
+                    "id": "sha256:823f14d29ccab07123f98a8e52459477703d23412572d15beceaaa84ec80b2b0"
+                }
+            ],
+            "id": "sha256:823f14d29ccab07123f98a8e52459477703d23412572d15beceaaa84ec80b2b0",
+            "complianceVulnerabilities": null,
+            "allCompliance": {},
+            "cveVulnerabilities": [
+                {
+                    "text": "",
+                    "id": 46,
+                    "severity": "high",
+                    "cvss": 7.5,
+                    "status": "",
+                    "cve": "CVE-2018-20679",
+                    "cause": "",
+                    "description": "An issue was discovered in BusyBox before 1.30.0. An out of bounds read in udhcp components (consumed by the DHCP server, client, and relay) allows a remote attacker to leak sensitive information from the stack by sending a crafted DHCP message. This is related to verification in udhcp_get_option() in networking/udhcp/common.c that 4-byte options are indeed 4 bytes.",
+                    "title": "",
+                    "vecStr": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+                    "exploit": "",
+                    "riskFactors": {
+                        "Attack complexity: low": {},
+                        "Attack vector: network": {},
+                        "High severity": {},
+                        "Recent vulnerability": {}
+                    },
+                    "link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2018-20679",
+                    "type": "image",
+                    "packageName": "busybox",
+                    "packageVersion": "1.28.4-r1",
+                    "layerTime": 1536704390,
+                    "templates": null,
+                    "twistlock": false,
+                    "published": 1547051340,
+                    "applicableRules": [
+                        "<1.30.0"
+                    ]
+                },
+                {
+                    "text": "",
+                    "id": 46,
+                    "severity": "high",
+                    "cvss": 7.5,
+                    "status": "",
+                    "cve": "CVE-2019-5747",
+                    "cause": "",
+                    "description": "An issue was discovered in BusyBox through 1.30.0. An out of bounds read in udhcp components (consumed by the DHCP server, client, and/or relay) might allow a remote attacker to leak sensitive information from the stack by sending a crafted DHCP message. This is related to assurance of a 4-byte length when decoding DHCP_SUBNET. NOTE: this issue exists because of an incomplete fix for CVE-2018-20679.",
+                    "title": "",
+                    "vecStr": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+                    "exploit": "",
+                    "riskFactors": {
+                        "Attack complexity: low": {},
+                        "Attack vector: network": {},
+                        "High severity": {},
+                        "Recent vulnerability": {}
+                    },
+                    "link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2019-5747",
+                    "type": "image",
+                    "packageName": "busybox",
+                    "packageVersion": "1.28.4-r1",
+                    "layerTime": 1536704390,
+                    "templates": null,
+                    "twistlock": false,
+                    "published": 1547051340,
+                    "applicableRules": [
+                        "<=1.30.0"
+                    ]
+                },
+                {
+                    "text": "",
+                    "id": 46,
+                    "severity": "medium",
+                    "cvss": 6.5,
+                    "status": "",
+                    "cve": "CVE-2018-20573",
+                    "cause": "",
+                    "description": "The Scanner::EnsureTokensInQueue function in yaml-cpp (aka LibYaml-C++) 0.6.2 allows remote attackers to cause a denial of service (stack consumption and application crash) via a crafted YAML file.",
+                    "title": "",
+                    "vecStr": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+                    "exploit": "",
+                    "riskFactors": {
+                        "Attack complexity: low": {},
+                        "Attack vector: network": {},
+                        "DoS": {},
+                        "Medium severity": {},
+                        "Recent vulnerability": {}
+                    },
+                    "link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2018-20573",
+                    "type": "image",
+                    "packageName": "yaml-cpp",
+                    "packageVersion": "0.6.2-r1",
+                    "layerTime": 1536704390,
+                    "templates": null,
+                    "twistlock": false,
+                    "published": 1546014540,
+                    "applicableRules": [
+                        "==0.6.2"
+                    ]
+                },
+                {
+                    "text": "",
+                    "id": 46,
+                    "severity": "medium",
+                    "cvss": 6.5,
+                    "status": "",
+                    "cve": "CVE-2018-20574",
+                    "cause": "",
+                    "description": "The SingleDocParser::HandleFlowMap function in yaml-cpp (aka LibYaml-C++) 0.6.2 allows remote attackers to cause a denial of service (stack consumption and application crash) via a crafted YAML file.",
+                    "title": "",
+                    "vecStr": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+                    "exploit": "",
+                    "riskFactors": {
+                        "Attack complexity: low": {},
+                        "Attack vector: network": {},
+                        "DoS": {},
+                        "Medium severity": {},
+                        "Recent vulnerability": {}
+                    },
+                    "link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2018-20574",
+                    "type": "image",
+                    "packageName": "yaml-cpp",
+                    "packageVersion": "0.6.2-r1",
+                    "layerTime": 1536704390,
+                    "templates": null,
+                    "twistlock": false,
+                    "published": 1546014540,
+                    "applicableRules": [
+                        "==0.6.2"
+                    ]
+                },
+                {
+                    "text": "",
+                    "id": 46,
+                    "severity": "medium",
+                    "cvss": 6.5,
+                    "status": "",
+                    "cve": "CVE-2019-6285",
+                    "cause": "",
+                    "description": "The SingleDocParser::HandleFlowSequence function in yaml-cpp (aka LibYaml-C++) 0.6.2 allows remote attackers to cause a denial of service (stack consumption and application crash) via a crafted YAML file.",
+                    "title": "",
+                    "vecStr": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+                    "exploit": "",
+                    "riskFactors": {
+                        "Attack complexity: low": {},
+                        "Attack vector: network": {},
+                        "DoS": {},
+                        "Medium severity": {},
+                        "Recent vulnerability": {}
+                    },
+                    "link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2019-6285",
+                    "type": "image",
+                    "packageName": "yaml-cpp",
+                    "packageVersion": "0.6.2-r1",
+                    "layerTime": 1536704390,
+                    "templates": null,
+                    "twistlock": false,
+                    "published": 1547504940,
+                    "applicableRules": [
+                        "==0.6.2"
+                    ]
+                },
+                {
+                    "text": "",
+                    "id": 46,
+                    "severity": "medium",
+                    "cvss": 6.5,
+                    "status": "",
+                    "cve": "CVE-2019-6292",
+                    "cause": "",
+                    "description": "An issue was discovered in singledocparser.cpp in yaml-cpp (aka LibYaml-C++) 0.6.2. Stack Exhaustion occurs in YAML::SingleDocParser, and there is a stack consumption problem caused by recursive stack frames: HandleCompactMap, HandleMap, HandleFlowSequence, HandleSequence, HandleNode. Remote attackers could leverage this vulnerability to cause a denial-of-service via a cpp file.",
+                    "title": "",
+                    "vecStr": "",
+                    "exploit": "",
+                    "riskFactors": {
+                        "DoS": {},
+                        "Medium severity": {},
+                        "Recent vulnerability": {}
+                    },
+                    "link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2019-6292",
+                    "type": "image",
+                    "packageName": "yaml-cpp",
+                    "packageVersion": "0.6.2-r1",
+                    "layerTime": 1536704390,
+                    "templates": null,
+                    "twistlock": false,
+                    "published": 1547512140,
+                    "applicableRules": [
+                        "==0.6.2"
+                    ]
+                },
+                {
+                    "text": "",
+                    "id": 46,
+                    "severity": "high",
+                    "cvss": 7.5,
+                    "status": "",
+                    "cve": "CVE-2018-20679",
+                    "cause": "",
+                    "description": "An issue was discovered in BusyBox before 1.30.0. An out of bounds read in udhcp components (consumed by the DHCP server, client, and relay) allows a remote attacker to leak sensitive information from the stack by sending a crafted DHCP message. This is related to verification in udhcp_get_option() in networking/udhcp/common.c that 4-byte options are indeed 4 bytes.",
+                    "title": "",
+                    "vecStr": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+                    "exploit": "",
+                    "riskFactors": {
+                        "Attack complexity: low": {},
+                        "Attack vector: network": {},
+                        "High severity": {},
+                        "Recent vulnerability": {}
+                    },
+                    "link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2018-20679",
+                    "type": "image",
+                    "packageName": "busybox (used in ssl_client)",
+                    "packageVersion": "1.28.4-r1",
+                    "layerTime": 1536704390,
+                    "templates": null,
+                    "twistlock": false,
+                    "published": 1547051340,
+                    "applicableRules": [
+                        "<1.30.0"
+                    ]
+                },
+                {
+                    "text": "",
+                    "id": 46,
+                    "severity": "high",
+                    "cvss": 7.5,
+                    "status": "",
+                    "cve": "CVE-2019-5747",
+                    "cause": "",
+                    "description": "An issue was discovered in BusyBox through 1.30.0. An out of bounds read in udhcp components (consumed by the DHCP server, client, and/or relay) might allow a remote attacker to leak sensitive information from the stack by sending a crafted DHCP message. This is related to assurance of a 4-byte length when decoding DHCP_SUBNET. NOTE: this issue exists because of an incomplete fix for CVE-2018-20679.",
+                    "title": "",
+                    "vecStr": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+                    "exploit": "",
+                    "riskFactors": {
+                        "Attack complexity: low": {},
+                        "Attack vector: network": {},
+                        "High severity": {},
+                        "Recent vulnerability": {}
+                    },
+                    "link": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2019-5747",
+                    "type": "image",
+                    "packageName": "busybox (used in ssl_client)",
+                    "packageVersion": "1.28.4-r1",
+                    "layerTime": 1536704390,
+                    "templates": null,
+                    "twistlock": false,
+                    "published": 1547051340,
+                    "applicableRules": [
+                        "<=1.30.0"
+                    ]
+                },
+                {
+                    "text": "",
+                    "id": 49,
+                    "severity": "moderate",
+                    "cvss": 9.8,
+                    "status": "fixed in >=4.17.11",
+                    "cve": "CVE-2018-16487",
+                    "cause": "",
+                    "description": "A prototype pollution vulnerability was found in lodash <4.17.11 where the functions merge, mergeWith, and defaultsDeep can be tricked into adding or modifying properties of Object.prototype.",
+                    "title": "",
+                    "vecStr": "",
+                    "exploit": "",
+                    "riskFactors": {
+                        "Has fix": {},
+                        "Medium severity": {},
+                        "Recent vulnerability": {}
+                    },
+                    "link": "https://www.npmjs.com/advisories/782",
+                    "type": "image",
+                    "packageName": "lodash",
+                    "packageVersion": "4.17.10",
+                    "layerTime": 1544662553,
+                    "templates": null,
+                    "twistlock": false,
+                    "published": 1549045740,
+                    "applicableRules": [
+                        "<4.17.11"
+                    ]
+                }
+            ],
+            "repoTag": {
+                "registry": "",
+                "repo": "twistlock/private",
+                "tag": "console_18_11_103",
+                "digest": ""
+            },
+            "tags": [
+                {
+                    "registry": "",
+                    "repo": "twistlock/private",
+                    "tag": "console_18_11_103",
+                    "digest": ""
+                }
+            ],
+            "pkgDistro": "alpine",
+            "pkgDistroRelease": "3.8.1",
+            "distro": "Alpine Linux v3.8",
+            "repoDigests": [],
+            "createdTime": "2018-12-13T00:55:57.924Z",
+            "data": {
+                "binaries": [
+                    {
+                        "name": "server",
+                        "path": "/app/server",
+                        "md5": "4105502164428c24e8af7b6a0a3020f1",
+                        "cveCount": 0,
+                        "layerTime": 0
+                    },
+                    {
+                        "name": "busybox",
+                        "path": "/bin/busybox",
+                        "md5": "b98177c7fdadbbf228e49638221f02a8",
+                        "version": "1.28.4",
+                        "cveCount": 162,
+                        "layerTime": 1536704390
+                    },
+                    {
+                        "name": "serverless.node",
+                        "path": "/data/serverless.node",
+                        "md5": "c3fe25ebd78d41dcb46e6acd9ab28e97",
+                        "cveCount": 0,
+                        "layerTime": 0
+                    },
+                    {
+                        "name": "twistcli",
+                        "path": "/data/twistcli",
+                        "md5": "1d0e9cd85535075df90b708e2269b577",
+                        "cveCount": 0,
+                        "layerTime": 0
+                    },
+                    {
+                        "name": "mkmntdirs",
+                        "path": "/sbin/mkmntdirs",
+                        "md5": "b4129997ea37966ae008233d255de436",
+                        "cveCount": 0,
+                        "layerTime": 0
+                    },
+                    {
+                        "name": "bsondump",
+                        "path": "/usr/bin/bsondump",
+                        "md5": "ce7c5d7cff855dc71554768148427195",
+                        "cveCount": 0,
+                        "layerTime": 0
+                    },
+                    {
+                        "name": "c_rehash",
+                        "path": "/usr/bin/c_rehash",
+                        "md5": "0d7c797d5db3b4c9cda74c043a363fdc",
+                        "cveCount": 0,
+                        "layerTime": 0
+                    },
+                    {
+                        "name": "getconf",
+                        "path": "/usr/bin/getconf",
+                        "md5": "2d28f7c6184dd9ca92f1924cb3347ddb",
+                        "cveCount": 0,
+                        "layerTime": 0
+                    },
+                    {
+                        "name": "getent",
+                        "path": "/usr/bin/getent",
+                        "md5": "777999f8e64a047e09377e50567dda4c",
+                        "cveCount": 0,
+                        "layerTime": 0
+                    },
+                    {
+                        "name": "iconv",
+                        "path": "/usr/bin/iconv",
+                        "md5": "3f5d02d2597bdcf7d5a489bebf45ec56",
+                        "cveCount": 0,
+                        "layerTime": 0
+                    },
+                    {
+                        "name": "mongo",
+                        "path": "/usr/bin/mongo",
+                        "md5": "cb1fa984319274d337f7f850a46504dc",
+                        "cveCount": 7,
+                        "layerTime": 1536704390
+                    },
+                    {
+                        "name": "mongod",
+                        "path": "/usr/bin/mongod",
+                        "md5": "763d6475e155c5aaa9097f93a45f6ec9",
+                        "cveCount": 7,
+                        "layerTime": 1536704390
+                    },
+                    {
+                        "name": "mongodump",
+                        "path": "/usr/bin/mongodump",
+                        "md5": "f03acafc0e6bec06016f590877368385",
+                        "cveCount": 0,
+                        "layerTime": 0
+                    },
+                    {
+                        "name": "mongorestore",
+                        "path": "/usr/bin/mongorestore",
+                        "md5": "72c9cdb2bd6b9d204fc86027cc6af6b5",
+                        "cveCount": 0,
+                        "layerTime": 0
+                    },
+                    {
+                        "name": "scanelf",
+                        "path": "/usr/bin/scanelf",
+                        "md5": "0f8663735b4d0200cbece1199192a9e3",
+                        "cveCount": 0,
+                        "layerTime": 0
+                    },
+                    {
+                        "name": "ssl_client",
+                        "path": "/usr/bin/ssl_client",
+                        "md5": "71d70313facc55decb9c103897f3d000",
+                        "cveCount": 0,
+                        "layerTime": 0
+                    },
+                    {
+                        "name": "update-ca-certificates",
+                        "path": "/usr/sbin/update-ca-certificates",
+                        "md5": "54d0966b0f475dc4276793f6dfc6f348",
+                        "cveCount": 0,
+                        "layerTime": 0
+                    }
+                ],
+                "Secrets": [],
+                "startupBinaries": [
+                    {
+                        "name": "server",
+                        "path": "/app/server",
+                        "md5": "4105502164428c24e8af7b6a0a3020f1",
+                        "cveCount": 0,
+                        "layerTime": 0
+                    }
+                ],
+                "pkgDistro": "alpine",
+                "pkgDistroRelease": "3.8.1",
+                "distro": "Alpine Linux v3.8",
+                "packages": [
+                    {
+                        "pkgsType": "package",
+                        "pkgs": [
+                            {
+                                "version": "1.1.19-r10",
+                                "name": "musl",
+                                "cveCount": 52,
+                                "license": "MIT",
+                                "layerTime": 1536704390
+                            },
+                            {
+                                "version": "1.28.4-r1",
+                                "name": "busybox",
+                                "cveCount": 162,
+                                "license": "GPL-2.0",
+                                "layerTime": 1536704390
+                            },
+                            {
+                                "version": "3.1.0-r0",
+                                "name": "alpine-baselayout",
+                                "cveCount": 0,
+                                "license": "GPL-2.0",
+                                "layerTime": 1536704390
+                            },
+                            {
+                                "version": "2.1-r1",
+                                "name": "alpine-keys",
+                                "cveCount": 0,
+                                "license": "MIT",
+                                "layerTime": 1536704390
+                            },
+                            {
+                                "version": "1.2.11-r1",
+                                "name": "zlib",
+                                "cveCount": 60,
+                                "license": "zlib",
+                                "layerTime": 1536704390
+                            },
+                            {
+                                "version": "20171114-r3",
+                                "name": "ca-certificates",
+                                "cveCount": 0,
+                                "license": "MPL-2.0 GPL-2.0-or-later",
+                                "layerTime": 1536704390
+                            },
+                            {
+                                "version": "8.42-r0",
+                                "name": "pcre",
+                                "cveCount": 91,
+                                "license": "BSD-3-Clause",
+                                "layerTime": 1536704390
+                            },
+                            {
+                                "version": "5.3.28-r0",
+                                "name": "db",
+                                "cveCount": 36,
+                                "license": "custom",
+                                "layerTime": 1536704390
+                            },
+                            {
+                                "version": "1.1.4-r4",
+                                "name": "snappy",
+                                "cveCount": 0,
+                                "license": "BSD-3-Clause",
+                                "layerTime": 1536704390
+                            },
+                            {
+                                "version": "0.6.2-r1",
+                                "name": "yaml-cpp",
+                                "cveCount": 46,
+                                "license": "MIT",
+                                "layerTime": 1536704390
+                            },
+                            {
+                                "version": "3.6.7-r0",
+                                "name": "mongodb",
+                                "cveCount": 91,
+                                "license": "AGPL3",
+                                "layerTime": 1536704390
+                            },
+                            {
+                                "version": "1.8.1-r1",
+                                "name": "libpcap",
+                                "cveCount": 46,
+                                "license": "BSD",
+                                "layerTime": 1536704390
+                            },
+                            {
+                                "version": "3.6.4-r0",
+                                "name": "mongodb-tools",
+                                "cveCount": 0,
+                                "license": "Apache",
+                                "layerTime": 1536704390
+                            },
+                            {
+                                "version": "8.42-r0",
+                                "name": "pcre",
+                                "binaryPkgs": [
+                                    "libpcrecpp"
+                                ],
+                                "cveCount": 91,
+                                "license": "BSD-3-Clause",
+                                "layerTime": 1536704390
+                            },
+                            {
+                                "version": "2.7.4-r0",
+                                "name": "libressl",
+                                "binaryPkgs": [
+                                    "libressl2.7-libcrypto",
+                                    "libressl2.7-libssl",
+                                    "libressl2.7-libtls"
+                                ],
+                                "cveCount": 12,
+                                "license": "custom",
+                                "layerTime": 1536704390
+                            },
+                            {
+                                "version": "1.28.4-r1",
+                                "name": "busybox",
+                                "binaryPkgs": [
+                                    "ssl_client"
+                                ],
+                                "cveCount": 162,
+                                "license": "GPL-2.0",
+                                "layerTime": 1536704390
+                            },
+                            {
+                                "version": "1.2.3-r0",
+                                "name": "pax-utils",
+                                "binaryPkgs": [
+                                    "scanelf"
+                                ],
+                                "cveCount": 4,
+                                "license": "GPL-2.0",
+                                "layerTime": 1536704390
+                            },
+                            {
+                                "version": "0.7.1-r0",
+                                "name": "libc-dev",
+                                "binaryPkgs": [
+                                    "libc-utils"
+                                ],
+                                "cveCount": 0,
+                                "license": "BSD",
+                                "layerTime": 1536704390
+                            },
+                            {
+                                "version": "1.66.0-r0",
+                                "name": "boost",
+                                "binaryPkgs": [
+                                    "boost-system",
+                                    "boost-filesystem",
+                                    "boost-iostreams",
+                                    "boost-program_options"
+                                ],
+                                "cveCount": 6,
+                                "license": "custom",
+                                "layerTime": 1536704390
+                            },
+                            {
+                                "version": "6.4.0-r9",
+                                "name": "gcc",
+                                "binaryPkgs": [
+                                    "libgcc",
+                                    "libstdc++"
+                                ],
+                                "cveCount": 32,
+                                "license": "GPL LGPL",
+                                "layerTime": 1544662549
+                            },
+                            {
+                                "version": "1.0.6-r6",
+                                "name": "bzip2",
+                                "binaryPkgs": [
+                                    "libbz2"
+                                ],
+                                "cveCount": 17,
+                                "license": "BSD",
+                                "layerTime": 1536704390
+                            },
+                            {
+                                "version": "2.1.26-r13",
+                                "name": "cyrus-sasl",
+                                "binaryPkgs": [
+                                    "libsasl"
+                                ],
+                                "cveCount": 5,
+                                "license": "custom",
+                                "layerTime": 1536704390
+                            },
+                            {
+                                "version": "1.1.19-r10",
+                                "name": "musl",
+                                "binaryPkgs": [
+                                    "musl-utils"
+                                ],
+                                "cveCount": 52,
+                                "license": "MIT BSD GPL2+",
+                                "layerTime": 1536704390
+                            }
+                        ]
+                    },
+                    {
+                        "pkgsType": "nodejs",
+                        "pkgs": [
+                            {
+                                "version": "1.6.9",
+                                "name": "angular-animate",
+                                "path": "/app/www/public/libs/angular-animate",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "1.6.9",
+                                "name": "angular-sanitize",
+                                "path": "/app/www/public/libs/angular-sanitize",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "",
+                                "name": "d3",
+                                "path": "/app/www/public/libs/d3",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "0.3.3",
+                                "name": "ng-csv",
+                                "path": "/app/www/public/libs/ng-csv",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "1.0.7",
+                                "name": "ng-focus-if",
+                                "path": "/app/www/public/libs/ng-focus-if",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "2.5.0",
+                                "name": "twistlock-console",
+                                "path": "/app/www",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "0.3.10",
+                                "name": "alertify",
+                                "path": "/app/www/public/libs/alertify",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "5.3.0",
+                                "name": "angular-dialog-service",
+                                "path": "/app/www/public/libs/angular-dialog-service",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "4.17.10",
+                                "name": "lodash",
+                                "path": "/app/www/public/libs/lodash",
+                                "cveCount": 2,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "2.5.1",
+                                "name": "nya-bootstrap-select",
+                                "path": "/app/www/public/libs/nya-bootstrap-select",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "1.4.1",
+                                "name": "ace-builds",
+                                "path": "/app/www/public/libs/ace-builds",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "1.5.5",
+                                "name": "clipboard",
+                                "path": "/app/www/public/libs/clipboard",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "",
+                                "name": "jquery",
+                                "path": "/app/www/public/libs/jquery",
+                                "cveCount": 31,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "1.8.3",
+                                "name": "underscore",
+                                "path": "/app/www/public/libs/lodash/vendor/underscore",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "2.5.1",
+                                "name": "@lordfriend/nya-bootstrap-select",
+                                "path": "/app/www/public/libs/nya-bootstrap-select",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "1.2.6",
+                                "name": "ace-builds",
+                                "path": "/app/www/public/libs/ace-builds",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "1.0.7",
+                                "name": "angular-ui-router",
+                                "path": "/app/www/public/libs/angular-ui-router",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "",
+                                "name": "angular-ui-select",
+                                "path": "/app/www/public/libs/angular-ui-select",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "0.19.8",
+                                "name": "ui-select",
+                                "path": "/app/www/public/libs/angular-ui-select",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "1.4.0",
+                                "name": "firebug-lite-debug",
+                                "path": "/app/www/public/libs/lodash/vendor/firebug-lite/src",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "2.1.8",
+                                "name": "angular-smart-table",
+                                "path": "/app/www/public/libs/angular-smart-table",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "1.1.1",
+                                "name": "angular-chart.js",
+                                "path": "/app/www/public/libs/angular-chart.js",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "",
+                                "name": "bootstrap",
+                                "path": "/app/www/public/libs/bootstrap",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "1.0.3",
+                                "name": "d3-polygon",
+                                "path": "/app/www/public/libs/d3-polygon",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "",
+                                "name": "d3-transition",
+                                "path": "/app/www/public/libs/d3-transition",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "",
+                                "name": "ng-focus-if",
+                                "path": "/app/www/public/libs/ng-focus-if",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "1.6.9",
+                                "name": "angular",
+                                "path": "/app/www/public/libs/angular",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "2.16.0",
+                                "name": "angular-translate",
+                                "path": "/app/www/public/libs/angular-translate",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "3.3.7",
+                                "name": "bootstrap",
+                                "path": "/app/www/public/libs/bootstrap",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "1.0.1",
+                                "name": "d3-selection-multi",
+                                "path": "/app/www/public/libs/d3-selection-multi",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "",
+                                "name": "font-awesome",
+                                "path": "/app/www/public/libs/font-awesome",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "1.3.3",
+                                "name": "backbone",
+                                "path": "/app/www/public/libs/lodash/vendor/backbone",
+                                "cveCount": 9,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "0.3.4",
+                                "name": "ng-csv",
+                                "path": "/app/www/public/libs/ng-csv",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "1.6.3",
+                                "name": "angular-mocks",
+                                "path": "/app/www/public/libs/angular-mocks",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "",
+                                "name": "d3-selection-multi",
+                                "path": "/app/www/public/libs/d3-selection-multi",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "1.1.1",
+                                "name": "d3-transition",
+                                "path": "/app/www/public/libs/d3-transition",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "1.8.3",
+                                "name": "underscore-min",
+                                "path": "/app/www/public/libs/lodash/vendor/underscore",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "0.3.11",
+                                "name": "ngstorage",
+                                "path": "/app/www/public/libs/ngstorage",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "2.5.0",
+                                "name": "angular-bootstrap",
+                                "path": "/app/www/public/libs/angular-bootstrap",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "2.7.2",
+                                "name": "chart.js",
+                                "path": "/app/www/public/libs/chart.js",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "",
+                                "name": "d3-polygon",
+                                "path": "/app/www/public/libs/d3-polygon",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "3.1.1",
+                                "name": "ng-tags-input",
+                                "path": "/app/www/public/libs/ng-tags-input",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            },
+                            {
+                                "version": "2.5.0",
+                                "name": "angular-ui-bootstrap",
+                                "path": "/app/www/public/libs/angular-bootstrap",
+                                "cveCount": 0,
+                                "license": "",
+                                "layerTime": 1544662553
+                            }
+                        ]
+                    }
+                ],
+                "files": []
+            },
+            "cveVulnerabilitiesCnt": 9,
+            "complianceVulnerabilitiesCnt": 0,
+            "cveVulnerabilityDistribution": {
+                "critical": 0,
+                "high": 4,
+                "medium": 5,
+                "low": 0,
+                "total": 9
+            },
+            "complianceDistribution": {
+                "critical": 0,
+                "high": 0,
+                "medium": 0,
+                "low": 0,
+                "total": 0
+            },
+            "vulnerabilityRiskScore": 0,
+            "complianceRiskScore": 0,
+            "layers": [
+                "sha256:df64d3292fd6194b7865d7326af5255db6d81e9df29f48adde61a918fbd8c332",
+                "sha256:319cc87e7b8046b3dd975e7a31690ba068ced54a06c5065c88fecfa2c71f1a42",
+                "sha256:e15e990a1b77aaed9ec42fd26b1d7942d0ae449ebb0751cee68421186f4bda67",
+                "sha256:2f48bd7c3f53f1b1bca3c005d1f92094d38b695ace533d347669ec1d2c0f84ab",
+                "sha256:905a9e85dbc554f757d8d7367b32d8c55f77a5a8442fc0bc5a0833cc60d8b681",
+                "sha256:eeaa560dc81a03fc6932bd8016ceafc3558cc821750aced4eb3dc04b77f85933",
+                "sha256:a6527b074fa30470dbbe77c07ee9eb1b9854a7a9d484f7d05d9e4d2c7e2ceeea"
+            ],
+            "topLayer": "sha256:a6527b074fa30470dbbe77c07ee9eb1b9854a7a9d484f7d05d9e4d2c7e2ceeea",
+            "riskFactors": {
+                "Attack complexity: low": {},
+                "Attack vector: network": {},
+                "DoS": {},
+                "Has fix": {},
+                "High severity": {},
+                "Medium severity": {},
+                "Recent vulnerability": {}
+            },
+            "labels": [
+                "twistlock.model.name:twistlock"
+            ],
+            "installedProducts": {
+                "docker": "18.09.1"
+            },
+            "version": "18.11.103",
+            "twistlockImage": true
+        },
+        "instances": [
+        ],
+        "hosts": {
+            "ubuntu-bionic": {
+                "modified": "2019-02-14T16:14:15.843Z"
+            }
+        },
+        "err": "",
+        "collections": [
+            "All"
+        ]
+    }
+]

--- a/twistlock/tests/fixtures/prisma_cloud/images.json
+++ b/twistlock/tests/fixtures/prisma_cloud/images.json
@@ -2661,5 +2661,2660 @@
             "All"
         ],
         "scanID": 0
-    }
+    },
+    {
+        "_id": "sha256:489e32f1e7ad38b3a93a9e17895ac2709d67cb02e77308085343532dd77f8bcf",
+        "hostname": "",
+        "scanTime": "2019-12-30T22:23:37.394Z",
+        "binaries": [
+            {
+                "name": "[",
+                "path": "/usr/bin/[",
+                "md5": "a4bb4e639dee3f382664445148317ab5",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "arch",
+                "path": "/usr/bin/arch",
+                "md5": "4efece241750655392d304c592f80e75",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "base64",
+                "path": "/usr/bin/base64",
+                "md5": "3bc2872fef2d71600a931ec9b4881583",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "basename",
+                "path": "/usr/bin/basename",
+                "md5": "6ee24baf5e4ba9c9925560a394694196",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "bash",
+                "path": "/usr/bin/bash",
+                "md5": "17e63331af636a41399f5e7a4f88a7eb",
+                "cveCount": 146,
+                "layerTime": 0
+            },
+            {
+                "name": "cat",
+                "path": "/usr/bin/cat",
+                "md5": "98b51c2a3efd088fe2ec632980c28e6c",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "certutil",
+                "path": "/usr/bin/certutil",
+                "md5": "fdecf2060d7ebbdff42d0f0b468ba40b",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "chcon",
+                "path": "/usr/bin/chcon",
+                "md5": "f36a722bef868793206041490b7530a7",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "chgrp",
+                "path": "/usr/bin/chgrp",
+                "md5": "a1953590c189125b4c885bc89d72d3b2",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "chmod",
+                "path": "/usr/bin/chmod",
+                "md5": "0e9bfe626ca444212e69672b5e11fbf4",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "chown",
+                "path": "/usr/bin/chown",
+                "md5": "800a98a6d0626ff6a249261f375b217c",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "cksum",
+                "path": "/usr/bin/cksum",
+                "md5": "fbe3d2c370104c033b348d94dc21075b",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "clear",
+                "path": "/usr/bin/clear",
+                "md5": "4db05aebb6ec4a74516741178a367c1d",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "cmsutil",
+                "path": "/usr/bin/cmsutil",
+                "md5": "da5c12d782de3d0a74d4d5ce0a333f4e",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "comm",
+                "path": "/usr/bin/comm",
+                "md5": "7889cbbd4b270496d75d1fcba884f484",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "cp",
+                "path": "/usr/bin/cp",
+                "md5": "ba9bf328ff6d897a188410c92b7c9214",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "crlutil",
+                "path": "/usr/bin/crlutil",
+                "md5": "d55802e69b7ce016022465357f009656",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "csplit",
+                "path": "/usr/bin/csplit",
+                "md5": "f2650862a8e4b787c2e693d14357d600",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "curl",
+                "path": "/usr/bin/curl",
+                "md5": "08102839efd218463a3ce93ec92a7643",
+                "cveCount": 1214,
+                "layerTime": 0
+            },
+            {
+                "name": "cut",
+                "path": "/usr/bin/cut",
+                "md5": "7f8924101deceb14f935c92fc6b509fe",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "date",
+                "path": "/usr/bin/date",
+                "md5": "77953e78bf4b8c6255e2974dc1807771",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "db_archive",
+                "path": "/usr/bin/db_archive",
+                "md5": "0771f1d92610e7412cff1f48783114ec",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "db_checkpoint",
+                "path": "/usr/bin/db_checkpoint",
+                "md5": "bc4ff05a93a9497ba6e572329daa6b06",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "db_deadlock",
+                "path": "/usr/bin/db_deadlock",
+                "md5": "7a8bd6b9ba0bd48cddcd31bd50bb1bf7",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "db_dump",
+                "path": "/usr/bin/db_dump",
+                "md5": "84be21a06938cc4621a66f31f884d810",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "db_dump185",
+                "path": "/usr/bin/db_dump185",
+                "md5": "87ce61cb07f3f445a05a10b8be748ff3",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "db_hotbackup",
+                "path": "/usr/bin/db_hotbackup",
+                "md5": "1a6c9f2e7a33af52c612a4f8dfe07583",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "db_load",
+                "path": "/usr/bin/db_load",
+                "md5": "d8626abf826863b7c6e486da041ef644",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "db_log_verify",
+                "path": "/usr/bin/db_log_verify",
+                "md5": "afa4e08190d0f1e5465e4c6bac457904",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "db_printlog",
+                "path": "/usr/bin/db_printlog",
+                "md5": "9d0acd1198e017d1f3b4c5601b43df8c",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "db_recover",
+                "path": "/usr/bin/db_recover",
+                "md5": "62810a334a3db21f3cdc1a036568a589",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "db_replicate",
+                "path": "/usr/bin/db_replicate",
+                "md5": "7a0d0d6bb25f955f1803ebafa9cc2866",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "db_stat",
+                "path": "/usr/bin/db_stat",
+                "md5": "20bbdb9099b3ea241868931ddb899433",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "db_tuner",
+                "path": "/usr/bin/db_tuner",
+                "md5": "1d0eb36b3498eee8172431a442f2011a",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "db_upgrade",
+                "path": "/usr/bin/db_upgrade",
+                "md5": "22fc41e02ae3585404c9b66c22ef4f03",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "db_verify",
+                "path": "/usr/bin/db_verify",
+                "md5": "738f24346f2c894d35ed303862056b8e",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "dd",
+                "path": "/usr/bin/dd",
+                "md5": "d9fb2c510ad1a7fe6b3e62052355387d",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "df",
+                "path": "/usr/bin/df",
+                "md5": "822bc9ea1c101c1ef48d0c1cee2a7038",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "dgawk",
+                "path": "/usr/bin/dgawk",
+                "md5": "5c86bbd89f90a736479792b527bfa8c3",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "dir",
+                "path": "/usr/bin/dir",
+                "md5": "80a9f481c3a239791593396ab579ee52",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "dircolors",
+                "path": "/usr/bin/dircolors",
+                "md5": "8e691ba90c4901858bc029d14b9f1166",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "dirname",
+                "path": "/usr/bin/dirname",
+                "md5": "785b3272fe1e8d49dd27b4b27d27c921",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "du",
+                "path": "/usr/bin/du",
+                "md5": "3a65c0c28c5801d7d9a62473ae27b118",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "echo",
+                "path": "/usr/bin/echo",
+                "md5": "0c401985db972463059b390a99c92d04",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "env",
+                "path": "/usr/bin/env",
+                "md5": "a42d1a043fce79227ec5c833db6ecfe1",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "expand",
+                "path": "/usr/bin/expand",
+                "md5": "b09d8763a98f84fdcc736503f3a74ffc",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "expr",
+                "path": "/usr/bin/expr",
+                "md5": "84180b66836b74ae40e13ee959a8a89e",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "factor",
+                "path": "/usr/bin/factor",
+                "md5": "d956dd67ea54a1f5b1e7db6759dca121",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "false",
+                "path": "/usr/bin/false",
+                "md5": "c03ec587b9d4aed36502ec1c7c4097c2",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "find",
+                "path": "/usr/bin/find",
+                "md5": "6e7ebd79fc8dbfd854129804bcd82dfe",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "fmt",
+                "path": "/usr/bin/fmt",
+                "md5": "56a5eec111f56922e6316d955b1d0b1f",
+                "cveCount": 1,
+                "layerTime": 0
+            },
+            {
+                "name": "fold",
+                "path": "/usr/bin/fold",
+                "md5": "0f79c420ce9283cdbc3dc2497e5ddb70",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "gawk",
+                "path": "/usr/bin/gawk",
+                "md5": "697198c8752f6ecd1c195406658bcaea",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "gencat",
+                "path": "/usr/bin/gencat",
+                "md5": "b19cf0b74bdc690965a4f5d9772a8a6f",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "getconf",
+                "path": "/usr/bin/getconf",
+                "md5": "e60a009d2c851cdbc2158b40a4cffa60",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "getent",
+                "path": "/usr/bin/getent",
+                "md5": "426ab0b4e127526aac21c2126617a4db",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "gpg-error",
+                "path": "/usr/bin/gpg-error",
+                "md5": "36c8a79d392e0a5e8c82ca17a270accd",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "grep",
+                "path": "/usr/bin/grep",
+                "md5": "acafaa0d3f65d05817d1feb54f66e45f",
+                "cveCount": 24,
+                "layerTime": 0
+            },
+            {
+                "name": "groups",
+                "path": "/usr/bin/groups",
+                "md5": "092a807d1abc77b7ce7099f9a12391d2",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "head",
+                "path": "/usr/bin/head",
+                "md5": "7e7ba73f27ac7d8214d92bc960cf9784",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "hostid",
+                "path": "/usr/bin/hostid",
+                "md5": "14191f216c9aeb11cb5b7d868b733d78",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "iconv",
+                "path": "/usr/bin/iconv",
+                "md5": "30887d1ef9c4563485358fd08a2ecdce",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "id",
+                "path": "/usr/bin/id",
+                "md5": "fdbae61d8a34c5bc5bb05520a1aed8fd",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "idn",
+                "path": "/usr/bin/idn",
+                "md5": "70f04830b24249746af03468721a0201",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "info",
+                "path": "/usr/bin/info",
+                "md5": "26ebe1f2c46ff400a21643d2b27b75c4",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "infocmp",
+                "path": "/usr/bin/infocmp",
+                "md5": "132bcce299ab4ae081e85037f88330ca",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "infokey",
+                "path": "/usr/bin/infokey",
+                "md5": "99a100e2fbca506e2eec617137451366",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "install",
+                "path": "/usr/bin/install",
+                "md5": "a9af16a9b8789b1984fecc9e4b9f1780",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "join",
+                "path": "/usr/bin/join",
+                "md5": "01358c4980e8e3c53eabafbd8f13067a",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "link",
+                "path": "/usr/bin/link",
+                "md5": "eeea9fae2fae09657e824a7687aac0f9",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "ln",
+                "path": "/usr/bin/ln",
+                "md5": "1fe363282baf93cae5439b46c6bdeb3b",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "locale",
+                "path": "/usr/bin/locale",
+                "md5": "49440abe3263814dc129ab068bf16a7b",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "localedef",
+                "path": "/usr/bin/localedef",
+                "md5": "bf81b80718577ee2570879b4af7877f5",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "logname",
+                "path": "/usr/bin/logname",
+                "md5": "24ce6a9386a9cd53240a2010874f9515",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "ls",
+                "path": "/usr/bin/ls",
+                "md5": "a1b8d46465f7b3e3486cd54b17099f9c",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "lua",
+                "path": "/usr/bin/lua",
+                "md5": "44b01625d6e5a81c4252672c738d2b9a",
+                "cveCount": 6,
+                "layerTime": 0
+            },
+            {
+                "name": "luac",
+                "path": "/usr/bin/luac",
+                "md5": "f773a7cfef49e01ab5ecf15447091c81",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "lz4",
+                "path": "/usr/bin/lz4",
+                "md5": "39032c17d0baa053234001b0f2001be8",
+                "cveCount": 31,
+                "layerTime": 0
+            },
+            {
+                "name": "lz4c",
+                "path": "/usr/bin/lz4c",
+                "md5": "767e0e526f24108d44078114f1d1cba5",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "makedb",
+                "path": "/usr/bin/makedb",
+                "md5": "ba104c13bfa742cc07f798d23f7c554d",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "md5sum",
+                "path": "/usr/bin/md5sum",
+                "md5": "67ce73798ea7da0811b19b3ff6e76e4e",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "mkdir",
+                "path": "/usr/bin/mkdir",
+                "md5": "05466b67088ebb776bf1d135d5e8ee61",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "mkfifo",
+                "path": "/usr/bin/mkfifo",
+                "md5": "4d09d68e5526c75ffd0cd46b5dbe31aa",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "mknod",
+                "path": "/usr/bin/mknod",
+                "md5": "58beb05b23b669a0589765f39f985810",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "mktemp",
+                "path": "/usr/bin/mktemp",
+                "md5": "a5b73a262a2b50586478c0ec9fab854b",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "modutil",
+                "path": "/usr/bin/modutil",
+                "md5": "ef613ed7daa99bf6c2a58a65fc19c046",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "mv",
+                "path": "/usr/bin/mv",
+                "md5": "ae90eba3483056c26e940a41f6bde3a7",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "nice",
+                "path": "/usr/bin/nice",
+                "md5": "91406be263d22c4afdaf3b938d6ccadf",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "nl",
+                "path": "/usr/bin/nl",
+                "md5": "10c3339ba95b127574ec287ef49fa5d5",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "nohup",
+                "path": "/usr/bin/nohup",
+                "md5": "6723c010c399e65711ad111d9757ce8d",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "nproc",
+                "path": "/usr/bin/nproc",
+                "md5": "ad4308b9f0e70426fb467f112f3596d2",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "nss-policy-check",
+                "path": "/usr/bin/nss-policy-check",
+                "md5": "bdc17a299ed6a9d8c7e61e8a65f914b7",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "numfmt",
+                "path": "/usr/bin/numfmt",
+                "md5": "8ed6fd99e00335d7833399b5bc1fa763",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "od",
+                "path": "/usr/bin/od",
+                "md5": "477b1dac9c935e985f299606d1415ede",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "p11-kit",
+                "path": "/usr/bin/p11-kit",
+                "md5": "b5e9bdeebf4f0fe66e2687abe51b5894",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "paste",
+                "path": "/usr/bin/paste",
+                "md5": "9b0304a41582a5e060c8cbbcbb87d96f",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "pathchk",
+                "path": "/usr/bin/pathchk",
+                "md5": "9fcb40f4637ba56330f513cbed97c0f1",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "pgawk",
+                "path": "/usr/bin/pgawk",
+                "md5": "03132364d3b013ac108d1cdfd6f78a4b",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "pinentry-curses",
+                "path": "/usr/bin/pinentry-curses",
+                "md5": "6a70e50163c25d0c0841aac33a6acbc2",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "pk12util",
+                "path": "/usr/bin/pk12util",
+                "md5": "192c95bccd5f3969baa6114d35ff2a42",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "pldd",
+                "path": "/usr/bin/pldd",
+                "md5": "9d0812351a8403b3a4a5051f2ee9af7d",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "pr",
+                "path": "/usr/bin/pr",
+                "md5": "8d3a11e835a9650282179f103bf952ce",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "printenv",
+                "path": "/usr/bin/printenv",
+                "md5": "f28dc789efb4f959a1e30eb5278db80f",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "printf",
+                "path": "/usr/bin/printf",
+                "md5": "644d89daf667779dd2b86e6040f1b9ec",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "ptx",
+                "path": "/usr/bin/ptx",
+                "md5": "4dc07bc30443450d7badde4f4f7134cb",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "pwd",
+                "path": "/usr/bin/pwd",
+                "md5": "c510b8af0fc9e02f0a238af5f9194cda",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "readlink",
+                "path": "/usr/bin/readlink",
+                "md5": "7a728347b1eada3a37b0caf2913ddef3",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "realpath",
+                "path": "/usr/bin/realpath",
+                "md5": "bcf0ab5afb2df03cbe6428e1374a5b13",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "rm",
+                "path": "/usr/bin/rm",
+                "md5": "5920c95b813e812f3192c3d57fd8a57c",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "rmdir",
+                "path": "/usr/bin/rmdir",
+                "md5": "d22fdf40b5a542dbeeabd0ad3d7093ff",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "rpcgen",
+                "path": "/usr/bin/rpcgen",
+                "md5": "f4253754c6130c2a2050af2280994b22",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "rpm",
+                "path": "/usr/bin/rpm",
+                "md5": "241ad974bbde249070177d07bbc2557c",
+                "cveCount": 71,
+                "layerTime": 0
+            },
+            {
+                "name": "rpm2cpio",
+                "path": "/usr/bin/rpm2cpio",
+                "md5": "31bb46ce20cc1b732927d37576f71abf",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "rpmdb",
+                "path": "/usr/bin/rpmdb",
+                "md5": "f3505c82f84e39df3c45e7258b472a9f",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "rpmkeys",
+                "path": "/usr/bin/rpmkeys",
+                "md5": "c5218e8645a665d08d41730881115945",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "runcon",
+                "path": "/usr/bin/runcon",
+                "md5": "f76e40a90f72e7588b59b665cd7827b6",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "sed",
+                "path": "/usr/bin/sed",
+                "md5": "0bb51827dba8348ca61f71f626ed442b",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "seq",
+                "path": "/usr/bin/seq",
+                "md5": "b226723094697fad898a6c71cdd3c301",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "sha1sum",
+                "path": "/usr/bin/sha1sum",
+                "md5": "50b5018e599b50b8dfcc53ab37034627",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "sha224sum",
+                "path": "/usr/bin/sha224sum",
+                "md5": "fe8062191464bc46ed54a67e850f7820",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "sha256sum",
+                "path": "/usr/bin/sha256sum",
+                "md5": "be5be43381f707d05d2c83c2e17a809b",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "sha384sum",
+                "path": "/usr/bin/sha384sum",
+                "md5": "088c7e6d4f8fd0620e60ee9a846779e1",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "sha512sum",
+                "path": "/usr/bin/sha512sum",
+                "md5": "067cd5291754af5771cbf405a154f439",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "shred",
+                "path": "/usr/bin/shred",
+                "md5": "8892ee10c3cda642d749571df646f1e0",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "shuf",
+                "path": "/usr/bin/shuf",
+                "md5": "82aaab52784dd8beaded93f463b8d3cb",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "signver",
+                "path": "/usr/bin/signver",
+                "md5": "4a7f1f82ba5cf82a6ee1dc48dda37c08",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "sleep",
+                "path": "/usr/bin/sleep",
+                "md5": "c8cbdaeda3bd07ff4528a5e95426351d",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "sort",
+                "path": "/usr/bin/sort",
+                "md5": "89f8e27eb31dbc5e933830827a10e55a",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "split",
+                "path": "/usr/bin/split",
+                "md5": "d617816c14ef1fd43b266f2fbf45daf7",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "sprof",
+                "path": "/usr/bin/sprof",
+                "md5": "7e7ce0ad77a4969345f99e766ca9ac00",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "sqlite3",
+                "path": "/usr/bin/sqlite3",
+                "md5": "9bb8f04d6e92fd7b9837b1fea0939ab2",
+                "cveCount": 279,
+                "layerTime": 0
+            },
+            {
+                "name": "ssltap",
+                "path": "/usr/bin/ssltap",
+                "md5": "3d9b66b8f3975306e28368f982fd018f",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "stat",
+                "path": "/usr/bin/stat",
+                "md5": "491e3463abfa88d595c4c45954b95f59",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "stdbuf",
+                "path": "/usr/bin/stdbuf",
+                "md5": "2ec009ab35a2aba58855d1d0edfb67e4",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "stty",
+                "path": "/usr/bin/stty",
+                "md5": "1bbc4f4c9a812b4efea01b2db9026390",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "sum",
+                "path": "/usr/bin/sum",
+                "md5": "4c203f3f7b937b8b1b707d7b399025c2",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "sync",
+                "path": "/usr/bin/sync",
+                "md5": "20b67a94710b6c607080f973cfeefc70",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "tabs",
+                "path": "/usr/bin/tabs",
+                "md5": "8bc4ee9094e97d3ad33df5403371258a",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "tac",
+                "path": "/usr/bin/tac",
+                "md5": "da6249c36d1a81f571ea0904b0b39770",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "tail",
+                "path": "/usr/bin/tail",
+                "md5": "bce26d249a9f7515b5d8e95e9b414db0",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "tee",
+                "path": "/usr/bin/tee",
+                "md5": "c7000e2345442f22efb96763409ceee3",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "test",
+                "path": "/usr/bin/test",
+                "md5": "71ca90f4f3fd85916efb819ba3e5d698",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "tic",
+                "path": "/usr/bin/tic",
+                "md5": "616799afdebd0a7f639af9eab9bc91ce",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "timeout",
+                "path": "/usr/bin/timeout",
+                "md5": "99f610663acbe70f73d8fe9fd282563f",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "toe",
+                "path": "/usr/bin/toe",
+                "md5": "90bccfe2313e2032a731c3d5836374d3",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "touch",
+                "path": "/usr/bin/touch",
+                "md5": "5f66a4fdd03a10a26ec9a750727c530b",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "tput",
+                "path": "/usr/bin/tput",
+                "md5": "4a54a691a19b20de4e01364b811e7ce7",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "tr",
+                "path": "/usr/bin/tr",
+                "md5": "60de74ebce71127fbe06ec295c8de6ec",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "true",
+                "path": "/usr/bin/true",
+                "md5": "0168029b20d2cdeed2d9168ea246c4ec",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "truncate",
+                "path": "/usr/bin/truncate",
+                "md5": "639b761aca3e0a1a81c117db76313425",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "trust",
+                "path": "/usr/bin/trust",
+                "md5": "7a64917bcfdf779d3a50346d8b6846f7",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "tset",
+                "path": "/usr/bin/tset",
+                "md5": "01b106b510ace4219309d8304cdc4836",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "tsort",
+                "path": "/usr/bin/tsort",
+                "md5": "e3d209d77d187124731c7b65b8a626b9",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "tty",
+                "path": "/usr/bin/tty",
+                "md5": "0bd1078456022e02daf4d166569b1a6c",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "uname",
+                "path": "/usr/bin/uname",
+                "md5": "c56b3bfd92cf98f085303e42602b6a5b",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "unexpand",
+                "path": "/usr/bin/unexpand",
+                "md5": "d96d6dc845f5e144049a014ba3853eb3",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "uniq",
+                "path": "/usr/bin/uniq",
+                "md5": "29da01a5c8e662bc8f6194e8b44b2056",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "unlink",
+                "path": "/usr/bin/unlink",
+                "md5": "580326fe7a2b64d8e416f5cac9d5b360",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "users",
+                "path": "/usr/bin/users",
+                "md5": "4d635d7ea1be9a5f41b11695c3885466",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "vdir",
+                "path": "/usr/bin/vdir",
+                "md5": "17cdc557a0f17945f603ec039e8c4c04",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "wc",
+                "path": "/usr/bin/wc",
+                "md5": "94764303a192e2d34d22690a65bb1ece",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "who",
+                "path": "/usr/bin/who",
+                "md5": "bdfbb5b89954bafa1b7cf4cc5a65e942",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "whoami",
+                "path": "/usr/bin/whoami",
+                "md5": "fb6aff38db891d6ce0d7cbd2dd687be7",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "xargs",
+                "path": "/usr/bin/xargs",
+                "md5": "0a6516b404ebfc80eb28d91bddb3da14",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "yes",
+                "path": "/usr/bin/yes",
+                "md5": "54b2fc9bc4ddf7df75367b1d265284a4",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "atob",
+                "path": "/usr/lib64/nss/unsupported-tools/atob",
+                "md5": "bf472692e84ea904997b7d8489df0619",
+                "cveCount": 1,
+                "layerTime": 0
+            },
+            {
+                "name": "bltest",
+                "path": "/usr/lib64/nss/unsupported-tools/bltest",
+                "md5": "a12a47f3819a0875dc7895c6696c161d",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "btoa",
+                "path": "/usr/lib64/nss/unsupported-tools/btoa",
+                "md5": "74896c9795b53a4d9ae26c74913c3ac7",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "derdump",
+                "path": "/usr/lib64/nss/unsupported-tools/derdump",
+                "md5": "de3524d950e296567c729ef8e8ccaa7b",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "fipstest",
+                "path": "/usr/lib64/nss/unsupported-tools/fipstest",
+                "md5": "71af3a0fe0f6c3566ac251eecb11bd00",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "listsuites",
+                "path": "/usr/lib64/nss/unsupported-tools/listsuites",
+                "md5": "7613683b9de502aa7a3655633ee762ab",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "ocspclnt",
+                "path": "/usr/lib64/nss/unsupported-tools/ocspclnt",
+                "md5": "108964dba5e04465b48f7366c2b11124",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "pp",
+                "path": "/usr/lib64/nss/unsupported-tools/pp",
+                "md5": "f8665f07a7b175ee56a91fc898213dda",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "selfserv",
+                "path": "/usr/lib64/nss/unsupported-tools/selfserv",
+                "md5": "4b024011f10ef99a40eafe02f580dd36",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "shlibsign",
+                "path": "/usr/lib64/nss/unsupported-tools/shlibsign",
+                "md5": "666bb02dd1f915fc58dfa721e9c9ae5d",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "signtool",
+                "path": "/usr/lib64/nss/unsupported-tools/signtool",
+                "md5": "38dd636e70e2a9818dc80eb2168424ae",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "strsclnt",
+                "path": "/usr/lib64/nss/unsupported-tools/strsclnt",
+                "md5": "0cbc472d23391fb8e2211b6c4d4e66b2",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "symkeyutil",
+                "path": "/usr/lib64/nss/unsupported-tools/symkeyutil",
+                "md5": "2357f9ec7e141efc265aa98b8fd03bd0",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "tstclnt",
+                "path": "/usr/lib64/nss/unsupported-tools/tstclnt",
+                "md5": "a3cb3fe906e36c09965dea94d45d6d77",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "vfychain",
+                "path": "/usr/lib64/nss/unsupported-tools/vfychain",
+                "md5": "f9f9ed96ba661ab9f54265de4b11bc95",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "vfyserv",
+                "path": "/usr/lib64/nss/unsupported-tools/vfyserv",
+                "md5": "df32c4b14199c568a4258d5d0b6eb82d",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "grcat",
+                "path": "/usr/libexec/awk/grcat",
+                "md5": "13a0c0a3d5803c0cf0a36f7242b1d93e",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "pwcat",
+                "path": "/usr/libexec/awk/pwcat",
+                "md5": "7a59a1ad094697c605dcb3a4e8b54418",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "POSIX_V6_LP64_OFF64",
+                "path": "/usr/libexec/getconf/POSIX_V6_LP64_OFF64",
+                "md5": "e60a009d2c851cdbc2158b40a4cffa60",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "POSIX_V7_LP64_OFF64",
+                "path": "/usr/libexec/getconf/POSIX_V7_LP64_OFF64",
+                "md5": "e60a009d2c851cdbc2158b40a4cffa60",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "XBS5_LP64_OFF64",
+                "path": "/usr/libexec/getconf/XBS5_LP64_OFF64",
+                "md5": "e60a009d2c851cdbc2158b40a4cffa60",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "p11-kit-remote",
+                "path": "/usr/libexec/p11-kit/p11-kit-remote",
+                "md5": "c32d47110a37df8e64baab28a83d123f",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "defender",
+                "path": "/usr/local/bin/defender",
+                "md5": "58e139eb4c4ad0242d6bf92e7e34be9a",
+                "cveCount": 0,
+                "layerTime": 1577005536
+            },
+            {
+                "name": "fsmon",
+                "path": "/usr/local/bin/fsmon",
+                "md5": "873213af5035b4ea888556dfe67b3ae6",
+                "cveCount": 0,
+                "layerTime": 1577005536
+            },
+            {
+                "name": "alternatives",
+                "path": "/usr/sbin/alternatives",
+                "md5": "3bbf56a107f3acc1145d3f1df44bf6e0",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "build-locale-archive",
+                "path": "/usr/sbin/build-locale-archive",
+                "md5": "5732962c4c6551e111033aa3d249f6d0",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "capsh",
+                "path": "/usr/sbin/capsh",
+                "md5": "1c7f6e244a4aba0011bc18ce3aa0ceeb",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "chkconfig",
+                "path": "/usr/sbin/chkconfig",
+                "md5": "7cff31f921e777e8239ec0a6048b0281",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "chroot",
+                "path": "/usr/sbin/chroot",
+                "md5": "f1621ae67f456c1942d97c498a87927e",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "getcap",
+                "path": "/usr/sbin/getcap",
+                "md5": "3bebb6444f89a2ff226b051fca7e190d",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "getpcaps",
+                "path": "/usr/sbin/getpcaps",
+                "md5": "d3eee439b14d124d10de70b1cd5a88c4",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "iconvconfig",
+                "path": "/usr/sbin/iconvconfig",
+                "md5": "adf8a22c96466e5fa9fef43f203f2f97",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "iconvconfig.x86_64",
+                "path": "/usr/sbin/iconvconfig.x86_64",
+                "md5": "adf8a22c96466e5fa9fef43f203f2f97",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "install-info",
+                "path": "/usr/sbin/install-info",
+                "md5": "25d23e5d0119ac85674bfced60d7d0b7",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "ldconfig",
+                "path": "/usr/sbin/ldconfig",
+                "md5": "c7267e94e74771ccdf9a5d27287f8c74",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "sasldblistusers2",
+                "path": "/usr/sbin/sasldblistusers2",
+                "md5": "d56ed86b16bfe1ac0ea18bdd4582bba9",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "saslpasswd2",
+                "path": "/usr/sbin/saslpasswd2",
+                "md5": "cbf142d4991681cb2be7043a07497945",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "sefcontext_compile",
+                "path": "/usr/sbin/sefcontext_compile",
+                "md5": "2f970fad787ba47b66e73395877b2ecd",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "setcap",
+                "path": "/usr/sbin/setcap",
+                "md5": "b444eab416967204cfd8c5e9243419c5",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "zdump",
+                "path": "/usr/sbin/zdump",
+                "md5": "3a35d2b515e5129cfc7914867c783f74",
+                "cveCount": 0,
+                "layerTime": 0
+            },
+            {
+                "name": "zic",
+                "path": "/usr/sbin/zic",
+                "md5": "39098b81512815721f244e8e4e34476a",
+                "cveCount": 0,
+                "layerTime": 0
+            }
+        ],
+        "Secrets": [],
+        "startupBinaries": [
+            {
+                "name": "defender",
+                "path": "/usr/local/bin/defender",
+                "md5": "58e139eb4c4ad0242d6bf92e7e34be9a",
+                "cveCount": 0,
+                "layerTime": 0
+            }
+        ],
+        "osDistro": "redhat",
+        "osDistroRelease": "RHEL7",
+        "distro": "Red Hat Enterprise Linux Server 7.7 (Maipo)",
+        "packages": [
+            {
+                "pkgsType": "package",
+                "pkgs": [
+                    {
+                        "version": "7.7-10.el7",
+                        "name": "redhat-release-server",
+                        "cveCount": 0,
+                        "license": "GPLv2",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "3.2-25.el7",
+                        "name": "filesystem",
+                        "cveCount": 2,
+                        "license": "Public Domain",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "5.9-14.20130511.el7_4",
+                        "name": "ncurses-base",
+                        "cveCount": 0,
+                        "license": "MIT",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "2.17-292.el7",
+                        "name": "glibc",
+                        "cveCount": 815,
+                        "license": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "5.9-14.20130511.el7_4",
+                        "name": "ncurses-libs",
+                        "cveCount": 2,
+                        "license": "MIT",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "2.5-10.el7",
+                        "name": "libsepol",
+                        "cveCount": 0,
+                        "license": "LGPLv2+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "2.5-14.1.el7",
+                        "name": "libselinux",
+                        "cveCount": 0,
+                        "license": "Public Domain",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "5.1-5.el7",
+                        "name": "info",
+                        "cveCount": 0,
+                        "license": "GPLv3+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "1.12-3.el7",
+                        "name": "libgpg-error",
+                        "cveCount": 0,
+                        "license": "LGPLv2+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "5.3.21-25.el7",
+                        "name": "libdb",
+                        "cveCount": 2,
+                        "license": "BSD and LGPLv2 and Sleepycat",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "2.2.51-14.el7",
+                        "name": "libacl",
+                        "cveCount": 0,
+                        "license": "LGPLv2+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "0.176-2.el7",
+                        "name": "elfutils-libelf",
+                        "cveCount": 18,
+                        "license": "GPLv2+ or LGPLv3+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "2.23.2-61.el7_7.1",
+                        "name": "libuuid",
+                        "cveCount": 5,
+                        "license": "BSD",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "1.7.4-1.el7",
+                        "name": "chkconfig",
+                        "cveCount": 0,
+                        "license": "GPLv2",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "6.2-11.el7",
+                        "name": "readline",
+                        "cveCount": 4,
+                        "license": "GPLv3+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "2.20-3.el7",
+                        "name": "grep",
+                        "cveCount": 24,
+                        "license": "GPLv3+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "0.7.5-4.el7",
+                        "name": "libcap-ng",
+                        "cveCount": 2,
+                        "license": "LGPLv2+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "0.23.5-3.el7",
+                        "name": "p11-kit",
+                        "cveCount": 0,
+                        "license": "BSD",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "4.0.2-4.el7_3.1",
+                        "name": "gawk",
+                        "cveCount": 0,
+                        "license": "GPLv3+ and GPL and LGPLv3+ and LGPL and BSD",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "4.5.11-6.el7",
+                        "name": "findutils",
+                        "cveCount": 5,
+                        "license": "GPLv3+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "0.11-4.el7_0",
+                        "name": "json-c",
+                        "cveCount": 16,
+                        "license": "MIT",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "0.8.1-17.el7",
+                        "name": "pinentry",
+                        "cveCount": 0,
+                        "license": "GPLv2+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "1.28-4.el7",
+                        "name": "libidn",
+                        "cveCount": 115,
+                        "license": "LGPLv2+ and GPLv3+ and GFDL",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "6.0.0-15.el7",
+                        "name": "gmp",
+                        "cveCount": 0,
+                        "license": "LGPLv3+ or GPLv2+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "0.2.5-4.el7",
+                        "name": "libverto",
+                        "cveCount": 0,
+                        "license": "MIT",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "0.23.5-3.el7",
+                        "name": "p11-kit-trust",
+                        "cveCount": 0,
+                        "license": "BSD",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "1.5.8-3.el7",
+                        "name": "keyutils-libs",
+                        "cveCount": 0,
+                        "license": "GPLv2+ and LGPLv2+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "1.0.2k-19.el7",
+                        "name": "openssl-libs",
+                        "cveCount": 85,
+                        "license": "OpenSSL",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "2.23.2-61.el7_7.1",
+                        "name": "libblkid",
+                        "cveCount": 5,
+                        "license": "LGPLv2+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "1.8.0-3.el7",
+                        "name": "libssh2",
+                        "cveCount": 236,
+                        "license": "BSD",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "7.29.0-54.el7_7.1",
+                        "name": "curl",
+                        "cveCount": 1214,
+                        "license": "MIT",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "4.11.3-40.el7",
+                        "name": "rpm",
+                        "cveCount": 71,
+                        "license": "GPLv2+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "3.44.0-4.el7_7",
+                        "name": "nss-util",
+                        "cveCount": 65,
+                        "license": "MPLv2.0",
+                        "layerTime": 1577005535
+                    },
+                    {
+                        "version": "3.44.0-8.el7_7",
+                        "name": "nss-softokn",
+                        "cveCount": 33,
+                        "license": "MPLv2.0",
+                        "layerTime": 1577005535
+                    },
+                    {
+                        "version": "3.44.0-7.el7_7",
+                        "name": "nss-sysinit",
+                        "cveCount": 96,
+                        "license": "MPLv2.0",
+                        "layerTime": 1577005535
+                    },
+                    {
+                        "version": "4.8.5-39.el7",
+                        "name": "libgcc",
+                        "cveCount": 1,
+                        "license": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "2.8.71-10.el7",
+                        "name": "setup",
+                        "cveCount": 3,
+                        "license": "Public Domain",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "10.0-7.el7",
+                        "name": "basesystem",
+                        "cveCount": 0,
+                        "license": "Public Domain",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "2019c-1.el7",
+                        "name": "tzdata",
+                        "cveCount": 0,
+                        "license": "Public Domain",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "2.17-292.el7",
+                        "name": "glibc-common",
+                        "cveCount": 106,
+                        "license": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "4.21.0-1.el7",
+                        "name": "nspr",
+                        "cveCount": 70,
+                        "license": "MPLv2.0",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "4.8.5-39.el7",
+                        "name": "libstdc++",
+                        "cveCount": 1,
+                        "license": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "4.2.46-33.el7",
+                        "name": "bash",
+                        "cveCount": 146,
+                        "license": "GPLv3+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "8.32-17.el7",
+                        "name": "pcre",
+                        "cveCount": 93,
+                        "license": "BSD",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "1.2.7-18.el7",
+                        "name": "zlib",
+                        "cveCount": 64,
+                        "license": "zlib and Boost",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "5.2.2-1.el7",
+                        "name": "xz-libs",
+                        "cveCount": 0,
+                        "license": "LGPLv2+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "1.0.6-13.el7",
+                        "name": "bzip2-libs",
+                        "cveCount": 1,
+                        "license": "BSD",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "2.4.46-13.el7",
+                        "name": "libattr",
+                        "cveCount": 0,
+                        "license": "LGPLv2+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "2.22-10.el7",
+                        "name": "libcap",
+                        "cveCount": 0,
+                        "license": "LGPLv2+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "4.2.2-5.el7",
+                        "name": "sed",
+                        "cveCount": 0,
+                        "license": "GPLv3+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "3.0.13-18.el7",
+                        "name": "libffi",
+                        "cveCount": 11,
+                        "license": "MIT and Public Domain",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "1.13-16.el7",
+                        "name": "popt",
+                        "cveCount": 0,
+                        "license": "MIT",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "1.42.9-16.el7",
+                        "name": "libcom_err",
+                        "cveCount": 4,
+                        "license": "MIT",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "3.7.17-8.el7",
+                        "name": "sqlite",
+                        "cveCount": 129,
+                        "license": "Public Domain",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "2.8.5-4.el7",
+                        "name": "audit-libs",
+                        "cveCount": 0,
+                        "license": "LGPLv2+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "5.1.4-15.el7",
+                        "name": "lua",
+                        "cveCount": 6,
+                        "license": "MIT",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "2.1.0-3.el7",
+                        "name": "libassuan",
+                        "cveCount": 0,
+                        "license": "LGPLv2+ and GPLv3+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "1.7.5-3.el7",
+                        "name": "lz4",
+                        "cveCount": 31,
+                        "license": "GPLv2+ and BSD",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "2.23.2-61.el7_7.1",
+                        "name": "libsmartcols",
+                        "cveCount": 0,
+                        "license": "LGPLv2+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "5.3.21-25.el7",
+                        "name": "libdb-utils",
+                        "cveCount": 0,
+                        "license": "BSD and LGPLv2 and Sleepycat",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "5.9-14.20130511.el7_4",
+                        "name": "ncurses",
+                        "cveCount": 294,
+                        "license": "MIT",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "0.1.4-11.el7_0",
+                        "name": "libyaml",
+                        "cveCount": 25,
+                        "license": "MIT",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "4.10-1.el7",
+                        "name": "libtasn1",
+                        "cveCount": 61,
+                        "license": "GPLv3+ and LGPLv2+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "2019.2.32-76.el7_7",
+                        "name": "ca-certificates",
+                        "cveCount": 0,
+                        "license": "Public Domain",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "8.22-24.el7",
+                        "name": "coreutils",
+                        "cveCount": 101,
+                        "license": "GPLv3+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "1.15.1-37.el7_7.2",
+                        "name": "krb5-libs",
+                        "cveCount": 62,
+                        "license": "MIT",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "2.23.2-61.el7_7.1",
+                        "name": "libmount",
+                        "cveCount": 4,
+                        "license": "LGPLv2+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "2.1.26-23.el7",
+                        "name": "cyrus-sasl-lib",
+                        "cveCount": 2,
+                        "license": "BSD with advertising",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "1.0.3-7.el7",
+                        "name": "nss-pem",
+                        "cveCount": 6,
+                        "license": "MPLv1.1",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "7.29.0-54.el7_7.1",
+                        "name": "libcurl",
+                        "cveCount": 87,
+                        "license": "MIT",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "4.11.3-40.el7",
+                        "name": "rpm-libs",
+                        "cveCount": 10,
+                        "license": "GPLv2+ and LGPLv2+ with exceptions",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "2.4.44-21.el7_6",
+                        "name": "openldap",
+                        "cveCount": 182,
+                        "license": "OpenLDAP",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "2.0.7-23.el7",
+                        "name": "pth",
+                        "cveCount": 0,
+                        "license": "LGPLv2+",
+                        "layerTime": 1574169944
+                    },
+                    {
+                        "version": "3.44.0-8.el7_7",
+                        "name": "nss-softokn-freebl",
+                        "cveCount": 27,
+                        "license": "MPLv2.0",
+                        "layerTime": 1577005535
+                    },
+                    {
+                        "version": "3.44.0-7.el7_7",
+                        "name": "nss",
+                        "cveCount": 504,
+                        "license": "MPLv2.0",
+                        "layerTime": 1577005535
+                    },
+                    {
+                        "version": "3.44.0-7.el7_7",
+                        "name": "nss-tools",
+                        "cveCount": 96,
+                        "license": "MPLv2.0",
+                        "layerTime": 1577005535
+                    }
+                ]
+            }
+        ],
+        "files": [],
+        "packageManager": true,
+        "image": {
+            "created": "0001-01-01T00:00:00Z"
+        },
+        "history": [
+            {
+                "created": 1574169944,
+                "sizeBytes": 81312807,
+                "id": "\u003cmissing\u003e"
+            },
+            {
+                "created": 1574169957,
+                "sizeBytes": 6936,
+                "id": "\u003cmissing\u003e"
+            },
+            {
+                "created": 1577005535,
+                "instruction": "RUN microdnf update -y \u0026\u0026 microdnf clean all     \u0026\u0026 rpm -e microdnf libdnf librhsm json-glib gobject-introspection libpeas shared-mime-info pkgconfig               libmodulemd librepo glib2 libxml2 gpgme gnupg2 libgcrypt expat libsolv",
+                "sizeBytes": 16030760,
+                "id": "\u003cmissing\u003e"
+            },
+            {
+                "created": 1577005536,
+                "instruction": "COPY multi:e9c2e2b7d7b254390c00b4fb871a8ecaa8de9fda9ed700203903e97fa060be28 in /usr/local/bin/ ",
+                "sizeBytes": 69803603,
+                "id": "\u003cmissing\u003e"
+            },
+            {
+                "created": 1577005538,
+                "instruction": "RUN rm -rf /etc/profile /etc/profile.d",
+                "id": "\u003cmissing\u003e"
+            },
+            {
+                "created": 1577005539,
+                "instruction": "COPY multi:d9479b3e909245fed7b2a900631718984857c0bf71a667337b81fc321d0adaae in /data/ ",
+                "sizeBytes": 3379153,
+                "id": "\u003cmissing\u003e"
+            },
+            {
+                "created": 1577005539,
+                "instruction": "COPY multi:10ae56fcf0fea99ce1f31db584076e5d9ac2e445fdf52a7033997720d0788dba in /twistlock/ ",
+                "sizeBytes": 74163,
+                "id": "\u003cmissing\u003e"
+            },
+            {
+                "created": 1577005540,
+                "instruction": "VOLUME [/tmp /data /var/tmp /twistlock/]",
+                "id": "\u003cmissing\u003e"
+            },
+            {
+                "created": 1577005540,
+                "instruction": "HEALTHCHECK \u0026{[\"CMD-SHELL\" \"sh /usr/local/bin/defender_health_check.sh\"] \"20m0s\" \"10s\" \"0s\" '\\x00'}",
+                "id": "\u003cmissing\u003e"
+            },
+            {
+                "created": 1577005540,
+                "instruction": "LABEL twistlock.model.name=twistlock",
+                "id": "\u003cmissing\u003e"
+            },
+            {
+                "tags": [
+                    "twistlock/private:defender_19_11_506"
+                ],
+                "created": 1577005540,
+                "instruction": "CMD [\"/usr/local/bin/defender\"]",
+                "id": "sha256:489e32f1e7ad38b3a93a9e17895ac2709d67cb02e77308085343532dd77f8bcf"
+            }
+        ],
+        "id": "sha256:489e32f1e7ad38b3a93a9e17895ac2709d67cb02e77308085343532dd77f8bcf",
+        "complianceIssues": null,
+        "allCompliance": {},
+        "vulnerabilities": [
+            {
+                "text": "",
+                "id": 46,
+                "severity": "moderate",
+                "cvss": 9.8,
+                "status": "affected",
+                "cve": "CVE-2019-9169",
+                "cause": "",
+                "description": "In the GNU C Library (aka glibc or libc6) through 2.29, proceed_next_node in posix/regexec.c has a heap-based buffer over-read via an attempted case-insensitive regular-expression match.",
+                "title": "",
+                "vecStr": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "exploit": "",
+                "riskFactors": {
+                    "Attack complexity: low": {},
+                    "Attack vector: network": {},
+                    "Medium severity": {},
+                    "Recent vulnerability": {}
+                },
+                "link": "https://access.redhat.com/security/cve/CVE-2019-9169",
+                "type": "image",
+                "packageName": "glibc",
+                "packageVersion": "2.17-292.el7",
+                "layerTime": 1574169944,
+                "templates": null,
+                "twistlock": false,
+                "published": 1551148140,
+                "applicableRules": [
+                    "\u003c=2.29"
+                ],
+                "discovered": "2019-12-30T22:23:37.394Z"
+            },
+            {
+                "text": "",
+                "id": 46,
+                "severity": "low",
+                "cvss": 8.8,
+                "status": "affected",
+                "cve": "CVE-2019-1010023",
+                "cause": "",
+                "description": "GNU Libc current is affected by: Re-mapping current loaded libray with malicious ELF file. The impact is: In worst case attacker may evaluate privileges. The component is: libld. The attack vector is: Attacker sends 2 ELF files to victim and asks to run ldd on it. ldd execute code.",
+                "title": "",
+                "vecStr": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "exploit": "",
+                "riskFactors": {
+                    "Attack complexity: low": {},
+                    "Recent vulnerability": {}
+                },
+                "link": "https://access.redhat.com/security/cve/CVE-2019-1010023",
+                "type": "image",
+                "packageName": "glibc",
+                "packageVersion": "2.17-292.el7",
+                "layerTime": 1574169944,
+                "templates": null,
+                "twistlock": false,
+                "published": 1563164100,
+                "applicableRules": [
+                    "*"
+                ],
+                "discovered": "2019-12-30T22:23:37.394Z"
+            },
+            {
+                "text": "",
+                "id": 46,
+                "severity": "low",
+                "cvss": 2.1,
+                "status": "affected",
+                "cve": "CVE-2019-19126",
+                "cause": "",
+                "description": "On the x86-64 architecture, the GNU C Library (aka glibc) before 2.31 fails to ignore the LD_PREFER_MAP_32BIT_EXEC environment variable during program execution after a security transition, allowing local attackers to restrict the possible mapping addresses for loaded libraries and thus bypass ASLR for a setuid program.",
+                "title": "",
+                "vecStr": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+                "exploit": "",
+                "riskFactors": {
+                    "Recent vulnerability": {}
+                },
+                "link": "https://access.redhat.com/security/cve/CVE-2019-19126",
+                "type": "image",
+                "packageName": "glibc",
+                "packageVersion": "2.17-292.el7",
+                "layerTime": 1574169944,
+                "templates": null,
+                "twistlock": false,
+                "published": 1574201700,
+                "applicableRules": [
+                    "\u003c2.31"
+                ],
+                "discovered": "2019-12-30T22:23:37.394Z"
+            },
+            {
+                "text": "",
+                "id": 46,
+                "severity": "low",
+                "cvss": 7.5,
+                "status": "fix deferred",
+                "cve": "CVE-2015-2059",
+                "cause": "",
+                "description": "The stringprep_utf8_to_ucs4 function in libin before 1.31, as used in jabberd2, allows context-dependent attackers to read system memory and possibly have other unspecified impact via invalid UTF-8 characters in a string, which triggers an out-of-bounds read.",
+                "title": "",
+                "vecStr": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+                "exploit": "",
+                "riskFactors": {
+                    "Attack vector: network": {}
+                },
+                "link": "https://access.redhat.com/security/cve/CVE-2015-2059",
+                "type": "image",
+                "packageName": "libidn",
+                "packageVersion": "1.28-4.el7",
+                "layerTime": 1574169944,
+                "templates": null,
+                "twistlock": false,
+                "published": 1439391540,
+                "applicableRules": [
+                    "\u003c=1.30"
+                ],
+                "discovered": "2019-12-30T22:23:37.394Z"
+            },
+            {
+                "text": "",
+                "id": 46,
+                "severity": "moderate",
+                "cvss": 5.8,
+                "status": "affected",
+                "cve": "CVE-2019-17498",
+                "cause": "",
+                "description": "In libssh2 v1.9.0 and earlier versions, the SSH_MSG_DISCONNECT logic in packet.c has an integer overflow in a bounds check, enabling an attacker to specify an arbitrary (out-of-bounds) offset for a subsequent memory read. A crafted SSH server may be able to disclose sensitive information or cause a denial of service condition on the client system when a user connects to the server.",
+                "title": "",
+                "vecStr": "AV:N/AC:M/Au:N/C:P/I:N/A:P",
+                "exploit": "",
+                "riskFactors": {
+                    "Attack complexity: low": {},
+                    "Attack vector: network": {},
+                    "DoS": {},
+                    "Medium severity": {},
+                    "Recent vulnerability": {}
+                },
+                "link": "https://access.redhat.com/security/cve/CVE-2019-17498",
+                "type": "image",
+                "packageName": "libssh2",
+                "packageVersion": "1.8.0-3.el7",
+                "layerTime": 1574169944,
+                "templates": null,
+                "twistlock": false,
+                "published": 1571696100,
+                "applicableRules": [
+                    "\u003c=1.9.0"
+                ],
+                "discovered": "2019-12-30T22:23:37.394Z"
+            },
+            {
+                "text": "",
+                "id": 46,
+                "severity": "low",
+                "cvss": 7.8,
+                "status": "affected",
+                "cve": "CVE-2019-5436",
+                "cause": "",
+                "description": "A heap buffer overflow in the TFTP receiving code allows for DoS or arbitrary code execution in libcurl versions 7.19.4 through 7.64.1.",
+                "title": "",
+                "vecStr": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+                "exploit": "",
+                "riskFactors": {
+                    "Attack complexity: low": {},
+                    "DoS": {},
+                    "Recent vulnerability": {}
+                },
+                "link": "https://access.redhat.com/security/cve/CVE-2019-5436",
+                "type": "image",
+                "packageName": "curl",
+                "packageVersion": "7.29.0-54.el7_7.1",
+                "layerTime": 1574169944,
+                "templates": null,
+                "twistlock": false,
+                "published": 1559071740,
+                "applicableRules": [
+                    "*"
+                ],
+                "discovered": "2019-12-30T22:23:37.394Z"
+            },
+            {
+                "text": "",
+                "id": 46,
+                "severity": "moderate",
+                "cvss": 7.5,
+                "status": "affected",
+                "cve": "CVE-2019-5482",
+                "cause": "",
+                "description": "Heap buffer overflow in the TFTP protocol handler in cURL 7.19.4 to 7.65.3.",
+                "title": "",
+                "vecStr": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+                "exploit": "",
+                "riskFactors": {
+                    "Attack complexity: low": {},
+                    "Medium severity": {},
+                    "Recent vulnerability": {}
+                },
+                "link": "https://access.redhat.com/security/cve/CVE-2019-5482",
+                "type": "image",
+                "packageName": "curl",
+                "packageVersion": "7.29.0-54.el7_7.1",
+                "layerTime": 1574169944,
+                "templates": null,
+                "twistlock": false,
+                "published": 1568661300,
+                "applicableRules": [
+                    "\u003c=7.65.3",
+                    "\u003e=7.19.4"
+                ],
+                "discovered": "2019-12-30T22:23:37.394Z"
+            },
+            {
+                "text": "",
+                "id": 46,
+                "severity": "moderate",
+                "cvss": 7.8,
+                "status": "affected",
+                "cve": "CVE-2019-9924",
+                "cause": "",
+                "description": "rbash in Bash before 4.4-beta2 did not prevent the shell user from modifying BASH_CMDS, thus allowing the user to execute any command with the permissions of the shell.",
+                "title": "",
+                "vecStr": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+                "exploit": "",
+                "riskFactors": {
+                    "Attack complexity: low": {},
+                    "Medium severity": {},
+                    "Recent vulnerability": {}
+                },
+                "link": "https://access.redhat.com/security/cve/CVE-2019-9924",
+                "type": "image",
+                "packageName": "bash",
+                "packageVersion": "4.2.46-33.el7",
+                "layerTime": 1574169944,
+                "templates": null,
+                "twistlock": false,
+                "published": 1553243340,
+                "applicableRules": [
+                    "\u003c4.4"
+                ],
+                "discovered": "2019-12-30T22:23:37.394Z"
+            },
+            {
+                "text": "",
+                "id": 46,
+                "severity": "important",
+                "cvss": 8.8,
+                "status": "affected",
+                "cve": "CVE-2019-5827",
+                "cause": "",
+                "description": "Integer overflow in SQLite via WebSQL in Google Chrome prior to 74.0.3729.131 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
+                "title": "",
+                "vecStr": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "exploit": "",
+                "riskFactors": {
+                    "Attack complexity: low": {},
+                    "Attack vector: network": {},
+                    "High severity": {},
+                    "Recent vulnerability": {}
+                },
+                "link": "https://access.redhat.com/security/cve/CVE-2019-5827",
+                "type": "image",
+                "packageName": "sqlite",
+                "packageVersion": "3.7.17-8.el7",
+                "layerTime": 1574169944,
+                "templates": null,
+                "twistlock": false,
+                "published": 1561655700,
+                "applicableRules": [
+                    "*"
+                ],
+                "discovered": "2019-12-30T22:23:37.394Z"
+            },
+            {
+                "text": "",
+                "id": 46,
+                "severity": "moderate",
+                "cvss": 9.8,
+                "status": "affected",
+                "cve": "CVE-2019-8457",
+                "cause": "",
+                "description": "SQLite3 from 3.6.0 to and including 3.27.2 is vulnerable to heap out-of-bound read in the rtreenode() function when handling invalid rtree tables.",
+                "title": "",
+                "vecStr": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "exploit": "",
+                "riskFactors": {
+                    "Attack complexity: low": {},
+                    "Attack vector: network": {},
+                    "Medium severity": {},
+                    "Recent vulnerability": {}
+                },
+                "link": "https://access.redhat.com/security/cve/CVE-2019-8457",
+                "type": "image",
+                "packageName": "sqlite",
+                "packageVersion": "3.7.17-8.el7",
+                "layerTime": 1574169944,
+                "templates": null,
+                "twistlock": false,
+                "published": 1559233740,
+                "applicableRules": [
+                    "\u003c=3.27.2",
+                    "\u003e=3.6.0"
+                ],
+                "discovered": "2019-12-30T22:23:37.394Z"
+            },
+            {
+                "text": "",
+                "id": 46,
+                "severity": "moderate",
+                "cvss": 4.9,
+                "status": "affected",
+                "cve": "CVE-2019-13057",
+                "cause": "",
+                "description": "An issue was discovered in the server in OpenLDAP before 2.4.48. When the server administrator delegates rootDN (database admin) privileges for certain databases but wants to maintain isolation (e.g., for multi-tenant deployments), slapd does not properly stop a rootDN from requesting authorization as an identity from another database during a SASL bind or with a proxyAuthz (RFC 4370) control. (It is not a common configuration to deploy a system where the server administrator and a DB administrator enjoy different levels of trust.)",
+                "title": "",
+                "vecStr": "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N",
+                "exploit": "",
+                "riskFactors": {
+                    "Attack complexity: low": {},
+                    "Attack vector: network": {},
+                    "Medium severity": {},
+                    "Recent vulnerability": {}
+                },
+                "link": "https://access.redhat.com/security/cve/CVE-2019-13057",
+                "type": "image",
+                "packageName": "openldap",
+                "packageVersion": "2.4.44-21.el7_6",
+                "layerTime": 1574169944,
+                "templates": null,
+                "twistlock": false,
+                "published": 1564146900,
+                "applicableRules": [
+                    "\u003c2.4.48"
+                ],
+                "discovered": "2019-12-30T22:23:37.394Z"
+            },
+            {
+                "text": "",
+                "id": 46,
+                "severity": "moderate",
+                "cvss": 5,
+                "status": "affected",
+                "cve": "CVE-2019-13565",
+                "cause": "",
+                "description": "An issue was discovered in OpenLDAP 2.x before 2.4.48. When using SASL authentication and session encryption, and relying on the SASL security layers in slapd access controls, it is possible to obtain access that would otherwise be denied via a simple bind for any identity covered in those ACLs. After the first SASL bind is completed, the sasl_ssf value is retained for all new non-SASL connections. Depending on the ACL configuration, this can affect different types of operations (searches, modifications, etc.). In other words, a successful authorization step completed by one user affects the authorization requirement for a different user.",
+                "title": "",
+                "vecStr": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+                "exploit": "",
+                "riskFactors": {
+                    "Attack vector: network": {},
+                    "Medium severity": {},
+                    "Recent vulnerability": {}
+                },
+                "link": "https://access.redhat.com/security/cve/CVE-2019-13565",
+                "type": "image",
+                "packageName": "openldap",
+                "packageVersion": "2.4.44-21.el7_6",
+                "layerTime": 1574169944,
+                "templates": null,
+                "twistlock": false,
+                "published": 1564146900,
+                "applicableRules": [
+                    "\u003c=2.4.47",
+                    "\u003e=2.0"
+                ],
+                "discovered": "2019-12-30T22:23:37.394Z"
+            },
+            {
+                "text": "",
+                "id": 46,
+                "severity": "moderate",
+                "cvss": 7.5,
+                "status": "affected",
+                "cve": "CVE-2019-11719",
+                "cause": "",
+                "description": "When importing a curve25519 private key in PKCS#8format with leading 0x00 bytes, it is possible to trigger an out-of-bounds read in the Network Security Services (NSS) library. This could lead to information disclosure. This vulnerability affects Firefox ESR \u003c 60.8, Firefox \u003c 68, and Thunderbird \u003c 60.8.",
+                "title": "",
+                "vecStr": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+                "exploit": "",
+                "riskFactors": {
+                    "Attack complexity: low": {},
+                    "Attack vector: network": {},
+                    "Medium severity": {},
+                    "Recent vulnerability": {}
+                },
+                "link": "https://access.redhat.com/security/cve/CVE-2019-11719",
+                "type": "image",
+                "packageName": "nss",
+                "packageVersion": "3.44.0-7.el7_7",
+                "layerTime": 1577005535,
+                "templates": null,
+                "twistlock": false,
+                "published": 1563891300,
+                "applicableRules": [
+                    "*"
+                ],
+                "discovered": "2019-12-30T22:23:37.394Z"
+            },
+            {
+                "text": "",
+                "id": 46,
+                "severity": "low",
+                "cvss": 5.3,
+                "status": "affected",
+                "cve": "CVE-2019-11727",
+                "cause": "",
+                "description": "A vulnerability exists where it possible to force Network Security Services (NSS) to sign CertificateVerify with PKCS#1 v1.5 signatures when those are the only ones advertised by server in CertificateRequest in TLS 1.3. PKCS#1 v1.5 signatures should not be used for TLS 1.3 messages. This vulnerability affects Firefox \u003c 68.",
+                "title": "",
+                "vecStr": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+                "exploit": "",
+                "riskFactors": {
+                    "Attack vector: network": {},
+                    "Recent vulnerability": {}
+                },
+                "link": "https://access.redhat.com/security/cve/CVE-2019-11727",
+                "type": "image",
+                "packageName": "nss",
+                "packageVersion": "3.44.0-7.el7_7",
+                "layerTime": 1577005535,
+                "templates": null,
+                "twistlock": false,
+                "published": 1563891300,
+                "applicableRules": [
+                    "*"
+                ],
+                "discovered": "2019-12-30T22:23:37.394Z"
+            },
+            {
+                "text": "",
+                "id": 46,
+                "severity": "moderate",
+                "cvss": 7.1,
+                "status": "affected",
+                "cve": "CVE-2019-11756",
+                "cause": "",
+                "description": "no description is available for this cve.",
+                "title": "",
+                "vecStr": "",
+                "exploit": "",
+                "riskFactors": {
+                    "Attack vector: network": {},
+                    "Medium severity": {},
+                    "Recent vulnerability": {}
+                },
+                "link": "https://access.redhat.com/security/cve/CVE-2019-11756",
+                "type": "image",
+                "packageName": "nss",
+                "packageVersion": "3.44.0-7.el7_7",
+                "layerTime": 1577005535,
+                "templates": null,
+                "twistlock": false,
+                "published": 1575936000,
+                "applicableRules": [
+                    "*"
+                ],
+                "discovered": "2019-12-30T22:23:37.394Z"
+            },
+            {
+                "text": "",
+                "id": 46,
+                "severity": "moderate",
+                "cvss": 8.1,
+                "status": "affected",
+                "cve": "CVE-2019-17006",
+                "cause": "",
+                "description": "no description is available for this cve.",
+                "title": "",
+                "vecStr": "",
+                "exploit": "",
+                "riskFactors": {
+                    "Attack vector: network": {},
+                    "Medium severity": {},
+                    "Recent vulnerability": {}
+                },
+                "link": "https://access.redhat.com/security/cve/CVE-2019-17006",
+                "type": "image",
+                "packageName": "nss",
+                "packageVersion": "3.44.0-7.el7_7",
+                "layerTime": 1577005535,
+                "templates": null,
+                "twistlock": false,
+                "published": 1577318400,
+                "applicableRules": [
+                    "*"
+                ],
+                "discovered": "2019-12-30T22:23:37.394Z"
+            }
+        ],
+        "repoTag": {
+            "registry": "",
+            "repo": "twistlock/private",
+            "tag": "defender_19_11_506"
+        },
+        "tags": [
+            {
+                "registry": "",
+                "repo": "twistlock/private",
+                "tag": "defender_19_11_506"
+            }
+        ],
+        "repoDigests": [],
+        "creationTime": "2019-12-22T09:05:40.741Z",
+        "vulnerabilitiesCount": 16,
+        "complianceIssuesCount": 0,
+        "vulnerabilityDistribution": {
+            "critical": 0,
+            "high": 1,
+            "medium": 10,
+            "low": 5,
+            "total": 16
+        },
+        "complianceDistribution": {
+            "critical": 0,
+            "high": 0,
+            "medium": 0,
+            "low": 0,
+            "total": 0
+        },
+        "vulnerabilityRiskScore": 11005,
+        "complianceRiskScore": 0,
+        "layers": [
+            "sha256:6f4acc6ac0c0ffaab4fe2fa3d615c736b0b69464ace2df69353005b6d94aad7b",
+            "sha256:d14729e6ca5b90409f4c912f344cbb29c171c372d65529a5eebd977e56463c58",
+            "sha256:778fd5ad77167eb1c1d7e789c17e536d45033a5641b1fd5d26d51df8db54beb9",
+            "sha256:5982df3322eebf7fb23b24b1c4ea47fe4613d57c6c4e31fa4d38cd6ca121d953",
+            "sha256:0e717e2beebd39549d8d4c160ffd06dd8b847a5a3f3d84cc10950fea6e91a0ea",
+            "sha256:bb4329cf9ab668e54ee924995dd18ec9a0bf524dc9c3f9b9003e838f3f30b2f5",
+            "sha256:421a077be289c45265b876a7dcfabce5c8206036fce505be3f4ba105315591bf"
+        ],
+        "topLayer": "sha256:421a077be289c45265b876a7dcfabce5c8206036fce505be3f4ba105315591bf",
+        "riskFactors": {
+            "Attack complexity: low": {},
+            "Attack vector: network": {},
+            "DoS": {},
+            "High severity": {},
+            "Medium severity": {},
+            "Recent vulnerability": {}
+        },
+        "labels": [
+            "distribution-scope:public",
+            "vcs-ref:22f607d32349cd03d6c60f3f5e23070d26a70927",
+            "build-date:2019-11-19T13:25:35.659917",
+            "com.redhat.license_terms:https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
+            "maintainer:Red Hat, Inc.",
+            "name:ubi7-minimal",
+            "release:211",
+            "summary:Provides the latest release of the minimal Red Hat Universal Base Image 7.",
+            "twistlock.model.name:twistlock",
+            "version:7.7",
+            "authoritative-source-url:registry.access.redhat.com",
+            "com.redhat.component:ubi7-minimal-container",
+            "description:The Universal Base Image Minimal is a stripped down image that uses microdnf as a package manager. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
+            "io.k8s.description:The Universal Base Image Minimal is a stripped down image that uses microdnf as a package manager. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
+            "io.k8s.display-name:Red Hat Universal Base Image 7 Minimal",
+            "vcs-type:git",
+            "architecture:x86_64",
+            "com.redhat.build-host:cpt-1008.osbs.prod.upshift.rdu2.redhat.com",
+            "vendor:Red Hat, Inc.",
+            "io.openshift.tags:minimal rhel7",
+            "url:https://access.redhat.com/containers/#/registry.access.redhat.com/ubi7-minimal/images/7.7-211"
+        ],
+        "installedProducts": {
+            "docker": "19.03.5",
+            "hasPackageManager": true
+        },
+        "scanVersion": "19.11.506",
+        "twistlockImage": true,
+        "firstScanTime": "2019-12-30T22:23:37.394Z",
+        "trust": {
+            "status": "trusted",
+            "reason": "learned as Trusted Image by Twistlock"
+        },
+        "instances": [
+        ],
+        "hosts": {
+            "ubuntu-xenial": {
+                "modified": "2019-12-30T22:23:37.394Z"
+            }
+        },
+        "err": "",
+        "collections": [
+            "All"
+        ],
+        "scanID": 0
+    }    
 ]

--- a/twistlock/tests/test_twistlock.py
+++ b/twistlock/tests/test_twistlock.py
@@ -89,6 +89,23 @@ def test_config_project(aggregator, instance, fixture_group):
         aggregator.assert_metric_has_tag(metric, project_tag)
 
 
+@pytest.mark.parametrize('fixture_group', ['twistlock', 'prisma_cloud'])
+def test_report_image_scan_empty_instances(aggregator, instance, fixture_group):
+    check = TwistlockCheck('twistlock', {}, [instance])
+
+    def mock_get(url, *args, **kwargs):
+        split_url = url.split('/')
+        path = split_url[-1]
+
+        if path != 'images':
+            return MockResponse(file_path=os.path.join(HERE, 'fixtures', fixture_group, '{}.json'.format(path)))
+        return MockResponse(file_path=os.path.join(HERE, 'fixtures', 'empty_images.json'))
+
+    with mock.patch('requests.get', side_effect=mock_get):
+        check.check(instance)
+        check.check(instance)
+
+
 def test_err_response(aggregator, instance):
 
     check = TwistlockCheck('twistlock', {}, [instance])


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This issue came up in a support case where the customer is getting an IndexError since their `/images` endpoint for Primsa Cloud returns an empty images array. We call the first Index directly with `instance = instances[0]` so this PR helps alleviate the `IndexError` issue from happening, allowing the rest of the check to go to completion.
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
