### PR TITLE
Revert "Bump psutil version to 5.9.7 (#16547)" (#17112)

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -61,7 +61,7 @@ prometheus-client,PyPI,Apache-2.0,Copyright 2015 Brian Brazil
 prometheus-client,PyPI,Apache-2.0,Copyright 2015 The Prometheus Authors
 protobuf,PyPI,BSD-3-Clause,Copyright 2008 Google Inc.
 protobuf,PyPI,BSD-3-Clause,Copyright 2014 protobuf@googlegroups.com
-psutil,PyPI,BSD-3-Clause,"Copyright (c) 2009, Jay Loden, Dave Daeschler, Giampaolo Rodola"
+psutil,PyPI,BSD-3-Clause,"Copyright (c) 2009, Jay Loden, Dave Daeschler, Giampaolo Rodola'"
 psycopg2-binary,PyPI,BSD-3-Clause,Copyright 2013 Federico Di Gregorio
 psycopg2-binary,PyPI,LGPL-3.0-only,Copyright (C) 2013 Federico Di Gregorio
 pyasn1,PyPI,BSD-3-Clause,"Copyright (c) 2005-2019, Ilya Etingof <etingof@gmail.com>"

--- a/btrfs/changelog.d/17112.added
+++ b/btrfs/changelog.d/17112.added
@@ -1,0 +1,1 @@
+Revert "Bump psutil version to 5.9.7 (#16547)"

--- a/btrfs/pyproject.toml
+++ b/btrfs/pyproject.toml
@@ -39,7 +39,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "psutil==5.9.7",
+    "psutil==5.9.0",
 ]
 
 [project.urls]

--- a/datadog_checks_base/changelog.d/17112.added
+++ b/datadog_checks_base/changelog.d/17112.added
@@ -1,0 +1,1 @@
+Revert "Bump psutil version to 5.9.7 (#16547)"

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -57,7 +57,7 @@ prometheus-client==0.12.0; python_version < '3.0'
 prometheus-client==0.20.0; python_version > '3.0'
 protobuf==3.17.3; python_version < '3.0'
 protobuf==4.25.3; python_version > '3.0'
-psutil==5.9.7
+psutil==5.9.0
 psycopg2-binary==2.9.9; python_version > '3.0'
 pyasn1==0.4.6
 pycryptodomex==3.20.0

--- a/disk/changelog.d/17112.added
+++ b/disk/changelog.d/17112.added
@@ -1,0 +1,1 @@
+Revert "Bump psutil version to 5.9.7 (#16547)"

--- a/disk/pyproject.toml
+++ b/disk/pyproject.toml
@@ -39,7 +39,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "psutil==5.9.7",
+    "psutil==5.9.0",
 ]
 
 [project.urls]

--- a/gunicorn/changelog.d/17112.added
+++ b/gunicorn/changelog.d/17112.added
@@ -1,0 +1,1 @@
+Revert "Bump psutil version to 5.9.7 (#16547)"

--- a/gunicorn/pyproject.toml
+++ b/gunicorn/pyproject.toml
@@ -39,7 +39,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "psutil==5.9.7",
+    "psutil==5.9.0",
 ]
 
 [project.urls]

--- a/ibm_mq/changelog.d/17112.added
+++ b/ibm_mq/changelog.d/17112.added
@@ -1,0 +1,1 @@
+Revert "Bump psutil version to 5.9.7 (#16547)"

--- a/ibm_mq/pyproject.toml
+++ b/ibm_mq/pyproject.toml
@@ -37,7 +37,7 @@ requires-python = ">=3.9"
 
 [project.optional-dependencies]
 deps = [
-    "psutil==5.9.7",
+    "psutil==5.9.0",
     "pymqi==1.12.10; (sys_platform != 'darwin' or platform_machine != 'arm64') and python_version > '3.0'",
 ]
 

--- a/network/changelog.d/17112.added
+++ b/network/changelog.d/17112.added
@@ -1,0 +1,1 @@
+Revert "Bump psutil version to 5.9.7 (#16547)"

--- a/network/pyproject.toml
+++ b/network/pyproject.toml
@@ -39,7 +39,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "psutil==5.9.7",
+    "psutil==5.9.0",
 ]
 
 [project.urls]

--- a/process/changelog.d/17112.added
+++ b/process/changelog.d/17112.added
@@ -1,0 +1,1 @@
+Revert "Bump psutil version to 5.9.7 (#16547)"

--- a/process/pyproject.toml
+++ b/process/pyproject.toml
@@ -39,7 +39,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "psutil==5.9.7",
+    "psutil==5.9.0",
 ]
 
 [project.urls]

--- a/system_core/changelog.d/17112.added
+++ b/system_core/changelog.d/17112.added
@@ -1,0 +1,1 @@
+Revert "Bump psutil version to 5.9.7 (#16547)"

--- a/system_core/pyproject.toml
+++ b/system_core/pyproject.toml
@@ -39,7 +39,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "psutil==5.9.7",
+    "psutil==5.9.0",
 ]
 
 [project.urls]

--- a/system_swap/changelog.d/17112.added
+++ b/system_swap/changelog.d/17112.added
@@ -1,0 +1,1 @@
+Revert "Bump psutil version to 5.9.7 (#16547)"

--- a/system_swap/pyproject.toml
+++ b/system_swap/pyproject.toml
@@ -39,7 +39,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "psutil==5.9.7",
+    "psutil==5.9.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
This reverts commit fde87226

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

Port https://github.com/DataDog/integrations-core/pull/17112 to master 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
