### PR TITLE
Automatically apply the `qa/skip-qa` to some PRs

### DIFF
--- a/.github/workflows/config/labeler.yml
+++ b/.github/workflows/config/labeler.yml
@@ -491,5 +491,9 @@ integration/zeek:
 - zeek/**/*
 integration/zk:
 - zk/**/*
+qa/skip-qa:
+- '**/__about__.py'
+- requirements-agent-release.txt
+- '*/CHANGELOG.md'
 release:
 - '**/__about__.py'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Automatically apply the `qa/skip-qa` to some PRs

### Motivation
<!-- What inspired you to submit this pull request? -->

So release PRs are skipped automatically by ddqa

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
