### PR TITLE
PostgreSQL: Optimise table count metrics

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -218,7 +218,7 @@ files:
         type: boolean
         example: false
     - name: collect_count_metrics
-      description: Collect count of user tables up to max_relations size from pg_stat_user_tables.
+      description: Collect count of user tables from pg_class.
       value:
         type: boolean
         example: true

--- a/postgres/changelog.d/17109.changed
+++ b/postgres/changelog.d/17109.changed
@@ -1,0 +1,1 @@
+PostgreSQL: Optimise table count query

--- a/postgres/changelog.d/17109.changed
+++ b/postgres/changelog.d/17109.changed
@@ -1,1 +1,1 @@
-PostgreSQL: Optimise table count query
+PostgreSQL: Optimise table count query. postgresql.table.count metric doesn't use max_relations parameter anymore and will always yield the total number of tables per schema. Parent table of partitions tables will also be included in the table count for PG 11, 12 and 13. All versions after PG 14 already included parent table.

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -166,7 +166,7 @@ instances:
     # collect_function_metrics: false
 
     ## @param collect_count_metrics - boolean - optional - default: true
-    ## Collect count of user tables up to max_relations size from pg_stat_user_tables.
+    ## Collect count of user tables from pg_class.
     #
     # collect_count_metrics: true
 

--- a/postgres/datadog_checks/postgres/metrics_cache.py
+++ b/postgres/datadog_checks/postgres/metrics_cache.py
@@ -16,7 +16,6 @@ from .util import (
     COMMON_ARCHIVER_METRICS,
     COMMON_BGW_METRICS,
     COMMON_METRICS,
-    COUNT_METRICS,
     DATABASE_SIZE_METRICS,
     DBM_MIGRATED_METRICS,
     NEWER_14_METRICS,
@@ -132,16 +131,6 @@ class PostgresMetricsCache:
             'relation': False,
             'name': 'bgw_metrics',
         }
-
-    def get_count_metrics(self):
-        if self._count_metrics is not None:
-            return self._count_metrics
-        metrics = dict(COUNT_METRICS)
-        metrics['query'] = COUNT_METRICS['query'].format(
-            metrics_columns="{metrics_columns}", table_count_limit=self.config.table_count_limit
-        )
-        self._count_metrics = metrics
-        return metrics
 
     def get_archiver_metrics(self, version):
         """Use COMMON_ARCHIVER_METRICS to read from pg_stat_archiver as

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -42,6 +42,7 @@ from .util import (
     AZURE_DEPLOYMENT_TYPE_TO_RESOURCE_TYPE,
     CLUSTER_VACUUM_PROGRESS_METRICS,
     CONNECTION_METRICS,
+    COUNT_METRICS,
     FUNCTION_METRICS,
     INDEX_PROGRESS_METRICS,
     QUERY_PG_CONTROL_CHECKPOINT,
@@ -666,7 +667,7 @@ class PostgreSql(AgentCheck):
             per_database_metric_scope.append(FUNCTION_METRICS)
         if self._config.collect_count_metrics:
             # Count metrics are collected from all databases discovered
-            per_database_metric_scope.append(self.metrics_cache.get_count_metrics())
+            per_database_metric_scope.append(COUNT_METRICS)
         if self.version >= V13:
             metric_scope.append(SLRU_METRICS)
 

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -244,22 +244,31 @@ COMMON_ARCHIVER_METRICS = {
 }
 
 
+# We used to use pg_stat_user_tables to count the number of tables and limit using max_relations.
+# This created multiple issues:
+# - pg_stat_user_tables is a view that group pg_class results by C.oid, N.nspname, C.relname. Doing the group by
+#   will generate a sort
+# - pg_stat_user_tables processes elements from pg_class that are dropped like toast tables and system tables
+# - we added another layer of sort (ORDER BY relname, relnamespace) to make the max_relations filter stable
+# Those sorts will eventually spill on temporary blocks if the number of relations is high enough, making this
+# query expensive to run.
+# In the end, we only care about the table count per schema so it's better to process the pg_class table directly.
+# We can filter tuples as much as possibles (we only care about relations and partition tables) and only do the
+# pg_namespace at the end, removing an expensive nested loop.
 COUNT_METRICS = {
     'descriptors': [('schemaname', 'schema')],
-    'metrics': {'pg_stat_user_tables': ('postgresql.table.count', AgentCheck.gauge)},
+    'metrics': {'count (*)': ('postgresql.table.count', AgentCheck.gauge)},
     'relation': False,
     'use_global_db_tag': True,
-    'query': fmt.format(
-        """
-SELECT schemaname, count(*) FROM
-(
-SELECT schemaname
-FROM {metrics_columns}
-ORDER BY schemaname, relname
-LIMIT {table_count_limit}
-) AS subquery GROUP BY schemaname
-    """
-    ),
+    'query': """
+SELECT N.nspname AS schemaname, {metrics_columns} FROM
+    (SELECT C.relnamespace
+    FROM pg_class C
+    WHERE C.relkind IN ('r', 'p')) AS subquery
+LEFT JOIN pg_namespace N ON (N.oid = relnamespace)
+WHERE N.nspname NOT IN ('pg_catalog', 'information_schema')
+GROUP BY N.nspname;
+    """,
     'name': 'count_metrics',
 }
 

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -206,11 +206,8 @@ def check_common_metrics(aggregator, expected_tags, count=1):
 
 def check_db_count(aggregator, expected_tags, count=1):
     table_count = 7
-    # We create 2 additional partition tables when partition is available
+    # We create 2 additional partition tables when partition is available + 2 parent tables
     if float(POSTGRES_VERSION) >= 11.0:
-        table_count = 9
-    # And PG >= 14 will also report the parent table
-    if float(POSTGRES_VERSION) >= 14.0:
         table_count = 11
     aggregator.assert_metric(
         'postgresql.table.count',

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -325,16 +325,6 @@ def test_can_connect_service_check(aggregator, integration_check, pg_instance):
     aggregator.reset()
 
 
-def test_schema_metrics(aggregator, integration_check, pg_instance):
-    pg_instance['table_count_limit'] = 1
-    check = integration_check(pg_instance)
-    check.check(pg_instance)
-
-    expected_tags = _get_expected_tags(check, pg_instance, db=DB_NAME, schema='public')
-    aggregator.assert_metric('postgresql.table.count', value=1, count=1, tags=expected_tags)
-    aggregator.assert_metric('postgresql.db.count', value=106, count=1)
-
-
 def test_connections_metrics(aggregator, integration_check, pg_instance):
     check = integration_check(pg_instance)
     check.check(pg_instance)


### PR DESCRIPTION
### What does this PR do?
Replace table count query from using `pg_stat_user_tables` view to directly calling `pg_class`. 
max_relation limit was also removed from the query.

### Motivation

We currently rely on `pg_stat_user_tables` to count the number of tables per schema. With a high number of tables, this view is expensive to query due to the order by and a lot of work is wasted as we ignore all toast tables and system schema like `pg_catalog` and `information_schema`.

We can replace this by a direct call to `pg_class`, filtering as much as possible early and keeping the price of `pg_namespace` join low by pushing the join to the end.

The `max_relation` limit was removed as keeping the results stable requires a sort on relation name and schema. That sort made the query more expensive than getting all results by far (see plans at the end).

### Additional Notes
New query plan on a db with 32K schema with 3 tables each
```
explain (analyze, buffers)
SELECT N.nspname, count(*) FROM
    (SELECT C.relnamespace
    FROM pg_class C
    WHERE C.relkind IN ('r', 'p')) AS subquery
LEFT JOIN pg_namespace N ON (N.oid = relnamespace)
GROUP BY N.nspname;
                                                             QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------
 HashAggregate  (cost=27494.39..27822.12 rows=32773 width=72) (actual time=220.594..228.349 rows=32770 loops=1)
   Group Key: n.nspname
   Batches: 1  Memory Usage: 7441kB
   Buffers: shared hit=17404
   ->  Hash Left Join  (cost=1372.39..27005.07 rows=97864 width=64) (actual time=11.475..189.945 rows=98372 loops=1)
         Hash Cond: (c.relnamespace = n.oid)
         Buffers: shared hit=17404
         ->  Seq Scan on pg_class c  (cost=0.00..25375.75 rows=97864 width=4) (actual time=0.007..146.737 rows=98372 loops=1)
               Filter: (relkind = ANY ('{r,p}'::"char"[]))
               Rows Removed by Filter: 590168
               Buffers: shared hit=16769
         ->  Hash  (cost=962.73..962.73 rows=32773 width=68) (actual time=11.452..11.453 rows=32775 loops=1)
               Buckets: 65536  Batches: 1  Memory Usage: 3713kB
               Buffers: shared hit=635
               ->  Seq Scan on pg_namespace n  (cost=0.00..962.73 rows=32773 width=68) (actual time=0.005..4.908 rows=32775 loops=1)
                     Buffers: shared hit=635
 Planning:
   Buffers: shared hit=8
 Planning Time: 0.171 ms
 Execution Time: 230.368 ms
```

Old query, 32K schemas, 3 tables per schemas, max_relations filter set to 1000:
```
explain (analyze, buffers)
SELECT schemaname, count(*) FROM
(
SELECT schemaname
FROM pg_stat_user_tables
ORDER BY schemaname, relname
LIMIT 1000
) AS subquery GROUP BY schemaname;

                                                                                                         QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 GroupAggregate  (cost=83242.22..83261.72 rows=200 width=72) (actual time=388.040..399.650 rows=334 loops=1)
   Group Key: pg_stat_all_tables.schemaname
   Buffers: shared hit=19899, temp read=6846 written=6864
   I/O Timings: temp read=12.400 write=64.545
   ->  Limit  (cost=83242.22..83244.72 rows=1000 width=128) (actual time=388.034..399.429 rows=1000 loops=1)
         Buffers: shared hit=19899, temp read=6846 written=6864
         I/O Timings: temp read=12.400 write=64.545
         ->  Sort  (cost=83242.22..83727.05 rows=193932 width=128) (actual time=388.032..399.324 rows=1000 loops=1)
               Sort Key: pg_stat_all_tables.schemaname, pg_stat_all_tables.relname
               Sort Method: top-N heapsort  Memory: 367kB
               Buffers: shared hit=19899, temp read=6846 written=6864
               I/O Timings: temp read=12.400 write=64.545
               ->  Subquery Scan on pg_stat_all_tables  (cost=47854.55..72609.14 rows=193932 width=128) (actual time=255.649..382.870 rows=98304 loops=1)
                     Buffers: shared hit=19899, temp read=6846 written=6864
                     I/O Timings: temp read=12.400 write=64.545
                     ->  Finalize GroupAggregate  (cost=47854.55..70669.82 rows=193932 width=292) (actual time=255.648..370.396 rows=98304 loops=1)
                           Group Key: c.oid, n.nspname
                           Buffers: shared hit=19899, temp read=6846 written=6864
                           I/O Timings: temp read=12.400 write=64.545
                           ->  Gather Merge  (cost=47854.55..67922.45 rows=161610 width=132) (actual time=255.641..331.873 rows=98304 loops=1)
                                 Workers Planned: 2
                                 Workers Launched: 2
                                 Buffers: shared hit=19899, temp read=6846 written=6864
                                 I/O Timings: temp read=12.400 write=64.545
                                 ->  Partial GroupAggregate  (cost=46854.53..48268.62 rows=80805 width=132) (actual time=252.923..298.610 rows=32768 loops=3)
                                       Group Key: c.oid, n.nspname
                                       Buffers: shared hit=19899, temp read=6846 written=6864
                                       I/O Timings: temp read=12.400 write=64.545
                                       ->  Sort  (cost=46854.53..47056.54 rows=80805 width=132) (actual time=252.915..273.777 rows=131072 loops=3)
                                             Sort Key: c.oid, n.nspname
                                             Sort Method: external merge  Disk: 18416kB
                                             Buffers: shared hit=19899, temp read=6846 written=6864
                                             I/O Timings: temp read=12.400 write=64.545
                                             Worker 0:  Sort Method: external merge  Disk: 18176kB
                                             Worker 1:  Sort Method: external merge  Disk: 18176kB
                                             ->  Parallel Hash Left Join  (cost=12812.55..34741.55 rows=80805 width=132) (actual time=85.014..186.280 rows=131072 loops=3)
                                                   Hash Cond: (c.oid = i.indrelid)
                                                   Buffers: shared hit=19743
                                                   ->  Hash Join  (cost=1536.20..22820.74 rows=80805 width=132) (actual time=32.354..101.338 rows=32768 loops=3)
                                                         Hash Cond: (c.relnamespace = n.oid)
                                                         Buffers: shared hit=18674
                                                         ->  Parallel Seq Scan on pg_class c  (cost=0.00..21072.38 rows=80818 width=72) (actual time=0.010..54.232 rows=65572 loops=3)
                                                               Filter: (relkind = ANY ('{r,t,m,p}'::"char"[]))
                                                               Rows Removed by Filter: 163941
                                                               Buffers: shared hit=16769
                                                         ->  Hash  (cost=1126.60..1126.60 rows=32768 width=68) (actual time=32.252..32.253 rows=32771 loops=3)
                                                               Buckets: 65536 (originally 32768)  Batches: 1 (originally 1)  Memory Usage: 3713kB
                                                               Buffers: shared hit=1905
                                                               ->  Seq Scan on pg_namespace n  (cost=0.00..1126.60 rows=32768 width=68) (actual time=0.052..24.213 rows=32771 loops=3)
                                                                     Filter: ((nspname <> ALL ('{pg_catalog,information_schema}'::name[])) AND (nspname !~ '^pg_toast'::text))
                                                                     Rows Removed by Filter: 4
                                                                     Buffers: shared hit=1905
                                                   ->  Parallel Hash  (cost=8715.51..8715.51 rows=204868 width=4) (actual time=51.929..51.930 rows=163894 loops=3)
                                                         Buckets: 524288  Batches: 1  Memory Usage: 23392kB
                                                         Buffers: shared hit=1053
                                                         ->  Parallel Index Only Scan using pg_index_indrelid_index on pg_index i  (cost=0.42..8715.51 rows=204868 width=4) (actual time=0.017..17.207 rows=163894 loops=3)
                                                               Heap Fetches: 17
                                                               Buffers: shared hit=1053
 Planning:
   Buffers: shared hit=30
 Planning Time: 0.513 ms
 Execution Time: 403.828 ms

```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
