### PR TITLE
[SQLServer] - Improve the logging around query obfuscation errors

### DIFF
--- a/sqlserver/changelog.d/17020.fixed
+++ b/sqlserver/changelog.d/17020.fixed
@@ -1,0 +1,1 @@
+Fix an issue where logging of obfuscation errors would still hide the statement when it's part of a stored procedure.

--- a/sqlserver/changelog.d/17020.fixed
+++ b/sqlserver/changelog.d/17020.fixed
@@ -1,1 +1,1 @@
-Fix an issue where logging of obfuscation errors would still hide the statement when it's part of a stored procedure.
+Fix an issue where logging of obfuscation errors would still hide the statement when it's part of a stored procedure. If the stored procedure obfuscation fails, the `procedure_signature` tag will be set to `__procedure_obfuscation_error__`.

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -286,12 +286,11 @@ class SqlserverActivity(DBMAsyncJob):
             # sqlserver doesn't have a boolean data type so convert integer to boolean
             comments, row['is_proc'], procedure_name = extract_sql_comments_and_procedure_name(row['text'])
             if row['is_proc'] and 'text' in row:
-                procedure_content = None
                 try:
                     procedure_statement = obfuscate_sql_with_metadata(
                         row['text'], self._config.obfuscator_options, replace_null_character=True
                     )
-                    procedure_content = procedure_statement['query']
+                    row['procedure_signature'] = compute_sql_signature(procedure_statement['query'])
                 except Exception as e:
                     row['procedure_signature'] = '__procedure_obfuscation_error__'
                     # if we fail to obfuscate the procedure text,
@@ -300,8 +299,6 @@ class SqlserverActivity(DBMAsyncJob):
                         self.log.warning("Failed to obfuscate stored procedure=[%s] | err=[%s]", repr(row['text']), e)
                     else:
                         self.log.debug("Failed to obfuscate stored procedure | err=[%s]", e)
-                if procedure_content:
-                    row['procedure_signature'] = compute_sql_signature(procedure_content)
             obfuscated_statement = statement['query']
             metadata = statement['metadata']
             row['dd_commands'] = metadata.get('commands', None)

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -293,7 +293,7 @@ class SqlserverActivity(DBMAsyncJob):
                     )
                     procedure_content = procedure_statement['query']
                 except Exception as e:
-                    row['procedure_signature'] = '__procedure_signature_error__'
+                    row['procedure_signature'] = '__procedure_obfuscation_error__'
                     # if we fail to obfuscate the procedure text,
                     # we should not mark query statement as failed to obfuscate
                     if self._config.log_unobfuscated_queries:

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -333,12 +333,14 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             obfuscated_statement = statement['query']
             query_signature = compute_sql_signature(obfuscated_statement)
 
+            procedure_signature = None
             if row['is_proc']:
                 try:
                     procedure_statement = obfuscate_sql_with_metadata(
                         row['text'], self._config.obfuscator_options, replace_null_character=True
                     )
                 except Exception as e:
+                    procedure_signature = '__procedure_obfuscation_error__'
                     if self._config.log_unobfuscated_queries:
                         self.log.warning("Failed to obfuscate stored procedure=[%s] | err=[%s]", repr(row['text']), e)
                     else:
@@ -358,6 +360,10 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             if procedure_statement:
                 row['procedure_text'] = procedure_statement['query']
                 row['procedure_signature'] = compute_sql_signature(procedure_statement['query'])
+
+            elif procedure_signature:
+                row['procedure_signature'] = procedure_signature
+
             if procedure_name:
                 row['procedure_name'] = procedure_name
 

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -348,7 +348,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                     if self._config.log_unobfuscated_queries:
                         self.log.warning("Failed to obfuscate stored procedure=[%s] | err=[%s]", repr(row['text']), e)
                     else:
-                        self.log.info(
+                        self.log.debug(
                             "Failed to obfuscate stored procedure for query_signature=[%s] | err=[%s]",
                             query_signature,
                             e,

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -340,11 +340,13 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                     )
                 except Exception as e:
                     if self._config.log_unobfuscated_queries:
-                        self.log.warning(
-                            "Failed to obfuscate stored procedure=[%s] | err=[%s]", repr(row['text']), e
-                        )
+                        self.log.warning("Failed to obfuscate stored procedure=[%s] | err=[%s]", repr(row['text']), e)
                     else:
-                        self.log.info("Failed to obfuscate stored procedure for query_signature=[%s] | err=[%s]", query_signature, e)
+                        self.log.info(
+                            "Failed to obfuscate stored procedure for query_signature=[%s] | err=[%s]",
+                            query_signature,
+                            e,
+                        )
                     self._check.count(
                         "dd.sqlserver.statements.error",
                         1,

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -356,7 +356,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                     self._check.count(
                         "dd.sqlserver.statements.error",
                         1,
-                        **self._check.debug_stats_kwargs(tags=["error:obfuscate-query-{}".format(type(e))])
+                        **self._check.debug_stats_kwargs(tags=["error:obfuscate-sproc-{}".format(type(e))])
                     )
                     # If we can't obfuscate the stored procedure, we don't need to give up for this row,
                     # we just won't have the association with the stored procedure in the metrics payload

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -308,23 +308,17 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         normalized_rows = []
 
         for row in rows:
+            # Attempt to obfuscate SQL statement with metadata
+            procedure_statement = None
             try:
-                # Attempt to obfuscate SQL statement with metadata
-                procedure_statement = None
                 statement = obfuscate_sql_with_metadata(
                     row['statement_text'], self._config.obfuscator_options, replace_null_character=True
                 )
                 comments, row['is_proc'], procedure_name = extract_sql_comments_and_procedure_name(row['text'])
 
-                if row['is_proc']:
-                    procedure_statement = obfuscate_sql_with_metadata(
-                        row['text'], self._config.obfuscator_options, replace_null_character=True
-                    )
-
             except Exception as e:
                 if self._config.log_unobfuscated_queries:
-                    raw_query_text = row['text'] if row.get('is_proc', False) else row['statement_text']
-                    self.log.warning("Failed to obfuscate query=[%s] | err=[%s]", repr(raw_query_text), e)
+                    self.log.warning("Failed to obfuscate query=[%s] | err=[%s]", repr(row['statement_text']), e)
                 else:
                     self.log.debug("Failed to obfuscate query | err=[%s]", e)
                 self._check.count(
@@ -332,11 +326,32 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                     1,
                     **self._check.debug_stats_kwargs(tags=["error:obfuscate-query-{}".format(type(e))])
                 )
+                # If we can't obfuscate the query, give up.
                 continue
 
             # Extract obfuscated statement and update row fields
             obfuscated_statement = statement['query']
-            row['dd_comments'] = comments
+            query_signature = compute_sql_signature(obfuscated_statement)
+
+            if row['is_proc']:
+                try:
+                    procedure_statement = obfuscate_sql_with_metadata(
+                        row['text'], self._config.obfuscator_options, replace_null_character=True
+                    )
+                except Exception as e:
+                    if self._config.log_unobfuscated_queries:
+                        self.log.warning(
+                            "Failed to obfuscate stored procedure=[%s] | err=[%s]", repr(row['text']), e
+                        )
+                    else:
+                        self.log.info("Failed to obfuscate stored procedure for query_signature=[%s] | err=[%s]", query_signature, e)
+                    self._check.count(
+                        "dd.sqlserver.statements.error",
+                        1,
+                        **self._check.debug_stats_kwargs(tags=["error:obfuscate-query-{}".format(type(e))])
+                    )
+                    # If we can't obfuscate the stored procedure, we don't need to give up for this row,
+                    # we just won't have the association with the stored procedure in the metrics payload
 
             if procedure_statement:
                 row['procedure_text'] = procedure_statement['query']
@@ -344,8 +359,9 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             if procedure_name:
                 row['procedure_name'] = procedure_name
 
+            row['dd_comments'] = comments
             row['text'] = obfuscated_statement
-            row['query_signature'] = compute_sql_signature(obfuscated_statement)
+            row['query_signature'] = query_signature
             row['query_hash'] = _hash_to_hex(row['query_hash'])
             row['query_plan_hash'] = _hash_to_hex(row['query_plan_hash'])
             row['plan_handle'] = _hash_to_hex(row['plan_handle'])

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -607,7 +607,7 @@ def test_activity_stored_procedure_failed_to_obfuscate(dbm_instance, datadog_age
         assert len(result_rows) == 1
         assert result_rows[0]['text'] == statement_text
         assert result_rows[0]['is_proc'] is True
-        assert 'procedure_signature' not in result_rows[0]
+        assert result_rows[0]['procedure_signature'] == '__procedure_obfuscation_error__'
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where enabling obfuscation error logging would still hide the statement text if the statement is part of a stored procedure. 

### Motivation

Customers enabling the logging of obfuscation errors can't debug which statement is causing the issue.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
