### PR TITLE
[SINT-1841] Run Datadog SCA in the CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -211,10 +211,10 @@ datadog_checks_base/datadog_checks/base/checks/windows/              @DataDog/wi
 
 # SaaS Integrations
 /cisco_umbrella_dns/                                                 @DataDog/saas-integrations
-/cisco_umbrella_dns/*.md                                             @DataDog/saas-integrations @DataDog/documentation      
+/cisco_umbrella_dns/*.md                                             @DataDog/saas-integrations @DataDog/documentation
 /cisco_umbrella_dns/manifest.json                                    @DataDog/saas-integrations @DataDog/documentation
 /cisco_duo/                                                          @DataDog/saas-integrations
-/cisco_duo/*.md                                                      @DataDog/saas-integrations @DataDog/documentation      
+/cisco_duo/*.md                                                      @DataDog/saas-integrations @DataDog/documentation
 /cisco_duo/manifest.json                                             @DataDog/saas-integrations @DataDog/documentation
 
 # To keep Security up-to-date with changes to the signing tool.
@@ -225,6 +225,6 @@ docs/developer/process/integration-release.md                         @DataDog/s
 # As well as the pipelines.
 /.github/workflows/                                                   @DataDog/agent-integrations
 /.gitlab-ci.yml                                                       @DataDog/agent-integrations
-
+/.gitlab/software_composition_analysis.yaml                           @DataDog/software-integrity-and-trust
 # Dev container
 /.devcontainer/                                                        @DataDog/agent-integrations @DataDog/container-integrations

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -243,3 +243,26 @@ validate-agent-build-builder:
     - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/Datadog/devtools.git --depth 1
     - docker buildx build --tag $VALIDATE_AGENT_BUILD . --push
   tags: [ "arch:amd64" ]
+
+datadog-sca-ci:
+  stage: build
+  tags: ["arch:amd64"]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci-sbom:2024011006
+  when: always
+  # We don't want to disrupt the pipeline so let's fail silently.
+  allow_failure: true
+  # This specifies the job does not have any dependency, meaning it can start as soon as it can.
+  needs: []
+  script:
+    # Disabling tracing to avoid leaking secrets.
+    # See https://www.gnu.org/software/bash/manual/bash.html#The-Set-Builtin:
+    # "Using ‘+’ rather than ‘-’ causes these options to be turned off"
+    - set +o xtrace
+    - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name "ci.integrations-core.datadog_api_key_org2" --with-decryption --query "Parameter.Value" --out text)
+    - export DD_APP_KEY=$(aws ssm get-parameter --region us-east-1 --name "ci.integrations-core.datadog_app_key_org2" --with-decryption --query "Parameter.Value" --out text)
+    - set -o xtrace
+    - trivy fs --output /tmp/trivy.sbom --format cyclonedx --offline-scan --skip-update .
+    # Required until we use datadog-ci version https://github.com/DataDog/datadog-ci/releases/tag/v2.30.0
+    # Current version is v2.27.0
+    - export DD_BETA_COMMANDS_ENABLED=true
+    - datadog-ci sbom upload --service integrations-core --env ci /tmp/trivy.sbom

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 include:
-  - /.gitlab/software_composition_analysis.yml
+  - /.gitlab/software_composition_analysis.yaml
 
 variables:
   TAGGER_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/integrations-core:tagger

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,6 @@
+include:
+  - /.gitlab/software_composition_analysis.yml
+
 variables:
   TAGGER_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/integrations-core:tagger
   VALIDATE_LOG_INTGS: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/integrations-core:validate_log_intgs
@@ -243,26 +246,3 @@ validate-agent-build-builder:
     - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/Datadog/devtools.git --depth 1
     - docker buildx build --tag $VALIDATE_AGENT_BUILD . --push
   tags: [ "arch:amd64" ]
-
-datadog-sca-ci:
-  stage: build
-  tags: ["arch:amd64"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci-sbom:2024011006
-  when: always
-  # We don't want to disrupt the pipeline so let's fail silently.
-  allow_failure: true
-  # This specifies the job does not have any dependency, meaning it can start as soon as it can.
-  needs: []
-  script:
-    # Disabling tracing to avoid leaking secrets.
-    # See https://www.gnu.org/software/bash/manual/bash.html#The-Set-Builtin:
-    # "Using ‘+’ rather than ‘-’ causes these options to be turned off"
-    - set +o xtrace
-    - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name "ci.integrations-core.datadog_api_key_org2" --with-decryption --query "Parameter.Value" --out text)
-    - export DD_APP_KEY=$(aws ssm get-parameter --region us-east-1 --name "ci.integrations-core.datadog_app_key_org2" --with-decryption --query "Parameter.Value" --out text)
-    - set -o xtrace
-    - trivy fs --output /tmp/trivy.sbom --format cyclonedx --offline-scan --skip-update .
-    # Required until we use datadog-ci version https://github.com/DataDog/datadog-ci/releases/tag/v2.30.0
-    # Current version is v2.27.0
-    - export DD_BETA_COMMANDS_ENABLED=true
-    - datadog-ci sbom upload --service integrations-core --env ci /tmp/trivy.sbom

--- a/.gitlab/software_composition_analysis.yaml
+++ b/.gitlab/software_composition_analysis.yaml
@@ -1,0 +1,23 @@
+---
+datadog-sca-ci:
+  stage: build
+  tags: ["arch:amd64"]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci-sbom:2024011006
+  when: always
+  # We don't want to disrupt the pipeline so let's fail silently.
+  allow_failure: true
+  # This specifies the job does not have any dependency, meaning it can start as soon as it can.
+  needs: []
+  script:
+    # Disabling tracing to avoid leaking secrets.
+    # See https://www.gnu.org/software/bash/manual/bash.html#The-Set-Builtin:
+    # "Using ‘+’ rather than ‘-’ causes these options to be turned off"
+    - set +o xtrace
+    - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name "ci.integrations-core.datadog_api_key_org2" --with-decryption --query "Parameter.Value" --out text)
+    - export DD_APP_KEY=$(aws ssm get-parameter --region us-east-1 --name "ci.integrations-core.datadog_app_key_org2" --with-decryption --query "Parameter.Value" --out text)
+    - set -o xtrace
+    - trivy fs --output /tmp/trivy.sbom --format cyclonedx --offline-scan --skip-update .
+    # Required until we use datadog-ci version https://github.com/DataDog/datadog-ci/releases/tag/v2.30.0
+    # Current version is v2.27.0
+    - export DD_BETA_COMMANDS_ENABLED=true
+    - datadog-ci sbom upload --service integrations-core --env ci /tmp/trivy.sbom


### PR DESCRIPTION
### What does this PR do?
Add a new Gitlab CI job listing this repository dependencies with trivy and uploading them to Datadog. This will make it possible to use the SCA product for this repository (see https://app.datadoghq.com/ci/code-analysis?limit=100&offset=0).

### Motivation
@DataDog/software-integrity-and-trust partners with @DataDog/static-analysis to dogfood their SCA product and secure Datadog's supply chain.

### Additional Notes
[Successful CI run](https://gitlab.ddbuild.io/DataDog/integrations-core/-/jobs/440579100)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
