### PR TITLE
Only run the `docs` job when needed on PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,7 @@ on:
     - 'docs/**'
     - 'ddev/**'
     - 'datadog_checks_dev/**'
+    - 'mkdocs.yml'
 
 jobs:
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches:
     - master
+    paths:
+    - 'docs/**'
+    - 'ddev/**'
+    - 'datadog_checks_dev/**'
 
 jobs:
   build:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Only run the `docs` job when needed on PRs

### Motivation
<!-- What inspired you to submit this pull request? -->

This job takes ~8 minutes, let's not run it if not strictly needed

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
