### PR TITLE
Pin requests-oauthlib for Py2

### DIFF
--- a/datadog_checks_base/changelog.d/17181.fixed
+++ b/datadog_checks_base/changelog.d/17181.fixed
@@ -1,0 +1,1 @@
+Pin requests-oauthlib for Py2

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -89,7 +89,8 @@ requests-kerberos==0.12.0; python_version < '3.0'
 requests-kerberos==0.14.0; python_version > '3.0'
 requests-ntlm==1.1.0; python_version < '3.0'
 requests-ntlm==1.2.0; python_version > '3.0'
-requests-oauthlib==1.3.1
+requests-oauthlib==1.3.1; python_version < '3.0'
+requests-oauthlib==1.4.0; python_version > '3.0'
 requests-toolbelt==1.0.0
 requests-unixsocket==0.3.0
 requests==2.27.1; python_version < '3.0'

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -85,7 +85,8 @@ http = [
     "requests-kerberos==0.14.0; python_version > '3.0'",
     "requests-ntlm==1.1.0; python_version < '3.0'",
     "requests-ntlm==1.2.0; python_version > '3.0'",
-    "requests-oauthlib==1.3.1",
+    "requests-oauthlib==1.4.0; python_version > '3.0'",
+    "requests-oauthlib==1.3.1; python_version < '3.0'",
     "win-inet-pton==1.1.0; sys_platform == 'win32' and python_version < '3.0'",
 ]
 json = [
@@ -94,6 +95,7 @@ json = [
 kube = [
     "kubernetes==18.20.0; python_version < '3.0'",
     "kubernetes==28.1.0; python_version > '3.0'",
+    "requests-oauthlib==1.3.1; python_version < '3.0'",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

requests-oauthlib v1.4.0 drops python support without updating the wheel metadata. That's why we have to explicitly pin to a version that still works with python 2.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
