### PR TITLE
Remove unsupported characters from README templates.

### DIFF
--- a/datadog_checks_dev/changelog.d/16759.fixed
+++ b/datadog_checks_dev/changelog.d/16759.fixed
@@ -1,0 +1,1 @@
+Remove unsupported characters from README templates.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/README.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/README.md
@@ -12,11 +12,11 @@ This integration monitors [{integration_name}][4].
 
 ### Configuration
 
-1. <List of steps to setup this Integration>
+Replace with steps to setup this Integration
 
 ### Validation
 
-<Steps to validate integration is functioning as expected>
+Replace with steps to validate integration is functioning as expected
 
 ## Data Collected
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/README.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/README.md
@@ -12,7 +12,7 @@ This integration monitors [{integration_name}][4].
 
 ### Configuration
 
-!!! TBD !!!
+!!! Add list of steps to set up this integration !!!
 
 ### Validation
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/README.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/README.md
@@ -12,11 +12,11 @@ This integration monitors [{integration_name}][4].
 
 ### Configuration
 
-Replace with steps to setup this Integration
+!!! TBD !!!
 
 ### Validation
 
-Replace with steps to validate integration is functioning as expected
+!!! TBD !!!
 
 ## Data Collected
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/README.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/README.md
@@ -16,7 +16,7 @@ This integration monitors [{integration_name}][4].
 
 ### Validation
 
-!!! TBD !!!
+!!! Add steps to validate integration is functioning as expected !!!
 
 ## Data Collected
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/metrics_pull/{check_name}/README.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/metrics_pull/{check_name}/README.md
@@ -12,11 +12,11 @@ This check monitors [{integration_name}][1].
 
 ### Configuration
 
-Replace with steps to configure this integration
+!!! TBD !!!
 
 ### Validation
 
-Replace with steps to validate integration is functioning as expected
+!!! TBD !!!
 
 ## Data Collected
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/metrics_pull/{check_name}/README.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/metrics_pull/{check_name}/README.md
@@ -12,11 +12,11 @@ This check monitors [{integration_name}][1].
 
 ### Configuration
 
-1. <List of steps to configure this integration>
+Replace with steps to configure this integration
 
 ### Validation
 
-<Steps to validate integration is functioning as expected>
+Replace with steps to validate integration is functioning as expected
 
 ## Data Collected
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/metrics_pull/{check_name}/README.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/metrics_pull/{check_name}/README.md
@@ -16,7 +16,7 @@ This check monitors [{integration_name}][1].
 
 ### Validation
 
-!!! TBD !!!
+!!! Add steps to validate integration is functioning as expected !!!
 
 ## Data Collected
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/metrics_pull/{check_name}/README.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/metrics_pull/{check_name}/README.md
@@ -12,7 +12,7 @@ This check monitors [{integration_name}][1].
 
 ### Configuration
 
-!!! TBD !!!
+!!! Add list of steps to set up this integration !!!
 
 ### Validation
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/README.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/README.md
@@ -12,11 +12,11 @@ This check monitors [{integration_name}][1].
 
 ### Configuration
 
-1. <List of steps to setup this Integration>
+Replace with steps to setup this Integration
 
 ### Validation
 
-<Steps to validate integration is functioning as expected>
+Replace with steps to validate integration is functioning as expected
 
 ## Data Collected
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/README.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/README.md
@@ -16,7 +16,7 @@ This check monitors [{integration_name}][1].
 
 ### Validation
 
-!!! TBD !!!
+!!! Add steps to validate integration is functioning as expected !!!
 
 ## Data Collected
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/README.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/README.md
@@ -12,11 +12,11 @@ This check monitors [{integration_name}][1].
 
 ### Configuration
 
-Replace with steps to setup this Integration
+!!! TBD !!!
 
 ### Validation
 
-Replace with steps to validate integration is functioning as expected
+!!! TBD !!!
 
 ## Data Collected
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/README.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/README.md
@@ -12,7 +12,7 @@ This check monitors [{integration_name}][1].
 
 ### Configuration
 
-!!! TBD !!!
+!!! Add list of steps to set up this integration !!!
 
 ### Validation
 


### PR DESCRIPTION
### What does this PR do?
Removes the angle brackets from these templates because they cause `integration sync` to fail in a confusing way.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
