### PR TITLE
Ensure that builds run to completion on merges

### DIFF
--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -16,8 +16,8 @@ on:
     - datadog_checks_base/datadog_checks/base/data/agent_requirements.in
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'pull_request' && true || false }}
 
 defaults:
   run:
@@ -95,7 +95,7 @@ jobs:
     - name: Pull image and build wheels
       if: steps.changed-files.outputs.builders_any_changed != 'true'
       run: |-
-        digest=$(jq -r '.${{ matrix.job.image }}' .deps/image_digests.json)
+        digest=$(jq -r '.["${{ matrix.job.image }}"]' .deps/image_digests.json)
         python .builders/build.py ${{ matrix.job.image }} --python 3 ${{ env.OUT_DIR }}/py3 --digest $digest
         python .builders/build.py ${{ matrix.job.image }} --python 2 ${{ env.OUT_DIR }}/py2 --digest $digest
 


### PR DESCRIPTION
### Motivation

PRs should be the only time where it's okay for in progress jobs to get canceled since no publishing would occur