### PR TITLE
Build cyrus-sasl statically into librdkafka for inclusion in wheel (macOS)

### DIFF
--- a/.builders/images/install-from-source.sh
+++ b/.builders/images/install-from-source.sh
@@ -9,6 +9,7 @@
 #    Can also use the `{{version}}` placeholder for replacemnet.
 # Optional:
 # - CONFIGURE_SCRIPT: Alternative to the default ./configure
+# - INSTALL_COMMAND: Specify a command for installation other than the default `make install`
 
 set -euxo pipefail
 
@@ -24,6 +25,6 @@ tar -C "${workdir}" -xf "${workdir}/${archive_name}"
 pushd "${workdir}/${relative_path}"
 ${CONFIGURE_SCRIPT:-./configure} "$@"
 make -j $(nproc)
-make install
+${INSTALL_COMMAND:-make install}
 popd
 rm -rf "${workdir}"

--- a/.builders/images/macos/builder_setup.sh
+++ b/.builders/images/macos/builder_setup.sh
@@ -89,17 +89,20 @@ RELATIVE_PATH="curl-{{version}}" \
 rm "${DD_PREFIX_PATH}/bin/curl"
 
 # Dependencies needed to build librdkafka (and thus, confluent-kafka) with kerberos support
-# Note that we don't ship these but rely on the Agent providing a working cyrus-sasl installation
-# with kerberos support, therefore we only need to watch out for the version of cyrus-sasl being
-# compatible with that in the Agent, the rest shouldn't matter much
 DOWNLOAD_URL="https://github.com/LMDB/lmdb/archive/LMDB_{{version}}.tar.gz" \
 VERSION="0.9.29" \
 SHA256="22054926b426c66d8f2bc22071365df6e35f3aacf19ad943bc6167d4cae3bebb" \
 RELATIVE_PATH="lmdb-LMDB_{{version}}/libraries/liblmdb" \
 CONFIGURE_SCRIPT="true" \
+INSTALL_COMMAND="make prefix=${DD_PREFIX_PATH} install" \
+XCFLAGS=${CFLAGS} \
   install-from-source
+# CFLAGS and LDFLAGS add compiler and linker flags to make static compilation work
+CFLAGS="${CFLAGS} -fPIC" \
+LDFLAGS="${LDFLAGS} -L${DD_PREFIX_PATH}/lib -lgssapi_krb5" \
 DOWNLOAD_URL="https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-{{version}}/cyrus-sasl-{{version}}.tar.gz" \
 VERSION="2.1.28" \
 SHA256="7ccfc6abd01ed67c1a0924b353e526f1b766b21f42d4562ee635a8ebfc5bb38c" \
 RELATIVE_PATH="cyrus-sasl-{{version}}" \
-  install-from-source --with-dblib=lmdb --enable-gssapi="${DD_PREFIX_PATH}" --disable-macos-framework
+  install-from-source --with-dblib=lmdb --enable-gssapi="${DD_PREFIX_PATH}" --disable-macos-framework \
+    --enable-static --disable-shared

--- a/.builders/images/macos/extra_build.sh
+++ b/.builders/images/macos/extra_build.sh
@@ -10,12 +10,16 @@ if [[ "${DD_BUILD_PYTHON_VERSION}" == "3" ]]; then
     # The librdkafka version needs to stay in sync with the confluent-kafka version,
     # thus we extract the version from the requirements file.
     kafka_version=$(grep 'confluent-kafka==' "${DD_MOUNT_DIR}/requirements.in" | sed -E 's/^.*([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+).*$/\1/')
+    LDFLAGS="${LDFLAGS} -L${DD_PREFIX_PATH}/lib -lgssapi_krb5 -llmdb" \
     DOWNLOAD_URL="https://github.com/confluentinc/librdkafka/archive/refs/tags/v{{version}}.tar.gz" \
       VERSION="${kafka_version}" \
       SHA256="2d49c35c77eeb3d42fa61c43757fcbb6a206daa560247154e60642bcdcc14d12" \
       RELATIVE_PATH="librdkafka-{{version}}" \
       bash install-from-source.sh --prefix="${DD_PREFIX_PATH}" --enable-sasl --enable-curl
 
+    # lmdb doesnt't get the actual full path in its install name which means delocate won't find it
+    # Luckily we can patch it here so that it does.
+    install_name_tool -change liblmdb.so "${DD_PREFIX_PATH}/lib/liblmdb.so" "${DD_PREFIX_PATH}/lib//librdkafka.1.dylib"
     always_build+=("confluent-kafka")
 fi
 


### PR DESCRIPTION

### What does this PR do?

Compile `cyrus-sasl` statically for macOS.

### Motivation

Follow-up to #16827.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
