### PR TITLE
More improvements to PR guidelines

### DIFF
--- a/docs/developer/guidelines/pr.md
+++ b/docs/developer/guidelines/pr.md
@@ -100,5 +100,5 @@ Different guidelines apply depending on which repo you are contributing to.
     It will add files in `changelog.d` folder inside the integrations that you have modified.
     Commit these files and push them to your PR.
     
-    If you decide that you do not need a changelog because the change you made won't be shipped with the agent, add the `changelog/no-changelog` label to the PR.
+    If you decide that you do not need a changelog because the change you made won't be shipped with the Agent, add the `changelog/no-changelog` label to the PR.
 

--- a/docs/developer/guidelines/pr.md
+++ b/docs/developer/guidelines/pr.md
@@ -1,10 +1,22 @@
 # Pull requests
 
+## Separation of concerns
+
+  Every pull request should do one thing only for easier Git management. For example, if you are
+    editing documentation and notice an error in the shipped example configuration, you should fix the
+    error in a separate pull request. Doing so will enable a clean cherry-pick or revert of the bug fix
+    should the need arise.
+
+## Merges
+
+  We only allow GitHub's [squash and merge][github-squash-and-merge] to keep a clean Git history.
+
+## Changelog entries
+
 Different guidelines apply depending on which repo you are contributing to.
 
 === "integrations-extras and marketplace"
 
-    ## Changelog entries
 
     Every PR must add a changelog entry to each integration that has had its shipped code modified.
 
@@ -85,16 +97,8 @@ Different guidelines apply depending on which repo you are contributing to.
 === "integrations-core"
 
     If you are contributing to [integrations-core](https://github.com/DataDog/integrations-core) all you need to do is use the [`release changelog new`](../ddev/cli.md#ddev-release-changelog-new) command.
-    It will take care of all the formalities.
-    Add the `changelog/no-changelog` label if you don't need a changelog.
+    It will add files in `changelog.d` folder inside the integrations that you have modified.
+    Commit these files and push them to your PR.
+    
+    If you decide that you do not need a changelog because the change you made won't be shipped with the agent, add the `changelog/no-changelog` label to the PR.
 
-## Separation of concerns
-
-  Every pull request should do one thing only for easier Git management. For example, if you are
-    editing documentation and notice an error in the shipped example configuration, you should fix the
-    error in a separate pull request. Doing so will enable a clean cherry-pick or revert of the bug fix
-    should the need arise.
-
-## Merges
-
-  We only allow GitHub's [squash and merge][github-squash-and-merge] to keep a clean Git history.

--- a/docs/developer/guidelines/pr.md
+++ b/docs/developer/guidelines/pr.md
@@ -3,13 +3,13 @@
 ## Separation of concerns
 
   Every pull request should do one thing only for easier Git management. For example, if you are
-    editing documentation and notice an error in the shipped example configuration, you should fix the
-    error in a separate pull request. Doing so will enable a clean cherry-pick or revert of the bug fix
+    editing documentation and notice an error in the shipped example configuration, fix the
+    error in a separate pull request. Doing so enables a clean cherry-pick or revert of the bug fix
     should the need arise.
 
 ## Merges
 
-  We only allow GitHub's [squash and merge][github-squash-and-merge] to keep a clean Git history.
+  Datadog only allows GitHub's [squash and merge][github-squash-and-merge] to keep a clean Git history.
 
 ## Changelog entries
 
@@ -97,7 +97,7 @@ Different guidelines apply depending on which repo you are contributing to.
 === "integrations-core"
 
     If you are contributing to [integrations-core](https://github.com/DataDog/integrations-core) all you need to do is use the [`release changelog new`](../ddev/cli.md#ddev-release-changelog-new) command.
-    It will add files in `changelog.d` folder inside the integrations that you have modified.
+    It adds files in the `changelog.d` folder inside the integrations that you have modified.
     Commit these files and push them to your PR.
     
     If you decide that you do not need a changelog because the change you made won't be shipped with the Agent, add the `changelog/no-changelog` label to the PR.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
- Changelog entries header is shared between different tabs.
- Shorter sections above changelog, less likely to be missed.
- Expand instructions for integrations-core.


### Motivation
<!-- What inspired you to submit this pull request? -->

Noticed when tried to link an external contributor to the docs.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
