### PR TITLE
Documentation improvements for testing commands:

### DIFF
--- a/ddev/changelog.d/16691.fixed
+++ b/ddev/changelog.d/16691.fixed
@@ -1,0 +1,1 @@
+Clarify how to pass arguments to the testing commands

--- a/ddev/src/ddev/cli/env/test.py
+++ b/ddev/src/ddev/cli/env/test.py
@@ -11,10 +11,10 @@ if TYPE_CHECKING:
     from ddev.cli.application import Application
 
 
-@click.command('test', short_help='Test environments')
+@click.command('test')
 @click.argument('intg_name', metavar='INTEGRATION')
 @click.argument('environment', required=False)
-@click.argument('args', nargs=-1)
+@click.argument('pytest_args', nargs=-1)
 @click.option('--dev', 'local_dev', is_flag=True, help='Install the local version of the integration')
 @click.option(
     '--base',
@@ -46,7 +46,7 @@ def test_command(
     *,
     intg_name: str,
     environment: str | None,
-    args: tuple[str, ...],
+    pytest_args: tuple[str, ...],
     local_dev: bool,
     local_base: bool,
     agent_build: str | None,
@@ -58,12 +58,19 @@ def test_command(
     """
     Test environments.
 
-    If no environment is specified, `active` is selected which will test all environments
+    This runs the end-to-end tests.
+
+    If no ENVIRONMENT is specified, `active` is selected which will test all environments
     that are currently running. You may choose `all` to test all environments whether or not
     they are running.
 
     Testing active environments will not stop them after tests complete. Testing environments
     that are not running will start and stop them automatically.
+
+    See these docs for to pass ENVIRONMENT and PYTEST_ARGS:
+
+    \b
+    https://datadoghq.dev/integrations-core/testing/
     """
     from ddev.cli.env.start import start
     from ddev.cli.env.stop import stop
@@ -135,7 +142,7 @@ def test_command(
 
             with EnvVars(env_vars):
                 ctx.invoke(
-                    test, target_spec=f'{intg_name}:{env_name}', args=args, junit=junit, hide_header=True, e2e=True
+                    test, target_spec=f'{intg_name}:{env_name}', args=pytest_args, junit=junit, hide_header=True, e2e=True
                 )
         finally:
             ctx.invoke(stop, intg_name=intg_name, environment=env_name, ignore_state=env_active)

--- a/ddev/src/ddev/cli/env/test.py
+++ b/ddev/src/ddev/cli/env/test.py
@@ -142,7 +142,12 @@ def test_command(
 
             with EnvVars(env_vars):
                 ctx.invoke(
-                    test, target_spec=f'{intg_name}:{env_name}', args=pytest_args, junit=junit, hide_header=True, e2e=True
+                    test,
+                    target_spec=f'{intg_name}:{env_name}',
+                    args=pytest_args,
+                    junit=junit,
+                    hide_header=True,
+                    e2e=True,
                 )
         finally:
             ctx.invoke(stop, intg_name=intg_name, environment=env_name, ignore_state=env_active)

--- a/ddev/src/ddev/cli/env/test.py
+++ b/ddev/src/ddev/cli/env/test.py
@@ -144,7 +144,7 @@ def test_command(
                 ctx.invoke(
                     test,
                     target_spec=f'{intg_name}:{env_name}',
-                    args=pytest_args,
+                    pytest_args=pytest_args,
                     junit=junit,
                     hide_header=True,
                     e2e=True,

--- a/ddev/src/ddev/cli/test/__init__.py
+++ b/ddev/src/ddev/cli/test/__init__.py
@@ -22,6 +22,7 @@ def fix_coverage_report(report_file: Path):
 
     report_file.write_bytes(report)
 
+
 epilog = '''
 Examples
 
@@ -37,6 +38,7 @@ ddev test postgres:py3.11-9.6 -- -m unit
 Run specific test in multiple environments:
 ddev test postgres:py3.11-9.6,py3.11-16.0 -- -k test_my_special_test
 '''
+
 
 @click.command(epilog=epilog)
 @click.argument('target_spec', required=False)

--- a/ddev/src/ddev/cli/test/__init__.py
+++ b/ddev/src/ddev/cli/test/__init__.py
@@ -22,10 +22,25 @@ def fix_coverage_report(report_file: Path):
 
     report_file.write_bytes(report)
 
+epilog = '''
+Examples
 
-@click.command(short_help='Run tests')
+\b
+List possible environments for postgres:
+ddev test -l postgres
+
+\b
+Run only unit tests:
+ddev test postgres:py3.11-9.6 -- -m unit
+
+\b
+Run specific test in multiple environments:
+ddev test postgres:py3.11-9.6,py3.11-16.0 -- -k test_my_special_test
+'''
+
+@click.command(epilog=epilog)
 @click.argument('target_spec', required=False)
-@click.argument('args', nargs=-1)
+@click.argument('pytest_args', nargs=-1)
 @click.option('--lint', '-s', is_flag=True, help='Run only lint & style checks')
 @click.option('--fmt', '-fs', is_flag=True, help='Run only the code formatter')
 @click.option('--bench', '-b', is_flag=True, help='Run only benchmarks')
@@ -44,7 +59,7 @@ def fix_coverage_report(report_file: Path):
 def test(
     app: Application,
     target_spec: str | None,
-    args: tuple[str, ...],
+    pytest_args: tuple[str, ...],
     lint: bool,
     fmt: bool,
     bench: bool,
@@ -61,7 +76,12 @@ def test(
     e2e: bool,
 ):
     """
-    Run tests.
+    Run unit and integration tests.
+
+    Please see these docs for to pass TARGET_SPEC and PYTEST_ARGS:
+
+    \b
+    https://datadoghq.dev/integrations-core/testing/
     """
     import json
     import os
@@ -210,7 +230,7 @@ def test(
             ):
                 env_vars[TestEnvVars.BASE_PACKAGE_VERSION] = target.minimum_base_package_version
 
-        command.extend(args)
+        command.extend(pytest_args)
 
         with target.path.as_cwd(env_vars=env_vars):
             app.display_debug(f'Command: {command}')


### PR DESCRIPTION


### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
- Remove unnecessary `short_help` option.
- Clearer name for pytest args
- Add link to official docs that explain how to pass environments and pytest args
- Add examples for unit/integration test command

### Motivation
<!-- What inspired you to submit this pull request? -->
Someone reached out on slack, their team-internal docs were out of date and they couldn't get the information they needed to get started from our docs.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
