### PR TITLE
[DOCS-7419] adding conf.yaml link to additional supported endpoints

### DIFF
--- a/argocd/README.md
+++ b/argocd/README.md
@@ -111,6 +111,8 @@ spec:
 # (...)
 ```
 
+**Note**: For the full list of supported endpoints, see the [conf.yaml example file][15].
+
 ##### Troubleshooting 
 
 **Clashing Tag Names**:
@@ -194,4 +196,5 @@ Need help? Contact [Datadog support][9].
 [12]: https://github.com/DataDog/integrations-core/blob/master/argocd/datadog_checks/argocd/data/conf.yaml.example
 [13]: https://github.com/DataDog/integrations-core/blob/7.45.x/argocd/datadog_checks/argocd/data/conf.yaml.example#L164-L166
 [14]: https://argo-cd.readthedocs.io/en/stable/operator-manual/metrics/#exposing-application-labels-as-prometheus-metrics
+[15]: https://github.com/DataDog/integrations-core/blob/master/argocd/datadog_checks/argocd/data/conf.yaml.example#L45-L72
 


### PR DESCRIPTION
### What does this PR do?
[DOCS-7419](https://datadoghq.atlassian.net/browse/DOCS-7419)
This PR provides a link to the section of the `conf.yaml` example file so users can more easily see the list of additional supported endpoints to configure.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.


[DOCS-7419]: https://datadoghq.atlassian.net/browse/DOCS-7419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ