### PR TITLE
Add a pre-commit hook to validate service checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,9 @@ repos:
       language: system
       files: '.+\.py'
       pass_filenames: false
+    - id: service_checks
+      name: Validate service checks
+      entry: ddev validate service-checks
+      language: system
+      files: '.*/assets/service_checks\.json'
+      pass_filenames: false


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add a pre-commit hook to validate service checks

### Motivation
<!-- What inspired you to submit this pull request? -->

Got an error in https://github.com/DataDog/integrations-core/pull/17070/files that could be easily validated before

### Additional Notes
<!-- Anything else we should know when reviewing? -->

The validate is blazing fast so it should not be a problem.

Example:

```
❯ pre-commit
Run linters..........................................(no files to check)Skipped                                                                                                                                                                                                                                                                                   
Validate service checks..................................................Failed
- hook id: service_checks
- exit code: 1

Validating service_checks.json files for 227 checks ...
airflow/service_checks.json... FAILED
  Can Connect is not a unique name
226 valid files
1 invalid files
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
