### PR TITLE
Bump the min base check version to 36.5.0

### DIFF
--- a/oracle/changelog.d/17197.added
+++ b/oracle/changelog.d/17197.added
@@ -1,0 +1,1 @@
+Bump the min base check version to 36.5.0

--- a/oracle/pyproject.toml
+++ b/oracle/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=32.6.0",
+    "datadog-checks-base>=36.5.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

With [this](https://github.com/DataDog/integrations-core/pull/16958) we now need a more recent version of the base check to support this feature.

It failed [here](https://github.com/DataDog/integrations-core/actions/runs/8291565112/job/22691522884#step:14:377)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
