### PR TITLE
Include zlib in wheels that need it

### DIFF
--- a/.builders/scripts/repair_wheels.py
+++ b/.builders/scripts/repair_wheels.py
@@ -77,6 +77,10 @@ def repair_linux(source_dir: str, built_dir: str, external_dir: str) -> None:
     policies = WheelPolicies()
     policy = policies.get_policy_by_name('manylinux2010_x86_64')
     abis = [policy['name'], *policy['aliases']]
+    # We edit the policy to remove zlib out of the whitelist to match the whitelisting policy we use
+    # on the Omnibus health check in the Agent
+    policy['lib_whitelist'].remove('libz.so.1')
+    del policy['symbol_versions']['ZLIB']
 
     for wheel in iter_wheels(source_dir):
         print(f'--> {wheel.name}')


### PR DESCRIPTION
### What does this PR do?

It removes zlib from the whitelist in the policies included with auditwheel, so that it gets included.

### Motivation

The Omnibus health check flags this library.

### Additional Notes

auditwheel whitelisted zlib in https://github.com/pypa/auditwheel/pull/334. The rationale is that this would be acceptable according to [PEP-600](https://peps.python.org/pep-0600/) due to zlib being shipped with all major distros supporting the base minimum glibc version.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
