### PR TITLE
Update auditwheel

### DIFF
--- a/.builders/images/runner_dependencies.txt
+++ b/.builders/images/runner_dependencies.txt
@@ -1,5 +1,5 @@
 python-dotenv==1.0.0
 urllib3==2.2.0
-auditwheel @ git+https://github.com/DataDog/auditwheel.git@64f212de1791858c21657763385b3879f93cdb04; sys_platform == 'linux'
+auditwheel==6.0.0; sys_platform == 'linux'
 delvewheel==1.5.2; sys_platform == 'win32'
 delocate==0.10.7; sys_platform == 'darwin'


### PR DESCRIPTION
### What does this PR do?

Replace our fork by the latest version of auditwheel which now includes the fix we needed.

### Motivation

Auditwheel released the fix we submitted for rpaths: https://github.com/pypa/auditwheel/releases/tag/6.0.0

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
