### PR TITLE
Add the `qa/skip-qa` label to PRs that bump dependencies

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -71,7 +71,7 @@ jobs:
         branch-suffix: timestamp
         delete-branch: true
         base: master
-        labels: bot
+        labels: bot,qa/skip-qa
         draft: false
     # We generate the changelog if and only if the PR was created
     - name: Update changelogs


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add the `qa/skip-qa` label to PRs that bump dependencies

### Motivation
<!-- What inspired you to submit this pull request? -->

- We used to not QA these kind of PRs and I forgot to add the label when I added the bot
- We do not really need to check anything if the tests are all green in the CI

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
