### PR TITLE
Add SLI metrics to kube_apiserver_metrics metadata.csv

### DIFF
--- a/kube_apiserver_metrics/metadata.csv
+++ b/kube_apiserver_metrics/metadata.csv
@@ -68,3 +68,5 @@ kube_apiserver.flowcontrol_request_concurrency_limit,gauge,,,,"Shared concurrenc
 kube_apiserver.flowcontrol_rejected_requests_total.count,count,,,,"Number of requests rejected by API Priority and Fairness subsystem",0,kubernetes_api_server_metrics, flowcontrol rejected requests total,
 kube_apiserver.flowcontrol_current_inqueue_requests,count,,,,"Number of requests currently pending in queues of the API Priority and Fairness subsystem",0,kubernetes_api_server_metrics, flowcontrol current inqueue requests,
 kube_apiserver.flowcontrol_dispatched_requests_total,count,,,,"Number of requests executed by API Priority and Fairness subsystem",0,kubernetes_api_server_metrics, flowcontrol dispatched requests total,
+kube_apiserver.slis.kubernetes_healthcheck,gauge,,,,"Result of a single kubernetes apiserver healthcheck (alpha; requires k8s v1.26+)",0,kubernetes_api_server_metrics,slis.kubernetes_healthcheck,
+kube_apiserver.slis.kubernetes_healthcheck_total,count,,,,"The monotonic count of all kubernetes apiserver healthchecks (alpha; requires k8s v1.26+)",0,kubernetes_api_server_metrics,slis.kubernetes_healthcheck_total,


### PR DESCRIPTION
### What does this PR do?
This adds the two metrics introduced in #16657 to the `metadata.csv`

### Motivation
I forgot to update the documentation with my previous PR 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
