### PR TITLE
Remove references to the old validate manifest command

### DIFF
--- a/ddev/changelog.d/17019.fixed
+++ b/ddev/changelog.d/17019.fixed
@@ -1,0 +1,1 @@
+Remove references to the old validate manifest command

--- a/ddev/src/ddev/cli/validate/manifest.py
+++ b/ddev/src/ddev/cli/validate/manifest.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
 def manifest(ctx: click.Context, integrations: tuple[str, ...]):
     """Validate integration manifests."""
     import httpx
-    from datadog_checks.dev.tooling.commands.validate.manifest import manifest as legacy_manifest_validation
 
     app: Application = ctx.obj
     validation_tracker = app.create_validation_tracker('Manifests')
@@ -47,5 +46,4 @@ def manifest(ctx: click.Context, integrations: tuple[str, ...]):
         validation_tracker.display()
         app.abort()
 
-    ctx.invoke(legacy_manifest_validation, check=integrations[0] if integrations else None, ignore_schema=True)
     validation_tracker.display()

--- a/ddev/tests/cli/validate/test_manifest.py
+++ b/ddev/tests/cli/validate/test_manifest.py
@@ -90,7 +90,6 @@ def test_passing(ddev, helpers, network_replay):
     assert result.exit_code == 0, result.output
     assert helpers.remove_trailing_spaces(result.output) == helpers.dedent(
         """
-        Validating manifest.json files for 1 checks ...
         Manifests
 
         Passed: 1

--- a/ddev/tests/conftest.py
+++ b/ddev/tests/conftest.py
@@ -188,7 +188,6 @@ def local_clone(isolation, local_repo) -> Generator[ClonedRepo, None, None]:
         PLATFORM.check_command_output(['git', 'config', 'commit.gpgsign', 'false'])
 
     # We pin the clone of the repo used for testing to have reproducible tests.
-
     cloned_repo = ClonedRepo(cloned_repo_path, 'f7f18ca567bd7712e08692f4e73104706d9942f3', 'ddev-testing')
     cloned_repo.reset_branch()
 

--- a/ddev/tests/conftest.py
+++ b/ddev/tests/conftest.py
@@ -188,6 +188,7 @@ def local_clone(isolation, local_repo) -> Generator[ClonedRepo, None, None]:
         PLATFORM.check_command_output(['git', 'config', 'commit.gpgsign', 'false'])
 
     # We pin the clone of the repo used for testing to have reproducible tests.
+
     cloned_repo = ClonedRepo(cloned_repo_path, 'f7f18ca567bd7712e08692f4e73104706d9942f3', 'ddev-testing')
     cloned_repo.reset_branch()
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove references to the old validate manifest command

### Motivation
<!-- What inspired you to submit this pull request? -->

Missed in https://github.com/DataDog/integrations-core/pull/17008, we now use the endpoint and the `validate-manifest` job to validate it

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
