### PR TITLE
Disable db connection pooling by default

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -14,9 +14,9 @@ try:
     import adodbapi
 except ImportError:
     adodbapi = None
-
 try:
     import pyodbc
+    pyodbc.pooling = False
 except ImportError:
     pyodbc = None
 

--- a/sqlserver/datadog_checks/sqlserver/connection_errors.py
+++ b/sqlserver/datadog_checks/sqlserver/connection_errors.py
@@ -7,7 +7,6 @@ from enum import Enum
 
 try:
     import pyodbc
-    pyodbc.pooling = False
 except ImportError:
     pyodbc = None
 

--- a/sqlserver/datadog_checks/sqlserver/connection_errors.py
+++ b/sqlserver/datadog_checks/sqlserver/connection_errors.py
@@ -7,6 +7,7 @@ from enum import Enum
 
 try:
     import pyodbc
+    pyodbc.pooling = False
 except ImportError:
     pyodbc = None
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -90,6 +90,7 @@ except ImportError:
 
 try:
     import pyodbc
+    pyodbc.pooling = False
 except ImportError:
     pyodbc = None
 


### PR DESCRIPTION
### What does this PR do?
Disables pooling of connections by default when using pyodbc. 
(https://groups.google.com/g/pyodbc/c/Mg6rFPb4gw8?pli=1)

### Motivation
A probable cause of an excessive number of connections.