### PR TITLE
Allow the codeowners validation in integrations-core

### DIFF
--- a/.github/workflows/run-validations.yml
+++ b/.github/workflows/run-validations.yml
@@ -151,7 +151,7 @@ jobs:
       if: inputs.ci
       run: ddev validate ci
 
-    - name: Validate every integration has a defined owner
+    - name: Validate the CODEOWNERS file
       if: inputs.codeowners
       run: ddev validate codeowners
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,6 +19,7 @@ jobs:
       # Validations
       agent-reqs: true
       ci: true
+      codeowners: true
       config: true
       dashboards: true
       dep: true

--- a/datadog_checks_dev/changelog.d/17199.added
+++ b/datadog_checks_dev/changelog.d/17199.added
@@ -1,0 +1,1 @@
+Allow the codeowners validation in integrations-core

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/codeowners.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/codeowners.py
@@ -54,30 +54,34 @@ def create_codeowners_map():
 @click.command(
     context_settings=CONTEXT_SETTINGS, short_help='Validate `CODEOWNERS` file has an entry for each integration'
 )
-def codeowners():
+@click.pass_context
+def codeowners(ctx):
     """Validate that every integration has an entry in the `CODEOWNERS` file."""
 
     has_failed = False
-    codeowner_map = create_codeowners_map()
-    codeowners_file = get_codeowners_file()
-    for integration, codeowner in codeowner_map.items():
-        if not codeowner:
-            has_failed = True
-            message = f"Integration {integration} does not have a valid `CODEOWNERS` entry."
-            echo_failure(message)
-            annotate_error(codeowners_file, message)
-        elif codeowner == "empty":
-            has_failed = True
-            message = f"Integration {integration} has a `CODEOWNERS` entry, but the codeowner is empty."
-            echo_failure(message)
-            annotate_error(codeowners_file, message)
-        elif not codeowner.startswith("@") and integration not in IGNORE_TILES:
-            has_failed = True
-            message = (
-                f"Integration {integration} has a `CODEOWNERS` entry, but the codeowner is not a username or team."
-            )
-            echo_failure(message)
-            annotate_error(codeowners_file, message)
+    is_core_check = ctx.obj['repo_choice'] == 'core'
+
+    if not is_core_check:  # We do not need this rule in integrations-core
+        codeowner_map = create_codeowners_map()
+        codeowners_file = get_codeowners_file()
+        for integration, codeowner in codeowner_map.items():
+            if not codeowner:
+                has_failed = True
+                message = f"Integration {integration} does not have a valid `CODEOWNERS` entry."
+                echo_failure(message)
+                annotate_error(codeowners_file, message)
+            elif codeowner == "empty":
+                has_failed = True
+                message = f"Integration {integration} has a `CODEOWNERS` entry, but the codeowner is empty."
+                echo_failure(message)
+                annotate_error(codeowners_file, message)
+            elif not codeowner.startswith("@") and integration not in IGNORE_TILES:
+                has_failed = True
+                message = (
+                    f"Integration {integration} has a `CODEOWNERS` entry, but the codeowner is not a username or team."
+                )
+                echo_failure(message)
+                annotate_error(codeowners_file, message)
 
     if not has_failed:
         echo_success("All integrations have valid codeowners.")

--- a/ddev/tests/cli/validate/conftest.py
+++ b/ddev/tests/cli/validate/conftest.py
@@ -2,17 +2,28 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
+from datadog_checks.dev.tooling.constants import set_root
 
 from ddev.repo.core import Repository
 
 
 def _fake_repo(tmp_path_factory, config_file, name):
+    set_root('')  # for dcd compatibility running the tests
     repo_path = tmp_path_factory.mktemp(name)
     repo = Repository(name, str(repo_path))
 
     config_file.model.repos[name] = str(repo.path)
     config_file.model.repo = name
     config_file.save()
+
+    write_file(
+        repo.path / '.github',
+        'CODEOWNERS',
+        """
+/dummy/                                 @DataDog/agent-integrations
+/dummy2/                                 @DataDog/agent-integrations
+""",
+    )
 
     write_file(
         repo_path / ".ddev",

--- a/ddev/tests/cli/validate/test_codeowners.py
+++ b/ddev/tests/cli/validate/test_codeowners.py
@@ -1,0 +1,27 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from .conftest import write_file
+
+
+def test_codeowners_integrations_core(fake_repo, ddev):
+    result = ddev('validate', 'codeowners')
+    assert result.exit_code == 0, result.output
+
+
+def test_codeowners_valid(fake_extras_repo, ddev):
+    result = ddev('-e', 'validate', 'codeowners')
+    assert result.exit_code == 0, result.output
+
+
+def test_codeowners_invalid(fake_extras_repo, ddev):
+    write_file(
+        fake_extras_repo.path / '.github',
+        'CODEOWNERS',
+        """
+/dummy/                                 @DataDog/agent-integrations
+""",
+    )
+    result = ddev('-e', 'validate', 'codeowners')
+    assert result.exit_code == 1, result.output
+    assert "Integration dummy2 does not have a valid `CODEOWNERS` entry." in result.output


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Allow the codeowners validation in integrations-core

### Motivation
<!-- What inspired you to submit this pull request? -->

We will very soon extend this validation to also validate stuff in integrations-core

### Additional Notes
<!-- Anything else we should know when reviewing? -->

We do not have any tests for this yet, I'll add them when I'll move them to ddev

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
