### PR TITLE
Require base check that has fix for null characters in query strings

### DIFF
--- a/sqlserver/changelog.d/16750.fixed
+++ b/sqlserver/changelog.d/16750.fixed
@@ -1,0 +1,1 @@
+Require base check that has fix for null characters in query strings

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=34.1.0",
+    "datadog-checks-base>=36.0.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Another follow-up to https://github.com/DataDog/integrations-core/pull/16742. sqlserver check needs the latest base check version to work.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
