### PR TITLE
[DBMON-3579] don't require relation metrics to be enabled to collect schemas

### DIFF
--- a/postgres/changelog.d/16870.changed
+++ b/postgres/changelog.d/16870.changed
@@ -1,0 +1,1 @@
+don't require relation metrics to be enabled to collect schemas

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -102,11 +102,6 @@ class PostgresConfig:
         self.statement_samples_config = instance.get('query_samples', instance.get('statement_samples', {})) or {}
         self.settings_metadata_config = instance.get('collect_settings', {}) or {}
         self.schemas_metadata_config = instance.get('collect_schemas', {"enabled": False})
-        if not self.relations and self.schemas_metadata_config['enabled']:
-            raise ConfigurationError(
-                'In order to collect schemas on this database, you must enable relation metrics collection.'
-            )
-
         self.resources_metadata_config = instance.get('collect_resources', {}) or {}
         self.statement_activity_config = instance.get('query_activity', {}) or {}
         self.statement_metrics_config = instance.get('query_metrics', {}) or {}


### PR DESCRIPTION
### What does this PR do?
We want to decouple schema collection from relations metrics, so remove this configuration enforcement. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
