### PR TITLE
[DBMON-3745] Propagate agent tags to postgres check

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -4,6 +4,14 @@ files:
   options:
   - template: init_config
     options:
+    - name: propagate_agent_tags
+      description: |
+        Set to `true` to propagate the tags from `datadog.yaml` to the check.
+        When set to `true`, the tags from `datadog.yaml` are added to the check's tags for all instances.        
+        NOTE: This option is by default opted-in. If you want to opt-out, set this option to `false`.
+      value:
+        example: true
+        type: boolean
     - template: init_config/default
   - template: instances
     options:
@@ -864,6 +872,15 @@ files:
         type: number
         example: 1800
         display_default: false
+    - name: propagate_agent_tags
+      description: |
+        Set to `true` to propagate the tags from `datadog.yaml` to the check.
+        When set to `true`, the tags from `datadog.yaml` are added to the check's tags.
+        This option takes precedence over the `propagate_agent_tags` option in `init_config`.
+        NOTE: This option is by default opted-in. If you want to opt-out, set this option to `false`.
+      value:
+        example: true
+        type: boolean
     - template: instances/default
       overrides:
         disable_generic_tags.hidden: False

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -8,6 +8,10 @@
 #     ddev -x validate models -s <INTEGRATION_NAME>
 
 
+def shared_propagate_agent_tags():
+    return True
+
+
 def instance_activity_metrics_excluded_aggregations():
     return []
 
@@ -106,6 +110,10 @@ def instance_pg_stat_statements_view():
 
 def instance_port():
     return 5432
+
+
+def instance_propagate_agent_tags():
+    return True
 
 
 def instance_query_timeout():

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -229,6 +229,7 @@ class InstanceConfig(BaseModel):
     password: Optional[str] = None
     pg_stat_statements_view: Optional[str] = None
     port: Optional[int] = None
+    propagate_agent_tags: Optional[bool] = None
     query_activity: Optional[QueryActivity] = None
     query_metrics: Optional[QueryMetrics] = None
     query_samples: Optional[QuerySamples] = None

--- a/postgres/datadog_checks/postgres/config_models/shared.py
+++ b/postgres/datadog_checks/postgres/config_models/shared.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
 
-from . import validators
+from . import defaults, validators
 
 
 class SharedConfig(BaseModel):
@@ -25,6 +25,7 @@ class SharedConfig(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    propagate_agent_tags: Optional[bool] = None
     service: Optional[str] = None
 
     @model_validator(mode='before')
@@ -37,6 +38,8 @@ class SharedConfig(BaseModel):
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
             value = getattr(validators, f'shared_{info.field_name}', identity)(value, field=field)
+        else:
+            value = getattr(defaults, f'shared_{info.field_name}', lambda: value)()
 
         return validation.utils.make_immutable(value)
 

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -2,6 +2,13 @@
 #
 init_config:
 
+    ## @param propagate_agent_tags - boolean - optional - default: true
+    ## Set to `true` to propagate the tags from `datadog.yaml` to the check.
+    ## When set to `true`, the tags from `datadog.yaml` are added to the check's tags for all instances.        
+    ## NOTE: This option is by default opted-in. If you want to opt-out, set this option to `false`.
+    #
+    # propagate_agent_tags: true
+
     ## @param service - string - optional
     ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
     ##
@@ -673,6 +680,14 @@ instances:
         ## Set to `true` to keep identifier quotations (e.g. `"my_table"`) in your normalized SQL statements.
         #
         # keep_identifier_quotation: false
+
+    ## @param propagate_agent_tags - boolean - optional - default: true
+    ## Set to `true` to propagate the tags from `datadog.yaml` to the check.
+    ## When set to `true`, the tags from `datadog.yaml` are added to the check's tags.
+    ## This option takes precedence over the `propagate_agent_tags` option in `init_config`.
+    ## NOTE: This option is by default opted-in. If you want to opt-out, set this option to `false`.
+    #
+    # propagate_agent_tags: true
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -108,7 +108,7 @@ class PostgreSql(AgentCheck):
                 "DEPRECATION NOTICE: The managed_identity option is deprecated and will be removed in a future version."
                 " Please use the new azure.managed_authentication option instead."
             )
-        self._config = PostgresConfig(self.instance)
+        self._config = PostgresConfig(self.instance, self.init_config)
         self.cloud_metadata = self._config.cloud_metadata
         self.tags = self._config.tags
         # Keep a copy of the tags without the internal resource tags so they can be used for paths that don't

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -71,8 +71,8 @@ def check():
 
 @pytest.fixture
 def integration_check():
-    def _check(instance):
-        c = PostgreSql('postgres', {}, [instance])
+    def _check(instance, init_config=None):
+        c = PostgreSql('postgres', init_config or {}, [instance])
         return c
 
     return _check
@@ -106,13 +106,13 @@ def pg_replica_logical():
 
 @pytest.fixture
 def metrics_cache(pg_instance):
-    config = PostgresConfig(instance=pg_instance)
+    config = PostgresConfig(instance=pg_instance, init_config={})
     return PostgresMetricsCache(config)
 
 
 @pytest.fixture
 def metrics_cache_replica(pg_replica_instance):
-    config = PostgresConfig(instance=pg_replica_instance)
+    config = PostgresConfig(instance=pg_replica_instance, init_config={})
     return PostgresMetricsCache(config)
 
 

--- a/postgres/tests/test_metrics_cache.py
+++ b/postgres/tests/test_metrics_cache.py
@@ -28,7 +28,7 @@ COMMON_AND_MAIN_CHECK_METRICS = dict(COMMON_METRICS, **DBM_MIGRATED_METRICS)
     ],
 )
 def test_aurora_replication_metrics(pg_instance, version, is_aurora, expected_metrics):
-    config = PostgresConfig(instance=pg_instance)
+    config = PostgresConfig(instance=pg_instance, init_config={})
     cache = PostgresMetricsCache(config)
     replication_metrics = cache.get_replication_metrics(version, is_aurora)
     assert replication_metrics == expected_metrics
@@ -50,7 +50,7 @@ def test_dbm_enabled_conn_metric(pg_instance, version, is_dbm_enabled, expected_
     pg_instance['dbm'] = is_dbm_enabled
     pg_instance['collect_resources'] = {'enabled': False}
     pg_instance['collect_database_size_metrics'] = False
-    config = PostgresConfig(instance=pg_instance)
+    config = PostgresConfig(instance=pg_instance, init_config={})
     cache = PostgresMetricsCache(config)
     instance_metrics = cache.get_instance_metrics(version)
     assert instance_metrics['metrics'] == expected_metrics

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -11,6 +11,7 @@ import pytest
 from flaky import flaky
 
 from datadog_checks.base.errors import ConfigurationError
+from datadog_checks.base.stubs import datadog_agent
 from datadog_checks.postgres import PostgreSql
 from datadog_checks.postgres.__about__ import __version__
 from datadog_checks.postgres.util import DatabaseHealthCheckError, PartialFormatter, fmt
@@ -1099,3 +1100,46 @@ def test_collect_wal_metrics_metrics(aggregator, integration_check, pg_instance,
     # if collect_wal_metrics is not set, wal metrics are collected on pg >= 10 by default
     expected_count = 0 if collect_wal_metrics is False else 1
     check_file_wal_metrics(aggregator, expected_tags=expected_tags, count=expected_count)
+
+
+@pytest.mark.parametrize(
+    'instance_propagate_agent_tags,init_config_propagate_agent_tags,should_propagate_agent_tags',
+    [
+        (True, True, True),
+        (True, False, True),  # instance config prevails
+        (False, True, False),  # instance config prevails
+        (False, False, False),
+        (None, True, True),  # init_config config applies to all instances
+        (None, False, False),  # init_config config applies to all instances
+        (None, None, True),  # default opted-in
+        (True, None, True),  # instance config prevails
+        (False, None, False),  # instance config prevails
+    ],
+)
+def test_propagate_agent_tags(
+    aggregator,
+    integration_check,
+    pg_instance,
+    instance_propagate_agent_tags,
+    init_config_propagate_agent_tags,
+    should_propagate_agent_tags,
+):
+    init_config = {}
+    if instance_propagate_agent_tags is not None:
+        pg_instance['propagate_agent_tags'] = instance_propagate_agent_tags
+    if init_config_propagate_agent_tags is not None:
+        init_config['propagate_agent_tags'] = init_config_propagate_agent_tags
+
+    agent_tags = ["my-env:test-env", "random:tag", "bar:foo"]
+
+    with mock.patch.object(datadog_agent, 'get_config', passthrough=True) as mock_agent:
+        mock_agent.side_effect = lambda option: agent_tags
+        check = integration_check(pg_instance, init_config)
+        assert check._config._should_propagate_agent_tags(pg_instance, init_config) == should_propagate_agent_tags
+        if should_propagate_agent_tags:
+            assert all(tag in check.tags for tag in agent_tags)
+            check.check(pg_instance)
+            expected_tags = _get_expected_tags(check, pg_instance, with_db=True)
+            aggregator.assert_service_check(
+                'postgres.can_connect', count=1, status=PostgreSql.OK, tags=expected_tags + agent_tags
+            )


### PR DESCRIPTION
### What does this PR do?
This PR adds an option (opted-in) to propagate agent tags from `datadog.yaml` to postgres check. 
Config option `propagate_agent_tags` is added to `init_config` and `instance` config block. 

When `propagate_agent_tags` is set in `init_config` but not in `instance`, this config will be applied to all available postgres check instances. 
When `propagate_agent_tags` is set in `instance` block, it takes precedence over `propagate_agent_tags` in `init_config`. 
When `propagate_agent_tags` is not explicitly set, it defaults to `true` as an opted-in feature. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
