### PR TITLE
Update OTel Collector dashboard column break group

### DIFF
--- a/otel/assets/dashboards/otel_collector_metrics_dashboard.json
+++ b/otel/assets/dashboards/otel_collector_metrics_dashboard.json
@@ -898,7 +898,7 @@
                                             },
                                             "formula": "query1"
                                         }
-],
+                                    ],
                                     "response_format": "scalar",
                                     "queries": [
                                         {

--- a/otel/assets/dashboards/otel_collector_metrics_dashboard.json
+++ b/otel/assets/dashboards/otel_collector_metrics_dashboard.json
@@ -7,10 +7,10 @@
             "id": 7581494098406438,
             "definition": {
                 "title": "About",
-                "type": "group",
+"type": "group",
                 "banner_img": "/static/images/integration_dashboard/otel_hero_1.png",
                 "show_title": false,
-                "layout_type": "ordered",
+                                "layout_type": "ordered",
                 "widgets": [
                     {
                         "id": 6416205973430436,
@@ -66,10 +66,10 @@
             "id": 6537209141697758,
             "definition": {
                 "title": "Overall Health",
-                "type": "group",
+"type": "group",
                 "background_color": "vivid_blue",
                 "show_title": true,
-                "layout_type": "ordered",
+                                "layout_type": "ordered",
                 "widgets": [
                     {
                         "id": 5573486690411152,
@@ -319,10 +319,10 @@
             "id": 8041422185924356,
             "definition": {
                 "title": "Component: Receivers",
-                "type": "group",
+"type": "group",
                 "background_color": "white",
                 "show_title": true,
-                "layout_type": "ordered",
+                                "layout_type": "ordered",
                 "widgets": [
                     {
                         "id": 64712743594636,
@@ -333,17 +333,17 @@
                             "type": "query_table",
                             "requests": [
                                 {
-                                    "formulas": [
+                                                                        "formulas": [
                                         {
                                             "alias": "Accepted metric points",
-                                            "conditional_formats": [],
+"conditional_formats": [],
                                             "limit": {
                                                 "count": 500,
                                                 "order": "asc"
                                             },
                                             "formula": "query1"
                                         }
-                                    ],
+],
                                     "response_format": "scalar",
                                     "queries": [
                                         {
@@ -372,7 +372,7 @@
                             "type": "query_table",
                             "requests": [
                                 {
-                                    "formulas": [
+                                                                        "formulas": [
                                         {
                                             "alias": "Accepted spans",
                                             "limit": {
@@ -381,7 +381,7 @@
                                             },
                                             "formula": "query1"
                                         }
-                                    ],
+],
                                     "response_format": "scalar",
                                     "queries": [
                                         {
@@ -837,10 +837,10 @@
             "id": 4869373166772386,
             "definition": {
                 "title": "Component: Processors",
-                "type": "group",
+"type": "group",
                 "background_color": "white",
                 "show_title": true,
-                "layout_type": "ordered",
+                                "layout_type": "ordered",
                 "widgets": [
                     {
                         "id": 7541839960022268,
@@ -851,7 +851,7 @@
                             "type": "query_table",
                             "requests": [
                                 {
-                                    "formulas": [
+                                                                        "formulas": [
                                         {
                                             "alias": "Average batch send size",
                                             "limit": {
@@ -860,7 +860,7 @@
                                             },
                                             "formula": "query1"
                                         }
-                                    ],
+],
                                     "response_format": "scalar",
                                     "queries": [
                                         {
@@ -898,7 +898,7 @@
                                             },
                                             "formula": "query1"
                                         }
-                                    ],
+],
                                     "response_format": "scalar",
                                     "queries": [
                                         {
@@ -1112,18 +1112,17 @@
                 "x": 0,
                 "y": 21,
                 "width": 12,
-                "height": 7,
-                "is_column_break": true
+                "height": 7
             }
         },
         {
             "id": 7510133872566486,
             "definition": {
                 "title": "Component: Exporters",
-                "type": "group",
+"type": "group",
                 "background_color": "white",
                 "show_title": true,
-                "layout_type": "ordered",
+                                "layout_type": "ordered",
                 "widgets": [
                     {
                         "id": 930313914228380,
@@ -1143,7 +1142,7 @@
                                             },
                                             "formula": "query1"
                                         }
-                                    ],
+],
                                     "response_format": "scalar",
                                     "queries": [
                                         {
@@ -1172,7 +1171,7 @@
                             "type": "query_table",
                             "requests": [
                                 {
-                                    "formulas": [
+                                                                        "formulas": [
                                         {
                                             "alias": "Sent spans",
                                             "limit": {
@@ -1181,7 +1180,7 @@
                                             },
                                             "formula": "query1"
                                         }
-                                    ],
+],
                                     "response_format": "scalar",
                                     "queries": [
                                         {
@@ -1630,7 +1629,8 @@
                 "x": 0,
                 "y": 28,
                 "width": 12,
-                "height": 11
+                "height": 11,
+                "is_column_break": true
             }
         },
         {

--- a/otel/assets/dashboards/otel_collector_metrics_dashboard.json
+++ b/otel/assets/dashboards/otel_collector_metrics_dashboard.json
@@ -7,10 +7,10 @@
             "id": 7581494098406438,
             "definition": {
                 "title": "About",
-"type": "group",
+                "type": "group",
                 "banner_img": "/static/images/integration_dashboard/otel_hero_1.png",
                 "show_title": false,
-                                "layout_type": "ordered",
+                "layout_type": "ordered",
                 "widgets": [
                     {
                         "id": 6416205973430436,
@@ -66,10 +66,10 @@
             "id": 6537209141697758,
             "definition": {
                 "title": "Overall Health",
-"type": "group",
+                "type": "group",
                 "background_color": "vivid_blue",
                 "show_title": true,
-                                "layout_type": "ordered",
+                "layout_type": "ordered",
                 "widgets": [
                     {
                         "id": 5573486690411152,
@@ -319,10 +319,10 @@
             "id": 8041422185924356,
             "definition": {
                 "title": "Component: Receivers",
-"type": "group",
+                "type": "group",
                 "background_color": "white",
                 "show_title": true,
-                                "layout_type": "ordered",
+                "layout_type": "ordered",
                 "widgets": [
                     {
                         "id": 64712743594636,
@@ -333,17 +333,17 @@
                             "type": "query_table",
                             "requests": [
                                 {
-                                                                        "formulas": [
+                                    "formulas": [
                                         {
                                             "alias": "Accepted metric points",
-"conditional_formats": [],
+                                            "conditional_formats": [],
                                             "limit": {
                                                 "count": 500,
                                                 "order": "asc"
                                             },
                                             "formula": "query1"
                                         }
-],
+                                    ],
                                     "response_format": "scalar",
                                     "queries": [
                                         {
@@ -372,7 +372,7 @@
                             "type": "query_table",
                             "requests": [
                                 {
-                                                                        "formulas": [
+                                    "formulas": [
                                         {
                                             "alias": "Accepted spans",
                                             "limit": {
@@ -381,7 +381,7 @@
                                             },
                                             "formula": "query1"
                                         }
-],
+                                    ],
                                     "response_format": "scalar",
                                     "queries": [
                                         {
@@ -837,10 +837,10 @@
             "id": 4869373166772386,
             "definition": {
                 "title": "Component: Processors",
-"type": "group",
+                "type": "group",
                 "background_color": "white",
                 "show_title": true,
-                                "layout_type": "ordered",
+                "layout_type": "ordered",
                 "widgets": [
                     {
                         "id": 7541839960022268,
@@ -851,7 +851,7 @@
                             "type": "query_table",
                             "requests": [
                                 {
-                                                                        "formulas": [
+                                    "formulas": [
                                         {
                                             "alias": "Average batch send size",
                                             "limit": {
@@ -860,7 +860,7 @@
                                             },
                                             "formula": "query1"
                                         }
-],
+                                    ],
                                     "response_format": "scalar",
                                     "queries": [
                                         {
@@ -1119,10 +1119,10 @@
             "id": 7510133872566486,
             "definition": {
                 "title": "Component: Exporters",
-"type": "group",
+                "type": "group",
                 "background_color": "white",
                 "show_title": true,
-                                "layout_type": "ordered",
+                "layout_type": "ordered",
                 "widgets": [
                     {
                         "id": 930313914228380,
@@ -1142,7 +1142,7 @@
                                             },
                                             "formula": "query1"
                                         }
-],
+                                    ],
                                     "response_format": "scalar",
                                     "queries": [
                                         {
@@ -1171,7 +1171,7 @@
                             "type": "query_table",
                             "requests": [
                                 {
-                                                                        "formulas": [
+                                    "formulas": [
                                         {
                                             "alias": "Sent spans",
                                             "limit": {
@@ -1180,7 +1180,7 @@
                                             },
                                             "formula": "query1"
                                         }
-],
+                                    ],
                                     "response_format": "scalar",
                                     "queries": [
                                         {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates OOTB OTel Collector dashboard to change column break group.

Before:
![Screenshot 2024-02-21 at 10 40 51 AM](https://github.com/DataDog/integrations-core/assets/17220434/0a920b5c-eb4c-459c-bdaf-690658a2f1e4)

After:
![Screenshot 2024-02-21 at 10 40 32 AM](https://github.com/DataDog/integrations-core/assets/17220434/865adcc7-405a-4dd7-b0e8-7026ae7b2bde)

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
