### PR TITLE
[CONTINT-3892] remove mutation_errors and update dashboard

### DIFF
--- a/datadog_cluster_agent/assets/dashboards/datadog_cluster_agent_overview.json
+++ b/datadog_cluster_agent/assets/dashboards/datadog_cluster_agent_overview.json
@@ -1393,7 +1393,7 @@
                             {
                                 "data_source": "metrics",
                                 "name": "query1",
-                                "query": "avg:datadog.cluster_agent.admission_webhooks.mutation_attempts{injected:true,$cluster,$namespace} by {mutation_type}"
+                                "query": "avg:datadog.cluster_agent.admission_webhooks.mutation_attempts{status:success,$cluster,$namespace} by {mutation_type, injected}"
                             }
                         ],
                         "response_format": "timeseries",
@@ -1415,59 +1415,6 @@
             },
             "layout": {
                 "x": 4,
-                "y": 16,
-                "width": 4,
-                "height": 2
-            }
-        },
-        {
-            "id": 4551516642114976,
-            "definition": {
-                "title": "Mutation errors by type and reason",
-                "show_legend": true,
-                "legend_layout": "auto",
-                "legend_columns": [
-                    "avg",
-                    "min",
-                    "max",
-                    "value",
-                    "sum"
-                ],
-                "type": "timeseries",
-                "requests": [
-                    {
-                        "formulas": [
-                            {
-                                "formula": "query1"
-                            }
-                        ],
-                        "on_right_yaxis": false,
-                        "queries": [
-                            {
-                                "data_source": "metrics",
-                                "name": "query1",
-                                "query": "avg:datadog.cluster_agent.admission_webhooks.mutation_errors{$cluster,$namespace} by {mutation_type,reason}"
-                            }
-                        ],
-                        "response_format": "timeseries",
-                        "style": {
-                            "palette": "dog_classic",
-                            "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "area"
-                    }
-                ],
-                "yaxis": {
-                    "include_zero": true,
-                    "scale": "linear",
-                    "min": "auto",
-                    "max": "auto"
-                },
-                "markers": []
-            },
-            "layout": {
-                "x": 8,
                 "y": 16,
                 "width": 4,
                 "height": 2
@@ -1583,7 +1530,7 @@
                             {
                                 "data_source": "metrics",
                                 "name": "query1",
-                                "query": "avg:datadog.cluster_agent.admission_webhooks.mutation_attempts{injected:false,$cluster,$namespace} by {mutation_type}"
+                                "query": "avg:datadog.cluster_agent.admission_webhooks.mutation_attempts{status:error,$cluster,$namespace} by {mutation_type}"
                             }
                         ],
                         "response_format": "timeseries",

--- a/datadog_cluster_agent/changelog.d/17195.removed
+++ b/datadog_cluster_agent/changelog.d/17195.removed
@@ -1,0 +1,1 @@
+removed `admission_webhooks.mutation_errors` metric in the `datadog_cluster_agent` integration

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
@@ -9,7 +9,6 @@ DEFAULT_METRICS = {
     'admission_webhooks_library_injection_attempts': 'admission_webhooks.library_injection_attempts',
     'admission_webhooks_library_injection_errors': 'admission_webhooks.library_injection_errors',
     'admission_webhooks_mutation_attempts': 'admission_webhooks.mutation_attempts',
-    'admission_webhooks_mutation_errors': 'admission_webhooks.mutation_errors',
     'admission_webhooks_patcher_attempts': 'admission_webhooks.patcher.attempts',
     'admission_webhooks_patcher_completed': 'admission_webhooks.patcher.completed',
     'admission_webhooks_patcher_errors': 'admission_webhooks.patcher.errors',

--- a/datadog_cluster_agent/tests/fixtures/metrics.txt
+++ b/datadog_cluster_agent/tests/fixtures/metrics.txt
@@ -1,12 +1,16 @@
 # HELP admission_webhooks_certificate_expiry Time left before the certificate expires in hours.
 # TYPE admission_webhooks_certificate_expiry gauge
 admission_webhooks_certificate_expiry 11.083180892013889
-# HELP admission_webhooks_mutation_attempts Number of pod mutation attempts by mutation type (agent config, standard tags).
+# HELP admission_webhooks_mutation_attempts Number of pod mutation attempts by mutation type
 # TYPE admission_webhooks_mutation_attempts gauge
-admission_webhooks_mutation_attempts{mutation_type="agent_config"} 100
-# HELP admission_webhooks_mutation_errors Number of mutation failures by mutation type (agent config, standard tags).
-# TYPE admission_webhooks_mutation_errors gauge
-admission_webhooks_mutation_errors{mutation_type="agent_config"} 1
+admission_webhooks_mutation_attempts{error="",injected="false",mutation_type="agent_sidecar",status="success"} 1
+admission_webhooks_mutation_attempts{error="",injected="false",mutation_type="cws_exec_instrumentation",status="success"} 1
+admission_webhooks_mutation_attempts{error="",injected="false",mutation_type="lib_injection",status="success"} 1
+admission_webhooks_mutation_attempts{error="",injected="false",mutation_type="standard_tags",status="success"} 2
+admission_webhooks_mutation_attempts{error="",injected="true",mutation_type="agent_config",status="success"} 2
+admission_webhooks_mutation_attempts{error="",injected="true",mutation_type="agent_sidecar",status="success"} 1
+admission_webhooks_mutation_attempts{error="",injected="true",mutation_type="cws_pod_instrumentation",status="success"} 2
+admission_webhooks_mutation_attempts{error="",injected="true",mutation_type="lib_injection",status="success"} 1
 # HELP admission_webhooks_reconcile_errors Number of reconcile errors per controller.
 # TYPE admission_webhooks_reconcile_errors gauge
 admission_webhooks_reconcile_errors{controller="secrets"} 5

--- a/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
+++ b/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
@@ -17,7 +17,6 @@ METRICS = [
     'admission_webhooks.library_injection_attempts',
     'admission_webhooks.library_injection_errors',
     'admission_webhooks.mutation_attempts',
-    'admission_webhooks.mutation_errors',
     'admission_webhooks.patcher.attempts',
     'admission_webhooks.patcher.completed',
     'admission_webhooks.patcher.errors',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR removes the `admission_webhooks_mutation_errors` metric and updates the DCA OOTB dashboard/

### Motivation
<!-- What inspired you to submit this pull request? -->
- `admission_webhooks_mutation_errors` is removed from the cluster agent telemetry in [this](https://github.com/DataDog/datadog-agent/pull/23770) PR

### Additional Notes
<!-- Anything else we should know when reviewing? -->
- Depends on:
   -  [PR](https://github.com/DataDog/datadog-agent/pull/23770)

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
