### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/release-hash-check.yml
+++ b/.github/workflows/release-hash-check.yml
@@ -26,7 +26,7 @@ jobs:
         git fetch origin master
         LAST_COMMON_COMMIT=$(git merge-base HEAD origin/master)
         FILES=$(git --no-pager diff --name-only $LAST_COMMON_COMMIT -- .in-toto | xargs echo)
-        echo "::set-output name=all::$FILES"
+        echo "all=$FILES" >> "$GITHUB_OUTPUT"
 
     - id: merge
       name: Merge branch into latest master


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter