### PR TITLE
Do not run the docs job on some PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches:
     - master
+    paths-ignore:
+    - '.github/**'
+    - 'manifest.json'
+    - 'hatch.toml'
+    - '**/tests/**'
 
 jobs:
   build:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Do not run the docs job on some PRs. This job take about 6 minutes

- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#patterns-to-match-file-paths

### Motivation
<!-- What inspired you to submit this pull request? -->

The docs job currently always run on PRs. We need it only when we modify something in the code or in the docs directly. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This list can be expanded in the future

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
