### PR TITLE
Exclude the kube* integrations from the openmetrics validation check

### DIFF
--- a/.ddev/config.toml
+++ b/.ddev/config.toml
@@ -131,7 +131,12 @@ tuf = 'https://github.com/theupdateframework/python-tuf'
 typing = 'https://github.com/python/typing'
 
 [overrides.validate.openmetrics]
-exclude = ["openmetrics"]
+exclude = [
+    "kube_apiserver_metrics",
+    "kube_controller_manager",
+    "kube_scheduler",
+    "openmetrics",
+]
 
 [overrides.validate.labeler]
 include = ["datadog_checks_tests_helper"]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
