### PR TITLE
Fix typo

### DIFF
--- a/nginx/changelog.d/16717.fixed
+++ b/nginx/changelog.d/16717.fixed
@@ -1,0 +1,1 @@
+Fix typo

--- a/nginx/datadog_checks/nginx/metrics.py
+++ b/nginx/datadog_checks/nginx/metrics.py
@@ -34,7 +34,7 @@ VTS_METRIC_MAP = {
     'nginx.upstream.down': 'nginx.upstream.peers.health_checks.last_passed',
 }
 
-# NGNINX Plus metrics that are sent as both a count and gauge for backwards compatibility
+# NGINX Plus metrics that are sent as both a count and gauge for backwards compatibility
 # The count metrics will have _count appended to their names
 METRICS_SEND_AS_COUNT = [
     'nginx.upstream.peers.responses.1xx',
@@ -112,11 +112,11 @@ METRICS_SEND_AS_COUNT = [
     'nginx.upstream.peers.unavail',
 ]
 
-# NGNINX Plus metrics that are sent as both a histogram and gauge for backwards compatibility
+# NGINX Plus metrics that are sent as both a histogram and gauge for backwards compatibility
 # The histogram metrics will have _histogram appended to their names
 METRICS_SEND_AS_HISTOGRAM = {'nginx.upstream.peers.response_time', 'nginx.stream.upstream.peers.response_time'}
 
-# NGNINX Plus metrics that are sent as only a count.
+# NGINX Plus metrics that are sent as only a count.
 # These metrics will not have _count appended to their names
 COUNT_METRICS = [
     'nginx.location_zone.responses.total',


### PR DESCRIPTION
### What does this PR do?
Fix typo in nginx/metrics.py

### Motivation
I'm a collaborator nginx-module-vts, while I investigated the datadog integration with vts module, I found a typo in some comments. Thus I fixed.

### Additional Notes
Nothing especially.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
