### PR TITLE
Document the `metric_prefix` option for custom queries

### DIFF
--- a/clickhouse/assets/configuration/spec.yaml
+++ b/clickhouse/assets/configuration/spec.yaml
@@ -73,6 +73,7 @@ files:
                 type: gauge
             tags:
               - test:clickhouse
+            metric_prefix: clickhouse
     - template: instances/default
   - template: logs
     example:

--- a/clickhouse/changelog.d/17061.fixed
+++ b/clickhouse/changelog.d/17061.fixed
@@ -1,0 +1,1 @@
+Document the `metric_prefix` option for custom queries

--- a/clickhouse/datadog_checks/clickhouse/data/conf.yaml.example
+++ b/clickhouse/datadog_checks/clickhouse/data/conf.yaml.example
@@ -149,6 +149,7 @@ instances:
     #       type: gauge
     #     tags:
     #     - test:clickhouse
+    #     metric_prefix: clickhouse
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/snowflake/assets/configuration/spec.yaml
+++ b/snowflake/assets/configuration/spec.yaml
@@ -200,6 +200,7 @@ files:
                   type: gauge
               tags:
                 - test:snowflake
+              metric_prefix: snowflake
       - template: instances/default
         overrides:
           min_collection_interval.description: |

--- a/snowflake/changelog.d/17061.fixed
+++ b/snowflake/changelog.d/17061.fixed
@@ -1,0 +1,1 @@
+Document the `metric_prefix` option for custom queries

--- a/snowflake/datadog_checks/snowflake/data/conf.yaml.example
+++ b/snowflake/datadog_checks/snowflake/data/conf.yaml.example
@@ -263,6 +263,7 @@ instances:
     #       type: gauge
     #     tags:
     #     - test:snowflake
+    #     metric_prefix: snowflake
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/vertica/assets/configuration/spec.yaml
+++ b/vertica/assets/configuration/spec.yaml
@@ -108,6 +108,7 @@ files:
                       type: tag
                   tags:
                     - test: vertica
+                  metric_prefix: vertica
           - name: client_lib_log_level
             description: |
               Vertica library log level.

--- a/vertica/changelog.d/17061.fixed
+++ b/vertica/changelog.d/17061.fixed
@@ -1,0 +1,1 @@
+Document the `metric_prefix` option for custom queries

--- a/vertica/datadog_checks/vertica/data/conf.yaml.example
+++ b/vertica/datadog_checks/vertica/data/conf.yaml.example
@@ -257,6 +257,7 @@ instances:
     #       type: tag
     #     tags:
     #     - test: vertica
+    #     metric_prefix: vertica
 
     ## @param client_lib_log_level - string - optional
     ## Vertica library log level.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Document the `metric_prefix` option for custom queries

### Motivation
<!-- What inspired you to submit this pull request? -->

Added in https://github.com/DataDog/integrations-core/pull/16958

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
