### PR TITLE
Print the info logs in the correct order in the `validate models -s` command

### DIFF
--- a/datadog_checks_dev/changelog.d/17066.fixed
+++ b/datadog_checks_dev/changelog.d/17066.fixed
@@ -1,0 +1,1 @@
+Print the info logs in the correct order in the `validate models -s` command

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/models.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/models.py
@@ -190,7 +190,12 @@ def models(ctx, check, sync, verbose):
 
             if not current_model_file_lines or not content_matches(current_model_file_lines, expected_model_file_lines):
                 if sync:
-                    echo_info(f'Writing data model file to `{model_file_path}`')
+                    check_display_queue.append(
+                        (
+                            echo_info,
+                            f'Writing data model file to `{model_file_path}`',
+                        )
+                    )
                     ensure_parent_dir_exists(model_file_path)
                     write_file_lines(model_file_path, expected_model_file_lines)
                 else:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Print the info logs in the correct order in the `validate models -s` command

### Motivation
<!-- What inspired you to submit this pull request? -->

Before:

```
❯ ddev validate models disk -s
Validating data models for 1 checks ...                                                                                                                                                                                                                                                                                                                           ─╯
Writing data model file to `/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/disk/datadog_checks/disk/config_models/defaults.py`
Writing data model file to `/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/disk/datadog_checks/disk/config_models/instance.py`
disk:
All 5 data model files are in sync!
```

After:

```
❯ ddev validate models disk -s
Validating data models for 1 checks ...                                                                                                                                                                                                                                                                                                                           ─╯
disk:
    Writing data model file to `/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/disk/datadog_checks/disk/config_models/defaults.py`
    Writing data model file to `/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/disk/datadog_checks/disk/config_models/instance.py`
All 5 data model files are in sync!
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

We don't have nice tests in dcd, I'll add them when I'll migrate this command to ddev

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
