### PR TITLE
update custom_queries configuration to support optional collection_interval

### DIFF
--- a/clickhouse/changelog.d/16957.added
+++ b/clickhouse/changelog.d/16957.added
@@ -1,0 +1,1 @@
+update custom_queries configuration to support optional collection_interval

--- a/clickhouse/datadog_checks/clickhouse/config_models/instance.py
+++ b/clickhouse/datadog_checks/clickhouse/config_models/instance.py
@@ -25,6 +25,7 @@ class CustomQuery(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    collection_interval: Optional[int] = None
     columns: Optional[tuple[MappingProxyType[str, Any], ...]] = None
     query: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None

--- a/clickhouse/datadog_checks/clickhouse/data/conf.yaml.example
+++ b/clickhouse/datadog_checks/clickhouse/data/conf.yaml.example
@@ -133,7 +133,12 @@ instances:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
     ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
-    ##                                    The default is the integration `min_collection_interval`.
+    ##     If collection_interval is not set, the query will be run every check run.
+    ##     If the collection interval is less than check collection interval, 
+    ##     the query will be run every check run.
+    ##     If the collection interval is greater than check collection interval, 
+    ##     the query will NOT BE RUN exactly at the collection interval.
+    ##     The query will be run at the next check run after the collection interval has passed.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo

--- a/clickhouse/datadog_checks/clickhouse/data/conf.yaml.example
+++ b/clickhouse/datadog_checks/clickhouse/data/conf.yaml.example
@@ -132,6 +132,8 @@ instances:
     ##              Columns without a name are ignored. To skip a column, enter:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
+    ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
+    ##                                    The default is the integration `min_collection_interval`.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo

--- a/datadog_checks_dev/changelog.d/16957.added
+++ b/datadog_checks_dev/changelog.d/16957.added
@@ -1,0 +1,1 @@
+update custom_queries configuration to support optional collection_interval

--- a/datadog_checks_dev/changelog.d/16957.added.1
+++ b/datadog_checks_dev/changelog.d/16957.added.1
@@ -1,1 +1,0 @@
-update custom_queries configuration to support optional collection_interval

--- a/datadog_checks_dev/changelog.d/16957.added.1
+++ b/datadog_checks_dev/changelog.d/16957.added.1
@@ -1,0 +1,1 @@
+update custom_queries configuration to support optional collection_interval

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/db.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/db.yaml
@@ -13,3 +13,4 @@
       - query: <QUERY>
         columns: <COLUMNS>
         tags: <TAGS>
+        collection_interval: <COLLECTION_INTERVAL>

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/db.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/db.yaml
@@ -60,7 +60,7 @@
                    - {}
     3. tags (optional) - A list of tags to apply to each metric.
     4. collection_interval (optional) - The frequency at which to collect the metrics.
-                                       The default is the integration's `min_collection_interval`.
+                                       The default is the integration `min_collection_interval`.
   value:
     type: array
     items:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/db.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/db.yaml
@@ -60,7 +60,12 @@
                    - {}
     3. tags (optional) - A list of tags to apply to each metric.
     4. collection_interval (optional) - The frequency at which to collect the metrics.
-                                       The default is the integration `min_collection_interval`.
+        If collection_interval is not set, the query will be run every check run.
+        If the collection interval is less than check collection interval, 
+        the query will be run every check run.
+        If the collection interval is greater than check collection interval, 
+        the query will NOT BE RUN exactly at the collection interval.
+        The query will be run at the next check run after the collection interval has passed.
   value:
     type: array
     items:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/db.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/db.yaml
@@ -59,6 +59,8 @@
                  Columns without a name are ignored. To skip a column, enter:
                    - {}
     3. tags (optional) - A list of tags to apply to each metric.
+    4. collection_interval (optional) - The frequency at which to collect the metrics.
+                                       The default is the integration's `min_collection_interval`.
   value:
     type: array
     items:
@@ -74,6 +76,8 @@
           type: array
           items:
             type: string
+        - name: collection_interval
+          type: integer
     example:
       - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
         columns:
@@ -83,3 +87,4 @@
             type: gauge
         tags:
           - test:<INTEGRATION>
+        collection_interval: 30

--- a/mysql/changelog.d/16957.added
+++ b/mysql/changelog.d/16957.added
@@ -1,0 +1,1 @@
+update custom_queries configuration to support optional collection_interval

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -51,6 +51,7 @@ class CustomQuery(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    collection_interval: Optional[int] = None
     columns: Optional[tuple[MappingProxyType[str, Any], ...]] = None
     query: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -149,7 +149,12 @@ instances:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
     ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
-    ##                                    The default is the integration `min_collection_interval`.
+    ##     If collection_interval is not set, the query will be run every check run.
+    ##     If the collection interval is less than check collection interval, 
+    ##     the query will be run every check run.
+    ##     If the collection interval is greater than check collection interval, 
+    ##     the query will NOT BE RUN exactly at the collection interval.
+    ##     The query will be run at the next check run after the collection interval has passed.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -148,6 +148,8 @@ instances:
     ##              Columns without a name are ignored. To skip a column, enter:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
+    ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
+    ##                                    The default is the integration `min_collection_interval`.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo

--- a/oracle/changelog.d/16957.added
+++ b/oracle/changelog.d/16957.added
@@ -1,0 +1,1 @@
+update custom_queries configuration to support optional collection_interval

--- a/oracle/datadog_checks/oracle/config_models/instance.py
+++ b/oracle/datadog_checks/oracle/config_models/instance.py
@@ -25,6 +25,7 @@ class CustomQuery(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    collection_interval: Optional[int] = None
     columns: Optional[tuple[MappingProxyType[str, Any], ...]] = None
     query: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None

--- a/oracle/datadog_checks/oracle/data/conf.yaml.example
+++ b/oracle/datadog_checks/oracle/data/conf.yaml.example
@@ -18,6 +18,7 @@ init_config:
     #   - query: <QUERY>
     #     columns: <COLUMNS>
     #     tags: <TAGS>
+    #     collection_interval: <COLLECTION_INTERVAL>
 
     ## @param service - string - optional
     ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
@@ -145,6 +146,8 @@ instances:
     ##              Columns without a name are ignored. To skip a column, enter:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
+    ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
+    ##                                    The default is the integration `min_collection_interval`.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
@@ -155,6 +158,7 @@ instances:
     #       type: gauge
     #     tags:
     #     - test:<INTEGRATION>
+    #     collection_interval: 30
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/oracle/datadog_checks/oracle/data/conf.yaml.example
+++ b/oracle/datadog_checks/oracle/data/conf.yaml.example
@@ -147,7 +147,12 @@ instances:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
     ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
-    ##                                    The default is the integration `min_collection_interval`.
+    ##     If collection_interval is not set, the query will be run every check run.
+    ##     If the collection interval is less than check collection interval, 
+    ##     the query will be run every check run.
+    ##     If the collection interval is greater than check collection interval, 
+    ##     the query will NOT BE RUN exactly at the collection interval.
+    ##     The query will be run at the next check run after the collection interval has passed.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo

--- a/sap_hana/changelog.d/16957.added
+++ b/sap_hana/changelog.d/16957.added
@@ -1,0 +1,1 @@
+update custom_queries configuration to support optional collection_interval

--- a/sap_hana/datadog_checks/sap_hana/config_models/instance.py
+++ b/sap_hana/datadog_checks/sap_hana/config_models/instance.py
@@ -25,6 +25,7 @@ class CustomQuery(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    collection_interval: Optional[int] = None
     columns: Optional[tuple[MappingProxyType[str, Any], ...]] = None
     query: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None

--- a/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
+++ b/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
@@ -17,6 +17,7 @@ init_config:
     #   - query: <QUERY>
     #     columns: <COLUMNS>
     #     tags: <TAGS>
+    #     collection_interval: <COLLECTION_INTERVAL>
 
     ## @param service - string - optional
     ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
@@ -137,6 +138,8 @@ instances:
     ##              Columns without a name are ignored. To skip a column, enter:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
+    ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
+    ##                                    The default is the integration `min_collection_interval`.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
@@ -147,6 +150,7 @@ instances:
     #       type: gauge
     #     tags:
     #     - test:<INTEGRATION>
+    #     collection_interval: 30
 
     ## @param persist_db_connections - boolean - optional - default: true
     ## Whether or not to persist database connections.

--- a/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
+++ b/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
@@ -139,7 +139,12 @@ instances:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
     ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
-    ##                                    The default is the integration `min_collection_interval`.
+    ##     If collection_interval is not set, the query will be run every check run.
+    ##     If the collection interval is less than check collection interval, 
+    ##     the query will be run every check run.
+    ##     If the collection interval is greater than check collection interval, 
+    ##     the query will NOT BE RUN exactly at the collection interval.
+    ##     The query will be run at the next check run after the collection interval has passed.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo

--- a/singlestore/changelog.d/16957.added
+++ b/singlestore/changelog.d/16957.added
@@ -1,0 +1,1 @@
+update custom_queries configuration to support optional collection_interval

--- a/singlestore/datadog_checks/singlestore/config_models/instance.py
+++ b/singlestore/datadog_checks/singlestore/config_models/instance.py
@@ -25,6 +25,7 @@ class CustomQuery(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    collection_interval: Optional[int] = None
     columns: Optional[tuple[MappingProxyType[str, Any], ...]] = None
     query: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None

--- a/singlestore/datadog_checks/singlestore/data/conf.yaml.example
+++ b/singlestore/datadog_checks/singlestore/data/conf.yaml.example
@@ -19,6 +19,7 @@ init_config:
     #   - query: <QUERY>
     #     columns: <COLUMNS>
     #     tags: <TAGS>
+    #     collection_interval: <COLLECTION_INTERVAL>
 
 ## Every instance is scheduled independently of the others.
 #
@@ -112,6 +113,8 @@ instances:
     ##              Columns without a name are ignored. To skip a column, enter:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
+    ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
+    ##                                    The default is the integration `min_collection_interval`.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
@@ -122,6 +125,7 @@ instances:
     #       type: gauge
     #     tags:
     #     - test:<INTEGRATION>
+    #     collection_interval: 30
 
     ## @param collect_system_metrics - boolean - optional - default: false
     ## Collect additional system metrics from the MV_SYSINFO_* tables. Disabled by default to limit

--- a/singlestore/datadog_checks/singlestore/data/conf.yaml.example
+++ b/singlestore/datadog_checks/singlestore/data/conf.yaml.example
@@ -114,7 +114,12 @@ instances:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
     ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
-    ##                                    The default is the integration `min_collection_interval`.
+    ##     If collection_interval is not set, the query will be run every check run.
+    ##     If the collection interval is less than check collection interval, 
+    ##     the query will be run every check run.
+    ##     If the collection interval is greater than check collection interval, 
+    ##     the query will NOT BE RUN exactly at the collection interval.
+    ##     The query will be run at the next check run after the collection interval has passed.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo

--- a/snowflake/changelog.d/16957.added
+++ b/snowflake/changelog.d/16957.added
@@ -1,0 +1,1 @@
+update custom_queries configuration to support optional collection_interval

--- a/snowflake/datadog_checks/snowflake/config_models/instance.py
+++ b/snowflake/datadog_checks/snowflake/config_models/instance.py
@@ -25,6 +25,7 @@ class CustomQuery(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    collection_interval: Optional[int] = None
     columns: Optional[tuple[MappingProxyType[str, Any], ...]] = None
     query: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None

--- a/snowflake/datadog_checks/snowflake/data/conf.yaml.example
+++ b/snowflake/datadog_checks/snowflake/data/conf.yaml.example
@@ -247,7 +247,12 @@ instances:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
     ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
-    ##                                    The default is the integration `min_collection_interval`.
+    ##     If collection_interval is not set, the query will be run every check run.
+    ##     If the collection interval is less than check collection interval, 
+    ##     the query will be run every check run.
+    ##     If the collection interval is greater than check collection interval, 
+    ##     the query will NOT BE RUN exactly at the collection interval.
+    ##     The query will be run at the next check run after the collection interval has passed.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo

--- a/snowflake/datadog_checks/snowflake/data/conf.yaml.example
+++ b/snowflake/datadog_checks/snowflake/data/conf.yaml.example
@@ -12,6 +12,7 @@ init_config:
     #   - query: <QUERY>
     #     columns: <COLUMNS>
     #     tags: <TAGS>
+    #     collection_interval: <COLLECTION_INTERVAL>
 
     ## @param proxy_host - string - optional
     ## The host of your proxy server.
@@ -245,6 +246,8 @@ instances:
     ##              Columns without a name are ignored. To skip a column, enter:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
+    ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
+    ##                                    The default is the integration `min_collection_interval`.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo

--- a/sqlserver/changelog.d/16957.added
+++ b/sqlserver/changelog.d/16957.added
@@ -1,0 +1,1 @@
+update custom_queries configuration to support optional collection_interval

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -51,6 +51,7 @@ class CustomQuery(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    collection_interval: Optional[int] = None
     columns: Optional[tuple[MappingProxyType[str, Any], ...]] = None
     query: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -22,6 +22,7 @@ init_config:
     #   - query: <QUERY>
     #     columns: <COLUMNS>
     #     tags: <TAGS>
+    #     collection_interval: <COLLECTION_INTERVAL>
 
     ## @param service - string - optional
     ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
@@ -593,6 +594,8 @@ instances:
     ##              Columns without a name are ignored. To skip a column, enter:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
+    ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
+    ##                                    The default is the integration `min_collection_interval`.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
@@ -603,6 +606,7 @@ instances:
     #       type: gauge
     #     tags:
     #     - test:<INTEGRATION>
+    #     collection_interval: 30
 
     ## @param stored_procedure - string - optional
     ## DEPRECATED - use `custom_queries` instead. For guidance, see:

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -595,7 +595,12 @@ instances:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
     ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
-    ##                                    The default is the integration `min_collection_interval`.
+    ##     If collection_interval is not set, the query will be run every check run.
+    ##     If the collection interval is less than check collection interval, 
+    ##     the query will be run every check run.
+    ##     If the collection interval is greater than check collection interval, 
+    ##     the query will NOT BE RUN exactly at the collection interval.
+    ##     The query will be run at the next check run after the collection interval has passed.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo

--- a/teradata/changelog.d/16957.added
+++ b/teradata/changelog.d/16957.added
@@ -1,0 +1,1 @@
+update custom_queries configuration to support optional collection_interval

--- a/teradata/datadog_checks/teradata/config_models/instance.py
+++ b/teradata/datadog_checks/teradata/config_models/instance.py
@@ -26,6 +26,7 @@ class CustomQuery(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    collection_interval: Optional[int] = None
     columns: Optional[tuple[MappingProxyType[str, Any], ...]] = None
     query: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None

--- a/teradata/datadog_checks/teradata/data/conf.yaml.example
+++ b/teradata/datadog_checks/teradata/data/conf.yaml.example
@@ -201,7 +201,12 @@ instances:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
     ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
-    ##                                    The default is the integration `min_collection_interval`.
+    ##     If collection_interval is not set, the query will be run every check run.
+    ##     If the collection interval is less than check collection interval, 
+    ##     the query will be run every check run.
+    ##     If the collection interval is greater than check collection interval, 
+    ##     the query will NOT BE RUN exactly at the collection interval.
+    ##     The query will be run at the next check run after the collection interval has passed.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo

--- a/teradata/datadog_checks/teradata/data/conf.yaml.example
+++ b/teradata/datadog_checks/teradata/data/conf.yaml.example
@@ -19,6 +19,7 @@ init_config:
     #   - query: <QUERY>
     #     columns: <COLUMNS>
     #     tags: <TAGS>
+    #     collection_interval: <COLLECTION_INTERVAL>
 
 ## Every instance is scheduled independently of the others.
 #
@@ -199,6 +200,8 @@ instances:
     ##              Columns without a name are ignored. To skip a column, enter:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
+    ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
+    ##                                    The default is the integration `min_collection_interval`.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
@@ -209,6 +212,7 @@ instances:
     #       type: gauge
     #     tags:
     #     - test:<INTEGRATION>
+    #     collection_interval: 30
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/vertica/changelog.d/16957.added
+++ b/vertica/changelog.d/16957.added
@@ -1,0 +1,1 @@
+update custom_queries configuration to support optional collection_interval

--- a/vertica/datadog_checks/vertica/config_models/instance.py
+++ b/vertica/datadog_checks/vertica/config_models/instance.py
@@ -25,6 +25,7 @@ class CustomQuery(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    collection_interval: Optional[int] = None
     columns: Optional[tuple[MappingProxyType[str, Any], ...]] = None
     query: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None

--- a/vertica/datadog_checks/vertica/data/conf.yaml.example
+++ b/vertica/datadog_checks/vertica/data/conf.yaml.example
@@ -241,7 +241,12 @@ instances:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
     ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
-    ##                                    The default is the integration `min_collection_interval`.
+    ##     If collection_interval is not set, the query will be run every check run.
+    ##     If the collection interval is less than check collection interval, 
+    ##     the query will be run every check run.
+    ##     If the collection interval is greater than check collection interval, 
+    ##     the query will NOT BE RUN exactly at the collection interval.
+    ##     The query will be run at the next check run after the collection interval has passed.
     #
     # custom_queries:
     #   - query: SELECT force_outer, table_name FROM v_catalog.tables

--- a/vertica/datadog_checks/vertica/data/conf.yaml.example
+++ b/vertica/datadog_checks/vertica/data/conf.yaml.example
@@ -240,6 +240,8 @@ instances:
     ##              Columns without a name are ignored. To skip a column, enter:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
+    ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
+    ##                                    The default is the integration `min_collection_interval`.
     #
     # custom_queries:
     #   - query: SELECT force_outer, table_name FROM v_catalog.tables

--- a/voltdb/changelog.d/16957.added
+++ b/voltdb/changelog.d/16957.added
@@ -1,0 +1,1 @@
+update custom_queries configuration to support optional collection_interval

--- a/voltdb/datadog_checks/voltdb/config_models/instance.py
+++ b/voltdb/datadog_checks/voltdb/config_models/instance.py
@@ -34,6 +34,7 @@ class CustomQuery(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    collection_interval: Optional[int] = None
     columns: Optional[tuple[MappingProxyType[str, Any], ...]] = None
     query: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None

--- a/voltdb/datadog_checks/voltdb/data/conf.yaml.example
+++ b/voltdb/datadog_checks/voltdb/data/conf.yaml.example
@@ -311,7 +311,12 @@ instances:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
     ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
-    ##                                    The default is the integration `min_collection_interval`.
+    ##     If collection_interval is not set, the query will be run every check run.
+    ##     If the collection interval is less than check collection interval, 
+    ##     the query will be run every check run.
+    ##     If the collection interval is greater than check collection interval, 
+    ##     the query will NOT BE RUN exactly at the collection interval.
+    ##     The query will be run at the next check run after the collection interval has passed.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo

--- a/voltdb/datadog_checks/voltdb/data/conf.yaml.example
+++ b/voltdb/datadog_checks/voltdb/data/conf.yaml.example
@@ -44,6 +44,7 @@ init_config:
     #   - query: <QUERY>
     #     columns: <COLUMNS>
     #     tags: <TAGS>
+    #     collection_interval: <COLLECTION_INTERVAL>
 
     ## @param service - string - optional
     ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
@@ -309,6 +310,8 @@ instances:
     ##              Columns without a name are ignored. To skip a column, enter:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
+    ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
+    ##                                    The default is the integration `min_collection_interval`.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
@@ -319,6 +322,7 @@ instances:
     #       type: gauge
     #     tags:
     #     - test:<INTEGRATION>
+    #     collection_interval: 30
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.


### PR DESCRIPTION
### What does this PR do?
PR #16765 introduced support of customizable `collection_interval` for custom queries. This PR adds an optional config option `collection_interval` to the `custom_queries` configuration template.  

### Motivation
`custom_queries` now supports optional `collection_interval`. This option can be useful to have a custom query that does not need to be executed on every check run. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
