### PR TITLE
Add the saved views to the weblogic manifest

### DIFF
--- a/weblogic/assets/saved_views/weblogic_overview.json
+++ b/weblogic/assets/saved_views/weblogic_overview.json
@@ -9,7 +9,7 @@
     "visible_facets": ["source", "host", "service", "status", "weblogic"],
     "options": {
       "group_bys": [
-        {"facet": "@weblogic.subsystem"},
+        {"facet": "@weblogic.subsystem"}
       ],
       "aggregations": [
         { "metric": "count", "type": "count" }

--- a/weblogic/manifest.json
+++ b/weblogic/manifest.json
@@ -58,6 +58,11 @@
     },
     "logs": {
       "source": "weblogic"
+    },
+    "saved_views": {
+      "weblogic_error_logs": "assets/saved_views/error_logs.json",
+      "weblogic_overview": "assets/saved_views/weblogic_overview.json",
+      "weblogic_patterns": "assets/saved_views/weblogic_patterns.json"
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The WebLogic integration has an assets/saved_views folder but they weren't registered in the manifest. This PR adds them there. 

### Motivation
<!-- What inspired you to submit this pull request? -->
I'm looking to integration saved_views into APW and noticed this was missing during my testing. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
