### PR TITLE
starting version in templates aligns with changelog type

### DIFF
--- a/datadog_checks_dev/changelog.d/16917.fixed
+++ b/datadog_checks_dev/changelog.d/16917.fixed
@@ -1,0 +1,1 @@
+Starting version in templates aligns with changelog type.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
@@ -194,6 +194,7 @@ def create(ctx, name, integration_type, location, non_interactive, quiet, dry_ru
                 f"\n    url='https://github.com/DataDog/integrations-{repo_choice}',"
             )
     template_fields['changelog_body'] = STATIC_CHANGELOG_BODY if repo_choice != 'core' else TOWNCRIER_BODY
+    template_fields['starting_version'] = '0.0.1' if repo_choice == 'core' else '1.0.0'
     config = construct_template_fields(name, repo_choice, integration_type, **template_fields)
 
     files = create_template_files(integration_type, root, config, repo_choice, read=not dry_run)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}/__about__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}/__about__.py
@@ -1,2 +1,2 @@
 {license_header}
-__version__ = '1.0.0'
+__version__ = '{starting_version}'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/datadog_checks/{check_name}/__about__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/datadog_checks/{check_name}/__about__.py
@@ -1,2 +1,2 @@
 {license_header}
-__version__ = '1.0.0'
+__version__ = '{starting_version}'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/datadog_checks/{check_name}/__about__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/datadog_checks/{check_name}/__about__.py
@@ -1,2 +1,2 @@
 {license_header}
-__version__ = '1.0.0'
+__version__ = '{starting_version}'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Follow-up to [Different changelog template depending on release process.](https://github.com/DataDog/integrations-core/pull/16693), we just forgot to change the `__about__.py` version too. Noticed this when fixing manually some of the new integrations.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
