### PR TITLE
[DBMON-3557] add read_timeout for reading from the connection in seconds

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -82,6 +82,13 @@ files:
               type: number
               example: 10
 
+          - name: read_timeout
+            description: |
+              The timeout for reading from the connection in seconds.
+            value:
+              type: number
+              example: 10
+
           - name: ssl
             description: |
               Use this section to configure a TLS connection between the Agent and MySQL.

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -78,6 +78,7 @@ files:
           - name: connect_timeout
             description: |
               Maximum number of seconds to wait before timing out when connecting to MySQL.
+              The default connection timeout is 10 seconds.
             value:
               type: number
               example: 10
@@ -85,6 +86,7 @@ files:
           - name: read_timeout
             description: |
               The timeout for reading from the connection in seconds.
+              The default read timeout is 10 seconds.
             value:
               type: number
               example: 10

--- a/mysql/changelog.d/16988.added
+++ b/mysql/changelog.d/16988.added
@@ -1,1 +1,1 @@
-[DBMON-3557] Add read_timeout (default to 10s) for reading from the connection in seconds
+Add read_timeout (default to 10s) for reading from the connection in seconds

--- a/mysql/changelog.d/16988.added
+++ b/mysql/changelog.d/16988.added
@@ -1,0 +1,1 @@
+[DBMON-3557] Add read_timeout (default to 10s) for reading from the connection in seconds

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -28,6 +28,7 @@ class MySQLConfig(object):
         self.additional_status = instance.get('additional_status', [])
         self.additional_variable = instance.get('additional_variable', [])
         self.connect_timeout = instance.get('connect_timeout', 10)
+        self.read_timeout = instance.get('read_timeout', 10)
         self.max_custom_queries = instance.get('max_custom_queries', DEFAULT_MAX_CUSTOM_QUERIES)
         self.charset = instance.get('charset')
         self.dbm_enabled = is_affirmative(instance.get('dbm', instance.get('deep_database_monitoring', False)))

--- a/mysql/datadog_checks/mysql/config_models/defaults.py
+++ b/mysql/datadog_checks/mysql/config_models/defaults.py
@@ -52,5 +52,9 @@ def instance_port():
     return 3306
 
 
+def instance_read_timeout():
+    return 10
+
+
 def instance_use_global_custom_queries():
     return 'true'

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -198,6 +198,7 @@ class InstanceConfig(BaseModel):
     query_activity: Optional[QueryActivity] = None
     query_metrics: Optional[QueryMetrics] = None
     query_samples: Optional[QuerySamples] = None
+    read_timeout: Optional[float] = None
     reported_hostname: Optional[str] = None
     service: Optional[str] = None
     sock: Optional[str] = None

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -74,6 +74,11 @@ instances:
     #
     # connect_timeout: 10
 
+    ## @param read_timeout - number - optional - default: 10
+    ## The timeout for reading from the connection in seconds.
+    #
+    # read_timeout: 10
+
     ## @param ssl - mapping - optional
     ## Use this section to configure a TLS connection between the Agent and MySQL.
     ##

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -71,11 +71,13 @@ instances:
 
     ## @param connect_timeout - number - optional - default: 10
     ## Maximum number of seconds to wait before timing out when connecting to MySQL.
+    ## The default connection timeout is 10 seconds.
     #
     # connect_timeout: 10
 
     ## @param read_timeout - number - optional - default: 10
     ## The timeout for reading from the connection in seconds.
+    ## The default read timeout is 10 seconds.
     #
     # read_timeout: 10
 

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -382,6 +382,7 @@ class MySql(AgentCheck):
         connection_args = {
             'ssl': ssl,
             'connect_timeout': self._config.connect_timeout,
+            'read_timeout': self._config.read_timeout,
             'autocommit': True,
         }
         if self._config.charset:

--- a/mysql/tests/test_connection.py
+++ b/mysql/tests/test_connection.py
@@ -25,6 +25,7 @@ def test_connection_with_defaults_file():
         'autocommit': True,
         'ssl': None,
         'connect_timeout': 10,
+        'read_timeout': 10,
         'read_default_file': '/foo/bar',
     }
     assert 'host' not in connection_args
@@ -44,6 +45,7 @@ def test_connection_with_sock():
         'autocommit': True,
         'ssl': None,
         'connect_timeout': 10,
+        'read_timeout': 10,
         'unix_socket': '/foo/bar',
         'user': 'ddog',
         'passwd': 'pwd',
@@ -63,6 +65,7 @@ def test_connection_with_host():
         'autocommit': True,
         'ssl': None,
         'connect_timeout': 10,
+        'read_timeout': 10,
         'user': 'ddog',
         'passwd': 'pwd',
         'host': 'localhost',
@@ -77,6 +80,7 @@ def test_connection_with_host_and_port():
         'autocommit': True,
         'ssl': None,
         'connect_timeout': 10,
+        'read_timeout': 10,
         'user': 'ddog',
         'passwd': 'pwd',
         'host': 'localhost',
@@ -98,5 +102,6 @@ def test_connection_with_charset(instance_basic):
         'port': common.PORT,
         'ssl': None,
         'connect_timeout': 10,
+        'read_timeout': 10,
         'charset': 'utf8mb4',
     }


### PR DESCRIPTION
### What does this PR do?
This PR adds a new config option `read_timeout` to specify the timeout for reading from the connection in seconds. The default `read_timeout` is 10s.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
