### PR TITLE
Strip debug symbols in compiled dependencies

### DIFF
--- a/.builders/build.py
+++ b/.builders/build.py
@@ -121,6 +121,7 @@ def build_macos():
             # Common compilation flags
             'LDFLAGS': f'-L{prefix_path}/lib',
             'CFLAGS': f'-I{prefix_path}/include -O2',
+            'CXXFLAGS': f'-I{prefix_path}/include -O2',
             # Build command for extra platform-specific build steps
             'DD_BUILD_COMMAND': f'bash {build_context_dir}/extra_build.sh'
         }

--- a/.builders/images/linux-aarch64/Dockerfile
+++ b/.builders/images/linux-aarch64/Dockerfile
@@ -9,9 +9,11 @@ ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
 COPY install-from-source.sh /
 
 ENV CFLAGS="-O2"
+ENV CXXFLAGS="${CFLAGS}"
 # Auditwheel will only set RPATH's for copied libs if an existing RPATH is found,
 # so we may as well set it to origin here anyway.
-ENV LDFLAGS="-Wl,-rpath,'\$\$ORIGIN'"
+# --strip-debug reduces binary sizes and improves reproducibility
+ENV LDFLAGS="-Wl,-rpath,'\$\$ORIGIN' -Wl,--strip-debug"
 
 # For Python 2, we get openssl(1) via yum just to get the necessary headers,
 # and we remove the package after compilation to prevent it from interfering

--- a/.builders/images/linux-x86_64/Dockerfile
+++ b/.builders/images/linux-x86_64/Dockerfile
@@ -9,9 +9,11 @@ ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
 COPY install-from-source.sh /
 
 ENV CFLAGS="-O2"
+ENV CXXFLAGS="${CFLAGS}"
 # Auditwheel will only set RPATH's for copied libs if an existing RPATH is found,
 # so we may as well set it to origin here anyway.
-ENV LDFLAGS="-Wl,-rpath,'\$\$ORIGIN'"
+# --strip-debug reduces binary sizes and improves reproducibility
+ENV LDFLAGS="-Wl,-rpath,'\$\$ORIGIN' -Wl,--strip-debug"
 
 # For Python 2, we get openssl(1) via yum just to get the necessary headers,
 # and we remove the package after compilation to prevent it from interfering


### PR DESCRIPTION
### What does this PR do?

Adds `--strip-debug` linker flag so that all binaries get stripped of debug symbols, reducing package size and improving reproducibility.

### Motivation

Looking for ways to improve build reproducibility and avoiding unnecessarily uploading equivalent packages.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
