### PR TITLE
Use arm64 runners to run arm64 build

### DIFF
--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-        - os: ubuntu-22.04
+        - os: arm-4core-linux
           image: linux-aarch64
         - os: ubuntu-22.04
           image: linux-x86_64
@@ -95,12 +95,30 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Python ${{ env.PYTHON_VERSION }}
+      if: matrix.job.image != 'linux-aarch64'
       uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
+    - name: Set up Python (with miniconda) and other aarch64 requirements
+      if: matrix.job.image == 'linux-aarch64'
+      run: |
+        mkdir -p ~/miniconda3
+        wget https://repo.anaconda.com/miniconda/Miniconda3-py311_24.1.2-0-Linux-aarch64.sh -O ~/miniconda3/miniconda.sh
+        bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
+        rm -rf ~/miniconda3/miniconda.sh
+        ~/miniconda3/bin/conda init bash
+
+    - name: Install docker
+      if: matrix.job.image == 'linux-aarch64'
+      run: |
+        curl -fsSL https://get.docker.com -o get-docker.sh
+        sudo sh get-docker.sh
+
     - name: Install management dependencies
-      run: pip install -r .builders/deps/host_dependencies.txt
+      run: |
+        PATH=~/miniconda3/bin/:${PATH}
+        pip install -r .builders/deps/host_dependencies.txt
 
     - name: Log in to GitHub Packages
       uses: docker/login-action@v3
@@ -109,31 +127,31 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set up QEMU
+    - name: Build image and wheels (arm64)
       if: matrix.job.image == 'linux-aarch64'
-      uses: docker/setup-qemu-action@v3
-      with:
-        platforms: arm64
+      run: |-
+        sudo /home/runner/miniconda3/bin/python .builders/build.py ${{ matrix.job.image }} --python 3 ${{ env.OUT_DIR }}/py3
+        sudo /home/runner/miniconda3/bin/python .builders/build.py ${{ matrix.job.image }} --python 2 ${{ env.OUT_DIR }}/py2
 
     - name: Build image and wheels
-      if: steps.changed-files.outputs.builders_any_changed == 'true'
+      if: steps.changed-files.outputs.builders_any_changed == 'true' && matrix.job.image != 'linux-aarch64'
       run: |-
         python .builders/build.py ${{ matrix.job.image }} --python 3 ${{ env.OUT_DIR }}/py3
         python .builders/build.py ${{ matrix.job.image }} --python 2 ${{ env.OUT_DIR }}/py2
 
     - name: Pull image and build wheels
-      if: steps.changed-files.outputs.builders_any_changed != 'true'
+      if: steps.changed-files.outputs.builders_any_changed != 'true' && matrix.job.image != 'linux-aarch64'
       run: |-
         digest=$(jq -r '.["${{ matrix.job.image }}"]' .deps/image_digests.json)
         python .builders/build.py ${{ matrix.job.image }} --python 3 ${{ env.OUT_DIR }}/py3 --digest $digest
         python .builders/build.py ${{ matrix.job.image }} --python 2 ${{ env.OUT_DIR }}/py2 --digest $digest
 
     - name: Publish image
-      if: github.event_name == 'push' && steps.changed-files.outputs.builders_any_changed == 'true'
+      if: github.event_name == 'push' && steps.changed-files.outputs.builders_any_changed == 'true' && matrix.job.image != 'linux-aarch64'
       run: docker push ${{ env.BUILDER_IMAGE }}
 
     - name: Save image digest
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' && matrix.job.image != 'linux-aarch64'
       run: >-
         docker inspect --format "{{index .RepoDigests 0}}" ${{ env.BUILDER_IMAGE }}
         | cut -d '@' -f 2

--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -109,18 +109,26 @@ jobs:
         rm -rf ~/miniconda3/miniconda.sh
         ~/miniconda3/bin/conda init bash
 
-    - name: Install docker
-      if: matrix.job.image == 'linux-aarch64'
-      run: |
-        curl -fsSL https://get.docker.com -o get-docker.sh
-        sudo sh get-docker.sh
+        # jq
+        wget https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-arm64 -O ~/miniconda3/bin/jq
+        chmod +x ~/miniconda3/bin/jq
 
     - name: Install management dependencies
       run: |
         PATH=~/miniconda3/bin/:${PATH}
         pip install -r .builders/deps/host_dependencies.txt
 
+    - name: Install docker and log in (arm64)
+      if: matrix.job.image == 'linux-aarch64'
+      run: |
+        curl -fsSL https://get.docker.com -o get-docker.sh
+        sudo sh get-docker.sh
+
+        # Logging in with sudo is necessary to get authorized with the registry when running docker under sudo
+        echo ${{ secrets.GITHUB_TOKEN }} | sudo docker login --username ${{ github.actor }} --password-stdin ghcr.io
+
     - name: Log in to GitHub Packages
+      if: matrix.job.image != 'linux-aarch64'
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
@@ -128,10 +136,18 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build image and wheels (arm64)
-      if: matrix.job.image == 'linux-aarch64'
+      if: steps.changed-files.outputs.builders_any_changed == 'true' && matrix.job.image == 'linux-aarch64'
       run: |-
         sudo /home/runner/miniconda3/bin/python .builders/build.py ${{ matrix.job.image }} --python 3 ${{ env.OUT_DIR }}/py3
         sudo /home/runner/miniconda3/bin/python .builders/build.py ${{ matrix.job.image }} --python 2 ${{ env.OUT_DIR }}/py2
+
+    - name: Pull image and build wheels (arm64)
+      if: steps.changed-files.outputs.builders_any_changed != 'true' && matrix.job.image == 'linux-aarch64'
+      run: |-
+        PATH=~/miniconda3/bin/:${PATH}
+        digest=$(jq -r '.["${{ matrix.job.image }}"]' .deps/image_digests.json)
+        sudo /home/runner/miniconda3/bin/python .builders/build.py ${{ matrix.job.image }} --python 3 ${{ env.OUT_DIR }}/py3 --digest $digest
+        sudo /home/runner/miniconda3/bin/python .builders/build.py ${{ matrix.job.image }} --python 2 ${{ env.OUT_DIR }}/py2 --digest $digest
 
     - name: Build image and wheels
       if: steps.changed-files.outputs.builders_any_changed == 'true' && matrix.job.image != 'linux-aarch64'

--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -113,9 +113,10 @@ jobs:
         wget https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-arm64 -O ~/miniconda3/bin/jq
         chmod +x ~/miniconda3/bin/jq
 
+        echo "PATH=~/miniconda3/bin/:${PATH}" >> "$GITHUB_ENV"
+
     - name: Install management dependencies
       run: |
-        PATH=~/miniconda3/bin/:${PATH}
         pip install -r .builders/deps/host_dependencies.txt
 
     - name: Install docker and log in (arm64)
@@ -144,7 +145,6 @@ jobs:
     - name: Pull image and build wheels (arm64)
       if: steps.changed-files.outputs.builders_any_changed != 'true' && matrix.job.image == 'linux-aarch64'
       run: |-
-        PATH=~/miniconda3/bin/:${PATH}
         digest=$(jq -r '.["${{ matrix.job.image }}"]' .deps/image_digests.json)
         sudo /home/runner/miniconda3/bin/python .builders/build.py ${{ matrix.job.image }} --python 3 ${{ env.OUT_DIR }}/py3 --digest $digest
         sudo /home/runner/miniconda3/bin/python .builders/build.py ${{ matrix.job.image }} --python 2 ${{ env.OUT_DIR }}/py2 --digest $digest


### PR DESCRIPTION
### What does this PR do?

Run aarch64 build natively instead of through QEMU.

### Motivation

Native arm64 runners being made available.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
