### PR TITLE
Set rpath to $ORIGIN

### DIFF
--- a/.builders/images/linux-x86_64/Dockerfile
+++ b/.builders/images/linux-x86_64/Dockerfile
@@ -5,6 +5,9 @@ FROM ${BASE_IMAGE}
 COPY install-from-source.sh /
 
 ENV CFLAGS="-O2"
+# Auditwheel will only set RPATH's for copied libs if an existing RPATH is found,
+# so we may as well set it to origin here anyway.
+ENV LDFLAGS="-Wl,-rpath,'\$\$ORIGIN'"
 
 # For Python 2, we get openssl(1) via yum just to get the necessary headers,
 # and we remove the package after compilation to prevent it from interfering


### PR DESCRIPTION
### What does this PR do?

Sets the `rpath` to `$ORIGIN` on the `LDFLAGS` so that all the libraries we ship have that set from the start.

### Motivation

Auditwheel only patches the `RPATH` if it's already set (or if `RUNPATH` is set). See [here](https://github.com/pypa/auditwheel/blob/db7962149a3e971eba3974a58edcb2226c787f8d/src/auditwheel/repair.py#L166-L167). That means that currently we can't rely on it to set the `RPATH` as needed by the health check.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
