### PR TITLE
Update performance counter base name query to lookup by lowercase counter name

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -46,8 +46,7 @@ COUNTER_TYPE_QUERY = """select distinct cntr_type
 BASE_NAME_QUERY = (
     """select distinct counter_name
        from sys.dm_os_performance_counters
-       where (counter_name=? or counter_name=?
-       or counter_name=?) and cntr_type=%s;"""
+       where lower(counter_name) IN (?, ?, ?) and cntr_type=%s;"""
     % PERF_LARGE_RAW_BASE
 )
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -658,10 +658,12 @@ class SQLServer(AgentCheck):
                 # and PERF_AVERAGE_BULK), we need two metrics: the metrics specified and
                 # a base metrics to get the ratio. There is no unique schema, so we generate
                 # the possible candidates, and we look at which ones exist in the db.
+                counter_name_lowercase = counter_name.lower()
+                # lowercase is used to avoid case sensitivity issues such as base vs. Base or BASE
                 candidates = (
-                    counter_name + " base",
-                    counter_name.replace("(ms)", "base"),
-                    counter_name.replace("Avg ", "") + " base",
+                    counter_name_lowercase + " base",
+                    counter_name_lowercase.replace("(ms)", "base"),
+                    counter_name_lowercase.replace("avg ", "") + " base",
                 )
                 try:
                     cursor.execute(BASE_NAME_QUERY, candidates)


### PR DESCRIPTION
### What does this PR do?
This PR updates performance counter base name query to lookup by lowercase counter name. Prior to the change, the base counter lookup query will fail to find the base counter name when the server collation is case sensitive. By forcing the lookup to use lowercase counter name, the query will work in both case sensitive and insensitive collation. 

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-3748

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
