### PR TITLE
Bump the min base check version to 34.2.0

### DIFF
--- a/kubelet/changelog.d/17196.added
+++ b/kubelet/changelog.d/17196.added
@@ -1,0 +1,1 @@
+Bump the min base check version to 34.2.0

--- a/kubelet/pyproject.toml
+++ b/kubelet/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=32.6.0",
+    "datadog-checks-base>=34.2.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump the min base check version to 34.2.0

### Motivation
<!-- What inspired you to submit this pull request? -->

[This](https://github.com/DataDog/integrations-core/pull/16856/files#diff-5667d0679f771917c408c64bc4f6fe3e07a79d03e663038809fe82804f636cd3R19) was [introduced](https://github.com/DataDog/integrations-core/pull/16012) in the base check 34.2.0 so it now [fails](https://github.com/DataDog/integrations-core/actions/runs/8291565112/job/22691510705#step:14:328) with older base checks
 
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
