### PR TITLE
Add zlib to macOS builder

### DIFF
--- a/.builders/images/macos/builder_setup.sh
+++ b/.builders/images/macos/builder_setup.sh
@@ -35,6 +35,14 @@ CONFIGURE_SCRIPT="./config" \
     no-module \
     no-comp no-idea no-mdc2 no-rc5 no-ssl3 no-gost
 
+# zlib
+CFLAGS="${CFLAGS} -fPIC"
+DOWNLOAD_URL="https://zlib.net/fossils/zlib-{{version}}.tar.gz" \
+VERSION="1.3.1" \
+SHA256="9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23" \
+RELATIVE_PATH="zlib-{{version}}" \
+  install-from-source
+
 # libxml & libxslt for lxml
 DOWNLOAD_URL="https://download.gnome.org/sources/libxml2/2.10/libxml2-{{version}}.tar.xz" \
 VERSION="2.10.3" \

--- a/.builders/scripts/repair_wheels.py
+++ b/.builders/scripts/repair_wheels.py
@@ -164,7 +164,6 @@ def repair_darwin(source_dir: str, built_dir: str, external_dir: str) -> None:
         r'libstdc\+\+\.6\.dylib',
         r'libc\+\+\.1\.dylib',
         r'^/System/Library/',
-        r'libz\.1\.dylib',
     ]]
 
     def copy_filt_func(libname):


### PR DESCRIPTION
### What does this PR do?

Compiles zlib for macOS so that it can be included in wheels.

### Motivation

Omnibus health check complains about it; for consistency with other OSes and with what we've been doing, I think it's best to just include it in wheels as needed.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
