### PR TITLE
Fix matching built wheels in uploading logic

### DIFF
--- a/.builders/tests/test_upload.py
+++ b/.builders/tests/test_upload.py
@@ -32,7 +32,7 @@ def setup_fake_bucket(monkeypatch):
             # but it should be good enough for what we use it for.
             return (
                 make_blob(f) for f in files
-                if f.startswith(prefix) and fnmatch.fnmatch(Path(f).name, match_glob)
+                if f.startswith(prefix) and fnmatch.fnmatch(f, match_glob)
             )
 
         bucket = mock.Mock()

--- a/.builders/upload.py
+++ b/.builders/upload.py
@@ -60,7 +60,7 @@ def display_message_block(message: str) -> None:
 
 def timestamp_build_number() -> int:
     """Produce a numeric timestamp to use as build numbers"""
-    return int(time.strftime('%Y%M%d%H%m%s'))
+    return int(time.strftime('%Y%m%d%H%M%S'))
 
 
 def hash_file(path: Path) -> str:

--- a/.builders/upload.py
+++ b/.builders/upload.py
@@ -137,8 +137,8 @@ def upload(targets_dir):
                 # https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-name-convention
                 name, version, python_tag, abi_tag, platform_tag = wheel.stem.split('-')
                 existing_wheels = list(bucket.list_blobs(
-                    prefix=f'{artifact_type}/{project_name}/',
-                    match_glob=f'{name}-{version}*-{python_tag}-{abi_tag}-{platform_tag}.whl',
+                    match_glob=(f'{artifact_type}/{project_name}/'
+                                f'{name}-{version}*-{python_tag}-{abi_tag}-{platform_tag}.whl'),
                 ))
                 if existing_wheels:
                     most_recent_wheel = max(existing_wheels, key=_build_number_of_wheel_blob)

--- a/.builders/upload.py
+++ b/.builders/upload.py
@@ -138,7 +138,7 @@ def upload(targets_dir):
                 name, version, python_tag, abi_tag, platform_tag = wheel.stem.split('-')
                 existing_wheels = list(bucket.list_blobs(
                     prefix=f'{artifact_type}/{project_name}/',
-                    match_glob=f'{name}-{version}-*-{abi_tag}-{platform_tag}.whl',
+                    match_glob=f'{name}-{version}*-{python_tag}-{abi_tag}-{platform_tag}.whl',
                 ))
                 if existing_wheels:
                     most_recent_wheel = max(existing_wheels, key=_build_number_of_wheel_blob)

--- a/.builders/upload.py
+++ b/.builders/upload.py
@@ -144,6 +144,8 @@ def upload(targets_dir):
                     most_recent_wheel = max(existing_wheels, key=_build_number_of_wheel_blob)
                     # Don't upload if it's the same file
                     if most_recent_wheel.metadata['sha256'] == sha256_digest:
+                        print(f'{prefix} {project_name}=={project_metadata["Version"]} already exists '
+                              'with the same hash')
                         continue
 
                 build_number = timestamp_build_number()


### PR DESCRIPTION
### What does this PR do?

- Fixes the timestamp format used in uploaded build numbers.
- Fixes how candidates to matched are obtained. I misunderstood how `match_glob` works in my initial implementation and it wasn't really matching anything.
- Adds an additional log file for more visibility.

### Motivation

Found that new builds were being uploaded even when it wasn't necessary.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
