### PR TITLE
Builders: Install openssl in default prefix and always build pyodbc

### DIFF
--- a/.builders/images/linux-aarch64/Dockerfile
+++ b/.builders/images/linux-aarch64/Dockerfile
@@ -40,12 +40,9 @@ RUN yum install -y perl-IPC-Cmd && \
  RELATIVE_PATH="openssl-{{version}}" \
  # https://docs.python.org/3/using/unix.html#custom-openssl
  INSTALL_COMMAND="make install_sw" \
- # no-module prevents the creation of dynamically loaded modules that would be problematic to bundle into Python wheels
  CONFIGURE_SCRIPT="./config" \
  bash install-from-source.sh \
- --prefix=/usr/local/ssl \
  --openssldir=/etc/pki/tls \
- --libdir=lib \
  -fPIC shared \
  # This prevents the creation of dynamically loaded modules that would be problematic to bundle into Python wheels
  no-module \
@@ -63,15 +60,12 @@ RUN yum install -y libffi-devel && \
  RELATIVE_PATH="Python-{{version}}" \
  bash install-from-source.sh \
  --prefix=/opt/python/${PYTHON_VERSION} \
- --with-openssl=/usr/local/ssl \
- --with-openssl-rpath=auto \
  --with-ensurepip=yes \
  --enable-ipv6 \
  --with-dbmliborder=
 ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
 # Set up virtual environment for Python 3
-RUN export LD_LIBRARY_PATH="/opt/python/${PYTHON_VERSION}/lib:${LD_LIBRARY_PATH}"; \
- /opt/python/${PYTHON_VERSION}/bin/python3 -m pip install --no-warn-script-location --upgrade pip \
+RUN /opt/python/${PYTHON_VERSION}/bin/python3 -m pip install --no-warn-script-location --upgrade pip \
  && /opt/python/${PYTHON_VERSION}/bin/python3 -m pip install --no-warn-script-location virtualenv \
  && /opt/python/${PYTHON_VERSION}/bin/python3 -m virtualenv /py3
 
@@ -114,7 +108,6 @@ RUN \
  --disable-static
 
 # libpq and pg_config as needed by psycopg2
-RUN yum install openssl-devel -y
 RUN \
  DOWNLOAD_URL="https://ftp.postgresql.org/pub/source/v{{version}}/postgresql-{{version}}.tar.bz2" \
  VERSION="16.0" \
@@ -180,7 +173,7 @@ RUN \
     --without-gnutls \
     --without-librtmp \
     --without-libssh2 \
-    --with-ssl=/usr/local/ssl \
+    --with-ssl=/usr/local \
  && rm /usr/local/bin/curl
 
 # https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

--- a/.builders/images/linux-aarch64/build_script.sh
+++ b/.builders/images/linux-aarch64/build_script.sh
@@ -25,10 +25,11 @@ if [[ "${DD_BUILD_PYTHON_VERSION}" == "3" ]]; then
         RELATIVE_PATH="librdkafka-{{version}}" \
         bash install-from-source.sh --enable-sasl --enable-curl
     always_build+=("confluent-kafka")
-else
-    echo "CFLAGS=\"-I/usr/local/ssl/include ${CFLAGS}\"" >> $DD_ENV_FILE
-    echo "LDFLAGS=\"-L/usr/local/ssl/lib ${LDFLAGS}\"" >> $DD_ENV_FILE
 
+    # The version of pyodbc is dynamically linked against a version of the odbc which doesn't come included in the wheel
+    # That causes the omnibus' health check to flag it. Forcing the build so that we do include it in the wheel.
+    always_build+=("pyodbc")
+else
     # Not working on Python 2
     sed -i '/aerospike==/d' /home/requirements.in
 fi


### PR DESCRIPTION
### What does this PR do?

- Install openssl in the default prefix and keep old openssl devel package uninstalled for the build. This makes it easy to find for programs looking for it in standard location.
- Always build pyodbc. Building pyodbc ourselves lets us include the odbc library in the wheel, which is the simplest way of preventing the omnibus healthcheck from flagging it.

### Motivation

Omnibus healthcheck reported failures ([example](https://gitlab.ddbuild.io/datadog/datadog-agent/builds/454874659)).
- Related to the openssl included in confluent-kafka
- Related to the odbc linked to by pyodbc.

In the case of openssl, this also brought to our attention that an old version of openssl was being included (the one installed via yum).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
