### PR TITLE
PG: Collection replication role tag by default

### DIFF
--- a/postgres/changelog.d/16895.changed
+++ b/postgres/changelog.d/16895.changed
@@ -1,0 +1,1 @@
+PostgreSQL: Enable replication role tag by default

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -85,7 +85,7 @@ class PostgresConfig:
         if is_affirmative(instance.get('collect_default_database', True)):
             self.ignore_databases = [d for d in self.ignore_databases if d != 'postgres']
         self.custom_queries = instance.get('custom_queries', [])
-        self.tag_replication_role = is_affirmative(instance.get('tag_replication_role', False))
+        self.tag_replication_role = is_affirmative(instance.get('tag_replication_role', True))
         self.custom_metrics = self._get_custom_metrics(instance.get('custom_metrics', []))
         self.max_relations = int(instance.get('max_relations', 300))
         self.min_collection_interval = instance.get('min_collection_interval', 15)

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -350,11 +350,6 @@ class PostgreSql(AgentCheck):
     def _get_debug_tags(self):
         return ['agent_hostname:{}'.format(self.agent_hostname)]
 
-    def _get_service_check_tags(self):
-        service_check_tags = []
-        service_check_tags.extend(self.tags)
-        return list(service_check_tags)
-
     def _get_replication_role(self):
         with self.db() as conn:
             with conn.cursor() as cursor:
@@ -984,7 +979,7 @@ class PostgreSql(AgentCheck):
             self.service_check(
                 self.SERVICE_CHECK_NAME,
                 AgentCheck.OK,
-                tags=self._get_service_check_tags(),
+                tags=self.tags,
             )
             self.log.info("Waiting for remote configuration to push instance configuration")
             return
@@ -1021,7 +1016,7 @@ class PostgreSql(AgentCheck):
             self.service_check(
                 self.SERVICE_CHECK_NAME,
                 AgentCheck.CRITICAL,
-                tags=self._get_service_check_tags(),
+                tags=tags,
                 message=message,
                 hostname=self.resolved_hostname,
             )
@@ -1030,7 +1025,7 @@ class PostgreSql(AgentCheck):
             self.service_check(
                 self.SERVICE_CHECK_NAME,
                 AgentCheck.OK,
-                tags=self._get_service_check_tags(),
+                tags=tags,
                 hostname=self.resolved_hostname,
             )
         finally:

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -126,13 +126,20 @@ def _iterate_metric_name(query):
             yield metric[0]
 
 
-def _get_expected_tags(check, pg_instance, **kwargs):
-    base_tags = pg_instance['tags'] + [
-        'port:{}'.format(pg_instance['port']),
-        'dd.internal.resource:database_instance:{}'.format(check.resolved_hostname),
-    ]
+def _get_expected_replication_tags(check, pg_instance, with_db=False, **kwargs):
+    return _get_expected_tags(check, pg_instance, with_db=with_db, role='standby', **kwargs)
+
+
+def _get_expected_tags(check, pg_instance, with_db=False, role='master', **kwargs):
+    base_tags = pg_instance['tags'] + [f'port:{pg_instance["port"]}']
+    if role:
+        base_tags.append(f'replication_role:{role}')
+    if with_db:
+        base_tags.append(f'db:{pg_instance["dbname"]}')
+    if check:
+        base_tags.append(f'dd.internal.resource:database_instance:{check.resolved_hostname}')
     for k, v in kwargs.items():
-        base_tags.append('{}:{}'.format(k, v))
+        base_tags.append(f'{k}:{v}')
     return base_tags
 
 

--- a/postgres/tests/test_deadlock.py
+++ b/postgres/tests/test_deadlock.py
@@ -10,7 +10,7 @@ import psycopg2
 import pytest
 from flaky import flaky
 
-from .common import DB_NAME, HOST, PORT, POSTGRES_VERSION
+from .common import DB_NAME, HOST, POSTGRES_VERSION, _get_expected_tags
 
 
 def wait_on_result(cursor=None, sql=None, binds=None, expected_value=None):
@@ -139,12 +139,7 @@ commit;
     aggregator.assert_metric(
         'postgresql.deadlocks.count',
         value=deadlocks_before + 1,
-        tags=pg_instance["tags"]
-        + [
-            "db:{}".format(DB_NAME),
-            "port:{}".format(PORT),
-            'dd.internal.resource:database_instance:{}'.format(check.resolved_hostname),
-        ],
+        tags=_get_expected_tags(check, pg_instance, db=pg_instance["dbname"]),
     )
 
     conn.close()

--- a/postgres/tests/test_e2e.py
+++ b/postgres/tests/test_e2e.py
@@ -4,15 +4,13 @@
 
 import pytest
 
-from .common import PORT, check_bgw_metrics, check_common_metrics
+from .common import _get_expected_tags, check_bgw_metrics, check_common_metrics
 
 
 @pytest.mark.e2e
 def test_e2e(dd_agent_check, pg_instance):
     aggregator = dd_agent_check(pg_instance, rate=True)
 
-    expected_tags = pg_instance['tags'] + [
-        'port:{}'.format(PORT),
-    ]
+    expected_tags = _get_expected_tags(None, pg_instance)
     check_bgw_metrics(aggregator, expected_tags)
     check_common_metrics(aggregator, expected_tags=expected_tags, count=None)

--- a/postgres/tests/test_logical_replication.py
+++ b/postgres/tests/test_logical_replication.py
@@ -7,10 +7,6 @@ from flaky import flaky
 from datadog_checks.postgres.util import STAT_SUBSCRIPTION_METRICS
 
 from .common import (
-    DB_NAME,
-    HOST,
-    PASSWORD_ADMIN,
-    USER_ADMIN,
     _get_expected_tags,
     _iterate_metric_name,
     assert_metric_at_least,
@@ -34,12 +30,6 @@ from .common import (
 from .utils import requires_over_10, requires_over_11, requires_over_14, requires_over_15
 
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]
-
-
-def _get_connection_string(instance):
-    return 'port={} host={} user={} password={} dbname={}'.format(
-        instance['port'], HOST, USER_ADMIN, PASSWORD_ADMIN, DB_NAME
-    )
 
 
 @requires_over_11
@@ -90,11 +80,7 @@ def test_subscription_stats_apply_errors(aggregator, integration_check, pg_repli
     #  16649 | subscription_persons  |                17 |                0 |
     #  16650 | subscription_cities   |                 0 |               16 |
     #  16651 | subscription_persons2 |                 0 |                0 |
-    expected_subscription_tags = pg_replica_logical['tags'] + [
-        'subscription_name:subscription_persons',
-        'port:{}'.format(pg_replica_logical['port']),
-        'dd.internal.resource:database_instance:{}'.format(check.resolved_hostname),
-    ]
+    expected_subscription_tags = _get_expected_tags(check, pg_replica_logical, subscription_name='subscription_persons')
     assert_metric_at_least(
         aggregator,
         'postgresql.subscription.apply_error',
@@ -114,11 +100,8 @@ def test_subscription_stats_sync_errors(aggregator, integration_check, pg_replic
     #  16649 | subscription_persons  |                17 |                0 |
     #  16650 | subscription_cities   |                 0 |               16 |
     #  16651 | subscription_persons2 |                 0 |                0 |
-    expected_subscription_tags = pg_replica_logical['tags'] + [
-        'subscription_name:subscription_cities',
-        'port:{}'.format(pg_replica_logical['port']),
-        'dd.internal.resource:database_instance:{}'.format(check.resolved_hostname),
-    ]
+
+    expected_subscription_tags = _get_expected_tags(check, pg_replica_logical, subscription_name='subscription_cities')
     check.check(pg_replica_logical)
     assert_metric_at_least(
         aggregator,
@@ -139,11 +122,8 @@ def test_stat_subscription(aggregator, integration_check, pg_replica_logical):
     #  16649 | subscription_persons  |     |       |              |                               |...
     #  16650 | subscription_cities   | 276 |       | 0/220954B0   | 2023-11-10 15:24:05.354626+00 |...
     #  16651 | subscription_persons2 |     |       |              |                               |...
-    expected_subscription_tags = pg_replica_logical['tags'] + [
-        'subscription_name:subscription_cities',
-        'port:{}'.format(pg_replica_logical['port']),
-        f'dd.internal.resource:database_instance:{check.resolved_hostname}',
-    ]
+    expected_subscription_tags = _get_expected_tags(check, pg_replica_logical, subscription_name='subscription_cities')
+
     # All age metrics should be reported
     for metric in _iterate_metric_name(STAT_SUBSCRIPTION_METRICS):
         assert_metric_at_least(
@@ -165,10 +145,7 @@ def test_subscription_state(aggregator, integration_check, pg_replica_logical):
     #  subscription_persons  | persons_indexed | ready
     #  subscription_persons2 | persons_indexed | initialize
     #  subscription_cities   | cities          | data_copied
-    base_tags = pg_replica_logical['tags'] + [
-        'port:{}'.format(pg_replica_logical['port']),
-        f'dd.internal.resource:database_instance:{check.resolved_hostname}',
-    ]
+    base_tags = _get_expected_tags(check, pg_replica_logical)
     expected_states = [
         ['subscription_name:subscription_persons', 'relation:persons_indexed', 'state:ready'],
         ['subscription_name:subscription_persons2', 'relation:persons_indexed', 'state:initialize'],

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -286,7 +286,7 @@ def test_can_connect_service_check(aggregator, integration_check, pg_instance):
     check = integration_check(pg_instance)
 
     check.check(pg_instance)
-    expected_tags = _get_expected_tags(check, pg_instance, db=DB_NAME)
+    expected_tags = _get_expected_tags(check, pg_instance, with_db=True)
     aggregator.assert_service_check('postgres.can_connect', count=1, status=PostgreSql.OK, tags=expected_tags)
     aggregator.reset()
 
@@ -297,7 +297,9 @@ def test_can_connect_service_check(aggregator, integration_check, pg_instance):
     with pytest.raises(AttributeError):
         check.db = mock.MagicMock(side_effect=AttributeError('foo'))
         check.check(pg_instance)
-    aggregator.assert_service_check('postgres.can_connect', count=1, status=PostgreSql.CRITICAL, tags=expected_tags)
+    # Since we can't connect to the host, we can't gather the replication role
+    tags_without_role = _get_expected_tags(check, pg_instance, with_db=True, role=None)
+    aggregator.assert_service_check('postgres.can_connect', count=1, status=PostgreSql.CRITICAL, tags=tags_without_role)
     aggregator.reset()
 
     # Third: connection still open but this time no error
@@ -646,7 +648,7 @@ def test_config_tags_is_unchanged_between_checks(integration_check, pg_instance)
     check = integration_check(pg_instance)
 
     # Put elements in set as we don't care about order, only elements equality
-    expected_tags = set(_get_expected_tags(check, pg_instance, db=DB_NAME))
+    expected_tags = set(_get_expected_tags(check, pg_instance, db=DB_NAME, role=None))
     for _ in range(3):
         check.check(pg_instance)
         assert set(check._config.tags) == expected_tags
@@ -850,7 +852,8 @@ def test_database_instance_cloud_metadata_aws(
         # we only assert the check ran if we don't expect a ConfigurationError
         assert check.cloud_metadata['aws']['managed_authentication']['enabled'] == expected_managed_auth_enabled
 
-        expected_tags = _get_expected_tags(check, pg_instance, db=DB_NAME)
+        role = None if expected_error else 'master'
+        expected_tags = _get_expected_tags(check, pg_instance, with_db=True, role=role)
         if "instance_endpoint" in aws_metadata:
             expected_tags.append("dd.internal.resource:aws_rds_instance:{}".format(aws_metadata["instance_endpoint"]))
 
@@ -998,7 +1001,8 @@ def test_database_instance_cloud_metadata_azure(
         # we only assert the check ran if we don't expect a ConfigurationError
         assert check.cloud_metadata['azure']['managed_authentication']['enabled'] == expected_managed_auth_enabled
 
-        expected_tags = _get_expected_tags(check, pg_instance, db=DB_NAME)
+        role = None if expected_error else 'master'
+        expected_tags = _get_expected_tags(check, pg_instance, with_db=True, role=role)
         if "fully_qualified_domain_name" in azure_metadata:
             expected_tags.append(
                 "dd.internal.resource:azure_postgresql_flexible_server:{}".format(
@@ -1040,3 +1044,30 @@ def test_host_autodiscover_init_config(aggregator, pg_host_autodiscover_init_con
     check_with_init.check({})
     # assert that the service check is OK
     aggregator.assert_service_check('postgres.can_connect', count=1, status=PostgreSql.OK)
+
+
+@requires_over_10
+def test_replication_tag(aggregator, integration_check, pg_instance):
+    test_metric = 'postgresql.db.count'
+
+    pg_instance['tag_replication_role'] = False
+    check = integration_check(pg_instance)
+
+    # no replication
+    check.check(pg_instance)
+    aggregator.assert_metric(test_metric, tags=_get_expected_tags(check, pg_instance, role=None))
+    aggregator.reset()
+
+    # role = master
+    pg_instance['tag_replication_role'] = True
+    check = integration_check(pg_instance)
+
+    check.check(pg_instance)
+    aggregator.assert_metric(test_metric, tags=_get_expected_tags(check, pg_instance, role='master'))
+    aggregator.reset()
+
+    # switchover: master -> standby
+    standby_role = 'standby'
+    check._get_replication_role = mock.MagicMock(return_value=standby_role)
+    check.check(pg_instance)
+    aggregator.assert_metric(test_metric, tags=_get_expected_tags(check, pg_instance, role=standby_role))

--- a/postgres/tests/test_pg_replication.py
+++ b/postgres/tests/test_pg_replication.py
@@ -8,7 +8,7 @@ from flaky import flaky
 
 from .common import (
     DB_NAME,
-    _get_expected_tags,
+    _get_expected_replication_tags,
     assert_metric_at_least,
     check_bgw_metrics,
     check_common_metrics,
@@ -37,7 +37,7 @@ def test_common_replica_metrics(aggregator, integration_check, metrics_cache_rep
     check.initialize_is_aurora()
     check.check(pg_replica_instance)
 
-    expected_tags = _get_expected_tags(check, pg_replica_instance)
+    expected_tags = _get_expected_replication_tags(check, pg_replica_instance)
     check_common_metrics(aggregator, expected_tags=expected_tags)
     check_bgw_metrics(aggregator, expected_tags)
     check_connection_metrics(aggregator, expected_tags=expected_tags)
@@ -62,7 +62,7 @@ def test_wal_receiver_metrics(aggregator, integration_check, pg_instance, pg_rep
     check = integration_check(pg_replica_instance)
     check._connect()
     check.initialize_is_aurora()
-    expected_tags = _get_expected_tags(check, pg_replica_instance, status='streaming')
+    expected_tags = _get_expected_replication_tags(check, pg_replica_instance, status='streaming')
     with _get_superconn(pg_instance) as conn:
         with conn.cursor() as cur:
             # Ask for a new txid to force a WAL change
@@ -102,7 +102,7 @@ def test_wal_receiver_metrics(aggregator, integration_check, pg_instance, pg_rep
 @requires_over_10
 def test_conflicts_lock(aggregator, integration_check, pg_instance, pg_replica_instance2):
     check = integration_check(pg_replica_instance2)
-    expected_tags = _get_expected_tags(check, pg_replica_instance2, db=DB_NAME)
+    expected_tags = _get_expected_replication_tags(check, pg_replica_instance2, db=DB_NAME)
 
     replica_con = _get_superconn(pg_replica_instance2)
     replica_con.set_session(autocommit=False)
@@ -134,7 +134,7 @@ def test_conflicts_lock(aggregator, integration_check, pg_instance, pg_replica_i
 @flaky(max_runs=5)
 def test_conflicts_snapshot(aggregator, integration_check, pg_instance, pg_replica_instance2):
     check = integration_check(pg_replica_instance2)
-    expected_tags = _get_expected_tags(check, pg_replica_instance2, db=DB_NAME)
+    expected_tags = _get_expected_replication_tags(check, pg_replica_instance2, db=DB_NAME)
 
     replica2_con = _get_superconn(pg_replica_instance2)
     replica2_con.set_session(autocommit=False)
@@ -166,7 +166,7 @@ def test_conflicts_snapshot(aggregator, integration_check, pg_instance, pg_repli
 @requires_over_10
 def test_conflicts_bufferpin(aggregator, integration_check, pg_instance, pg_replica_instance2):
     check = integration_check(pg_replica_instance2)
-    expected_tags = _get_expected_tags(check, pg_replica_instance2, db=DB_NAME)
+    expected_tags = _get_expected_replication_tags(check, pg_replica_instance2, db=DB_NAME)
 
     with _get_superconn(pg_instance) as conn:
         with conn.cursor() as cur:

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -8,7 +8,7 @@ from flaky import flaky
 from datadog_checks.base import ConfigurationError
 from datadog_checks.postgres.relationsmanager import QUERY_PG_CLASS, RelationsManager
 
-from .common import DB_NAME, HOST, PORT, _get_expected_tags, _iterate_metric_name, assert_metric_at_least
+from .common import DB_NAME, HOST, _get_expected_tags, _iterate_metric_name, assert_metric_at_least
 from .utils import _get_superconn, _wait_for_value, requires_over_11
 
 RELATION_METRICS = [
@@ -235,14 +235,12 @@ def test_vacuum_age(aggregator, integration_check, pg_instance):
             1,
             'persons',
             [
-                'port:{}'.format(PORT),
                 'db:datadog_test',
                 'lock_mode:AccessExclusiveLock',
                 'lock_type:relation',
                 'granted:True',
                 'table:persons',
                 'schema:public',
-                'dd.internal.resource:database_instance:stubbed.hostname',
             ],
             id="test with single table lock should return 1",
         ),
@@ -284,7 +282,7 @@ def test_locks_metrics(aggregator, integration_check, pg_instance, relations, lo
     check_with_lock(check, pg_instance, lock_table_name)
 
     if tags is not None:
-        expected_tags = pg_instance['tags'] + tags
+        expected_tags = _get_expected_tags(check, pg_instance) + tags
         aggregator.assert_metric('postgresql.locks', count=lock_count, tags=expected_tags)
     else:
         aggregator.assert_metric('postgresql.locks', count=lock_count)

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -27,7 +27,14 @@ from datadog_checks.postgres.statements import PG_STAT_STATEMENTS_METRICS_COLUMN
 from datadog_checks.postgres.util import payload_pg_version
 from datadog_checks.postgres.version_utils import V12
 
-from .common import DB_NAME, HOST, PORT, PORT_REPLICA2, POSTGRES_VERSION
+from .common import (
+    DB_NAME,
+    HOST,
+    PORT_REPLICA2,
+    POSTGRES_VERSION,
+    _get_expected_replication_tags,
+    _get_expected_tags,
+)
 from .utils import _get_conn, _get_superconn, requires_over_10, run_one_check
 
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]
@@ -175,7 +182,7 @@ def test_statement_metrics(
     assert event['ddagentversion'] == datadog_agent.get_version()
     assert event['ddagenthostname'] == datadog_agent.get_hostname()
     assert event['min_collection_interval'] == dbm_instance['query_metrics']['collection_interval']
-    expected_dbm_metrics_tags = {'foo:bar', 'port:{}'.format(PORT)}
+    expected_dbm_metrics_tags = set(_get_expected_tags(None, dbm_instance))
     assert set(event['tags']) == expected_dbm_metrics_tags
     obfuscated_param = '?' if POSTGRES_VERSION.split('.')[0] == "9" else '$1'
 
@@ -419,21 +426,6 @@ def dbm_instance_replica2(pg_instance):
     return pg_instance
 
 
-def _expected_dbm_instance_tags(dbm_instance):
-    return dbm_instance['tags'] + [
-        'port:{}'.format(PORT),
-        'db:{}'.format(dbm_instance['dbname']),
-    ]
-
-
-def _expected_dbm_job_err_tags(dbm_instance):
-    return dbm_instance['tags'] + [
-        'port:{}'.format(PORT),
-        'db:{}'.format(dbm_instance['dbname']),
-        'dd.internal.resource:database_instance:stubbed.hostname',
-    ]
-
-
 @pytest.mark.parametrize(
     "dbname,expected_db_explain_error",
     [
@@ -535,11 +527,8 @@ def test_failed_explain_handling(
     for _ in range(failed_explain_test_repeat_count):
         check.statement_samples._run_and_track_explain(dbname, query, query, query)
 
-    expected_tags = dbm_instance['tags'] + [
-        'db:{}'.format(DB_NAME),
-        'port:{}'.format(PORT),
-        'agent_hostname:stubbed.hostname',
-        expected_error_tag,
+    expected_tags = _get_expected_tags(None, dbm_instance, with_db=True, agent_hostname='stubbed.hostname') + [
+        expected_error_tag
     ]
 
     aggregator.assert_metric(
@@ -664,10 +653,7 @@ def test_statement_samples_collect(
     check = integration_check(dbm_instance)
     check._connect()
 
-    tags = dbm_instance['tags'] + [
-        'port:{}'.format(PORT),
-        'db:{}'.format(dbname),
-    ]
+    tags = _get_expected_tags(None, dbm_instance, db=dbname)
 
     conn = psycopg2.connect(host=HOST, dbname=dbname, user=user, password=password)
     # we are able to see the full query (including the raw parameters) in pg_stat_activity because psycopg2 uses
@@ -1047,9 +1033,7 @@ def test_activity_snapshot_collection(
 
         assert 'query' not in bobs_query
 
-        expected_tags = dbm_instance['tags'] + [
-            'port:{}'.format(PORT),
-        ]
+        expected_tags = _get_expected_tags(None, dbm_instance)
 
         # check postgres_connections are set
         assert len(event['postgres_connections']) > 0
@@ -1284,11 +1268,7 @@ def test_statement_run_explain_errors(
     assert explain_err_code == expected_explain_err_code
     assert err == expected_err
 
-    expected_tags = dbm_instance['tags'] + [
-        'db:{}'.format(DB_NAME),
-        'port:{}'.format(PORT),
-        'agent_hostname:stubbed.hostname',
-    ]
+    expected_tags = _get_expected_tags(None, dbm_instance, with_db=True, agent_hostname='stubbed.hostname')
 
     aggregator.assert_metric(
         'dd.postgres.statement_samples.error',
@@ -1405,19 +1385,21 @@ def test_load_pg_settings(aggregator, integration_check, dbm_instance, db_user):
     if db_user == 'datadog_no_catalog':
         aggregator.assert_metric(
             "dd.postgres.error",
-            tags=_expected_dbm_instance_tags(dbm_instance)
-            + [
-                'error:load-pg-settings',
-                'agent_hostname:stubbed.hostname',
-                'dd.internal.resource:database_instance:stubbed.hostname',
-            ],
+            tags=_get_expected_tags(
+                check,
+                dbm_instance,
+                role=None,
+                with_db=True,
+                error='load-pg-settings',
+                agent_hostname='stubbed.hostname',
+            ),
             hostname='stubbed.hostname',
         )
     else:
         assert len(aggregator.metrics("dd.postgres.error")) == 0
 
 
-def test_pg_settings_caching(aggregator, integration_check, dbm_instance):
+def test_pg_settings_caching(integration_check, dbm_instance):
     dbm_instance["username"] = "datadog"
     dbm_instance["dbname"] = "postgres"
     check = integration_check(dbm_instance)
@@ -1605,7 +1587,7 @@ def test_async_job_inactive_stop(aggregator, integration_check, dbm_instance):
     for job in ['query-metrics', 'query-samples']:
         aggregator.assert_metric(
             "dd.postgres.async_job.inactive_stop",
-            tags=_expected_dbm_job_err_tags(dbm_instance) + ['job:' + job],
+            tags=_get_expected_tags(check, dbm_instance, with_db=True, job=job),
         )
 
 
@@ -1623,7 +1605,7 @@ def test_async_job_cancel_cancel(aggregator, integration_check, dbm_instance):
     for job in ['query-metrics', 'query-samples']:
         aggregator.assert_metric(
             "dd.postgres.async_job.cancel",
-            tags=_expected_dbm_job_err_tags(dbm_instance) + ['job:' + job],
+            tags=_get_expected_tags(check, dbm_instance, with_db=True, job=job),
         )
 
 
@@ -1648,11 +1630,13 @@ def test_statement_samples_invalid_activity_view(aggregator, integration_check, 
     check.statement_samples._job_loop_future.result()
     aggregator.assert_metric(
         "dd.postgres.async_job.error",
-        tags=_expected_dbm_job_err_tags(dbm_instance)
-        + [
-            'job:query-samples',
-            "error:database-<class 'psycopg2.errors.UndefinedTable'>",
-        ],
+        tags=_get_expected_tags(
+            check,
+            dbm_instance,
+            with_db=True,
+            job='query-samples',
+            error="database-<class 'psycopg2.errors.UndefinedTable'>",
+        ),
     )
 
 
@@ -1782,11 +1766,8 @@ def test_statement_metrics_database_errors(
     ):
         run_one_check(check, dbm_instance)
 
-    expected_tags = dbm_instance['tags'] + [
-        'db:{}'.format(DB_NAME),
-        'port:{}'.format(PORT),
-        'agent_hostname:stubbed.hostname',
-        expected_error_tag,
+    expected_tags = _get_expected_tags(None, dbm_instance, with_db=True, agent_hostname='stubbed.hostname') + [
+        expected_error_tag
     ]
 
     aggregator.assert_metric(
@@ -1848,10 +1829,7 @@ def test_pg_stat_statements_dealloc(aggregator, integration_check, dbm_instance_
         cur.execute("SELECT COUNT(*) FROM pg_stat_statements(false);")
         count_statements = cur.fetchall()[0][0]
 
-    expected_tags = dbm_instance_replica2['tags'] + [
-        'port:{}'.format(PORT_REPLICA2),
-        'db:{}'.format(DB_NAME),
-    ]
+    expected_tags = _get_expected_replication_tags(None, dbm_instance_replica2, db=DB_NAME)
     aggregator.assert_metric("postgresql.pg_stat_statements.max", value=100, tags=expected_tags)
     if float(POSTGRES_VERSION) >= 14.0:
         aggregator.assert_metric("postgresql.pg_stat_statements.dealloc", value=0, tags=expected_tags)

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -14,9 +14,6 @@ from six import iteritems
 
 from datadog_checks.postgres import PostgreSql, util
 
-from .common import PORT, check_performance_metrics
-from .utils import requires_over_10
-
 pytestmark = pytest.mark.unit
 
 
@@ -241,71 +238,6 @@ def test_resolved_hostname_metadata(check, test_case):
         m.assert_any_call('test:123', 'resolved_hostname', test_case)
 
 
-@requires_over_10
-@pytest.mark.usefixtures('mock_cursor_for_replica_stats')
-def test_replication_stats(aggregator, integration_check, pg_instance):
-    check = integration_check(pg_instance)
-    check.check(pg_instance)
-    base_tags = [
-        'foo:bar',
-        'port:5432',
-        'dd.internal.resource:database_instance:{}'.format(check.resolved_hostname),
-    ]
-    app1_tags = base_tags + [
-        'wal_sync_state:async',
-        'wal_state:streaming',
-        'wal_app_name:app1',
-        'wal_client_addr:1.1.1.1',
-    ]
-    app2_tags = base_tags + [
-        'wal_sync_state:sync',
-        'wal_state:backup',
-        'wal_app_name:app2',
-        'wal_client_addr:1.1.1.1',
-    ]
-
-    aggregator.assert_metric('postgresql.db.count', 0, base_tags)
-    for suffix in ('wal_write_lag', 'wal_flush_lag', 'wal_replay_lag', 'backend_xmin_age'):
-        metric_name = 'postgresql.replication.{}'.format(suffix)
-        aggregator.assert_metric(metric_name, 12, app1_tags)
-        aggregator.assert_metric(metric_name, 13, app2_tags)
-
-    check_performance_metrics(aggregator, check.debug_stats_kwargs()['tags'])
-
-    aggregator.assert_all_metrics_covered()
-
-
-def test_replication_tag(aggregator, integration_check, pg_instance):
-    REPLICATION_TAG_TEST_METRIC = 'postgresql.db.count'
-
-    check = integration_check(pg_instance)
-    expected_tags = pg_instance['tags'] + [
-        'port:{}'.format(PORT),
-        'dd.internal.resource:database_instance:{}'.format(check.resolved_hostname),
-    ]
-
-    # default configuration (no replication)
-    check.check(pg_instance)
-    aggregator.assert_metric(REPLICATION_TAG_TEST_METRIC, tags=expected_tags)
-    aggregator.reset()
-
-    # role = master
-    pg_instance['tag_replication_role'] = True
-    check = integration_check(pg_instance)
-
-    check.check(pg_instance)
-    ROLE_TAG = "replication_role:master"
-    aggregator.assert_metric(REPLICATION_TAG_TEST_METRIC, tags=expected_tags + [ROLE_TAG])
-    aggregator.reset()
-
-    # switchover: master -> standby
-    STANDBY = "standby"
-    check._get_replication_role = MagicMock(return_value=STANDBY)
-    check.check(pg_instance)
-    ROLE_TAG = "replication_role:{}".format(STANDBY)
-    aggregator.assert_metric(REPLICATION_TAG_TEST_METRIC, tags=expected_tags + [ROLE_TAG])
-
-
 def test_query_timeout_connection_string(aggregator, integration_check, pg_instance):
     pg_instance['password'] = ''
     pg_instance['query_timeout'] = 1000
@@ -348,8 +280,7 @@ def test_server_tag_(disable_generic_tags, expected_tags, pg_instance):
     instance = copy.deepcopy(pg_instance)
     instance['disable_generic_tags'] = disable_generic_tags
     check = PostgreSql('test_instance', {}, [instance])
-    tags = check._get_service_check_tags()
-    assert set(tags) == expected_tags
+    assert set(check.tags) == expected_tags
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?
Enable tag replication role by default.

### Motivation
The tag information (`master` or `standby`) is extremely useful to have to identify who is the primary in a cluster. It is also cheap to get (only a call to `pg_is_in_recovery`) and a db host will mostly be tagged with a single value except when a promotion happens. By enabling it by default, we can rely on its presence for other part of the product like watchdog alerts. 

### Additional Notes
The unit test `test_replication_stats` was removed as it was redundant with integration test done on a replica. 
`test_replication_tag` was moved from test_unit since it relies on an existing pg_instance. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
