### PR TITLE
[DBMON-3642] Proper handle events_statements_* timer_end overflow

### DIFF
--- a/mysql/changelog.d/16936.fixed
+++ b/mysql/changelog.d/16936.fixed
@@ -1,0 +1,1 @@
+[DBMON-3642] Proper handle events_statements_* timer_end overflow

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -53,7 +53,8 @@ EVENTS_STATEMENTS_SAMPLE_EXCLUDE_KEYS = {
     'current_schema',
     # used for signature
     'digest_text',
-    'timer_end_time_s',
+    'uptime' 'now',
+    'timer_end',
     'max_timer_wait_ns',
     'timer_start',
     # included as network.client.ip
@@ -70,7 +71,9 @@ EVENTS_STATEMENTS_CURRENT_QUERY = re.sub(
         digest,
         digest_text,
         timer_start,
-        @startup_time_s+timer_end*1e-12 as timer_end_time_s,
+        @uptime as uptime,
+        unix_timestamp() as now,
+        timer_end,
         timer_wait / 1000 AS timer_wait_ns,
         lock_time / 1000 AS lock_time_ns,
         rows_affected,
@@ -101,11 +104,11 @@ EVENTS_STATEMENTS_CURRENT_QUERY = re.sub(
 """,
 ).strip()
 
-STARTUP_TIME_SUBQUERY = re.sub(
+UPTIME_SUBQUERY = re.sub(
     r'\s+',
     ' ',
     """
-    (SELECT UNIX_TIMESTAMP()-VARIABLE_VALUE
+    (SELECT VARIABLE_VALUE
     FROM {global_status_table}
     WHERE VARIABLE_NAME='UPTIME')
 """,
@@ -141,6 +144,9 @@ PYMYSQL_MISSING_EXPLAIN_STATEMENT_PROC_ERRORS = frozenset(
         pymysql.constants.ER.PROCACCESS_DENIED_ERROR,
     }
 )
+
+# the max value of signed BIGINT type column
+BIGINT_MAX = 2**63 - 1
 
 
 class DBExplainErrorCode(Enum):
@@ -324,9 +330,7 @@ class MySQLStatementSamples(DBMAsyncJob):
         with closing(self._get_db_connection().cursor(pymysql.cursors.DictCursor)) as cursor:
             self._cursor_run(
                 cursor,
-                "set @startup_time_s = {}".format(
-                    STARTUP_TIME_SUBQUERY.format(global_status_table=self._global_status_table)
-                ),
+                "set @uptime = {}".format(UPTIME_SUBQUERY.format(global_status_table=self._global_status_table)),
             )
             self._cursor_run(cursor, EVENTS_STATEMENTS_CURRENT_QUERY)
             rows = cursor.fetchall()
@@ -428,7 +432,7 @@ class MySQLStatementSamples(DBMAsyncJob):
         query_plan_cache_key = (query_cache_key, plan_signature)
         if self._seen_samples_ratelimiter.acquire(query_plan_cache_key):
             return {
-                "timestamp": row["timer_end_time_s"] * 1000,
+                "timestamp": self._calculate_timer_end(row),
                 "dbm_type": "plan",
                 "host": self._check.resolved_hostname,
                 "ddagentversion": datadog_agent.get_version(),
@@ -465,6 +469,12 @@ class MySQLStatementSamples(DBMAsyncJob):
     def _collect_plans_for_statements(self, rows):
         for row in rows:
             try:
+                if not row['timer_end']:
+                    # If an event is produced from an instrument that has TIMED = NO,
+                    # timing information is not collected,
+                    # and TIMER_START, TIMER_END, and TIMER_WAIT are all NULL.
+                    self._log.debug("Skipping statement with missing timer_end: %s", row)
+                    continue
                 event = self._collect_plan_for_statement(row)
                 if event:
                     yield event
@@ -799,3 +809,20 @@ class MySQLStatementSamples(DBMAsyncJob):
     @staticmethod
     def _can_explain(obfuscated_statement):
         return obfuscated_statement.split(' ', 1)[0].lower() in SUPPORTED_EXPLAIN_STATEMENTS
+
+    @staticmethod
+    def _calculate_timer_end(row):
+        """
+        Calculate the timer_end_time_s from the timer_end, now and uptime fields
+        """
+        # timer_end is in picoseconds and uptime is in seconds
+        # timer_end can overflow, so we need to calcuate how many times it overflowed
+        timer_end = row['timer_end']
+        now = row['now']
+        uptime = int(row['uptime'])
+
+        bigint_max_in_seconds = BIGINT_MAX * 1e-12
+        # when timer_end is greater than bigint_max_in_seconds, we need to add the difference to the uptime
+        seconds_to_add = uptime // bigint_max_in_seconds * bigint_max_in_seconds
+        timer_end_time_s = now - uptime + seconds_to_add + timer_end * 1e-12
+        return int(timer_end_time_s * 1000)

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -53,7 +53,8 @@ EVENTS_STATEMENTS_SAMPLE_EXCLUDE_KEYS = {
     'current_schema',
     # used for signature
     'digest_text',
-    'uptime' 'now',
+    'uptime',
+    'now',
     'timer_end',
     'max_timer_wait_ns',
     'timer_start',


### PR DESCRIPTION
### What does this PR do?
This PR handles the case when events_statements_* `timer_end` overflows. `timer_end` is in picosecond has column type `BIGINT`, when it overflows and wrapped around, the calculated of statement timestamp based on server `UPTIME` could become stale. 
This PR handles this case by calculate "how many time timer_end overflowed" and makes up the difference. 

### Motivation
MySQL explain plan events are dropped when timestamp is stale. This change ensures we don't get a stake timestamp.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
