### PR TITLE
[ECOS-1140] Backfill integration manifest fields.

### DIFF
--- a/active_directory/manifest.json
+++ b/active_directory/manifest.json
@@ -40,7 +40,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10068,
+      "auto_install": true
     },
     "dashboards": {
       "Active Directory": "assets/dashboards/active_directory.json"

--- a/activemq/manifest.json
+++ b/activemq/manifest.json
@@ -48,7 +48,9 @@
       },
       "process_signatures": [
         "activemq"
-      ]
+      ],
+      "source_type_id": 40,
+      "auto_install": true
     },
     "dashboards": {
       "activemq": "assets/dashboards/activemq_dashboard.json",

--- a/activemq_xml/manifest.json
+++ b/activemq_xml/manifest.json
@@ -42,7 +42,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10240,
+      "auto_install": true
     },
     "logs": {
       "source": "activemq"

--- a/aerospike/manifest.json
+++ b/aerospike/manifest.json
@@ -40,7 +40,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10067,
+      "auto_install": true
     },
     "dashboards": {
       "Aerospike Overview": "assets/dashboards/overview.json"

--- a/airbyte/manifest.json
+++ b/airbyte/manifest.json
@@ -24,9 +24,9 @@
       "metrics": {
         "prefix": "airbyte.",
         "check": [
-            "airbyte.metrics_reporter.est_num_metrics_emitted_by_reporter",
-            "airbyte.worker.attempt.created",
-            "airbyte.cron.jobs_run"
+          "airbyte.metrics_reporter.est_num_metrics_emitted_by_reporter",
+          "airbyte.worker.attempt.created",
+          "airbyte.cron.jobs_run"
         ],
         "metadata_path": "metadata.csv"
       },
@@ -39,13 +39,15 @@
         "airbyte-server",
         "airbyte-workers",
         "uvicorn connector_builder.entrypoint:app"
-      ]
+      ],
+      "source_type_id": 10386,
+      "auto_install": true
     },
     "dashboards": {
-        "airbyte_overview": "assets/dashboards/airbyte_overview.json"
+      "airbyte_overview": "assets/dashboards/airbyte_overview.json"
     },
     "monitors": {
-        "long_running_jobs": "assets/monitors/long_running_jobs.json"
+      "long_running_jobs": "assets/monitors/long_running_jobs.json"
     }
   },
   "author": {

--- a/airflow/manifest.json
+++ b/airflow/manifest.json
@@ -45,7 +45,9 @@
       },
       "process_signatures": [
         "airflow"
-      ]
+      ],
+      "source_type_id": 10083,
+      "auto_install": true
     },
     "dashboards": {
       "Airflow Overview": "assets/dashboards/overview.json"

--- a/amazon_eks/manifest.json
+++ b/amazon_eks/manifest.json
@@ -40,7 +40,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10018,
+      "auto_install": true
     }
   }
 }

--- a/amazon_eks_blueprints/manifest.json
+++ b/amazon_eks_blueprints/manifest.json
@@ -37,7 +37,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10268,
+      "auto_install": true
     }
   }
 }

--- a/amazon_msk/manifest.json
+++ b/amazon_msk/manifest.json
@@ -41,7 +41,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10080,
+      "auto_install": true
     },
     "dashboards": {
       "Amazon MSK Overview": "assets/dashboards/overview.json"

--- a/ambari/manifest.json
+++ b/ambari/manifest.json
@@ -41,7 +41,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10064,
+      "auto_install": true
     },
     "dashboards": {
       "Ambari base dashboard": "assets/dashboards/base_dashboard.json"

--- a/apache/manifest.json
+++ b/apache/manifest.json
@@ -46,7 +46,9 @@
         "httpd",
         "apache",
         "apache2"
-      ]
+      ],
+      "source_type_id": 30,
+      "auto_install": true
     },
     "dashboards": {
       "apache": "assets/dashboards/apache_dashboard.json"

--- a/arangodb/manifest.json
+++ b/arangodb/manifest.json
@@ -43,7 +43,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10266,
+      "auto_install": true
     },
     "dashboards": {
       "ArangoDB Overview": "assets/dashboards/arangodb_overview.json"

--- a/argocd/manifest.json
+++ b/argocd/manifest.json
@@ -48,7 +48,9 @@
         "argocd-repo-server",
         "argocd-server",
         "argocd-notifications-controller"
-      ]
+      ],
+      "source_type_id": 10314,
+      "auto_install": true
     },
     "logs": {
       "source": "argocd"

--- a/aspdotnet/manifest.json
+++ b/aspdotnet/manifest.json
@@ -40,7 +40,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10039,
+      "auto_install": true
     },
     "dashboards": {
       "ASP.NET - Overview": "assets/dashboards/overview.json"

--- a/avi_vantage/manifest.json
+++ b/avi_vantage/manifest.json
@@ -47,7 +47,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10189,
+      "auto_install": true
     },
     "dashboards": {
       "Avi Vantage - Overview": "assets/dashboards/overview.json"

--- a/azure_active_directory/manifest.json
+++ b/azure_active_directory/manifest.json
@@ -37,7 +37,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10106,
+      "auto_install": true
     },
     "logs": {
       "source": "azure.active_directory"

--- a/azure_iot_edge/manifest.json
+++ b/azure_iot_edge/manifest.json
@@ -44,7 +44,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10125,
+      "auto_install": true
     },
     "dashboards": {
       "azure_iot_edge": "assets/dashboards/overview.json"

--- a/boundary/manifest.json
+++ b/boundary/manifest.json
@@ -42,7 +42,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10280,
+      "auto_install": true
     },
     "monitors": {
       "[Boundary] High active connections": "assets/monitors/active_connections.json"

--- a/btrfs/manifest.json
+++ b/btrfs/manifest.json
@@ -40,7 +40,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 89,
+      "auto_install": true
     },
     "dashboards": {
       "btrfs": "assets/dashboards/btrfs_dashboard.json"

--- a/cacti/manifest.json
+++ b/cacti/manifest.json
@@ -40,7 +40,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 25,
+      "auto_install": true
     },
     "logs": {
       "source": "cacti"

--- a/calico/manifest.json
+++ b/calico/manifest.json
@@ -46,7 +46,9 @@
       ],
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10236,
+      "auto_install": true
     },
     "dashboards": {
       "[calico] dashboard overview": "./assets/dashboards/calico_overview.json"

--- a/cassandra/manifest.json
+++ b/cassandra/manifest.json
@@ -46,7 +46,9 @@
       },
       "process_signatures": [
         "java org.apache.cassandra.service.CassandraDaemon"
-      ]
+      ],
+      "source_type_id": 33,
+      "auto_install": true
     },
     "dashboards": {
       "cassandra-overview": "assets/dashboards/cassandra_overview.json",

--- a/cassandra_nodetool/manifest.json
+++ b/cassandra_nodetool/manifest.json
@@ -41,7 +41,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10238,
+      "auto_install": true
     }
   }
 }

--- a/ceph/manifest.json
+++ b/ceph/manifest.json
@@ -43,7 +43,13 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
-      "process_signatures": ["ceph-mon", "ceph-mgr", "ceph-osd"]
+      "process_signatures": [
+        "ceph-mon",
+        "ceph-mgr",
+        "ceph-osd"
+      ],
+      "source_type_id": 138,
+      "auto_install": true
     },
     "dashboards": {
       "ceph": "assets/dashboards/overview.json"

--- a/cert_manager/manifest.json
+++ b/cert_manager/manifest.json
@@ -43,7 +43,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10161,
+      "auto_install": true
     },
     "dashboards": {
       "Cert-Manager Overview Dashboard": "assets/dashboards/certmanager_overview.json"

--- a/cilium/manifest.json
+++ b/cilium/manifest.json
@@ -44,12 +44,14 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }, 
+      },
       "process_signatures": [
         "cilium-operator-generic",
         "cilium-agent",
         "cilium-health-responder"
-      ]
+      ],
+      "source_type_id": 10077,
+      "auto_install": true
     },
     "dashboards": {
       "Cilium Overview": "assets/dashboards/overview.json"

--- a/cisco_aci/manifest.json
+++ b/cisco_aci/manifest.json
@@ -41,7 +41,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 210,
+      "auto_install": true
     },
     "dashboards": {
       "cisco_aci": "assets/dashboards/cisco_aci_dashboard.json"

--- a/citrix_hypervisor/manifest.json
+++ b/citrix_hypervisor/manifest.json
@@ -42,7 +42,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10198,
+      "auto_install": true
     },
     "monitors": {
       "VM CPU high": "assets/monitors/vm_cpu_high.json",

--- a/clickhouse/manifest.json
+++ b/clickhouse/manifest.json
@@ -43,7 +43,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10078,
+      "auto_install": true
     },
     "dashboards": {
       "ClickHouse Overview": "assets/dashboards/overview.json"

--- a/cloudera/manifest.json
+++ b/cloudera/manifest.json
@@ -37,7 +37,9 @@
       },
       "process_signatures": [
         "cdp"
-      ]
+      ],
+      "source_type_id": 10318,
+      "auto_install": true
     },
     "dashboards": {
       "Cloudera Data Platform Overview": "assets/dashboards/cloudera_overview.json"

--- a/cockroachdb/manifest.json
+++ b/cockroachdb/manifest.json
@@ -45,7 +45,11 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
-      "process_signatures": ["cockroach"]
+      "process_signatures": [
+        "cockroach"
+      ],
+      "source_type_id": 10036,
+      "auto_install": true
     },
     "dashboards": {
       "CockroachDB Overview": "assets/dashboards/overview.json"

--- a/confluent_platform/manifest.json
+++ b/confluent_platform/manifest.json
@@ -41,7 +41,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10091,
+      "auto_install": true
     },
     "dashboards": {
       "Confluent Platform Overview": "assets/dashboards/overview.json"

--- a/consul/manifest.json
+++ b/consul/manifest.json
@@ -51,7 +51,9 @@
         "consul agent",
         "consul_agent",
         "consul-agent"
-      ]
+      ],
+      "source_type_id": 122,
+      "auto_install": true
     },
     "dashboards": {
       "consul": "assets/dashboards/consul_dashboard.json"

--- a/consul_connect/manifest.json
+++ b/consul_connect/manifest.json
@@ -36,7 +36,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10174,
+      "auto_install": true
     },
     "logs": {
       "source": "envoy"

--- a/container/manifest.json
+++ b/container/manifest.json
@@ -39,7 +39,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10242,
+      "auto_install": true
     },
     "dashboards": {
       "Containers": "assets/dashboards/containers.json"

--- a/containerd/manifest.json
+++ b/containerd/manifest.json
@@ -39,7 +39,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10082,
+      "auto_install": true
     }
   }
 }

--- a/coredns/manifest.json
+++ b/coredns/manifest.json
@@ -46,7 +46,9 @@
       },
       "process_signatures": [
         "coredns"
-      ]
+      ],
+      "source_type_id": 10038,
+      "auto_install": true
     },
     "dashboards": {
       "CoreDNS": "assets/dashboards/coredns.json"

--- a/couch/manifest.json
+++ b/couch/manifest.json
@@ -47,7 +47,11 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
-      "process_signatures": ["couchjs"]
+      "process_signatures": [
+        "couchjs"
+      ],
+      "source_type_id": 20,
+      "auto_install": true
     },
     "dashboards": {
       "couchdb": "assets/dashboards/CouchDB-overview_dashboard.json",

--- a/couchbase/manifest.json
+++ b/couchbase/manifest.json
@@ -44,7 +44,11 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
-      "process_signatures": ["beam.smp couchbase"]
+      "process_signatures": [
+        "beam.smp couchbase"
+      ],
+      "source_type_id": 59,
+      "auto_install": true
     },
     "dashboards": {
       "couchbase": "assets/dashboards/couchbase_dashboard.json"

--- a/cri/manifest.json
+++ b/cri/manifest.json
@@ -38,7 +38,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10043,
+      "auto_install": true
     },
     "dashboards": {
       "cri": "assets/dashboards/overview.json"

--- a/crio/manifest.json
+++ b/crio/manifest.json
@@ -41,7 +41,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10044,
+      "auto_install": true
     },
     "dashboards": {
       "crio": "assets/dashboards/overview.json"

--- a/databricks/manifest.json
+++ b/databricks/manifest.json
@@ -35,7 +35,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10152,
+      "auto_install": true
     },
     "logs": {
       "source": "spark"

--- a/datadog_cluster_agent/manifest.json
+++ b/datadog_cluster_agent/manifest.json
@@ -41,7 +41,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10108,
+      "auto_install": true
     },
     "dashboards": {
       "Datadog Cluster Agent - Overview": "assets/dashboards/datadog_cluster_agent_overview.json"

--- a/datadog_operator/manifest.json
+++ b/datadog_operator/manifest.json
@@ -28,9 +28,11 @@
         "check": "datadog.operator.go_info",
         "metadata_path": "metadata.csv"
       },
-    "service_checks": {
-      "metadata_path": "assets/service_checks.json"
-      }
+      "service_checks": {
+        "metadata_path": "assets/service_checks.json"
+      },
+      "source_type_id": 10341,
+      "auto_install": true
     }
   },
   "author": {

--- a/dcgm/manifest.json
+++ b/dcgm/manifest.json
@@ -37,7 +37,9 @@
       },
       "process_signatures": [
         "dcgm-exporter"
-      ]
+      ],
+      "source_type_id": 10374,
+      "auto_install": true
     },
     "dashboards": {
       "DCGM Exporter (Nvidia GPU Monitoring) Overview": "assets/dashboards/dcgm_overview.json"

--- a/dotnetclr/manifest.json
+++ b/dotnetclr/manifest.json
@@ -39,7 +39,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10069,
+      "auto_install": true
     }
   }
 }

--- a/druid/manifest.json
+++ b/druid/manifest.json
@@ -43,7 +43,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10074,
+      "auto_install": true
     },
     "dashboards": {
       "Druid Overview": "assets/dashboards/overview.json"

--- a/ecs_fargate/manifest.json
+++ b/ecs_fargate/manifest.json
@@ -47,7 +47,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10033,
+      "auto_install": true
     },
     "dashboards": {
       "Amazon Fargate": "assets/dashboards/amazon_fargate_overview.json"

--- a/eks_anywhere/manifest.json
+++ b/eks_anywhere/manifest.json
@@ -40,7 +40,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10248,
+      "auto_install": true
     }
   }
 }

--- a/elastic/manifest.json
+++ b/elastic/manifest.json
@@ -44,7 +44,11 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
-      "process_signatures": ["java org.elasticsearch.bootstrap.Elasticsearch"]
+      "process_signatures": [
+        "java org.elasticsearch.bootstrap.Elasticsearch"
+      ],
+      "source_type_id": 37,
+      "auto_install": true
     },
     "dashboards": {
       "elasticsearch": "assets/dashboards/overview.json",

--- a/envoy/manifest.json
+++ b/envoy/manifest.json
@@ -45,7 +45,9 @@
       },
       "process_signatures": [
         "envoy"
-      ]
+      ],
+      "source_type_id": 10012,
+      "auto_install": true
     },
     "dashboards": {
       "Envoy - Overview": "assets/dashboards/envoy_overview.json"

--- a/etcd/manifest.json
+++ b/etcd/manifest.json
@@ -50,7 +50,9 @@
       },
       "process_signatures": [
         "etcd"
-      ]
+      ],
+      "source_type_id": 111,
+      "auto_install": true
     },
     "dashboards": {
       "Etcd Overview": "assets/dashboards/etcd_overview.json",

--- a/exchange_server/manifest.json
+++ b/exchange_server/manifest.json
@@ -39,7 +39,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10023,
+      "auto_install": true
     },
     "dashboards": {
       "Exchange Server Overview": "assets/dashboards/overview.json"

--- a/external_dns/manifest.json
+++ b/external_dns/manifest.json
@@ -42,7 +42,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10075,
+      "auto_install": true
     }
   }
 }

--- a/flink/manifest.json
+++ b/flink/manifest.json
@@ -56,7 +56,9 @@
         "java org.apache.flink.table.gateway.SqlGateway",
         "java org.apache.flink.table.client.SqlClient",
         "java org.apache.flink.yarn.cli.FlinkYarnSessionCli"
-      ]
+      ],
+      "source_type_id": 10088,
+      "auto_install": true
     },
     "dashboards": {
       "Flink Overview": "assets/dashboards/overview.json"

--- a/fluentd/manifest.json
+++ b/fluentd/manifest.json
@@ -47,7 +47,9 @@
         "td-agent",
         "fluentd",
         "ruby td-agent"
-      ]
+      ],
+      "source_type_id": 108,
+      "auto_install": true
     },
     "dashboards": {
       "fluentd": "assets/dashboards/fluentd_dashboard.json"

--- a/fluxcd/manifest.json
+++ b/fluxcd/manifest.json
@@ -41,7 +41,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10302,
+      "auto_install": true
     },
     "dashboards": {
       "Fluxcd": "assets/dashboards/fluxcd.json"

--- a/foundationdb/manifest.json
+++ b/foundationdb/manifest.json
@@ -37,12 +37,17 @@
       },
       "metrics": {
         "prefix": "foundationdb.",
-        "check": ["foundationdb.processes", "foundationdb.instances"],
+        "check": [
+          "foundationdb.processes",
+          "foundationdb.instances"
+        ],
         "metadata_path": "metadata.csv"
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10258,
+      "auto_install": true
     },
     "dashboards": {
       "FoundationDB Latency Probe": "assets/dashboards/foundationdb_latency_probe.json",

--- a/gearmand/manifest.json
+++ b/gearmand/manifest.json
@@ -44,7 +44,9 @@
       "process_signatures": [
         "gearmand",
         "gearman"
-      ]
+      ],
+      "source_type_id": 52,
+      "auto_install": true
     },
     "dashboards": {
       "gearman": "assets/dashboards/gearman_dashboard.json"

--- a/gitlab/manifest.json
+++ b/gitlab/manifest.json
@@ -53,7 +53,9 @@
         "gitlab-kas",
         "gitlab-workhorse",
         "gitlab-ctl"
-      ]
+      ],
+      "source_type_id": 10026,
+      "auto_install": true
     },
     "dashboards": {
       "Gitlab Overview": "assets/dashboards/overview.json"

--- a/gitlab_runner/manifest.json
+++ b/gitlab_runner/manifest.json
@@ -48,7 +48,9 @@
       "process_signatures": [
         "gitlab-runner",
         "gitlab-ci-multi-runner"
-      ]
+      ],
+      "source_type_id": 10028,
+      "auto_install": true
     },
     "logs": {
       "source": "gitlab_runner"

--- a/glusterfs/manifest.json
+++ b/glusterfs/manifest.json
@@ -41,7 +41,12 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
-      "process_signatures": ["glusterd", "gluster"]
+      "process_signatures": [
+        "glusterd",
+        "gluster"
+      ],
+      "source_type_id": 10145,
+      "auto_install": true
     },
     "dashboards": {
       "Red Hat Gluster Storage": "assets/dashboards/red_hat_gluster_storage.json"

--- a/go_expvar/manifest.json
+++ b/go_expvar/manifest.json
@@ -41,7 +41,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 77,
+      "auto_install": true
     }
   }
 }

--- a/gunicorn/manifest.json
+++ b/gunicorn/manifest.json
@@ -43,7 +43,9 @@
       },
       "process_signatures": [
         "gunicorn: master"
-      ]
+      ],
+      "source_type_id": 60,
+      "auto_install": true
     },
     "dashboards": {
       "gunicorn": "assets/dashboards/gunicorn_dashboard.json"

--- a/haproxy/manifest.json
+++ b/haproxy/manifest.json
@@ -50,7 +50,9 @@
         "haproxy",
         "haproxy-master",
         "haproxy-controller"
-      ]
+      ],
+      "source_type_id": 38,
+      "auto_install": true
     },
     "dashboards": {
       "haproxy": "assets/dashboards/overview.json",

--- a/harbor/manifest.json
+++ b/harbor/manifest.json
@@ -42,7 +42,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10063,
+      "auto_install": true
     },
     "dashboards": {
       "Harbor Overview": "assets/dashboards/overview.json"

--- a/hazelcast/manifest.json
+++ b/hazelcast/manifest.json
@@ -46,7 +46,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10095,
+      "auto_install": true
     },
     "dashboards": {
       "Hazelcast Overview": "assets/dashboards/overview.json"

--- a/hdfs_datanode/manifest.json
+++ b/hdfs_datanode/manifest.json
@@ -41,7 +41,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10196,
+      "auto_install": true
     },
     "dashboards": {
       "hdfs_datanode": "assets/dashboards/hdfs_datanode_dashboard.json"

--- a/hdfs_namenode/manifest.json
+++ b/hdfs_namenode/manifest.json
@@ -41,7 +41,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10227,
+      "auto_install": true
     },
     "dashboards": {
       "hdfs_namenode": "assets/dashboards/hdfs_namenode_dashboard.json"

--- a/helm/manifest.json
+++ b/helm/manifest.json
@@ -40,7 +40,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10257,
+      "auto_install": true
     },
     "dashboards": {
       "Helm - Overview": "assets/dashboards/overview.json"

--- a/hive/manifest.json
+++ b/hive/manifest.json
@@ -41,7 +41,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10062,
+      "auto_install": true
     },
     "dashboards": {
       "Hive Overview": "assets/dashboards/overview.json"

--- a/hivemq/manifest.json
+++ b/hivemq/manifest.json
@@ -43,7 +43,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10101,
+      "auto_install": true
     },
     "dashboards": {
       "HiveMQ": "assets/dashboards/hivemq.json"

--- a/hudi/manifest.json
+++ b/hudi/manifest.json
@@ -41,7 +41,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10217,
+      "auto_install": true
     },
     "dashboards": {
       "Hudi Overview": "assets/dashboards/overview.json"

--- a/hyperv/manifest.json
+++ b/hyperv/manifest.json
@@ -40,7 +40,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10046,
+      "auto_install": true
     },
     "dashboards": {
       "hyper-v": "assets/dashboards/overview.json"

--- a/iam_access_analyzer/manifest.json
+++ b/iam_access_analyzer/manifest.json
@@ -31,7 +31,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10081,
+      "auto_install": true
     }
   },
   "author": {

--- a/ibm_ace/manifest.json
+++ b/ibm_ace/manifest.json
@@ -41,7 +41,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10262,
+      "auto_install": true
     },
     "dashboards": {
       "IBM ACE Overview": "assets/dashboards/overview.json"

--- a/ibm_db2/manifest.json
+++ b/ibm_db2/manifest.json
@@ -42,7 +42,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10054,
+      "auto_install": true
     },
     "dashboards": {
       "IBM Db2 Overview": "assets/dashboards/overview.json"

--- a/ibm_i/manifest.json
+++ b/ibm_i/manifest.json
@@ -40,7 +40,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10219,
+      "auto_install": true
     },
     "dashboards": {
       "IBM i Overview": "assets/dashboards/ibm_i_overview.json"

--- a/ibm_mq/manifest.json
+++ b/ibm_mq/manifest.json
@@ -43,7 +43,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10049,
+      "auto_install": true
     },
     "dashboards": {
       "IBM MQ": "assets/dashboards/overview.json"

--- a/ibm_was/manifest.json
+++ b/ibm_was/manifest.json
@@ -42,7 +42,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10048,
+      "auto_install": true
     },
     "dashboards": {
       "IBM_WAS": "assets/dashboards/overview.json"

--- a/ignite/manifest.json
+++ b/ignite/manifest.json
@@ -44,7 +44,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10100,
+      "auto_install": true
     },
     "dashboards": {
       "Ignite Overview": "assets/dashboards/ignite_overview.json"

--- a/iis/manifest.json
+++ b/iis/manifest.json
@@ -39,7 +39,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 46,
+      "auto_install": true
     },
     "dashboards": {
       "iis": "assets/dashboards/iis_dashboard.json",

--- a/impala/manifest.json
+++ b/impala/manifest.json
@@ -39,7 +39,9 @@
         "impalad",
         "catalogd",
         "statestored"
-      ]
+      ],
+      "source_type_id": 10301,
+      "auto_install": true
     },
     "logs": {
       "source": "impala"

--- a/istio/manifest.json
+++ b/istio/manifest.json
@@ -51,7 +51,9 @@
       "process_signatures": [
         "pilot-agent proxy router",
         "envoy envoy-rev0.json"
-      ]
+      ],
+      "source_type_id": 10017,
+      "auto_install": true
     },
     "dashboards": {
       "Istio base dashboard": "assets/dashboards/istio_overview.json",

--- a/jboss_wildfly/manifest.json
+++ b/jboss_wildfly/manifest.json
@@ -41,7 +41,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10060,
+      "auto_install": true
     },
     "dashboards": {
       "JBoss WildFly": "assets/dashboards/jboss_wildfly.json"

--- a/jmeter/manifest.json
+++ b/jmeter/manifest.json
@@ -40,7 +40,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10164,
+      "auto_install": true
     },
     "dashboards": {
       "JMeter Overview": "assets/dashboards/JMeterOverview.json"

--- a/journald/manifest.json
+++ b/journald/manifest.json
@@ -36,7 +36,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10167,
+      "auto_install": true
     }
   }
 }

--- a/kafka/manifest.json
+++ b/kafka/manifest.json
@@ -48,7 +48,9 @@
       },
       "process_signatures": [
         "java kafka.kafka"
-      ]
+      ],
+      "source_type_id": 64,
+      "auto_install": true
     },
     "dashboards": {
       "kafka": "assets/dashboards/kafka_dashboard.json"

--- a/kafka_consumer/manifest.json
+++ b/kafka_consumer/manifest.json
@@ -41,7 +41,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10239,
+      "auto_install": true
     }
   }
 }

--- a/karpenter/manifest.json
+++ b/karpenter/manifest.json
@@ -39,7 +39,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10437,
+      "auto_install": true
     },
     "dashboards": {
       "karpenter_overview": "assets/dashboards/karpenter_overview.json"

--- a/kong/manifest.json
+++ b/kong/manifest.json
@@ -44,7 +44,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 141,
+      "auto_install": true
     },
     "dashboards": {
       "Kong Overview OpenMetrics": "assets/dashboards/kong_overview_openmetrics.json",

--- a/kube_apiserver_metrics/manifest.json
+++ b/kube_apiserver_metrics/manifest.json
@@ -42,7 +42,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10197,
+      "auto_install": true
     },
     "dashboards": {
       "Kubernetes API Server - Overview": "assets/dashboards/overview.json"

--- a/kube_controller_manager/manifest.json
+++ b/kube_controller_manager/manifest.json
@@ -43,7 +43,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10055,
+      "auto_install": true
     },
     "dashboards": {
       "kube_controller_manager": "assets/dashboards/overview.json"

--- a/kube_dns/manifest.json
+++ b/kube_dns/manifest.json
@@ -43,7 +43,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10294,
+      "auto_install": true
     }
   }
 }

--- a/kube_metrics_server/manifest.json
+++ b/kube_metrics_server/manifest.json
@@ -43,7 +43,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10061,
+      "auto_install": true
     },
     "dashboards": {
       "Kubernetes Metrics Server - Overview": "assets/dashboards/overview.json"

--- a/kube_proxy/manifest.json
+++ b/kube_proxy/manifest.json
@@ -43,7 +43,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10290,
+      "auto_install": true
     }
   }
 }

--- a/kube_scheduler/manifest.json
+++ b/kube_scheduler/manifest.json
@@ -44,7 +44,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10056,
+      "auto_install": true
     },
     "dashboards": {
       "kube_scheduler": "assets/dashboards/overview.json"

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -42,7 +42,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 128,
+      "auto_install": true
     },
     "dashboards": {
       "kubernetes": "assets/dashboards/kubernetes_dashboard.json",

--- a/kyototycoon/manifest.json
+++ b/kyototycoon/manifest.json
@@ -43,7 +43,11 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
-      "process_signatures": ["ktserver"]
+      "process_signatures": [
+        "ktserver"
+      ],
+      "source_type_id": 62,
+      "auto_install": true
     },
     "dashboards": {
       "kyototycoon": "assets/dashboards/kyototycoon_dashboard.json"

--- a/langchain/manifest.json
+++ b/langchain/manifest.json
@@ -33,9 +33,11 @@
         "check": "langchain.request.duration",
         "metadata_path": "metadata.csv"
       },
-      "service_checks":{
+      "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10372,
+      "auto_install": true
     },
     "dashboards": {
       "LangChain Overview Dashboard": "assets/dashboards/overview_dashboard.json"

--- a/lighttpd/manifest.json
+++ b/lighttpd/manifest.json
@@ -44,7 +44,9 @@
       },
       "process_signatures": [
         "lighttpd"
-      ]
+      ],
+      "source_type_id": 58,
+      "auto_install": true
     },
     "dashboards": {
       "lighttpd": "assets/dashboards/lighttpd_dashboard.json"

--- a/linkerd/manifest.json
+++ b/linkerd/manifest.json
@@ -48,7 +48,9 @@
       },
       "process_signatures": [
         "linkerd"
-      ]
+      ],
+      "source_type_id": 10019,
+      "auto_install": true
     },
     "dashboards": {
       "Linkerd - Overview": "assets/dashboards/overview.json"

--- a/mapr/manifest.json
+++ b/mapr/manifest.json
@@ -40,7 +40,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10073,
+      "auto_install": true
     },
     "dashboards": {
       "MapR - Overview": "assets/dashboards/mapr_overview.json"

--- a/mapreduce/manifest.json
+++ b/mapreduce/manifest.json
@@ -41,7 +41,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 133,
+      "auto_install": true
     },
     "dashboards": {
       "mapreduce": "assets/dashboards/mapreduce_dashboard.json"

--- a/marathon/manifest.json
+++ b/marathon/manifest.json
@@ -45,7 +45,9 @@
       },
       "process_signatures": [
         "start --master mesos marathon"
-      ]
+      ],
+      "source_type_id": 82,
+      "auto_install": true
     },
     "dashboards": {
       "marathon-overview": "assets/dashboards/marathon-overview_dashboard.json"

--- a/marklogic/manifest.json
+++ b/marklogic/manifest.json
@@ -43,7 +43,11 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
-      "process_signatures": ["MarkLogic"]
+      "process_signatures": [
+        "MarkLogic"
+      ],
+      "source_type_id": 10124,
+      "auto_install": true
     },
     "dashboards": {
       "MarkLogic - Overview": "assets/dashboards/overview.json"

--- a/mcache/manifest.json
+++ b/mcache/manifest.json
@@ -45,7 +45,9 @@
       },
       "process_signatures": [
         "memcached"
-      ]
+      ],
+      "source_type_id": 32,
+      "auto_install": true
     },
     "dashboards": {
       "memcached": "assets/dashboards/memcached_dashboard.json",

--- a/mesos_master/manifest.json
+++ b/mesos_master/manifest.json
@@ -47,7 +47,9 @@
       "process_signatures": [
         "mesos-master.sh",
         "mesos-agent.sh"
-      ]
+      ],
+      "source_type_id": 10156,
+      "auto_install": true
     },
     "saved_views": {
       "mesos-master_processes": "assets/saved_views/mesos-master_processes.json"

--- a/mesos_slave/manifest.json
+++ b/mesos_slave/manifest.json
@@ -44,7 +44,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 81,
+      "auto_install": true
     },
     "dashboards": {
       "mesos": "assets/dashboards/mesos_overview.json"

--- a/mongo/manifest.json
+++ b/mongo/manifest.json
@@ -43,7 +43,11 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
-      "process_signatures": ["mongod"]
+      "process_signatures": [
+        "mongod"
+      ],
+      "source_type_id": 19,
+      "auto_install": true
     },
     "dashboards": {
       "mongodb": "assets/dashboards/overview.json"

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -43,7 +43,11 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
-      "process_signatures": ["mysqld"]
+      "process_signatures": [
+        "mysqld"
+      ],
+      "source_type_id": 18,
+      "auto_install": true
     },
     "dashboards": {
       "mysql": "assets/dashboards/overview.json",

--- a/nagios/manifest.json
+++ b/nagios/manifest.json
@@ -45,7 +45,9 @@
       },
       "process_signatures": [
         "nagios"
-      ]
+      ],
+      "source_type_id": 3,
+      "auto_install": true
     },
     "saved_views": {
       "nagios_processes": "assets/saved_views/nagios_processes.json"

--- a/nginx/manifest.json
+++ b/nginx/manifest.json
@@ -48,7 +48,9 @@
       },
       "process_signatures": [
         "nginx: master process"
-      ]
+      ],
+      "source_type_id": 31,
+      "auto_install": true
     },
     "dashboards": {
       "NGINX Plus base overview": "assets/dashboards/plus_overview.json",

--- a/nginx_ingress_controller/manifest.json
+++ b/nginx_ingress_controller/manifest.json
@@ -45,7 +45,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10050,
+      "auto_install": true
     },
     "dashboards": {
       "nginx_ingress_controller": "assets/dashboards/overview.json"

--- a/nvidia_jetson/manifest.json
+++ b/nvidia_jetson/manifest.json
@@ -37,7 +37,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10134,
+      "auto_install": true
     },
     "dashboards": {
       "Nvidia Jetson": "assets/dashboards/nvidia_jetson.json"

--- a/nvidia_triton/manifest.json
+++ b/nvidia_triton/manifest.json
@@ -38,16 +38,20 @@
       },
       "process_signatures": [
         "tritonserver"
-      ]
+      ],
+      "auto_install": true
     },
-    "dashboards": {"nvidia_triton": "assets/dashboards/nvidia_triton_overview.json"},
+    "dashboards": {
+      "nvidia_triton": "assets/dashboards/nvidia_triton_overview.json"
+    },
     "monitors": {
       "[Nvidia Triton] GPU utilization is high": "assets/monitors/gpu_utilization.json",
       "[Nvidia Triton] CPU Memory Usage is high": "assets/monitors/cpu_memory.json"
-
     },
-    "logs": {"source": "nvidia_triton"}
-    },
+    "logs": {
+      "source": "nvidia_triton"
+    }
+  },
   "author": {
     "support_email": "help@datadoghq.com",
     "name": "Datadog",

--- a/oke/manifest.json
+++ b/oke/manifest.json
@@ -37,7 +37,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10255,
+      "auto_install": true
     }
   }
 }

--- a/oom_kill/manifest.json
+++ b/oom_kill/manifest.json
@@ -37,7 +37,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10293,
+      "auto_install": true
     }
   }
 }

--- a/openai/manifest.json
+++ b/openai/manifest.json
@@ -48,12 +48,17 @@
       },
       "metrics": {
         "prefix": "openai.",
-        "check": ["openai.request.duration", "openai.api.usage.n_requests"],
+        "check": [
+          "openai.request.duration",
+          "openai.api.usage.n_requests"
+        ],
         "metadata_path": "metadata.csv"
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10348,
+      "auto_install": true
     },
     "dashboards": {
       "OpenAI Overview Dashboard": "assets/dashboards/overview_dashboard.json",

--- a/openldap/manifest.json
+++ b/openldap/manifest.json
@@ -42,7 +42,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10040,
+      "auto_install": true
     },
     "dashboards": {
       "OpenLDAP Overview": "assets/dashboards/openldap_overview.json"

--- a/openmetrics/manifest.json
+++ b/openmetrics/manifest.json
@@ -36,7 +36,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10045,
+      "auto_install": true
     }
   }
 }

--- a/openshift/manifest.json
+++ b/openshift/manifest.json
@@ -45,7 +45,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10024,
+      "auto_install": true
     }
   }
 }

--- a/openstack/manifest.json
+++ b/openstack/manifest.json
@@ -46,7 +46,9 @@
       },
       "process_signatures": [
         "stack.sh"
-      ]
+      ],
+      "source_type_id": 125,
+      "auto_install": true
     },
     "dashboards": {
       "openstack": "assets/dashboards/openstack_dashboard.json"

--- a/openstack_controller/manifest.json
+++ b/openstack_controller/manifest.json
@@ -42,7 +42,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10226,
+      "auto_install": true
     },
     "dashboards": {
       "OpenStack Controller Overview": "assets/dashboards/openstack-controller.json",

--- a/oracle/manifest.json
+++ b/oracle/manifest.json
@@ -43,7 +43,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10000,
+      "auto_install": true
     },
     "dashboards": {
       "oracle": "assets/dashboards/oracle_overview.json",

--- a/otel/manifest.json
+++ b/otel/manifest.json
@@ -44,7 +44,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 312,
+      "auto_install": true
     },
     "dashboards": {
       "OpenTelemetry Dashboard": "assets/dashboards/otel_host_metrics_dashboard.json",

--- a/pan_firewall/manifest.json
+++ b/pan_firewall/manifest.json
@@ -40,7 +40,9 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
-      "process_signatures": []
+      "process_signatures": [],
+      "source_type_id": 10155,
+      "auto_install": true
     },
     "dashboards": {
       "Palo Alto Networks Firewall Overview": "assets/dashboards/palo_alto_networks_firewall_overview.json"

--- a/pdh_check/manifest.json
+++ b/pdh_check/manifest.json
@@ -34,7 +34,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10065,
+      "auto_install": true
     }
   }
 }

--- a/pgbouncer/manifest.json
+++ b/pgbouncer/manifest.json
@@ -42,7 +42,11 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
-      "process_signatures": ["pgbouncer"]
+      "process_signatures": [
+        "pgbouncer"
+      ],
+      "source_type_id": 118,
+      "auto_install": true
     },
     "dashboards": {
       "pgbouncer": "assets/dashboards/pgbouncer_dashboard.json"

--- a/php_fpm/manifest.json
+++ b/php_fpm/manifest.json
@@ -52,7 +52,9 @@
         "restart php-fpm",
         "systemctl restart php-fpm.service",
         "php7.0-fpm.service"
-      ]
+      ],
+      "source_type_id": 117,
+      "auto_install": true
     },
     "dashboards": {
       "php-fpm": "assets/dashboards/php-fpm_dashboard.json"

--- a/pivotal_pks/manifest.json
+++ b/pivotal_pks/manifest.json
@@ -37,7 +37,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10034,
+      "auto_install": true
     }
   }
 }

--- a/podman/manifest.json
+++ b/podman/manifest.json
@@ -32,7 +32,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10267,
+      "auto_install": true
     }
   }
 }

--- a/postfix/manifest.json
+++ b/postfix/manifest.json
@@ -44,7 +44,9 @@
       "process_signatures": [
         "postfix start",
         "sendmail -bd"
-      ]
+      ],
+      "source_type_id": 66,
+      "auto_install": true
     },
     "dashboards": {
       "postfix": "assets/dashboards/postfix_dashboard.json"

--- a/postgres/manifest.json
+++ b/postgres/manifest.json
@@ -39,7 +39,10 @@
       },
       "metrics": {
         "prefix": "postgresql.",
-        "check": ["postgresql.connections", "postgresql.max_connections"],
+        "check": [
+          "postgresql.connections",
+          "postgresql.max_connections"
+        ],
         "metadata_path": "metadata.csv"
       },
       "service_checks": {
@@ -49,7 +52,9 @@
         "postgres -D",
         "pg_ctl start -l logfile",
         "postgres -c 'pg_ctl start -D -l"
-      ]
+      ],
+      "source_type_id": 28,
+      "auto_install": true
     },
     "dashboards": {
       "postgresql": "assets/dashboards/postgresql_dashboard.json",

--- a/powerdns_recursor/manifest.json
+++ b/powerdns_recursor/manifest.json
@@ -47,7 +47,9 @@
       "process_signatures": [
         "pdns_server",
         "systemctl start pdns@"
-      ]
+      ],
+      "source_type_id": 144,
+      "auto_install": true
     },
     "dashboards": {
       "powerdns": "assets/dashboards/powerdns_dashboard.json"

--- a/presto/manifest.json
+++ b/presto/manifest.json
@@ -42,7 +42,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10057,
+      "auto_install": true
     },
     "dashboards": {
       "Presto Overview": "assets/dashboards/overview.json"

--- a/prometheus/manifest.json
+++ b/prometheus/manifest.json
@@ -36,7 +36,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10013,
+      "auto_install": true
     }
   }
 }

--- a/proxysql/manifest.json
+++ b/proxysql/manifest.json
@@ -43,7 +43,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10096,
+      "auto_install": true
     },
     "dashboards": {
       "ProxySQL Overview": "assets/dashboards/overview.json"

--- a/pulsar/manifest.json
+++ b/pulsar/manifest.json
@@ -45,7 +45,9 @@
       },
       "process_signatures": [
         "java org.apache.pulsar.PulsarStandaloneStarter"
-      ]
+      ],
+      "source_type_id": 10143,
+      "auto_install": true
     },
     "logs": {
       "source": "pulsar"

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -46,7 +46,9 @@
       "process_signatures": [
         "rabbitmq",
         "rabbitmq-server"
-      ]
+      ],
+      "source_type_id": 51,
+      "auto_install": true
     },
     "dashboards": {
       "rabbitmq_screenboard": "assets/dashboards/rabbitmq_screenboard_dashboard.json",
@@ -57,7 +59,6 @@
       "message_unacknowledge_rate_anomaly": "assets/monitors/message_unacknowledge_rate_anomaly.json",
       "disk_usage_prometheus": "assets/monitors/disk_usage_prometheus.json",
       "message_unack_prometheus": "assets/monitors/message_unack_prometheus.json"
-
     },
     "saved_views": {
       "pid_overview": "assets/saved_views/status_overview.json",

--- a/ray/manifest.json
+++ b/ray/manifest.json
@@ -40,7 +40,9 @@
         "python -m ray.util.client.server",
         "gcs_server",
         "raylet"
-      ]
+      ],
+      "source_type_id": 10393,
+      "auto_install": true
     },
     "monitors": {
       "high cpu utilization": "assets/monitors/cpu_utilization.json",

--- a/redisdb/manifest.json
+++ b/redisdb/manifest.json
@@ -45,7 +45,11 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
-      "process_signatures": ["redis-server"]
+      "process_signatures": [
+        "redis-server"
+      ],
+      "source_type_id": 21,
+      "auto_install": true
     },
     "dashboards": {
       "redis": "assets/dashboards/overview.json"

--- a/rethinkdb/manifest.json
+++ b/rethinkdb/manifest.json
@@ -43,7 +43,11 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
-      "process_signatures": ["rethinkdb"]
+      "process_signatures": [
+        "rethinkdb"
+      ],
+      "source_type_id": 10092,
+      "auto_install": true
     },
     "dashboards": {
       "RethinkDB Overview": "assets/dashboards/overview.json"

--- a/riak/manifest.json
+++ b/riak/manifest.json
@@ -42,7 +42,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 50,
+      "auto_install": true
     },
     "dashboards": {
       "riak": "assets/dashboards/riak_dashboard.json"

--- a/riakcs/manifest.json
+++ b/riakcs/manifest.json
@@ -42,7 +42,11 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
-      "process_signatures": ["riak-cs start"]
+      "process_signatures": [
+        "riak-cs start"
+      ],
+      "source_type_id": 110,
+      "auto_install": true
     },
     "dashboards": {
       "riakcs": "assets/dashboards/riakcs_dashboard.json"

--- a/sap_hana/manifest.json
+++ b/sap_hana/manifest.json
@@ -42,7 +42,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10076,
+      "auto_install": true
     },
     "dashboards": {
       "SAP HANA Overview": "assets/dashboards/overview.json"

--- a/scylla/manifest.json
+++ b/scylla/manifest.json
@@ -43,7 +43,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10087,
+      "auto_install": true
     },
     "dashboards": {
       "Scylla Overview": "assets/dashboards/overview.json"

--- a/sidekiq/manifest.json
+++ b/sidekiq/manifest.json
@@ -41,7 +41,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10093,
+      "auto_install": true
     },
     "dashboards": {
       "Sidekiq Overview": "assets/dashboards/overview.json"

--- a/silk/manifest.json
+++ b/silk/manifest.json
@@ -43,7 +43,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10250,
+      "auto_install": true
     },
     "dashboards": {
       "Silk - Overview": "assets/dashboards/silk_overview.json"

--- a/singlestore/manifest.json
+++ b/singlestore/manifest.json
@@ -44,7 +44,11 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
-      "process_signatures": ["memsqld"]
+      "process_signatures": [
+        "memsqld"
+      ],
+      "source_type_id": 10215,
+      "auto_install": true
     },
     "dashboards": {
       "Singlestore Overview": "assets/dashboards/overview.json"

--- a/snmp/manifest.json
+++ b/snmp/manifest.json
@@ -43,7 +43,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 78,
+      "auto_install": true
     },
     "dashboards": {
       "Interface Performance": "assets/dashboards/interface_performance.json",

--- a/snmp_american_power_conversion/manifest.json
+++ b/snmp_american_power_conversion/manifest.json
@@ -31,7 +31,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10329,
+      "auto_install": true
     }
   },
   "author": {

--- a/snmp_arista/manifest.json
+++ b/snmp_arista/manifest.json
@@ -31,7 +31,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10328,
+      "auto_install": true
     }
   },
   "author": {

--- a/snmp_aruba/manifest.json
+++ b/snmp_aruba/manifest.json
@@ -31,7 +31,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10354,
+      "auto_install": true
     }
   },
   "author": {

--- a/snmp_chatsworth_products/manifest.json
+++ b/snmp_chatsworth_products/manifest.json
@@ -31,7 +31,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10330,
+      "auto_install": true
     }
   },
   "author": {

--- a/snmp_check_point/manifest.json
+++ b/snmp_check_point/manifest.json
@@ -31,7 +31,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10334,
+      "auto_install": true
     }
   },
   "author": {

--- a/snmp_cisco/manifest.json
+++ b/snmp_cisco/manifest.json
@@ -36,7 +36,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10136,
+      "auto_install": true
     }
   }
 }

--- a/snmp_dell/manifest.json
+++ b/snmp_dell/manifest.json
@@ -36,7 +36,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10147,
+      "auto_install": true
     }
   }
 }

--- a/snmp_f5/manifest.json
+++ b/snmp_f5/manifest.json
@@ -36,7 +36,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10179,
+      "auto_install": true
     },
     "dashboards": {
       "F5-Networks": "assets/dashboards/f5-networks.json"

--- a/snmp_fortinet/manifest.json
+++ b/snmp_fortinet/manifest.json
@@ -30,7 +30,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10331,
+      "auto_install": true
     }
   },
   "author": {

--- a/snmp_hewlett_packard_enterprise/manifest.json
+++ b/snmp_hewlett_packard_enterprise/manifest.json
@@ -31,7 +31,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10332,
+      "auto_install": true
     }
   },
   "author": {

--- a/snmp_juniper/manifest.json
+++ b/snmp_juniper/manifest.json
@@ -36,7 +36,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10146,
+      "auto_install": true
     }
   }
 }

--- a/snmp_netapp/manifest.json
+++ b/snmp_netapp/manifest.json
@@ -31,7 +31,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10333,
+      "auto_install": true
     }
   },
   "author": {

--- a/snowflake/manifest.json
+++ b/snowflake/manifest.json
@@ -43,7 +43,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10123,
+      "auto_install": true
     },
     "dashboards": {
       "Snowflake": "assets/dashboards/snowflake.json",

--- a/solr/manifest.json
+++ b/solr/manifest.json
@@ -44,7 +44,11 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
-      "process_signatures": ["solr start"]
+      "process_signatures": [
+        "solr start"
+      ],
+      "source_type_id": 42,
+      "auto_install": true
     },
     "dashboards": {
       "solr": "assets/dashboards/solr_dashboard.json"

--- a/sonarqube/manifest.json
+++ b/sonarqube/manifest.json
@@ -47,7 +47,9 @@
       "process_signatures": [
         "java org.sonar.server.app.WebServer",
         "java org.sonar.ce.app.CeServer"
-      ]
+      ],
+      "source_type_id": 10132,
+      "auto_install": true
     },
     "dashboards": {
       "Sonarqube Overview": "assets/dashboards/overview.json"

--- a/spark/manifest.json
+++ b/spark/manifest.json
@@ -46,7 +46,9 @@
         "java org.apache.spark.deploy.SparkSubmit",
         "java org.apache.spark.deploy.worker.Worker",
         "java org.apache.spark.deploy.master.Master"
-      ]
+      ],
+      "source_type_id": 142,
+      "auto_install": true
     },
     "dashboards": {
       "spark": "assets/dashboards/spark_dashboard.json",

--- a/sqlserver/manifest.json
+++ b/sqlserver/manifest.json
@@ -42,7 +42,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 45,
+      "auto_install": true
     },
     "dashboards": {
       "SQLServer-Overview": "assets/dashboards/SQLServer-Overview_dashboard.json",

--- a/squid/manifest.json
+++ b/squid/manifest.json
@@ -42,7 +42,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10022,
+      "auto_install": true
     },
     "logs": {
       "source": "squid"

--- a/ssh_check/manifest.json
+++ b/ssh_check/manifest.json
@@ -48,7 +48,9 @@
         "sftp",
         "sshd",
         "sshd:"
-      ]
+      ],
+      "source_type_id": 90,
+      "auto_install": true
     }
   }
 }

--- a/statsd/manifest.json
+++ b/statsd/manifest.json
@@ -41,7 +41,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10086,
+      "auto_install": true
     },
     "logs": {
       "source": "statsd"

--- a/strimzi/manifest.json
+++ b/strimzi/manifest.json
@@ -43,7 +43,9 @@
       ],
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10352,
+      "auto_install": true
     },
     "monitors": {
       "cluster_operate_resource_state": "assets/monitors/cluster_operator_resource.json",

--- a/supervisord/manifest.json
+++ b/supervisord/manifest.json
@@ -46,7 +46,9 @@
       "process_signatures": [
         "python supervisord",
         "supervisord"
-      ]
+      ],
+      "source_type_id": 116,
+      "auto_install": true
     },
     "saved_views": {
       "supervisord_processes": "assets/saved_views/supervisord_processes.json"

--- a/systemd/manifest.json
+++ b/systemd/manifest.json
@@ -37,7 +37,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10066,
+      "auto_install": true
     },
     "dashboards": {
       "Systemd Overview": "assets/dashboards/overview.json"

--- a/tcp_queue_length/manifest.json
+++ b/tcp_queue_length/manifest.json
@@ -38,7 +38,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10295,
+      "auto_install": true
     }
   }
 }

--- a/teamcity/manifest.json
+++ b/teamcity/manifest.json
@@ -50,7 +50,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 109,
+      "auto_install": true
     },
     "dashboards": {
       "TeamCity Overview": "assets/dashboards/overview.json"

--- a/temporal/manifest.json
+++ b/temporal/manifest.json
@@ -37,7 +37,9 @@
       },
       "process_signatures": [
         "temporal-server"
-      ]
+      ],
+      "source_type_id": 10337,
+      "auto_install": true
     },
     "logs": {
       "source": "temporal"

--- a/tenable/manifest.json
+++ b/tenable/manifest.json
@@ -36,7 +36,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10089,
+      "auto_install": true
     },
     "logs": {
       "source": "tenable"

--- a/teradata/manifest.json
+++ b/teradata/manifest.json
@@ -41,7 +41,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10275,
+      "auto_install": true
     },
     "dashboards": {
       "Teradata Overview": "assets/dashboards/teradata_overview.json"

--- a/terraform/manifest.json
+++ b/terraform/manifest.json
@@ -36,7 +36,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10153,
+      "auto_install": true
     }
   }
 }

--- a/tls/manifest.json
+++ b/tls/manifest.json
@@ -42,7 +42,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10058,
+      "auto_install": true
     },
     "dashboards": {
       "TLS Overview": "assets/dashboards/overview.json"

--- a/tokumx/manifest.json
+++ b/tokumx/manifest.json
@@ -43,7 +43,9 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
-      "process_signatures": []
+      "process_signatures": [],
+      "source_type_id": 74,
+      "auto_install": true
     },
     "dashboards": {
       "tokumx": "assets/dashboards/tokumx_dashboard.json"

--- a/tomcat/manifest.json
+++ b/tomcat/manifest.json
@@ -45,7 +45,9 @@
       },
       "process_signatures": [
         "java tomcat"
-      ]
+      ],
+      "source_type_id": 43,
+      "auto_install": true
     },
     "dashboards": {
       "tomcat--overview": "assets/dashboards/overview.json",

--- a/torchserve/manifest.json
+++ b/torchserve/manifest.json
@@ -41,7 +41,9 @@
       },
       "process_signatures": [
         "torchserve"
-      ]
+      ],
+      "source_type_id": 10357,
+      "auto_install": true
     },
     "monitors": {
       "error_ratio": "assets/monitors/error_ratio.json"

--- a/traffic_server/manifest.json
+++ b/traffic_server/manifest.json
@@ -48,7 +48,9 @@
         "traffic_manager",
         "traffic_server",
         "trafficserver start"
-      ]
+      ],
+      "source_type_id": 10259,
+      "auto_install": true
     },
     "dashboards": {
       "Traffic Server - Overview": "assets/dashboards/overview.json"

--- a/twemproxy/manifest.json
+++ b/twemproxy/manifest.json
@@ -41,7 +41,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10070,
+      "auto_install": true
     },
     "dashboards": {
       "Twemproxy - Overview": "assets/dashboards/twemproxy_overview.json"

--- a/twistlock/manifest.json
+++ b/twistlock/manifest.json
@@ -45,7 +45,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10052,
+      "auto_install": true
     },
     "dashboards": {
       "Twistlock": "assets/dashboards/overview.json"

--- a/varnish/manifest.json
+++ b/varnish/manifest.json
@@ -47,7 +47,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 29,
+      "auto_install": true
     },
     "dashboards": {
       "varnish": "assets/dashboards/varnish_dashboard.json"

--- a/vault/manifest.json
+++ b/vault/manifest.json
@@ -45,7 +45,9 @@
       },
       "process_signatures": [
         "vault server"
-      ]
+      ],
+      "source_type_id": 10059,
+      "auto_install": true
     },
     "dashboards": {
       "Vault - Overview": "assets/dashboards/vault_overview_legacy.json",

--- a/vertica/manifest.json
+++ b/vertica/manifest.json
@@ -42,7 +42,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10072,
+      "auto_install": true
     },
     "dashboards": {
       "Vertica Overview": "assets/dashboards/overview.json"

--- a/voltdb/manifest.json
+++ b/voltdb/manifest.json
@@ -43,7 +43,11 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
-      "process_signatures": ["voltdb"]
+      "process_signatures": [
+        "voltdb"
+      ],
+      "source_type_id": 10149,
+      "auto_install": true
     },
     "dashboards": {
       "VoltDB - Overview": "assets/dashboards/voltdb_overview.json"

--- a/vsphere/manifest.json
+++ b/vsphere/manifest.json
@@ -45,7 +45,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 85,
+      "auto_install": true
     },
     "dashboards": {
       "vsphere-overview": "assets/dashboards/vsphere_overview.json",

--- a/weaviate/manifest.json
+++ b/weaviate/manifest.json
@@ -37,7 +37,9 @@
       },
       "process_signatures": [
         "/bin/weaviate"
-      ]
+      ],
+      "source_type_id": 10371,
+      "auto_install": true
     },
     "monitors": {
       "node_status": "assets/monitors/node_status.json"

--- a/weblogic/manifest.json
+++ b/weblogic/manifest.json
@@ -45,7 +45,9 @@
       },
       "process_signatures": [
         "java weblogic.Server"
-      ]
+      ],
+      "source_type_id": 10245,
+      "auto_install": true
     },
     "dashboards": {
       "overview": "assets/dashboards/overview.json",

--- a/wincrashdetect/manifest.json
+++ b/wincrashdetect/manifest.json
@@ -32,7 +32,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10389,
+      "auto_install": true
     }
   }
 }

--- a/windows_performance_counters/manifest.json
+++ b/windows_performance_counters/manifest.json
@@ -35,7 +35,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10241,
+      "auto_install": true
     }
   }
 }

--- a/windows_service/manifest.json
+++ b/windows_service/manifest.json
@@ -34,7 +34,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 112,
+      "auto_install": true
     }
   }
 }

--- a/winkmem/manifest.json
+++ b/winkmem/manifest.json
@@ -37,7 +37,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 10254,
+      "auto_install": true
     }
   }
 }

--- a/wmi_check/manifest.json
+++ b/wmi_check/manifest.json
@@ -34,7 +34,9 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "source_type_id": 115,
+      "auto_install": true
     }
   }
 }

--- a/yarn/manifest.json
+++ b/yarn/manifest.json
@@ -45,7 +45,9 @@
       "process_signatures": [
         "java org.apache.hadoop.yarn.server.resourcemanager.ResourceManager",
         "java org.apache.hadoop.yarn.server.nodemanager.NodeManager"
-      ]
+      ],
+      "source_type_id": 134,
+      "auto_install": true
     },
     "dashboards": {
       "yarn": "assets/dashboards/yarn_dashboard.json",

--- a/zk/manifest.json
+++ b/zk/manifest.json
@@ -46,7 +46,9 @@
       "process_signatures": [
         "zkServer.sh start",
         "java zoo.cfg"
-      ]
+      ],
+      "source_type_id": 48,
+      "auto_install": true
     },
     "dashboards": {
       "zookeeper": "assets/dashboards/zookeeper_dashboard.json"


### PR DESCRIPTION
### What does this PR do?
Backfills the manifests with the soon-to-be-required source_type_id and auto_install fields.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
