### PR TITLE
Mark the `test_vacuum_age` test as flaky

### DIFF
--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -3,6 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import psycopg2
 import pytest
+from flaky import flaky
 
 from datadog_checks.base import ConfigurationError
 from datadog_checks.postgres.relationsmanager import QUERY_PG_CLASS, RelationsManager
@@ -192,6 +193,7 @@ def test_index_metrics(aggregator, integration_check, pg_instance):
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
+@flaky(max_runs=5)
 def test_vacuum_age(aggregator, integration_check, pg_instance):
     pg_instance['relations'] = ['persons']
     pg_instance['dbname'] = 'datadog_test'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Mark the `test_vacuum_age` test as flaky

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/integrations-core/actions/runs/7621280878/job/20757461388

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I created https://datadoghq.atlassian.net/browse/DBMON-3472

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
