### PR TITLE
Implement builder caching for macOS build

### DIFF
--- a/.builders/images/macos/builder_setup.sh
+++ b/.builders/images/macos/builder_setup.sh
@@ -10,8 +10,6 @@ set -euxo pipefail
 "${DD_PYTHON2}" -m pip install --no-warn-script-location virtualenv
 "${DD_PYTHON2}" -m virtualenv py2
 
-"${DD_PYTHON3}" -m pip install --no-warn-script-location -r "${DD_MOUNT_DIR}/build_context/runner_dependencies.txt"
-
 # Install always with our own prefix path
 cp "${DD_MOUNT_DIR}/build_context/install-from-source.sh" .
 install-from-source() {

--- a/.builders/images/macos/builder_setup.sh
+++ b/.builders/images/macos/builder_setup.sh
@@ -11,6 +11,7 @@ set -euxo pipefail
 "${DD_PYTHON2}" -m virtualenv py2
 
 # Install always with our own prefix path
+mkdir -p "${DD_PREFIX_PATH}"
 cp "${DD_MOUNT_DIR}/build_context/install-from-source.sh" .
 install-from-source() {
     bash "install-from-source.sh" --prefix="${DD_PREFIX_PATH}" "$@"
@@ -21,6 +22,8 @@ IBM_MQ_VERSION=9.2.4.0-IBM-MQ-DevToolkit
 curl --retry 5 --fail "https://s3.amazonaws.com/dd-agent-omnibus/ibm-mq-backup/${IBM_MQ_VERSION}-MacX64.pkg" -o /tmp/mq_client.pkg
 sudo installer -pkg /tmp/mq_client.pkg -target /
 rm -rf /tmp/mq_client.pkg
+# Copy under prefix so that it can be cached
+cp -R /opt/mqm "${DD_PREFIX_PATH}"
 
 # openssl
 DOWNLOAD_URL="https://www.openssl.org/source/openssl-{{version}}.tar.gz" \

--- a/.builders/images/macos/extra_build.sh
+++ b/.builders/images/macos/extra_build.sh
@@ -23,6 +23,9 @@ if [[ "${DD_BUILD_PYTHON_VERSION}" == "3" ]]; then
     always_build+=("confluent-kafka")
 fi
 
+# Make sure IBM MQ libraries are found under /opt/mqm even when we're using the builder cache
+sudo cp -Rf "${DD_PREFIX_PATH}/mqm" /opt
+
 # Empty arrays are flagged as unset when using the `-u` flag. This is the safest way to work around that
 # (see https://stackoverflow.com/a/61551944)
 pip_no_binary=${always_build[@]+"${always_build[@]}"}

--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -151,16 +151,32 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install management dependencies
-      run: ${DD_PYTHON3} -m pip install -r .builders/deps/host_dependencies.txt
+      run: |
+        ${DD_PYTHON3} -m pip install -r .builders/deps/host_dependencies.txt
+        ${DD_PYTHON3} -m pip install --no-warn-script-location -r ".builders/images/runner_dependencies.txt"
+
+    - name: Cache builder root
+      id: cache-builder-root
+      uses: actions/cache@v3.3.3
+      with:
+        path: "~/builder_root"
+        key: macos-deps-builder-root-cache-${{ hashFiles('./.builders/images/macos/*', './.builders/images/*', './.builders/deps/*', './.builders/build.py') }}
 
     - name: Run the build
       env:
         # This sets the minimum macOS version compatible for all built artifacts
         MACOSX_DEPLOYMENT_TARGET: "10.12"
+        CACHE_HIT: ${{ steps.cache-builder-root.outputs.cache-hit }}
       run: |-
-        mkdir builder_root
-        ${DD_PYTHON3} .builders/build.py --builder-root builder_root --python 3 ${{ env.OUT_DIR }}/py3
-        ${DD_PYTHON3} .builders/build.py --builder-root builder_root --python 2 ${{ env.OUT_DIR }}/py2 --skip-setup
+        # If we hit the cache, we can skip builder setup
+        if [[ ${CACHE_HIT} == "true" ]]; then
+          ${DD_PYTHON3} .builders/build.py --builder-root builder_root --python 3 ${{ env.OUT_DIR }}/py3 --skip-setup
+        else
+          mkdir ~/builder_root
+          ${DD_PYTHON3} .builders/build.py --builder-root ~/builder_root --python 3 ${{ env.OUT_DIR }}/py3
+        fi
+        # At this point we can always skip builder setup since it's equivalent for python versions
+        ${DD_PYTHON3} .builders/build.py --builder-root ~/builder_root --python 2 ${{ env.OUT_DIR }}/py2 --skip-setup
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -169,7 +169,7 @@ jobs:
         MACOSX_DEPLOYMENT_TARGET: "10.12"
         CACHE_HIT: ${{ steps.cache-builder-root.outputs.cache-hit }}
       run: |-
-        # If we hit the cache, we skip the builder setup
+        # If we hit the cache, we can skip the builder setup
         if [[ ${CACHE_HIT} == "true" ]]; then
           ${DD_PYTHON3} .builders/build.py --builder-root ~/builder_root --python 3 ${{ env.OUT_DIR }}/py3 --skip-setup
         else

--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -168,9 +168,9 @@ jobs:
         MACOSX_DEPLOYMENT_TARGET: "10.12"
         CACHE_HIT: ${{ steps.cache-builder-root.outputs.cache-hit }}
       run: |-
-        # If we hit the cache, we can skip builder setup
+        # If we hit the cache, we skip the builder setup
         if [[ ${CACHE_HIT} == "true" ]]; then
-          ${DD_PYTHON3} .builders/build.py --builder-root builder_root --python 3 ${{ env.OUT_DIR }}/py3 --skip-setup
+          ${DD_PYTHON3} .builders/build.py --builder-root ~/builder_root --python 3 ${{ env.OUT_DIR }}/py3 --skip-setup
         else
           mkdir ~/builder_root
           ${DD_PYTHON3} .builders/build.py --builder-root ~/builder_root --python 3 ${{ env.OUT_DIR }}/py3

--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -159,7 +159,8 @@ jobs:
       id: cache-builder-root
       uses: actions/cache@v3.3.3
       with:
-        path: "~/builder_root"
+        path: |
+          ~/builder_root
         key: macos-deps-builder-root-cache-${{ hashFiles('./.builders/images/macos/*', './.builders/images/*', './.builders/deps/*', './.builders/build.py') }}
 
     - name: Run the build


### PR DESCRIPTION
### What does this PR do?

Cache whatever the builder setup stores inside the "builder root". This is an attempt at mimicking the caching that we get with Docker for all the other platforms.

Most of the necessary machinery was already in place the implementation of the builder setup was done with this in mind. This just adds the necessary code to the CI workflow.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
