### PR TITLE
Switch to os.scandir for Python >= 3.5

### DIFF
--- a/datadog_checks_base/changelog.d/16702.removed
+++ b/datadog_checks_base/changelog.d/16702.removed
@@ -1,0 +1,1 @@
+Drop scandir depedency for Python >= 3.5

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -94,7 +94,7 @@ requests-unixsocket==0.3.0
 requests==2.27.1; python_version < '3.0'
 requests==2.31.0; python_version > '3.0'
 rethinkdb==2.4.9
-scandir==1.10.0
+scandir==1.10.0; python_version < '3.5'
 securesystemslib[crypto,pynacl]==0.28.0; python_version > '3.0'
 semver==2.13.0; python_version < '3.0'
 semver==3.0.2; python_version > '3.0'

--- a/directory/changelog.d/16702.fixed
+++ b/directory/changelog.d/16702.fixed
@@ -1,0 +1,1 @@
+Switch to os.scandir for Python >= 3.5

--- a/directory/datadog_checks/directory/traverse.py
+++ b/directory/datadog_checks/directory/traverse.py
@@ -5,7 +5,11 @@ import platform
 import sys
 
 import six
-from scandir import scandir
+
+try:
+    from os import scandir
+except ImportError:
+    from scandir import scandir
 
 
 def _walk(top, onerror=None, followlinks=False):

--- a/directory/pyproject.toml
+++ b/directory/pyproject.toml
@@ -39,6 +39,7 @@ dynamic = [
 
 [project.optional-dependencies]
 deps = [
+    # Starting with Python 3.5 'scandir.scandir' is in the standard library as 'os.scandir'.
     "scandir==1.10.0; python_version < '3.5'",
 ]
 

--- a/directory/pyproject.toml
+++ b/directory/pyproject.toml
@@ -39,7 +39,7 @@ dynamic = [
 
 [project.optional-dependencies]
 deps = [
-    "scandir==1.10.0",
+    "scandir==1.10.0; python_version < '3.5'",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

1. This function was added to standard lib in python 3.5, scandir itself claims [support until 3.7](https://github.com/benhoyt/scandir/blob/e33140fe0dfe5b967e9eb2595b6e6e8eb3c91a64/setup.py#L82)
2. fix tests on at least macos m1 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
