### PR TITLE
[DBMON-3619] Add support for Postgres Wal metric

### DIFF
--- a/postgres/changelog.d/17144.added
+++ b/postgres/changelog.d/17144.added
@@ -1,0 +1,1 @@
+add wal metrics

--- a/postgres/changelog.d/17144.added
+++ b/postgres/changelog.d/17144.added
@@ -1,1 +1,1 @@
-add wal metrics
+Added support for new query metrics wal_bytes, wal_records, and wal_fpi for PG versions >= 13. These metrics can now be accessed under postgresql.queries.wal_bytes, postgresql.queries.wal_records, and postgresql.queries.wal_fpi. In order to collect these metrics Database Monitoring must be enabled. 

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -72,6 +72,9 @@ PG_STAT_STATEMENTS_METRICS_COLUMNS = (
             'local_blks_written',
             'temp_blks_read',
             'temp_blks_written',
+            'wal_records',
+            'wal_fpi',
+            'wal_bytes',
         }
     )
     | PG_STAT_STATEMENTS_TIMING_COLUMNS

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -348,17 +348,16 @@ def test_statement_metrics_cloud_metadata(
     for conn in connections.values():
         conn.close()
 
+
 @requires_over_13
-def test_wal_metrics(
-    aggregator, integration_check, dbm_instance
-):
+def test_wal_metrics(aggregator, integration_check, dbm_instance):
     dbm_instance['pg_stat_statements_view'] = "pg_stat_statements"
     # don't need samples for this test
     dbm_instance['query_samples'] = {'enabled': False}
     dbm_instance['query_activity'] = {'enabled': False}
     # very low collection interval for test purposes
     dbm_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
-    
+
     connections = {}
 
     def _run_queries():
@@ -382,7 +381,6 @@ def test_wal_metrics(
     assert all('wal_bytes' in entry for entry in event['postgres_rows'])
     assert all('wal_fpi' in entry for entry in event['postgres_rows'])
     assert all('wal_bytes' in entry for entry in event['postgres_rows'])
-
 
     for conn in connections.values():
         conn.close()

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -190,12 +190,6 @@ def test_statement_metrics(
     assert len(aggregator.metrics("postgresql.pg_stat_statements.count")) != 0
     dbm_samples = aggregator.get_event_platform_events("dbm-samples")
 
-    #Verify we are collecting wal_metrics which are supported starting pg13
-    if float(POSTGRES_VERSION) >= 13:
-        assert all('wal_bytes' in entry for entry in event['postgres_rows'])
-        assert all('wal_fpi' in entry for entry in event['postgres_rows'])
-        assert all('wal_bytes' in entry for entry in event['postgres_rows'])
-
     for username, _, dbname, query, _ in SAMPLE_QUERIES:
         expected_query = query % obfuscated_param
         query_signature = compute_sql_signature(expected_query)

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -35,7 +35,7 @@ from .common import (
     _get_expected_replication_tags,
     _get_expected_tags,
 )
-from .utils import _get_conn, _get_superconn, requires_over_10, run_one_check
+from .utils import _get_conn, _get_superconn, requires_over_10, requires_over_13, run_one_check
 
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]
 
@@ -189,6 +189,12 @@ def test_statement_metrics(
     assert len(aggregator.metrics("postgresql.pg_stat_statements.max")) != 0
     assert len(aggregator.metrics("postgresql.pg_stat_statements.count")) != 0
     dbm_samples = aggregator.get_event_platform_events("dbm-samples")
+
+    #Verify we are collecting wal_metrics which are supported starting pg13
+    if float(POSTGRES_VERSION) >= 13:
+        assert all('wal_bytes' in entry for entry in event['postgres_rows'])
+        assert all('wal_fpi' in entry for entry in event['postgres_rows'])
+        assert all('wal_bytes' in entry for entry in event['postgres_rows'])
 
     for username, _, dbname, query, _ in SAMPLE_QUERIES:
         expected_query = query % obfuscated_param
@@ -344,6 +350,45 @@ def test_statement_metrics_cloud_metadata(
     assert event['ddagenthostname'] == datadog_agent.get_hostname()
     assert event['min_collection_interval'] == dbm_instance['query_metrics']['collection_interval']
     assert event['cloud_metadata'] == output_cloud_metadata, "wrong cloud_metadata"
+
+    for conn in connections.values():
+        conn.close()
+
+@requires_over_13
+def test_wal_metrics(
+    aggregator, integration_check, dbm_instance
+):
+    dbm_instance['pg_stat_statements_view'] = "pg_stat_statements"
+    # don't need samples for this test
+    dbm_instance['query_samples'] = {'enabled': False}
+    dbm_instance['query_activity'] = {'enabled': False}
+    # very low collection interval for test purposes
+    dbm_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
+    
+    connections = {}
+
+    def _run_queries():
+        for user, password, dbname, query, arg in SAMPLE_QUERIES:
+            if dbname not in connections:
+                connections[dbname] = psycopg2.connect(host=HOST, dbname=dbname, user=user, password=password)
+            connections[dbname].cursor().execute(query, (arg,))
+
+    check = integration_check(dbm_instance)
+    check._connect()
+
+    _run_queries()
+    run_one_check(check, dbm_instance)
+    _run_queries()
+    run_one_check(check, dbm_instance)
+
+    events = aggregator.get_event_platform_events("dbm-metrics")
+    assert len(events) == 1, "should capture exactly one metrics payload"
+    event = events[0]
+
+    assert all('wal_bytes' in entry for entry in event['postgres_rows'])
+    assert all('wal_fpi' in entry for entry in event['postgres_rows'])
+    assert all('wal_bytes' in entry for entry in event['postgres_rows'])
+
 
     for conn in connections.values():
         conn.close()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds support for collecting wall metrics from postgres which become available after PG13.
The exact metrics are
- wal_bytes
- wal_fpi
- wal_records

These metrics are useful when tuning INSERT/DELETE/UPDATE operations
### Motivation
<!-- What inspired you to submit this pull request? -->
https://datadoghq.atlassian.net/browse/DBMON-3619

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Backend Change Pr:https://github.com/DataDog/dd-go/pull/126362


### Review checklist (to be filled by reviewers)
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
