### PR TITLE
Fix the labeler config for releases

### DIFF
--- a/.github/workflows/config/labeler.yml
+++ b/.github/workflows/config/labeler.yml
@@ -3,7 +3,7 @@ base_package:
 changelog/no-changelog:
 - any:
   - requirements-agent-release.txt
-  - '*/__about__.py'
+  - '**/__about__.py'
 - all:
   - '!*/datadog_checks/**'
   - '!*/pyproject.toml'
@@ -490,4 +490,4 @@ integration/zeek:
 integration/zk:
 - zk/**/*
 release:
-- '*/__about__.py'
+- '**/__about__.py'

--- a/airflow/datadog_checks/airflow/__about__.py
+++ b/airflow/datadog_checks/airflow/__about__.py
@@ -1,5 +1,4 @@
 # (C) Datadog, Inc. 2019
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
 __version__ = '5.0.0'

--- a/airflow/datadog_checks/airflow/__about__.py
+++ b/airflow/datadog_checks/airflow/__about__.py
@@ -1,4 +1,5 @@
 # (C) Datadog, Inc. 2019
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
 __version__ = '5.0.0'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix the labeler config for releases 

### Motivation
<!-- What inspired you to submit this pull request? -->

In https://github.com/DataDog/integrations-core/pull/16729 we drop the requirement file because it is not needed. However `*/__about__.py` is wrong because this file is in a sub-directory. So this pattern basically never worked 😅 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Spotted on https://github.com/DataDog/integrations-core/pull/17053

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
