### PR TITLE
Use rest config by default in lab instance

### DIFF
--- a/openstack_controller/tests/conftest.py
+++ b/openstack_controller/tests/conftest.py
@@ -60,8 +60,8 @@ def dd_environment():
                 'ssl_verify': False,
                 'nova_microversion': '2.93',
                 'ironic_microversion': '1.80',
-                'openstack_cloud_name': 'test_cloud',
-                'openstack_config_file_path': '/home/openstack_controller/tests/config/openstack_config_updated.yaml',
+                '#openstack_cloud_name': 'test_cloud',
+                '#openstack_config_file_path': '/home/openstack_controller/tests/config/openstack_config_updated.yaml',
                 'endpoint_region_id': 'RegionOne',
                 'use_legacy_check_version': False,
             }


### PR DESCRIPTION
### What does this PR do?
Uses rest config as the default in the lab instance, while leaving the options for the SDK version in the config but commented out. 

### Motivation
the REST configuration of the openstack controller check is more common than the SDK config. So when testing it is usually more beneficial to test the REST method. The rest method also performs more custom logic so we often want to test it more thoroughly.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
