### PR TITLE
Streamline aarch64 dependency build.

### DIFF
--- a/.builders/images/linux-aarch64/Dockerfile
+++ b/.builders/images/linux-aarch64/Dockerfile
@@ -75,19 +75,6 @@ RUN export LD_LIBRARY_PATH="/opt/python/${PYTHON_VERSION}/lib:${LD_LIBRARY_PATH}
  && /opt/python/${PYTHON_VERSION}/bin/python3 -m pip install --no-warn-script-location virtualenv \
  && /opt/python/${PYTHON_VERSION}/bin/python3 -m virtualenv /py3
 
-# Rust toolchain
-ENV RUST_VERSION="nightly-2022-05-15"
-ENV RUSTC_SHA256="32a1532f7cef072a667bac53f1a5542c99666c4071af0c9549795bbdb2069ec1"
-ENV RUSTUP_VERSION="1.24.3"
-ENV RUSTUP_SHA256="32a1532f7cef072a667bac53f1a5542c99666c4071af0c9549795bbdb2069ec1"
-RUN curl -sSL -o rustup-init "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/aarch64-unknown-linux-gnu/rustup-init" \
- && echo "${RUSTUP_SHA256}  rustup-init" | sha256sum --check \
- && chmod +x ./rustup-init \
- && ./rustup-init -y --profile minimal --default-toolchain "${RUST_VERSION}" \
- && echo "${RUSTC_SHA256}  $HOME/.cargo/bin/rustc" | sha256sum --check \
- && rm ./rustup-init
-ENV PATH="/root/.cargo/bin:${PATH}"
-
 # krb5 for dependencies that require kerberos support
 RUN \
  DOWNLOAD_URL="https://kerberos.org/dist/krb5/1.20/krb5-{{version}}.tar.gz" \

--- a/.builders/images/linux-aarch64/build_script.sh
+++ b/.builders/images/linux-aarch64/build_script.sh
@@ -31,16 +31,6 @@ if [[ "${DD_BUILD_PYTHON_VERSION}" == "3" ]]; then
         RELATIVE_PATH="librdkafka-{{version}}" \
         bash install-from-source.sh --enable-sasl --enable-curl
     always_build+=("confluent-kafka")
-
-    # pydantic-core
-    pydantic_core_version="2.1.2"
-    curl -L "https://github.com/pydantic/pydantic-core/archive/refs/tags/v${pydantic_core_version}.tar.gz" \
-        | tar -C /tmp -xzf -
-    pushd "/tmp/pydantic-core-${pydantic_core_version}"
-    patch -p1 -i "${DD_MOUNT_DIR}/patches/pydantic-core-for-manylinux1.patch"
-    build_wheels --no-deps .
-    echo "pydantic-core == ${pydantic_core_version}" >> "${PIP_CONSTRAINT}"
-    popd
 else
     echo "CFLAGS=\"-I/usr/local/ssl/include ${CFLAGS}\"" >> $DD_ENV_FILE
     echo "LDFLAGS=\"-L/usr/local/ssl/lib ${LDFLAGS}\"" >> $DD_ENV_FILE

--- a/.builders/images/linux-aarch64/build_script.sh
+++ b/.builders/images/linux-aarch64/build_script.sh
@@ -6,12 +6,6 @@ build_wheels() {
     /py${DD_BUILD_PYTHON_VERSION}/bin/python -m pip wheel "$@"
 }
 
-export PIP_CONSTRAINT="/pip_constraints.txt"
-echo "PIP_CONSTRAINT=\"${PIP_CONSTRAINT}\"" >> $DD_ENV_FILE
-
-# bcrypt >= 4.1.0 requires rust >= 1.64, which dropped support for glibc 2.12 (~Centos 6)
-echo "bcrypt < 4.1.0" >> "${PIP_CONSTRAINT}"
-
 # We don't support pymqi on ARM for now
 sed -i '/pymqi==/d' /home/requirements.in
 


### PR DESCRIPTION
### What does this PR do?

- Move platform-based requirements logic to environment markers.
- Remove patching and rust installation inherited from the equivalent x64 images.

### Motivation

I was looking into some other aarch64 related failure when I realized that I had missed these possible improvements when we originally introduced this builder. Considering how long aarch64 builds currently take, the pydantic-core and rust related removals should at least help a little.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
