### PR TITLE
Update the labeler token

### DIFF
--- a/.github/workflows/labeler-reusable.yml
+++ b/.github/workflows/labeler-reusable.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/labeler@v4
         with:
           configuration-path: .github/workflows/config/labeler.yml
-          repo-token: "${{ secrets.repo-token }}"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: ""   # workaround for sync-labels bug:
                             # https://github.com/actions/labeler/issues/112#issuecomment-1000491676
       - name: Add team labels


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

The former token no longer has SSO. We need SSO to create the token if it does not exist, not to apply labels.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I'm creating a GH app right now to replace the old bot

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
