### PR TITLE
[Release] Bumped datadog_cluster_agent version to 2.11.0 (#16967)

### DIFF
--- a/datadog_cluster_agent/CHANGELOG.md
+++ b/datadog_cluster_agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 2.11.0 / 2024-02-26
+
+***Added***:
+
+* Collect language detection metrics ([#16928](https://github.com/DataDog/integrations-core/pull/16928))
+
 ## 2.10.0 / 2024-02-16
 
 ***Added***:

--- a/datadog_cluster_agent/changelog.d/16928.added
+++ b/datadog_cluster_agent/changelog.d/16928.added
@@ -1,1 +1,0 @@
-collect language detection metrics in datadog_cluster_agent integration

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/__about__.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '2.10.0'
+__version__ = '2.11.0'

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -35,7 +35,7 @@ datadog-coredns==3.2.0; sys_platform == 'linux2'
 datadog-couch==6.2.0
 datadog-couchbase==3.2.0
 datadog-crio==2.6.0
-datadog-datadog-cluster-agent==2.10.0
+datadog-datadog-cluster-agent==2.11.0
 datadog-dcgm==2.3.0
 datadog-directory==2.1.1
 datadog-disk==5.2.0


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Port https://github.com/DataDog/integrations-core/pull/16967 to master

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
