### PR TITLE
Explicitly list `localhost` as the address when port-forwarding with kind to avoid opening a pop-up

### DIFF
--- a/datadog_checks_dev/changelog.d/17016.fixed
+++ b/datadog_checks_dev/changelog.d/17016.fixed
@@ -1,0 +1,1 @@
+Explicitly list `localhost` as the address when port-forwarding with kind to avoid opening a pop-up

--- a/datadog_checks_dev/datadog_checks/dev/kube_port_forward.py
+++ b/datadog_checks_dev/datadog_checks/dev/kube_port_forward.py
@@ -51,7 +51,8 @@ class PortForwardUp(LazyFunction):
                     'kubectl',
                     'port-forward',
                     '--address',
-                    ip,
+                    # Explicitly add localhost to avoid getting a popup each time we use this
+                    'localhost,{}'.format(ip),
                     '--namespace',
                     self.namespace,
                     "{}/{}".format(self.resource, self.resource_name),


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Explicitly list `localhost` as the address when port-forwarding with kind to avoid opening a pop-up

### Motivation
<!-- What inspired you to submit this pull request? -->

When we run a e2e test with kind and port-forward, we get an annoying pop-up for each port-forward we do. Specifying `localhost` avoid it

![Screenshot 2024-02-29 at 14 05 22](https://github.com/DataDog/integrations-core/assets/1266346/e3ddc7e6-cfa8-4d4f-9a04-2bff37fd0c6b)



### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
