### PR TITLE
Print raw output of the agent if the metric name is empty

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/_env.py
+++ b/datadog_checks_dev/datadog_checks/dev/_env.py
@@ -131,6 +131,10 @@ def replay_check_run(agent_collector, stub_aggregator, stub_agent):
                 if data.get('source_type_name') == 'JMX':
                     raw_metric_type = JMX_TO_INAPP_TYPES.get(raw_metric_type, raw_metric_type)
                 metric_type = stub_aggregator.METRIC_ENUM_MAP[raw_metric_type]
+
+                if not data['metric']:
+                    print(data)
+
                 stub_aggregator.submit_metric_e2e(
                     # device is only present when replaying e2e tests. In integration tests it will be a tag
                     check_name,

--- a/mapreduce/pyproject.toml
+++ b/mapreduce/pyproject.toml
@@ -60,3 +60,6 @@ include = [
 dev-mode-dirs = [
     ".",
 ]
+
+[tool.pytest.ini_options]
+addopts = "--capture=no"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Print raw output of the agent if the metric name is empty. This won't be released

### Motivation
<!-- What inspired you to submit this pull request? -->

We try to debug [this](https://github.com/DataDog/integrations-core/actions/runs/8276747701/job/22645912805) in the CI which we can't reproduce locally. We think there's a bug in the aggregator, having the output will allow us to debug it

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
