### PR TITLE
[DBMON-3495] Replace embedded null characters in query text

### DIFF
--- a/datadog_checks_base/changelog.d/16742.fixed
+++ b/datadog_checks_base/changelog.d/16742.fixed
@@ -1,0 +1,1 @@
+[DBMON-3495] Replace embedded null characters with empty string in query text

--- a/datadog_checks_base/changelog.d/16742.fixed
+++ b/datadog_checks_base/changelog.d/16742.fixed
@@ -1,1 +1,1 @@
-[DBMON-3495] Replace embedded null characters with empty string in query text
+[DBMON-3495] Add `replace_null_character` option to replace embedded null characters with empty string in query text

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -195,7 +195,7 @@ def default_json_event_encoding(o):
 def obfuscate_sql_with_metadata(query, options=None, replace_null_character=False):
     if not query:
         return {'query': '', 'metadata': {}}
-    
+
     if replace_null_character:
         # replace embedded null characters \x00 before obfuscating
         # WHY NOT ALWAYS REPLACE?
@@ -222,6 +222,7 @@ def obfuscate_sql_with_metadata(query, options=None, replace_null_character=Fals
     tables = [table.strip() for table in tables.split(',') if table != ''] if tables else None
     statement_with_metadata['metadata']['tables'] = tables
     return statement_with_metadata
+
 
 class DBMAsyncJob(object):
     # Set an arbitrary high limit so that dbm async jobs (which aren't CPU bound) don't

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -193,14 +193,22 @@ def default_json_event_encoding(o):
 
 
 def obfuscate_sql_with_metadata(query, options=None, replace_null_character=False):
+    """
+    Obfuscate a SQL query and return the obfuscated query and metadata.
+    :param str query: The SQL query to obfuscate.
+    :param dict options: Obfuscation options to pass to the obfuscator.
+    :param bool replace_null_character: Whether to replace embedded null characters \x00 before obfuscating.
+        Note: Setting this parameter to true involves an extra string traversal and copy. 
+        Do set this to true if the database allows embedded null characters in text fields, for example SQL Server.
+        Otherwise obfuscation will fail if the query contains embedded null characters.
+    :return: A dict containing the obfuscated query and metadata.
+    :rtype: dict
+    """
     if not query:
         return {'query': '', 'metadata': {}}
 
     if replace_null_character:
         # replace embedded null characters \x00 before obfuscating
-        # WHY NOT ALWAYS REPLACE?
-        # To avoid one extra string traversal and copy.
-        # DBMS like postgresql does not allow null characters in text fields
         query = query.replace('\x00', '')
 
     statement = datadog_agent.obfuscate_sql(query, options)

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -198,7 +198,7 @@ def obfuscate_sql_with_metadata(query, options=None, replace_null_character=Fals
     :param str query: The SQL query to obfuscate.
     :param dict options: Obfuscation options to pass to the obfuscator.
     :param bool replace_null_character: Whether to replace embedded null characters \x00 before obfuscating.
-        Note: Setting this parameter to true involves an extra string traversal and copy. 
+        Note: Setting this parameter to true involves an extra string traversal and copy.
         Do set this to true if the database allows embedded null characters in text fields, for example SQL Server.
         Otherwise obfuscation will fail if the query contains embedded null characters.
     :return: A dict containing the obfuscated query and metadata.

--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -169,6 +169,32 @@ def test_obfuscate_sql_with_metadata(obfuscator_return_value, expected_value):
     assert statement['metadata'] == {}
 
 
+@pytest.mark.parametrize(
+    "input_query,expected_query,replace_null_character",
+    [
+        (
+            "SELECT * FROM randomtable where name = '123\x00'",
+            "SELECT * FROM randomtable where name = '123'",
+            True,
+        ),
+        (
+            "SELECT * FROM randomtable where name = '123\x00'",
+            "SELECT * FROM randomtable where name = '123\x00'",
+            False,
+        ),
+    ]
+)
+def test_obfuscate_sql_with_metadata_replace_null_character(input_query, expected_query, replace_null_character):
+    def _mock_obfuscate_sql(query, options=None):
+        return json.dumps({'query': query, 'metadata': {}})
+
+    # Check that it can handle null characters
+    with mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent:
+        mock_agent.side_effect = _mock_obfuscate_sql
+        statement = obfuscate_sql_with_metadata(input_query, None, replace_null_character=replace_null_character)
+        assert statement['query'] == expected_query
+
+
 class TestJob(DBMAsyncJob):
     def __init__(self, check, run_sync=False, enabled=True, rate_limit=10, min_collection_interval=15):
         super(TestJob, self).__init__(

--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -182,7 +182,7 @@ def test_obfuscate_sql_with_metadata(obfuscator_return_value, expected_value):
             "SELECT * FROM randomtable where name = '123\x00'",
             False,
         ),
-    ]
+    ],
 )
 def test_obfuscate_sql_with_metadata_replace_null_character(input_query, expected_query, replace_null_character):
     def _mock_obfuscate_sql(query, options=None):

--- a/sqlserver/changelog.d/16742.fixed
+++ b/sqlserver/changelog.d/16742.fixed
@@ -1,0 +1,1 @@
+[DBMON-3495] Replace embedded null characters with empty string in query text

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -280,12 +280,16 @@ class SqlserverActivity(DBMAsyncJob):
         if 'statement_text' not in row:
             return self._sanitize_row(row)
         try:
-            statement = obfuscate_sql_with_metadata(row['statement_text'], self._config.obfuscator_options, replace_null_character=True)
+            statement = obfuscate_sql_with_metadata(
+                row['statement_text'], self._config.obfuscator_options, replace_null_character=True
+            )
             # sqlserver doesn't have a boolean data type so convert integer to boolean
             comments, row['is_proc'], procedure_name = extract_sql_comments_and_procedure_name(row['text'])
             if row['is_proc'] and 'text' in row:
                 try:
-                    procedure_statement = obfuscate_sql_with_metadata(row['text'], self._config.obfuscator_options, replace_null_character=True)
+                    procedure_statement = obfuscate_sql_with_metadata(
+                        row['text'], self._config.obfuscator_options, replace_null_character=True
+                    )
                     # procedure_signature is used to link this activity event with
                     # its related plan events
                     row['procedure_signature'] = compute_sql_signature(procedure_statement['query'])

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -280,12 +280,12 @@ class SqlserverActivity(DBMAsyncJob):
         if 'statement_text' not in row:
             return self._sanitize_row(row)
         try:
-            statement = obfuscate_sql_with_metadata(row['statement_text'], self._config.obfuscator_options)
+            statement = obfuscate_sql_with_metadata(row['statement_text'], self._config.obfuscator_options, replace_null_character=True)
             # sqlserver doesn't have a boolean data type so convert integer to boolean
             comments, row['is_proc'], procedure_name = extract_sql_comments_and_procedure_name(row['text'])
             if row['is_proc'] and 'text' in row:
                 try:
-                    procedure_statement = obfuscate_sql_with_metadata(row['text'], self._config.obfuscator_options)
+                    procedure_statement = obfuscate_sql_with_metadata(row['text'], self._config.obfuscator_options, replace_null_character=True)
                     # procedure_signature is used to link this activity event with
                     # its related plan events
                     row['procedure_signature'] = compute_sql_signature(procedure_statement['query'])
@@ -293,7 +293,7 @@ class SqlserverActivity(DBMAsyncJob):
                     # if we fail to obfuscate the procedure text,
                     # we should not mark query statement as failed to obfuscate
                     if self._config.log_unobfuscated_queries:
-                        self.log.warning("Failed to obfuscate stored procedure=[%s] | err=[%s]", row['text'], e)
+                        self.log.warning("Failed to obfuscate stored procedure=[%s] | err=[%s]", repr(row['text']), e)
                     else:
                         self.log.debug("Failed to obfuscate stored procedure | err=[%s]", e)
             obfuscated_statement = statement['query']
@@ -306,7 +306,7 @@ class SqlserverActivity(DBMAsyncJob):
                 row['procedure_name'] = procedure_name
         except Exception as e:
             if self._config.log_unobfuscated_queries:
-                self.log.warning("Failed to obfuscate query=[%s] | err=[%s]", row['statement_text'], e)
+                self.log.warning("Failed to obfuscate query=[%s] | err=[%s]", repr(row['statement_text']), e)
             else:
                 self.log.debug("Failed to obfuscate query | err=[%s]", e)
             obfuscated_statement = "ERROR: failed to obfuscate"

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -311,11 +311,15 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             try:
                 # Attempt to obfuscate SQL statement with metadata
                 procedure_statement = None
-                statement = obfuscate_sql_with_metadata(row['statement_text'], self._config.obfuscator_options, replace_null_character=True)
+                statement = obfuscate_sql_with_metadata(
+                    row['statement_text'], self._config.obfuscator_options, replace_null_character=True
+                )
                 comments, row['is_proc'], procedure_name = extract_sql_comments_and_procedure_name(row['text'])
 
                 if row['is_proc']:
-                    procedure_statement = obfuscate_sql_with_metadata(row['text'], self._config.obfuscator_options, replace_null_character=True)
+                    procedure_statement = obfuscate_sql_with_metadata(
+                        row['text'], self._config.obfuscator_options, replace_null_character=True
+                    )
 
             except Exception as e:
                 if self._config.log_unobfuscated_queries:

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -193,7 +193,7 @@ def obfuscate_xml_plan(raw_plan, obfuscator_options=None):
         for k in XML_PLAN_OBFUSCATION_ATTRS:
             val = e.attrib.get(k, None)
             if val:
-                statement = obfuscate_sql_with_metadata(val, obfuscator_options)
+                statement = obfuscate_sql_with_metadata(val, obfuscator_options, replace_null_character=True)
                 e.attrib[k] = ensure_unicode(statement['query'])
     return to_native_string(ET.tostring(tree, encoding="UTF-8"))
 
@@ -311,16 +311,16 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             try:
                 # Attempt to obfuscate SQL statement with metadata
                 procedure_statement = None
-                statement = obfuscate_sql_with_metadata(row['statement_text'], self._config.obfuscator_options)
+                statement = obfuscate_sql_with_metadata(row['statement_text'], self._config.obfuscator_options, replace_null_character=True)
                 comments, row['is_proc'], procedure_name = extract_sql_comments_and_procedure_name(row['text'])
 
                 if row['is_proc']:
-                    procedure_statement = obfuscate_sql_with_metadata(row['text'], self._config.obfuscator_options)
+                    procedure_statement = obfuscate_sql_with_metadata(row['text'], self._config.obfuscator_options, replace_null_character=True)
 
             except Exception as e:
                 if self._config.log_unobfuscated_queries:
                     raw_query_text = row['text'] if row.get('is_proc', False) else row['statement_text']
-                    self.log.warning("Failed to obfuscate query=[%s] | err=[%s]", raw_query_text, e)
+                    self.log.warning("Failed to obfuscate query=[%s] | err=[%s]", repr(raw_query_text), e)
                 else:
                     self.log.debug("Failed to obfuscate query | err=[%s]", e)
                 self._check.count(

--- a/sqlserver/tests/compose-ha/sql/aoag_primary.sql
+++ b/sqlserver/tests/compose-ha/sql/aoag_primary.sql
@@ -86,6 +86,17 @@ GRANT EXECUTE on procedureWithLargeCommment to bob;
 GRANT EXECUTE on procedureWithLargeCommment to fred;
 GO
 
+-- test procedure with embedded null characters
+CREATE PROCEDURE nullCharTest
+AS
+BEGIN
+ SELECT * FROM ϑings WHERE name = 'foo\x00';
+END;
+GO
+GRANT EXECUTE on nullCharTest to bob;
+GRANT EXECUTE on nullCharTest to fred;
+GO
+
 -- create test procedure for metrics loading feature
 USE master;
 GO

--- a/sqlserver/tests/compose-high-cardinality-windows/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality-windows/setup.sql
@@ -89,6 +89,17 @@ GRANT EXECUTE on procedureWithLargeCommment to bob;
 GRANT EXECUTE on procedureWithLargeCommment to fred;
 GO
 
+-- test procedure with embedded null characters
+CREATE PROCEDURE nullCharTest
+AS
+BEGIN
+ SELECT * FROM ϑings WHERE name = 'foo\x00';
+END;
+GO
+GRANT EXECUTE on nullCharTest to bob;
+GRANT EXECUTE on nullCharTest to fred;
+GO
+
 -- create an offline database to have an unavailable database to test with
 CREATE DATABASE unavailable_db;
 GO

--- a/sqlserver/tests/compose-high-cardinality/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality/setup.sql
@@ -112,6 +112,17 @@ GRANT EXECUTE on procedureWithLargeCommment to bob;
 GRANT EXECUTE on procedureWithLargeCommment to fred;
 GO
 
+-- test procedure with embedded null characters
+CREATE PROCEDURE nullCharTest
+AS
+BEGIN
+ SELECT * FROM ϑings WHERE name = 'foo\x00';
+END;
+GO
+GRANT EXECUTE on nullCharTest to bob;
+GRANT EXECUTE on nullCharTest to fred;
+GO
+
 -- Create test database for integration tests.
 -- Only bob and fred have read/write access to this database.
 CREATE DATABASE datadog_test;

--- a/sqlserver/tests/compose-windows/setup.sql
+++ b/sqlserver/tests/compose-windows/setup.sql
@@ -89,6 +89,17 @@ GRANT EXECUTE on procedureWithLargeCommment to bob;
 GRANT EXECUTE on procedureWithLargeCommment to fred;
 GO
 
+-- test procedure with embedded null characters
+CREATE PROCEDURE nullCharTest
+AS
+BEGIN
+ SELECT * FROM ϑings WHERE name = 'foo\x00';
+END;
+GO
+GRANT EXECUTE on nullCharTest to bob;
+GRANT EXECUTE on nullCharTest to fred;
+GO
+
 -- create an offline database to have an unavailable database to test with
 CREATE DATABASE unavailable_db;
 GO

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -69,6 +69,17 @@ GRANT EXECUTE on procedureWithLargeCommment to bob;
 GRANT EXECUTE on procedureWithLargeCommment to fred;
 GO
 
+-- test procedure with embedded null characters
+CREATE PROCEDURE nullCharTest
+AS
+BEGIN
+ SELECT * FROM ϑings WHERE name = 'foo\x00';
+END;
+GO
+GRANT EXECUTE on nullCharTest to bob;
+GRANT EXECUTE on nullCharTest to fred;
+GO
+
 -- create an offline database to have an unavailable database to test with
 CREATE DATABASE unavailable_db;
 GO

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -959,9 +959,7 @@ def test_statement_stored_procedure_characters_limit(
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_statement_with_embedded_characters(
-    aggregator, datadog_agent, dd_run_check, dbm_instance, bob_conn
-):
+def test_statement_with_embedded_characters(aggregator, datadog_agent, dd_run_check, dbm_instance, bob_conn):
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
     query = "EXEC nullCharTest;"
 

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -957,6 +957,41 @@ def test_statement_stored_procedure_characters_limit(
         assert "procedure_signature" in matched_rows[0]
 
 
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_statement_with_embedded_characters(
+    aggregator, datadog_agent, dd_run_check, dbm_instance, bob_conn
+):
+    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
+    query = "EXEC nullCharTest;"
+
+    def _obfuscate_sql(sql_query, options=None):
+        return json.dumps({'query': sql_query, 'metadata': {}})
+
+    # Execute the query with the mocked obfuscate_sql. The result should produce an event payload with the metadata.
+    with mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent:
+        mock_agent.side_effect = _obfuscate_sql
+        dd_run_check(check)
+        bob_conn.execute_with_retries(query, (), database="datadog_test")
+        dd_run_check(check)
+        aggregator.reset()
+        bob_conn.execute_with_retries(query, (), database="datadog_test")
+        dd_run_check(check)
+
+    # dbm-metrics
+    dbm_metrics = aggregator.get_event_platform_events("dbm-metrics")
+    assert len(dbm_metrics) == 1, "should have collected exactly one dbm-metrics payload"
+    payload = dbm_metrics[0]
+    # metrics rows
+    sqlserver_rows = payload.get('sqlserver_rows', [])
+    assert sqlserver_rows, "should have collected some sqlserver query metrics rows"
+
+    matched_rows = [s for s in sqlserver_rows if s.get("procedure_name") == "nullchartest"]
+    assert matched_rows, "should have collected the metric row with expected procedure name"
+    assert "text" in matched_rows[0]
+    assert "\x00" not in matched_rows[0]["text"]
+
+
 def _mock_database_list():
     Row = namedtuple('Row', 'name')
     fetchall_results = [


### PR DESCRIPTION
### What does this PR do?
This PR
- [datadog_checks_base] Add `replace_null_character` option in `obfuscate_sql_with_metadata` to replace embedded nulls with empty string
- [sqlserver] Replaces all embedded nulls in sql statement text 

### Motivation
Fix error `ValueError: embedded null character` in obfuscation and logging. 
```
2024-01-26 18:18:57 EST | CORE | ERROR | (pkg/collector/python/datadog_agent.go:129 in LogMessage) | sqlserver:5632e6fae0b72e41 | (tracking.py:84) | operation collect_statement_metrics_and_plans error
Traceback (most recent call last):
  File "C:\Program Files\Datadog\Datadog Agent\embedded3\Lib\site-packages\datadog_checks\sqlserver\statements.py", line 314, in _normalize_queries
    statement = obfuscate_sql_with_metadata(row['statement_text'], self._config.obfuscator_options)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Datadog\Datadog Agent\embedded3\Lib\site-packages\datadog_checks\base\utils\db\utils.py", line 199, in obfuscate_sql_with_metadata
    statement = datadog_agent.obfuscate_sql(query, options)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: embedded null character

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Program Files\Datadog\Datadog Agent\embedded3\Lib\site-packages\datadog_checks\base\utils\tracking.py", line 71, in wrapper
    result = function(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Datadog\Datadog Agent\embedded3\Lib\site-packages\datadog_checks\sqlserver\statements.py", line 412, in collect_statement_metrics_and_plans
    rows = self._collect_metrics_rows(cursor)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Datadog\Datadog Agent\embedded3\Lib\site-packages\datadog_checks\sqlserver\statements.py", line 361, in _collect_metrics_rows
    rows = self._normalize_queries(rows)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Datadog\Datadog Agent\embedded3\Lib\site-packages\datadog_checks\sqlserver\statements.py", line 323, in _normalize_queries
    self.log.warning("Failed to obfuscate query=[%s] | err=[%s]", raw_query_text, e)
  File "C:\Program Files\Datadog\Datadog Agent\embedded3\Lib\logging\__init__.py", line 1855, in warning
    self.log(WARNING, msg, *args, **kwargs)
  File "C:\Program Files\Datadog\Datadog Agent\embedded3\Lib\logging\__init__.py", line 1887, in log
    self.logger.log(level, msg, *args, **kwargs)
  File "C:\Program Files\Datadog\Datadog Agent\embedded3\Lib\logging\__init__.py", line 1559, in log
    self._log(level, msg, args, **kwargs)
  File "C:\Program Files\Datadog\Datadog Agent\embedded3\Lib\logging\__init__.py", line 1634, in _log
    self.handle(record)
  File "C:\Program Files\Datadog\Datadog Agent\embedded3\Lib\logging\__init__.py", line 1644, in handle
    self.callHandlers(record)
  File "C:\Program Files\Datadog\Datadog Agent\embedded3\Lib\logging\__init__.py", line 1706, in callHandlers
    hdlr.handle(record)
  File "C:\Program Files\Datadog\Datadog Agent\embedded3\Lib\logging\__init__.py", line 978, in handle
    self.emit(record)
  File "C:\Program Files\Datadog\Datadog Agent\embedded3\Lib\site-packages\datadog_checks\base\log.py", line 117, in emit
    datadog_agent.log(message, record.levelno)
ValueError: embedded null character
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
