### PR TITLE
Fix `PIP_NO_BINARY` syntax and ensure pyobdc is always built in linux

### DIFF
--- a/.builders/images/linux-aarch64/build_script.sh
+++ b/.builders/images/linux-aarch64/build_script.sh
@@ -34,10 +34,9 @@ else
     sed -i '/aerospike==/d' /home/requirements.in
 fi
 
-# Empty arrays are flagged as unset when using the `-u` flag. This is the safest way to work around that
-# (see https://stackoverflow.com/a/61551944)
-pip_no_binary=${always_build[@]+"${always_build[@]}"}
+# package names passed to PIP_NO_BINARY need to be separated by commas
+pip_no_binary=$(IFS=, ; printf "${always_build[*]-}")
 if [[ "$pip_no_binary" ]]; then
     # If there are any packages that must always be built, inform pip
-    echo "PIP_NO_BINARY=\"${pip_no_binary}\"" >> $DD_ENV_FILE
+    echo "PIP_NO_BINARY=${pip_no_binary}" >> $DD_ENV_FILE
 fi

--- a/.builders/images/linux-x86_64/build_script.sh
+++ b/.builders/images/linux-x86_64/build_script.sh
@@ -22,6 +22,10 @@ if [[ "${DD_BUILD_PYTHON_VERSION}" == "3" ]]; then
         RELATIVE_PATH="librdkafka-{{version}}" \
         bash install-from-source.sh --enable-sasl --enable-curl
     always_build+=("confluent-kafka")
+
+    # The version of pyodbc is dynamically linked against a version of the odbc which doesn't come included in the wheel
+    # That causes the omnibus' health check to flag it. Forcing the build so that we do include it in the wheel.
+    always_build+=("pyodbc")
 fi
 
 # package names passed to PIP_NO_BINARY need to be separated by commas

--- a/.builders/images/linux-x86_64/build_script.sh
+++ b/.builders/images/linux-x86_64/build_script.sh
@@ -24,10 +24,9 @@ if [[ "${DD_BUILD_PYTHON_VERSION}" == "3" ]]; then
     always_build+=("confluent-kafka")
 fi
 
-# Empty arrays are flagged as unset when using the `-u` flag. This is the safest way to work around that
-# (see https://stackoverflow.com/a/61551944)
-pip_no_binary=${always_build[@]+"${always_build[@]}"}
+# package names passed to PIP_NO_BINARY need to be separated by commas
+pip_no_binary=$(IFS=, ; printf "${always_build[*]-}")
 if [[ "$pip_no_binary" ]]; then
     # If there are any packages that must always be built, inform pip
-    echo "PIP_NO_BINARY=\"${pip_no_binary}\"" >> $DD_ENV_FILE
+    echo "PIP_NO_BINARY=${pip_no_binary}" >> $DD_ENV_FILE
 fi


### PR DESCRIPTION
### What does this PR do?
Fixes `PIP_NO_BINARY` syntax and ensures pyobdc is always built in linux
### Motivation

#17142 tried to force the installation of pyodbc for linux-aarch64 to avoid an omnibus health-check issue. However, we were passing package names separated by spaces to `PIP_NO_BINARY` when it actually expects commas, so it turns out we were still using the pyodbc from PyPI.

In addition, with the update of the linux-x86 image to manylinux2014, we now also need to do the same thing in that platform.

### Additional Notes

Proof it builds it now:
- https://github.com/DataDog/integrations-core/actions/runs/8294569329/job/22699839228?pr=17186#step:10:37891
- https://github.com/DataDog/integrations-core/actions/runs/8294569329/job/22699839525?pr=17186#step:12:36956

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
