### PR TITLE
Update the labeler config for releases

### DIFF
--- a/.github/workflows/config/labeler.yml
+++ b/.github/workflows/config/labeler.yml
@@ -482,5 +482,4 @@ integration/yarn:
 integration/zk:
 - zk/**/*
 release:
-- requirements-agent-release.txt
 - '*/__about__.py'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update the labeler config for releases 

### Motivation
<!-- What inspired you to submit this pull request? -->

Checks that are not included in the agent (namely checks_dev, ddev) don't get the release label

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
