### PR TITLE
Make the e2e environment less flaky

### DIFF
--- a/kafka_consumer/tests/common.py
+++ b/kafka_consumer/tests/common.py
@@ -87,7 +87,7 @@ elif AUTHENTICATION == "kerberos":
     E2E_INSTANCE["sasl_kerberos_keytab"] = "/var/lib/secret/localhost.key"
 
 
-def _get_cluster_id():
+def get_cluster_id():
     config = {
         "bootstrap.servers": INSTANCE['kafka_connect_str'],
         "socket.timeout.ms": 1000,
@@ -95,11 +95,11 @@ def _get_cluster_id():
     }
     config.update(get_authentication_configuration(INSTANCE))
     client = AdminClient(config)
-    return client.list_topics(timeout=1).cluster_id
+    return client.list_topics(timeout=5).cluster_id
 
 
 def assert_check_kafka(aggregator, consumer_groups):
-    cluster_id = _get_cluster_id()
+    cluster_id = get_cluster_id()
     for name, consumer_group in consumer_groups.items():
         for topic, partitions in consumer_group.items():
             for partition in partitions:

--- a/kafka_consumer/tests/conftest.py
+++ b/kafka_consumer/tests/conftest.py
@@ -15,6 +15,7 @@ from datadog_checks.dev.ci import running_on_ci
 from datadog_checks.kafka_consumer import KafkaCheck
 
 from . import common
+from .common import get_cluster_id
 from .runners import Consumer, Producer
 
 
@@ -36,6 +37,7 @@ def dd_environment():
             [
                 WaitFor(create_topics, attempts=60, wait=3),
                 WaitFor(initialize_topics),
+                WaitFor(is_cluster_id_available),
             ]
         )
 
@@ -56,6 +58,10 @@ def dd_environment():
                 'instances': [common.E2E_INSTANCE],
                 'init_config': {'kafka_timeout': 30},
             }, common.E2E_METADATA
+
+
+def is_cluster_id_available():
+    return get_cluster_id() is not None
 
 
 @pytest.fixture

--- a/kafka_consumer/tests/test_integration.py
+++ b/kafka_consumer/tests/test_integration.py
@@ -105,7 +105,7 @@ def test_monitor_broker_highwatermarks(
     kafka_instance['consumer_groups'] = {'my_consumer': {'marvel': None}}
     kafka_instance['monitor_all_broker_highwatermarks'] = is_enabled
     dd_run_check(check(kafka_instance))
-    cluster_id = common._get_cluster_id()
+    cluster_id = common.get_cluster_id()
 
     # After refactor and library migration, write unit tests to assert expected metric values
     aggregator.assert_metric('kafka.broker_offset', count=broker_offset_metric_count)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add a condition to the e2e env to make sure we can get the cluster id

### Motivation
<!-- What inspired you to submit this pull request? -->

Sometimes this info is not yet available and the broker does not respond https://github.com/DataDog/integrations-core/actions/runs/8093321612/job/22115795857#step:15:779

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
