### PR TITLE
Revert nginx tag changes (#16872 and #16797)

### DIFF
--- a/nginx/changelog.d/16797.fixed
+++ b/nginx/changelog.d/16797.fixed
@@ -1,1 +1,0 @@
-nginx metrics should have same tags as service checks

--- a/nginx/changelog.d/16872.fixed
+++ b/nginx/changelog.d/16872.fixed
@@ -1,1 +1,0 @@
-Rename host tag to nginx_host

--- a/nginx/datadog_checks/nginx/nginx.py
+++ b/nginx/datadog_checks/nginx/nginx.py
@@ -73,7 +73,7 @@ class Nginx(AgentCheck):
         for row in metrics:
             try:
                 name, value, row_tags, metric_type = row
-                tags = row_tags + ['nginx_host:%s' % self.hostname_from_url, 'port:%s' % self.port_from_url]
+                tags = row_tags + ['host:%s' % self.hostname_from_url, 'port:%s' % self.port_from_url]
                 if self.use_vts:
                     name, handled, conn = self._translate_from_vts(name, value, tags, handled, conn)
                     if name is None:

--- a/nginx/datadog_checks/nginx/nginx.py
+++ b/nginx/datadog_checks/nginx/nginx.py
@@ -53,9 +53,6 @@ class Nginx(AgentCheck):
         self.only_query_enabled_endpoints = self.instance.get("only_query_enabled_endpoints", False)
         self.plus_api_version = str(self.instance.get("plus_api_version", 2))
         self.use_vts = self.instance.get('use_vts', False)
-        parsed_url = urlparse(self.url)
-        self.hostname_from_url = parsed_url.hostname
-        self.port_from_url = parsed_url.port or 80
 
         if 'nginx_status_url' not in self.instance:
             raise ConfigurationError('NginX instance missing "nginx_status_url" value.')
@@ -72,8 +69,7 @@ class Nginx(AgentCheck):
 
         for row in metrics:
             try:
-                name, value, row_tags, metric_type = row
-                tags = row_tags + ['host:%s' % self.hostname_from_url, 'port:%s' % self.port_from_url]
+                name, value, tags, metric_type = row
                 if self.use_vts:
                     name, handled, conn = self._translate_from_vts(name, value, tags, handled, conn)
                     if name is None:
@@ -224,8 +220,12 @@ class Nginx(AgentCheck):
 
     def _perform_service_check(self, url):
         # Submit a service check for status page availability.
+        parsed_url = urlparse(url)
+        nginx_host = parsed_url.hostname
+        nginx_port = parsed_url.port or 80
+
         service_check_name = 'nginx.can_connect'
-        service_check_tags = ['host:%s' % self.hostname_from_url, 'port:%s' % self.port_from_url] + self.custom_tags
+        service_check_tags = ['host:%s' % nginx_host, 'port:%s' % nginx_port] + self.custom_tags
         try:
             self.log.debug("Querying URL: %s", url)
             r = self._perform_request(url)

--- a/nginx/tests/test_e2e.py
+++ b/nginx/tests/test_e2e.py
@@ -13,18 +13,21 @@ from . import common
 def test_e2e(dd_agent_check, instance):
     aggregator = dd_agent_check(instance, rate=True)
 
+    aggregator.assert_metric('nginx.net.writing', count=2, tags=common.TAGS)
+    aggregator.assert_metric('nginx.net.waiting', count=2, tags=common.TAGS)
+    aggregator.assert_metric('nginx.net.reading', count=2, tags=common.TAGS)
+    aggregator.assert_metric('nginx.net.conn_dropped_per_s', count=1, tags=common.TAGS)
+    aggregator.assert_metric('nginx.net.conn_opened_per_s', count=1, tags=common.TAGS)
+    aggregator.assert_metric('nginx.net.request_per_s', count=1, tags=common.TAGS)
+
+    aggregator.assert_metric('nginx.net.connections', count=2, tags=common.TAGS)
+
+    aggregator.assert_all_metrics_covered()
+
     tags = common.TAGS + [
         'nginx_host:{}'.format(common.HOST),
         'port:{}'.format(common.PORT),
     ]
-    aggregator.assert_metric('nginx.net.writing', count=2, tags=tags)
-    aggregator.assert_metric('nginx.net.waiting', count=2, tags=tags)
-    aggregator.assert_metric('nginx.net.reading', count=2, tags=tags)
-    aggregator.assert_metric('nginx.net.conn_dropped_per_s', count=1, tags=tags)
-    aggregator.assert_metric('nginx.net.conn_opened_per_s', count=1, tags=tags)
-    aggregator.assert_metric('nginx.net.request_per_s', count=1, tags=tags)
-    aggregator.assert_metric('nginx.net.connections', count=2, tags=tags)
-    aggregator.assert_all_metrics_covered()
     aggregator.assert_service_check('nginx.can_connect', status=Nginx.OK, tags=tags)
 
 
@@ -33,32 +36,29 @@ def test_e2e(dd_agent_check, instance):
 def test_e2e_vts(dd_agent_check, instance_vts):
     aggregator = dd_agent_check(instance_vts, rate=True)
 
-    tags = common.TAGS + [
-        'nginx_host:{}'.format(common.HOST),
-        'port:{}'.format(common.PORT),
-    ]
-    aggregator.assert_metric('nginx.net.writing', count=2, tags=tags)
-    aggregator.assert_metric('nginx.net.waiting', count=2, tags=tags)
-    aggregator.assert_metric('nginx.net.reading', count=2, tags=tags)
-    aggregator.assert_metric('nginx.net.conn_dropped_per_s', count=1, tags=tags)
-    aggregator.assert_metric('nginx.net.conn_opened_per_s', count=1, tags=tags)
-    aggregator.assert_metric('nginx.net.request_per_s', count=1, tags=tags)
+    aggregator.assert_metric('nginx.net.writing', count=2, tags=common.TAGS)
+    aggregator.assert_metric('nginx.net.waiting', count=2, tags=common.TAGS)
+    aggregator.assert_metric('nginx.net.reading', count=2, tags=common.TAGS)
+    aggregator.assert_metric('nginx.net.conn_dropped_per_s', count=1, tags=common.TAGS)
+    aggregator.assert_metric('nginx.net.conn_opened_per_s', count=1, tags=common.TAGS)
+    aggregator.assert_metric('nginx.net.request_per_s', count=1, tags=common.TAGS)
 
-    tags_server_zone = tags + ['server_zone:*']
+    tags_server_zone = common.TAGS + ['server_zone:*']
 
-    aggregator.assert_metric('nginx.connections.active', count=2, tags=tags)
+    aggregator.assert_metric('nginx.connections.active', count=2, tags=common.TAGS)
     aggregator.assert_metric('nginx.server_zone.sent', count=2, tags=tags_server_zone)
     aggregator.assert_metric('nginx.server_zone.sent_count', count=1, tags=tags_server_zone)
     aggregator.assert_metric('nginx.server_zone.received', count=2, tags=tags_server_zone)
     aggregator.assert_metric('nginx.server_zone.received_count', count=1, tags=tags_server_zone)
-    aggregator.assert_metric('nginx.requests.total_count', count=1, tags=tags)
-    aggregator.assert_metric('nginx.requests.total', count=2, tags=tags)
-    aggregator.assert_metric('nginx.timestamp', count=2, tags=tags)
+    aggregator.assert_metric('nginx.requests.total_count', count=1, tags=common.TAGS)
+    aggregator.assert_metric('nginx.requests.total', count=2, tags=common.TAGS)
+    aggregator.assert_metric('nginx.timestamp', count=2, tags=common.TAGS)
     aggregator.assert_metric('nginx.server_zone.requests_count', count=1, tags=tags_server_zone)
-    aggregator.assert_metric('nginx.load_timestamp', count=2, tags=tags)
+    aggregator.assert_metric('nginx.load_timestamp', count=2, tags=common.TAGS)
     aggregator.assert_metric('nginx.server_zone.requests', count=2, tags=tags_server_zone)
-    aggregator.assert_metric('nginx.connections.accepted', count=2, tags=tags)
-    aggregator.assert_metric('nginx.connections.accepted_count', count=1, tags=tags)
+    aggregator.assert_metric('nginx.connections.accepted', count=2, tags=common.TAGS)
+    aggregator.assert_metric('nginx.connections.accepted_count', count=1, tags=common.TAGS)
+
     aggregator.assert_metric('nginx.server_zone.responses.1xx_count', count=1, tags=tags_server_zone)
     aggregator.assert_metric('nginx.server_zone.responses.2xx_count', count=1, tags=tags_server_zone)
     aggregator.assert_metric('nginx.server_zone.responses.3xx_count', count=1, tags=tags_server_zone)
@@ -71,4 +71,9 @@ def test_e2e_vts(dd_agent_check, instance_vts):
     aggregator.assert_metric('nginx.server_zone.responses.5xx', count=2, tags=tags_server_zone)
 
     aggregator.assert_all_metrics_covered()
+
+    tags = common.TAGS + [
+        'nginx_host:{}'.format(common.HOST),
+        'port:{}'.format(common.PORT),
+    ]
     aggregator.assert_service_check('nginx.can_connect', status=Nginx.OK, tags=tags)

--- a/nginx/tests/test_nginx.py
+++ b/nginx/tests/test_nginx.py
@@ -7,7 +7,7 @@ import mock
 import pytest
 import requests
 
-from .common import FIXTURES_PATH, HOST, NGINX_VERSION, PORT, PORT_SSL, TAGS, USING_VTS
+from .common import FIXTURES_PATH, HOST, NGINX_VERSION, PORT, TAGS, USING_VTS
 from .utils import mocked_perform_request, requires_static_version
 
 pytestmark = [pytest.mark.skipif(USING_VTS, reason='Using VTS'), pytest.mark.integration]
@@ -20,8 +20,8 @@ def test_connect(check, instance, aggregator):
     """
     check = check(instance)
     check.check(instance)
+    aggregator.assert_metric("nginx.net.connections", tags=TAGS, count=1)
     extra_tags = ['nginx_host:{}'.format(HOST), 'port:{}'.format(PORT)]
-    aggregator.assert_metric("nginx.net.connections", tags=TAGS + extra_tags, count=1)
     aggregator.assert_service_check('nginx.can_connect', tags=TAGS + extra_tags)
 
 
@@ -33,8 +33,7 @@ def test_connect_ssl(check, instance_ssl, aggregator):
     instance_ssl['ssl_validation'] = False
     check_no_ssl = check(instance_ssl)
     check_no_ssl.check(instance_ssl)
-    extra_tags = ['nginx_host:{}'.format(HOST), 'port:{}'.format(PORT_SSL)]
-    aggregator.assert_metric("nginx.net.connections", tags=TAGS + extra_tags, count=1)
+    aggregator.assert_metric("nginx.net.connections", tags=TAGS, count=1)
 
     # assert ssl validation throws an error
     with pytest.raises(requests.exceptions.SSLError):

--- a/nginx/tests/test_plus_api.py
+++ b/nginx/tests/test_plus_api.py
@@ -78,7 +78,7 @@ def test_plus_api_v5(check, instance_plus_v7, aggregator):
     # total number of metrics should be higher than v4 w/ resolvers and http location zones data
     assert_num_metrics(aggregator, 1261)
 
-    base_tags = ['bar:bar', 'foo:foo', 'nginx_host:localhost', 'port:8080']
+    base_tags = ['bar:bar', 'foo:foo']
 
     # resolvers endpoint
     resolvers_tags = base_tags + ['resolver:resolver-http']
@@ -135,7 +135,7 @@ def test_plus_api_v6(check, instance_plus_v7, aggregator):
     # total number of metrics should be higher than v5 w/ http limit conns, http limit reqs, and stream limit conns
     assert_num_metrics(aggregator, 1277)
 
-    base_tags = ['bar:bar', 'foo:foo', 'nginx_host:localhost', 'port:8080']
+    base_tags = ['bar:bar', 'foo:foo']
 
     # same tests for v3
     aggregator.assert_metric_has_tag('nginx.stream.zone_sync.zone.records_total', 'zone:zone1', count=1)
@@ -190,7 +190,7 @@ def test_plus_api_v7(check, instance_plus_v7, aggregator, only_query_enabled_end
     # with codes data for http upstream, http server zones, and http location zone
     assert_num_metrics(aggregator, 1352)
 
-    base_tags = ['bar:bar', 'foo:foo', 'nginx_host:localhost', 'port:8080']
+    base_tags = ['bar:bar', 'foo:foo']
 
     # same tests for v3
     aggregator.assert_metric_has_tag('nginx.stream.zone_sync.zone.records_total', 'zone:zone1', count=1)
@@ -304,7 +304,7 @@ def test_plus_api_v7_no_stream(check, instance, aggregator):
     # Number of metrics should be low since stream is disabled
     assert_num_metrics(aggregator, 1025)
 
-    base_tags = ['bar:bar', 'foo:foo', 'nginx_host:localhost', 'port:8080']
+    base_tags = ['bar:bar', 'foo:foo']
 
     # test that stream metrics are not emitted
     aggregator.assert_metric('nginx.stream.zone_sync.zone.records_total', count=0)

--- a/nginx/tests/test_vts.py
+++ b/nginx/tests/test_vts.py
@@ -6,7 +6,7 @@ import pytest
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.nginx import VTS_METRIC_MAP
 
-from .common import HOST, PORT, TAGS, USING_VTS, VTS_MOCKED_METRICS, mock_http_responses
+from .common import TAGS, USING_VTS, VTS_MOCKED_METRICS, mock_http_responses
 
 pytestmark = [pytest.mark.skipif(not USING_VTS, reason='Not using VTS')]
 
@@ -41,11 +41,10 @@ def test_vts(check, instance_vts, aggregator):
         'nginx.upstream.peers.backup',
     ]
 
-    extra_tags = ['nginx_host:{}'.format(HOST), 'port:{}'.format(PORT)]
     for mapped in VTS_METRIC_MAP.values():
         if mapped in skip_metrics:
             continue
-        aggregator.assert_metric(mapped, tags=TAGS + extra_tags)
+        aggregator.assert_metric(mapped, tags=TAGS)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
This reverts commit a0d9e91.### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
There are problems in the webapp with us submitting metrics tagged as `host`. It's too close to a release for us to investigate this properly, so we're reverting all changes for now.

fyi @keisku we'll have to tackle this again in the next release, I'm afraid.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
