### PR TITLE
Add the `all` argument to `ddev test`

### DIFF
--- a/ddev/changelog.d/16859.added
+++ b/ddev/changelog.d/16859.added
@@ -1,0 +1,1 @@
+Add the `all` argument to `ddev test`

--- a/ddev/src/ddev/cli/test/__init__.py
+++ b/ddev/src/ddev/cli/test/__init__.py
@@ -105,6 +105,9 @@ def test(
         for integration in app.repo.integrations.iter_changed():
             if integration.is_testable:
                 targets[integration.name] = integration
+    elif target_name == 'all':
+        for integration in app.repo.integrations.iter_testable('all'):
+            targets[integration.name] = integration
     else:
         try:
             integration = app.repo.integrations.get(target_name)

--- a/ddev/tests/cli/test/test_test.py
+++ b/ddev/tests/cli/test/test_test.py
@@ -7,6 +7,7 @@ import sys
 
 import pytest
 
+from ddev.repo.core import Repository
 from ddev.utils.structures import EnvVars
 
 
@@ -160,6 +161,22 @@ class TestStandard:
                 [sys.executable, '-m', 'hatch', 'env', 'run', '--ignore-compat', '--', 'test', '--tb', 'short'],
                 shell=False,
             ),
+        ]
+
+    def test_all_targets(self, ddev, helpers, mocker, repository):
+        repo = Repository("core", str(repository.path))
+        run = mocker.patch('subprocess.run', return_value=mocker.MagicMock(returncode=0))
+
+        result = ddev('test', 'all')
+
+        assert result.exit_code == 0, result.output
+
+        assert run.call_args_list == [
+            mocker.call(
+                [sys.executable, '-m', 'hatch', 'env', 'run', '--ignore-compat', '--', 'test', '--tb', 'short'],
+                shell=False,
+            )
+            for _ in repo.integrations.iter_testable('all')
         ]
 
     def test_argument_forwarding(self, ddev, helpers, mocker):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add the `all` argument to `ddev test`

### Motivation
<!-- What inspired you to submit this pull request? -->

I wanted to run black on every single integration but could not with `ddev test all -fs`

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
