### PR TITLE
Fix the validation of metadata files

### DIFF
--- a/ddev/changelog.d/17136.fixed
+++ b/ddev/changelog.d/17136.fixed
@@ -1,0 +1,1 @@
+Fix the validation of metadata files

--- a/ddev/src/ddev/cli/validate/metadata.py
+++ b/ddev/src/ddev/cli/validate/metadata.py
@@ -66,13 +66,15 @@ def metadata(app: Application, integrations: tuple[str, ...], check_duplicates: 
     """
     Validate `metadata.csv` files
 
-    If `check` is specified, only the check will be validated, if check value is
-    'changed' will only apply to changed checks, an 'all' or empty `check` value
-    will validate all README files.
+    If `integrations` is specified, only the check will be validated, an 'all' or empty value will validate all
+    metadata.csv files, a `changed` value will validate changed integrations.
     """
     from ddev.cli.validate import metadata_utils
 
     validation_tracker = app.create_validation_tracker('Metrics validation')
+
+    if not integrations:
+        integrations = ('all',)
 
     excluded = set(app.repo.config.get('/overrides/validate/metrics/exclude', []))
     for current_check in app.repo.integrations.iter(integrations):

--- a/ddev/src/ddev/repo/core.py
+++ b/ddev/src/ddev/repo/core.py
@@ -192,12 +192,13 @@ class IntegrationRegistry:
         return integration
 
     def __finalize_selection(self, selection: Iterable[str]) -> set[str] | None:
-        if not selection:
+        if not selection or 'changed' in selection:
             return self.__get_changed_root_entries() or None
-        elif 'all' in selection:
+
+        if 'all' in selection:
             return set()
-        else:
-            return set(selection)
+
+        return set(selection)
 
     def __get_changed_root_entries(self) -> set[str]:
         return {relative_path.split('/', 1)[0] for relative_path in self.repo.git.changed_files}

--- a/ddev/tests/repo/test_core.py
+++ b/ddev/tests/repo/test_core.py
@@ -115,6 +115,15 @@ class TestIntegrationsIteration:
         assert [integration.name for integration in integrations] == selection
         assert list(iter_method(selection)) == integrations
 
+    def test_integrations_iteration_selection_changed(self, repository):
+        repo = Repository(repository.path.name, str(repository.path))
+
+        (repo.path / 'tekton' / 'foo.txt').touch()
+        selection = ['changed']
+        integrations = list(repo.integrations.iter(selection))
+
+        assert [integration.name for integration in integrations] == ["tekton"]
+
     @pytest.mark.parametrize(
         "method_name, integration_filter",
         iter_test_params,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix the validation of metadata files 

### Motivation
<!-- What inspired you to submit this pull request? -->

The validation in the CI does not work anymore because `changed` is not recognized anymore and an empty list is now considered as `changed` in ddev while it used to be considered `all` in dcd 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I'll improve the testing part of the command in a follow-up PR. I want to bring the validation back ASAP

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
