### PR TITLE
Add missing custom tags to the `can_connect` service check

### DIFF
--- a/harbor/changelog.d/17194.fixed
+++ b/harbor/changelog.d/17194.fixed
@@ -1,0 +1,1 @@
+Add missing custom tags to the `can_connect` service check

--- a/harbor/datadog_checks/harbor/harbor.py
+++ b/harbor/datadog_checks/harbor/harbor.py
@@ -99,7 +99,7 @@ class HarborCheck(AgentCheck):
             self._submit_read_only_status(api, tags)
         except Exception:
             self.log.exception("An error occurred when collecting Harbor metrics")
-            self.service_check(CAN_CONNECT, AgentCheck.CRITICAL)
+            self.service_check(CAN_CONNECT, AgentCheck.CRITICAL, tags)
             raise
         else:
-            self.service_check(CAN_CONNECT, AgentCheck.OK)
+            self.service_check(CAN_CONNECT, AgentCheck.OK, tags)

--- a/harbor/tests/common.py
+++ b/harbor/tests/common.py
@@ -23,8 +23,8 @@ HARBOR_METRICS = [
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 URL = 'http://{}'.format(get_docker_hostname())
-INSTANCE = {'url': URL, 'username': 'NotAnAdmin', 'password': 'Str0ngPassw0rd'}
-ADMIN_INSTANCE = {'url': URL, 'username': 'admin', 'password': 'Harbor12345'}
+INSTANCE = {'url': URL, 'username': 'NotAnAdmin', 'password': 'Str0ngPassw0rd', 'tags': ['environment:test']}
+ADMIN_INSTANCE = {'url': URL, 'username': 'admin', 'password': 'Harbor12345', 'tags': ['environment:test']}
 
 HEALTH_FIXTURE = {
     "status": "healthy",

--- a/harbor/tests/test_harbor.py
+++ b/harbor/tests/test_harbor.py
@@ -52,6 +52,8 @@ def assert_basic_case(aggregator):
 
 
 def assert_service_checks(aggregator):
-    aggregator.assert_service_check('harbor.can_connect', status=HarborCheck.OK)
+    aggregator.assert_service_check('harbor.can_connect', status=HarborCheck.OK, tags=['environment:test'])
     for c in HARBOR_COMPONENTS:
-        aggregator.assert_service_check('harbor.status', status=mock.ANY, tags=['component:{}'.format(c)])
+        aggregator.assert_service_check(
+            'harbor.status', status=mock.ANY, tags=['component:{}'.format(c), 'environment:test']
+        )


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add missing custom tags to the `can_connect` service check

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/integrations-core/issues/17188

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
