### PR TITLE
[ECOS-1179] Sync the auto_install flag and source type id for the docker integration

### DIFF
--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -28,6 +28,8 @@
   "oauth": {},
   "assets": {
     "integration": {
+      "auto_install": true,
+      "source_type_id": 73,
       "source_type_name": "Docker",
       "process_signatures": [
         "dockerd",

--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -28,7 +28,7 @@
   "oauth": {},
   "assets": {
     "integration": {
-      "auto_install": false,
+      "auto_install": true,
       "source_type_id": 73,
       "source_type_name": "Docker",
       "process_signatures": [

--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -28,7 +28,7 @@
   "oauth": {},
   "assets": {
     "integration": {
-      "auto_install": true,
+      "auto_install": false,
       "source_type_id": 73,
       "source_type_name": "Docker",
       "process_signatures": [


### PR DESCRIPTION
### What does this PR do?
The docker integration definition and assets appear to exist both in dogweb code here: https://github.com/DataDog/dogweb/tree/prod/integration/docker and in the integrations-core repo here: https://github.com/DataDog/integrations-core/tree/master/docker_daemon .

We'd like to consolidate these assets in one place as part of cleaning up hacks in the integration publishing code like this one: https://github.com/DataDog/declarative-integration-pipeline/blob/2043224e62d52c6c410c15ee0af582f478989c4c/declarative_integrations/create_agent_integration/constants.py#L163

This PR ensures that the source_type_id and auto_install flag match between the 2 repos.

This is a no-op for customers because the integration loader for dogweb services will ignore this manifest.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
