### PR TITLE
Exclude former teammates from QA card assignment

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -24,6 +24,11 @@ github_team = "agent-integrations"
 # Our team stopped doing QA so stop assigning QA tasks to us directly
 # Leaving the team in the config so we can manually assign our team if needed
 # github_labels = ["team/agent-integrations"]
+exclude_members = [
+  "ofek",
+  "alopezz",
+  "hithwen",
+]
 
 [teams."Platform Integrations"]
 jira_project = "PLINT"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

This past release showed that we still have **some QA cards to assign** to the `agent-integrations` team:
1. New/migrated integrations.
2. Changes to datadog-agent repo.

We have some folks who are part of the github team who we would like to exclude from getting QA cards.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
