### PR TITLE
[ECOS-1128] Allow script to run on apps that lack integration assets.

### DIFF
--- a/ddev/changelog.d/16682.fixed
+++ b/ddev/changelog.d/16682.fixed
@@ -1,0 +1,1 @@
+Allow CI matrix script to run on apps that lack integration assets.

--- a/ddev/src/ddev/utils/scripts/ci_matrix.py
+++ b/ddev/src/ddev/utils/scripts/ci_matrix.py
@@ -223,7 +223,7 @@ def construct_job_matrix(root: Path, targets: list[str]) -> list[dict[str, Any]]
 
             if target in display_overrides:
                 config['name'] = display_overrides[target]
-            elif manifest:
+            elif manifest and 'integration' in manifest.get('assets', {}):
                 config['name'] = manifest['assets']['integration']['source_type_name']
             else:
                 config['name'] = target


### PR DESCRIPTION
### What does this PR do?
Prevents CI failures like this one: https://github.com/DataDog/integrations-extras/actions/runs/7617723824/job/20747356953?pr=2265

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
