### PR TITLE
Add PG server version as tag

### DIFF
--- a/postgres/changelog.d/16900.added
+++ b/postgres/changelog.d/16900.added
@@ -1,0 +1,1 @@
+PostgreSQL: Add postgresql server version as a tag

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -126,18 +126,22 @@ def _iterate_metric_name(query):
             yield metric[0]
 
 
-def _get_expected_replication_tags(check, pg_instance, with_db=False, **kwargs):
-    return _get_expected_tags(check, pg_instance, with_db=with_db, role='standby', **kwargs)
+def _get_expected_replication_tags(check, pg_instance, with_host=True, with_db=False, with_version=True, **kwargs):
+    return _get_expected_tags(
+        check, pg_instance, with_host=with_host, with_db=with_db, with_version=with_version, role='standby', **kwargs
+    )
 
 
-def _get_expected_tags(check, pg_instance, with_db=False, role='master', **kwargs):
+def _get_expected_tags(check, pg_instance, with_host=True, with_db=False, with_version=True, role='master', **kwargs):
     base_tags = pg_instance['tags'] + [f'port:{pg_instance["port"]}']
     if role:
         base_tags.append(f'replication_role:{role}')
     if with_db:
         base_tags.append(f'db:{pg_instance["dbname"]}')
-    if check:
+    if with_host:
         base_tags.append(f'dd.internal.resource:database_instance:{check.resolved_hostname}')
+    if with_version and check.raw_version:
+        base_tags.append(f'postgresql_version:{check.raw_version}')
     for k, v in kwargs.items():
         base_tags.append(f'{k}:{v}')
     return base_tags

--- a/postgres/tests/test_e2e.py
+++ b/postgres/tests/test_e2e.py
@@ -5,12 +5,18 @@
 import pytest
 
 from .common import _get_expected_tags, check_bgw_metrics, check_common_metrics
+from .utils import _get_conn
 
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check, pg_instance):
+def test_e2e(check, dd_agent_check, pg_instance):
     aggregator = dd_agent_check(pg_instance, rate=True)
 
-    expected_tags = _get_expected_tags(None, pg_instance)
+    conn = _get_conn(pg_instance)
+    with conn.cursor() as cur:
+        cur.execute("SHOW server_version;")
+        check.raw_version = cur.fetchone()[0]
+
+    expected_tags = _get_expected_tags(check, pg_instance, with_host=False)
     check_bgw_metrics(aggregator, expected_tags)
     check_common_metrics(aggregator, expected_tags=expected_tags, count=None)

--- a/postgres/tests/test_logical_replication.py
+++ b/postgres/tests/test_logical_replication.py
@@ -101,8 +101,8 @@ def test_subscription_stats_sync_errors(aggregator, integration_check, pg_replic
     #  16650 | subscription_cities   |                 0 |               16 |
     #  16651 | subscription_persons2 |                 0 |                0 |
 
-    expected_subscription_tags = _get_expected_tags(check, pg_replica_logical, subscription_name='subscription_cities')
     check.check(pg_replica_logical)
+    expected_subscription_tags = _get_expected_tags(check, pg_replica_logical, subscription_name='subscription_cities')
     assert_metric_at_least(
         aggregator,
         'postgresql.subscription.sync_error',

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -298,7 +298,7 @@ def test_can_connect_service_check(aggregator, integration_check, pg_instance):
         check.db = mock.MagicMock(side_effect=AttributeError('foo'))
         check.check(pg_instance)
     # Since we can't connect to the host, we can't gather the replication role
-    tags_without_role = _get_expected_tags(check, pg_instance, with_db=True, role=None)
+    tags_without_role = _get_expected_tags(check, pg_instance, with_db=True, with_version=False, role=None)
     aggregator.assert_service_check('postgres.can_connect', count=1, status=PostgreSql.CRITICAL, tags=tags_without_role)
     aggregator.reset()
 
@@ -648,7 +648,7 @@ def test_config_tags_is_unchanged_between_checks(integration_check, pg_instance)
     check = integration_check(pg_instance)
 
     # Put elements in set as we don't care about order, only elements equality
-    expected_tags = set(_get_expected_tags(check, pg_instance, db=DB_NAME, role=None))
+    expected_tags = set(_get_expected_tags(check, pg_instance, db=DB_NAME, with_version=False, role=None))
     for _ in range(3):
         check.check(pg_instance)
         assert set(check._config.tags) == expected_tags

--- a/postgres/tests/test_pg_replication.py
+++ b/postgres/tests/test_pg_replication.py
@@ -62,7 +62,6 @@ def test_wal_receiver_metrics(aggregator, integration_check, pg_instance, pg_rep
     check = integration_check(pg_replica_instance)
     check._connect()
     check.initialize_is_aurora()
-    expected_tags = _get_expected_replication_tags(check, pg_replica_instance, status='streaming')
     with _get_superconn(pg_instance) as conn:
         with conn.cursor() as cur:
             # Ask for a new txid to force a WAL change
@@ -72,6 +71,7 @@ def test_wal_receiver_metrics(aggregator, integration_check, pg_instance, pg_rep
     time.sleep(0.2)
 
     check.check(pg_replica_instance)
+    expected_tags = _get_expected_replication_tags(check, pg_replica_instance, status='streaming')
     aggregator.assert_metric('postgresql.wal_receiver.last_msg_send_age', count=1, tags=expected_tags)
     aggregator.assert_metric('postgresql.wal_receiver.last_msg_receipt_age', count=1, tags=expected_tags)
     aggregator.assert_metric('postgresql.wal_receiver.latest_end_age', count=1, tags=expected_tags)
@@ -102,7 +102,6 @@ def test_wal_receiver_metrics(aggregator, integration_check, pg_instance, pg_rep
 @requires_over_10
 def test_conflicts_lock(aggregator, integration_check, pg_instance, pg_replica_instance2):
     check = integration_check(pg_replica_instance2)
-    expected_tags = _get_expected_replication_tags(check, pg_replica_instance2, db=DB_NAME)
 
     replica_con = _get_superconn(pg_replica_instance2)
     replica_con.set_session(autocommit=False)
@@ -125,6 +124,7 @@ def test_conflicts_lock(aggregator, integration_check, pg_instance, pg_replica_i
     )
 
     check.check(pg_replica_instance2)
+    expected_tags = _get_expected_replication_tags(check, pg_replica_instance2, db=DB_NAME)
     aggregator.assert_metric('postgresql.conflicts.lock', value=1, tags=expected_tags)
 
     replica_con.close()
@@ -134,7 +134,6 @@ def test_conflicts_lock(aggregator, integration_check, pg_instance, pg_replica_i
 @flaky(max_runs=5)
 def test_conflicts_snapshot(aggregator, integration_check, pg_instance, pg_replica_instance2):
     check = integration_check(pg_replica_instance2)
-    expected_tags = _get_expected_replication_tags(check, pg_replica_instance2, db=DB_NAME)
 
     replica2_con = _get_superconn(pg_replica_instance2)
     replica2_con.set_session(autocommit=False)
@@ -157,6 +156,7 @@ def test_conflicts_snapshot(aggregator, integration_check, pg_instance, pg_repli
         query="select confl_snapshot from pg_stat_database_conflicts where datname='datadog_test';",
     )
     check.check(pg_replica_instance2)
+    expected_tags = _get_expected_replication_tags(check, pg_replica_instance2, db=DB_NAME)
     aggregator.assert_metric('postgresql.conflicts.snapshot', value=1, tags=expected_tags)
 
     replica2_con.close()
@@ -166,7 +166,6 @@ def test_conflicts_snapshot(aggregator, integration_check, pg_instance, pg_repli
 @requires_over_10
 def test_conflicts_bufferpin(aggregator, integration_check, pg_instance, pg_replica_instance2):
     check = integration_check(pg_replica_instance2)
-    expected_tags = _get_expected_replication_tags(check, pg_replica_instance2, db=DB_NAME)
 
     with _get_superconn(pg_instance) as conn:
         with conn.cursor() as cur:
@@ -193,4 +192,5 @@ def test_conflicts_bufferpin(aggregator, integration_check, pg_instance, pg_repl
     )
 
     check.check(pg_replica_instance2)
+    expected_tags = _get_expected_replication_tags(check, pg_replica_instance2, db=DB_NAME)
     aggregator.assert_metric('postgresql.conflicts.bufferpin', value=1, tags=expected_tags)


### PR DESCRIPTION
### What does this PR do?
Add a new `postgresql_version` tag to all metrics.

### Motivation
Making version available as a metric tag provides multiple benefits:
- We can observe the change of version from minor or major upgrades that could explain instance restarts during a maintenance windows.
- We can list the number of instances per version and track outdated clusters

### Additional Notes
`copy.tag` was removed as `self.gauge` is already creating a copy of normalised tags so there's no need for this additional copy.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
