### PR TITLE
Fix fluxcd default address documentation

### DIFF
--- a/fluxcd/README.md
+++ b/fluxcd/README.md
@@ -30,7 +30,7 @@ For older versions of the Agent, [use these steps to install][10] the integratio
     init_config:
       ...
     instances:
-      - openmetrics_endpoint: http://<FLUXCD_ADDRESS>:8080
+      - openmetrics_endpoint: http://<FLUXCD_ADDRESS>:8080/metrics
     ```
 
 2. [Restart the Agent][5] after modifying the configuration.
@@ -46,7 +46,7 @@ This is an example configuration of a Docker label inside `docker-compose.yml`. 
 
 ```yaml
 labels:
-  com.datadoghq.ad.checks: '{"fluxcd":{"instances":[{"openmetrics_endpoint":"http://%%host%%:8080"}]}}'
+  com.datadoghq.ad.checks: '{"fluxcd":{"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics"}]}}'
 ```
 
 <!-- xxz tab xxx -->
@@ -69,7 +69,7 @@ metadata:
         "fluxcd": {
           "instances": [
             {
-              "openmetrics_endpoint": "http://%%host%%:8080",
+              "openmetrics_endpoint": "http://%%host%%:8080/metrics",
             }
           ]
         }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update the documentation for FluxCD integration to point the openmetrics endpoint towards the [default location](https://fluxcd.io/flux/monitoring/metrics/#controller-metrics). 

### Motivation
<!-- What inspired you to submit this pull request? -->

The configuration did not work when copy pasting.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
