### PR TITLE
Tag images with a digest of the build context, replacing digest

### DIFF
--- a/.builders/build.py
+++ b/.builders/build.py
@@ -178,6 +178,7 @@ def build_or_pull_image(
         image: str, digest: Optional[str] = None, build_args: Optional[str] = None, verbose: bool = False
 ) -> str:
     """Build or pull an image and return the full name including tag"""
+    target_image = 'ghcr.io/datadog/agent-int-builder'
     image_path = HERE / 'images' / image
     if not image_path.is_dir():
         abort(f'Image does not exist: {image_path}')
@@ -195,7 +196,7 @@ def build_or_pull_image(
             build_args.extend(build_args)
 
         build_context_hash = hash_build_context(build_context_dir, build_args)
-        image_name = f'ghcr.io/datadog/agent-int-builder:{build_context_hash}'
+        image_name = f'{target_image}:{build_context_hash}'
 
         print(f'Hash for the build context: {build_context_hash}')
 
@@ -221,6 +222,9 @@ def build_or_pull_image(
             build_command.extend(['--build-arg', build_arg])
 
         check_process(build_command)
+
+        # Add a tag identifying the platform
+        check_process(['docker', 'tag', image_name, f'{target_image}:{image}'])
 
         return image_name
 

--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -113,10 +113,9 @@ jobs:
     - name: Publish image
       if: github.event_name == 'push'
       run: |-
-        # Push it as tagged with a digest
+        # Push it with the build-context hash tag
         docker push ${{ steps.build-image-and-wheels.outputs.builder_image }}
         # Push it with the platform tag as well
-        docker tag ${{ steps.build-image-and-wheels.outputs.builder_image }} ${{ env.BUILDER_IMAGE }}
         docker push ${{ env.BUILDER_IMAGE }}
 
     - name: Save image digest

--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -78,18 +78,6 @@ jobs:
       with:
         fetch-depth: 2
 
-    # On pull requests, ensure that changed files are determined before checking out the code so
-    # that we use the GitHub API, otherwise we would have to fetch the entire history (depth: 0)
-    - name: Get changed files
-      id: changed-files
-      uses: tj-actions/changed-files@v42
-      with:
-        files_yaml: |-
-          builders:
-          - .builders/**
-          dependencies:
-          - ${{ env.DIRECT_DEPENDENCY_FILE }}
-
     - name: Checkout code
       if: github.event_name == 'pull_request'
       uses: actions/checkout@v4
@@ -115,22 +103,21 @@ jobs:
       with:
         platforms: arm64
 
-    - name: Build image and wheels
-      if: steps.changed-files.outputs.builders_any_changed == 'true'
-      run: |-
-        python .builders/build.py ${{ matrix.job.image }} --python 3 ${{ env.OUT_DIR }}/py3
-        python .builders/build.py ${{ matrix.job.image }} --python 2 ${{ env.OUT_DIR }}/py2
-
-    - name: Pull image and build wheels
-      if: steps.changed-files.outputs.builders_any_changed != 'true'
+    - name: Pull or build image and build wheels
+      id: build-image-and-wheels
       run: |-
         digest=$(jq -r '.["${{ matrix.job.image }}"]' .deps/image_digests.json)
-        python .builders/build.py ${{ matrix.job.image }} --python 3 ${{ env.OUT_DIR }}/py3 --digest $digest
+        python .builders/build.py ${{ matrix.job.image }} --outputs-file "${GITHUB_OUTPUT}" --python 3 ${{ env.OUT_DIR }}/py3 --digest $digest
         python .builders/build.py ${{ matrix.job.image }} --python 2 ${{ env.OUT_DIR }}/py2 --digest $digest
 
     - name: Publish image
-      if: github.event_name == 'push' && steps.changed-files.outputs.builders_any_changed == 'true'
-      run: docker push ${{ env.BUILDER_IMAGE }}
+      if: github.event_name == 'push'
+      run: |-
+        # Push it as tagged with a digest
+        docker push ${{ steps.build-image-and-wheels.outputs.builder_image }}
+        # Push it with the platform tag as well
+        docker tag ${{ steps.build-image-and-wheels.outputs.builder_image }} ${{ env.BUILDER_IMAGE }}
+        docker push ${{ env.BUILDER_IMAGE }}
 
     - name: Save image digest
       if: github.event_name == 'push'


### PR DESCRIPTION
### What does this PR do?

Tags builder images based on a computed build context.

### Motivation

This should provide the following improvements:

- No longer need to update the digests in a separate PR.
- Avoid relying on logic related to whether files has changed (and on its interaction with whichever digests are recorded on the current repo revision)
- Only rebuild images when it's actually needed, so that e.g. updating a dockerfile for a platform will not require rebuilding for another, or updating code that is not used during image build would no longer retrigger a rebuild.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
