### PR TITLE
Tweaks to Linux dependency build

### DIFF
--- a/.builders/images/linux-x86_64/Dockerfile
+++ b/.builders/images/linux-x86_64/Dockerfile
@@ -4,6 +4,8 @@ FROM ${BASE_IMAGE}
 # Script for the common task of fetching a source tarball, compiling and installing it
 COPY install-from-source.sh /
 
+ENV CFLAGS="-O2"
+
 # For Python 2, we get openssl(1) via yum just to get the necessary headers,
 # and we remove the package after compilation to prevent it from interfering
 # with the use of openssl3 everywhere else

--- a/.builders/images/linux-x86_64/Dockerfile
+++ b/.builders/images/linux-x86_64/Dockerfile
@@ -156,6 +156,29 @@ RUN \
  SHA256="7ccfc6abd01ed67c1a0924b353e526f1b766b21f42d4562ee635a8ebfc5bb38c" \
  RELATIVE_PATH="cyrus-sasl-{{version}}" \
  bash install-from-source.sh --with-dblib=lmdb --enable-gssapi=/usr/local
+# curl
+RUN \
+ DOWNLOAD_URL="https://curl.haxx.se/download/curl-{{version}}.tar.gz" \
+ VERSION="8.4.0" \
+ SHA256="816e41809c043ff285e8c0f06a75a1fa250211bbfb2dc0a037eeef39f1a9e427" \
+ RELATIVE_PATH="curl-{{version}}" \
+  bash install-from-source.sh \
+    --disable-manual \
+    --disable-debug \
+    --enable-optimize \
+    --disable-static \
+    --disable-ldap \
+    --disable-ldaps \
+    --disable-rtsp \
+    --enable-proxy \
+    --disable-dependency-tracking \
+    --enable-ipv6 \
+    --without-libidn \
+    --without-gnutls \
+    --without-librtmp \
+    --without-libssh2 \
+    --with-ssl=/usr/local \
+ && rm /usr/local/bin/curl
 
 # Environment variables to help openssl crate find OpenSSL
 ENV OPENSSL_LIB_DIR="/usr/local/lib64"

--- a/.builders/images/linux-x86_64/build_script.sh
+++ b/.builders/images/linux-x86_64/build_script.sh
@@ -24,7 +24,7 @@ if [[ "${DD_BUILD_PYTHON_VERSION}" == "3" ]]; then
         VERSION="${kafka_version}" \
         SHA256="2d49c35c77eeb3d42fa61c43757fcbb6a206daa560247154e60642bcdcc14d12" \
         RELATIVE_PATH="librdkafka-{{version}}" \
-        bash install-from-source.sh --enable-sasl
+        bash install-from-source.sh --enable-sasl --enable-curl
     always_build+=("confluent-kafka")
 
     # pydantic-core


### PR DESCRIPTION
### What does this PR do?

Adds optimization flag to all compilations and compiles librdkakfa with curl support.

### Motivation

Equivalents found in Omnibus:
- https://github.com/DataDog/omnibus-ruby/blob/f3cbfdcf00a208cc165a30da80a95c456b5fa25a/lib/omnibus/software.rb#L788C25-L788C64
- https://github.com/DataDog/datadog-agent/pull/22040/files

I found out about this while working on the MacOS build and made a note to add them to the Linux build.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
