### PR TITLE
DBMON-3546: Add auto_conf.yaml example for auto discovery configuration

### DIFF
--- a/mysql/changelog.d/16932.added
+++ b/mysql/changelog.d/16932.added
@@ -1,0 +1,1 @@
+DBMON-3546: Add auto_conf.yaml example for auto discovery configuration

--- a/mysql/datadog_checks/mysql/data/conf_aws_aurora.yaml.default
+++ b/mysql/datadog_checks/mysql/data/conf_aws_aurora.yaml.default
@@ -1,0 +1,30 @@
+ad_identifiers:
+  - _dbm_mysql_aurora
+init_config:
+instances:
+    ## @param host - string - optional
+    ## MySQL host to connect to.
+    ## NOTE: Even if the host is "localhost", the agent connects to MySQL using TCP/IP, unless you also
+    ## provide a value for the sock key (below).
+    #
+  - host: "%%host%%"
+
+    ## @param port - number - optional - default: 3306
+    ## Port to use when connecting to MySQL.
+    #
+    port: "%%port%%"
+
+    ## This block defines the configuration for AWS RDS and Aurora instances.
+    ##
+    ## Complete this section if you have installed the Datadog AWS Integration
+    ## (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances
+    ## with MySQL integration telemetry.
+    ##
+    ## These values are only applied when `dbm: true` option is set.
+    #
+    aws:
+      instance_endpoint: "%%host%%"
+
+    tags:
+      - "dbclusteridentifier:%%extra_dbclusteridentifier%%"
+      - "region:%%extra_region%%"

--- a/postgres/changelog.d/16932.added
+++ b/postgres/changelog.d/16932.added
@@ -1,0 +1,1 @@
+DBMON-3546: Add auto_conf.yaml example for auto discovery configuration

--- a/postgres/datadog_checks/postgres/data/auto_conf.yaml
+++ b/postgres/datadog_checks/postgres/data/auto_conf.yaml
@@ -1,0 +1,51 @@
+ad_identifiers:
+  - database_monitoring_aurora
+init_config:
+instances:
+  ## @param host - string - optional
+  ## The hostname to connect to.
+  ## NOTE: Even if the server name is `localhost`, the Agent connects to PostgreSQL using TCP/IP unless you also
+  ## provide a value for the sock key.
+  #
+  - host: "%%host%%"
+
+    ## @param port - integer - optional - default: 5432
+    ## The port to use when connecting to PostgreSQL.
+    #
+    port: "%%port%%"
+
+    ## This block defines the configuration for AWS RDS and Aurora instances.
+    ##
+    ## Complete this section if you have installed the Datadog AWS Integration
+    ## (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances
+    ## with Postgres integration telemetry or to use IAM Authentication with RDS.
+    ##
+    aws:
+      instance_endpoint: "%%host%%"
+      region: "%%extra_region%%"
+      ## @param managed_authentication - mapping - optional
+      ## Configure section used for AWS IAM Authentication with RDS.
+      ##
+      ## This supports using IAM database authentication to connect to your database instance.
+      ##
+      ## For more information on configuration, see
+      ## https://docs.datadoghq.com/database_monitoring/guide/managed_authentication
+      ##
+      ## For more information on RDS IAM Authentication, see the AWS docs
+      ## https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Connecting.html
+      ##
+      ## To enable IAM Authentication, set `aws.managed_authentication.enabled` to `true`.
+      ## If `aws.managed_authentication.enabled` is set, then the `password` fields will be ignored.
+      ## `aws.region` is required to enable IAM Authentication.
+      #
+      managed_authentication:
+        enabled: "%%extra_managed_authentication_enabled%%"
+
+    ## @param tags - list of strings - optional
+    ## A list of tags to attach to every metric and service check emitted by this instance.
+    ##
+    ## Learn more about tagging at https://docs.datadoghq.com/tagging
+    #
+    tags:
+      - "dbclusteridentifier:%%extra_dbclusteridentifier%%"
+      - "region:%%extra_region%%"

--- a/postgres/datadog_checks/postgres/data/conf_aws_aurora.yaml.default
+++ b/postgres/datadog_checks/postgres/data/conf_aws_aurora.yaml.default
@@ -1,5 +1,5 @@
 ad_identifiers:
-  - database_monitoring_aurora
+  - _dbm_postgres_aurora
 init_config:
 instances:
   ## @param host - string - optional
@@ -41,11 +41,6 @@ instances:
       managed_authentication:
         enabled: "%%extra_managed_authentication_enabled%%"
 
-    ## @param tags - list of strings - optional
-    ## A list of tags to attach to every metric and service check emitted by this instance.
-    ##
-    ## Learn more about tagging at https://docs.datadoghq.com/tagging
-    #
     tags:
       - "dbclusteridentifier:%%extra_dbclusteridentifier%%"
       - "region:%%extra_region%%"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds new auto configuration example files for `postgres` and `mysql` customers who want to configure auto-discovery of their aurora replicas. Config is based on the work done in this PR https://github.com/DataDog/datadog-agent/pull/23216

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
