### PR TITLE
Mark the `test_e2e` test flaky and retry it if needed

### DIFF
--- a/gitlab/tests/test_e2e.py
+++ b/gitlab/tests/test_e2e.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import pytest
+from flaky import flaky
 
 from datadog_checks.dev.utils import get_metadata_metrics
 
@@ -18,6 +19,23 @@ def test_e2e_legacy(dd_agent_check, legacy_config):
 
 
 @pytest.mark.parametrize('use_openmetrics', [True, False], indirect=True)
+@flaky(max_runs=5)
+# GitLab can start returning 502s even if all the conditions were met in the e2e env.
+# Example:
+# tests/test_e2e.py::test_e2e[True] PASSED                                 [ 66%]
+# tests/test_e2e.py::test_e2e[False] FAILED                                [100%]
+#
+# =================================== FAILURES ===================================
+# _______________________________ test_e2e[False] ________________________________
+# tests/test_e2e.py:22: in test_e2e
+#     aggregator = dd_agent_check(get_config(use_openmetrics), rate=True)
+# ...
+# E     File "/home/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py", line 854, in poll
+# E       response.raise_for_status()
+# E     File "/opt/datadog-agent/embedded/lib/python3.11/site-packages/requests/models.py", line 1021,
+# in raise_for_status
+# E       raise HTTPError(http_error_msg, response=self)
+# E   requests.exceptions.HTTPError: 502 Server Error: Bad Gateway for url: http://localhost:8086/-/metrics
 def test_e2e(dd_agent_check, get_config, use_openmetrics):
     aggregator = dd_agent_check(get_config(use_openmetrics), rate=True)
     assert_check(aggregator, use_openmetrics=use_openmetrics)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Mark the `test_e2e` test flaky and retry it if needed

### Motivation
<!-- What inspired you to submit this pull request? -->

GitLab can start returning 502s even after all the conditions in the e2e env were met: https://github.com/DataDog/integrations-core/actions/runs/8092578398/job/22113596713#step:15:497

The previous test ran successfully so GitLab returned a 200, I'm not sure we can do anything about it, besides retrying 🙁 We have unit tests to cover this error

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
