### PR TITLE
Fix a deprecation warning

### DIFF
--- a/ddev/changelog.d/17021.fixed
+++ b/ddev/changelog.d/17021.fixed
@@ -1,0 +1,1 @@
+Fix a deprecation warning

--- a/ddev/src/ddev/utils/github.py
+++ b/ddev/src/ddev/utils/github.py
@@ -122,7 +122,9 @@ class GitHubManager:
         return response.text
 
     def create_label(self, name, color):
-        self.__api_post(self.LABELS_API.format(repo_id=self.repo_id), content=json.dumps({'name': name, 'color': color}))
+        self.__api_post(
+            self.LABELS_API.format(repo_id=self.repo_id), content=json.dumps({'name': name, 'color': color})
+        )
 
     def get_label(self, name):
         return self.__api_get(f'{self.LABELS_API.format(repo_id=self.repo_id)}/{name}')

--- a/ddev/src/ddev/utils/github.py
+++ b/ddev/src/ddev/utils/github.py
@@ -122,7 +122,7 @@ class GitHubManager:
         return response.text
 
     def create_label(self, name, color):
-        self.__api_post(self.LABELS_API.format(repo_id=self.repo_id), data=json.dumps({'name': name, 'color': color}))
+        self.__api_post(self.LABELS_API.format(repo_id=self.repo_id), content=json.dumps({'name': name, 'color': color}))
 
     def get_label(self, name):
         return self.__api_get(f'{self.LABELS_API.format(repo_id=self.repo_id)}/{name}')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix a deprecation warning 

### Motivation
<!-- What inspired you to submit this pull request? -->

```tests/utils/test_github.py::TestCreateLabel::test_create_label
  /Users/florent.clarret/Library/Application Support/hatch/env/virtual/ddev/U6fecnxT/ddev/lib/python3.11/site-packages/httpx/_content.py:204: DeprecationWarning: Use 'content=<...>' to upload raw bytes/text content.
    warnings.warn(message, DeprecationWarning)
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
