### PR TITLE
[DBMON-3691] set collect_wal_metrics to false will disable wal file metrics collection for all pg versions

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -258,8 +258,9 @@ files:
     - name: collect_wal_metrics
       description: |
         Collect metrics about WAL file age.
-        NOTE: You must be running the check local to your database if you want to enable this option.
-        Starting PG10, wal metrics are collected by default using `pg_ls_waldir` and don't need local access anymore.
+        NOTE: 
+        For Postgres 9.6 and below, you must run the check local to your database if you want to enable this option.
+        Starting Postgres 10, WAL file metrics are enabled by default using `pg_ls_waldir` and don't need local access.
       value:
         type: boolean
         example: false

--- a/postgres/changelog.d/16990.added
+++ b/postgres/changelog.d/16990.added
@@ -1,0 +1,1 @@
+[DBMON-3691] set collect_wal_metrics to false will disable wal file metrics collection for all pg versions

--- a/postgres/changelog.d/16990.added
+++ b/postgres/changelog.d/16990.added
@@ -1,1 +1,1 @@
-[DBMON-3691] set collect_wal_metrics to false will disable wal file metrics collection for all pg versions
+Set `collect_wal_metrics` to false will disable wal file metrics collection for all pg versions

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -2,6 +2,8 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 # https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
+from typing import Optional
+
 from six import PY2, PY3, iteritems
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
@@ -78,7 +80,7 @@ class PostgresConfig:
         self.collect_activity_metrics = is_affirmative(instance.get('collect_activity_metrics', False))
         self.activity_metrics_excluded_aggregations = instance.get('activity_metrics_excluded_aggregations', [])
         self.collect_database_size_metrics = is_affirmative(instance.get('collect_database_size_metrics', True))
-        self.collect_wal_metrics = is_affirmative(instance.get('collect_wal_metrics', False))
+        self.collect_wal_metrics = self._should_collect_wal_metrics(instance.get('collect_wal_metrics'))
         self.collect_bloat_metrics = is_affirmative(instance.get('collect_bloat_metrics', False))
         self.data_directory = instance.get('data_directory', None)
         self.ignore_databases = instance.get('ignore_databases', DEFAULT_IGNORE_DATABASES)
@@ -257,3 +259,11 @@ class PostgresConfig:
                 raise ConfigurationError('Azure client_id must be set when using Azure managed authentication')
             managed_authentication['enabled'] = enabled
         return managed_authentication
+
+    @staticmethod
+    def _should_collect_wal_metrics(collect_wal_metrics) -> Optional[bool]:
+        if collect_wal_metrics is not None:
+            # if the user has explicitly set the value, return the boolean
+            return is_affirmative(collect_wal_metrics)
+
+        return None

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -204,8 +204,9 @@ instances:
 
     ## @param collect_wal_metrics - boolean - optional - default: false
     ## Collect metrics about WAL file age.
-    ## NOTE: You must be running the check local to your database if you want to enable this option.
-    ## Starting PG10, wal metrics are collected by default using `pg_ls_waldir` and don't need local access anymore.
+    ## NOTE: 
+    ## For Postgres 9.6 and below, you must run the check local to your database if you want to enable this option.
+    ## Starting Postgres 10, WAL file metrics are enabled by default using `pg_ls_waldir` and don't need local access.
     #
     # collect_wal_metrics: false
 

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -287,7 +287,9 @@ class PostgreSql(AgentCheck):
             # ERROR:  Function pg_stat_get_wal_receiver() is currently not supported in Aurora
             if self.is_aurora is False:
                 queries.append(QUERY_PG_STAT_WAL_RECEIVER)
-                queries.append(WAL_FILE_METRICS)
+                if self._config.collect_wal_metrics is not False:
+                    # collect wal metrics for pg >= 10 only if the user has not explicitly disabled it
+                    queries.append(WAL_FILE_METRICS)
             queries.append(QUERY_PG_REPLICATION_SLOTS)
             queries.append(VACUUM_PROGRESS_METRICS)
             queries.append(STAT_SUBSCRIPTION_METRICS)
@@ -1021,6 +1023,7 @@ class PostgreSql(AgentCheck):
                 self.statement_samples.run_job_loop(tags)
                 self.metadata_samples.run_job_loop(tags)
             if self._config.collect_wal_metrics:
+                # collect wal metrics for pg < 10, disabled by enabled
                 self._collect_wal_metrics()
             self._send_database_instance_metadata()
         except Exception as e:

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -1075,3 +1075,20 @@ def test_replication_tag(aggregator, integration_check, pg_instance):
     check._get_replication_role = mock.MagicMock(return_value=standby_role)
     check.check(pg_instance)
     aggregator.assert_metric(test_metric, tags=_get_expected_tags(check, pg_instance, role=standby_role))
+
+
+@pytest.mark.parametrize(
+    'collect_wal_metrics',
+    [True, False, None],
+)
+@requires_over_10
+def test_collect_wal_metrics_metrics(aggregator, integration_check, pg_instance, collect_wal_metrics):
+    pg_instance['collect_wal_metrics'] = collect_wal_metrics
+    check = integration_check(pg_instance)
+    check.is_aurora = False
+    check.check(pg_instance)
+
+    expected_tags = _get_expected_tags(check, pg_instance)
+    # if collect_wal_metrics is not set, wal metrics are collected on pg >= 10 by default
+    expected_count = 0 if collect_wal_metrics is False else 1
+    check_file_wal_metrics(aggregator, expected_tags=expected_tags, count=expected_count)


### PR DESCRIPTION
### What does this PR do?
This PR makes existing config `collect_wal_metrics` applicable for all postgres versions. 

### Motivation
Prior to this PR, WAL file metrics are collected by default on PG version 10 using function `pg_ls_waldir`. However executing `pg_ls_waldir` function requires `cloudsqlsuperuser` role on GCP Cloud SQL for Postgres. Granting superuser role to datadog monitoring user is often not recommended. As a workaround, we suggest user to create a stored procedure with superuser access and grant the execution privilege to datadog user.  The workaround resolves the issue of collecting WAL file metrics, but it does not stop error messages flood in agent log.
This PR let user set `collect_wal_metrics` to false to disable collecting WAL file metics from function `pg_ls_waldir`.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
