### PR TITLE
Run the `release-auto` GitLab job on release branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -179,6 +179,7 @@ release-auto:
   image: $TAGGER_IMAGE
   only:
     - master
+    - ^\d+\.\d+\.x$
   except:
     - schedules
   script:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Run the `release-auto` GitLab job on release branches

### Motivation
<!-- What inspired you to submit this pull request? -->

- Currently we only run this job on the master branch
- When we need to release something off another branch, we need to rely on the [manual job](https://github.com/DataDog/integrations-core/blob/florentclarret/release_branch/.gitlab-ci.yml#L192-L212) that is triggered once we pushed the release tag with `ddev release tag`
- We often release integrations from the release branch, and we will do that more and more often in the future, to the point where releasing the integrations off the release branch will be the norm, and no longer the exception
- Running this job on release branches will allow us to avoid forgetting about pushing the tags

Note that for beta releases we can still manually push the tag to another branch to trigger the pipeline

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
