### PR TITLE
Add more conditions to the e2e env

### DIFF
--- a/harbor/tests/common.py
+++ b/harbor/tests/common.py
@@ -11,7 +11,7 @@ HARBOR_COMPONENTS = ['chartmuseum', 'registry', 'redis', 'jobservice', 'registry
 
 HARBOR_VERSION = [int(i) for i in os.environ['HARBOR_VERSION'].split('.')]
 
-USERS_URL = '/api/users/' if HARBOR_VERSION < VERSION_2_2 else '/api/v2.0/users/'
+USERS_PATH = '/api/users/' if HARBOR_VERSION < VERSION_2_2 else '/api/v2.0/users/'
 
 HARBOR_METRICS = [
     # Metric_name, requires admin privileges

--- a/harbor/tests/conftest.py
+++ b/harbor/tests/conftest.py
@@ -8,8 +8,8 @@ import pytest
 import requests
 from mock import patch
 
-from datadog_checks.dev import LazyFunction, docker_run
-from datadog_checks.dev.conditions import CheckDockerLogs, CheckEndpoints, WaitFor
+from datadog_checks.dev import docker_run
+from datadog_checks.dev.conditions import CheckDockerLogs, WaitFor
 from datadog_checks.dev.http import MockResponse
 from datadog_checks.harbor import HarborCheck
 from datadog_checks.harbor.api import HarborAPI

--- a/harbor/tests/conftest.py
+++ b/harbor/tests/conftest.py
@@ -9,7 +9,7 @@ import requests
 from mock import patch
 
 from datadog_checks.dev import LazyFunction, docker_run
-from datadog_checks.dev.conditions import CheckDockerLogs
+from datadog_checks.dev.conditions import CheckDockerLogs, CheckEndpoints
 from datadog_checks.dev.http import MockResponse
 from datadog_checks.harbor import HarborCheck
 from datadog_checks.harbor.api import HarborAPI
@@ -50,6 +50,7 @@ def dd_environment(e2e_instance):
     conditions = [
         CheckDockerLogs(compose_file, expected_log, wait=3),
         lambda: time.sleep(4),
+        CheckEndpoints(URL + USERS_URL),
         CreateSimpleUser(),
     ]
     with docker_run(compose_file, conditions=conditions, attempts=3):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add more conditions to the e2e env

### Motivation
<!-- What inspired you to submit this pull request? -->

- We currently do not retry the check on this URL, if it fails the first time we try to call it, we fail the try and retry completely
- https://github.com/DataDog/integrations-core/actions/runs/7648392751/job/20841166307

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
