### PR TITLE
[MySQL] - SDBM-830 - Make the autocommit explicit

### DIFF
--- a/mysql/changelog.d/17002.fixed
+++ b/mysql/changelog.d/17002.fixed
@@ -1,1 +1,1 @@
-[MySQL] - SDBM-830 - Make the autocommit explicit
+Explicitly activate autocommit mode for monitoring connections

--- a/mysql/changelog.d/17002.fixed
+++ b/mysql/changelog.d/17002.fixed
@@ -1,0 +1,1 @@
+[MySQL] - SDBM-830 - Make the autocommit explicit

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -17,7 +17,7 @@ from datadog_checks.base.utils.db.utils import DBMAsyncJob, obfuscate_sql_with_m
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 
-from .util import DatabaseConfigurationError, get_truncation_state, warning_with_tags
+from .util import DatabaseConfigurationError, connect_with_autocommit, get_truncation_state, warning_with_tags
 
 try:
     import datadog_agent
@@ -272,7 +272,7 @@ class MySQLActivity(DBMAsyncJob):
         pymysql connections are not thread safe, so we can't reuse the same connection from the main check.
         """
         if not self._db:
-            self._db = pymysql.connect(**self._connection_args)
+            self._db = connect_with_autocommit(**self._connection_args)
         return self._db
 
     def _close_db_conn(self):

--- a/mysql/datadog_checks/mysql/metadata.py
+++ b/mysql/datadog_checks/mysql/metadata.py
@@ -7,6 +7,8 @@ from operator import attrgetter
 
 import pymysql
 
+from .util import connect_with_autocommit
+
 try:
     import datadog_agent
 except ImportError:
@@ -70,7 +72,7 @@ class MySQLMetadata(DBMAsyncJob):
         :return:
         """
         if not self._db:
-            self._db = pymysql.connect(**self._connection_args)
+            self._db = connect_with_autocommit(**self._connection_args)
         return self._db
 
     def _close_db_conn(self):

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -76,7 +76,7 @@ from .queries import (
 )
 from .statement_samples import MySQLStatementSamples
 from .statements import MySQLStatementMetrics
-from .util import DatabaseConfigurationError  # noqa: F401
+from .util import DatabaseConfigurationError, connect_with_autocommit  # noqa: F401
 from .version_utils import get_version
 
 try:
@@ -424,13 +424,7 @@ class MySql(AgentCheck):
         db = None
         try:
             connect_args = self._get_connection_args()
-            db = pymysql.connect(**connect_args)
-            with closing(db.cursor()) as cursor:
-                # PyMYSQL only sets autocommit if it receives a different value from the server
-                # see https://github.com/PyMySQL/PyMySQL/blob/bbd049f40db9c696574ce6f31669880042c56d79/pymysql/connections.py#L443-L447
-                # but there are cases where the server will not send a correct value for autocommit, so we
-                # set it explicitly to ensure it's set correctly
-                cursor.execute("SET AUTOCOMMIT=1")
+            db = connect_with_autocommit(**connect_args)
             self.log.debug("Connected to MySQL")
             self.service_check_tags = list(set(service_check_tags))
             self.service_check(

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -425,6 +425,12 @@ class MySql(AgentCheck):
         try:
             connect_args = self._get_connection_args()
             db = pymysql.connect(**connect_args)
+            with closing(db.cursor()) as cursor:
+                # PyMYSQL only sets autocommit if it receives a different value from the server
+                # see https://github.com/PyMySQL/PyMySQL/blob/bbd049f40db9c696574ce6f31669880042c56d79/pymysql/connections.py#L443-L447
+                # but there are cases where the server will not send a correct value for autocommit, so we
+                # set it explicitly to ensure it's set correctly
+                cursor.execute("SET AUTOCOMMIT=1")
             self.log.debug("Connected to MySQL")
             self.service_check_tags = list(set(service_check_tags))
             self.service_check(

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -29,7 +29,13 @@ from datadog_checks.base.utils.db.utils import (
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 
-from .util import DatabaseConfigurationError, StatementTruncationState, get_truncation_state, warning_with_tags
+from .util import (
+    DatabaseConfigurationError,
+    StatementTruncationState,
+    connect_with_autocommit,
+    get_truncation_state,
+    warning_with_tags,
+)
 
 SUPPORTED_EXPLAIN_STATEMENTS = frozenset({'select', 'table', 'delete', 'insert', 'replace', 'update', 'with'})
 
@@ -270,7 +276,7 @@ class MySQLStatementSamples(DBMAsyncJob):
         :return:
         """
         if not self._db:
-            self._db = pymysql.connect(**self._connection_args)
+            self._db = connect_with_autocommit(**self._connection_args)
         return self._db
 
     def _close_db_conn(self):

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -19,7 +19,7 @@ from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_e
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 
-from .util import DatabaseConfigurationError, warning_with_tags
+from .util import DatabaseConfigurationError, connect_with_autocommit, warning_with_tags
 
 try:
     import datadog_agent
@@ -97,7 +97,7 @@ class MySQLStatementMetrics(DBMAsyncJob):
         :return:
         """
         if not self._db:
-            self._db = pymysql.connect(**self._connection_args)
+            self._db = connect_with_autocommit(**self._connection_args)
         return self._db
 
     def _close_db_conn(self):

--- a/mysql/datadog_checks/mysql/util.py
+++ b/mysql/datadog_checks/mysql/util.py
@@ -2,9 +2,9 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import pymysql
 from enum import Enum
 from contextlib import closing
-import pymysql
 
 
 class DatabaseConfigurationError(Enum):

--- a/mysql/datadog_checks/mysql/util.py
+++ b/mysql/datadog_checks/mysql/util.py
@@ -3,6 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 from enum import Enum
+from contextlib import closing
+import pymysql
 
 
 class DatabaseConfigurationError(Enum):
@@ -40,3 +42,15 @@ def get_truncation_state(statement):
     # a statement is truncated
     truncated = statement[-3:] == '...'
     return StatementTruncationState.truncated if truncated else StatementTruncationState.not_truncated
+
+
+def connect_with_autocommit(**connect_args):
+    db = pymysql.connect(**connect_args)
+    with closing(db.cursor()) as cursor:
+        # PyMYSQL only sets autocommit if it receives a different value from the server
+        # see https://github.com/PyMySQL/PyMySQL/blob/bbd049f40db9c696574ce6f31669880042c56d79/pymysql/connections.py#L443-L447
+        # but there are cases where the server will not send a correct value for autocommit, so we
+        # set it explicitly to ensure it's set correctly
+        cursor.execute("SET AUTOCOMMIT=1")
+
+    return db

--- a/mysql/datadog_checks/mysql/util.py
+++ b/mysql/datadog_checks/mysql/util.py
@@ -2,9 +2,10 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-import pymysql
-from enum import Enum
 from contextlib import closing
+from enum import Enum
+
+import pymysql
 
 
 class DatabaseConfigurationError(Enum):


### PR DESCRIPTION
### What does this PR do?

- Sets the autocommit explicitly when opening a new connection.

### Motivation

PyMYSQL will only set autocommit as true when it detects from the server status that it's disabled. We suspect that there are some situations such as [this](https://repost.aws/questions/QUSRDBZhpGQjibIl0xUQTe5w/mysql-aurora-8-0-and-pymysql-issue-with-autocommit), [this](https://github.com/dolthub/dolt/issues/1712) or [this](https://bugs.mysql.com/bug.php?id=66884) where MySQL is misreporting the autocommit status. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
