### PR TITLE
[DBMON-3435] Update mariadb 10.10 to 10.11

### DIFF
--- a/mysql/hatch.toml
+++ b/mysql/hatch.toml
@@ -33,7 +33,7 @@ version = [
   "10.5",  # EOL 24 June 2025
   "10.8",
   "10.9",
-  "10.10.7-debian-11-r2", # EOL 17 November 2023
+  "10.11",
 ]
 
 [envs.default.overrides]


### PR DESCRIPTION
### What does this PR do?
This PR updates test env mariadb 10.10 to 10.11. mariadb 10.10 is deprecated in https://github.com/bitnami/containers/pull/56652

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
