### PR TITLE
Add a method to assert several metric tags at once

### DIFF
--- a/datadog_checks_base/changelog.d/17134.added
+++ b/datadog_checks_base/changelog.d/17134.added
@@ -1,0 +1,1 @@
+Add a method to assert several metric tags at once

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -212,6 +212,10 @@ class AggregatorStub(object):
             for stub in self._histogram_buckets.get(to_native_string(name), [])
         ]
 
+    def assert_metric_has_tags(self, metric_name, tags, count=None, at_least=1):
+        for tag in tags:
+            self.assert_metric_has_tag(metric_name, tag, count, at_least)
+
     def assert_metric_has_tag(self, metric_name, tag, count=None, at_least=1):
         """
         Assert a metric is tagged with tag

--- a/datadog_checks_base/tests/stubs/test_aggregator_metric_has_tag.py
+++ b/datadog_checks_base/tests/stubs/test_aggregator_metric_has_tag.py
@@ -1,0 +1,32 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from datadog_checks.base import AgentCheck
+
+
+class TestMetricHasTag:
+    @pytest.mark.parametrize(
+        'tags, at_least',
+        [
+            pytest.param([], 1, id='no tags'),
+            pytest.param(['tag1:value1', 'tag2:value2'], 1, id='all tags'),
+            pytest.param(['tag1:value1'], 1, id='some tags'),
+            pytest.param(['tag3:value3'], 0, id='extra tag with at_least=0'),
+        ],
+    )
+    def test_assert_metric_has_tags(self, aggregator, tags, at_least):
+        check = AgentCheck()
+
+        check.gauge('test.metric', 1, tags=['tag1:value1', 'tag2:value2'])
+        aggregator.assert_metric_has_tags('test.metric', tags, at_least=at_least)
+
+    def test_assert_metric_does_not_have_one_tag(self, aggregator):
+        check = AgentCheck()
+        check.gauge('test.metric', 1, tags=['tag1:value1', 'tag2:value2'])
+
+        with pytest.raises(
+            AssertionError, match="The metric 'test.metric' was found but not with the tag 'tag3:value3'."
+        ):
+            aggregator.assert_metric_has_tags('test.metric', ['tag1:value1', 'tag3:value3'])


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add a method to assert several metric tags at once

### Motivation
<!-- What inspired you to submit this pull request? -->

I always end up in my tests with something like this

```python
        for tag in tags:
            self.assert_metric_has_tag(metric_name, tag)
```

Having it (and tested) in the aggregator will allow me to avoid copy/paste stuff around

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
