### PR TITLE
[DBMON-3271] DBM integrations now defaulted to use new go-sqllexer pkg to obfuscate sql statements

### DIFF
--- a/mysql/changelog.d/16681.added
+++ b/mysql/changelog.d/16681.added
@@ -1,0 +1,1 @@
+[DBMON-3271] DBM integrations now defaulted to use new go-sqllexer pkg to obfuscate sql statements

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -72,7 +72,7 @@ class MySQLConfig(object):
             'collect_comments': is_affirmative(obfuscator_options_config.get('collect_comments', True)),
             # Config to enable/disable obfuscation of sql statements with go-sqllexer pkg
             # Valid values for this can be found at https://github.com/DataDog/datadog-agent/blob/main/pkg/obfuscate/obfuscate.go#L108
-            'obfuscation_mode': obfuscator_options_config.get('obfuscation_mode', ''),
+            'obfuscation_mode': obfuscator_options_config.get('obfuscation_mode', 'obfuscate_and_normalize'),
             'remove_space_between_parentheses': is_affirmative(
                 obfuscator_options_config.get('remove_space_between_parentheses', False)
             ),

--- a/postgres/changelog.d/16681.added
+++ b/postgres/changelog.d/16681.added
@@ -1,0 +1,1 @@
+[DBMON-3271] DBM integrations now defaulted to use new go-sqllexer pkg to obfuscate sql statements

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -143,7 +143,7 @@ class PostgresConfig:
             'collect_comments': is_affirmative(obfuscator_options_config.get('collect_comments', True)),
             # Config to enable/disable obfuscation of sql statements with go-sqllexer pkg
             # Valid values for this can be found at https://github.com/DataDog/datadog-agent/blob/main/pkg/obfuscate/obfuscate.go#L108
-            'obfuscation_mode': obfuscator_options_config.get('obfuscation_mode', ''),
+            'obfuscation_mode': obfuscator_options_config.get('obfuscation_mode', 'obfuscate_and_normalize'),
             'remove_space_between_parentheses': is_affirmative(
                 obfuscator_options_config.get('remove_space_between_parentheses', False)
             ),

--- a/sqlserver/changelog.d/16681.added
+++ b/sqlserver/changelog.d/16681.added
@@ -1,0 +1,1 @@
+[DBMON-3271] DBM integrations now defaulted to use new go-sqllexer pkg to obfuscate sql statements

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -66,7 +66,7 @@ class SQLServerConfig:
                     'collect_comments': is_affirmative(obfuscator_options_config.get('collect_comments', True)),
                     # Config to enable/disable obfuscation of sql statements with go-sqllexer pkg
                     # Valid values for this can be found at https://github.com/DataDog/datadog-agent/blob/main/pkg/obfuscate/obfuscate.go#L108
-                    'obfuscation_mode': obfuscator_options_config.get('obfuscation_mode', ''),
+                    'obfuscation_mode': obfuscator_options_config.get('obfuscation_mode', 'obfuscate_and_normalize'),
                     'remove_space_between_parentheses': is_affirmative(
                         obfuscator_options_config.get('remove_space_between_parentheses', False)
                     ),


### PR DESCRIPTION
### What does this PR do?
This PR defaults postgres, mysql and sqlserver integrations' `obfuscation_mode` to `obfuscate_and_normalize`. With this change, the integration will use `go-sqllexer` as the default sql statements obfuscator.

### Motivation
Default to `go-sqllexer` as the default sql statements obfuscator to better obfuscation on edge cases and error handling. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
