### PR TITLE
[PLINT-303] Report Teleport Auth Service and Backends metrics

### DIFF
--- a/teleport/datadog_checks/teleport/check.py
+++ b/teleport/datadog_checks/teleport/check.py
@@ -4,9 +4,9 @@
 
 from datadog_checks.base import OpenMetricsBaseCheckV2
 
-from .metrics import COMMON_METRICS_MAP, PROXY_METRICS_MAP
+from .metrics import AUTH_METRICS_MAP, COMMON_METRICS_MAP, PROXY_METRICS_MAP
 
-METRIC_MAP = {**COMMON_METRICS_MAP, **PROXY_METRICS_MAP}
+METRIC_MAP = {**COMMON_METRICS_MAP, **PROXY_METRICS_MAP, **AUTH_METRICS_MAP}
 
 
 class TeleportCheck(OpenMetricsBaseCheckV2):

--- a/teleport/datadog_checks/teleport/metrics.py
+++ b/teleport/datadog_checks/teleport/metrics.py
@@ -115,5 +115,12 @@ AUTH_BACKEND_FIRESTORE_METRICS_MAP = {
     "firestore_events_backend_write_seconds": "auth.backend.firestore.events.backend_write_seconds",
 }
 
+AUTH_GCP_GCS_METRICS_MAP = {
+    "gcs_event_storage_downloads_seconds" : "auth.backend.gcs.event_storage.downloads_seconds",
+    "gcs_event_storage_downloads": "auth.backend.gcs.event_storage.downloads",
+    "gcs_event_storage_uploads_seconds" : "auth.backend.gcs.event_storage.uploads_seconds",
+    "gcs_event_storage_uploads": "auth.backend.gcs.event_storage.uploads",
+}
 
-AUTH_METRICS_MAP = {**AUTH_SERVICE_METRICS_MAP, **AUTH_AUDIT_LOG_METRICS_MAP, **AUTH_BACKEND_S3_METRICS_MAP, **AUTH_BACKEND_CACHE_METRICS_MAP, **AUTH_BACKEND_DYNAMO_METRICS_MAP, **AUTH_BACKEND_FIRESTORE_METRICS_MAP } # noqa: E501
+
+AUTH_METRICS_MAP = {**AUTH_SERVICE_METRICS_MAP, **AUTH_AUDIT_LOG_METRICS_MAP, **AUTH_BACKEND_S3_METRICS_MAP, **AUTH_BACKEND_CACHE_METRICS_MAP, **AUTH_BACKEND_DYNAMO_METRICS_MAP, **AUTH_BACKEND_FIRESTORE_METRICS_MAP, **AUTH_GCP_GCS_METRICS_MAP} # noqa: E501

--- a/teleport/datadog_checks/teleport/metrics.py
+++ b/teleport/datadog_checks/teleport/metrics.py
@@ -3,14 +3,14 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 COMMON_METRICS_MAP = {
-    'process_state': 'process.state',
-    'certificate_mismatch': 'certificate_mismatch',
-    'rx': 'rx',
-    'server_interactive_sessions_total': 'server_interactive_sessions_total',
-    'teleport_build_info': 'teleport.build_info',
-    'teleport_cache_events': 'teleport.cache_events',
-    'teleport_cache_stale_events': 'teleport.cache_stale_events',
-    'tx': 'tx',
+    "process_state": "process.state",
+    "certificate_mismatch": "certificate_mismatch",
+    "rx": "rx",
+    "server_interactive_sessions_total": "server_interactive_sessions_total",
+    "teleport_build_info": "teleport.build_info",
+    "teleport_cache_events": "teleport.cache_events",
+    "teleport_cache_stale_events": "teleport.cache_stale_events",
+    "tx": "tx",
 }
 
 PROXY_METRICS_MAP = {
@@ -20,10 +20,6 @@ PROXY_METRICS_MAP = {
     "grpc_client_handled": "proxy.grpc.client.handled",
     "grpc_client_msg_received": "proxy.grpc.client.msg_received",
     "grpc_client_msg_sent": "proxy.grpc.client.msg_sent",
-    "grpc_server_handled": "proxy.grpc.server.handled",
-    "grpc_server_msg_received": "proxy.grpc.server.msg_received",
-    "grpc_server_msg_sent": "proxy.grpc.server.msg_sent",
-    "grpc_server_started": "proxy.grpc.server.started",
     "proxy_connection_limit_exceeded": "proxy.connection_limit_exceeded",
     "proxy_peer_client_dial_error": "proxy.peer_client.dial_error",
     "proxy_peer_server_connections": "proxy.peer_server.connections",
@@ -47,4 +43,47 @@ PROXY_METRICS_MAP = {
     "teleport_proxy_db_attempted_servers_total": "proxy.teleport_proxy_db_attempted_servers_total",
     "teleport_proxy_db_connection_tls_config_time_seconds": "proxy.teleport_proxy_db_connection_tls_config_time_seconds",  # noqa: E501
     "teleport_proxy_db_active_connections_total": "proxy.teleport_proxy_db_active_connections_total",
+}
+
+AUTH_SERVICE_METRICS_MAP = {
+    "auth_generate_requests_throttled": "auth.generate_requests_throttled",
+    "auth_generate_requests": {"name": "auth.generate_requests", "type": "native_dynamic"},
+    "auth_generate_seconds": "auth.generate_seconds",
+    "grpc_server_handled": "auth.grpc.server.handled",
+    "grpc_server_msg_received": "auth.grpc.server.msg_received",
+    "grpc_server_msg_sent": "auth.grpc.server.msg_sent",
+    "grpc_server_started": "auth.grpc.server.started",
+    "cluster_name_not_found": "auth.cluster_name_not_found",
+    "teleport_connected_resources": "auth.connected.resources",
+    "teleport_registered_servers": "auth.registered.servers",
+    "teleport_registered_servers_by_install_methods": "auth.registered.servers_by_install_methods",
+    "user_login": "auth.user.login",
+    "teleport_migrations": "auth.migrations",
+    "watcher_event_sizes": "auth.watcher.event_sizes",
+    "watcher_events": "auth.watcher.events",
+}
+
+AUTH_AUDIT_LOG_METRICS_MAP = {
+    "audit_failed_disk_monitoring": "auth.audit_log.failed_disk_monitoring",
+    "audit_failed_emit_events": "auth.audit_log.failed_emit_events",
+    "audit_percentage_disk_space_used": "auth.audit_log.percentage_disk_space_used",
+    "audit_server_open_files": "auth.audit_log.server_open_files",
+    "teleport_audit_emit_events": "auth.audit_log.emit_events",
+    "teleport_audit_parquetlog_batch_processing_seconds": "auth.audit_log.parquetlog.batch_processing_seconds",
+    "teleport_audit_parquetlog_s3_flush_seconds": "auth.audit_log.parquetlog.s3_flush_seconds",
+    "teleport_audit_parquetlog_delete_events_seconds": "auth.audit_log.parquetlog.delete_events_seconds",
+    "teleport_audit_parquetlog_batch_size": "auth.audit_log.parquetlog.batch_size",
+    "teleport_audit_parquetlog_batch_count": "auth.audit_log.parquetlog.batch_count",
+    "teleport_audit_parquetlog_last_processed_timestamp": "auth.audit_log.parquetlog.last_processed_timestamp",
+    "teleport_audit_parquetlog_age_oldest_processed_message": "auth.audit_log.parquetlog.age_oldest_processed_message",
+    "teleport_audit_parquetlog_errors_from_collect_count": "auth.audit_log.parquetlog.errors_from_collect_count",
+}
+
+AUTH_BACKEND_S3_METRICS_MAP = {
+    "s3_requests": "auth.backend.s3.requests",
+    "s3_requests_seconds": "auth.backend.s3.requests_seconds",
+}
+
+AUTH_METRICS_MAP = {
+    **AUTH_SERVICE_METRICS_MAP, **AUTH_AUDIT_LOG_METRICS_MAP, **AUTH_BACKEND_S3_METRICS_MAP
 }

--- a/teleport/datadog_checks/teleport/metrics.py
+++ b/teleport/datadog_checks/teleport/metrics.py
@@ -84,6 +84,18 @@ AUTH_BACKEND_S3_METRICS_MAP = {
     "s3_requests_seconds": "auth.backend.s3.requests_seconds",
 }
 
-AUTH_METRICS_MAP = {
-    **AUTH_SERVICE_METRICS_MAP, **AUTH_AUDIT_LOG_METRICS_MAP, **AUTH_BACKEND_S3_METRICS_MAP
+AUTH_BACKEND_CACHE_METRICS_MAP = {
+    "backend_batch_read_requests": "auth.backend.cache.backend_batch_read_requests",
+    "backend_batch_read_seconds": "auth.backend.cache.backend_batch_read_seconds",
+    "backend_batch_write_requests": "auth.backend.cache.backend_batch_write_requests",
+    "backend_batch_write_seconds": "auth.backend.cache.backend_batch_write_seconds",
+    "backend_read_requests": "auth.backend.cache.backend_read_requests",
+    "backend_read_seconds": "auth.backend.cache.backend_read_seconds",
+    "backend_requests": "auth.backend.cache.backend_requests",
+    "backend_write_requests": "auth.backend.cache.backend_write_requests",
+    "backend_write_seconds": "auth.backend.cache.backend_write_seconds",
+    "watcher_event_sizes": "auth.backend.cache.watcher.event_sizes",
+    "watcher_events": "auth.backend.cache.watcher.events",
 }
+
+AUTH_METRICS_MAP = {**AUTH_SERVICE_METRICS_MAP, **AUTH_AUDIT_LOG_METRICS_MAP, **AUTH_BACKEND_S3_METRICS_MAP, **AUTH_BACKEND_CACHE_METRICS_MAP}

--- a/teleport/datadog_checks/teleport/metrics.py
+++ b/teleport/datadog_checks/teleport/metrics.py
@@ -116,9 +116,9 @@ AUTH_BACKEND_FIRESTORE_METRICS_MAP = {
 }
 
 AUTH_GCP_GCS_METRICS_MAP = {
-    "gcs_event_storage_downloads_seconds" : "auth.backend.gcs.event_storage.downloads_seconds",
+    "gcs_event_storage_downloads_seconds": "auth.backend.gcs.event_storage.downloads_seconds",
     "gcs_event_storage_downloads": "auth.backend.gcs.event_storage.downloads",
-    "gcs_event_storage_uploads_seconds" : "auth.backend.gcs.event_storage.uploads_seconds",
+    "gcs_event_storage_uploads_seconds": "auth.backend.gcs.event_storage.uploads_seconds",
     "gcs_event_storage_uploads": "auth.backend.gcs.event_storage.uploads",
 }
 
@@ -136,4 +136,13 @@ AUTH_ETCD_METRICS_MAP = {
 }
 
 
-AUTH_METRICS_MAP = {**AUTH_SERVICE_METRICS_MAP, **AUTH_AUDIT_LOG_METRICS_MAP, **AUTH_BACKEND_S3_METRICS_MAP, **AUTH_BACKEND_CACHE_METRICS_MAP, **AUTH_BACKEND_DYNAMO_METRICS_MAP, **AUTH_BACKEND_FIRESTORE_METRICS_MAP, **AUTH_GCP_GCS_METRICS_MAP, **AUTH_ETCD_METRICS_MAP} # noqa: E501
+AUTH_METRICS_MAP = {
+    **AUTH_SERVICE_METRICS_MAP,
+    **AUTH_AUDIT_LOG_METRICS_MAP,
+    **AUTH_BACKEND_S3_METRICS_MAP,
+    **AUTH_BACKEND_CACHE_METRICS_MAP,
+    **AUTH_BACKEND_DYNAMO_METRICS_MAP,
+    **AUTH_BACKEND_FIRESTORE_METRICS_MAP,
+    **AUTH_GCP_GCS_METRICS_MAP,
+    **AUTH_ETCD_METRICS_MAP,
+}  # noqa: E501

--- a/teleport/datadog_checks/teleport/metrics.py
+++ b/teleport/datadog_checks/teleport/metrics.py
@@ -98,4 +98,9 @@ AUTH_BACKEND_CACHE_METRICS_MAP = {
     "watcher_events": "auth.backend.cache.watcher.events",
 }
 
-AUTH_METRICS_MAP = {**AUTH_SERVICE_METRICS_MAP, **AUTH_AUDIT_LOG_METRICS_MAP, **AUTH_BACKEND_S3_METRICS_MAP, **AUTH_BACKEND_CACHE_METRICS_MAP}
+AUTH_BACKEND_DYNAMO_METRICS_MAP = {
+    "dynamo_requests": "auth.backend.dynamo.requests",
+    "dynamo_requests_seconds": "auth.backend.dynamo.requests_seconds",
+}
+
+AUTH_METRICS_MAP = {**AUTH_SERVICE_METRICS_MAP, **AUTH_AUDIT_LOG_METRICS_MAP, **AUTH_BACKEND_S3_METRICS_MAP, **AUTH_BACKEND_CACHE_METRICS_MAP, **AUTH_BACKEND_DYNAMO_METRICS_MAP } # noqa: E501

--- a/teleport/datadog_checks/teleport/metrics.py
+++ b/teleport/datadog_checks/teleport/metrics.py
@@ -103,4 +103,17 @@ AUTH_BACKEND_DYNAMO_METRICS_MAP = {
     "dynamo_requests_seconds": "auth.backend.dynamo.requests_seconds",
 }
 
-AUTH_METRICS_MAP = {**AUTH_SERVICE_METRICS_MAP, **AUTH_AUDIT_LOG_METRICS_MAP, **AUTH_BACKEND_S3_METRICS_MAP, **AUTH_BACKEND_CACHE_METRICS_MAP, **AUTH_BACKEND_DYNAMO_METRICS_MAP } # noqa: E501
+AUTH_BACKEND_FIRESTORE_METRICS_MAP = {
+    "firestore_events_backend_batch_read_requests": "auth.backend.firestore.events.backend_batch_read_requests",
+    "firestore_events_backend_batch_read_seconds": "auth.backend.firestore.events.backend_batch_read_seconds",
+    "firestore_events_backend_batch_write_requests": "auth.backend.firestore.events.backend_batch_write_requests",
+    "firestore_events_backend_batch_write_seconds": "auth.backend.firestore.events.backend_batch_write_seconds",
+    "firestore_events_backend_read_requests": "auth.backend.firestore.events.backend_read_requests",
+    "firestore_events_backend_read_seconds": "auth.backend.firestore.events.backend_read_seconds",
+    "firestore_events_backend_requests": "auth.backend.firestore.events.backend_requests",
+    "firestore_events_backend_write_requests": "auth.backend.firestore.events.backend_write_requests",
+    "firestore_events_backend_write_seconds": "auth.backend.firestore.events.backend_write_seconds",
+}
+
+
+AUTH_METRICS_MAP = {**AUTH_SERVICE_METRICS_MAP, **AUTH_AUDIT_LOG_METRICS_MAP, **AUTH_BACKEND_S3_METRICS_MAP, **AUTH_BACKEND_CACHE_METRICS_MAP, **AUTH_BACKEND_DYNAMO_METRICS_MAP, **AUTH_BACKEND_FIRESTORE_METRICS_MAP } # noqa: E501

--- a/teleport/datadog_checks/teleport/metrics.py
+++ b/teleport/datadog_checks/teleport/metrics.py
@@ -122,5 +122,18 @@ AUTH_GCP_GCS_METRICS_MAP = {
     "gcs_event_storage_uploads": "auth.backend.gcs.event_storage.uploads",
 }
 
+AUTH_ETCD_METRICS_MAP = {
+    "etcd_backend_batch_read_requests": "auth.backend.etcd.backend_batch_read_requests",
+    "etcd_backend_batch_read_seconds": "auth.backend.etcd.backend_batch_read_seconds",
+    "etcd_backend_read_requests": "auth.backend.etcd.backend_read_requests",
+    "etcd_backend_read_seconds": "auth.backend.etcd.backend_read_seconds",
+    "etcd_backend_tx_requests": "auth.backend.etcd.backend_tx_requests",
+    "etcd_backend_tx_seconds": "auth.backend.etcd.backend_tx_seconds",
+    "etcd_backend_write_requests": "auth.backend.etcd.backend_write_requests",
+    "etcd_backend_write_seconds": "auth.backend.etcd.backend_write_seconds",
+    "teleport_etcd_events": "auth.backend.etcd.teleport_etcd_events",
+    "teleport_etcd_event_backpressure": "auth.backend.etcd.teleport_etcd_event_backpressure",
+}
 
-AUTH_METRICS_MAP = {**AUTH_SERVICE_METRICS_MAP, **AUTH_AUDIT_LOG_METRICS_MAP, **AUTH_BACKEND_S3_METRICS_MAP, **AUTH_BACKEND_CACHE_METRICS_MAP, **AUTH_BACKEND_DYNAMO_METRICS_MAP, **AUTH_BACKEND_FIRESTORE_METRICS_MAP, **AUTH_GCP_GCS_METRICS_MAP} # noqa: E501
+
+AUTH_METRICS_MAP = {**AUTH_SERVICE_METRICS_MAP, **AUTH_AUDIT_LOG_METRICS_MAP, **AUTH_BACKEND_S3_METRICS_MAP, **AUTH_BACKEND_CACHE_METRICS_MAP, **AUTH_BACKEND_DYNAMO_METRICS_MAP, **AUTH_BACKEND_FIRESTORE_METRICS_MAP, **AUTH_GCP_GCS_METRICS_MAP, **AUTH_ETCD_METRICS_MAP} # noqa: E501

--- a/teleport/tests/fixtures/metrics.txt
+++ b/teleport/tests/fixtures/metrics.txt
@@ -1294,3 +1294,44 @@ firestore_events_backend_write_seconds_bucket{le="1"} 15000
 firestore_events_backend_write_seconds_bucket{le="+Inf"} 16500
 firestore_events_backend_write_seconds_count 16500
 firestore_events_backend_write_seconds_sum 5250
+
+
+# HELP gcs_event_storage_downloads_seconds Latency for GCS download operations.
+# TYPE gcs_event_storage_downloads_seconds histogram
+gcs_event_storage_downloads_seconds_bucket{le="0.005"} 100
+gcs_event_storage_downloads_seconds_bucket{le="0.01"} 300
+gcs_event_storage_downloads_seconds_bucket{le="0.025"} 500
+gcs_event_storage_downloads_seconds_bucket{le="0.05"} 700
+gcs_event_storage_downloads_seconds_bucket{le="0.075"} 900
+gcs_event_storage_downloads_seconds_bucket{le="0.1"} 1100
+gcs_event_storage_downloads_seconds_bucket{le="0.25"} 1300
+gcs_event_storage_downloads_seconds_bucket{le="0.5"} 1500
+gcs_event_storage_downloads_seconds_bucket{le="0.75"} 1700
+gcs_event_storage_downloads_seconds_bucket{le="1"} 1900
+gcs_event_storage_downloads_seconds_bucket{le="+Inf"} 2000
+gcs_event_storage_downloads_seconds_count 2000
+gcs_event_storage_downloads_seconds_sum 600
+
+# HELP gcs_event_storage_downloads Number of downloads from the GCS backend.
+# TYPE gcs_event_storage_downloads counter
+gcs_event_storage_downloads 4500
+
+# HELP gcs_event_storage_uploads_seconds Latency for GCS upload operations.
+# TYPE gcs_event_storage_uploads_seconds histogram
+gcs_event_storage_uploads_seconds_bucket{le="0.005"} 200
+gcs_event_storage_uploads_seconds_bucket{le="0.01"} 400
+gcs_event_storage_uploads_seconds_bucket{le="0.025"} 600
+gcs_event_storage_uploads_seconds_bucket{le="0.05"} 800
+gcs_event_storage_uploads_seconds_bucket{le="0.075"} 1000
+gcs_event_storage_uploads_seconds_bucket{le="0.1"} 1200
+gcs_event_storage_uploads_seconds_bucket{le="0.25"} 1400
+gcs_event_storage_uploads_seconds_bucket{le="0.5"} 1600
+gcs_event_storage_uploads_seconds_bucket{le="0.75"} 1800
+gcs_event_storage_uploads_seconds_bucket{le="1"} 2000
+gcs_event_storage_uploads_seconds_bucket{le="+Inf"} 2200
+gcs_event_storage_uploads_seconds_count 2200
+gcs_event_storage_uploads_seconds_sum 700
+
+# HELP gcs_event_storage_uploads Number of uploads to the GCS backend.
+# TYPE gcs_event_storage_uploads counter
+gcs_event_storage_uploads 5000

--- a/teleport/tests/fixtures/metrics.txt
+++ b/teleport/tests/fixtures/metrics.txt
@@ -1233,3 +1233,64 @@ dynamo_requests_seconds_bucket{le="10"} 0
 dynamo_requests_seconds_bucket{le="+Inf"} 0
 dynamo_requests_seconds_sum 0
 dynamo_requests_seconds_count 0
+
+
+# HELP firestore_events_backend_batch_read_requests Number of batch read requests to Cloud Firestore events.
+# TYPE firestore_events_backend_batch_read_requests counter
+firestore_events_backend_batch_read_requests 150
+
+# HELP firestore_events_backend_batch_read_seconds Latency for Cloud Firestore events batch read operations.
+# TYPE firestore_events_backend_batch_read_seconds histogram
+firestore_events_backend_batch_read_seconds_bucket{le="0.005"} 250
+firestore_events_backend_batch_read_seconds_bucket{le="0.01"} 500
+firestore_events_backend_batch_read_seconds_bucket{le="0.025"} 750
+firestore_events_backend_batch_read_seconds_bucket{le="0.05"} 1000
+firestore_events_backend_batch_read_seconds_bucket{le="0.075"} 1200
+firestore_events_backend_batch_read_seconds_bucket{le="0.1"} 1500
+firestore_events_backend_batch_read_seconds_bucket{le="0.25"} 2000
+firestore_events_backend_batch_read_seconds_bucket{le="0.5"} 2500
+firestore_events_backend_batch_read_seconds_bucket{le="0.75"} 2750
+firestore_events_backend_batch_read_seconds_bucket{le="1"} 3000
+firestore_events_backend_batch_read_seconds_bucket{le="+Inf"} 3200
+firestore_events_backend_batch_read_seconds_count 3200
+firestore_events_backend_batch_read_seconds_sum 800
+
+# HELP firestore_events_backend_batch_write_requests Number of batch write requests to Cloud Firestore events.
+# TYPE firestore_events_backend_batch_write_requests counter
+firestore_events_backend_batch_write_requests 4800
+
+# HELP firestore_events_backend_batch_write_seconds Latency for Cloud Firestore events batch write operations.
+# TYPE firestore_events_backend_batch_write_seconds histogram
+firestore_events_backend_batch_write_seconds_bucket{le="0.005"} 1000
+firestore_events_backend_batch_write_seconds_bucket{le="0.01"} 2000
+firestore_events_backend_batch_write_seconds_bucket{le="0.025"} 3000
+firestore_events_backend_batch_write_seconds_bucket{le="0.05"} 4000
+firestore_events_backend_batch_write_seconds_bucket{le="0.075"} 5000
+firestore_events_backend_batch_write_seconds_bucket{le="0.1"} 6000
+firestore_events_backend_batch_write_seconds_bucket{le="0.25"} 7000
+firestore_events_backend_batch_write_seconds_bucket{le="0.5"} 8000
+firestore_events_backend_batch_write_seconds_bucket{le="0.75"} 9000
+firestore_events_backend_batch_write_seconds_bucket{le="1"} 10000
+firestore_events_backend_batch_write_seconds_bucket{le="+Inf"} 11000
+firestore_events_backend_batch_write_seconds_count 11000
+firestore_events_backend_batch_write_seconds_sum 3500
+
+# HELP firestore_events_backend_write_requests Number of write requests to Cloud Firestore events.
+# TYPE firestore_events_backend_write_requests counter
+firestore_events_backend_write_requests 7500
+
+# HELP firestore_events_backend_write_seconds Latency for Cloud Firestore events write operations.
+# TYPE firestore_events_backend_write_seconds histogram
+firestore_events_backend_write_seconds_bucket{le="0.005"} 1500
+firestore_events_backend_write_seconds_bucket{le="0.01"} 3000
+firestore_events_backend_write_seconds_bucket{le="0.025"} 4500
+firestore_events_backend_write_seconds_bucket{le="0.05"} 6000
+firestore_events_backend_write_seconds_bucket{le="0.075"} 7500
+firestore_events_backend_write_seconds_bucket{le="0.1"} 9000
+firestore_events_backend_write_seconds_bucket{le="0.25"} 10500
+firestore_events_backend_write_seconds_bucket{le="0.5"} 12000
+firestore_events_backend_write_seconds_bucket{le="0.75"} 13500
+firestore_events_backend_write_seconds_bucket{le="1"} 15000
+firestore_events_backend_write_seconds_bucket{le="+Inf"} 16500
+firestore_events_backend_write_seconds_count 16500
+firestore_events_backend_write_seconds_sum 5250

--- a/teleport/tests/fixtures/metrics.txt
+++ b/teleport/tests/fixtures/metrics.txt
@@ -1207,3 +1207,29 @@ s3_requests_seconds_bucket{le="10"} 0
 s3_requests_seconds_bucket{le="+Inf"} 0
 s3_requests_seconds_sum 0
 s3_requests_seconds_count 0
+
+
+# HELP dynamo_requests_total Total number of requests to the DYNAMO API.
+# TYPE dynamo_requests_total counter
+dynamo_requests_total 4000
+
+# HELP dynamo_requests Total number of requests to the DYNAMO API grouped by result.
+# TYPE dynamo_requests counter
+dynamo_requests{result="success"} 3200
+dynamo_requests{result="failure"} 800
+
+# TYPE dynamo_requests_seconds histogram
+dynamo_requests_seconds_bucket{le="0.005"} 0
+dynamo_requests_seconds_bucket{le="0.01"} 0
+dynamo_requests_seconds_bucket{le="0.025"} 0
+dynamo_requests_seconds_bucket{le="0.05"} 0
+dynamo_requests_seconds_bucket{le="0.1"} 0
+dynamo_requests_seconds_bucket{le="0.25"} 0
+dynamo_requests_seconds_bucket{le="0.5"} 0
+dynamo_requests_seconds_bucket{le="1"} 0
+dynamo_requests_seconds_bucket{le="2.5"} 0
+dynamo_requests_seconds_bucket{le="5"} 0
+dynamo_requests_seconds_bucket{le="10"} 0
+dynamo_requests_seconds_bucket{le="+Inf"} 0
+dynamo_requests_seconds_sum 0
+dynamo_requests_seconds_count 0

--- a/teleport/tests/fixtures/metrics.txt
+++ b/teleport/tests/fixtures/metrics.txt
@@ -1045,3 +1045,165 @@ watcher_events_bucket{resource="/watch_status",le="800"} 4
 watcher_events_bucket{resource="/watch_status",le="+Inf"} 4
 watcher_events_sum{resource="/watch_status"} 1193
 watcher_events_count{resource="/watch_status"} 4
+
+# HELP audit_failed_disk_monitoring Number of times disk monitoring failed.
+# TYPE audit_failed_disk_monitoring counter
+audit_failed_disk_monitoring 14
+
+# HELP audit_failed_emit_events Number of times emitting audit events failed.
+# TYPE audit_failed_emit_events counter
+audit_failed_emit_events 7
+
+# HELP audit_percentage_disk_space_used Percentage of disk space used.
+# TYPE audit_percentage_disk_space_used gauge
+audit_percentage_disk_space_used 65.3
+
+# HELP audit_server_open_files Number of open audit files.
+# TYPE audit_server_open_files gauge
+audit_server_open_files 30
+
+# HELP auth_generate_requests_throttled_total Number of throttled requests to generate new server keys.
+# TYPE auth_generate_requests_throttled_total counter
+auth_generate_requests_throttled_total 20
+
+# HELP auth_generate_requests_total Number of requests to generate new server keys.
+# TYPE auth_generate_requests_total counter
+auth_generate_requests_total 90
+
+# HELP auth_generate_requests Number of current generate requests.
+# TYPE auth_generate_requests gauge
+auth_generate_requests 15
+
+# HELP auth_generate_seconds Latency for generate requests.
+# TYPE auth_generate_seconds histogram
+auth_generate_seconds_bucket{le="0.005"} 0
+auth_generate_seconds_bucket{le="0.01"} 1
+auth_generate_seconds_bucket{le="0.025"} 3
+auth_generate_seconds_bucket{le="0.05"} 5
+auth_generate_seconds_bucket{le="0.075"} 7
+auth_generate_seconds_bucket{le="0.1"} 8
+auth_generate_seconds_bucket{le="0.25"} 10
+auth_generate_seconds_bucket{le="0.5"} 14
+auth_generate_seconds_bucket{le="0.75"} 20
+auth_generate_seconds_bucket{le="1"} 25
+auth_generate_seconds_bucket{le="+Inf"} 30
+auth_generate_seconds_sum 33.0
+auth_generate_seconds_count 30
+
+# TYPE teleport_audit_emit_events counter
+teleport_audit_emit_events_total 0
+
+# TYPE teleport_audit_parquetlog_batch_processing_seconds histogram
+teleport_audit_parquetlog_batch_processing_seconds_bucket{le="0.005"} 0
+teleport_audit_parquetlog_batch_processing_seconds_bucket{le="0.01"} 0
+teleport_audit_parquetlog_batch_processing_seconds_bucket{le="0.025"} 0
+teleport_audit_parquetlog_batch_processing_seconds_bucket{le="0.05"} 0
+teleport_audit_parquetlog_batch_processing_seconds_bucket{le="0.1"} 0
+teleport_audit_parquetlog_batch_processing_seconds_bucket{le="0.25"} 0
+teleport_audit_parquetlog_batch_processing_seconds_bucket{le="0.5"} 0
+teleport_audit_parquetlog_batch_processing_seconds_bucket{le="1"} 0
+teleport_audit_parquetlog_batch_processing_seconds_bucket{le="2.5"} 0
+teleport_audit_parquetlog_batch_processing_seconds_bucket{le="5"} 0
+teleport_audit_parquetlog_batch_processing_seconds_bucket{le="10"} 0
+teleport_audit_parquetlog_batch_processing_seconds_bucket{le="+Inf"} 0
+teleport_audit_parquetlog_batch_processing_seconds_sum 0
+teleport_audit_parquetlog_batch_processing_seconds_count 0
+
+# TYPE teleport_audit_parquetlog_s3_flush_seconds histogram
+teleport_audit_parquetlog_s3_flush_seconds_bucket{le="0.005"} 0
+teleport_audit_parquetlog_s3_flush_seconds_bucket{le="0.01"} 0
+teleport_audit_parquetlog_s3_flush_seconds_bucket{le="0.025"} 0
+teleport_audit_parquetlog_s3_flush_seconds_bucket{le="0.05"} 0
+teleport_audit_parquetlog_s3_flush_seconds_bucket{le="0.1"} 0
+teleport_audit_parquetlog_s3_flush_seconds_bucket{le="0.25"} 0
+teleport_audit_parquetlog_s3_flush_seconds_bucket{le="0.5"} 0
+teleport_audit_parquetlog_s3_flush_seconds_bucket{le="1"} 0
+teleport_audit_parquetlog_s3_flush_seconds_bucket{le="2.5"} 0
+teleport_audit_parquetlog_s3_flush_seconds_bucket{le="5"} 0
+teleport_audit_parquetlog_s3_flush_seconds_bucket{le="10"} 0
+teleport_audit_parquetlog_s3_flush_seconds_bucket{le="+Inf"} 0
+teleport_audit_parquetlog_s3_flush_seconds_sum 0
+teleport_audit_parquetlog_s3_flush_seconds_count 0
+
+# TYPE teleport_audit_parquetlog_delete_events_seconds histogram
+teleport_audit_parquetlog_delete_events_seconds_bucket{le="0.005"} 0
+teleport_audit_parquetlog_delete_events_seconds_bucket{le="0.01"} 0
+teleport_audit_parquetlog_delete_events_seconds_bucket{le="0.025"} 0
+teleport_audit_parquetlog_delete_events_seconds_bucket{le="0.05"} 0
+teleport_audit_parquetlog_delete_events_seconds_bucket{le="0.1"} 0
+teleport_audit_parquetlog_delete_events_seconds_bucket{le="0.25"} 0
+teleport_audit_parquetlog_delete_events_seconds_bucket{le="0.5"} 0
+teleport_audit_parquetlog_delete_events_seconds_bucket{le="1"} 0
+teleport_audit_parquetlog_delete_events_seconds_bucket{le="2.5"} 0
+teleport_audit_parquetlog_delete_events_seconds_bucket{le="5"} 0
+teleport_audit_parquetlog_delete_events_seconds_bucket{le="10"} 0
+teleport_audit_parquetlog_delete_events_seconds_bucket{le="+Inf"} 0
+teleport_audit_parquetlog_delete_events_seconds_sum 0
+teleport_audit_parquetlog_delete_events_seconds_count 0
+
+# TYPE teleport_audit_parquetlog_batch_size histogram
+teleport_audit_parquetlog_batch_size_bucket{le="500"} 0
+teleport_audit_parquetlog_batch_size_bucket{le="1000"} 0
+teleport_audit_parquetlog_batch_size_bucket{le="1500"} 0
+teleport_audit_parquetlog_batch_size_bucket{le="2000"} 0
+teleport_audit_parquetlog_batch_size_bucket{le="2500"} 0
+teleport_audit_parquetlog_batch_size_bucket{le="3000"} 0
+teleport_audit_parquetlog_batch_size_bucket{le="3500"} 0
+teleport_audit_parquetlog_batch_size_bucket{le="4000"} 0
+teleport_audit_parquetlog_batch_size_bucket{le="4500"} 0
+teleport_audit_parquetlog_batch_size_bucket{le="5000"} 0
+teleport_audit_parquetlog_batch_size_bucket{le="+Inf"} 0
+teleport_audit_parquetlog_batch_size_sum 0
+teleport_audit_parquetlog_batch_size_count 0
+
+# TYPE teleport_audit_parquetlog_batch_count counter
+teleport_audit_parquetlog_batch_count 0
+
+# TYPE teleport_audit_parquetlog_last_processed_timestamp gauge
+teleport_audit_parquetlog_last_processed_timestamp 0
+
+# TYPE teleport_audit_parquetlog_age_oldest_processed_message gauge
+teleport_audit_parquetlog_age_oldest_processed_message 0
+
+# TYPE teleport_audit_parquetlog_errors_from_collect_count counter
+teleport_audit_parquetlog_errors_from_collect_count 0
+
+# TYPE teleport_connected_resources gauge
+teleport_connected_resources 0
+
+# TYPE teleport_registered_servers gauge
+teleport_registered_servers 0
+
+# TYPE teleport_registered_servers_by_install_methods gauge
+teleport_registered_servers_by_install_methods 0
+
+# TYPE user_login_total counter
+user_login_total 0
+
+# TYPE teleport_migrations gauge
+teleport_migrations 0
+
+# HELP s3_requests_total Total number of requests to the S3 API.
+# TYPE s3_requests_total counter
+s3_requests_total 4000
+
+# HELP s3_requests Total number of requests to the S3 API grouped by result.
+# TYPE s3_requests counter
+s3_requests{result="success"} 3200
+s3_requests{result="failure"} 800
+
+# TYPE s3_requests_seconds histogram
+s3_requests_seconds_bucket{le="0.005"} 0
+s3_requests_seconds_bucket{le="0.01"} 0
+s3_requests_seconds_bucket{le="0.025"} 0
+s3_requests_seconds_bucket{le="0.05"} 0
+s3_requests_seconds_bucket{le="0.1"} 0
+s3_requests_seconds_bucket{le="0.25"} 0
+s3_requests_seconds_bucket{le="0.5"} 0
+s3_requests_seconds_bucket{le="1"} 0
+s3_requests_seconds_bucket{le="2.5"} 0
+s3_requests_seconds_bucket{le="5"} 0
+s3_requests_seconds_bucket{le="10"} 0
+s3_requests_seconds_bucket{le="+Inf"} 0
+s3_requests_seconds_sum 0
+s3_requests_seconds_count 0

--- a/teleport/tests/fixtures/metrics.txt
+++ b/teleport/tests/fixtures/metrics.txt
@@ -1335,3 +1335,93 @@ gcs_event_storage_uploads_seconds_sum 700
 # HELP gcs_event_storage_uploads Number of uploads to the GCS backend.
 # TYPE gcs_event_storage_uploads counter
 gcs_event_storage_uploads 5000
+
+
+# HELP etcd_backend_batch_read_requests Number of read requests to the etcd database.
+# TYPE etcd_backend_batch_read_requests counter
+etcd_backend_batch_read_requests 200
+
+# HELP etcd_backend_batch_read_seconds Latency for etcd read operations.
+# TYPE etcd_backend_batch_read_seconds histogram
+etcd_backend_batch_read_seconds_bucket{le="0.005"} 20
+etcd_backend_batch_read_seconds_bucket{le="0.01"} 40
+etcd_backend_batch_read_seconds_bucket{le="0.025"} 80
+etcd_backend_batch_read_seconds_bucket{le="0.05"} 120
+etcd_backend_batch_read_seconds_bucket{le="0.075"} 150
+etcd_backend_batch_read_seconds_bucket{le="0.1"} 160
+etcd_backend_batch_read_seconds_bucket{le="0.25"} 180
+etcd_backend_batch_read_seconds_bucket{le="0.5"} 190
+etcd_backend_batch_read_seconds_bucket{le="0.75"} 195
+etcd_backend_batch_read_seconds_bucket{le="1"} 200
+etcd_backend_batch_read_seconds_bucket{le="+Inf"} 200
+etcd_backend_batch_read_seconds_sum 400.0
+etcd_backend_batch_read_seconds_count 200
+
+# HELP etcd_backend_read_requests Number of read requests to the etcd database.
+# TYPE etcd_backend_read_requests counter
+etcd_backend_read_requests 1000
+
+# HELP etcd_backend_read_seconds Latency for etcd read operations.
+# TYPE etcd_backend_read_seconds histogram
+etcd_backend_read_seconds_bucket{le="0.005"} 100
+etcd_backend_read_seconds_bucket{le="0.01"} 200
+etcd_backend_read_seconds_bucket{le="0.025"} 400
+etcd_backend_read_seconds_bucket{le="0.05"} 600
+etcd_backend_read_seconds_bucket{le="0.075"} 800
+etcd_backend_read_seconds_bucket{le="0.1"} 900
+etcd_backend_read_seconds_bucket{le="0.25"} 950
+etcd_backend_read_seconds_bucket{le="0.5"} 975
+etcd_backend_read_seconds_bucket{le="0.75"} 990
+etcd_backend_read_seconds_bucket{le="1"} 1000
+etcd_backend_read_seconds_bucket{le="+Inf"} 1000
+etcd_backend_read_seconds_sum 2000.0
+etcd_backend_read_seconds_count 1000
+
+# HELP etcd_backend_tx_requests Number of transaction requests to the database.
+# TYPE etcd_backend_tx_requests counter
+etcd_backend_tx_requests 500
+
+# HELP etcd_backend_tx_seconds Latency for etcd transaction operations.
+# TYPE etcd_backend_tx_seconds histogram
+etcd_backend_tx_seconds_bucket{le="0.005"} 50
+etcd_backend_tx_seconds_bucket{le="0.01"} 100
+etcd_backend_tx_seconds_bucket{le="0.025"} 200
+etcd_backend_tx_seconds_bucket{le="0.05"} 300
+etcd_backend_tx_seconds_bucket{le="0.075"} 400
+etcd_backend_tx_seconds_bucket{le="0.1"} 450
+etcd_backend_tx_seconds_bucket{le="0.25"} 475
+etcd_backend_tx_seconds_bucket{le="0.5"} 490
+etcd_backend_tx_seconds_bucket{le="0.75"} 498
+etcd_backend_tx_seconds_bucket{le="1"} 500
+etcd_backend_tx_seconds_bucket{le="+Inf"} 500
+etcd_backend_tx_seconds_sum 1000.0
+etcd_backend_tx_seconds_count 500
+
+# HELP etcd_backend_write_requests Number of write requests to the database.
+# TYPE etcd_backend_write_requests counter
+etcd_backend_write_requests 1200
+
+# HELP etcd_backend_write_seconds Latency for etcd write operations.
+# TYPE etcd_backend_write_seconds histogram
+etcd_backend_write_seconds_bucket{le="0.005"} 120
+etcd_backend_write_seconds_bucket{le="0.01"} 240
+etcd_backend_write_seconds_bucket{le="0.025"} 480
+etcd_backend_write_seconds_bucket{le="0.05"} 720
+etcd_backend_write_seconds_bucket{le="0.075"} 960
+etcd_backend_write_seconds_bucket{le="0.1"} 1080
+etcd_backend_write_seconds_bucket{le="0.25"} 1140
+etcd_backend_write_seconds_bucket{le="0.5"} 1176
+etcd_backend_write_seconds_bucket{le="0.75"} 1194
+etcd_backend_write_seconds_bucket{le="1"} 1200
+etcd_backend_write_seconds_bucket{le="+Inf"} 1200
+etcd_backend_write_seconds_sum 2400.0
+etcd_backend_write_seconds_count 1200
+
+# HELP teleport_etcd_events Total number of etcd events processed.
+# TYPE teleport_etcd_events counter
+teleport_etcd_events 2000
+
+# HELP teleport_etcd_event_backpressure Total number of times event processing encountered backpressure.
+# TYPE teleport_etcd_event_backpressure counter
+teleport_etcd_event_backpressure 3
+

--- a/teleport/tests/test_auth.py
+++ b/teleport/tests/test_auth.py
@@ -24,12 +24,6 @@ AUTH_METRICS = [
     "auth.cluster_name_not_found.count",
     "auth.user.login.count",
     "auth.migrations",
-    "auth.watcher.event_sizes.bucket",
-    "auth.watcher.event_sizes.count",
-    "auth.watcher.event_sizes.sum",
-    "auth.watcher.events.bucket",
-    "auth.watcher.events.count",
-    "auth.watcher.events.sum",
 ]
 
 AUTH_AUDIT_LOG_METRICS = [
@@ -59,6 +53,31 @@ AUTH_BACKEND_S3_METRICS = [
     "auth.backend.s3.requests_seconds.sum",
 ]
 
+AUTH_BACKEND_CACHE_METRICS = [
+    "auth.backend.cache.backend_batch_read_requests.count",
+    "auth.backend.cache.backend_batch_read_seconds.bucket",
+    "auth.backend.cache.backend_batch_read_seconds.count",
+    "auth.backend.cache.backend_batch_read_seconds.sum",
+    "auth.backend.cache.backend_batch_write_requests.count",
+    "auth.backend.cache.backend_batch_write_seconds.bucket",
+    "auth.backend.cache.backend_batch_write_seconds.count",
+    "auth.backend.cache.backend_batch_write_seconds.sum",
+    "auth.backend.cache.backend_read_requests.count",
+    "auth.backend.cache.backend_read_seconds.bucket",
+    "auth.backend.cache.backend_read_seconds.count",
+    "auth.backend.cache.backend_read_seconds.sum",
+    "auth.backend.cache.backend_requests.count",
+    "auth.backend.cache.backend_write_requests.count",
+    "auth.backend.cache.backend_write_seconds.bucket",
+    "auth.backend.cache.backend_write_seconds.count",
+    "auth.backend.cache.backend_write_seconds.sum",
+    "auth.backend.cache.watcher.event_sizes.count",
+    "auth.backend.cache.watcher.event_sizes.sum",
+    "auth.backend.cache.watcher.events.bucket",
+    "auth.backend.cache.watcher.events.count",
+    "auth.backend.cache.watcher.events.sum",
+]
+
 
 def test_auth_teleport_metrics(dd_run_check, aggregator, mock_http_response):
     fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
@@ -71,7 +90,6 @@ def test_auth_teleport_metrics(dd_run_check, aggregator, mock_http_response):
     for metric in AUTH_METRICS:
         aggregator.assert_metric(f"teleport.{metric}")
 
-
 def test_auth_audit_log_teleport_metrics(dd_run_check, aggregator, mock_http_response):
     fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
     mock_http_response(file_path=fixtures_path)
@@ -83,7 +101,6 @@ def test_auth_audit_log_teleport_metrics(dd_run_check, aggregator, mock_http_res
     for metric in AUTH_AUDIT_LOG_METRICS:
         aggregator.assert_metric(f"teleport.{metric}")
 
-
 def test_auth_backend_s3_teleport_metrics(dd_run_check, aggregator, mock_http_response):
     fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
     mock_http_response(file_path=fixtures_path)
@@ -93,4 +110,15 @@ def test_auth_backend_s3_teleport_metrics(dd_run_check, aggregator, mock_http_re
     dd_run_check(check)
 
     for metric in AUTH_BACKEND_S3_METRICS:
+        aggregator.assert_metric(f"teleport.{metric}")
+
+def test_auth_backend_cache_teleport_metrics(dd_run_check, aggregator, mock_http_response):
+    fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
+    mock_http_response(file_path=fixtures_path)
+
+    instance = {"diagnostic_url": "http://hostname:3000"}
+    check = TeleportCheck("teleport", {}, [instance])
+    dd_run_check(check)
+
+    for metric in AUTH_BACKEND_CACHE_METRICS:
         aggregator.assert_metric(f"teleport.{metric}")

--- a/teleport/tests/test_auth.py
+++ b/teleport/tests/test_auth.py
@@ -111,6 +111,27 @@ AUTH_BACKEND_GCP_GCS_METRICS = [
     "auth.backend.gcs.event_storage.uploads.count",
 ]
 
+AUTH_BACKEND_ETCD_METRICS = [
+    "auth.backend.etcd.backend_batch_read_requests.count",
+    "auth.backend.etcd.backend_batch_read_seconds.bucket",
+    "auth.backend.etcd.backend_batch_read_seconds.count",
+    "auth.backend.etcd.backend_batch_read_seconds.sum",
+    "auth.backend.etcd.backend_read_requests.count",
+    "auth.backend.etcd.backend_read_seconds.bucket",
+    "auth.backend.etcd.backend_read_seconds.count",
+    "auth.backend.etcd.backend_read_seconds.sum",
+    "auth.backend.etcd.backend_tx_requests.count",
+    "auth.backend.etcd.backend_tx_seconds.bucket",
+    "auth.backend.etcd.backend_tx_seconds.count",
+    "auth.backend.etcd.backend_tx_seconds.sum",
+    "auth.backend.etcd.backend_write_requests.count",
+    "auth.backend.etcd.backend_write_seconds.bucket",
+    "auth.backend.etcd.backend_write_seconds.count",
+    "auth.backend.etcd.backend_write_seconds.sum",
+    "auth.backend.etcd.teleport_etcd_events.count",
+    "auth.backend.etcd.teleport_etcd_event_backpressure.count",
+]
+
 
 def test_auth_teleport_metrics(dd_run_check, aggregator, mock_http_response):
     fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
@@ -187,4 +208,15 @@ def test_auth_backend_gcp_gcs_teleport_metrics(dd_run_check, aggregator, mock_ht
     dd_run_check(check)
 
     for metric in AUTH_BACKEND_GCP_GCS_METRICS:
+        aggregator.assert_metric(f"teleport.{metric}")
+
+def test_auth_backend_etcd_teleport_metrics(dd_run_check, aggregator, mock_http_response):
+    fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
+    mock_http_response(file_path=fixtures_path)
+
+    instance = {"diagnostic_url": "http://hostname:3000"}
+    check = TeleportCheck("teleport", {}, [instance])
+    dd_run_check(check)
+
+    for metric in AUTH_BACKEND_ETCD_METRICS:
         aggregator.assert_metric(f"teleport.{metric}")

--- a/teleport/tests/test_auth.py
+++ b/teleport/tests/test_auth.py
@@ -144,6 +144,7 @@ def test_auth_teleport_metrics(dd_run_check, aggregator, mock_http_response):
     for metric in AUTH_METRICS:
         aggregator.assert_metric(f"teleport.{metric}")
 
+
 def test_auth_audit_log_teleport_metrics(dd_run_check, aggregator, mock_http_response):
     fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
     mock_http_response(file_path=fixtures_path)
@@ -154,6 +155,7 @@ def test_auth_audit_log_teleport_metrics(dd_run_check, aggregator, mock_http_res
 
     for metric in AUTH_AUDIT_LOG_METRICS:
         aggregator.assert_metric(f"teleport.{metric}")
+
 
 def test_auth_backend_s3_teleport_metrics(dd_run_check, aggregator, mock_http_response):
     fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
@@ -166,6 +168,7 @@ def test_auth_backend_s3_teleport_metrics(dd_run_check, aggregator, mock_http_re
     for metric in AUTH_BACKEND_S3_METRICS:
         aggregator.assert_metric(f"teleport.{metric}")
 
+
 def test_auth_backend_cache_teleport_metrics(dd_run_check, aggregator, mock_http_response):
     fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
     mock_http_response(file_path=fixtures_path)
@@ -176,6 +179,7 @@ def test_auth_backend_cache_teleport_metrics(dd_run_check, aggregator, mock_http
 
     for metric in AUTH_BACKEND_CACHE_METRICS:
         aggregator.assert_metric(f"teleport.{metric}")
+
 
 def test_auth_backend_dynamo_teleport_metrics(dd_run_check, aggregator, mock_http_response):
     fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
@@ -188,6 +192,7 @@ def test_auth_backend_dynamo_teleport_metrics(dd_run_check, aggregator, mock_htt
     for metric in AUTH_BACKEND_DYNAMO_METRICS:
         aggregator.assert_metric(f"teleport.{metric}")
 
+
 def test_auth_backend_firestore_teleport_metrics(dd_run_check, aggregator, mock_http_response):
     fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
     mock_http_response(file_path=fixtures_path)
@@ -199,6 +204,7 @@ def test_auth_backend_firestore_teleport_metrics(dd_run_check, aggregator, mock_
     for metric in AUTH_BACKEND_FIRESTORE_METRICS:
         aggregator.assert_metric(f"teleport.{metric}")
 
+
 def test_auth_backend_gcp_gcs_teleport_metrics(dd_run_check, aggregator, mock_http_response):
     fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
     mock_http_response(file_path=fixtures_path)
@@ -209,6 +215,7 @@ def test_auth_backend_gcp_gcs_teleport_metrics(dd_run_check, aggregator, mock_ht
 
     for metric in AUTH_BACKEND_GCP_GCS_METRICS:
         aggregator.assert_metric(f"teleport.{metric}")
+
 
 def test_auth_backend_etcd_teleport_metrics(dd_run_check, aggregator, mock_http_response):
     fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")

--- a/teleport/tests/test_auth.py
+++ b/teleport/tests/test_auth.py
@@ -78,6 +78,13 @@ AUTH_BACKEND_CACHE_METRICS = [
     "auth.backend.cache.watcher.events.sum",
 ]
 
+AUTH_BACKEND_DYNAMO_METRICS = [
+    "auth.backend.dynamo.requests.count",
+    "auth.backend.dynamo.requests_seconds.bucket",
+    "auth.backend.dynamo.requests_seconds.count",
+    "auth.backend.dynamo.requests_seconds.sum",
+]
+
 
 def test_auth_teleport_metrics(dd_run_check, aggregator, mock_http_response):
     fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
@@ -121,4 +128,15 @@ def test_auth_backend_cache_teleport_metrics(dd_run_check, aggregator, mock_http
     dd_run_check(check)
 
     for metric in AUTH_BACKEND_CACHE_METRICS:
+        aggregator.assert_metric(f"teleport.{metric}")
+
+def test_auth_backend_dynamo_teleport_metrics(dd_run_check, aggregator, mock_http_response):
+    fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
+    mock_http_response(file_path=fixtures_path)
+
+    instance = {"diagnostic_url": "http://hostname:3000"}
+    check = TeleportCheck("teleport", {}, [instance])
+    dd_run_check(check)
+
+    for metric in AUTH_BACKEND_DYNAMO_METRICS:
         aggregator.assert_metric(f"teleport.{metric}")

--- a/teleport/tests/test_auth.py
+++ b/teleport/tests/test_auth.py
@@ -85,6 +85,21 @@ AUTH_BACKEND_DYNAMO_METRICS = [
     "auth.backend.dynamo.requests_seconds.sum",
 ]
 
+AUTH_BACKEND_FIRESTORE_METRICS = [
+    "auth.backend.firestore.events.backend_batch_read_requests.count",
+    "auth.backend.firestore.events.backend_batch_read_seconds.bucket",
+    "auth.backend.firestore.events.backend_batch_read_seconds.count",
+    "auth.backend.firestore.events.backend_batch_read_seconds.sum",
+    "auth.backend.firestore.events.backend_batch_write_requests.count",
+    "auth.backend.firestore.events.backend_batch_write_seconds.bucket",
+    "auth.backend.firestore.events.backend_batch_write_seconds.count",
+    "auth.backend.firestore.events.backend_batch_write_seconds.sum",
+    "auth.backend.firestore.events.backend_write_requests.count",
+    "auth.backend.firestore.events.backend_write_seconds.bucket",
+    "auth.backend.firestore.events.backend_write_seconds.count",
+    "auth.backend.firestore.events.backend_write_seconds.sum",
+]
+
 
 def test_auth_teleport_metrics(dd_run_check, aggregator, mock_http_response):
     fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
@@ -139,4 +154,15 @@ def test_auth_backend_dynamo_teleport_metrics(dd_run_check, aggregator, mock_htt
     dd_run_check(check)
 
     for metric in AUTH_BACKEND_DYNAMO_METRICS:
+        aggregator.assert_metric(f"teleport.{metric}")
+
+def test_auth_backend_firestore_teleport_metrics(dd_run_check, aggregator, mock_http_response):
+    fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
+    mock_http_response(file_path=fixtures_path)
+
+    instance = {"diagnostic_url": "http://hostname:3000"}
+    check = TeleportCheck("teleport", {}, [instance])
+    dd_run_check(check)
+
+    for metric in AUTH_BACKEND_FIRESTORE_METRICS:
         aggregator.assert_metric(f"teleport.{metric}")

--- a/teleport/tests/test_auth.py
+++ b/teleport/tests/test_auth.py
@@ -100,6 +100,17 @@ AUTH_BACKEND_FIRESTORE_METRICS = [
     "auth.backend.firestore.events.backend_write_seconds.sum",
 ]
 
+AUTH_BACKEND_GCP_GCS_METRICS = [
+    "auth.backend.gcs.event_storage.downloads_seconds.bucket",
+    "auth.backend.gcs.event_storage.downloads_seconds.count",
+    "auth.backend.gcs.event_storage.downloads_seconds.sum",
+    "auth.backend.gcs.event_storage.downloads.count",
+    "auth.backend.gcs.event_storage.uploads_seconds.bucket",
+    "auth.backend.gcs.event_storage.uploads_seconds.count",
+    "auth.backend.gcs.event_storage.uploads_seconds.sum",
+    "auth.backend.gcs.event_storage.uploads.count",
+]
+
 
 def test_auth_teleport_metrics(dd_run_check, aggregator, mock_http_response):
     fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
@@ -165,4 +176,15 @@ def test_auth_backend_firestore_teleport_metrics(dd_run_check, aggregator, mock_
     dd_run_check(check)
 
     for metric in AUTH_BACKEND_FIRESTORE_METRICS:
+        aggregator.assert_metric(f"teleport.{metric}")
+
+def test_auth_backend_gcp_gcs_teleport_metrics(dd_run_check, aggregator, mock_http_response):
+    fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
+    mock_http_response(file_path=fixtures_path)
+
+    instance = {"diagnostic_url": "http://hostname:3000"}
+    check = TeleportCheck("teleport", {}, [instance])
+    dd_run_check(check)
+
+    for metric in AUTH_BACKEND_GCP_GCS_METRICS:
         aggregator.assert_metric(f"teleport.{metric}")

--- a/teleport/tests/test_auth.py
+++ b/teleport/tests/test_auth.py
@@ -1,0 +1,96 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import os
+
+import pytest
+
+from datadog_checks.dev import get_here
+from datadog_checks.teleport import TeleportCheck
+
+pytestmark = [pytest.mark.unit]
+
+AUTH_METRICS = [
+    "auth.generate_requests_throttled.count",
+    "auth.generate_requests.count",
+    "auth.generate_seconds.bucket",
+    "auth.generate_seconds.count",
+    "auth.generate_seconds.sum",
+    "auth.grpc.server.handled.count",
+    "auth.grpc.server.msg_received.count",
+    "auth.grpc.server.msg_sent.count",
+    "auth.grpc.server.started.count",
+    "auth.cluster_name_not_found.count",
+    "auth.user.login.count",
+    "auth.migrations",
+    "auth.watcher.event_sizes.bucket",
+    "auth.watcher.event_sizes.count",
+    "auth.watcher.event_sizes.sum",
+    "auth.watcher.events.bucket",
+    "auth.watcher.events.count",
+    "auth.watcher.events.sum",
+]
+
+AUTH_AUDIT_LOG_METRICS = [
+    "auth.audit_log.failed_disk_monitoring.count",
+    "auth.audit_log.failed_emit_events.count",
+    "auth.audit_log.emit_events.count",
+    "auth.audit_log.parquetlog.batch_processing_seconds.bucket",
+    "auth.audit_log.parquetlog.batch_processing_seconds.count",
+    "auth.audit_log.parquetlog.batch_processing_seconds.sum",
+    "auth.audit_log.parquetlog.s3_flush_seconds.bucket",
+    "auth.audit_log.parquetlog.s3_flush_seconds.count",
+    "auth.audit_log.parquetlog.s3_flush_seconds.sum",
+    "auth.audit_log.parquetlog.delete_events_seconds.bucket",
+    "auth.audit_log.parquetlog.delete_events_seconds.count",
+    "auth.audit_log.parquetlog.delete_events_seconds.sum",
+    "auth.audit_log.parquetlog.batch_size.bucket",
+    "auth.audit_log.parquetlog.batch_size.count",
+    "auth.audit_log.parquetlog.batch_size.sum",
+    "auth.audit_log.parquetlog.batch_count.count",
+    "auth.audit_log.parquetlog.errors_from_collect_count.count",
+]
+
+AUTH_BACKEND_S3_METRICS = [
+    "auth.backend.s3.requests.count",
+    "auth.backend.s3.requests_seconds.bucket",
+    "auth.backend.s3.requests_seconds.count",
+    "auth.backend.s3.requests_seconds.sum",
+]
+
+
+def test_auth_teleport_metrics(dd_run_check, aggregator, mock_http_response):
+    fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
+    mock_http_response(file_path=fixtures_path)
+
+    instance = {"diagnostic_url": "http://hostname:3000"}
+    check = TeleportCheck("teleport", {}, [instance])
+    dd_run_check(check)
+
+    for metric in AUTH_METRICS:
+        aggregator.assert_metric(f"teleport.{metric}")
+
+
+def test_auth_audit_log_teleport_metrics(dd_run_check, aggregator, mock_http_response):
+    fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
+    mock_http_response(file_path=fixtures_path)
+
+    instance = {"diagnostic_url": "http://hostname:3000"}
+    check = TeleportCheck("teleport", {}, [instance])
+    dd_run_check(check)
+
+    for metric in AUTH_AUDIT_LOG_METRICS:
+        aggregator.assert_metric(f"teleport.{metric}")
+
+
+def test_auth_backend_s3_teleport_metrics(dd_run_check, aggregator, mock_http_response):
+    fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
+    mock_http_response(file_path=fixtures_path)
+
+    instance = {"diagnostic_url": "http://hostname:3000"}
+    check = TeleportCheck("teleport", {}, [instance])
+    dd_run_check(check)
+
+    for metric in AUTH_BACKEND_S3_METRICS:
+        aggregator.assert_metric(f"teleport.{metric}")

--- a/teleport/tests/test_common.py
+++ b/teleport/tests/test_common.py
@@ -14,7 +14,7 @@ pytestmark = [pytest.mark.unit]
 
 def test_connect_exception(dd_run_check):
     instance = {}
-    check = TeleportCheck('teleport', {}, [instance])
+    check = TeleportCheck("teleport", {}, [instance])
     with pytest.raises(Exception):
         dd_run_check(check)
 
@@ -32,11 +32,11 @@ COMMON_METRICS = [
 
 
 def test_common_teleport_metrics(dd_run_check, aggregator, mock_http_response):
-    fixtures_path = os.path.join(get_here(), 'fixtures', 'metrics.txt')
+    fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
     mock_http_response(file_path=fixtures_path)
 
     instance = {"diagnostic_url": "http://hostname:3000"}
-    check = TeleportCheck('teleport', {}, [instance])
+    check = TeleportCheck("teleport", {}, [instance])
     dd_run_check(check)
 
     for metric in COMMON_METRICS:

--- a/teleport/tests/test_integration.py
+++ b/teleport/tests/test_integration.py
@@ -6,20 +6,20 @@ import pytest
 
 from datadog_checks.teleport import TeleportCheck
 
-pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]
+pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("dd_environment")]
 
 
 def test_connect_ok(aggregator, dd_run_check):
     instance = {"diagnostic_url": "http://127.0.0.1:3000"}
-    check = TeleportCheck('teleport', {}, [instance])
+    check = TeleportCheck("teleport", {}, [instance])
     dd_run_check(check)
-    aggregator.assert_service_check('teleport.health.up', status=TeleportCheck.OK, count=1)
-    aggregator.assert_service_check('teleport.health.up', status=TeleportCheck.CRITICAL, count=0)
+    aggregator.assert_service_check("teleport.health.up", status=TeleportCheck.OK, count=1)
+    aggregator.assert_service_check("teleport.health.up", status=TeleportCheck.CRITICAL, count=0)
 
 
 def test_check_collects_teleport_common_metrics(aggregator, dd_run_check):
     instance = {"diagnostic_url": "http://127.0.0.1:3000"}
-    check = TeleportCheck('teleport', {}, [instance])
+    check = TeleportCheck("teleport", {}, [instance])
     dd_run_check(check)
 
     aggregator.assert_metric("teleport.process.state")

--- a/teleport/tests/test_proxy.py
+++ b/teleport/tests/test_proxy.py
@@ -18,10 +18,6 @@ PROXY_METRICS = [
     "proxy.grpc.client.handled.count",
     "proxy.grpc.client.msg_received.count",
     "proxy.grpc.client.msg_sent.count",
-    "proxy.grpc.server.handled.count",
-    "proxy.grpc.server.msg_received.count",
-    "proxy.grpc.server.msg_sent.count",
-    "proxy.grpc.server.started.count",
     "proxy.connection_limit_exceeded.count",
     "proxy.peer_client.dial_error.count",
     "proxy.peer_server.connections",
@@ -68,11 +64,11 @@ PROXY_METRICS = [
 
 
 def test_proxy_teleport_metrics(dd_run_check, aggregator, mock_http_response):
-    fixtures_path = os.path.join(get_here(), 'fixtures', 'metrics.txt')
+    fixtures_path = os.path.join(get_here(), "fixtures", "metrics.txt")
     mock_http_response(file_path=fixtures_path)
 
     instance = {"diagnostic_url": "http://hostname:3000"}
-    check = TeleportCheck('teleport', {}, [instance])
+    check = TeleportCheck("teleport", {}, [instance])
     dd_run_check(check)
 
     for metric in PROXY_METRICS:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Reports metrics for the Auth Service and Backends as documented [here](https://goteleport.com/docs/reference/metrics/#auth-service-and-backends).
Fixes some auth metrics that were reported as proxy metrics `grpc_server*`.

### Motivation
<!-- What inspired you to submit this pull request? -->
https://datadoghq.atlassian.net/browse/PLINT-303

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
