### PR TITLE
Adding further information regarding `include_units`

### DIFF
--- a/journald/README.md
+++ b/journald/README.md
@@ -105,7 +105,7 @@ In Datadog Agent version `7.37.0`+, you can filter _user-level_ units by using t
 - `include_user_units`: Includes all user-level units specified.
 - `exclude_user_units`: Excludes all user-level units specified.
 
-**Note**: Use the `*` wildcard in `exclude_units` or `exclude_user_units` to specify a particular Journald log. Further note that `*` will not work with `include_units`, by default if no units for both System and User, and no matches are defined, all journal logs will be collected.
+**Note**: Use the `*` wildcard in `exclude_units` or `exclude_user_units` to specify a particular Journald log. The `*` wildcard does not work with `include_units`. By default, if there are no units for neither system nor user, and no matches are defined, all journal logs are collected.
 
 Example:
 

--- a/journald/README.md
+++ b/journald/README.md
@@ -85,7 +85,7 @@ If your journal is located elsewhere, add a `path` parameter with the correspond
 
 You can filter specific _system-level_ units by using these parameters:
 
-- `include_units`: Includes all system-level units specified. To collect
+- `include_units`: Includes all system-level units specified.
 - `exclude_units`: Excludes all system-level units specified.
 
 

--- a/journald/README.md
+++ b/journald/README.md
@@ -85,7 +85,7 @@ If your journal is located elsewhere, add a `path` parameter with the correspond
 
 You can filter specific _system-level_ units by using these parameters:
 
-- `include_units`: Includes all system-level units specified.
+- `include_units`: Includes all system-level units specified. To collect
 - `exclude_units`: Excludes all system-level units specified.
 
 
@@ -105,7 +105,7 @@ In Datadog Agent version `7.37.0`+, you can filter _user-level_ units by using t
 - `include_user_units`: Includes all user-level units specified.
 - `exclude_user_units`: Excludes all user-level units specified.
 
-**Note**: Use the `*` wildcard in `exclude_units` or `exclude_user_units` to specify a particular Journald log.
+**Note**: Use the `*` wildcard in `exclude_units` or `exclude_user_units` to specify a particular Journald log. Further note that `*` will not work with `include_units`, by default if no units for both System and User, and no matches are defined, all journal logs will be collected.
 
 Example:
 


### PR DESCRIPTION
### What does this PR do?
This PR adds the fact that to collect all logs, we do not need to add a wildcard to the `include_units` section.

### Motivation
- Working on a customer case [AGENT-11124], we discovered that the following prevented log collection:
```
include_units: 
  - *
```

### Supporting Documentation:
- https://github.com/DataDog/datadog-agent/blob/7.50.x/pkg/logs/tailers/journald/tailer.go#L116-L126

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.


[AGENT-11124]: https://datadoghq.atlassian.net/browse/AGENT-11124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ