### PR TITLE
Extract hardcoded additional integrations from the `validate labeler` command to the config file

### DIFF
--- a/.ddev/config.toml
+++ b/.ddev/config.toml
@@ -133,6 +133,9 @@ typing = 'https://github.com/python/typing'
 [overrides.validate.openmetrics]
 exclude = ["openmetrics"]
 
+[overrides.validate.labeler]
+include = ["datadog_checks_tests_helper"]
+
 [overrides.validate.metrics]
 exclude = [
     'disk',

--- a/ddev/changelog.d/16845.fixed
+++ b/ddev/changelog.d/16845.fixed
@@ -1,0 +1,1 @@
+Extract hardcoded additional integrations from the `validate labeler` command to the config file

--- a/ddev/src/ddev/cli/validate/labeler.py
+++ b/ddev/src/ddev/cli/validate/labeler.py
@@ -28,8 +28,10 @@ def labeler(app: Application, sync: bool):
         return
 
     valid_integrations = dict.fromkeys(i.name for i in app.repo.integrations.iter("all"))
-    # Remove this when we remove the `datadog_checks_tests_helper` package
-    valid_integrations['datadog_checks_tests_helper'] = None
+
+    include = set(app.repo.config.get('/overrides/validate/labeler/include', []))
+    for integration in include:
+        valid_integrations[integration] = None
 
     pr_labels_config_path = app.repo.path / '.github' / 'workflows' / 'config' / 'labeler.yml'
     if not pr_labels_config_path.exists():

--- a/ddev/tests/cli/validate/conftest.py
+++ b/ddev/tests/cli/validate/conftest.py
@@ -14,6 +14,14 @@ def _fake_repo(tmp_path_factory, config_file, name):
     config_file.model.repo = name
     config_file.save()
 
+    write_file(
+        repo_path / ".ddev",
+        'config.toml',
+        """[overrides.validate.labeler]
+include = ["datadog_checks_tests_helper"]
+""",
+    )
+
     for integration in ('dummy', 'dummy2'):
         write_file(
             repo_path / integration,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Extract hardcoded additional integrations from the `validate labeler` command to the config file

### Motivation
<!-- What inspired you to submit this pull request? -->

This config file is there to avoid hardcoded values in ddev

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
