### PR TITLE
feat: Collect 'argocd_app_labels' argocd metric

### DIFF
--- a/argocd/README.md
+++ b/argocd/README.md
@@ -29,6 +29,8 @@ The Datadog Agent can collect the exposed metrics using this integration. Follow
 
 Ensure that the Prometheus-formatted metrics are exposed in your Argo CD cluster. This is enabled by default if using Argo CD's [default manifests][10]. For the Agent to gather all metrics, each of the three aforementioned components needs to be annotated. For more information about annotations, see the [Autodiscovery Integration Templates][4] for guidance. Additional configuration options are available by reviewing the [sample argocd.d/conf.yaml][12].
 
+There are use-cases where Argo CD Applications contain labels that are desired to be exposed as Prometheus metrics. These labels are available via the `argocd_app_labels` metric, which is disabled on the Application Controller by default. Refer to the [ArgoCD Documentation][14] for instructions to enable it.
+
 Example configurations:
 
 **Application Controller**:
@@ -191,4 +193,5 @@ Need help? Contact [Datadog support][9].
 [11]: https://docs.datadoghq.com/integrations/openmetrics/
 [12]: https://github.com/DataDog/integrations-core/blob/master/argocd/datadog_checks/argocd/data/conf.yaml.example
 [13]: https://github.com/DataDog/integrations-core/blob/7.45.x/argocd/datadog_checks/argocd/data/conf.yaml.example#L164-L166
+[14]: https://argo-cd.readthedocs.io/en/stable/operator-manual/metrics/#exposing-application-labels-as-prometheus-metrics
 

--- a/argocd/README.md
+++ b/argocd/README.md
@@ -29,7 +29,7 @@ The Datadog Agent can collect the exposed metrics using this integration. Follow
 
 Ensure that the Prometheus-formatted metrics are exposed in your Argo CD cluster. This is enabled by default if using Argo CD's [default manifests][10]. For the Agent to gather all metrics, each of the three aforementioned components needs to be annotated. For more information about annotations, see the [Autodiscovery Integration Templates][4] for guidance. Additional configuration options are available by reviewing the [sample argocd.d/conf.yaml][12].
 
-There are use-cases where Argo CD Applications contain labels that are desired to be exposed as Prometheus metrics. These labels are available via the `argocd_app_labels` metric, which is disabled on the Application Controller by default. Refer to the [ArgoCD Documentation][14] for instructions to enable it.
+There are use cases where Argo CD Applications contain labels that need to be exposed as Prometheus metrics. These labels are available using the `argocd_app_labels` metric, which is disabled on the Application Controller by default. Refer to the [ArgoCD Documentation][14] for instructions on how to enable it.
 
 Example configurations:
 

--- a/argocd/changelog.d/16897.added
+++ b/argocd/changelog.d/16897.added
@@ -1,0 +1,1 @@
+Collect 'argocd_app_labels' argocd metric

--- a/argocd/datadog_checks/argocd/metrics.py
+++ b/argocd/datadog_checks/argocd/metrics.py
@@ -44,6 +44,7 @@ APPLICATION_CONTROLLER = {
     'argocd_app_info': 'app.info',
     'argocd_app_reconcile': 'app.reconcile',
     'argocd_app_sync': 'app.sync',
+    'argocd_app_labels': 'app.labels',
     'argocd_cluster_api_resource_objects': 'cluster.api.resource_objects',
     'argocd_cluster_api_resources': 'cluster.api.resources',
     'argocd_cluster_cache_age_seconds': 'cluster.cache.age.seconds',

--- a/argocd/metadata.csv
+++ b/argocd/metadata.csv
@@ -48,6 +48,7 @@ argocd.app_controller.app.reconcile.bucket,count,,,,Application reconciliation p
 argocd.app_controller.app.reconcile.count,count,,,,The count aggregation of the application reconciliation performance histogram,0,argocd,app_controller app reconcile count,
 argocd.app_controller.app.reconcile.sum,count,,,,The sum aggregation of the application reconciliation performance histogram,0,argocd,app_controller app reconcile sum,
 argocd.app_controller.app.sync.count,count,,,,The total number of application syncs,0,argocd,app_controller app sync,
+argocd.app_controller.app.labels,gauge,,,,Argo Application labels converted to Prometheus labels. The metric value is constant. Disabled by default, see integration documentation for how to enable.,0,argocd,app_controller app labels,
 argocd.app_controller.cluster.api.resource_objects,gauge,,object,,The number of Kubernetes resource objects in the cache,0,argocd,app_controller cluster api resource_objects,
 argocd.app_controller.cluster.api.resources,gauge,,resource,,The number of monitored kubernetes API resources.,0,argocd,app_controller cluster api resources,
 argocd.app_controller.cluster.cache.age.seconds,gauge,,second,,The age of the cluster cache in seconds,0,argocd,app_controller cluster cache age seconds,


### PR DESCRIPTION
### What does this PR do?

PR adds the `argocd_app_labels` argocd metric for collection

### Motivation

Having app labels available in a metric will be useful for routing alerts using ArgoCD metrics based on application labels

### Additional Notes

- [Exposing Application Labels as Prometheus Metrics](https://argo-cd.readthedocs.io/en/stable/operator-manual/metrics/#exposing-application-labels-as-prometheus-metrics)

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
