### PR TITLE
update default table schema collection limit to 300

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -534,8 +534,8 @@ files:
             Maximum amount of tables the Agent collects from the instance.
           value:
             type: number
-            example: 1000
-            display_default: 1000
+            example: 300
+            display_default: 300
         - name: max_columns
           description: |
             Maximum amount of columns the Agent collects per table.

--- a/postgres/changelog.d/16880.fixed
+++ b/postgres/changelog.d/16880.fixed
@@ -1,0 +1,1 @@
+update default table schema collection limit to 300

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -427,10 +427,10 @@ instances:
         #
         # enabled: false
 
-        ## @param max_tables - number - optional - default: 1000
+        ## @param max_tables - number - optional - default: 300
         ## Maximum amount of tables the Agent collects from the instance.
         #
-        # max_tables: 1000
+        # max_tables: 300
 
         ## @param max_columns - number - optional - default: 50
         ## Maximum amount of columns the Agent collects per table.

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -316,7 +316,7 @@ class PostgresMetadata(DBMAsyncJob):
 
         If any tables are partitioned, only the master paritition table name will be returned, and none of its children.
         """
-        limit = self._config.schemas_metadata_config.get("max_tables", 1000)
+        limit = self._config.schemas_metadata_config.get("max_tables", 300)
         if self._config.relations:
             if VersionUtils.transform_version(str(self._check.version))["version.major"] == "9":
                 cursor.execute(PG_TABLES_QUERY_V9.format(schema_oid=schema_id))


### PR DESCRIPTION
[DBMON-3483] 

### What does this PR do?
Until recently we required table metrics to be enabled to collect table information via schemas collection. Relation metrics have a default limit of 300 relations, this provided a hidden default of 300 relations we would collect via schema collection.
Since we no longer require relation metrics for schema collection, we are lowering the default relations collection limit for schemas to match the previous hidden default. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.


[DBMON-3483]: https://datadoghq.atlassian.net/browse/DBMON-3483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ