### PR TITLE
Add source_type_id and auto_install to nfsstat integration folder

### DIFF
--- a/nfsstat/manifest.json
+++ b/nfsstat/manifest.json
@@ -25,6 +25,8 @@
   },
   "assets": {
     "integration": {
+      "auto_install": false,
+      "source_type_id": 9164582,
       "source_type_name": "Nfsstat",
       "configuration": {
         "spec": "assets/configuration/spec.yaml"

--- a/nfsstat/manifest.json
+++ b/nfsstat/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "2.0.0",
   "app_uuid": "423f4b03-ce99-4ffc-a553-e522ebd451be",
-  "app_id": "system",
+  "app_id": "nfsstat",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add source_type_id and auto_install to the nfsstat integration manifest

### Motivation
<!-- What inspired you to submit this pull request? -->
Because this integration has logs assets defined, I need to allow it to go through APW. In order to remove this integration from the blacklist, it needs to have all the expected manifest fields

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Note: I generated this source_type_id by running `ddev create` and took the generated value. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
