### PR TITLE
support custom metric_prefix in QueryExecutor

### DIFF
--- a/datadog_checks_base/changelog.d/16958.added
+++ b/datadog_checks_base/changelog.d/16958.added
@@ -1,0 +1,1 @@
+support custom metric_prefix in QueryExecutor

--- a/datadog_checks_base/datadog_checks/base/utils/db/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/core.py
@@ -128,11 +128,11 @@ class QueryExecutor(object):
                         submission_queue.append((transformer, column_value))
 
                 for transformer, value in submission_queue:
-                    transformer(sources, value, tags=tags, hostname=self.hostname)
+                    transformer(sources, value, tags=tags, hostname=self.hostname, raw=query.metric_name_raw)
 
                 for name, transformer in extra_transformers:
                     try:
-                        result = transformer(sources, tags=tags, hostname=self.hostname)
+                        result = transformer(sources, tags=tags, hostname=self.hostname, raw=query.metric_name_raw)
                     except Exception as e:
                         self.logger.error('Error transforming %s: %s', name, e)
                         continue

--- a/datadog_checks_base/datadog_checks/base/utils/db/query.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/query.py
@@ -45,6 +45,8 @@ class Query(object):
                         If the collection interval is greater than check collection interval,
                         the query will NOT BE RUN exactly at the collection interval.
                         The query will be run at the next check run after the collection interval has passed.
+                - (Optional) metric_prefix (str): The prefix to add to the metric name.
+                    Note: If the metric prefix is None, the default metric prefix `<INTEGRATION>.` will be used.
         '''
         # Contains the data to fill the rest of the attributes
         self.query_data = deepcopy(query_data or {})  # type: Dict[str, Any]
@@ -62,6 +64,8 @@ class Query(object):
         # The last time the query was executed. If None, the query has never been executed.
         # This is only used when the collection_interval is not None.
         self.__last_execution_time = None  # type: float
+        # whether to ignore any defined namespace prefix. True when `metric_prefix` is defined.
+        self.metric_name_raw = False  # type: bool
 
     def compile(
         self,
@@ -83,6 +87,13 @@ class Query(object):
             raise ValueError('query field `name` is required')
         elif not isinstance(query_name, str):
             raise ValueError('query field `name` must be a string')
+
+        metric_prefix = self.query_data.get('metric_prefix')
+        if metric_prefix is not None:
+            if not isinstance(metric_prefix, str):
+                raise ValueError('field `metric_prefix` for {} must be a string'.format(query_name))
+            elif not metric_prefix:
+                raise ValueError('field `metric_prefix` for {} must not be empty'.format(query_name))
 
         query = self.query_data.get('query')
         if not query:
@@ -137,9 +148,13 @@ class Query(object):
             elif column_type not in column_transformers:
                 raise ValueError('unknown type `{}` for column {} of {}'.format(column_type, column_name, query_name))
 
+            __column_type_is_tag = column_type in ('tag', 'tag_list', 'tag_not_null')
             modifiers = {key: value for key, value in column.items() if key not in ('name', 'type')}
 
             try:
+                if not __column_type_is_tag and metric_prefix:
+                    # if metric_prefix is defined, we prepend it to the column name
+                    column_name = "{}.{}".format(metric_prefix, column_name)
                 transformer = column_transformers[column_type](column_transformers, column_name, **modifiers)
             except Exception as e:
                 error = 'error compiling type `{}` for column {} of {}: {}'.format(
@@ -152,7 +167,7 @@ class Query(object):
                 # this we set the context to None. https://www.python.org/dev/peps/pep-0409/
                 raise_from(type(e)(error), None)
             else:
-                if column_type in ('tag', 'tag_list', 'tag_not_null'):
+                if __column_type_is_tag:
                     column_data.append((column_name, (column_type, transformer)))
                 else:
                     # All these would actually submit data. As that is the default case, we represent it as
@@ -240,6 +255,7 @@ class Query(object):
         self.extra_transformers = tuple(extra_data)
         self.base_tags = tags
         self.collection_interval = collection_interval
+        self.metric_name_raw = metric_prefix is not None
         del self.query_data
 
     def should_execute(self):

--- a/datadog_checks_base/tests/base/utils/db/test_custom_queries.py
+++ b/datadog_checks_base/tests/base/utils/db/test_custom_queries.py
@@ -258,6 +258,6 @@ class TestCustomQueries:
         query_manager.compile_queries()
         query_manager.execute()
 
-        metric_name = f'{metric_prefix}.test.foo' if metric_prefix else 'test.test.foo'
+        metric_name = '{}.test.foo'.format(metric_prefix) if metric_prefix else 'test.test.foo'
         aggregator.assert_metric(metric_name, 1, metric_type=aggregator.GAUGE, tags=['test:foo', 'test:bar'])
         aggregator.assert_all_metrics_covered()

--- a/datadog_checks_base/tests/base/utils/db/test_custom_queries.py
+++ b/datadog_checks_base/tests/base/utils/db/test_custom_queries.py
@@ -226,3 +226,38 @@ class TestCustomQueries:
         aggregator.assert_metric('test.statement.baz', count=0, metric_type=aggregator.GAUGE, tags=['test:bar'])
 
         aggregator.assert_all_metrics_covered()
+
+    @pytest.mark.parametrize(
+        "metric_prefix",
+        [
+            pytest.param(None, id='no_prefix'),
+            pytest.param('custom_prefix', id='with_prefix'),
+        ],
+    )
+    def test_metric_prefix(self, aggregator, metric_prefix):
+        check = AgentCheck(
+            'test',
+            {
+                'global_custom_queries': [
+                    {
+                        'metric_prefix': metric_prefix,
+                        'query': 'foo',
+                        'columns': [{'name': 'test.foo', 'type': 'gauge'}],
+                        'tags': ['test:bar'],
+                    },
+                ],
+            },
+            [{}],
+        )
+        check.__NAMESPACE__ = 'test'
+        query_manager = create_query_manager(
+            check=check,
+            executor=mock_executor([[1]]),
+            tags=['test:foo'],
+        )
+        query_manager.compile_queries()
+        query_manager.execute()
+
+        metric_name = f'{metric_prefix}.test.foo' if metric_prefix else 'test.test.foo'
+        aggregator.assert_metric(metric_name, 1, metric_type=aggregator.GAUGE, tags=['test:foo', 'test:bar'])
+        aggregator.assert_all_metrics_covered()

--- a/oracle/changelog.d/16958.fixed
+++ b/oracle/changelog.d/16958.fixed
@@ -1,0 +1,1 @@
+support custom metric_prefix in QueryExecutor and remove manual fix of metric_prefix


### PR DESCRIPTION
### What does this PR do?
This PR adds an optional `metric_prefix` to QueryExecutor to support override the default metric prefix `<INTEGRATION>` namespace. When `metric_prefix` is set to none empty string, the custom query metrics will use the provided metric_prefix instead of the integration namespace. 

TODO: custom_queries configuration template change will be updated in follow up PR.

### Motivation
This is the first step to migrate Postgres custom_queries to `QueryManager`. Postgres integration custom_queries currently support customizable `metric_prefix` as documented [here](https://docs.datadoghq.com/integrations/faq/postgres-custom-metric-collection-explained/#configuration). Customer has found this `metric_prefix` useful as it overrides the default `postgresql` metric prefix. For example, customer can have a simple query report on order counts by status.
```yaml
custom_queries:
      - metric_prefix: mywarehouse.orders
        query: |
          SELECT status, COUNT(1) as count
          FROM orders
          WHERE created_at >= CURRENT_DATE - INTERVAL '1 months'
          GROUP BY status;
        columns:
          - name: status
            type: tag
          - name: count
            type: gauge
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
