### PR TITLE
[DBMON-3288] Perform database connection health check at the start of check run

### DIFF
--- a/postgres/changelog.d/17007.added
+++ b/postgres/changelog.d/17007.added
@@ -1,0 +1,1 @@
+Perform database connection health check at the start of check run

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -216,7 +216,6 @@ class PostgreSql(AgentCheck):
         """
         db context manager that yields a healthy connection to the main database
         """
-        print(self._db)
         if not self._db or self._db.closed:
             # if the connection is closed, we need to reinitialize the connection
             self._db = self._new_connection(self._config.dbname)

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -83,6 +83,10 @@ class DBExplainError(Enum):
     no_plan_returned_with_prepared_statement = 'no_plan_returned_with_prepared_statement'
 
 
+class DatabaseHealthCheckError(Exception):
+    pass
+
+
 def warning_with_tags(warning_message, *args, **kwargs):
     if args:
         warning_message = warning_message % args

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1841,7 +1841,7 @@ def test_pg_stat_statements_dealloc(aggregator, integration_check, dbm_instance_
     with conn.cursor() as cur:
         # pg_stat_statements_reset should be tracked
         # Do enough queries to reach the maximum
-        for i in range(101 - count_statements):
+        for i in range(102 - count_statements):
             parameters = ','.join([str(a) for a in range(i)])
             cur.execute("select {};".format(parameters))
 


### PR DESCRIPTION
### What does this PR do?
This PR adds an explicit postgres database connection health check at the start of every check run. 
Postgres integration establish the database connection on first check run and maintains the open connection until the check is canceled or closed by server. Prior to the PR, the integration implicitly relies on query operations performed on the open connection to update the Service Check status `postgres.can_connect`. When an uncaught exception is raised, the service check will be updated to `CRITICAL`. 
This PR performs explicit health check by executing a simple `SELECT 1` to ensure the connection is healthy.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
