### PR TITLE
test_activity_nested_blocking_transactions is flaky

### DIFF
--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -59,6 +59,7 @@ SERVER_METRICS = [
 
 SQLSERVER_MAJOR_VERSION = int(os.environ.get('SQLSERVER_MAJOR_VERSION'))
 SQLSERVER_ENGINE_EDITION = int(os.environ.get('SQLSERVER_ENGINE_EDITION'))
+WINDOWS_SQLSERVER_DRIVER = os.environ.get('WINDOWS_SQLSERVER_DRIVER')
 
 
 def get_expected_file_stats_metrics():

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -59,7 +59,6 @@ SERVER_METRICS = [
 
 SQLSERVER_MAJOR_VERSION = int(os.environ.get('SQLSERVER_MAJOR_VERSION'))
 SQLSERVER_ENGINE_EDITION = int(os.environ.get('SQLSERVER_ENGINE_EDITION'))
-WINDOWS_SQLSERVER_DRIVER = os.environ.get('WINDOWS_SQLSERVER_DRIVER')
 
 
 def get_expected_file_stats_metrics():

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -17,13 +17,13 @@ from copy import copy
 import mock
 import pytest
 from dateutil import parser
-from flaky import flaky
 
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding
+from datadog_checks.dev.ci import running_on_windows_ci
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.activity import DM_EXEC_REQUESTS_COLS, _hash_to_hex
 
-from .common import CHECK_NAME, OPERATION_TIME_METRIC_NAME
+from .common import CHECK_NAME, OPERATION_TIME_METRIC_NAME, WINDOWS_SQLSERVER_DRIVER
 from .conftest import DEFAULT_TIMEOUT
 
 try:
@@ -204,7 +204,9 @@ def test_collect_load_activity(
     )
 
 
-@flaky(max_runs=5)
+@pytest.mark.skipif(
+    running_on_windows_ci() and WINDOWS_SQLSERVER_DRIVER == 'SQLNCLI11', reason='Test flakes on this set up'
+)
 def test_activity_nested_blocking_transactions(
     aggregator,
     instance_docker,

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -204,9 +204,7 @@ def test_collect_load_activity(
     )
 
 
-@pytest.mark.skipif(
-    running_on_windows_ci() and SQLSERVER_MAJOR_VERSION == 2019, reason='Test flakes on this set up'
-)
+@pytest.mark.skipif(running_on_windows_ci() and SQLSERVER_MAJOR_VERSION == 2019, reason='Test flakes on this set up')
 def test_activity_nested_blocking_transactions(
     aggregator,
     instance_docker,

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -23,7 +23,7 @@ from datadog_checks.dev.ci import running_on_windows_ci
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.activity import DM_EXEC_REQUESTS_COLS, _hash_to_hex
 
-from .common import CHECK_NAME, OPERATION_TIME_METRIC_NAME, WINDOWS_SQLSERVER_DRIVER
+from .common import CHECK_NAME, OPERATION_TIME_METRIC_NAME, SQLSERVER_MAJOR_VERSION
 from .conftest import DEFAULT_TIMEOUT
 
 try:
@@ -205,7 +205,7 @@ def test_collect_load_activity(
 
 
 @pytest.mark.skipif(
-    running_on_windows_ci() and WINDOWS_SQLSERVER_DRIVER == 'SQLNCLI11', reason='Test flakes on this set up'
+    running_on_windows_ci() and SQLSERVER_MAJOR_VERSION == 2019, reason='Test flakes on this set up'
 )
 def test_activity_nested_blocking_transactions(
     aggregator,

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -17,6 +17,7 @@ from copy import copy
 import mock
 import pytest
 from dateutil import parser
+from flaky import flaky
 
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding
 from datadog_checks.sqlserver import SQLServer
@@ -203,6 +204,7 @@ def test_collect_load_activity(
     )
 
 
+@flaky(max_runs=5)
 def test_activity_nested_blocking_transactions(
     aggregator,
     instance_docker,


### PR DESCRIPTION
### What does this PR do?
Skip `test_activity_nested_blocking_transactions` on windows sqlserver 2019 as it's flaky

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
