### PR TITLE
[DBMON-3618] Add support for collecting plan time metrics from PG_STAT_STATEMENTS 

### DIFF
--- a/postgres/changelog.d/17148.added
+++ b/postgres/changelog.d/17148.added
@@ -1,0 +1,3 @@
+Added support for collecting total_plan_time, max_plan_time, mean_plan_time , min_plan_time, stddev_plan_time query metrics for PostgreSQL versions 13 and above.
+These new query metrics can now be accessed under postgresql.queries.total_plan_time, postgresql.queries.max_plan_time, postgresql.queries.mean_plan_time, postgresql.queries.min_plan_time, and postgresql.queries.stddev_plan_time.
+To collect these metrics Database monitoring needs to be enabled. You will also need to enable pg_stat_statements.track_planning in your database.

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -79,7 +79,7 @@ PG_STAT_STATEMENTS_METRICS_COLUMNS = (
             'min_plan_time',
             'max_plan_time',
             'mean_plan_time',
-            'stddev_plan_time'
+            'stddev_plan_time',
         }
     )
     | PG_STAT_STATEMENTS_TIMING_COLUMNS

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -75,6 +75,11 @@ PG_STAT_STATEMENTS_METRICS_COLUMNS = (
             'wal_records',
             'wal_fpi',
             'wal_bytes',
+            'total_plan_time',
+            'min_plan_time',
+            'max_plan_time',
+            'mean_plan_time',
+            'stddev_plan_time'
         }
     )
     | PG_STAT_STATEMENTS_TIMING_COLUMNS

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1888,3 +1888,42 @@ def test_pg_stat_statements_dealloc(aggregator, integration_check, dbm_instance_
     if float(POSTGRES_VERSION) >= 14.0:
         aggregator.assert_metric("postgresql.pg_stat_statements.dealloc", value=1, tags=expected_tags)
     aggregator.assert_metric("postgresql.pg_stat_statements.count", tags=expected_tags)
+
+
+@requires_over_13
+def test_plan_time_metrics(aggregator, integration_check, dbm_instance):
+    dbm_instance['pg_stat_statements_view'] = "pg_stat_statements"
+    # don't need samples for this test
+    dbm_instance['query_samples'] = {'enabled': False}
+    dbm_instance['query_activity'] = {'enabled': False}
+    # very low collection interval for test purposes
+    dbm_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
+
+    connections = {}
+
+    def _run_queries():
+        for user, password, dbname, query, arg in SAMPLE_QUERIES:
+            if dbname not in connections:
+                connections[dbname] = psycopg2.connect(host=HOST, dbname=dbname, user=user, password=password)
+            connections[dbname].cursor().execute(query, (arg,))
+
+    check = integration_check(dbm_instance)
+    check._connect()
+
+    _run_queries()
+    run_one_check(check, dbm_instance)
+    _run_queries()
+    run_one_check(check, dbm_instance)
+
+    events = aggregator.get_event_platform_events("dbm-metrics")
+    assert len(events) == 1, "should capture exactly one metrics payload"
+    event = events[0]
+
+    assert all('total_plan_time' in entry for entry in event['postgres_rows'])
+    assert all('min_plan_time' in entry for entry in event['postgres_rows'])
+    assert all('max_plan_time' in entry for entry in event['postgres_rows'])
+    assert all('mean_plan_time' in entry for entry in event['postgres_rows'])
+    assert all('stddev_plan_time' in entry for entry in event['postgres_rows'])
+
+    for conn in connections.values():
+        conn.close()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds support for collection plan time metrics from PG_STAT_STATEMENTS for PG 13 and up. This will help users verify any optimizations they are making to their queries to reduce the amount of time the PG database takes to plan the query.

The following are the newly added metrics
- total_plan_time
- min_plan_time
- max_plan_time
- mean_plan_time
- stddev_plan_time

### Motivation
<!-- What inspired you to submit this pull request? -->
https://datadoghq.atlassian.net/browse/DBMON-3618
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
