### PR TITLE
Add `linux_aarch64` as pattern for arm64 linux lockfile resolution

### DIFF
--- a/.builders/lock.py
+++ b/.builders/lock.py
@@ -20,7 +20,7 @@ DIRECT_DEP_FILE = REPO_DIR / 'datadog_checks_base' / 'datadog_checks' / 'base' /
 CONSTANTS_FILE = REPO_DIR / 'ddev' / 'src' / 'ddev' / 'repo' / 'constants.py'
 TARGET_TAG_PATTERNS = {
     'linux-x86_64': 'manylinux.*_x86_64|linux_x86_64',
-    'linux-aarch64': 'manylinux.*_aarch64',
+    'linux-aarch64': 'manylinux.*_aarch64|linux_aarch64',
     'windows-x86_64': 'win_amd64',
     'macos-x86_64': 'macosx.*_(x86_64|intel|universal2)',
 }


### PR DESCRIPTION
### What does this PR do?

Adds a missing pattern to the patterns we use to match platforms when resolving the final lock file.

### Motivation

PyYAML was failing to resolve: https://github.com/DataDog/integrations-core/actions/runs/8114079173/job/22188895871#step:8:31

The reason being that the file we're uploading in that case is named `PyYAML-5.4.1-1-cp27-cp27mu-linux_aarch64.whl` which wasn't matched by our logic, causing this specific dependency (pyyaml 5.4.1 for py2 for aarch64) to not be found.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
