### PR TITLE
[gitlab] disable e2e tests in child agent pipeline

### DIFF
--- a/.gitlab/validate-agent-build/trigger_agent_build.py
+++ b/.gitlab/validate-agent-build/trigger_agent_build.py
@@ -18,7 +18,6 @@ def trigger_pipeline():
     if r.status_code != 200:
         print(f"Tag '{RELEASE_BRANCH}' is not a release tag, falling back to main")
         trigger_ref = "main"
-    # TODO: Opt out of kitchen tests when the appropriate flag is implemented.
     data = {
         "token": CI_TOKEN,
         "ref": trigger_ref,
@@ -27,7 +26,10 @@ def trigger_pipeline():
             "RELEASE_VERSION_7": "nightly-a7",
             "BUCKET_BRANCH": "none",
             "INTEGRATIONS_CORE_VERSION": os.environ['CI_COMMIT_REF_NAME'],
+            # disable kitchen tests
             "RUN_KITCHEN_TESTS": "false",
+            # disable e2e tests
+            "RUN_E2E_TESTS": "off",
         }
     }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add `RUN_E2E_TESTS=off` environment variable to child `datadog-agent` child pipeline, according to https://github.com/DataDog/datadog-agent/blob/main/.gitlab-ci.yml#L214

### Motivation
<!-- What inspired you to submit this pull request? -->

Disable e2e tests when running datadog-agent children pipelines. The goal of those pipelines is to ensure the build and packaging steps still work when we update dependencies on integrations-core side.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
