### PR TITLE
Use forked version of auditwheel with correct rpath patching

### DIFF
--- a/.builders/images/runner_dependencies.txt
+++ b/.builders/images/runner_dependencies.txt
@@ -1,5 +1,5 @@
 python-dotenv==1.0.0
 urllib3==2.2.0
-auditwheel==5.4.0; sys_platform == 'linux'
+auditwheel @ git+https://github.com/DataDog/auditwheel.git@64f212de1791858c21657763385b3879f93cdb04; sys_platform == 'linux'
 delvewheel==1.5.2; sys_platform == 'win32'
 delocate==0.10.7; sys_platform == 'darwin'


### PR DESCRIPTION
### What does this PR do?

Changes version of auditwheel to use a patched fork that sets the RPATH the way we want.

https://github.com/pypa/auditwheel/compare/main...DataDog:auditwheel:alopez/set-correct-rpath-on-copied-libs

### Motivation

When trying to integrate our repaired wheels into the Agent build, Omnibus' health check failed. The reason is related to what is reported in https://github.com/pypa/auditwheel/issues/451. The summary of the issue is that `ldd` can't find the libraries linked from libraries that are copied into the wheel because the `RPATH` of the copied libraries does not point to the right location.

### Additional Notes

This required some changes to the repair script that calls functions within auditwheel because apparently that API is not really stable.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
