### PR TITLE
update sqlserver windows test env

### DIFF
--- a/.ddev/config.toml
+++ b/.ddev/config.toml
@@ -57,7 +57,6 @@ runners = { linux = ["ubuntu-20.04"] }
 
 [overrides.ci.sqlserver]
 platforms = ["windows", "linux"]
-runners = { windows = ["windows-2019"] }
 
 [overrides.ci.tcp_check]
 platforms = ["linux", "windows"]

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -2905,7 +2905,7 @@ jobs:
       job-name: SQL Server on Windows
       target: sqlserver
       platform: windows
-      runner: '["windows-2019"]'
+      runner: '["windows-2022"]'
       repo: "${{ inputs.repo }}"
       python-version: "${{ inputs.python-version }}"
       standard: ${{ inputs.standard }}

--- a/docs/developer/meta/ci/testing.md
+++ b/docs/developer/meta/ci/testing.md
@@ -130,7 +130,7 @@ To override the runners for each platform, one can set the `overrides.ci.<TARGET
 
 ```toml
 [overrides.ci.sqlserver]
-runners = { windows = ["windows-2019"] }
+runners = { windows = ["windows-2022"] }
 ```
 
 ### Exclusion

--- a/sqlserver/hatch.toml
+++ b/sqlserver/hatch.toml
@@ -15,7 +15,7 @@ setup = ["single", "ha"]
 python = ["3.11"]
 os = ["windows"]
 driver = ["SQLOLEDB", "SQLNCLI11", "MSOLEDBSQL", "odbc"]
-version = ["2019"]
+version = ["2019", "2022"]
 setup = ["single"]
 
 # The high cardinality environment is meant to be used for local dev/testing
@@ -23,7 +23,7 @@ setup = ["single"]
 # query, we can do that by uncommenting this env setup. Note, you should make sure to set you
 # DD_API_KEY in order to send the related metrics to staging for evaluation.
 #[[envs.default.matrix]]
-#python = ["3.9"]
+#python = ["3.11"]
 #os = ["linux"]
 #driver = ["odbc"]
 #version = ["2019", "2022"]
@@ -54,9 +54,9 @@ matrix.setup.env-vars = [
 matrix.version.env-vars = [
   { key = "SQLSERVER_MAJOR_VERSION" },
   { key = "SQLSERVER_ENGINE_EDITION" },
-  { key = "SQLSERVER_IMAGE_TAG", value = "2017-CU24-ubuntu-16.04", if = ["2017"], platform = ["linux"] },
-  { key = "SQLSERVER_IMAGE_TAG", value = "2019-CU11-ubuntu-16.04", if = ["2019"], platform = ["linux"] },
-  { key = "SQLSERVER_IMAGE_TAG", value = "2022-CU9-ubuntu-20.04", if = ["2022"], platform = ["linux"] },
+  { key = "SQLSERVER_IMAGE_TAG", value = "2017-latest", if = ["2017"], platform = ["linux"] },
+  { key = "SQLSERVER_IMAGE_TAG", value = "2019-latest", if = ["2019"], platform = ["linux"] },
+  { key = "SQLSERVER_IMAGE_TAG", value = "2022-latest", if = ["2022"], platform = ["linux"] },
   { key = "SQLSERVER_BASE_IMAGE", value = "datadog/docker-library:sqlserver_{matrix:version}", platform = ["windows"] },
 ]
 matrix.driver.env-vars = [

--- a/sqlserver/hatch.toml
+++ b/sqlserver/hatch.toml
@@ -15,7 +15,7 @@ setup = ["single", "ha"]
 python = ["3.11"]
 os = ["windows"]
 driver = ["SQLOLEDB", "SQLNCLI11", "MSOLEDBSQL", "odbc"]
-version = ["2019"]
+version = ["2017", "2019"]
 setup = ["single"]
 
 # The high cardinality environment is meant to be used for local dev/testing

--- a/sqlserver/hatch.toml
+++ b/sqlserver/hatch.toml
@@ -15,7 +15,7 @@ setup = ["single", "ha"]
 python = ["3.11"]
 os = ["windows"]
 driver = ["SQLOLEDB", "SQLNCLI11", "MSOLEDBSQL", "odbc"]
-version = ["2019", "2022"]
+version = ["2019"]
 setup = ["single"]
 
 # The high cardinality environment is meant to be used for local dev/testing

--- a/sqlserver/tests/compose-high-cardinality-windows/docker-compose.yaml
+++ b/sqlserver/tests/compose-high-cardinality-windows/docker-compose.yaml
@@ -7,5 +7,6 @@ services:
       dockerfile: Dockerfile
       args:
         - SQLSERVER_BASE_IMAGE=${SQLSERVER_BASE_IMAGE}
+    isolation: hyperv
     ports:
       - "1433:1433"

--- a/sqlserver/tests/compose-windows/docker-compose.yaml
+++ b/sqlserver/tests/compose-windows/docker-compose.yaml
@@ -7,5 +7,6 @@ services:
       dockerfile: Dockerfile
       args:
         - SQLSERVER_BASE_IMAGE=${SQLSERVER_BASE_IMAGE}
+    isolation: hyperv
     ports:
       - "1433:1433"

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -432,8 +432,8 @@ def test_connection_failure(aggregator, dd_run_check, instance_docker):
             "failed_tcp_connection",
             {"host": "localhost,9999"},
             {
-                "odbc-windows|MSOLEDBSQL": "TCP Provider: No connection could be made"
-                " because the target machine actively refused it",
+                "odbc-windows|MSOLEDBSQL": "TCP-connection\\(ERROR: No connection could be made "
+                "because the target machine actively refused it\\).*",
                 "SQLOLEDB|SQLNCLI11": "TCP-connection\\(ERROR: No connection could be made "
                 "because the target machine actively refused it\\).*"
                 "could not open database requested by login",


### PR DESCRIPTION
### What does this PR do?
This PR adds `sqlserver-2017` & `sqlserver-2022` to windows test env matrix. 

`isolation: hyperv` is added to docker-compose to resolve issue `The container operating system does not match the host operating system`.  This is a common issue when attempting to run Windows container images, as Windows containers require the host and container's base image to share the same kernel version. Hyper-V isolation provides a workaround for compatibility issues, allow us to use `windows-2022` runner for all sqlserver windows tests.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
