### PR TITLE
Do not sign `ddev` after the release

### DIFF
--- a/datadog_checks_dev/changelog.d/16737.fixed
+++ b/datadog_checks_dev/changelog.d/16737.fixed
@@ -1,0 +1,1 @@
+Do not sign `ddev` after the release

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/make.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/make.py
@@ -87,7 +87,7 @@ def make(ctx, checks, version, end, initial_release, skip_sign, sign_only, exclu
         abort('Please create a release branch, you do not want to commit to master directly.')
 
     # Signing is done by a pipeline in a separate commit
-    if not core_workflow and not sign_only:
+    if not core_workflow and not sign_only or checks == ["ddev"]:
         skip_sign = True
 
     # Keep track of the list of checks that have been updated.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/make.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/make.py
@@ -87,7 +87,7 @@ def make(ctx, checks, version, end, initial_release, skip_sign, sign_only, exclu
         abort('Please create a release branch, you do not want to commit to master directly.')
 
     # Signing is done by a pipeline in a separate commit
-    if not core_workflow and not sign_only or checks == ["ddev"]:
+    if (not core_workflow and not sign_only) or checks == ["ddev"]:
         skip_sign = True
 
     # Keep track of the list of checks that have been updated.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Do not sign `ddev` after the release

### Motivation
<!-- What inspired you to submit this pull request? -->

- When we release ddev, we end up with an empty signature file: https://github.com/DataDog/integrations-core/pull/16732
- Then the release pipeline fails because of that
- So we have to manually update the signatures: https://github.com/DataDog/integrations-core/pull/16735

If we stop signing it, no need to update the signatures again

### Additional Notes
<!-- Anything else we should know when reviewing? -->

kinda related to https://datadoghq.atlassian.net/browse/AITS-188

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
