### PR TITLE
[DBMON-2609] use digest_text to compute query signature for collected activities

### DIFF
--- a/mysql/changelog.d/17029.fixed
+++ b/mysql/changelog.d/17029.fixed
@@ -1,0 +1,1 @@
+Use digest_text to compute query signature for collected activities

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -35,6 +35,7 @@ SELECT
     thread_a.processlist_command,
     thread_a.processlist_state,
     COALESCE(statement.sql_text, thread_a.PROCESSLIST_info) AS sql_text,
+    statement.digest_text as digest_text,
     statement.timer_start AS event_timer_start,
     statement.timer_end AS event_timer_end,
     statement.lock_time,
@@ -210,7 +211,11 @@ class MySQLActivity(DBMAsyncJob):
         if "sql_text" not in row:
             return row
         try:
-            self._finalize_row(row, obfuscate_sql_with_metadata(row["sql_text"], self._obfuscator_options))
+            self._finalize_row(
+                row,
+                obfuscate_sql_with_metadata(row["sql_text"], self._obfuscator_options),
+                obfuscate_sql_with_metadata(row.get("digest_text"), self._obfuscator_options),
+            )
         except Exception as e:
             if self._config.log_unobfuscated_queries:
                 self._log.warning("Failed to obfuscate query=[%s] | err=[%s]", row["sql_text"], e)
@@ -225,11 +230,16 @@ class MySQLActivity(DBMAsyncJob):
         return {key: val for key, val in row.items() if val is not None}
 
     @staticmethod
-    def _finalize_row(row, statement):
-        # type: (Dict[str], Dict[str]) -> None
-        obfuscated_statement = statement["query"]
-        row["sql_text"] = obfuscated_statement
-        row["query_signature"] = compute_sql_signature(obfuscated_statement)
+    def _finalize_row(row, statement, digest_statement):
+        # type: (Dict[str], Dict[str], Dict[str]) -> None
+        row["sql_text"] = statement["query"]
+        if digest_statement["query"]:
+            # if digest_text is not NULL, use it to compute the query signature
+            row["query_signature"] = compute_sql_signature(digest_statement["query"])
+        else:
+            # fallback to sql_text when digest_text is NULL
+            # MySQL < 8.0 sometimes have NULL digest_text even when statements_digest consumer is enabled
+            row["query_signature"] = compute_sql_signature(statement["query"])
 
         metadata = statement["metadata"]
         row["dd_commands"] = metadata.get("commands", None)

--- a/mysql/tests/compose/mysql.conf
+++ b/mysql/tests/compose/mysql.conf
@@ -12,11 +12,10 @@ performance-schema-consumer-events-statements-current=ON
 performance-schema-consumer-events-statements-history=ON
 performance-schema-consumer-events-statements-history-long=ON
 performance-schema-consumer-events-waits-current=ON
-
-[mysqld-5.7]
-performance_schema_max_sql_text_length = 4096
+max_digest_length=4096
+performance_schema_max_digest_length=4096
+performance_schema_max_sql_text_length=4096
 
 [mysqld-8.0]
 general_log_file = /opt/bitnami/mysql/logs/mysql.log
 slow_query_log_file = /opt/bitnami/mysql/logs/mysql_slow.log
-performance_schema_max_sql_text_length = 4096


### PR DESCRIPTION
### What does this PR do?
This PR add `digest_text` to MySQL activity query and use `digest_text` (post obfuscation) to computed query signature whenever `digest_text` is not NULL. 

Prior to the change, `query_signature` differs in Query Samples & Explain Plans
![image](https://github.com/DataDog/integrations-core/assets/4964070/ea88f6d0-aeaa-4220-8374-af1f146cc3c8)
![image](https://github.com/DataDog/integrations-core/assets/4964070/e29d7f0a-2e74-4df7-90f2-f52a561651e0)

With this fix, `query_signature` is the same now  in Query Samples & Explain Plans
![image](https://github.com/DataDog/integrations-core/assets/4964070/e6217a39-d0fb-4428-a49a-c40e3b4d989a)
![image](https://github.com/DataDog/integrations-core/assets/4964070/4abcbaa7-c773-424c-813c-4bd1e37e2345)

### Motivation
The PR fixes an annoying mismatch in query_signature between MySQL query activity and explain plan

### Additional Notes
`digest_text` can be NULL in MySQL version < 8.0 even when `statements_digest` consumer is enabled. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
