### PR TITLE
Add a pre-commit hook to validate the labeler config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,9 @@ repos:
       language: system
       files: '.*/assets/service_checks\.json'
       pass_filenames: false
+    - id: labeler_config
+      name: Validate labeler config
+      entry: ddev validate labeler
+      language: system
+      files: '\.github/workflows/config/labeler\.yml'
+      pass_filenames: false


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add a pre-commit hook to validate the labeler config

### Motivation
<!-- What inspired you to submit this pull request? -->

I left one error when I modified it in https://github.com/DataDog/integrations-core/pull/17132 that would have been caught by the validation command

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
