### PR TITLE
[DBMON-3582] Skip index usage collection for tempdb

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -206,6 +206,17 @@ files:
       value:
         type: boolean
         example: true
+    - name: include_index_usage_metrics_tempdb
+      description: |
+        Configure the collection of user table index usage statistics in tempdb database from the
+        `sys.dm_db_index_usage_stats` DMV.
+
+        By default, we do not collect index usage statistics in the tempdb database, as those queries
+        might cause blocking. This configuration parameter allows enabling the collection of this metric.
+        This parameter is ignored if 'include_index_usage_metrics' is set to false.
+      value:
+        type: boolean
+        example: false
     - name: index_usage_metrics_interval
       description: |
         Configure the interval (in seconds) for the collection of index usage statistics from the 

--- a/sqlserver/changelog.d/16977.fixed
+++ b/sqlserver/changelog.d/16977.fixed
@@ -1,0 +1,1 @@
+[DBMON-3582] Skip index usage collection for tempdb, fixes a blocking query

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -26,6 +26,7 @@ class SQLServerConfig:
 
         self.proc: str = instance.get('stored_procedure')
         self.custom_metrics: list[dict] = init_config.get('custom_metrics', [])
+        self.include_index_usage_metrics_tempdb: bool = is_affirmative(instance.get('include_index_usage_metrics_tempdb', False))
 
         # DBM
         self.dbm_enabled: bool = is_affirmative(instance.get('dbm', False))

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -26,7 +26,9 @@ class SQLServerConfig:
 
         self.proc: str = instance.get('stored_procedure')
         self.custom_metrics: list[dict] = init_config.get('custom_metrics', [])
-        self.include_index_usage_metrics_tempdb: bool = is_affirmative(instance.get('include_index_usage_metrics_tempdb', False))
+        self.include_index_usage_metrics_tempdb: bool = is_affirmative(
+            instance.get('include_index_usage_metrics_tempdb', False)
+        )
 
         # DBM
         self.dbm_enabled: bool = is_affirmative(instance.get('dbm', False))

--- a/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
@@ -76,7 +76,7 @@ def instance_include_index_usage_metrics():
     return True
 
 
-def include_index_usage_metrics_tempdb():
+def instance_include_index_usage_metrics_tempdb():
     return False
 
 

--- a/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
@@ -76,6 +76,10 @@ def instance_include_index_usage_metrics():
     return True
 
 
+def include_index_usage_metrics_tempdb():
+    return False
+
+
 def instance_include_instance_metrics():
     return True
 

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -173,6 +173,7 @@ class InstanceConfig(BaseModel):
     include_db_fragmentation_metrics: Optional[bool] = None
     include_fci_metrics: Optional[bool] = None
     include_index_usage_metrics: Optional[bool] = None
+    include_index_usage_metrics_tempdb: Optional[bool] = None
     include_instance_metrics: Optional[bool] = None
     include_master_files_metrics: Optional[bool] = None
     include_primary_log_shipping_metrics: Optional[bool] = None

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -196,7 +196,7 @@ instances:
     # include_index_usage_metrics: true
 
     ## @param include_index_usage_metrics_tempdb - boolean - optional - default: false
-    ## Configure the collection of user table index usage statistics in tempdb database from the 
+    ## Configure the collection of user table index usage statistics in tempdb database from the
     ## `sys.dm_db_index_usage_stats` DMV.
     ##
     ## By default, we do not collect index usage statistics in the tempdb database, as those queries

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -195,6 +195,16 @@ instances:
     #
     # include_index_usage_metrics: true
 
+    ## @param include_index_usage_metrics_tempdb - boolean - optional - default: false
+    ## Configure the collection of user table index usage statistics in tempdb database from the 
+    ## `sys.dm_db_index_usage_stats` DMV.
+    ##
+    ## By default, we do not collect index usage statistics in the tempdb database, as those queries
+    ## might cause blocking. This configuration parameter allows enabling the collection of this metric.
+    ## This parameter is ignored if 'include_index_usage_metrics' is set to false.
+    #
+    # include_index_usage_metrics_tempdb: false
+
     ## @param index_usage_metrics_interval - integer - optional - default: 300
     ## Configure the interval (in seconds) for the collection of index usage statistics from the 
     ## `sys.dm_db_index_usage_stats` DMV. 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -878,6 +878,7 @@ class SQLServer(AgentCheck):
             self._index_usage_last_check_ts = now
             self.log.debug('Collecting index usage statistics')
             default_database = self.instance.get('database', self.connection.DEFAULT_DATABASE)
+            # Filter out tempdb as the query might be blocking and it's index usage information is not relevant
             db_names = [d.name for d in self.databases if d != 'tempdb'] or ([default_database] if default_database != 'tempdb' else [])
                     
             with self.connection.get_managed_cursor() as cursor:

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -879,11 +879,10 @@ class SQLServer(AgentCheck):
             self.log.debug('Collecting index usage statistics')
             default_database = self.instance.get('database', self.connection.DEFAULT_DATABASE)
             # Filter out tempdb as the query might be blocking and it's index usage information is not relevant
-            include_temdb_in_metric = is_affirmative(self.instance.get('include_index_usage_metrics_tempdb', False))
-
-            db_names = [d.name for d in self.databases if include_temdb_in_metric or d != 'tempdb'] or (
-                [default_database] if include_temdb_in_metric or default_database != 'tempdb' else []
-            )
+            db_names = [d.name for d in self.databases] or [self.instance.get('database', self.connection.DEFAULT_DATABASE)]
+            include_index_usage_metrics_tempdb = is_affirmative(self.instance.get('include_index_usage_metrics_tempdb', False))
+            if not include_index_usage_metrics_tempdb:
+                db_names = [db_name for db_name in db_names if db_name != 'tempdb']
 
             with self.connection.get_managed_cursor() as cursor:
                 cursor.execute(

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -877,9 +877,9 @@ class SQLServer(AgentCheck):
         if not self._index_usage_last_check_ts or now - self._index_usage_last_check_ts > interval:
             self._index_usage_last_check_ts = now
             self.log.debug('Collecting index usage statistics')
-            db_names = [d.name for d in self.databases] or [
-                self.instance.get('database', self.connection.DEFAULT_DATABASE)
-            ]
+            default_database = self.instance.get('database', self.connection.DEFAULT_DATABASE)
+            db_names = [d.name for d in self.databases if d != 'tempdb'] or ([default_database] if default_database != 'tempdb' else [])
+                    
             with self.connection.get_managed_cursor() as cursor:
                 cursor.execute(
                     'select DB_NAME()'

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -7,7 +7,6 @@ import copy
 import functools
 import time
 from collections import defaultdict
-
 import six
 from cachetools import TTLCache
 
@@ -880,8 +879,7 @@ class SQLServer(AgentCheck):
             default_database = self.instance.get('database', self.connection.DEFAULT_DATABASE)
             # Filter out tempdb as the query might be blocking and it's index usage information is not relevant
             db_names = [d.name for d in self.databases] or [self.instance.get('database', self.connection.DEFAULT_DATABASE)]
-            include_index_usage_metrics_tempdb = is_affirmative(self.instance.get('include_index_usage_metrics_tempdb', False))
-            if not include_index_usage_metrics_tempdb:
+            if not self._config.include_index_usage_metrics_tempdb:
                 db_names = [db_name for db_name in db_names if db_name != 'tempdb']
 
             with self.connection.get_managed_cursor() as cursor:

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -876,7 +876,6 @@ class SQLServer(AgentCheck):
         if not self._index_usage_last_check_ts or now - self._index_usage_last_check_ts > interval:
             self._index_usage_last_check_ts = now
             self.log.debug('Collecting index usage statistics')
-            default_database = self.instance.get('database', self.connection.DEFAULT_DATABASE)
             # Filter out tempdb as the query might be blocking and it's index usage information is not relevant
             db_names = [d.name for d in self.databases] or [self.instance.get('database', self.connection.DEFAULT_DATABASE)]
             if not self._config.include_index_usage_metrics_tempdb:

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -7,6 +7,7 @@ import copy
 import functools
 import time
 from collections import defaultdict
+
 import six
 from cachetools import TTLCache
 
@@ -877,7 +878,9 @@ class SQLServer(AgentCheck):
             self._index_usage_last_check_ts = now
             self.log.debug('Collecting index usage statistics')
             # Filter out tempdb as the query might be blocking and it's index usage information is not relevant
-            db_names = [d.name for d in self.databases] or [self.instance.get('database', self.connection.DEFAULT_DATABASE)]
+            db_names = [d.name for d in self.databases] or [
+                self.instance.get('database', self.connection.DEFAULT_DATABASE)
+            ]
             if not self._config.include_index_usage_metrics_tempdb:
                 db_names = [db_name for db_name in db_names if db_name != 'tempdb']
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -879,8 +879,11 @@ class SQLServer(AgentCheck):
             self.log.debug('Collecting index usage statistics')
             default_database = self.instance.get('database', self.connection.DEFAULT_DATABASE)
             # Filter out tempdb as the query might be blocking and it's index usage information is not relevant
-            db_names = [d.name for d in self.databases if d != 'tempdb'] or ([default_database] if default_database != 'tempdb' else [])
-                    
+            include_temdb_in_metric = is_affirmative(self.instance.get('include_index_usage_metrics_tempdb', False))
+            
+            db_names = [d.name for d in self.databases if include_temdb_in_metric or d != 'tempdb'] \
+            or ([default_database] if include_temdb_in_metric or default_database != 'tempdb' else [])
+            
             with self.connection.get_managed_cursor() as cursor:
                 cursor.execute(
                     'select DB_NAME()'

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -880,10 +880,11 @@ class SQLServer(AgentCheck):
             default_database = self.instance.get('database', self.connection.DEFAULT_DATABASE)
             # Filter out tempdb as the query might be blocking and it's index usage information is not relevant
             include_temdb_in_metric = is_affirmative(self.instance.get('include_index_usage_metrics_tempdb', False))
-            
-            db_names = [d.name for d in self.databases if include_temdb_in_metric or d != 'tempdb'] \
-            or ([default_database] if include_temdb_in_metric or default_database != 'tempdb' else [])
-            
+
+            db_names = [d.name for d in self.databases if include_temdb_in_metric or d != 'tempdb'] or (
+                [default_database] if include_temdb_in_metric or default_database != 'tempdb' else []
+            )
+
             with self.connection.get_managed_cursor() as cursor:
                 cursor.execute(
                     'select DB_NAME()'


### PR DESCRIPTION
### What does this PR do?
This PR filters out tempdb from the index usage query.

### Motivation
In the sqlserver integration a query collects statistics on the index usage. This query was flagged as blocking - https://datadoghq.atlassian.net/browse/DBMON-3582. As tempdb is an internal DB used to store temporary data it was decided to not query it's index usage.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
