### PR TITLE
Fix metric to check aerospike

### DIFF
--- a/aerospike/manifest.json
+++ b/aerospike/manifest.json
@@ -34,7 +34,10 @@
       },
       "metrics": {
         "prefix": "aerospike.",
-        "check": "aerospike.uptime",
+        "check": [
+          "aerospike.uptime",
+          "aerospike.namespace.memory_free_pct"
+        ],    
         "metadata_path": "metadata.csv"
       },
       "service_checks": {


### PR DESCRIPTION
### What does this PR do?
Metric to check is using a legacy one. This PR adds a new metric from the OMv2 implementation.
