### PR TITLE
[SDBM-857] skip sqlserver.latches.latch_wait_time metric on sqlserver version 2014 and lower

### DIFF
--- a/sqlserver/changelog.d/17063.fixed
+++ b/sqlserver/changelog.d/17063.fixed
@@ -1,0 +1,1 @@
+Skip `sqlserver.latches.latch_wait_time metric` on SQL Server version 2012 and 2014.

--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -106,7 +106,6 @@ INSTANCE_METRICS = [
     # SQLServer:Locks
     ('sqlserver.stats.lock_waits', 'Lock Waits/sec', '_Total'),  # BULK_COUNT
     ('sqlserver.latches.latch_waits', 'Latch Waits/sec', ''),  # BULK_COUNT
-    ('sqlserver.latches.latch_wait_time', 'Average Latch Wait Time (ms)', ''),  # BULK_COUNT
     ('sqlserver.locks.deadlocks', 'Number of Deadlocks/sec', '_Total'),  # BULK_COUNT
     # SQLServer:Plan Cache
     ('sqlserver.cache.object_counts', 'Cache Object Counts', '_Total'),
@@ -119,6 +118,15 @@ INSTANCE_METRICS = [
     ('sqlserver.transactions.version_cleanup_rate', 'Version Cleanup rate (KB/s)', ''),
     ('sqlserver.transactions.version_generation_rate', 'Version Generation rate (KB/s)', ''),
     ('sqlserver.transactions.longest_transaction_running_time', 'Longest Transaction Running Time', ''),
+]
+
+# SQLServer version >= 2016
+# Default performance table metrics - Database Instance level
+# datadog metric name, counter name, instance name
+INSTANCE_METRICS_NEWER_2016 = [
+    # SQLServer:Locks
+    # base counter Average Latch Wait Time Base is available starting with SQL Server 2016
+    ('sqlserver.latches.latch_wait_time', 'Average Latch Wait Time (ms)', ''),  # BULK_COUNT
 ]
 
 # Performance table metrics, initially configured to track at instance-level only

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -51,6 +51,7 @@ from datadog_checks.sqlserver.const import (
     ENGINE_EDITION_SQL_DATABASE,
     INSTANCE_METRICS,
     INSTANCE_METRICS_DATABASE,
+    INSTANCE_METRICS_NEWER_2016,
     PERF_AVERAGE_BULK,
     PERF_COUNTER_BULK_COUNT,
     PERF_COUNTER_LARGE_RAWCOUNT,
@@ -430,6 +431,7 @@ class SQLServer(AgentCheck):
         Will also create and cache cursors to query the db.
         """
 
+        major_version = self.static_info_cache.get(STATIC_INFO_MAJOR_VERSION)
         metrics_to_collect = []
         tags = self.instance.get('tags', [])
 
@@ -438,6 +440,8 @@ class SQLServer(AgentCheck):
         # to avoid sending duplicate metrics
         if is_affirmative(self.instance.get('include_instance_metrics', True)):
             common_metrics = list(INSTANCE_METRICS)
+            if major_version and major_version >= 2016:
+                common_metrics.extend(INSTANCE_METRICS_NEWER_2016)
             if not self._config.dbm_enabled:
                 common_metrics.extend(DBM_MIGRATED_METRICS)
             if not self.databases:

--- a/sqlserver/tests/test_metrics.py
+++ b/sqlserver/tests/test_metrics.py
@@ -370,7 +370,7 @@ def test_check_tempdb_file_space_usage_metrics(
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-@pytest.mark.skipif(SQLSERVER_MAJOR_VERSION < 2016, reason='Test flakes on this set up')
+@pytest.mark.skipif(SQLSERVER_MAJOR_VERSION < 2016, reason='Metric not supported')
 def test_check_incr_fraction_metrics(
     aggregator,
     dd_run_check,

--- a/sqlserver/tests/test_metrics.py
+++ b/sqlserver/tests/test_metrics.py
@@ -37,6 +37,7 @@ from .common import (
     EXPECTED_QUERY_EXECUTOR_AO_METRICS_REPLICA_COMMON,
     EXPECTED_QUERY_EXECUTOR_AO_METRICS_SECONDARY,
     SERVER_METRICS,
+    SQLSERVER_MAJOR_VERSION,
 )
 from .utils import always_on, not_windows_ci
 
@@ -369,6 +370,7 @@ def test_check_tempdb_file_space_usage_metrics(
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
+@pytest.mark.skipif(SQLSERVER_MAJOR_VERSION < 2016, reason='Test flakes on this set up')
 def test_check_incr_fraction_metrics(
     aggregator,
     dd_run_check,


### PR DESCRIPTION
### What does this PR do?
This PR skips `sqlserver.latches.latch_wait_time` metric on sqlserver versionn 2014 and lower.

### Motivation
The base counter `Average Latch Wait Time Base` is available starting with SQL Server 2016. Without the base counter, the integration is not able to compute the `sqlserver.latches.latch_wait_time` metric.
Below docs show no `Average Latch Wait Time Base` counter in SQL Server 2012 and 2014. 
- [SQL Server 2012](https://learn.microsoft.com/en-us/previous-versions/sql/sql-server-2012/ms177421(v=sql.110))
- [SQL Server 2014](https://learn.microsoft.com/en-us/previous-versions/sql/2014/relational-databases/performance-monitor/sql-server-latches-object?view=sql-server-2014)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
