### PR TITLE
Don't crash when config spec lacks any default templates

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
@@ -110,7 +110,7 @@ def config(ctx, check, sync, verbose):
 
         if not default_temp:
             message = "Missing default template in init_config or instances section"
-            check_display_queue.append(lambda message=message: echo_failure(message))
+            check_display_queue.append(lambda message=message, **kwargs: echo_failure(message, **kwargs))
             annotate_error(spec_file_path, message)
 
         if spec.errors:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix a crash in ddev when `spec.yaml` is missing default templates.

#### Before

Assuming we have an integration `foo` with a `spec.yaml` that's missing default templates in the sections `template: init_config` or `template: instances` we get this error:
```
Validating default configuration files for 1 checks...
foo:
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /Users/ilia.kurenkov/go/src/github.com/DataDog/integrations-core/ddev/src/ddev/cli/__init__.py:1 │
│ 60 in main                                                                                       │
│                                                                                                  │
│   157 │   manager.hook.register_commands()                                                       │
│   158 │                                                                                          │
│   159 │   try:                                                                                   │
│ ❱ 160 │   │   return ddev(prog_name='ddev', windows_expand_args=False)                           │
│   161 │   except Exception:                                                                      │
│   162 │   │   from rich.console import Console                                                   │
│   163                                                                                            │
│                                                                                                  │
│ /Users/ilia.kurenkov/.pyenv/versions/3.11.1/envs/ddev/lib/python3.11/site-packages/click/core.py │
│ :1157 in __call__                                                                                │
│                                                                                                  │
│ /Users/ilia.kurenkov/.pyenv/versions/3.11.1/envs/ddev/lib/python3.11/site-packages/click/core.py │
│ :1078 in main                                                                                    │
│                                                                                                  │
│ /Users/ilia.kurenkov/.pyenv/versions/3.11.1/envs/ddev/lib/python3.11/site-packages/click/core.py │
│ :1688 in invoke                                                                                  │
│                                                                                                  │
│ /Users/ilia.kurenkov/.pyenv/versions/3.11.1/envs/ddev/lib/python3.11/site-packages/click/core.py │
│ :1688 in invoke                                                                                  │
│                                                                                                  │
│ /Users/ilia.kurenkov/.pyenv/versions/3.11.1/envs/ddev/lib/python3.11/site-packages/click/core.py │
│ :1434 in invoke                                                                                  │
│                                                                                                  │
│ /Users/ilia.kurenkov/.pyenv/versions/3.11.1/envs/ddev/lib/python3.11/site-packages/click/core.py │
│ :783 in invoke                                                                                   │
│                                                                                                  │
│ /Users/ilia.kurenkov/.pyenv/versions/3.11.1/envs/ddev/lib/python3.11/site-packages/click/decorat │
│ ors.py:33 in new_func                                                                            │
│                                                                                                  │
│ /Users/ilia.kurenkov/go/src/github.com/DataDog/integrations-core/datadog_checks_dev/datadog_chec │
│ ks/dev/tooling/commands/validate/config.py:160 in config                                         │
│                                                                                                  │
│   157 │   │   │   if verbose:                                                                    │
│   158 │   │   │   │   check_display_queue.append(lambda **kwargs: echo_info('Valid spec', **kw   │
│   159 │   │   │   for display in check_display_queue:                                            │
│ ❱ 160 │   │   │   │   display(indent=True)                                                       │
│   161 │                                                                                          │
│   162 │   num_files = len(file_counter)                                                          │
│   163 │   files_failed = len(files_failed)                                                       │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: config.<locals>.<lambda>() got an unexpected keyword argument 'indent'
```

#### After
```
Validating default configuration files for 1 checks...
foo:
    Missing default template in init_config or instances section
All 2 configuration files are valid!
```
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
