### PR TITLE
timer_end is bigint unsigned

### DIFF
--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -146,8 +146,8 @@ PYMYSQL_MISSING_EXPLAIN_STATEMENT_PROC_ERRORS = frozenset(
     }
 )
 
-# the max value of signed BIGINT type column
-BIGINT_MAX = 2**63 - 1
+# the max value of unsigned BIGINT type column
+BIGINT_MAX = 2**64 - 1
 
 
 class DBExplainErrorCode(Enum):


### PR DESCRIPTION
### What does this PR do?
This PR fixes the max value for `timer_end` because the column type is `bigint unsigned`. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
Skipping changelog as this PR is just a fix of #16936 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
