### PR TITLE
[ECOS-1235] Add logs-backend to CODEOWNERS of assets/logs files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@ conf.yaml.default     @DataDog/documentation @DataDog/agent-integrations @DataDo
 auto_conf.yaml        @DataDog/documentation @DataDog/agent-integrations @DataDog/container-integrations
 manifest.json         @DataDog/documentation @DataDog/agent-integrations
 **/assets             @DataDog/documentation @DataDog/agent-integrations
+**/assets/logs        @DataDog/logs-backend @DataDog/documentation @DataDog/agent-integrations
 
 # Checks base
 /datadog_checks_base/                                          @DataDog/agent-integrations
@@ -23,86 +24,114 @@ manifest.json         @DataDog/documentation @DataDog/agent-integrations
 /cert_manager/                            @DataDog/container-integrations @DataDog/agent-integrations
 /cert_manager/*.md                        @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /cert_manager/manifest.json               @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/cert_manager/assets/logs/                @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /container/                               @DataDog/container-integrations @DataDog/agent-integrations
 /container/*.md                           @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /container/manifest.json                  @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/container/assets/logs/                   @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /containerd/                              @DataDog/container-integrations @DataDog/agent-integrations
 /containerd/*.md                          @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /containerd/manifest.json                 @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/containerd/assets/logs/                  @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /cri/                                     @DataDog/container-integrations @DataDog/agent-integrations
 /cri/*.md                                 @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /cri/manifest.json                        @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/cri/assets/logs/                         @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /crio/                                    @DataDog/container-integrations @DataDog/agent-integrations
 /crio/*.md                                @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /crio/manifest.json                       @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/crio/assets/logs/                        @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /datadog_cluster_agent/                   @DataDog/container-integrations @DataDog/agent-integrations
 /datadog_cluster_agent/*.md               @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/datadog_cluster_agent/assets/logs/       @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /datadog_operator/                        @DataDog/container-ecosystems @DataDog/agent-integrations
 /datadog_operator/*.md                    @DataDog/container-ecosystems @DataDog/agent-integrations @DataDog/documentation
+/datadog_operator/assets/logs/            @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /docker_daemon/                           @DataDog/container-integrations @DataDog/agent-integrations
 /docker_daemon/*.md                       @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /docker_daemon/metadata.csv               @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /docker_daemon/manifest.json              @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/docker_daemon/assets/logs/               @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /ecs_fargate/                             @DataDog/container-integrations @DataDog/agent-integrations
 /ecs_fargate/*.md                         @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /ecs_fargate/manifest.json                @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/ecs_fargate/assets/logs/                 @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /eks_fargate/                             @DataDog/container-integrations @DataDog/agent-integrations
 /eks_fargate/*.md                         @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /eks_fargate/manifest.json                @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/eks_fargate/assets/logs/                 @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /helm/                                    @DataDog/container-integrations @DataDog/agent-integrations
 /helm/*.md                                @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /helm/manifest.json                       @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/helm/assets/logs/                        @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /kube_apiserver_metrics/                  @DataDog/container-integrations @DataDog/agent-integrations
 /kube_apiserver_metrics/*.md              @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /kube_apiserver_metrics/manifest.json     @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/kube_apiserver_metrics/assets/logs/      @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /kube_controller_manager/                 @DataDog/container-integrations @DataDog/agent-integrations
 /kube_controller_manager/*.md             @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /kube_controller_manager/manifest.json    @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/kube_controller_manager/assets/logs/     @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /kube_dns/                                @DataDog/container-integrations @DataDog/agent-integrations
 /kube_dns/*.md                            @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /kube_dns/manifest.json                   @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/kube_dns/assets/logs/                    @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /kube_metrics_server/                     @DataDog/container-integrations @DataDog/agent-integrations
 /kube_metrics_server/*.md                 @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /kube_metrics_server/manifest.json        @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/kube_metrics_server/assets/logs/         @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /kube_proxy/                              @DataDog/container-integrations @DataDog/agent-integrations
 /kube_proxy/*.md                          @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /kube_proxy/manifest.json                 @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/kube_proxy/assets/logs/                  @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /kube_scheduler/                          @DataDog/container-integrations @DataDog/agent-integrations
 /kube_scheduler/*.md                      @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /kube_scheduler/manifest.json             @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/kube_scheduler/assets/logs/              @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /kubelet/                                 @DataDog/container-integrations @DataDog/agent-integrations
 /kubelet/*.md                             @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /kubelet/manifest.json                    @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/kubelet/assets/logs/                     @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /kubernetes/                              @DataDog/container-integrations @DataDog/agent-integrations
 /kubernetes/*.md                          @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /kubernetes/manifest.json                 @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/kubernetes/assets/logs/                  @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /kubernetes_state/                        @DataDog/container-integrations @DataDog/agent-integrations
 /kubernetes_state/*.md                    @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /kubernetes_state/manifest.json           @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/kubernetes_state/assets/logs/            @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /kubernetes_state_core/                   @DataDog/container-integrations @DataDog/agent-integrations
 /kubernetes_state_core/*.md               @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /kubernetes_state_core/manifest.json      @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/kubernetes_state_core/assets/logs/       @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /nginx_ingress_controller/                @DataDog/container-integrations @DataDog/agent-integrations
 /nginx_ingress_controller/*.md            @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /nginx_ingress_controller/manifest.json   @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/nginx_ingress_controller/assets/logs/    @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /oom_kill/                                @DataDog/container-integrations @DataDog/agent-integrations
 /oom_kill/*.md                            @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /oom_kill/manifest.json                   @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/oom_kill/assets/logs/                    @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /openmetrics/                             @DataDog/container-integrations @DataDog/agent-integrations
 /openmetrics/*.md                         @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /openmetrics/manifest.json                @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/openmetrics/assets/logs/                 @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /podman/                                  @DataDog/container-integrations @DataDog/agent-integrations
 /podman/*.md                              @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /podman/manifest.json                     @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/podman/assets/logs/                      @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /tcp_queue_length/                        @DataDog/container-integrations @DataDog/agent-integrations
 /tcp_queue_length/*.md                    @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /tcp_queue_length/manifest.json           @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/tcp_queue_length/assets/logs/            @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 
 # NDM
 /snmp/                                                             @DataDog/network-device-monitoring @DataDog/agent-integrations
 /snmp/*.md                                                         @DataDog/network-device-monitoring @DataDog/agent-integrations @DataDog/documentation
 /snmp_*/                                                           @DataDog/network-device-monitoring @DataDog/agent-integrations
 /snmp_*/*.md                                                       @DataDog/network-device-monitoring @DataDog/agent-integrations @DataDog/documentation
+/snmp*/assets/logs/                                                @DataDog/network-device-monitoring @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
+
 /datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/ @DataDog/network-device-monitoring @DataDog/agent-integrations
 /docs/developer/tutorials/snmp/                                    @DataDog/network-device-monitoring @DataDog/agent-integrations @DataDog/documentation
 
@@ -110,42 +139,53 @@ manifest.json         @DataDog/documentation @DataDog/agent-integrations
 /citrix_hypervisor/                     @DataDog/platform-integrations @DataDog/agent-integrations
 /citrix_hypervisor/manifest.json        @DataDog/platform-integrations @DataDog/agent-integrations @DataDog/documentation
 /citrix_hypervisor/*.md                 @DataDog/platform-integrations @DataDog/agent-integrations @DataDog/documentation
+/citrix_hypervisor/assets/logs/         @DataDog/platform-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /cloudera/                              @DataDog/platform-integrations @DataDog/agent-integrations
 /cloudera/manifest.json                 @DataDog/platform-integrations @DataDog/agent-integrations @DataDog/documentation
 /cloudera/*.md                          @DataDog/platform-integrations @DataDog/agent-integrations @DataDog/documentation
+/cloudera/assets/logs/                  @DataDog/platform-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /cloud_foundry_api/                     @DataDog/platform-integrations @DataDog/agent-integrations
 /cloud_foundry_api/manifest.json        @DataDog/platform-integrations @DataDog/agent-integrations @DataDog/documentation
 /cloud_foundry_api/*.md                 @DataDog/platform-integrations @DataDog/agent-integrations @DataDog/documentation
+/cloud_foundry_api/assets/logs/         @DataDog/platform-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /openstack/                             @DataDog/platform-integrations @DataDog/agent-integrations
 /openstack/*.md                         @DataDog/platform-integrations @DataDog/agent-integrations @DataDog/documentation
 /openstack/manifest.json                @DataDog/platform-integrations @DataDog/agent-integrations @DataDog/documentation
+/openstack/assets/logs/                 @DataDog/platform-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /openstack_controller/                  @DataDog/platform-integrations @DataDog/agent-integrations
 /openstack_controller/manifest.json     @DataDog/platform-integrations @DataDog/agent-integrations @DataDog/documentation
 /openstack_controller/*.md              @DataDog/platform-integrations @DataDog/agent-integrations @DataDog/documentation
+/openstack_controller/assets/logs/      @DataDog/platform-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /vsphere/                               @DataDog/platform-integrations @DataDog/agent-integrations
 /vsphere/manifest.json                  @DataDog/platform-integrations @DataDog/agent-integrations @DataDog/documentation
 /vsphere/*.md                           @DataDog/platform-integrations @DataDog/agent-integrations @DataDog/documentation
+/vsphere/assets/logs/                   @DataDog/platform-integrations @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 
 # System checks
 /disk/                                    @DataDog/agent-integrations @DataDog/windows-agent
 /disk/*.md                                @DataDog/agent-integrations @DataDog/windows-agent @DataDog/documentation
 /disk/manifest.json                       @DataDog/agent-integrations @DataDog/windows-agent @DataDog/documentation
+/disk/assets/logs/                        @DataDog/agent-integrations @DataDog/windows-agent @DataDog/documentation @DataDog/logs-backend
 /network/                                 @DataDog/agent-integrations @DataDog/windows-agent
 /network/*.md                             @DataDog/agent-integrations @DataDog/windows-agent @DataDog/documentation
 /network/manifest.json                    @DataDog/agent-integrations @DataDog/windows-agent @DataDog/documentation
+/network/assets/logs/                     @DataDog/agent-integrations @DataDog/windows-agent @DataDog/documentation @DataDog/logs-backend
 /process/                                 @DataDog/agent-integrations @DataDog/windows-agent
 /process/*.md                             @DataDog/agent-integrations @DataDog/windows-agent @DataDog/documentation
 /process/manifest.json                    @DataDog/agent-integrations @DataDog/windows-agent @DataDog/documentation
+/process/assets/logs/                     @DataDog/agent-integrations @DataDog/windows-agent @DataDog/documentation @DataDog/logs-backend
 
 # OpenTelemetry
 /otel/                                    @DataDog/opentelemetry @DataDog/agent-integrations
 /otel/*.md                                @DataDog/opentelemetry @DataDog/agent-integrations @DataDog/documentation
 /otel/manifest.json                       @DataDog/opentelemetry @DataDog/agent-integrations @DataDog/documentation
+/otel/assets/logs/                        @DataDog/opentelemetry @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 
 # Agent Platform
 /nvidia_jetson/                           @DataDog/agent-platform @DataDog/agent-integrations
 /nvidia_jetson/*.md                       @DataDog/agent-platform @DataDog/agent-integrations @DataDog/documentation
 /nvidia_jetson/manifest.json              @DataDog/agent-platform @DataDog/agent-integrations @DataDog/documentation
+/nvidia_jetson/assets/logs/               @DataDog/agent-platform @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 
 # Database monitoring
 **/base/utils/db/utils.py                           @DataDog/agent-integrations @DataDog/database-monitoring-agent
@@ -157,19 +197,25 @@ datadog_checks_base/tests/**/test_db_statements.py  @DataDog/database-monitoring
 /postgres/                                          @DataDog/database-monitoring-agent @DataDog/agent-integrations
 /postgres/*.md                                      @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation
 /postgres/manifest.json                             @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation
+/postgres/assets/logs/                                @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /mysql/                                             @DataDog/database-monitoring-agent @DataDog/agent-integrations
 /mysql/*.md                                         @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation
 /mysql/manifest.json                                @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation
+/mysql/assets/logs/                                @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /sqlserver/                                         @DataDog/database-monitoring-agent @DataDog/agent-integrations
 /sqlserver/*.md                                     @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation
 /sqlserver/manifest.json                            @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation
+/sqlserver/assets/logs/                                @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /oracle/                                            @DataDog/database-monitoring-agent @DataDog/agent-integrations
 /oracle/*.md                                        @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation
 /oracle/manifest.json                               @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation
+/oracle/assets/logs/                                @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 
 # APM Integrations
 /langchain/         @DataDog/ml-observability @DataDog/agent-integrations @DataDog/documentation
+/langchain/assets/logs/  @DataDog/ml-observability @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /openai/            @DataDog/ml-observability @DataDog/agent-integrations @DataDog/documentation
+/openai/assets/logs/  @DataDog/ml-observability @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 
 
 # Windows agent
@@ -178,47 +224,62 @@ datadog_checks_base/datadog_checks/base/checks/windows/              @DataDog/wi
 /active_directory/                                                   @DataDog/windows-agent @DataDog/agent-integrations
 /active_directory/*.md                                               @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
 /active_directory/manifest.json                                      @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
+/active_directory/assets/logs/                                              @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /aspdotnet/                                                          @DataDog/windows-agent @DataDog/agent-integrations
 /aspdotnet/*.md                                                      @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
 /aspdotnet/manifest.json                                             @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
+/aspdotnet/assets/logs/                                              @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /dotnetclr/                                                          @DataDog/windows-agent @DataDog/agent-integrations
 /dotnetclr/*.md                                                      @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
 /dotnetclr/manifest.json                                             @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
+/dotnetclr/assets/logs/                                              @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /exchange_server/                                                    @DataDog/windows-agent @DataDog/agent-integrations
 /exchange_server/*.md                                                @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
 /exchange_server/manifest.json                                       @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
+/exchange_server/assets/logs/                                              @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /hyperv/                                                             @DataDog/windows-agent @DataDog/agent-integrations
 /hyperv/*.md                                                         @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
 /hyperv/manifest.json                                                @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
+/hyperv/assets/logs/                                              @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /iis/                                                                @DataDog/windows-agent @DataDog/agent-integrations
 /iis/*.md                                                            @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
 /iis/manifest.json                                                   @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
+/iis/assets/logs/                                              @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /pdh_check/                                                          @DataDog/windows-agent @DataDog/agent-integrations
 /pdh_check/*.md                                                      @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
 /pdh_check/manifest.json                                             @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
+/pdh_check/assets/logs/                                              @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /win32_event_log/                                                    @DataDog/windows-agent @DataDog/agent-integrations
 /win32_event_log/*.md                                                @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
 /win32_event_log/manifest.json                                       @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
+/win32_event_log/assets/logs/                                        @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /windows_performance_counters/                                       @DataDog/windows-agent @DataDog/agent-integrations
 /windows_performance_counters/*.md                                   @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
 /windows_performance_counters/manifest.json                          @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
+/windows_performance_counters/assets/logs/                           @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /windows_registry/                                                   @DataDog/windows-agent @DataDog/agent-integrations
 /windows_registry/*.md                                               @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
 /windows_registry/manifest.json                                      @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
+/windows_registry/assets/logs/                                       @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /windows_service/                                                    @DataDog/windows-agent @DataDog/agent-integrations
 /windows_service/*.md                                                @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
 /windows_service/manifest.json                                       @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
+/windows_service/assets/logs/                                        @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 /wmi_check/                                                          @DataDog/windows-agent @DataDog/agent-integrations
 /wmi_check/*.md                                                      @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
 /wmi_check/manifest.json                                             @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation
+/wmi_check/assets/logs/                                              @DataDog/windows-agent @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
 
 # SaaS Integrations
 /cisco_umbrella_dns/                                                 @DataDog/saas-integrations
 /cisco_umbrella_dns/*.md                                             @DataDog/saas-integrations @DataDog/documentation
 /cisco_umbrella_dns/manifest.json                                    @DataDog/saas-integrations @DataDog/documentation
+/cisco_umbrella_dns/assets/logs/                                     @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-backend
+
 /cisco_duo/                                                          @DataDog/saas-integrations
 /cisco_duo/*.md                                                      @DataDog/saas-integrations @DataDog/documentation
 /cisco_duo/manifest.json                                             @DataDog/saas-integrations @DataDog/documentation
+/cisco_duo/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-backend
 
 # To keep Security up-to-date with changes to the signing tool.
 /datadog_checks_dev/datadog_checks/dev/tooling/signing.py             @DataDog/software-integrity-and-trust @DataDog/agent-integrations @trishankatdatadog


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Similar to https://github.com/DataDog/marketplace/pull/1025
The goal is to make @DataDog/logs-backend be CODEOWNERS of any integration's logs pipeline. 
I updated all integration codeowners to reflect this while still leaving their current owners in place. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
