### PR TITLE
[gitlab] improve datadog-agent pipeline variables

### DIFF
--- a/.gitlab/validate-agent-build/trigger_agent_build.py
+++ b/.gitlab/validate-agent-build/trigger_agent_build.py
@@ -24,7 +24,8 @@ def trigger_pipeline():
         "variables": {
             "RELEASE_VERSION_6": "nightly",
             "RELEASE_VERSION_7": "nightly-a7",
-            "BUCKET_BRANCH": "none",
+            "BUCKET_BRANCH": "dev",
+            "DEPLOY_AGENT": "false",
             "INTEGRATIONS_CORE_VERSION": os.environ['CI_COMMIT_REF_NAME'],
             # disable kitchen tests
             "RUN_KITCHEN_TESTS": "false",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Use `BUCKET_BRANCH: "dev"` and `DEPLOY_AGENT: "false"` instead of `BUCKET_BRANCH: "none"`

### Motivation
<!-- What inspired you to submit this pull request? -->

`BUCKET_BRANCH: "none"` is a legacy value, moving to defaults values, but using explicit here for readability. `BUCKET_BRANCH: "dev"` allows to avoid issues such as this [datadog-agent child pipeline](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/28491285) that was running some post build jobs like kitchen deploy ones, that deploy for tests, and failing as deployment jobs were uploading packaging missing the pipeline id. 

Test deployments should always include the pipeline_id. We'll come back to merge the `"RUN_KITCHEN_TESTS": "false", "RUN_E2E_TESTS": "off"` options when working on  https://datadoghq.atlassian.net/browse/APL-2844

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
