### PR TITLE
Lock dependencies with direct references

### DIFF
--- a/.builders/lock.py
+++ b/.builders/lock.py
@@ -2,15 +2,67 @@ from __future__ import annotations
 
 import argparse
 import json
-import shutil
 from hashlib import sha256
 from pathlib import Path
 
+from google.cloud import storage
+from packaging.version import Version
+
+BUCKET_NAME = 'dd-agent-int-deps'
+STORAGE_URL = f'https://storage.googleapis.com/{BUCKET_NAME}'
 BUILDER_DIR = Path(__file__).parent
 REPO_DIR = BUILDER_DIR.parent
 RESOLUTION_DIR = REPO_DIR / '.deps'
 LOCK_FILE_DIR = RESOLUTION_DIR / 'resolved'
 DIRECT_DEP_FILE = REPO_DIR / 'datadog_checks_base' / 'datadog_checks' / 'base' / 'data' / 'agent_requirements.in'
+
+
+def generate_lock_file(requirements_file: Path, lock_file: Path) -> None:
+    dependencies: dict[str, str] = {}
+    with requirements_file.open(encoding='utf-8') as f:
+        for line in f.readlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            name, version = line.split('==')
+            dependencies[name] = version
+
+    lock_file_lines = []
+
+    client = storage.Client()
+    bucket = client.bucket(BUCKET_NAME)
+    for project, version in sorted(dependencies.items()):
+        project_version = Version(version)
+        for artifact_type in ('built', 'external'):
+            candidates = {}
+            for blob in bucket.list_blobs(prefix=f'{artifact_type}/{project}/'):
+                if not blob.name.endswith('.whl'):
+                    continue
+
+                wheel_name = blob.name.split('/')[-1]
+                parts = wheel_name[:-4].split('-')
+                if Version(parts[1]) != project_version:
+                    continue
+
+                build_number = int(parts[2]) if len(parts) == 6 else -1
+                candidates[build_number] = blob
+
+            if not candidates:
+                continue
+
+            selected = candidates[max(candidates)]
+            selected.reload()
+            sha256_digest = selected.metadata['sha256']
+            index_url = f'{STORAGE_URL}/{selected.name}'
+            lock_file_lines.append(f'{project} @ {index_url}#sha256={sha256_digest}')
+
+            break
+        else:
+            raise RuntimeError(f'Could not find any wheels: {project}=={version}')
+
+    lock_file_lines.append('')
+    lock_file.write_text('\n'.join(lock_file_lines), encoding='utf-8')
 
 
 def main():
@@ -33,8 +85,9 @@ def main():
     for target in Path(args.targets_dir).iterdir():
         for python_version in target.iterdir():
             if python_version.name.startswith('py'):
-                lock_file = python_version / 'frozen.txt'
-                shutil.copyfile(lock_file, LOCK_FILE_DIR / f'{target.name}_{python_version.name}.txt')
+                generate_lock_file(
+                    python_version / 'frozen.txt', LOCK_FILE_DIR / f'{target.name}_{python_version.name}.txt'
+                )
 
         if (image_digest_file := target / 'image_digest').is_file():
             image_digests[target.name] = image_digest_file.read_text(encoding='utf-8').strip()

--- a/.builders/lock.py
+++ b/.builders/lock.py
@@ -41,6 +41,7 @@ def generate_lock_file(requirements_file: Path, lock_file: Path) -> None:
                     continue
 
                 wheel_name = blob.name.split('/')[-1]
+                # https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-name-convention
                 parts = wheel_name[:-4].split('-')
                 if Version(parts[1]) != project_version:
                     continue

--- a/.builders/scripts/build_wheels.py
+++ b/.builders/scripts/build_wheels.py
@@ -4,7 +4,6 @@ import argparse
 import os
 import subprocess
 import sys
-from hashlib import sha256
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -125,14 +124,12 @@ def main():
             project_metadata = extract_metadata(entry)
             project_name = normalize_project_name(project_metadata['Name'])
             project_version = project_metadata['Version']
-            wheel_hash = sha256(entry.read_bytes()).hexdigest()
-            dependencies[project_name] = (project_version, wheel_hash)
+            dependencies[project_name] = project_version
 
     final_requirements = MOUNT_DIR / 'frozen.txt'
     with final_requirements.open('w', encoding='utf-8') as f:
-        for project_name, (project_version, wheel_hash) in sorted(dependencies.items()):
-            f.write(f'{project_name}=={project_version} \\\n')
-            f.write(f'  --hash=sha256:{wheel_hash}\n')
+        for project_name, project_version in sorted(dependencies.items()):
+            f.write(f'{project_name}=={project_version}\n')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

- Makes all built wheels use a build number
- Generate the full lock file as a final step
- Use direct references

### Motivation

- Using a build number allows us to make changes in our build system without overwriting filenames which would break expected hashes during Agent builds
- Also some built packages on Linux don't actually produce unique filenames because they are actually pure Python and therefore the hash becomes tied to whatever happens to be uploaded last