### PR TITLE
improve sqlserver db check

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -447,7 +447,7 @@ class Connection(object):
         password = self.instance.get('password')
         database = self.instance.get(db_key) if db_name is None else db_name
         driver = self.instance.get('driver')
-        host = self._get_host_with_port()
+        host = self.get_host_with_port()
 
         if not dsn:
             if not host:
@@ -467,7 +467,7 @@ class Connection(object):
                 driver = self.DEFAULT_DRIVER
         return dsn, host, username, password, database, driver
 
-    def _get_host_with_port(self):
+    def get_host_with_port(self):
         """Return a string with correctly formatted host and, if necessary, port.
         If the host string in the config contains a port, that port is used.
         If not, any port provided as a separate port config option is used.

--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -59,6 +59,7 @@ expected_sys_databases_columns = [
 ]
 
 DATABASE_SERVICE_CHECK_QUERY = """SELECT 1;"""
+SWITCH_DB_STATEMENT = """USE {};"""
 
 VALID_METRIC_TYPES = ('gauge', 'rate', 'histogram')
 

--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -58,6 +58,8 @@ expected_sys_databases_columns = [
     'physical_database_name',
 ]
 
+DATABASE_SERVICE_CHECK_QUERY = """SELECT 1;"""
+
 VALID_METRIC_TYPES = ('gauge', 'rate', 'histogram')
 
 SERVICE_CHECK_NAME = 'sqlserver.can_connect'

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -7,6 +7,7 @@ import copy
 import functools
 import time
 from collections import defaultdict
+
 import six
 from cachetools import TTLCache
 
@@ -728,19 +729,9 @@ class SQLServer(AgentCheck):
                     check_err_message = "Database {} connection service check failed: {}"
                     try:
                         cursor.execute(SWITCH_DB_STATEMENT.format(db.name))
-                    except Exception as e:
-                        self.log.warning(check_err_message.format(db.name, str(e)))
-                        self.handle_service_check(
-                            AgentCheck.CRITICAL,
-                            self.connection.get_host_with_port(),
-                            db.name,
-                            check_err_message.format(db.name, str(e)),
-                            False,
-                        )
-                        continue
-                    try:
                         cursor.execute(DATABASE_SERVICE_CHECK_QUERY)
                         cursor.fetchall()
+                        self.handle_service_check(AgentCheck.OK, self.connection.get_host_with_port(), db.name, False)
                     except Exception as e:
                         self.log.warning(check_err_message.format(db.name, str(e)))
                         self.handle_service_check(
@@ -751,8 +742,7 @@ class SQLServer(AgentCheck):
                             False,
                         )
                         continue
-                    self.handle_service_check(AgentCheck.OK, self.connection.get_host_with_port(), db.name, False)
-                #set here back to master
+            # Switch DB back to MASTER
             with self.connection.get_managed_cursor() as cursor:
                 cursor.execute(SWITCH_DB_STATEMENT.format(self.connection.DEFAULT_DATABASE))
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
+
 import copy
 import functools
 import time
@@ -710,7 +711,7 @@ class SQLServer(AgentCheck):
         cfg_inst['hostname'] = self.resolved_hostname
 
         return cls(cfg_inst, base_name, metric_type, column, self.log)
-    
+
     def _check_connections_by_connecting_to_db(self):
         for db in self.databases:
             if db.name != self.connection.DEFAULT_DATABASE:
@@ -719,7 +720,7 @@ class SQLServer(AgentCheck):
                 except Exception as e:
                     # service_check errors on auto discovered databases should not abort the check
                     self.log.warning("failed service check for auto discovered database: %s", e)
-    
+
     def _check_connections_by_use_db(self):
         with self.connection.open_managed_default_connection():
             with self.connection.get_managed_cursor() as cursor:
@@ -729,15 +730,27 @@ class SQLServer(AgentCheck):
                     try:
                         cursor.execute(switch_db_statment)
                     except Exception as e:
-                        self.log.warning(check_err_message.format(db.name, str(e)))                            
-                        self.handle_service_check(AgentCheck.CRITICAL, self.connection.get_host_with_port(), db.name, check_err_message.format(db.name, str(e)), False)
+                        self.log.warning(check_err_message.format(db.name, str(e)))
+                        self.handle_service_check(
+                            AgentCheck.CRITICAL,
+                            self.connection.get_host_with_port(),
+                            db.name,
+                            check_err_message.format(db.name, str(e)),
+                            False,
+                        )
                         continue
-                    try:    
+                    try:
                         cursor.execute(DATABASE_SERVICE_CHECK_QUERY)
                         cursor.fetchall()
                     except Exception as e:
                         self.log.warning(check_err_message.format(db.name, str(e)))
-                        self.handle_service_check(AgentCheck.CRITICAL, self.connection.get_host_with_port(), db.name, check_err_message.format(db.name, str(e)), False)
+                        self.handle_service_check(
+                            AgentCheck.CRITICAL,
+                            self.connection.get_host_with_port(),
+                            db.name,
+                            check_err_message.format(db.name, str(e)),
+                            False,
+                        )
                         continue
                     self.handle_service_check(AgentCheck.OK, self.connection.get_host_with_port(), db.name, False)
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
-#import pdb
+import pdb
 import copy
 import functools
 import time
@@ -711,47 +711,45 @@ class SQLServer(AgentCheck):
         cfg_inst['hostname'] = self.resolved_hostname
 
         return cls(cfg_inst, base_name, metric_type, column, self.log)
+    
+    def _check_connections_by_connecting_to_db(self):
+        for db in self.databases:
+            if db.name != self.connection.DEFAULT_DATABASE:
+                try:
+                    self.connection.check_database_conns(db.name)
+                except Exception as e:
+                    # service_check errors on auto discovered databases should not abort the check
+                    self.log.warning("failed service check for auto discovered database: %s", e)
+    
+    def _check_connections_by_use_db(self):
+        with self.connection.open_managed_default_connection():
+            with self.connection.get_managed_cursor() as cursor:
+                for db in self.databases:
+                    switch_db_statment = "USE {};".format(db.name)
+                    check_err_message = "Database {} connection service check failed: {}"
+                    try:
+                        cursor.execute(switch_db_statment)
+                    except Exception as e:
+                        self.log.warning(check_err_message.format(db.name, str(e)))                            
+                        self.handle_service_check(AgentCheck.CRITICAL, self.connection.get_host_with_port(), db.name, check_err_message.format(db.name, str(e)), False)
+                        continue
+                    try:    
+                        cursor.execute(DATABASE_SERVICE_CHECK_QUERY)
+                        cursor.fetchall()
+                    except Exception as e:
+                        check_err_message = f"Database {db.name} connection service check failed: {str(e)}"
+                        self.log.warning(check_err_message.format(db.name, str(e)))
+                        self.handle_service_check(AgentCheck.CRITICAL, self.connection.get_host_with_port(), db.name, check_err_message.format(db.name, str(e)), False)
+                        continue
+                    self.handle_service_check(AgentCheck.OK, self.connection.get_host_with_port(), db.name, False)
 
     def _check_database_conns(self):
         engine_edition = self.static_info_cache.get(STATIC_INFO_ENGINE_EDITION)
         if is_azure_sql_database(engine_edition):
-            for db in self.databases:
-                if db.name != self.connection.DEFAULT_DATABASE:
-                    try:
-                        self.connection.check_database_conns(db.name)
-                    except Exception as e:
-                        # service_check errors on auto discovered databases should not abort the check
-                        self.log.warning("failed service check for auto discovered database: %s", e)
+            #This method is more costefull but 
+            self._check_connection_by_connecting_to_db()
         else:
-            with self.connection.open_managed_default_connection():
-                with self.connection.get_managed_cursor() as cursor:
-                    for db in self.databases:
-                        switch_db_statment = "USE {};".format(db.name)
-                        try: 
-                            #pdb.set_trace()
-                            cursor.execute(switch_db_statment)
-                        except Exception as e:
-                            self.log.error("Couldn't execute USE {} statement the exception is '{}'".format(db.name, str(e)))
-                            print(e)
-                            continue
-                            # if somehow we are ended up on some cloud where we cannot do switch what should we log?
-                            # or it can be a DB problem already rather than config 
-                        
-                            #test on windows will we get an exception or not ? Or it will faile silently 
-                        try:
-                            #pdb.set_trace()    
-                            cursor.execute(DATABASE_SERVICE_CHECK_QUERY)
-                            cursor.fetchall()
-                        except Exception as e:
-                            check_err_message = f"Database {db.name} connection service check failed: {str(e)}"
-                            self.log.warning(check_err_message)
-                            self.handle_service_check(AgentCheck.CRITICAL, self.connection.get_host_with_port(), db.name, check_err_message, False)
-                            #debug if this continue will work
-                            continue
-                            #inform here that it didn't work with a different error msg
-                        self.handle_service_check(AgentCheck.OK, self.connection.get_host_with_port(), db.name, False)
-        #we are not returning to master DB as connection is closed, check that it works.
-
+            self._check_connections_by_use_db()
 
     def check(self, _):
         if self.do_check:

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -742,8 +742,7 @@ class SQLServer(AgentCheck):
                             False,
                         )
                         continue
-            # Switch DB back to MASTER
-            with self.connection.get_managed_cursor() as cursor:
+                # Switch DB back to MASTER
                 cursor.execute(SWITCH_DB_STATEMENT.format(self.connection.DEFAULT_DATABASE))
 
     def _check_database_conns(self):

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -737,7 +737,6 @@ class SQLServer(AgentCheck):
                         cursor.execute(DATABASE_SERVICE_CHECK_QUERY)
                         cursor.fetchall()
                     except Exception as e:
-                        check_err_message = f"Database {db.name} connection service check failed: {str(e)}"
                         self.log.warning(check_err_message.format(db.name, str(e)))
                         self.handle_service_check(AgentCheck.CRITICAL, self.connection.get_host_with_port(), db.name, check_err_message.format(db.name, str(e)), False)
                         continue
@@ -746,7 +745,7 @@ class SQLServer(AgentCheck):
     def _check_database_conns(self):
         engine_edition = self.static_info_cache.get(STATIC_INFO_ENGINE_EDITION)
         if is_azure_sql_database(engine_edition):
-            #This method is more costefull but 
+            # On Azure, we can't use a less costly approach.
             self._check_connection_by_connecting_to_db()
         else:
             self._check_connections_by_use_db()

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
-import pdb
 import copy
 import functools
 import time

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -3,7 +3,9 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
 from copy import copy, deepcopy
+
 import pytest
+
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.__about__ import __version__
 from datadog_checks.sqlserver.connection import SQLConnectionError

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
 from copy import copy, deepcopy
-
 import pytest
 
 from datadog_checks.sqlserver import SQLServer

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -4,7 +4,6 @@
 import logging
 from copy import copy, deepcopy
 import pytest
-
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.__about__ import __version__
 from datadog_checks.sqlserver.connection import SQLConnectionError


### PR DESCRIPTION
### What does this PR do?
This PR changes the way we perform service check for auto discovered databases on non Azure SQL dabases.

### Motivation
Creating a connection to each DB is costly and doesn't yield additional value when we can use 'use db_name'.

### Additional Notes
test is in tests/test_integration.py - test_autodiscovery_db_service_checks
We don't have an Azure test env, so only the newly added cost path will be tested.
We might wont to use an extra configuration parameter for testing or let be with the idea that we will get Azure test env eventually.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
