### PR TITLE
[Release] Bumped datadog_cluster_agent version to 2.11.1 (#17013)

### DIFF
--- a/datadog_cluster_agent/CHANGELOG.md
+++ b/datadog_cluster_agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 2.11.1 / 2024-02-29
+
+***Fixed***:
+
+* Fix process language detection metrics ([#17001](https://github.com/DataDog/integrations-core/pull/17001))
+
 ## 2.11.0 / 2024-02-26
 
 ***Added***:

--- a/datadog_cluster_agent/changelog.d/17001.fixed
+++ b/datadog_cluster_agent/changelog.d/17001.fixed
@@ -1,1 +1,0 @@
-fix process language detection  metrics in `datadog_cluster_agent` integration

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/__about__.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '2.11.0'
+__version__ = '2.11.1'

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -35,7 +35,7 @@ datadog-coredns==3.2.0; sys_platform == 'linux2'
 datadog-couch==6.2.0
 datadog-couchbase==3.2.0
 datadog-crio==2.6.0
-datadog-datadog-cluster-agent==2.11.0
+datadog-datadog-cluster-agent==2.11.1
 datadog-dcgm==2.3.0
 datadog-directory==2.1.1
 datadog-disk==5.2.0


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Port https://github.com/DataDog/integrations-core/pull/17013 to master

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
