### PR TITLE
PostgreSQL: Add system_identifier as a metric tag

### DIFF
--- a/postgres/changelog.d/16911.added
+++ b/postgres/changelog.d/16911.added
@@ -1,0 +1,1 @@
+PostgreSQL: Add system_identifier as a metric tag

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -132,7 +132,9 @@ def _get_expected_replication_tags(check, pg_instance, with_host=True, with_db=F
     )
 
 
-def _get_expected_tags(check, pg_instance, with_host=True, with_db=False, with_version=True, role='master', **kwargs):
+def _get_expected_tags(
+    check, pg_instance, with_host=True, with_db=False, with_version=True, with_sys_id=True, role='master', **kwargs
+):
     base_tags = pg_instance['tags'] + [f'port:{pg_instance["port"]}']
     if role:
         base_tags.append(f'replication_role:{role}')
@@ -140,6 +142,8 @@ def _get_expected_tags(check, pg_instance, with_host=True, with_db=False, with_v
         base_tags.append(f'db:{pg_instance["dbname"]}')
     if with_host:
         base_tags.append(f'dd.internal.resource:database_instance:{check.resolved_hostname}')
+    if with_sys_id and check.system_identifier:
+        base_tags.append(f'system_identifier:{check.system_identifier}')
     if with_version and check.raw_version:
         base_tags.append(f'postgresql_version:{check.raw_version}')
     for k, v in kwargs.items():

--- a/postgres/tests/test_e2e.py
+++ b/postgres/tests/test_e2e.py
@@ -17,6 +17,9 @@ def test_e2e(check, dd_agent_check, pg_instance):
         cur.execute("SHOW server_version;")
         check.raw_version = cur.fetchone()[0]
 
+        cur.execute("SELECT system_identifier FROM pg_control_system();")
+        check.system_identifier = cur.fetchone()[0]
+
     expected_tags = _get_expected_tags(check, pg_instance, with_host=False)
     check_bgw_metrics(aggregator, expected_tags)
     check_common_metrics(aggregator, expected_tags=expected_tags, count=None)

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -298,7 +298,9 @@ def test_can_connect_service_check(aggregator, integration_check, pg_instance):
         check.db = mock.MagicMock(side_effect=AttributeError('foo'))
         check.check(pg_instance)
     # Since we can't connect to the host, we can't gather the replication role
-    tags_without_role = _get_expected_tags(check, pg_instance, with_db=True, with_version=False, role=None)
+    tags_without_role = _get_expected_tags(
+        check, pg_instance, with_db=True, with_version=False, with_sys_id=False, role=None
+    )
     aggregator.assert_service_check('postgres.can_connect', count=1, status=PostgreSql.CRITICAL, tags=tags_without_role)
     aggregator.reset()
 
@@ -648,7 +650,9 @@ def test_config_tags_is_unchanged_between_checks(integration_check, pg_instance)
     check = integration_check(pg_instance)
 
     # Put elements in set as we don't care about order, only elements equality
-    expected_tags = set(_get_expected_tags(check, pg_instance, db=DB_NAME, with_version=False, role=None))
+    expected_tags = set(
+        _get_expected_tags(check, pg_instance, db=DB_NAME, with_version=False, with_sys_id=False, role=None)
+    )
     for _ in range(3):
         check.check(pg_instance)
         assert set(check._config.tags) == expected_tags


### PR DESCRIPTION
### What does this PR do?
Add `system_identifier` tag to all PostgreSQL metrics.

### Motivation
[pg_control_system](https://pgpedia.info/p/pg_control_system.html) was introduced in PG 9.6 and expose the `system_identifier` from the control file. 
This `system_identifier` is initialised during initdb to identify an installation in an unique way. An interesting property of this system identifier is that it is shared between the primary and its replicas. This means we can use it as a way to identify clusters and aggregate/filter metrics per cluster.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
