### PR TITLE
Build cyrus-sasl statically into librdkafka for inclusion in wheel (Linux)

### DIFF
--- a/.builders/images/linux-x86_64/Dockerfile
+++ b/.builders/images/linux-x86_64/Dockerfile
@@ -136,9 +136,6 @@ RUN \
  bash install-from-source.sh --disable-readline --with-included-ltdl --enable-ltdl-install
 
 # Dependencies needed to build librdkafka (and thus, confluent-kafka) with kerberos support
-# Note that we don't ship these but rely on the Agent providing a working cyrus-sasl installation
-# with kerberos support, therefore we only need to watch out for the version of cyrus-sasl being
-# compatible with that in the Agent, the rest shouldn't matter much
 RUN \
  DOWNLOAD_URL="https://github.com/LMDB/lmdb/archive/LMDB_{{version}}.tar.gz" \
  VERSION="0.9.29" \
@@ -154,11 +151,16 @@ RUN \
  RELATIVE_PATH="e2fsprogs-{{version}}" \
  bash install-from-source.sh --enable-elf-shlibs
 RUN \
+ # Add -fPIC to let librdkafka link against it statically
+ CFLAGS="${CFLAGS} -fPIC" \
+ # Explicitly ask the linker to use gssapi_krb5, otherwise static compilation fails
+ LDFLAGS="${LDFLAGS} -L/usr/local/lib -lgssapi_krb5" \
  DOWNLOAD_URL="https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-{{version}}/cyrus-sasl-{{version}}.tar.gz" \
  VERSION="2.1.28" \
  SHA256="7ccfc6abd01ed67c1a0924b353e526f1b766b21f42d4562ee635a8ebfc5bb38c" \
  RELATIVE_PATH="cyrus-sasl-{{version}}" \
- bash install-from-source.sh --with-dblib=lmdb --enable-gssapi=/usr/local
+ bash install-from-source.sh --with-dblib=lmdb --enable-gssapi=/usr/local \
+    --enable-static --disable-shared
 # curl
 RUN \
  DOWNLOAD_URL="https://curl.haxx.se/download/curl-{{version}}.tar.gz" \

--- a/.builders/images/linux-x86_64/build_script.sh
+++ b/.builders/images/linux-x86_64/build_script.sh
@@ -20,6 +20,8 @@ if [[ "${DD_BUILD_PYTHON_VERSION}" == "3" ]]; then
     # The librdkafka version needs to stay in sync with the confluent-kafka version,
     # thus we extract the version from the requirements file.
     kafka_version=$(grep 'confluent-kafka==' /home/requirements.in | sed -E 's/^.*([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+).*$/\1/')
+    # Libraries need to be explicitly specified for static linking to work properly
+    LDFLAGS="${LDFLAGS} -L/usr/local/lib -lkrb5 -lgssapi_krb5 -llmdb" \
     DOWNLOAD_URL="https://github.com/confluentinc/librdkafka/archive/refs/tags/v{{version}}.tar.gz" \
         VERSION="${kafka_version}" \
         SHA256="2d49c35c77eeb3d42fa61c43757fcbb6a206daa560247154e60642bcdcc14d12" \

--- a/.builders/scripts/repair_wheels.py
+++ b/.builders/scripts/repair_wheels.py
@@ -67,10 +67,6 @@ def repair_linux(source_dir: str, built_dir: str, external_dir: str) -> None:
     exclusions = frozenset({
         # pymqi
         'libmqic_r.so',
-        # confluent_kafka
-        # We leave cyrus-sasl out of the wheel because of the complexity involved in bundling it portably.
-        # This means the confluent-kafka wheel will have a runtime dependency on this library
-        'libsasl2.so.3',
     })
 
     # Hardcoded policy to the minimum we need to currently support


### PR DESCRIPTION
### What does this PR do?

Compiles `cyrus-sasl` statically.

### Motivation

Being able to create a self-contained wheel for the confluent-kafka-python package.

### Additional Notes

- [Topic in official docs](https://www.cyrusimap.org/sasl/sasl/advanced.html#using-cyrus-sasl-as-a-static-library). The caveats don't apply for our case, as we don't expect to add mechanisms to an existing Agent installation without upgrading the whole agent (for which case a recompiled version of the library could be shipped).
- I tested this by running e2e tests using an ad-hoc datadog-agent docker image based on the official one with these two changes:
  - Deleting all library files associated to sasl2, libgssapi, and librdkafka from the Agent's embedded environment.
  - Forcing installation of the separately built wheels onto the Agent's Python environment.
- I hope to achieve something similar with the macOS build in a follow up.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
