### PR TITLE
Add a `config` option to the `serve-openmetrics-payload` script.

### DIFF
--- a/ddev/changelog.d/16836.added
+++ b/ddev/changelog.d/16836.added
@@ -1,0 +1,1 @@
+Add a `config` option to the `serve-openmetrics-payload` script.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add a `config` option to the `serve-openmetrics-payload` script.

- By default we only set the `openmetrics_endpoint`
- The endpoint will be overriden no matter what to use the right URL to collect the metrics

Example:

```
❯ cat config.yaml
instances:                                                                                                                                                                                                                                                                                                                                                
  - openmetrics_endpoint: test
    min_collection_interval: 10
❯ ddev meta scripts serve-openmetrics-payload -c config.yaml ray ray_worker.txt
Digest: sha256:3c1672ec3ce46edea83bac19ec5d1347793218f23a60565f5b00430ecebf2148
Status: Image is up to date for datadog/agent-dev:master-py3
docker.io/datadog/agent-dev:master-py3
Waiting 10 seconds...
Check status -> ddev env agent ray serve-openmetrics-payload status
Trigger run -> ddev env agent ray serve-openmetrics-payload check
Config file -> /Users/florent.clarret/Library/Application Support/ddev/env/ray/serve-openmetrics-payload/config/ray.yaml
Starting the webserver... Use ctrl+c to stop it.
127.0.0.1 - - [09/Feb/2024 09:11:52] "GET /metrics HTTP/1.1" 200 -
127.0.0.1 - - [09/Feb/2024 09:12:02] "GET /metrics HTTP/1.1" 200 -
127.0.0.1 - - [09/Feb/2024 09:12:12] "GET /metrics HTTP/1.1" 200 -
```

### Motivation
<!-- What inspired you to submit this pull request? -->

- We currently need to tweak the code to modify the instance, which is not possible for people that are using the released version of ddev
- It's currently not possible to use the default openmetrics check because we need to configure the metrics to collect

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
