### PR TITLE
Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

### DIFF
--- a/activemq_xml/changelog.d/16981.fixed
+++ b/activemq_xml/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/activemq_xml/datadog_checks/activemq_xml/data/conf.yaml.example
+++ b/activemq_xml/datadog_checks/activemq_xml/data/conf.yaml.example
@@ -316,8 +316,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/aerospike/changelog.d/16981.fixed
+++ b/aerospike/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/aerospike/datadog_checks/aerospike/data/conf.yaml.example
+++ b/aerospike/datadog_checks/aerospike/data/conf.yaml.example
@@ -510,8 +510,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/airflow/changelog.d/16981.fixed
+++ b/airflow/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/airflow/datadog_checks/airflow/data/conf.yaml.example
+++ b/airflow/datadog_checks/airflow/data/conf.yaml.example
@@ -287,8 +287,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/amazon_msk/changelog.d/16981.fixed
+++ b/amazon_msk/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
+++ b/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
@@ -561,8 +561,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/ambari/changelog.d/16981.fixed
+++ b/ambari/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/ambari/datadog_checks/ambari/data/conf.yaml.example
+++ b/ambari/datadog_checks/ambari/data/conf.yaml.example
@@ -316,8 +316,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/apache/changelog.d/16981.fixed
+++ b/apache/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/apache/datadog_checks/apache/data/conf.yaml.example
+++ b/apache/datadog_checks/apache/data/conf.yaml.example
@@ -287,8 +287,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/arangodb/changelog.d/16981.fixed
+++ b/arangodb/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/arangodb/datadog_checks/arangodb/data/conf.yaml.example
+++ b/arangodb/datadog_checks/arangodb/data/conf.yaml.example
@@ -510,8 +510,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/argocd/changelog.d/16981.fixed
+++ b/argocd/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/argocd/datadog_checks/argocd/data/conf.yaml.example
+++ b/argocd/datadog_checks/argocd/data/conf.yaml.example
@@ -531,8 +531,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/avi_vantage/changelog.d/16981.fixed
+++ b/avi_vantage/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example
+++ b/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example
@@ -521,8 +521,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/azure_iot_edge/changelog.d/16981.fixed
+++ b/azure_iot_edge/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
@@ -427,8 +427,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/boundary/changelog.d/16981.fixed
+++ b/boundary/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/boundary/datadog_checks/boundary/data/conf.yaml.example
+++ b/boundary/datadog_checks/boundary/data/conf.yaml.example
@@ -515,8 +515,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/calico/changelog.d/16981.fixed
+++ b/calico/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/calico/datadog_checks/calico/data/conf.yaml.example
+++ b/calico/datadog_checks/calico/data/conf.yaml.example
@@ -510,8 +510,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/cert_manager/changelog.d/16981.fixed
+++ b/cert_manager/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/cert_manager/datadog_checks/cert_manager/data/conf.yaml.example
+++ b/cert_manager/datadog_checks/cert_manager/data/conf.yaml.example
@@ -510,8 +510,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/cilium/changelog.d/16981.fixed
+++ b/cilium/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/cilium/datadog_checks/cilium/data/conf.yaml.example
+++ b/cilium/datadog_checks/cilium/data/conf.yaml.example
@@ -526,8 +526,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/cisco_aci/changelog.d/16981.fixed
+++ b/cisco_aci/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/cisco_aci/datadog_checks/cisco_aci/data/conf.yaml.example
+++ b/cisco_aci/datadog_checks/cisco_aci/data/conf.yaml.example
@@ -231,8 +231,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/citrix_hypervisor/changelog.d/16981.fixed
+++ b/citrix_hypervisor/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/citrix_hypervisor/datadog_checks/citrix_hypervisor/data/conf.yaml.example
+++ b/citrix_hypervisor/datadog_checks/citrix_hypervisor/data/conf.yaml.example
@@ -287,8 +287,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/cloud_foundry_api/changelog.d/16981.fixed
+++ b/cloud_foundry_api/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/cloud_foundry_api/datadog_checks/cloud_foundry_api/data/conf.yaml.example
+++ b/cloud_foundry_api/datadog_checks/cloud_foundry_api/data/conf.yaml.example
@@ -181,8 +181,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/cockroachdb/changelog.d/16981.fixed
+++ b/cockroachdb/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
+++ b/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
@@ -511,8 +511,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/consul/changelog.d/16981.fixed
+++ b/consul/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -370,8 +370,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/coredns/changelog.d/16981.fixed
+++ b/coredns/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/coredns/datadog_checks/coredns/data/conf.yaml.example
+++ b/coredns/datadog_checks/coredns/data/conf.yaml.example
@@ -521,8 +521,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/couch/changelog.d/16981.fixed
+++ b/couch/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/couch/datadog_checks/couch/data/conf.yaml.example
+++ b/couch/datadog_checks/couch/data/conf.yaml.example
@@ -376,8 +376,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/couchbase/changelog.d/16981.fixed
+++ b/couchbase/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/couchbase/datadog_checks/couchbase/data/conf.yaml.example
+++ b/couchbase/datadog_checks/couchbase/data/conf.yaml.example
@@ -305,8 +305,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/crio/changelog.d/16981.fixed
+++ b/crio/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/crio/datadog_checks/crio/data/conf.yaml.example
+++ b/crio/datadog_checks/crio/data/conf.yaml.example
@@ -422,8 +422,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/datadog_checks_dev/changelog.d/16981.fixed
+++ b/datadog_checks_dev/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
@@ -268,8 +268,8 @@
   description: |
     The path to a file of concatenated CA certificates in PEM format or a directory
     containing several CA certificates in PEM format. If a directory, the directory
-    must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    must have been processed using the `openssl rehash` command. See:
+    https://www.openssl.org/docs/man3.2/man1/c_rehash.html
 - name: tls_protocols_allowed
   value:
     example:

--- a/datadog_cluster_agent/changelog.d/16981.fixed
+++ b/datadog_cluster_agent/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/auto_conf.yaml
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/auto_conf.yaml
@@ -430,8 +430,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
@@ -422,8 +422,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/dcgm/changelog.d/16981.fixed
+++ b/dcgm/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/dcgm/datadog_checks/dcgm/data/conf.yaml.example
+++ b/dcgm/datadog_checks/dcgm/data/conf.yaml.example
@@ -510,8 +510,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/druid/changelog.d/16981.fixed
+++ b/druid/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/druid/datadog_checks/druid/data/conf.yaml.example
+++ b/druid/datadog_checks/druid/data/conf.yaml.example
@@ -287,8 +287,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/ecs_fargate/changelog.d/16981.fixed
+++ b/ecs_fargate/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/ecs_fargate/datadog_checks/ecs_fargate/data/conf.yaml.default
+++ b/ecs_fargate/datadog_checks/ecs_fargate/data/conf.yaml.default
@@ -291,8 +291,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/ecs_fargate/datadog_checks/ecs_fargate/data/conf.yaml.example
+++ b/ecs_fargate/datadog_checks/ecs_fargate/data/conf.yaml.example
@@ -283,8 +283,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/eks_fargate/changelog.d/16981.fixed
+++ b/eks_fargate/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/eks_fargate/datadog_checks/eks_fargate/data/conf.yaml.default
+++ b/eks_fargate/datadog_checks/eks_fargate/data/conf.yaml.default
@@ -291,8 +291,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/eks_fargate/datadog_checks/eks_fargate/data/conf.yaml.example
+++ b/eks_fargate/datadog_checks/eks_fargate/data/conf.yaml.example
@@ -283,8 +283,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/elastic/changelog.d/16981.fixed
+++ b/elastic/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -467,8 +467,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/envoy/changelog.d/16981.fixed
+++ b/envoy/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/envoy/datadog_checks/envoy/data/conf.yaml.example
+++ b/envoy/datadog_checks/envoy/data/conf.yaml.example
@@ -522,8 +522,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/etcd/changelog.d/16981.fixed
+++ b/etcd/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -422,8 +422,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/external_dns/changelog.d/16981.fixed
+++ b/external_dns/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/external_dns/datadog_checks/external_dns/data/conf.yaml.example
+++ b/external_dns/datadog_checks/external_dns/data/conf.yaml.example
@@ -422,8 +422,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/fluentd/changelog.d/16981.fixed
+++ b/fluentd/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/fluentd/datadog_checks/fluentd/data/conf.yaml.example
+++ b/fluentd/datadog_checks/fluentd/data/conf.yaml.example
@@ -351,8 +351,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/fluxcd/changelog.d/16981.fixed
+++ b/fluxcd/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/fluxcd/datadog_checks/fluxcd/data/conf.yaml.example
+++ b/fluxcd/datadog_checks/fluxcd/data/conf.yaml.example
@@ -510,8 +510,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/gitlab/changelog.d/16981.fixed
+++ b/gitlab/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -537,8 +537,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/gitlab_runner/changelog.d/16981.fixed
+++ b/gitlab_runner/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
+++ b/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
@@ -476,8 +476,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/go_expvar/changelog.d/16981.fixed
+++ b/go_expvar/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/go_expvar/datadog_checks/go_expvar/data/conf.yaml.example
+++ b/go_expvar/datadog_checks/go_expvar/data/conf.yaml.example
@@ -326,8 +326,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/haproxy/changelog.d/16981.fixed
+++ b/haproxy/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/haproxy/datadog_checks/haproxy/data/conf.yaml.example
+++ b/haproxy/datadog_checks/haproxy/data/conf.yaml.example
@@ -522,8 +522,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/harbor/changelog.d/16981.fixed
+++ b/harbor/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/harbor/datadog_checks/harbor/data/conf.yaml.example
+++ b/harbor/datadog_checks/harbor/data/conf.yaml.example
@@ -289,8 +289,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/hazelcast/changelog.d/16981.fixed
+++ b/hazelcast/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
+++ b/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
@@ -464,8 +464,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/hdfs_datanode/changelog.d/16981.fixed
+++ b/hdfs_datanode/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/data/conf.yaml.example
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/data/conf.yaml.example
@@ -293,8 +293,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/hdfs_namenode/changelog.d/16981.fixed
+++ b/hdfs_namenode/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
@@ -293,8 +293,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/http_check/changelog.d/16981.fixed
+++ b/http_check/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -471,8 +471,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/ibm_was/changelog.d/16981.fixed
+++ b/ibm_was/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/ibm_was/datadog_checks/ibm_was/data/conf.yaml.example
+++ b/ibm_was/datadog_checks/ibm_was/data/conf.yaml.example
@@ -288,8 +288,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/impala/changelog.d/16981.fixed
+++ b/impala/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/impala/datadog_checks/impala/data/conf.yaml.example
+++ b/impala/datadog_checks/impala/data/conf.yaml.example
@@ -520,8 +520,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/istio/changelog.d/16981.fixed
+++ b/istio/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -550,8 +550,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/karpenter/changelog.d/16981.fixed
+++ b/karpenter/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/karpenter/datadog_checks/karpenter/data/conf.yaml.example
+++ b/karpenter/datadog_checks/karpenter/data/conf.yaml.example
@@ -511,8 +511,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/kong/changelog.d/16981.fixed
+++ b/kong/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/kong/datadog_checks/kong/data/conf.yaml.example
+++ b/kong/datadog_checks/kong/data/conf.yaml.example
@@ -521,8 +521,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/kube_apiserver_metrics/changelog.d/16981.fixed
+++ b/kube_apiserver_metrics/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
@@ -429,8 +429,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/kube_controller_manager/changelog.d/16981.fixed
+++ b/kube_controller_manager/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
@@ -464,8 +464,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/kube_dns/changelog.d/16981.fixed
+++ b/kube_dns/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/kube_dns/datadog_checks/kube_dns/data/conf.yaml.example
+++ b/kube_dns/datadog_checks/kube_dns/data/conf.yaml.example
@@ -422,8 +422,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/kube_metrics_server/changelog.d/16981.fixed
+++ b/kube_metrics_server/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
+++ b/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
@@ -429,8 +429,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/kube_proxy/changelog.d/16981.fixed
+++ b/kube_proxy/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/kube_proxy/datadog_checks/kube_proxy/data/conf.yaml.example
+++ b/kube_proxy/datadog_checks/kube_proxy/data/conf.yaml.example
@@ -422,8 +422,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/kube_scheduler/changelog.d/16981.fixed
+++ b/kube_scheduler/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
@@ -443,8 +443,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/kubelet/changelog.d/16981.fixed
+++ b/kubelet/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/kubelet/datadog_checks/kubelet/data/conf.yaml.default
+++ b/kubelet/datadog_checks/kubelet/data/conf.yaml.default
@@ -464,8 +464,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/kubelet/datadog_checks/kubelet/data/conf.yaml.example
+++ b/kubelet/datadog_checks/kubelet/data/conf.yaml.example
@@ -456,8 +456,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/kubernetes_state/changelog.d/16981.fixed
+++ b/kubernetes_state/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
@@ -436,8 +436,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/kyototycoon/changelog.d/16981.fixed
+++ b/kyototycoon/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/kyototycoon/datadog_checks/kyototycoon/data/conf.yaml.example
+++ b/kyototycoon/datadog_checks/kyototycoon/data/conf.yaml.example
@@ -292,8 +292,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/lighttpd/changelog.d/16981.fixed
+++ b/lighttpd/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
+++ b/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
@@ -287,8 +287,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/linkerd/changelog.d/16981.fixed
+++ b/linkerd/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/linkerd/datadog_checks/linkerd/data/conf.yaml.example
+++ b/linkerd/datadog_checks/linkerd/data/conf.yaml.example
@@ -517,8 +517,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/mapreduce/changelog.d/16981.fixed
+++ b/mapreduce/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/mapreduce/datadog_checks/mapreduce/data/conf.yaml.example
+++ b/mapreduce/datadog_checks/mapreduce/data/conf.yaml.example
@@ -349,8 +349,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/marathon/changelog.d/16981.fixed
+++ b/marathon/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/marathon/datadog_checks/marathon/data/conf.yaml.example
+++ b/marathon/datadog_checks/marathon/data/conf.yaml.example
@@ -338,8 +338,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/marklogic/changelog.d/16981.fixed
+++ b/marklogic/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/marklogic/datadog_checks/marklogic/data/conf.yaml.example
+++ b/marklogic/datadog_checks/marklogic/data/conf.yaml.example
@@ -311,8 +311,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/mesos_master/changelog.d/16981.fixed
+++ b/mesos_master/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/mesos_master/datadog_checks/mesos_master/data/conf.yaml.example
+++ b/mesos_master/datadog_checks/mesos_master/data/conf.yaml.example
@@ -282,8 +282,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/mesos_slave/changelog.d/16981.fixed
+++ b/mesos_slave/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
+++ b/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
@@ -299,8 +299,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/nginx/changelog.d/16981.fixed
+++ b/nginx/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/nginx/datadog_checks/nginx/data/conf.yaml.example
+++ b/nginx/datadog_checks/nginx/data/conf.yaml.example
@@ -331,8 +331,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/nginx_ingress_controller/changelog.d/16981.fixed
+++ b/nginx_ingress_controller/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
@@ -430,8 +430,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/nvidia_triton/changelog.d/16981.fixed
+++ b/nvidia_triton/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/nvidia_triton/datadog_checks/nvidia_triton/data/conf.yaml.example
+++ b/nvidia_triton/datadog_checks/nvidia_triton/data/conf.yaml.example
@@ -485,8 +485,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/openmetrics/changelog.d/16981.fixed
+++ b/openmetrics/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -520,8 +520,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/openstack_controller/changelog.d/16981.fixed
+++ b/openstack_controller/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/openstack_controller/datadog_checks/openstack_controller/data/conf.yaml.example
+++ b/openstack_controller/datadog_checks/openstack_controller/data/conf.yaml.example
@@ -324,8 +324,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/php_fpm/changelog.d/16981.fixed
+++ b/php_fpm/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/php_fpm/datadog_checks/php_fpm/data/conf.yaml.example
+++ b/php_fpm/datadog_checks/php_fpm/data/conf.yaml.example
@@ -323,8 +323,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/powerdns_recursor/changelog.d/16981.fixed
+++ b/powerdns_recursor/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/powerdns_recursor/datadog_checks/powerdns_recursor/data/conf.yaml.example
+++ b/powerdns_recursor/datadog_checks/powerdns_recursor/data/conf.yaml.example
@@ -312,8 +312,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/pulsar/changelog.d/16981.fixed
+++ b/pulsar/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/pulsar/datadog_checks/pulsar/data/conf.yaml.example
+++ b/pulsar/datadog_checks/pulsar/data/conf.yaml.example
@@ -510,8 +510,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/rabbitmq/changelog.d/16981.fixed
+++ b/rabbitmq/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -546,8 +546,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/ray/changelog.d/16981.fixed
+++ b/ray/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/ray/datadog_checks/ray/data/conf.yaml.example
+++ b/ray/datadog_checks/ray/data/conf.yaml.example
@@ -510,8 +510,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/riak/changelog.d/16981.fixed
+++ b/riak/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/riak/datadog_checks/riak/data/conf.yaml.example
+++ b/riak/datadog_checks/riak/data/conf.yaml.example
@@ -287,8 +287,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/scylla/changelog.d/16981.fixed
+++ b/scylla/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/scylla/datadog_checks/scylla/data/conf.yaml.example
+++ b/scylla/datadog_checks/scylla/data/conf.yaml.example
@@ -541,8 +541,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/silk/changelog.d/16981.fixed
+++ b/silk/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/silk/datadog_checks/silk/data/conf.yaml.example
+++ b/silk/datadog_checks/silk/data/conf.yaml.example
@@ -297,8 +297,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/sonarqube/changelog.d/16981.fixed
+++ b/sonarqube/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+++ b/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
@@ -441,8 +441,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/spark/changelog.d/16981.fixed
+++ b/spark/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/spark/datadog_checks/spark/data/conf.yaml.example
+++ b/spark/datadog_checks/spark/data/conf.yaml.example
@@ -377,8 +377,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/squid/changelog.d/16981.fixed
+++ b/squid/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/squid/datadog_checks/squid/data/conf.yaml.example
+++ b/squid/datadog_checks/squid/data/conf.yaml.example
@@ -337,8 +337,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/strimzi/changelog.d/16981.fixed
+++ b/strimzi/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/strimzi/datadog_checks/strimzi/data/conf.yaml.example
+++ b/strimzi/datadog_checks/strimzi/data/conf.yaml.example
@@ -521,8 +521,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/teamcity/changelog.d/16981.fixed
+++ b/teamcity/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/teamcity/datadog_checks/teamcity/data/conf.yaml.example
+++ b/teamcity/datadog_checks/teamcity/data/conf.yaml.example
@@ -499,8 +499,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/temporal/changelog.d/16981.fixed
+++ b/temporal/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/temporal/datadog_checks/temporal/data/conf.yaml.example
+++ b/temporal/datadog_checks/temporal/data/conf.yaml.example
@@ -513,8 +513,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/torchserve/changelog.d/16981.fixed
+++ b/torchserve/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/torchserve/datadog_checks/torchserve/data/conf.yaml.example
+++ b/torchserve/datadog_checks/torchserve/data/conf.yaml.example
@@ -516,8 +516,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
@@ -874,8 +874,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
@@ -1259,8 +1259,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/traffic_server/changelog.d/16981.fixed
+++ b/traffic_server/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/traffic_server/datadog_checks/traffic_server/data/conf.yaml.example
+++ b/traffic_server/datadog_checks/traffic_server/data/conf.yaml.example
@@ -313,8 +313,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/twistlock/changelog.d/16981.fixed
+++ b/twistlock/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/twistlock/datadog_checks/twistlock/data/conf.yaml.example
+++ b/twistlock/datadog_checks/twistlock/data/conf.yaml.example
@@ -295,8 +295,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/vault/changelog.d/16981.fixed
+++ b/vault/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/vault/datadog_checks/vault/data/conf.yaml.example
+++ b/vault/datadog_checks/vault/data/conf.yaml.example
@@ -510,8 +510,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/voltdb/changelog.d/16981.fixed
+++ b/voltdb/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/voltdb/datadog_checks/voltdb/data/conf.yaml.example
+++ b/voltdb/datadog_checks/voltdb/data/conf.yaml.example
@@ -178,8 +178,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/vsphere/changelog.d/16981.fixed
+++ b/vsphere/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -653,8 +653,8 @@ instances:
         ## @param tls_ca_cert - string - optional
         ## The path to a file of concatenated CA certificates in PEM format or a directory
         ## containing several CA certificates in PEM format. If a directory, the directory
-        ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-        ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+        ## must have been processed using the `openssl rehash` command. See:
+        ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
         #
         # tls_ca_cert: <CA_CERT_PATH>
 

--- a/weaviate/changelog.d/16981.fixed
+++ b/weaviate/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/weaviate/datadog_checks/weaviate/data/conf.yaml.example
+++ b/weaviate/datadog_checks/weaviate/data/conf.yaml.example
@@ -516,8 +516,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/yarn/changelog.d/16981.fixed
+++ b/yarn/changelog.d/16981.fixed
@@ -1,0 +1,1 @@
+Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

--- a/yarn/datadog_checks/yarn/data/conf.yaml.example
+++ b/yarn/datadog_checks/yarn/data/conf.yaml.example
@@ -421,8 +421,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update the description for the `tls_ca_cert` config option to use `openssl rehash` instead of `c_rehash`

### Motivation
<!-- What inspired you to submit this pull request? -->

`c_rehash` has a CVE and we should discourage people from using it: https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2022-1292

We will most likely remove this script from the Agent

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
