### PR TITLE
Fix metadata debug logging error due to mismatched arguments

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/metadata.py
+++ b/sqlserver/datadog_checks/sqlserver/metadata.py
@@ -121,7 +121,7 @@ class SqlserverMetadata(DBMAsyncJob):
     def _load_settings_rows(self, cursor):
         self.log.debug("collecting sql server instance settings")
         query = self._get_settings_query_cached(cursor)
-        self.log.debug("Running query [%s] %s", query)
+        self.log.debug("Running query [%s]", query)
         cursor.execute(query)
         columns = [i[0] for i in cursor.description]
         # construct row dicts manually as there's no DictCursor for pyodbc


### PR DESCRIPTION
### What does this PR do?
Fix metadata debug logging error due to mismatched arguments

![image](https://github.com/DataDog/integrations-core/assets/4964070/15126799-5159-4b12-9f10-c483849a1d10)

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
