### PR TITLE
Update the configuration to include the `metric_prefix` option

### DIFF
--- a/clickhouse/changelog.d/17065.fixed
+++ b/clickhouse/changelog.d/17065.fixed
@@ -1,0 +1,1 @@
+Update the configuration to include the `metric_prefix` option

--- a/clickhouse/datadog_checks/clickhouse/config_models/instance.py
+++ b/clickhouse/datadog_checks/clickhouse/config_models/instance.py
@@ -27,6 +27,7 @@ class CustomQuery(BaseModel):
     )
     collection_interval: Optional[int] = None
     columns: Optional[tuple[MappingProxyType[str, Any], ...]] = None
+    metric_prefix: Optional[str] = None
     query: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None
 

--- a/clickhouse/datadog_checks/clickhouse/data/conf.yaml.example
+++ b/clickhouse/datadog_checks/clickhouse/data/conf.yaml.example
@@ -139,6 +139,7 @@ instances:
     ##     If the collection interval is greater than check collection interval, 
     ##     the query will NOT BE RUN exactly at the collection interval.
     ##     The query will be run at the next check run after the collection interval has passed.
+    ## 5. metric_prefix (optional) - The prefix to apply to each metric.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo

--- a/datadog_checks_dev/changelog.d/17065.fixed
+++ b/datadog_checks_dev/changelog.d/17065.fixed
@@ -1,0 +1,1 @@
+Update the configuration to include the `metric_prefix` option

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/db.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/db.yaml
@@ -66,6 +66,7 @@
         If the collection interval is greater than check collection interval, 
         the query will NOT BE RUN exactly at the collection interval.
         The query will be run at the next check run after the collection interval has passed.
+    5. metric_prefix (optional) - The prefix to apply to each metric.
   value:
     type: array
     items:
@@ -83,6 +84,8 @@
             type: string
         - name: collection_interval
           type: integer
+        - name: metric_prefix
+          type: string
     example:
       - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
         columns:
@@ -93,3 +96,4 @@
         tags:
           - test:<INTEGRATION>
         collection_interval: 30
+        metric_prefix: foo_prefix

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -128,6 +128,7 @@ files:
                       type: gauge
                   tags:
                     - test:mysql
+                  metric_prefix: mysql
           - name: additional_status
             description: |
               Set this parameter to collect additional MySQL status variables as metrics

--- a/mysql/changelog.d/17065.fixed
+++ b/mysql/changelog.d/17065.fixed
@@ -1,0 +1,1 @@
+Update the configuration to include the `metric_prefix` option

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -53,6 +53,7 @@ class CustomQuery(BaseModel):
     )
     collection_interval: Optional[int] = None
     columns: Optional[tuple[MappingProxyType[str, Any], ...]] = None
+    metric_prefix: Optional[str] = None
     query: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None
 

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -162,6 +162,7 @@ instances:
     ##     If the collection interval is greater than check collection interval, 
     ##     the query will NOT BE RUN exactly at the collection interval.
     ##     The query will be run at the next check run after the collection interval has passed.
+    ## 5. metric_prefix (optional) - The prefix to apply to each metric.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
@@ -172,6 +173,7 @@ instances:
     #       type: gauge
     #     tags:
     #     - test:mysql
+    #     metric_prefix: mysql
 
     ## @param additional_status - list of mappings - optional
     ## Set this parameter to collect additional MySQL status variables as metrics

--- a/oracle/changelog.d/17065.fixed
+++ b/oracle/changelog.d/17065.fixed
@@ -1,0 +1,1 @@
+Update the configuration to include the `metric_prefix` option

--- a/oracle/datadog_checks/oracle/config_models/instance.py
+++ b/oracle/datadog_checks/oracle/config_models/instance.py
@@ -27,6 +27,7 @@ class CustomQuery(BaseModel):
     )
     collection_interval: Optional[int] = None
     columns: Optional[tuple[MappingProxyType[str, Any], ...]] = None
+    metric_prefix: Optional[str] = None
     query: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None
 

--- a/oracle/datadog_checks/oracle/data/conf.yaml.example
+++ b/oracle/datadog_checks/oracle/data/conf.yaml.example
@@ -153,6 +153,7 @@ instances:
     ##     If the collection interval is greater than check collection interval, 
     ##     the query will NOT BE RUN exactly at the collection interval.
     ##     The query will be run at the next check run after the collection interval has passed.
+    ## 5. metric_prefix (optional) - The prefix to apply to each metric.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
@@ -164,6 +165,7 @@ instances:
     #     tags:
     #     - test:<INTEGRATION>
     #     collection_interval: 30
+    #     metric_prefix: foo_prefix
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/sap_hana/changelog.d/17065.fixed
+++ b/sap_hana/changelog.d/17065.fixed
@@ -1,0 +1,1 @@
+Update the configuration to include the `metric_prefix` option

--- a/sap_hana/datadog_checks/sap_hana/config_models/instance.py
+++ b/sap_hana/datadog_checks/sap_hana/config_models/instance.py
@@ -27,6 +27,7 @@ class CustomQuery(BaseModel):
     )
     collection_interval: Optional[int] = None
     columns: Optional[tuple[MappingProxyType[str, Any], ...]] = None
+    metric_prefix: Optional[str] = None
     query: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None
 

--- a/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
+++ b/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
@@ -145,6 +145,7 @@ instances:
     ##     If the collection interval is greater than check collection interval, 
     ##     the query will NOT BE RUN exactly at the collection interval.
     ##     The query will be run at the next check run after the collection interval has passed.
+    ## 5. metric_prefix (optional) - The prefix to apply to each metric.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
@@ -156,6 +157,7 @@ instances:
     #     tags:
     #     - test:<INTEGRATION>
     #     collection_interval: 30
+    #     metric_prefix: foo_prefix
 
     ## @param persist_db_connections - boolean - optional - default: true
     ## Whether or not to persist database connections.

--- a/singlestore/changelog.d/17065.fixed
+++ b/singlestore/changelog.d/17065.fixed
@@ -1,0 +1,1 @@
+Update the configuration to include the `metric_prefix` option

--- a/singlestore/datadog_checks/singlestore/config_models/instance.py
+++ b/singlestore/datadog_checks/singlestore/config_models/instance.py
@@ -27,6 +27,7 @@ class CustomQuery(BaseModel):
     )
     collection_interval: Optional[int] = None
     columns: Optional[tuple[MappingProxyType[str, Any], ...]] = None
+    metric_prefix: Optional[str] = None
     query: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None
 

--- a/singlestore/datadog_checks/singlestore/data/conf.yaml.example
+++ b/singlestore/datadog_checks/singlestore/data/conf.yaml.example
@@ -120,6 +120,7 @@ instances:
     ##     If the collection interval is greater than check collection interval, 
     ##     the query will NOT BE RUN exactly at the collection interval.
     ##     The query will be run at the next check run after the collection interval has passed.
+    ## 5. metric_prefix (optional) - The prefix to apply to each metric.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
@@ -131,6 +132,7 @@ instances:
     #     tags:
     #     - test:<INTEGRATION>
     #     collection_interval: 30
+    #     metric_prefix: foo_prefix
 
     ## @param collect_system_metrics - boolean - optional - default: false
     ## Collect additional system metrics from the MV_SYSINFO_* tables. Disabled by default to limit

--- a/snowflake/changelog.d/17065.fixed
+++ b/snowflake/changelog.d/17065.fixed
@@ -1,0 +1,1 @@
+Update the configuration to include the `metric_prefix` option

--- a/snowflake/datadog_checks/snowflake/config_models/instance.py
+++ b/snowflake/datadog_checks/snowflake/config_models/instance.py
@@ -27,6 +27,7 @@ class CustomQuery(BaseModel):
     )
     collection_interval: Optional[int] = None
     columns: Optional[tuple[MappingProxyType[str, Any], ...]] = None
+    metric_prefix: Optional[str] = None
     query: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None
 

--- a/snowflake/datadog_checks/snowflake/data/conf.yaml.example
+++ b/snowflake/datadog_checks/snowflake/data/conf.yaml.example
@@ -253,6 +253,7 @@ instances:
     ##     If the collection interval is greater than check collection interval, 
     ##     the query will NOT BE RUN exactly at the collection interval.
     ##     The query will be run at the next check run after the collection interval has passed.
+    ## 5. metric_prefix (optional) - The prefix to apply to each metric.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo

--- a/sqlserver/changelog.d/17065.fixed
+++ b/sqlserver/changelog.d/17065.fixed
@@ -1,0 +1,1 @@
+Update the configuration to include the `metric_prefix` option

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -53,6 +53,7 @@ class CustomQuery(BaseModel):
     )
     collection_interval: Optional[int] = None
     columns: Optional[tuple[MappingProxyType[str, Any], ...]] = None
+    metric_prefix: Optional[str] = None
     query: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None
 

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -611,6 +611,7 @@ instances:
     ##     If the collection interval is greater than check collection interval, 
     ##     the query will NOT BE RUN exactly at the collection interval.
     ##     The query will be run at the next check run after the collection interval has passed.
+    ## 5. metric_prefix (optional) - The prefix to apply to each metric.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
@@ -622,6 +623,7 @@ instances:
     #     tags:
     #     - test:<INTEGRATION>
     #     collection_interval: 30
+    #     metric_prefix: foo_prefix
 
     ## @param stored_procedure - string - optional
     ## DEPRECATED - use `custom_queries` instead. For guidance, see:

--- a/teradata/changelog.d/17065.fixed
+++ b/teradata/changelog.d/17065.fixed
@@ -1,0 +1,1 @@
+Update the configuration to include the `metric_prefix` option

--- a/teradata/datadog_checks/teradata/config_models/instance.py
+++ b/teradata/datadog_checks/teradata/config_models/instance.py
@@ -28,6 +28,7 @@ class CustomQuery(BaseModel):
     )
     collection_interval: Optional[int] = None
     columns: Optional[tuple[MappingProxyType[str, Any], ...]] = None
+    metric_prefix: Optional[str] = None
     query: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None
 

--- a/teradata/datadog_checks/teradata/data/conf.yaml.example
+++ b/teradata/datadog_checks/teradata/data/conf.yaml.example
@@ -207,6 +207,7 @@ instances:
     ##     If the collection interval is greater than check collection interval, 
     ##     the query will NOT BE RUN exactly at the collection interval.
     ##     The query will be run at the next check run after the collection interval has passed.
+    ## 5. metric_prefix (optional) - The prefix to apply to each metric.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
@@ -218,6 +219,7 @@ instances:
     #     tags:
     #     - test:<INTEGRATION>
     #     collection_interval: 30
+    #     metric_prefix: foo_prefix
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/vertica/changelog.d/17065.fixed
+++ b/vertica/changelog.d/17065.fixed
@@ -1,0 +1,1 @@
+Update the configuration to include the `metric_prefix` option

--- a/vertica/datadog_checks/vertica/config_models/instance.py
+++ b/vertica/datadog_checks/vertica/config_models/instance.py
@@ -27,6 +27,7 @@ class CustomQuery(BaseModel):
     )
     collection_interval: Optional[int] = None
     columns: Optional[tuple[MappingProxyType[str, Any], ...]] = None
+    metric_prefix: Optional[str] = None
     query: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None
 

--- a/vertica/datadog_checks/vertica/data/conf.yaml.example
+++ b/vertica/datadog_checks/vertica/data/conf.yaml.example
@@ -247,6 +247,7 @@ instances:
     ##     If the collection interval is greater than check collection interval, 
     ##     the query will NOT BE RUN exactly at the collection interval.
     ##     The query will be run at the next check run after the collection interval has passed.
+    ## 5. metric_prefix (optional) - The prefix to apply to each metric.
     #
     # custom_queries:
     #   - query: SELECT force_outer, table_name FROM v_catalog.tables

--- a/voltdb/changelog.d/17065.fixed
+++ b/voltdb/changelog.d/17065.fixed
@@ -1,0 +1,1 @@
+Update the configuration to include the `metric_prefix` option

--- a/voltdb/datadog_checks/voltdb/config_models/instance.py
+++ b/voltdb/datadog_checks/voltdb/config_models/instance.py
@@ -36,6 +36,7 @@ class CustomQuery(BaseModel):
     )
     collection_interval: Optional[int] = None
     columns: Optional[tuple[MappingProxyType[str, Any], ...]] = None
+    metric_prefix: Optional[str] = None
     query: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None
 

--- a/voltdb/datadog_checks/voltdb/data/conf.yaml.example
+++ b/voltdb/datadog_checks/voltdb/data/conf.yaml.example
@@ -317,6 +317,7 @@ instances:
     ##     If the collection interval is greater than check collection interval, 
     ##     the query will NOT BE RUN exactly at the collection interval.
     ##     The query will be run at the next check run after the collection interval has passed.
+    ## 5. metric_prefix (optional) - The prefix to apply to each metric.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
@@ -328,6 +329,7 @@ instances:
     #     tags:
     #     - test:<INTEGRATION>
     #     collection_interval: 30
+    #     metric_prefix: foo_prefix
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update the configuration to include the `metric_prefix` option

### Motivation
<!-- What inspired you to submit this pull request? -->

Added in the base check in https://github.com/DataDog/integrations-core/pull/16958

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Noticed we forgot it working on a support case

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
