### PR TITLE
Remove unnecessary logic around init config auto discovery configuration

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -8,11 +8,13 @@ files:
   - template: instances
     options:
     - name: host
+      required: true
       description: |
         The hostname to connect to.
         NOTE: Even if the server name is `localhost`, the Agent connects to PostgreSQL using TCP/IP unless you also
         provide a value for the sock key.
       value:
+        example: "localhost"
         type: string
     - name: port
       description: The port to use when connecting to PostgreSQL.
@@ -21,8 +23,10 @@ files:
         example: 5432
     - name: username
       description: The Datadog username created to connect to PostgreSQL.
+      required: true
       value:
-          type: string
+        type: string
+        example: datadog
     - name: password
       description: The password associated with the Datadog user.
       value:

--- a/postgres/changelog.d/17005.removed
+++ b/postgres/changelog.d/17005.removed
@@ -1,1 +1,0 @@
-Remove unnecessary logic around init config auto discovery configuration

--- a/postgres/changelog.d/17005.removed
+++ b/postgres/changelog.d/17005.removed
@@ -1,0 +1,1 @@
+Remove unnecessary logic around init config auto discovery configuration

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -26,17 +26,15 @@ class PostgresConfig:
     GAUGE = AgentCheck.gauge
     MONOTONIC = AgentCheck.monotonic_count
 
-    def __init__(self, init_config, instance):
-        autodiscover_config = init_config.get('autodiscover_hosts', {})
-        self.host_autodiscovery_enabled = is_affirmative(autodiscover_config.get('enabled', False))
+    def __init__(self, instance):
         self.host = instance.get('host', '')
-        if not self.host and not self.host_autodiscovery_enabled:
+        if not self.host:
             raise ConfigurationError('Specify a Postgres host to connect to.')
         self.port = instance.get('port', '')
         if self.port != '':
             self.port = int(self.port)
         self.user = instance.get('username', '')
-        if not self.user and not self.host_autodiscovery_enabled:
+        if not self.user:
             raise ConfigurationError('Please specify a user to connect to Postgres.')
         self.password = instance.get('password', '')
         self.dbname = instance.get('dbname', 'postgres')

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -215,7 +215,7 @@ class InstanceConfig(BaseModel):
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
     gcp: Optional[Gcp] = None
-    host: Optional[str] = None
+    host: str
     idle_connection_timeout: Optional[int] = None
     ignore_databases: Optional[tuple[str, ...]] = None
     log_unobfuscated_plans: Optional[bool] = None
@@ -244,7 +244,7 @@ class InstanceConfig(BaseModel):
     table_count_limit: Optional[int] = None
     tag_replication_role: Optional[bool] = None
     tags: Optional[tuple[str, ...]] = None
-    username: Optional[str] = None
+    username: str
 
     @model_validator(mode='before')
     def _initial_validation(cls, values):

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -13,23 +13,22 @@ init_config:
 #
 instances:
 
-  -
-    ## @param host - string - optional
+    ## @param host - string - required
     ## The hostname to connect to.
     ## NOTE: Even if the server name is `localhost`, the Agent connects to PostgreSQL using TCP/IP unless you also
     ## provide a value for the sock key.
     #
-    # host: <HOST>
+  - host: localhost
 
     ## @param port - integer - optional - default: 5432
     ## The port to use when connecting to PostgreSQL.
     #
     # port: 5432
 
-    ## @param username - string - optional
+    ## @param username - string - required
     ## The Datadog username created to connect to PostgreSQL.
     #
-    # username: <USERNAME>
+    username: datadog
 
     ## @param password - string - optional
     ## The password associated with the Datadog user.

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -107,7 +107,7 @@ class PostgreSql(AgentCheck):
                 "DEPRECATION NOTICE: The managed_identity option is deprecated and will be removed in a future version."
                 " Please use the new azure.managed_authentication option instead."
             )
-        self._config = PostgresConfig(self.init_config, self.instance)
+        self._config = PostgresConfig(self.instance)
         self.cloud_metadata = self._config.cloud_metadata
         self.tags = self._config.tags
         # Keep a copy of the tags without the internal resource tags so they can be used for paths that don't
@@ -125,14 +125,9 @@ class PostgreSql(AgentCheck):
         self._clean_state()
         self.check_initializations.append(lambda: RelationsManager.validate_relations_config(self._config.relations))
         self.check_initializations.append(self.set_resolved_hostname_metadata)
-        # initialize connections if host autodiscovery is disabled or if host autodiscovery is enabled but the host
-        # is set in the config
-        if not self._config.host_autodiscovery_enabled or (
-            self._config.host_autodiscovery_enabled and self._config.host
-        ):
-            self.check_initializations.append(self._connect)
-            self.check_initializations.append(self.load_version)
-            self.check_initializations.append(self.initialize_is_aurora)
+        self.check_initializations.append(self._connect)
+        self.check_initializations.append(self.load_version)
+        self.check_initializations.append(self.initialize_is_aurora)
         self.tags_without_db = [t for t in copy.copy(self.tags) if not t.startswith("db:")]
         self.autodiscovery = self._build_autodiscovery()
         self._dynamic_queries = []
@@ -982,16 +977,6 @@ class PostgreSql(AgentCheck):
         }
 
     def check(self, _):
-        if self._config.host_autodiscovery_enabled and not self._config.host:
-            # emit status check that we are waiting on remote-config to
-            # push instance configuration to us, skip this check
-            self.service_check(
-                self.SERVICE_CHECK_NAME,
-                AgentCheck.OK,
-                tags=self.tags,
-            )
-            self.log.info("Waiting for remote configuration to push instance configuration")
-            return
         tags = copy.copy(self.tags)
         self.tags_without_db = [t for t in copy.copy(self.tags) if not t.startswith("db:")]
         # Collect metrics

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -84,20 +84,6 @@ def pg_instance():
 
 
 @pytest.fixture
-def pg_init_config():
-    return {}
-
-
-@pytest.fixture
-def pg_host_autodiscover_init_config():
-    return {
-        'autodiscover_hosts': {
-            'enabled': True,
-        }
-    }
-
-
-@pytest.fixture
 def pg_replica_instance():
     instance = copy.deepcopy(INSTANCE)
     instance['port'] = PORT_REPLICA
@@ -119,14 +105,14 @@ def pg_replica_logical():
 
 
 @pytest.fixture
-def metrics_cache(pg_init_config, pg_instance):
-    config = PostgresConfig(init_config=pg_init_config, instance=pg_instance)
+def metrics_cache(pg_instance):
+    config = PostgresConfig(instance=pg_instance)
     return PostgresMetricsCache(config)
 
 
 @pytest.fixture
-def metrics_cache_replica(pg_init_config, pg_replica_instance):
-    config = PostgresConfig(init_config=pg_init_config, instance=pg_replica_instance)
+def metrics_cache_replica(pg_replica_instance):
+    config = PostgresConfig(instance=pg_replica_instance)
     return PostgresMetricsCache(config)
 
 

--- a/postgres/tests/test_metrics_cache.py
+++ b/postgres/tests/test_metrics_cache.py
@@ -27,8 +27,8 @@ COMMON_AND_MAIN_CHECK_METRICS = dict(COMMON_METRICS, **DBM_MIGRATED_METRICS)
         pytest.param(V9_2, True, {}),
     ],
 )
-def test_aurora_replication_metrics(pg_instance, pg_init_config, version, is_aurora, expected_metrics):
-    config = PostgresConfig(init_config=pg_init_config, instance=pg_instance)
+def test_aurora_replication_metrics(pg_instance, version, is_aurora, expected_metrics):
+    config = PostgresConfig(instance=pg_instance)
     cache = PostgresMetricsCache(config)
     replication_metrics = cache.get_replication_metrics(version, is_aurora)
     assert replication_metrics == expected_metrics
@@ -46,11 +46,11 @@ def test_aurora_replication_metrics(pg_instance, pg_init_config, version, is_aur
         pytest.param(V9_2, False, dict(COMMON_AND_MAIN_CHECK_METRICS, **NEWER_92_METRICS)),
     ],
 )
-def test_dbm_enabled_conn_metric(pg_instance, pg_init_config, version, is_dbm_enabled, expected_metrics):
+def test_dbm_enabled_conn_metric(pg_instance, version, is_dbm_enabled, expected_metrics):
     pg_instance['dbm'] = is_dbm_enabled
     pg_instance['collect_resources'] = {'enabled': False}
     pg_instance['collect_database_size_metrics'] = False
-    config = PostgresConfig(init_config=pg_init_config, instance=pg_instance)
+    config = PostgresConfig(instance=pg_instance)
     cache = PostgresMetricsCache(config)
     instance_metrics = cache.get_instance_metrics(version)
     assert instance_metrics['metrics'] == expected_metrics

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -1042,14 +1042,6 @@ def assert_state_set(check):
     assert check.metrics_cache.replication_metrics
 
 
-def test_host_autodiscover_init_config(aggregator, pg_host_autodiscover_init_config):
-    check_with_init = PostgreSql('test_instance', pg_host_autodiscover_init_config, [{}])
-    assert check_with_init._config.host_autodiscovery_enabled is True
-    check_with_init.check({})
-    # assert that the service check is OK
-    aggregator.assert_service_check('postgres.can_connect', count=1, status=PostgreSql.OK)
-
-
 @requires_over_10
 def test_replication_tag(aggregator, integration_check, pg_instance):
     test_metric = 'postgresql.db.count'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Effectively reverts https://github.com/DataDog/integrations-core/pull/16540, since we have since changed how we pass auto discovery configuration to the agent 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
