### PR TITLE
[PLINT-317] Add support for infrastructure metrics

### DIFF
--- a/esxi/datadog_checks/esxi/constants.py
+++ b/esxi/datadog_checks/esxi/constants.py
@@ -33,5 +33,5 @@ ALL_RESOURCES = [
 
 RESOURCE_TYPE_TO_NAME = {
     HOST_RESOURCE: 'host',
-    VM_RESOURCE: 'VM',
+    VM_RESOURCE: 'vm',
 }

--- a/esxi/datadog_checks/esxi/metrics.py
+++ b/esxi/datadog_checks/esxi/metrics.py
@@ -401,6 +401,6 @@ VM_METRICS = {
     'virtualDisk.writeOIO.latest',
 }
 RESOURCE_NAME_TO_METRICS = {
-    "VM": VM_METRICS,
+    "vm": VM_METRICS,
     "host": HOST_METRICS,
 }

--- a/esxi/metadata.csv
+++ b/esxi/metadata.csv
@@ -211,3 +211,5 @@ esxi.virtualDisk.writeIOSize.latest,gauge,,,,"Average write request size in byte
 esxi.virtualDisk.writeLatencyUS.latest,gauge,,microsecond,,"Write latency in microseconds",0,esxi,virtualdisk wr lat us,
 esxi.virtualDisk.writeLoadMetric.latest,gauge,,,,Storage DRS virtual disk metric for the write workload model,0,esxi,virtualdisk writeLoadMetric latest,
 esxi.virtualDisk.writeOIO.latest,gauge,,request,,Average number of outstanding write requests to the virtual disk,0,esxi,virtualdisk writeOIO latest,
+esxi.host.count,gauge,,,,Timeseries with value 1 for each ESXi Host. Make 'sum by {X}' queries to count all the Hosts with the tag X.,0,esxi,host count,
+esxi.vm.count,gauge,,,,Timeseries with value 1 for each VM. Make 'sum by {X}' queries to count all the VMs with the tag X.,0,esxi,vm count,

--- a/esxi/tests/test_unit.py
+++ b/esxi/tests/test_unit.py
@@ -156,14 +156,14 @@ def test_external_host_tags(vcsim_instance, datadog_agent, dd_run_check):
             'esxi': [
                 'esxi_datacenter:dc2',
                 'esxi_folder:folder_1',
-                'esxi_type:VM',
+                'esxi_type:vm',
                 'esxi_url:127.0.0.1:8989',
             ]
         },
     )
     datadog_agent.assert_external_tags(
         'vm2',
-        {'esxi': ['esxi_cluster:c1', 'esxi_compute:c1', 'esxi_type:VM', 'esxi_url:127.0.0.1:8989']},
+        {'esxi': ['esxi_cluster:c1', 'esxi_compute:c1', 'esxi_type:vm', 'esxi_url:127.0.0.1:8989']},
     )
 
 
@@ -268,7 +268,7 @@ def test_external_host_tags_all_resources(vcsim_instance, datadog_agent, dd_run_
         'vm1',
         {
             'esxi': [
-                'esxi_type:VM',
+                'esxi_type:vm',
                 'esxi_cluster:c1',
                 'esxi_url:127.0.0.1:8989',
             ]


### PR DESCRIPTION
### What does this PR do?
- Adds `esxi.host.count` and `esxi.vm.count` metrics to the esxi integration
- also make the VM resource type name lowercase to match the other resource type names

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
Is `esxi.host.count` needed if it will always be 1?
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
