### PR TITLE
Move DCA integration to OMv2

### DIFF
--- a/datadog_cluster_agent/assets/configuration/spec.yaml
+++ b/datadog_cluster_agent/assets/configuration/spec.yaml
@@ -4,12 +4,18 @@ files:
   options:
   - template: init_config
     options:
-      - template: init_config/openmetrics_legacy
+      - template: init_config/openmetrics
   - template: instances
     options:
-      - template: instances/openmetrics_legacy
+      - template: instances/openmetrics_legacy_base
         overrides:
+          prometheus_url.required: false
           prometheus_url.value.example: http://localhost:5000/metrics
+      - template: instances/openmetrics
+        hidden: true
+        overrides:
+          openmetrics_endpoint.required: false
+          openmetrics_endpoint.value.example: http://localhost:5000/metrics
 - name: auto_conf.yaml
   options:
   - template: ad_identifiers

--- a/datadog_cluster_agent/changelog.d/17023.added
+++ b/datadog_cluster_agent/changelog.d/17023.added
@@ -1,0 +1,2 @@
+Allow datadog-cluster-agent integration to use OpenMetrics V2, defaulting to OpenMetrics V1.
+Activating usage of OpenMetrics V2 for datadog-cluster-agent is not backward compatible and existing monitors and dashboards need to be adapted.

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
@@ -2,65 +2,33 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from datadog_checks.base import OpenMetricsBaseCheck
+from six import PY2
 
-DEFAULT_METRICS = {
-    'admission_webhooks_certificate_expiry': 'admission_webhooks.certificate_expiry',
-    'admission_webhooks_library_injection_attempts': 'admission_webhooks.library_injection_attempts',
-    'admission_webhooks_library_injection_errors': 'admission_webhooks.library_injection_errors',
-    'admission_webhooks_mutation_attempts': 'admission_webhooks.mutation_attempts',
-    'admission_webhooks_mutation_errors': 'admission_webhooks.mutation_errors',
-    'admission_webhooks_patcher_attempts': 'admission_webhooks.patcher.attempts',
-    'admission_webhooks_patcher_completed': 'admission_webhooks.patcher.completed',
-    'admission_webhooks_patcher_errors': 'admission_webhooks.patcher.errors',
-    'admission_webhooks_rc_provider_configs': 'admission_webhooks.rc_provider.configs',
-    'admission_webhooks_rc_provider_configs_invalid': 'admission_webhooks.rc_provider.invalid_configs',
-    'admission_webhooks_reconcile_errors': 'admission_webhooks.reconcile_errors',
-    'admission_webhooks_reconcile_success': 'admission_webhooks.reconcile_success',
-    'admission_webhooks_response_duration': 'admission_webhooks.response_duration',
-    'admission_webhooks_webhooks_received': 'admission_webhooks.webhooks_received',
-    'aggregator__flush': 'aggregator.flush',
-    'aggregator__processed': 'aggregator.processed',
-    'api_requests': 'api_requests',
-    'autodiscovery_errors': 'autodiscovery.errors',
-    'autodiscovery_poll_duration': 'autodiscovery.poll_duration',
-    'autodiscovery_watched_resources': 'autodiscovery.watched_resources',
-    'cluster_checks_busyness': 'cluster_checks.busyness',
-    'cluster_checks_configs_dangling': 'cluster_checks.configs_dangling',
-    'cluster_checks_configs_dispatched': 'cluster_checks.configs_dispatched',
-    'cluster_checks_configs_info': 'cluster_checks.configs_info',
-    'cluster_checks_failed_stats_collection': 'cluster_checks.failed_stats_collection',
-    'cluster_checks_nodes_reporting': 'cluster_checks.nodes_reporting',
-    'cluster_checks_rebalancing_decisions': 'cluster_checks.rebalancing_decisions',
-    'cluster_checks_rebalancing_duration_seconds': 'cluster_checks.rebalancing_duration_seconds',
-    'cluster_checks_successful_rebalancing_moves': 'cluster_checks.successful_rebalancing_moves',
-    'cluster_checks_updating_stats_duration_seconds': 'cluster_checks.updating_stats_duration_seconds',
-    'datadog_requests': 'datadog.requests',
-    'endpoint_checks_configs_dispatched': 'endpoint_checks.configs_dispatched',
-    'external_metrics': 'external_metrics',
-    'external_metrics_api_elapsed': 'external_metrics.api_elapsed',
-    'external_metrics_api_requests': 'external_metrics.api_requests',
-    'external_metrics_datadog_metrics': 'external_metrics.datadog_metrics',
-    'external_metrics_delay_seconds': 'external_metrics.delay_seconds',
-    'external_metrics_processed_value': 'external_metrics.processed_value',
-    'go_goroutines': 'go.goroutines',
-    'go_memstats_alloc_bytes': 'go.memstats.alloc_bytes',
-    'go_threads': 'go.threads',
-    'kubernetes_apiserver_emitted_events': 'kubernetes_apiserver.emitted_events',
-    'kubernetes_apiserver_kube_events': 'kubernetes_apiserver.kube_events',
-    'language_detection_dca_handler_processed_requests': 'language_detection_dca_handler.processed_requests',
-    'language_detection_patcher_patches': 'language_detection_patcher.patches',
-    'rate_limit_queries_limit': 'datadog.rate_limit_queries.limit',
-    'rate_limit_queries_period': 'datadog.rate_limit_queries.period',
-    'rate_limit_queries_remaining': 'datadog.rate_limit_queries.remaining',
-    'rate_limit_queries_remaining_min': 'datadog.rate_limit_queries.remaining_min',
-    'rate_limit_queries_reset': 'datadog.rate_limit_queries.reset',
-    'secret_backend__elapsed_ms': 'secret_backend.elapsed',
-}
+from datadog_checks.base import OpenMetricsBaseCheck
+from datadog_checks.base.errors import ConfigurationError
+
+from .metrics import METRICS_MAP
 
 
 class DatadogClusterAgentCheck(OpenMetricsBaseCheck):
     DEFAULT_METRIC_LIMIT = 0
+
+    def __new__(cls, name, init_config, instances):
+        instance = instances[0]
+
+        if instance.get('openmetrics_endpoint'):
+            if PY2:
+                raise ConfigurationError(
+                    'This version of the integration is only available when using Python 3. '
+                    'Check https://docs.datadoghq.com/agent/guide/agent-v6-python-3/ '
+                    'for more information or use the older style config.'
+                )
+            # TODO: when we drop Python 2 move this import up top
+            from .check_v2 import DatadogClusterAgentCheckV2
+
+            return DatadogClusterAgentCheckV2(name, init_config, instances)
+
+        return super(DatadogClusterAgentCheck, cls).__new__(cls)
 
     def __init__(self, name, init_config, instances):
         super(DatadogClusterAgentCheck, self).__init__(
@@ -71,7 +39,7 @@ class DatadogClusterAgentCheck(OpenMetricsBaseCheck):
                 'datadog.cluster_agent': {
                     'prometheus_url': 'http://localhost:5000/metrics',
                     'namespace': 'datadog.cluster_agent',
-                    'metrics': [DEFAULT_METRICS],
+                    'metrics': [METRICS_MAP],
                     'label_joins': {
                         'leader_election_is_leader': {
                             'labels_to_match': ['*'],

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check_v2.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check_v2.py
@@ -1,0 +1,34 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from datadog_checks.base import OpenMetricsBaseCheckV2
+from datadog_checks.base.checks.openmetrics.v2.scraper import OpenMetricsCompatibilityScraper
+
+from .config_models import ConfigMixin
+from .metrics import METRICS_MAP, construct_metrics_config
+
+
+class DatadogClusterAgentCheckV2(OpenMetricsBaseCheckV2, ConfigMixin):
+    __NAMESPACE__ = 'datadog.cluster_agent'
+
+    DEFAULT_METRIC_LIMIT = 0
+
+    def __init__(self, name, init_config, instances):
+        super().__init__(name, init_config, instances)
+
+    def get_default_config(self):
+        return {
+            'openmetrics_endpoint': 'http://localhost:5000/metrics',
+            'metrics': construct_metrics_config(METRICS_MAP, {}),
+            'share_labels': {
+                'leader_election_is_leader': {
+                    'labels': ['is_leader'],
+                    'values': [1]
+                }
+            },
+            'histogram_buckets_as_distributions': True,
+        }
+
+    def create_scraper(self, config):
+        return OpenMetricsCompatibilityScraper(self, self.get_config_with_defaults(config))

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/defaults.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/defaults.py
@@ -28,6 +28,22 @@ def instance_bearer_token_refresh_interval():
     return 60
 
 
+def instance_cache_metric_wildcards():
+    return True
+
+
+def instance_cache_shared_labels():
+    return True
+
+
+def instance_collect_counters_with_distributions():
+    return False
+
+
+def instance_collect_histogram_buckets():
+    return True
+
+
 def instance_disable_generic_tags():
     return False
 
@@ -36,8 +52,20 @@ def instance_empty_default_hostname():
     return False
 
 
+def instance_enable_health_service_check():
+    return True
+
+
 def instance_health_service_check():
     return True
+
+
+def instance_histogram_buckets_as_distributions():
+    return False
+
+
+def instance_ignore_connection_errors():
+    return False
 
 
 def instance_kerberos_auth():
@@ -64,12 +92,24 @@ def instance_namespace():
     return 'service'
 
 
+def instance_non_cumulative_histogram_buckets():
+    return False
+
+
+def instance_openmetrics_endpoint():
+    return 'http://localhost:5000/metrics'
+
+
 def instance_persist_connections():
     return False
 
 
+def instance_prometheus_url():
+    return 'http://localhost:5000/metrics'
+
+
 def instance_request_size():
-    return 10
+    return 16
 
 
 def instance_send_distribution_buckets():
@@ -100,6 +140,14 @@ def instance_skip_proxy():
     return False
 
 
+def instance_tag_by_endpoint():
+    return True
+
+
+def instance_telemetry():
+    return False
+
+
 def instance_timeout():
     return 10
 
@@ -114,6 +162,10 @@ def instance_tls_use_host_header():
 
 def instance_tls_verify():
     return True
+
+
+def instance_use_latest_spec():
+    return False
 
 
 def instance_use_legacy_auth_encoding():

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/instance.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/instance.py
@@ -29,6 +29,16 @@ class AuthToken(BaseModel):
     writer: Optional[MappingProxyType[str, Any]] = None
 
 
+class ExtraMetric(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        extra='allow',
+        frozen=True,
+    )
+    name: Optional[str] = None
+    type: Optional[str] = None
+
+
 class IgnoreMetricsByLabels(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -74,6 +84,15 @@ class Proxy(BaseModel):
     no_proxy: Optional[tuple[str, ...]] = None
 
 
+class ShareLabel(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    labels: Optional[tuple[str, ...]] = None
+    match: Optional[tuple[str, ...]] = None
+
+
 class InstanceConfig(BaseModel):
     model_config = ConfigDict(
         validate_default=True,
@@ -89,13 +108,25 @@ class InstanceConfig(BaseModel):
     bearer_token_auth: Optional[Union[bool, str]] = None
     bearer_token_path: Optional[str] = None
     bearer_token_refresh_interval: Optional[int] = None
+    cache_metric_wildcards: Optional[bool] = None
+    cache_shared_labels: Optional[bool] = None
+    collect_counters_with_distributions: Optional[bool] = None
+    collect_histogram_buckets: Optional[bool] = None
     connect_timeout: Optional[float] = None
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
+    enable_health_service_check: Optional[bool] = None
     exclude_labels: Optional[tuple[str, ...]] = None
+    exclude_metrics: Optional[tuple[str, ...]] = None
+    exclude_metrics_by_labels: Optional[MappingProxyType[str, Union[bool, tuple[str, ...]]]] = None
     extra_headers: Optional[MappingProxyType[str, Any]] = None
+    extra_metrics: Optional[tuple[Union[str, MappingProxyType[str, Union[str, ExtraMetric]]], ...]] = None
     headers: Optional[MappingProxyType[str, Any]] = None
     health_service_check: Optional[bool] = None
+    histogram_buckets_as_distributions: Optional[bool] = None
+    hostname_format: Optional[str] = None
+    hostname_label: Optional[str] = None
+    ignore_connection_errors: Optional[bool] = None
     ignore_metrics: Optional[tuple[str, ...]] = None
     ignore_metrics_by_labels: Optional[IgnoreMetricsByLabels] = None
     ignore_tags: Optional[tuple[str, ...]] = None
@@ -115,13 +146,18 @@ class InstanceConfig(BaseModel):
     metrics: Optional[tuple[Union[str, MappingProxyType[str, str]], ...]] = None
     min_collection_interval: Optional[float] = None
     namespace: Optional[str] = None
+    non_cumulative_histogram_buckets: Optional[bool] = None
     ntlm_domain: Optional[str] = None
+    openmetrics_endpoint: Optional[str] = None
     password: Optional[str] = None
     persist_connections: Optional[bool] = None
     prometheus_metrics_prefix: Optional[str] = None
-    prometheus_url: str
+    prometheus_url: Optional[str] = None
     proxy: Optional[Proxy] = None
+    raw_line_filters: Optional[tuple[str, ...]] = None
+    raw_metric_prefix: Optional[str] = None
     read_timeout: Optional[float] = None
+    rename_labels: Optional[MappingProxyType[str, Any]] = None
     request_size: Optional[float] = None
     send_distribution_buckets: Optional[bool] = None
     send_distribution_counts_as_monotonic: Optional[bool] = None
@@ -130,8 +166,11 @@ class InstanceConfig(BaseModel):
     send_monotonic_counter: Optional[bool] = None
     send_monotonic_with_gauge: Optional[bool] = None
     service: Optional[str] = None
+    share_labels: Optional[MappingProxyType[str, Union[bool, ShareLabel]]] = None
     skip_proxy: Optional[bool] = None
+    tag_by_endpoint: Optional[bool] = None
     tags: Optional[tuple[str, ...]] = None
+    telemetry: Optional[bool] = None
     timeout: Optional[float] = None
     tls_ca_cert: Optional[str] = None
     tls_cert: Optional[str] = None
@@ -141,6 +180,7 @@ class InstanceConfig(BaseModel):
     tls_use_host_header: Optional[bool] = None
     tls_verify: Optional[bool] = None
     type_overrides: Optional[MappingProxyType[str, Any]] = None
+    use_latest_spec: Optional[bool] = None
     use_legacy_auth_encoding: Optional[bool] = None
     use_process_start_time: Optional[bool] = None
     username: Optional[str] = None

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/auto_conf.yaml
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/auto_conf.yaml
@@ -347,11 +347,6 @@ instances:
     ##     client_secret (required): The client secret.
     ##     basic_auth: Whether the provider expects credentials to be transmitted in
     ##                 an HTTP Basic Auth header. The default is: false
-    ##     options: Mapping of additional options to pass to the provider, such as the audience
-    ##              or the scope. For example:
-    ##                 options:
-    ##                   audience: https://example.com
-    ##                   scope: read:example
     ##
     ## The available writers are:
     ##

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
@@ -45,10 +45,11 @@ init_config:
 #
 instances:
 
-    ## @param prometheus_url - string - required
+  -
+    ## @param prometheus_url - string - optional - default: http://localhost:5000/metrics
     ## The URL where your application metrics are exposed by Prometheus.
     #
-  - prometheus_url: http://localhost:5000/metrics
+    # prometheus_url: http://localhost:5000/metrics
 
     ## @param prometheus_metrics_prefix - string - optional
     ## Removes a given <PREFIX> from exposed Prometheus metrics.
@@ -339,11 +340,6 @@ instances:
     ##     client_secret (required): The client secret.
     ##     basic_auth: Whether the provider expects credentials to be transmitted in
     ##                 an HTTP Basic Auth header. The default is: false
-    ##     options: Mapping of additional options to pass to the provider, such as the audience
-    ##              or the scope. For example:
-    ##                 options:
-    ##                   audience: https://example.com
-    ##                   scope: read:example
     ##
     ## The available writers are:
     ##
@@ -476,10 +472,10 @@ instances:
     #
     # read_timeout: <READ_TIMEOUT>
 
-    ## @param request_size - number - optional - default: 10
+    ## @param request_size - number - optional - default: 16
     ## The number of kibibytes (KiB) to read from streaming HTTP responses at a time.
     #
-    # request_size: 10
+    # request_size: 16
 
     ## @param log_requests - boolean - optional - default: false
     ## Whether or not to debug log the HTTP(S) requests made, including the method and URL.

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/metrics.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/metrics.py
@@ -1,0 +1,75 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+METRICS_MAP = {
+    'admission_webhooks_certificate_expiry': 'admission_webhooks.certificate_expiry',
+    'admission_webhooks_library_injection_attempts': 'admission_webhooks.library_injection_attempts',
+    'admission_webhooks_library_injection_errors': 'admission_webhooks.library_injection_errors',
+    'admission_webhooks_mutation_attempts': 'admission_webhooks.mutation_attempts',
+    'admission_webhooks_mutation_errors': 'admission_webhooks.mutation_errors',
+    'admission_webhooks_patcher_attempts': 'admission_webhooks.patcher.attempts',
+    'admission_webhooks_patcher_completed': 'admission_webhooks.patcher.completed',
+    'admission_webhooks_patcher_errors': 'admission_webhooks.patcher.errors',
+    'admission_webhooks_rc_provider_configs': 'admission_webhooks.rc_provider.configs',
+    'admission_webhooks_rc_provider_configs_invalid': 'admission_webhooks.rc_provider.invalid_configs',
+    'admission_webhooks_reconcile_errors': 'admission_webhooks.reconcile_errors',
+    'admission_webhooks_reconcile_success': 'admission_webhooks.reconcile_success',
+    'admission_webhooks_response_duration': 'admission_webhooks.response_duration',
+    'admission_webhooks_webhooks_received': 'admission_webhooks.webhooks_received',
+    'aggregator__flush': 'aggregator.flush',
+    'aggregator__processed': 'aggregator.processed',
+    'api_requests': 'api_requests',
+    'autodiscovery_errors': 'autodiscovery.errors',
+    'autodiscovery_poll_duration': 'autodiscovery.poll_duration',
+    'autodiscovery_watched_resources': 'autodiscovery.watched_resources',
+    'cluster_checks_busyness': 'cluster_checks.busyness',
+    'cluster_checks_configs_dangling': 'cluster_checks.configs_dangling',
+    'cluster_checks_configs_dispatched': 'cluster_checks.configs_dispatched',
+    'cluster_checks_configs_info': 'cluster_checks.configs_info',
+    'cluster_checks_failed_stats_collection': 'cluster_checks.failed_stats_collection',
+    'cluster_checks_nodes_reporting': 'cluster_checks.nodes_reporting',
+    'cluster_checks_rebalancing_decisions': 'cluster_checks.rebalancing_decisions',
+    'cluster_checks_rebalancing_duration_seconds': 'cluster_checks.rebalancing_duration_seconds',
+    'cluster_checks_successful_rebalancing_moves': 'cluster_checks.successful_rebalancing_moves',
+    'cluster_checks_updating_stats_duration_seconds': 'cluster_checks.updating_stats_duration_seconds',
+    'datadog_requests': 'datadog.requests',
+    'endpoint_checks_configs_dispatched': 'endpoint_checks.configs_dispatched',
+    'external_metrics': 'external_metrics',
+    'external_metrics_api_elapsed': 'external_metrics.api_elapsed',
+    'external_metrics_api_requests': 'external_metrics.api_requests',
+    'external_metrics_datadog_metrics': 'external_metrics.datadog_metrics',
+    'external_metrics_delay_seconds': 'external_metrics.delay_seconds',
+    'external_metrics_processed_value': 'external_metrics.processed_value',
+    'go_goroutines': 'go.goroutines',
+    'go_memstats_alloc_bytes': 'go.memstats.alloc_bytes',
+    'go_threads': 'go.threads',
+    'kubernetes_apiserver_emitted_events': 'kubernetes_apiserver.emitted_events',
+    'kubernetes_apiserver_kube_events': 'kubernetes_apiserver.kube_events',
+    'language_detection_dca_handler_processed_requests': 'language_detection_dca_handler.processed_requests',
+    'language_detection_patcher_patches': 'language_detection_patcher.patches',
+    'rate_limit_queries_limit': 'datadog.rate_limit_queries.limit',
+    'rate_limit_queries_period': 'datadog.rate_limit_queries.period',
+    'rate_limit_queries_remaining': 'datadog.rate_limit_queries.remaining',
+    'rate_limit_queries_remaining_min': 'datadog.rate_limit_queries.remaining_min',
+    'rate_limit_queries_reset': 'datadog.rate_limit_queries.reset',
+    'secret_backend__elapsed_ms': 'secret_backend.elapsed',
+}
+
+
+def construct_metrics_config(metric_map, type_overrides):
+    metrics = []
+    for raw_metric_name, metric_name in metric_map.items():
+        if raw_metric_name.endswith('_total'):
+            raw_metric_name = raw_metric_name[:-6]
+            metric_name = metric_name[:-6]
+        elif metric_name.endswith('.count'):
+            metric_name = metric_name[:-6]
+
+        config = {raw_metric_name: {'name': metric_name}}
+        if raw_metric_name in type_overrides:
+            config[raw_metric_name]['type'] = type_overrides[raw_metric_name]
+
+        metrics.append(config)
+
+    return metrics

--- a/datadog_cluster_agent/tests/conftest.py
+++ b/datadog_cluster_agent/tests/conftest.py
@@ -1,23 +1,28 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
 import os
-from copy import deepcopy
 
 import mock
 import pytest
 
-INSTANCE = {'prometheus_url': 'http://localhost:5000/metrics'}
+URL = 'http://localhost:5000/metrics'
 
 
 @pytest.fixture(scope='session')
 def dd_environment():
-    yield deepcopy(INSTANCE)
+    yield instance_v1()
 
 
 @pytest.fixture
-def instance():
-    return deepcopy(INSTANCE)
+def instance_v1():
+    return {'prometheus_url': URL}
+
+
+@pytest.fixture
+def instance_v2():
+    return {'openmetrics_endpoint': URL}
 
 
 @pytest.fixture()

--- a/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
+++ b/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
@@ -1,8 +1,8 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from typing import Any, Dict  # noqa: F401
 
+from six import PY2
 import pytest
 
 from datadog_checks.base import AgentCheck
@@ -69,15 +69,64 @@ METRICS = [
     'secret_backend.elapsed',
 ]
 
+METRICS_V2 = [
+    'admission_webhooks.certificate_expiry',
+    'admission_webhooks.library_injection_attempts.count',
+    'admission_webhooks.library_injection_errors.count',
+    'admission_webhooks.mutation_attempts',
+    'admission_webhooks.mutation_errors',
+    'admission_webhooks.patcher.attempts.count',
+    'admission_webhooks.patcher.completed.count',
+    'admission_webhooks.patcher.errors.count',
+    'admission_webhooks.rc_provider.configs',
+    'admission_webhooks.rc_provider.invalid_configs',
+    'admission_webhooks.reconcile_errors',
+    'admission_webhooks.reconcile_success',
+    'admission_webhooks.webhooks_received',
+    'aggregator.flush.count',
+    'aggregator.processed.count',
+    'api_requests.count',
+    'autodiscovery.errors',
+    'autodiscovery.watched_resources',
+    'cluster_checks.busyness',
+    'cluster_checks.configs_dangling',
+    'cluster_checks.configs_dispatched',
+    'cluster_checks.configs_info',
+    'cluster_checks.failed_stats_collection.count',
+    'cluster_checks.nodes_reporting',
+    'cluster_checks.rebalancing_decisions.count',
+    'cluster_checks.rebalancing_duration_seconds',
+    'cluster_checks.successful_rebalancing_moves.count',
+    'cluster_checks.updating_stats_duration_seconds',
+    'datadog.rate_limit_queries.limit',
+    'datadog.rate_limit_queries.period',
+    'datadog.rate_limit_queries.remaining',
+    'datadog.rate_limit_queries.remaining_min',
+    'datadog.rate_limit_queries.reset',
+    'datadog.requests.count',
+    'endpoint_checks.configs_dispatched',
+    'external_metrics',
+    'external_metrics.api_requests',
+    'external_metrics.datadog_metrics',
+    'external_metrics.delay_seconds',
+    'external_metrics.processed_value',
+    'go.goroutines',
+    'go.memstats.alloc_bytes',
+    'go.threads',
+    'kubernetes_apiserver.emitted_events.count',
+    'kubernetes_apiserver.kube_events.count',
+    'language_detection_dca_handler.processed_requests.count',
+    'language_detection_patcher.patches.count',
+    'secret_backend.elapsed',
+]
 
-def test_check(aggregator, instance, mock_metrics_endpoint):
-    # type: (AggregatorStub, Dict[str, Any]) -> None
-    check = DatadogClusterAgentCheck('datadog_cluster_agent', {}, [instance])
+
+def test_check(aggregator, dd_run_check, instance_v1, mock_metrics_endpoint):
+    check = DatadogClusterAgentCheck('datadog_cluster_agent', {}, [instance_v1])
 
     # dry run to build mapping for label joins
-    check.check(instance)
-
-    check.check(instance)
+    dd_run_check(check)
+    dd_run_check(check)
 
     for metric in METRICS:
         aggregator.assert_metric(NAMESPACE + '.' + metric)
@@ -85,6 +134,23 @@ def test_check(aggregator, instance, mock_metrics_endpoint):
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())
+
+
+@pytest.mark.skipif(PY2, reason='OpenMetrics V2 is only available with Python 3')
+def test_check_v2(aggregator, dd_run_check, instance_v2, mock_metrics_endpoint):
+    check = DatadogClusterAgentCheck('datadog_cluster_agent', {}, [instance_v2])
+
+    # dry run to build mapping for label joins
+    dd_run_check(check)
+    dd_run_check(check)
+
+    for metric in METRICS_V2:
+        aggregator.assert_metric(NAMESPACE + '.' + metric)
+        aggregator.assert_metric_has_tag_prefix(NAMESPACE + '.' + metric, 'is_leader:')
+
+    aggregator.assert_all_metrics_covered()
+    # Can't use metadata metrics for now, as we default to v1 metrics
+    # aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 
 
 # Minimal E2E testing


### PR DESCRIPTION
### What does this PR do?

Allow Cluster Agent integration to run with OMv2.
However not migrating to default OMv1 as it breaks backward compatibility.

### Motivation
Allow usage of OMv2.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
