### PR TITLE
Extract hardcoded dependencies from the `dep updates` command to the config file

### DIFF
--- a/.ddev/config.toml
+++ b/.ddev/config.toml
@@ -147,3 +147,46 @@ exclude = [
     'system_swap',
     'tcp_check',
 ]
+
+[overrides.dep.updates]
+exclude = [
+    'ddtrace',  # https://github.com/DataDog/integrations-core/pull/9132
+    'foundationdb',  # Breaking datadog_checks_base tests
+    'pyasn1',  # https://github.com/pyasn1/pyasn1/issues/52
+    'pysnmp',  # Breaking snmp tests
+    'aerospike',  # v8+ breaks agent build.
+    # We need pydantic 2.0.2 for the rpm x64 agent build (see https://github.com/DataDog/datadog-agent/pull/18303)
+    'pydantic',
+    # https://github.com/DataDog/integrations-core/pull/16080
+    'lxml',
+    # We need to keep an `oracledb` version that uses the same version of odpi that is used in godror in the agent repo.
+    # Somehow we do not load the right version. Until we find out how and why, we need to keep both
+    # libs in sync with the same version of odpi.
+    'oracledb',
+    # We're not ready to switch to v3 of the postgres library, see:
+    # https://github.com/DataDog/integrations-core/pull/15859
+    'psycopg2-binary',
+    # orjson ... requires rustc 1.65+, but the latest we can have (thanks CentOS 6) is 1.62.
+    # We get the following error when compiling orjson on Centos 6:
+    # error: package `associative-cache v2.0.0` cannot be built because it requires rustc 1.65 or newer,
+    # while the currently active rustc version is 1.62.0-nightly
+    # Here's orjson switching to rustc 1.65:
+    # https://github.com/ijl/orjson/commit/ce9bae876657ed377d761bf1234b040e2cc13d3c
+    'orjson',
+    # 2.4.10 is broken on py2 and they did not yank the version
+    'rethinkdb',
+    # cryptography>=42 requires rust>=1.63.0. We have rust 1.62 on centos 6
+    # https://github.com/DataDog/datadog-agent/pull/22268
+    'cryptography',
+    # Brings urllib 2.0.7 which breaks `test_uds_request` in the base check
+    # https://github.com/kubernetes-client/python/pull/2131
+    'kubernetes',
+    'psutil',
+]
+
+# Dependencies for the downloader that are security-related and should be updated separately from the others
+security_deps = [
+    'in-toto',
+    'tuf',
+    'securesystemslib',
+]

--- a/ddev/changelog.d/16846.fixed
+++ b/ddev/changelog.d/16846.fixed
@@ -1,0 +1,1 @@
+Extract hardcoded dependencies from the `dep updates` command to the config file

--- a/ddev/src/ddev/cli/dep.py
+++ b/ddev/src/ddev/cli/dep.py
@@ -16,44 +16,6 @@ from packaging.version import InvalidVersion, Version
 
 from ddev.repo.constants import PYTHON_VERSION
 
-# Dependencies to ignore when update dependencies
-IGNORED_DEPS = {
-    'ddtrace',  # https://github.com/DataDog/integrations-core/pull/9132
-    'foundationdb',  # Breaking datadog_checks_base tests
-    'pyasn1',  # https://github.com/pyasn1/pyasn1/issues/52
-    'pysnmp',  # Breaking snmp tests
-    'aerospike',  # v8+ breaks agent build.
-    # We need pydantic 2.0.2 for the rpm x64 agent build (see https://github.com/DataDog/datadog-agent/pull/18303)
-    'pydantic',
-    # https://github.com/DataDog/integrations-core/pull/16080
-    'lxml',
-    # We need to keep an `oracledb` version that uses the same version of odpi that is used in godror in the agent repo.
-    # Somehow we do not load the right version. Until we find out how and why, we need to keep both
-    # libs in sync with the same version of odpi.
-    'oracledb',
-    # We're not ready to switch to v3 of the postgres library, see:
-    # https://github.com/DataDog/integrations-core/pull/15859
-    'psycopg2-binary',
-    # orjson ... requires rustc 1.65+, but the latest we can have (thanks CentOS 6) is 1.62.
-    # We get the following error when compiling orjson on Centos 6:
-    # error: package `associative-cache v2.0.0` cannot be built because it requires rustc 1.65 or newer,
-    # while the currently active rustc version is 1.62.0-nightly
-    # Here's orjson switching to rustc 1.65:
-    # https://github.com/ijl/orjson/commit/ce9bae876657ed377d761bf1234b040e2cc13d3c
-    'orjson',
-    # 2.4.10 is broken on py2 and they did not yank the version
-    'rethinkdb',
-    # cryptography>=42 requires rust>=1.63.0. We have rust 1.62 on centos 6
-    # https://github.com/DataDog/datadog-agent/pull/22268
-    'cryptography',
-    # Brings urllib 2.0.7 which breaks `test_uds_request` in the base check
-    # https://github.com/kubernetes-client/python/pull/2131
-    'kubernetes',
-}
-
-# Dependencies for the downloader that are security-related and should be updated separately from the others
-SECURITY_DEPS = {'in-toto', 'tuf', 'securesystemslib'}
-
 SUPPORTED_PYTHON_MINOR_VERSIONS = {'2': '2.7', '3': PYTHON_VERSION}
 
 
@@ -229,9 +191,10 @@ def scrape_version_data(urls):
 @click.pass_context
 @click.pass_obj
 def updates(app, ctx, sync_dependencies, include_security_deps, batch_size):
-    ignore_deps = set(IGNORED_DEPS)
+    ignore_deps = set(app.repo.config.get('/overrides/dep/updates/exclude', []))
+
     if not include_security_deps:
-        ignore_deps.update(SECURITY_DEPS)
+        ignore_deps.update(set(app.repo.config.get('/overrides/dep/updates/security_deps', [])))
     ignore_deps = {canonicalize_name(d) for d in ignore_deps}
 
     dependencies, errors = read_agent_dependencies(app.repo)

--- a/ddev/tests/cli/test_dep.py
+++ b/ddev/tests/cli/test_dep.py
@@ -218,7 +218,16 @@ dep-a==1.2.3; python_version > '3.0'
 """
         assert requirements.strip('\n') == expected.strip('\n')
 
-    def test_ignored_deps(self, ddev):
+    def test_ignored_deps(self, ddev, config_file):
+        path = config_file.path.parent / '.ddev'
+        path.mkdir(parents=True, exist_ok=True)
+        (path / 'config.toml').write_text(
+            """[overrides.dep.updates]
+exclude = [
+    'ddtrace',
+]"""
+        )
+
         self.add_integration('foo', ["ddtrace==1.0.0"])
         self.write_requirements()
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Extract hardcoded dependencies from the `dep updates` command to the config file

### Motivation
<!-- What inspired you to submit this pull request? -->

- This will avoid us to clutter the changelog with "allow ddev to bump XYZ dependencies".
- This config file is there to avoid hardcoded values in ddev

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
