### PR TITLE
Update default OTel Collector dashboard with telemetry source tag

### DIFF
--- a/otel/assets/dashboards/otel_collector_metrics_dashboard.json
+++ b/otel/assets/dashboards/otel_collector_metrics_dashboard.json
@@ -1983,7 +1983,52 @@
                         "layout": {
                             "x": 0,
                             "y": 0,
-                            "width": 6,
+                            "width": 3,
+                            "height": 2
+                        }
+                    },
+                    {
+                        "id": 7083501826441510,
+                        "definition": {
+                            "title": "Spans/s",
+                            "show_legend": true,
+                            "legend_layout": "auto",
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "type": "timeseries",
+                            "requests": [
+                                {
+                                    "formulas": [
+                                        {
+                                            "formula": "query1"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_spans{$host}.as_rate()",
+                                            "data_source": "metrics",
+                                            "name": "query1"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "palette": "dog_classic",
+                                        "line_type": "solid",
+                                        "line_width": "normal"
+                                    },
+                                    "display_type": "line"
+                                }
+                            ]
+                        },
+                        "layout": {
+                            "x": 3,
+                            "y": 0,
+                            "width": 3,
                             "height": 2
                         }
                     },
@@ -2071,9 +2116,9 @@
                         }
                     },
                     {
-                        "id": 7083501826441510,
+                        "id": 8355231721049742,
                         "definition": {
-                            "title": "Spans/s",
+                            "title": "Bytes/s",
                             "show_legend": true,
                             "legend_layout": "auto",
                             "legend_columns": [
@@ -2093,7 +2138,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_spans{$host}.as_rate()",
+                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_bytes{$host}.as_rate()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2106,12 +2151,71 @@
                                     },
                                     "display_type": "line"
                                 }
-                            ]
+                            ],
+                            "yaxis": {
+                                "include_zero": true,
+                                "scale": "linear",
+                                "label": "",
+                                "min": "auto",
+                                "max": "auto"
+                            }
                         },
                         "layout": {
                             "x": 0,
                             "y": 2,
-                            "width": 6,
+                            "width": 3,
+                            "height": 2
+                        }
+                    },
+                    {
+                        "id": 916753513797492,
+                        "definition": {
+                            "title": "Payloads/s",
+                            "show_legend": true,
+                            "legend_layout": "auto",
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "type": "timeseries",
+                            "requests": [
+                                {
+                                    "formulas": [
+                                        {
+                                            "formula": "query1"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_payloads{$host}.as_rate()",
+                                            "data_source": "metrics",
+                                            "name": "query1"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "palette": "dog_classic",
+                                        "line_type": "solid",
+                                        "line_width": "normal"
+                                    },
+                                    "display_type": "line"
+                                }
+                            ],
+                            "yaxis": {
+                                "include_zero": true,
+                                "scale": "linear",
+                                "label": "",
+                                "min": "auto",
+                                "max": "auto"
+                            }
+                        },
+                        "layout": {
+                            "x": 3,
+                            "y": 2,
+                            "width": 3,
                             "height": 2
                         }
                     },
@@ -2182,61 +2286,30 @@
                         }
                     },
                     {
-                        "id": 8355231721049742,
+                        "id": 2391069929057274,
                         "definition": {
-                            "title": "Bytes/s",
-                            "show_legend": true,
-                            "legend_layout": "auto",
-                            "legend_columns": [
-                                "avg",
-                                "min",
-                                "max",
-                                "value",
-                                "sum"
-                            ],
-                            "type": "timeseries",
-                            "requests": [
-                                {
-                                    "formulas": [
-                                        {
-                                            "formula": "query1"
-                                        }
-                                    ],
-                                    "queries": [
-                                        {
-                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_bytes{$host}.as_rate()",
-                                            "data_source": "metrics",
-                                            "name": "query1"
-                                        }
-                                    ],
-                                    "response_format": "timeseries",
-                                    "style": {
-                                        "palette": "dog_classic",
-                                        "line_type": "solid",
-                                        "line_width": "normal"
-                                    },
-                                    "display_type": "line"
-                                }
-                            ],
-                            "yaxis": {
-                                "include_zero": true,
-                                "scale": "linear",
-                                "label": "",
-                                "min": "auto",
-                                "max": "auto"
-                            }
+                            "type": "note",
+                            "content": "Traces and spans ingested/s represents the rate of OTLP traces received and processed by the trace API. The trace API receives data from both the Datadog Exporter and the Datadog Connector, which can be grouped by the `source` tag.",
+                            "background_color": "white",
+                            "font_size": "12",
+                            "text_align": "left",
+                            "vertical_align": "center",
+                            "show_tick": true,
+                            "tick_pos": "50%",
+                            "tick_edge": "right",
+                            "has_padding": true
                         },
                         "layout": {
                             "x": 0,
                             "y": 4,
-                            "width": 3,
+                            "width": 2,
                             "height": 2
                         }
                     },
                     {
-                        "id": 916753513797492,
+                        "id": 8797660477705488,
                         "definition": {
-                            "title": "Payloads/s",
+                            "title": "Traces Ingested/s",
                             "show_legend": true,
                             "legend_layout": "auto",
                             "legend_columns": [
@@ -2246,6 +2319,7 @@
                                 "value",
                                 "sum"
                             ],
+                            "time": {},
                             "type": "timeseries",
                             "requests": [
                                 {
@@ -2256,7 +2330,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_payloads{$host}.as_rate()",
+                                            "query": "sum:otelcol_datadog_trace_agent_otlp_traces{$host, source:datadogexporter}.as_rate()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2267,7 +2341,7 @@
                                         "line_type": "solid",
                                         "line_width": "normal"
                                     },
-                                    "display_type": "line"
+                                    "display_type": "bars"
                                 }
                             ],
                             "yaxis": {
@@ -2279,9 +2353,62 @@
                             }
                         },
                         "layout": {
-                            "x": 3,
+                            "x": 2,
                             "y": 4,
-                            "width": 3,
+                            "width": 2,
+                            "height": 2
+                        }
+                    },
+                    {
+                        "id": 8662297609527868,
+                        "definition": {
+                            "title": "Spans Ingested/s",
+                            "show_legend": true,
+                            "legend_layout": "auto",
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "time": {},
+                            "type": "timeseries",
+                            "requests": [
+                                {
+                                    "formulas": [
+                                        {
+                                            "formula": "query1"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "query": "sum:otelcol_datadog_trace_agent_otlp_spans{$host, source:datadogexporter}.as_rate()",
+                                            "data_source": "metrics",
+                                            "name": "query1"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "palette": "dog_classic",
+                                        "line_type": "solid",
+                                        "line_width": "normal"
+                                    },
+                                    "display_type": "bars"
+                                }
+                            ],
+                            "yaxis": {
+                                "include_zero": true,
+                                "scale": "linear",
+                                "label": "",
+                                "min": "auto",
+                                "max": "auto"
+                            }
+                        },
+                        "layout": {
+                            "x": 4,
+                            "y": 4,
+                            "width": 2,
                             "height": 2
                         }
                     },
@@ -2404,7 +2531,155 @@
                         "layout": {
                             "x": 0,
                             "y": 0,
-                            "width": 4,
+                            "width": 3,
+                            "height": 2
+                        }
+                    },
+                    {
+                        "id": 9004774405386442,
+                        "definition": {
+                            "type": "note",
+                            "content": "**Note:** The metrics in this section have a `source` tag which indicates the component they originate from. These Datadog Connector telemetry metrics are being generated by the exporter, but the stats themselves are generated and sent by the Datadog Connector. This is why some of these metrics have a source of `datadogexporter`.",
+                            "background_color": "white",
+                            "font_size": "12",
+                            "text_align": "left",
+                            "vertical_align": "center",
+                            "show_tick": false,
+                            "tick_pos": "50%",
+                            "tick_edge": "right",
+                            "has_padding": true
+                        },
+                        "layout": {
+                            "x": 3,
+                            "y": 0,
+                            "width": 3,
+                            "height": 2
+                        }
+                    },
+                    {
+                        "id": 3312471392848186,
+                        "definition": {
+                            "type": "note",
+                            "content": "Traces and spans ingested/s represents the rate of OTLP traces received and processed by the trace API. The trace API receives data from both the Datadog Exporter and the Datadog Connector, which can be grouped by the `source` tag.",
+                            "background_color": "white",
+                            "font_size": "12",
+                            "text_align": "left",
+                            "vertical_align": "center",
+                            "show_tick": true,
+                            "tick_pos": "50%",
+                            "tick_edge": "right",
+                            "has_padding": true
+                        },
+                        "layout": {
+                            "x": 6,
+                            "y": 0,
+                            "width": 2,
+                            "height": 2
+                        }
+                    },
+                    {
+                        "id": 3256701085410466,
+                        "definition": {
+                            "title": "Traces Ingested/s",
+                            "show_legend": true,
+                            "legend_layout": "auto",
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "time": {},
+                            "type": "timeseries",
+                            "requests": [
+                                {
+                                    "formulas": [
+                                        {
+                                            "formula": "query1"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "query": "sum:otelcol_datadog_trace_agent_otlp_traces{$host,source:datadogconnector}.as_rate()",
+                                            "data_source": "metrics",
+                                            "name": "query1"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "palette": "dog_classic",
+                                        "line_type": "solid",
+                                        "line_width": "normal"
+                                    },
+                                    "display_type": "bars"
+                                }
+                            ],
+                            "yaxis": {
+                                "include_zero": true,
+                                "scale": "linear",
+                                "label": "",
+                                "min": "auto",
+                                "max": "auto"
+                            }
+                        },
+                        "layout": {
+                            "x": 8,
+                            "y": 0,
+                            "width": 2,
+                            "height": 2
+                        }
+                    },
+                    {
+                        "id": 4752297048334012,
+                        "definition": {
+                            "title": "Spans Ingested/s",
+                            "show_legend": true,
+                            "legend_layout": "auto",
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "time": {},
+                            "type": "timeseries",
+                            "requests": [
+                                {
+                                    "formulas": [
+                                        {
+                                            "formula": "query1"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "query": "sum:otelcol_datadog_trace_agent_otlp_spans{$host,source:datadogconnector}.as_rate()",
+                                            "data_source": "metrics",
+                                            "name": "query1"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "palette": "dog_classic",
+                                        "line_type": "solid",
+                                        "line_width": "normal"
+                                    },
+                                    "display_type": "bars"
+                                }
+                            ],
+                            "yaxis": {
+                                "include_zero": true,
+                                "scale": "linear",
+                                "label": "",
+                                "min": "auto",
+                                "max": "auto"
+                            }
+                        },
+                        "layout": {
+                            "x": 10,
+                            "y": 0,
+                            "width": 2,
                             "height": 2
                         }
                     },
@@ -2447,9 +2722,9 @@
                             ]
                         },
                         "layout": {
-                            "x": 4,
-                            "y": 0,
-                            "width": 4,
+                            "x": 0,
+                            "y": 2,
+                            "width": 3,
                             "height": 2
                         }
                     },
@@ -2492,8 +2767,74 @@
                             ]
                         },
                         "layout": {
+                            "x": 3,
+                            "y": 2,
+                            "width": 3,
+                            "height": 2
+                        }
+                    },
+                    {
+                        "id": 2247423855597712,
+                        "definition": {
+                            "type": "note",
+                            "content": "If an error occurs while flushing stats from the Collector to Datadog, then the payload may be retried. A high number of retries may be indicative of a network problem.",
+                            "background_color": "white",
+                            "font_size": "12",
+                            "text_align": "left",
+                            "vertical_align": "center",
+                            "show_tick": true,
+                            "tick_pos": "50%",
+                            "tick_edge": "right",
+                            "has_padding": true
+                        },
+                        "layout": {
+                            "x": 6,
+                            "y": 2,
+                            "width": 2,
+                            "height": 2
+                        }
+                    },
+                    {
+                        "id": 2702360482430454,
+                        "definition": {
+                            "title": "Stats Writer Retries",
+                            "show_legend": true,
+                            "legend_layout": "auto",
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "type": "timeseries",
+                            "requests": [
+                                {
+                                    "formulas": [
+                                        {
+                                            "formula": "query1"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_retries{$host}.as_count()",
+                                            "data_source": "metrics",
+                                            "name": "query1"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "palette": "dog_classic",
+                                        "line_type": "solid",
+                                        "line_width": "normal"
+                                    },
+                                    "display_type": "bars"
+                                }
+                            ]
+                        },
+                        "layout": {
                             "x": 8,
-                            "y": 0,
+                            "y": 2,
                             "width": 4,
                             "height": 2
                         }
@@ -2538,7 +2879,7 @@
                         },
                         "layout": {
                             "x": 0,
-                            "y": 2,
+                            "y": 4,
                             "width": 3,
                             "height": 2
                         }
@@ -2583,111 +2924,7 @@
                         },
                         "layout": {
                             "x": 3,
-                            "y": 2,
-                            "width": 3,
-                            "height": 2
-                        }
-                    },
-                    {
-                        "id": 5777593901299880,
-                        "definition": {
-                            "title": "Traces Ingested/s",
-                            "show_legend": true,
-                            "legend_layout": "auto",
-                            "legend_columns": [
-                                "avg",
-                                "min",
-                                "max",
-                                "value",
-                                "sum"
-                            ],
-                            "type": "timeseries",
-                            "requests": [
-                                {
-                                    "formulas": [
-                                        {
-                                            "formula": "query1"
-                                        }
-                                    ],
-                                    "queries": [
-                                        {
-                                            "query": "sum:otelcol_datadog_trace_agent_otlp_traces{$host}.as_rate()",
-                                            "data_source": "metrics",
-                                            "name": "query1"
-                                        }
-                                    ],
-                                    "response_format": "timeseries",
-                                    "style": {
-                                        "palette": "dog_classic",
-                                        "line_type": "solid",
-                                        "line_width": "normal"
-                                    },
-                                    "display_type": "bars"
-                                }
-                            ],
-                            "yaxis": {
-                                "include_zero": true,
-                                "scale": "linear",
-                                "label": "",
-                                "min": "auto",
-                                "max": "auto"
-                            }
-                        },
-                        "layout": {
-                            "x": 6,
-                            "y": 2,
-                            "width": 3,
-                            "height": 2
-                        }
-                    },
-                    {
-                        "id": 1807303556983148,
-                        "definition": {
-                            "title": "Spans Ingested/s",
-                            "show_legend": true,
-                            "legend_layout": "auto",
-                            "legend_columns": [
-                                "avg",
-                                "min",
-                                "max",
-                                "value",
-                                "sum"
-                            ],
-                            "type": "timeseries",
-                            "requests": [
-                                {
-                                    "formulas": [
-                                        {
-                                            "formula": "query1"
-                                        }
-                                    ],
-                                    "queries": [
-                                        {
-                                            "query": "sum:otelcol_datadog_trace_agent_otlp_spans{$host}.as_rate()",
-                                            "data_source": "metrics",
-                                            "name": "query1"
-                                        }
-                                    ],
-                                    "response_format": "timeseries",
-                                    "style": {
-                                        "palette": "dog_classic",
-                                        "line_type": "solid",
-                                        "line_width": "normal"
-                                    },
-                                    "display_type": "bars"
-                                }
-                            ],
-                            "yaxis": {
-                                "include_zero": true,
-                                "scale": "linear",
-                                "label": "",
-                                "min": "auto",
-                                "max": "auto"
-                            }
-                        },
-                        "layout": {
-                            "x": 9,
-                            "y": 2,
+                            "y": 4,
                             "width": 3,
                             "height": 2
                         }
@@ -2707,7 +2944,7 @@
                             "has_padding": true
                         },
                         "layout": {
-                            "x": 0,
+                            "x": 6,
                             "y": 4,
                             "width": 2,
                             "height": 2
@@ -2737,72 +2974,6 @@
                                     "queries": [
                                         {
                                             "query": "sum:otelcol_datadog_trace_agent_stats_writer_errors{$host}.as_count()",
-                                            "data_source": "metrics",
-                                            "name": "query1"
-                                        }
-                                    ],
-                                    "response_format": "timeseries",
-                                    "style": {
-                                        "palette": "dog_classic",
-                                        "line_type": "solid",
-                                        "line_width": "normal"
-                                    },
-                                    "display_type": "bars"
-                                }
-                            ]
-                        },
-                        "layout": {
-                            "x": 2,
-                            "y": 4,
-                            "width": 4,
-                            "height": 2
-                        }
-                    },
-                    {
-                        "id": 2247423855597712,
-                        "definition": {
-                            "type": "note",
-                            "content": "If an error occurs while flushing stats from the Collector to Datadog, then the payload may be retried. A high number of retries may be indicative of a network problem.",
-                            "background_color": "white",
-                            "font_size": "12",
-                            "text_align": "left",
-                            "vertical_align": "center",
-                            "show_tick": true,
-                            "tick_pos": "50%",
-                            "tick_edge": "right",
-                            "has_padding": true
-                        },
-                        "layout": {
-                            "x": 6,
-                            "y": 4,
-                            "width": 2,
-                            "height": 2
-                        }
-                    },
-                    {
-                        "id": 2702360482430454,
-                        "definition": {
-                            "title": "Stats Writer Retries",
-                            "show_legend": true,
-                            "legend_layout": "auto",
-                            "legend_columns": [
-                                "avg",
-                                "min",
-                                "max",
-                                "value",
-                                "sum"
-                            ],
-                            "type": "timeseries",
-                            "requests": [
-                                {
-                                    "formulas": [
-                                        {
-                                            "formula": "query1"
-                                        }
-                                    ],
-                                    "queries": [
-                                        {
-                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_retries{$host}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates the following sections in the default OTel Collector dashboard:
<img width="1730" alt="Screenshot 2024-03-06 at 4 39 17 PM" src="https://github.com/DataDog/integrations-core/assets/17220434/1d369d5e-73d5-44ee-8252-207115ce943f">
<img width="1733" alt="Screenshot 2024-03-06 at 4 39 53 PM" src="https://github.com/DataDog/integrations-core/assets/17220434/28b5d671-9852-4268-b4d0-996f8e70ab23">

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
