### PR TITLE
fix: Corrected spelling error in Kafka Connect Metrics

### DIFF
--- a/confluent_platform/changelog.d/17107.fixed
+++ b/confluent_platform/changelog.d/17107.fixed
@@ -1,0 +1,1 @@
+Correct spelling error in Kafka Connect Metrics

--- a/confluent_platform/datadog_checks/confluent_platform/data/metrics.yaml
+++ b/confluent_platform/datadog_checks/confluent_platform/data/metrics.yaml
@@ -769,7 +769,7 @@ jmx_metrics:
                 "unassigned": 0
                 "running": 1
                 "paused": 2
-                "falied": 3
+                "failed": 3
                 "destroyed": 4
 
   # Kafka Connect Metrics


### PR DESCRIPTION
Changed 'falied' to 'failed' in the status attribute values of Kafka Connect Metrics. This correction ensures accurate status tracking for connectors.

### What does this PR do?
This pull request corrects a spelling error in the Kafka Connect Metrics. Specifically, it changes 'falied' to 'failed' in the status attribute values.

### Motivation
The motivation for this change was to ensure accurate status tracking of Kafka connectors. The incorrect spelling could potentially lead to misinterpretation of the connector status, affecting monitoring and debugging processes.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
