### PR TITLE
remove Logs from Active Directory docs

### DIFF
--- a/active_directory/README.md
+++ b/active_directory/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Get metrics and logs from Microsoft Active Directory to visualize and monitor its performances.
+Get metrics from Microsoft Active Directory to visualize and monitor its performances.
 
 ## Setup
 
@@ -21,33 +21,6 @@ If installing the Datadog Agent on a domain environment, see [the installation r
 2. [Restart the Agent][5]
 
 **Note**: Versions 1.13.0 or later of this check use a new implementation for metric collection, which requires Python 3. For hosts that are unable to use Python 3, or if you would like to use a legacy version of this check, refer to the following [config][10].
-
-#### Log collection
-
-_Available for Agent versions >6.0_
-
-1. Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
-
-   ```yaml
-   logs_enabled: true
-   ```
-
-2. Add this configuration block to your `active_directory.d/conf.yaml` file to start collecting your Active Directory Logs:
-
-   ```yaml
-   logs:
-     - type: file
-       path: C:\path\to\my\directory\file.log
-       source: ruby
-       service: "<MY_SERVICE>"
-   ```
-
-   Change the `path` and `service` parameter values and configure them for your environment.
-   See the [sample active_directory.d/conf.yaml][4] for all available configuration options.
-
-3. This integration is intended for the [Active Directory Module for Ruby][6]. If you are not using the Ruby module, change the `source` value to `active_directory` and configure the `path` for your environment.
-
-4. [Restart the Agent][5].
 
 ### Validation
 
@@ -76,7 +49,6 @@ Need help? Contact [Datadog support][9].
 [3]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [4]: https://github.com/DataDog/integrations-core/blob/master/active_directory/datadog_checks/active_directory/data/conf.yaml.example
 [5]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[6]: https://www.rubydoc.info/gems/activedirectory/0.9.3
 [7]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [8]: https://github.com/DataDog/integrations-core/blob/master/active_directory/metadata.csv
 [9]: https://docs.datadoghq.com/help/

--- a/active_directory/assets/configuration/spec.yaml
+++ b/active_directory/assets/configuration/spec.yaml
@@ -18,9 +18,3 @@ files:
     - template: instances/pdh_legacy
       hidden: true
     - template: instances/default
-  - template: logs
-    example:
-    - type: file
-      path: C:\path\to\my\directory\file.log
-      source: ruby
-      service: <SERVICE_NAME>

--- a/active_directory/datadog_checks/active_directory/data/conf.yaml.example
+++ b/active_directory/datadog_checks/active_directory/data/conf.yaml.example
@@ -166,24 +166,3 @@ instances:
     #   - <INCLUDE_REGEX>
     #   exclude:
     #   - <EXCLUDE_REGEX>
-
-## Log Section
-##
-## type - required - Type of log input source (tcp / udp / file / windows_event).
-## port / path / channel_path - required - Set port if type is tcp or udp.
-##                                         Set path if type is file.
-##                                         Set channel_path if type is windows_event.
-## source  - required - Attribute that defines which integration sent the logs.
-## encoding - optional - For file specifies the file encoding. Default is utf-8. Other
-##                       possible values are utf-16-le and utf-16-be.
-## service - optional - The name of the service that generates the log.
-##                      Overrides any `service` defined in the `init_config` section.
-## tags - optional - Add tags to the collected logs.
-##
-## Discover Datadog log collection: https://docs.datadoghq.com/logs/log_collection/
-#
-# logs:
-#   - type: file
-#     path: C:\path\to\my\directory\file.log
-#     source: ruby
-#     service: <SERVICE_NAME>

--- a/active_directory/manifest.json
+++ b/active_directory/manifest.json
@@ -13,8 +13,7 @@
     "media": [],
     "classifier_tags": [
       "Supported OS::Windows",
-      "Category::OS & System",
-      "Category::Log Collection"
+      "Category::OS & System"
     ]
   },
   "author": {


### PR DESCRIPTION
### What does this PR do?
removing references to Logs feature that doesn't exist, undoing this PR: https://github.com/DataDog/integrations-core/pull/1813/files

### Motivation
https://datadoghq.atlassian.net/browse/WINA-649

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
