### PR TITLE
tag sqlserver agent queries

### DIFF
--- a/sqlserver/changelog.d/17162.added
+++ b/sqlserver/changelog.d/17162.added
@@ -1,0 +1,1 @@
+Tag sqlserver agent queries with service:datadog-agent

--- a/sqlserver/datadog_checks/sqlserver/cursor.py
+++ b/sqlserver/datadog_checks/sqlserver/cursor.py
@@ -23,7 +23,7 @@ class CommenterCursorWrapper:
         self.__cursor = cursor
 
     def execute(self, query, *params):
-        query = add_sql_comment(query, prepand=False, **self.__attributes)
+        query = add_sql_comment(query, True, **self.__attributes)
         return self.__cursor.execute(query, *params)
 
     def __getattr__(self, item):

--- a/sqlserver/datadog_checks/sqlserver/cursor.py
+++ b/sqlserver/datadog_checks/sqlserver/cursor.py
@@ -1,0 +1,32 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from datadog_checks.base.utils.db.sql_commenter import add_sql_comment
+
+DD_QUERY_ATTRIBUTES = {
+    'service': 'datadog-agent',
+}
+
+
+class CommenterCursorWrapper:
+    '''
+    Simple wrapper around a cursor that prepands a comment before executing each query
+
+    Why not extend pyodbc.Cursor or adodbapi.Cursor?
+    - we want to be able to use this with any cursor, not just a specific one.
+    - classes that are implemented in C or are part of a module that does not support subclassing in this way.
+    i.e. class CommenterCursor(pyodbc.Cursor) is not possible because pyodbc.Cursor is implemented in C.
+    '''
+
+    def __init__(self, cursor):
+        self.__attributes = DD_QUERY_ATTRIBUTES
+        self.__cursor = cursor
+
+    def execute(self, query, *params):
+        query = add_sql_comment(query, prepand=False, **self.__attributes)
+        return self.__cursor.execute(query, *params)
+
+    def __getattr__(self, item):
+        # This method ensures that any other attributes or methods not explicitly defined here
+        # are passed through to the underlying cursor.
+        return getattr(self.__cursor, item)

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -489,6 +489,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                     "metadata": {
                         "tables": row['dd_tables'],
                         "commands": row['dd_commands'],
+                        "comments": row.get('dd_comments', None),
                     },
                 },
                 'sqlserver': {

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=36.0.0",
+    "datadog-checks-base>=36.5.0",
 ]
 dynamic = [
     "version",

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -333,7 +333,7 @@ def test_connection_cleanup(instance_docker):
             with check.connection.get_managed_cursor() as cursor:
                 assert len(check.connection._conns) == 1
                 cursor.execute("gimme some data")
-    assert "incorrect syntax" in str(e).lower()
+    assert "incorrect syn" in str(e).lower()
     assert len(check.connection._conns) == 0, "connection should have been closed"
 
     # application exception

--- a/sqlserver/tests/test_cursor.py
+++ b/sqlserver/tests/test_cursor.py
@@ -42,4 +42,4 @@ def __check_prepand_sql_comment(sa_conn):
             )
             result = cursor.fetchall()
             assert len(result) > 0
-            assert result[0][0].endswith('/* service=\'datadog-agent\' */')
+            assert result[0][0].startswith('/* service=\'datadog-agent\' */')

--- a/sqlserver/tests/test_cursor.py
+++ b/sqlserver/tests/test_cursor.py
@@ -1,0 +1,45 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from datadog_checks.sqlserver import SQLServer
+
+from .common import CHECK_NAME
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_integration_connection_with_commenter_cursor(instance_docker, sa_conn):
+    check = SQLServer(CHECK_NAME, {}, [instance_docker])
+    check.initialize_connection()
+
+    with check.connection.open_managed_default_connection():
+        with check.connection.get_managed_cursor() as cursor:
+            cursor.execute("SELECT /* testcomments */ count(*) from sys.databases where name = 'master'")
+            result = cursor.fetchone()
+            assert result[0] == 1
+            __check_prepand_sql_comment(sa_conn)
+
+    check.cancel()
+
+
+def __check_prepand_sql_comment(sa_conn):
+    # collect text from dm_exec_requests CROSS APPLY sys.dm_exec_sql_text(sql_handle)
+    # assert /* service='datadog-agent' */ is present in the query
+    with sa_conn as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT
+                    st.text
+                FROM
+                    sys.dm_exec_query_stats AS qs
+                CROSS APPLY
+                    sys.dm_exec_sql_text(qs.sql_handle) AS st
+                WHERE st.text LIKE '%testcomments%'
+                """
+            )
+            result = cursor.fetchall()
+            assert len(result) > 0
+            assert result[0][0].endswith('/* service=\'datadog-agent\' */')

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -490,12 +490,12 @@ def test_statement_metrics_limit(
     "metadata,expected_metadata_payload",
     [
         (
-            {'tables_csv': 'sys.databases', 'commands': ['SELECT'], 'comments': ['-- Test comment']},
-            {'tables': ['sys.databases'], 'commands': ['SELECT'], 'comments': ['-- Test comment']},
+            {'tables_csv': 'sys.databases', 'commands': ['SELECT']},
+            {'tables': ['sys.databases'], 'commands': ['SELECT']},
         ),
         (
-            {'tables_csv': '', 'commands': None, 'comments': None},
-            {'tables': None, 'commands': None, 'comments': None},
+            {'tables_csv': '', 'commands': None},
+            {'tables': None, 'commands': None},
         ),
     ],
 )
@@ -504,9 +504,7 @@ def test_statement_metadata(
 ):
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
 
-    query = '''
-    -- Test comment
-    select * from sys.sysusers'''
+    query = "select * from sys.databases /* service='datadog-agent' */"
     query_signature = '6d1d070f9b6c5647'
 
     def _run_query():
@@ -531,7 +529,7 @@ def test_statement_metadata(
     sample = matching[0]
     assert sample['db']['metadata']['tables'] == expected_metadata_payload['tables']
     assert sample['db']['metadata']['commands'] == expected_metadata_payload['commands']
-    assert sample['db']['metadata']['comments'] == expected_metadata_payload['comments']
+    assert sample['db']['metadata']['comments'] == ["/* service='datadog-agent' */"]
 
     fqt_samples = [
         s for s in dbm_samples if s.get('dbm_type') == 'fqt' and s['db']['query_signature'] == query_signature
@@ -540,6 +538,7 @@ def test_statement_metadata(
     fqt = fqt_samples[0]
     assert fqt['db']['metadata']['tables'] == expected_metadata_payload['tables']
     assert fqt['db']['metadata']['commands'] == expected_metadata_payload['commands']
+    assert fqt['db']['metadata']['comments'] == ["/* service='datadog-agent' */"]
 
     dbm_metrics = aggregator.get_event_platform_events("dbm-metrics")
     assert len(dbm_metrics) == 1
@@ -727,7 +726,7 @@ def test_statement_basic_metrics_query(datadog_conn_docker, dbm_instance):
         columns = [i[0] for i in cursor.description]
         # construct row dicts manually as there's no DictCursor for pyodbc
         rows = [dict(zip(columns, row)) for row in cursor.fetchall()]
-        matching = [r for r in rows if r['text'] == test_query]
+        matching = [r for r in rows if r['statement_text'] == test_query]
         assert matching, "the test query should be visible in the query stats, found all rows: {}".format(rows)
         row = matching[0]
 

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -73,7 +73,7 @@ def test_db_exists(get_cursor, mock_connect, instance_docker_defaults, dd_run_ch
     mock_connect.__enter__ = mock.Mock(return_value='foo')
 
     mock_results = mock.MagicMock()
-    mock_results.__iter__.return_value = db_results
+    mock_results.fetchall.return_value = db_results
     get_cursor.return_value = mock_results
 
     instance = copy.copy(instance_docker_defaults)
@@ -137,7 +137,7 @@ def test_azure_cross_database_queries_excluded(get_cursor, mock_connect, instanc
     mock_connect.__enter__ = mock.Mock(return_value='foo')
 
     mock_results = mock.MagicMock()
-    mock_results.__iter__.return_value = db_results
+    mock_results.fetchall.return_value = db_results
     get_cursor.return_value = mock_results
 
     instance = copy.copy(instance_docker_defaults)


### PR DESCRIPTION
### What does this PR do?
This PR uses `add_sql_comment` to tag all sqlserver integration queries with `service:datadog-agent`. This allows user to filter agent integration queries in query samples and explain plans.
![image](https://github.com/DataDog/integrations-core/assets/4964070/4d10d5e3-b500-49d5-a1ac-a6fba62ae9dd)
![image](https://github.com/DataDog/integrations-core/assets/4964070/1f18df95-4adb-4b00-adb9-9fb67d5dbc6f)


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
