### PR TITLE
florentclarret/cigitlabci/release jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -166,16 +166,16 @@ notify-failed-pipeline:
 release-auto:
   stage: release
   image: $TAGGER_IMAGE
-#  only:
-#    - master
-#    - /^\d+\.\d+\.x$/
+  only:
+    - master
+    - /^\d+\.\d+\.x$/
   except:
     - schedules
   script:
     - ddev --version
-#    - ddev config set core .
-#    # Prefix every line with a timestamp
-#    - ./.gitlab/tagger/tag-release.sh 2>&1 | ts "[%H:%M:%S %Z]  "
+    - ddev config set core .
+    # Prefix every line with a timestamp
+    - ./.gitlab/tagger/tag-release.sh 2>&1 | ts "[%H:%M:%S %Z]  "
   tags: [ "runner:main" ]
   needs: []
 
@@ -234,12 +234,12 @@ validate-log-intgs-builder:
 validate-agent-build-builder:
   stage: build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:24.0.4-gbi-focal
-#  only:
-#    changes:
-#      - .gitlab/validate-agent-build/**/*
-#      - .gitlab-ci.yml
-#    refs:
-#      - master
+  only:
+    changes:
+      - .gitlab/validate-agent-build/**/*
+      - .gitlab-ci.yml
+    refs:
+      - master
   script:
     - cd .gitlab/validate-agent-build/
     - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/Datadog/devtools.git --depth 1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -166,16 +166,16 @@ notify-failed-pipeline:
 release-auto:
   stage: release
   image: $TAGGER_IMAGE
-  only:
-    - master
-    - /^\d+\.\d+\.x$/
+#  only:
+#    - master
+#    - /^\d+\.\d+\.x$/
   except:
     - schedules
   script:
     - ddev --version
-    - ddev config set core .
-    # Prefix every line with a timestamp
-    - ./.gitlab/tagger/tag-release.sh 2>&1 | ts "[%H:%M:%S %Z]  "
+#    - ddev config set core .
+#    # Prefix every line with a timestamp
+#    - ./.gitlab/tagger/tag-release.sh 2>&1 | ts "[%H:%M:%S %Z]  "
   tags: [ "runner:main" ]
   needs: []
 
@@ -234,12 +234,12 @@ validate-log-intgs-builder:
 validate-agent-build-builder:
   stage: build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:24.0.4-gbi-focal
-  only:
-    changes:
-      - .gitlab/validate-agent-build/**/*
-      - .gitlab-ci.yml
-    refs:
-      - master
+#  only:
+#    changes:
+#      - .gitlab/validate-agent-build/**/*
+#      - .gitlab-ci.yml
+#    refs:
+#      - master
   script:
     - cd .gitlab/validate-agent-build/
     - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/Datadog/devtools.git --depth 1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -177,6 +177,7 @@ release-auto:
     # Prefix every line with a timestamp
     - ./.gitlab/tagger/tag-release.sh 2>&1 | ts "[%H:%M:%S %Z]  "
   tags: [ "runner:main" ]
+  needs: []
 
 release-manual:
   stage: release
@@ -199,6 +200,7 @@ release-manual:
           ./.gitlab/tagger/build-packages.sh
       fi
   tags: [ "runner:main" ]
+  needs: []
 
 tagger-image-builder:
   stage: build


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Start the release jobs directly, without waiting for the previous stages to finish.

### Motivation
<!-- What inspired you to submit this pull request? -->

If one of the previous stage is red for whatever reason (timeout or anything else), the release job is never triggered. Happened this morning [here](https://gitlab.ddbuild.io/DataDog/integrations-core/-/pipelines/28793987) 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- Tested on https://gitlab.ddbuild.io/DataDog/integrations-core/-/pipelines/28802336, see commit history
- https://docs.gitlab.com/ee/ci/yaml/#needs

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
