### PR TITLE
[SINT-INTERRUPT] Update SCA CI image

### DIFF
--- a/.gitlab/software_composition_analysis.yaml
+++ b/.gitlab/software_composition_analysis.yaml
@@ -2,7 +2,7 @@
 datadog-sca-ci:
   stage: build
   tags: ["arch:amd64"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci-sbom:2024011006
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-static-analyzer:2024031801
   when: always
   # We don't want to disrupt the pipeline so let's fail silently.
   allow_failure: true
@@ -16,8 +16,5 @@ datadog-sca-ci:
     - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name "ci.integrations-core.datadog_api_key_org2" --with-decryption --query "Parameter.Value" --out text)
     - export DD_APP_KEY=$(aws ssm get-parameter --region us-east-1 --name "ci.integrations-core.datadog_app_key_org2" --with-decryption --query "Parameter.Value" --out text)
     - set -o xtrace
-    - trivy fs --output /tmp/trivy.sbom --format cyclonedx --offline-scan --skip-update .
-    # Required until we use datadog-ci version https://github.com/DataDog/datadog-ci/releases/tag/v2.30.0
-    # Current version is v2.27.0
-    - export DD_BETA_COMMANDS_ENABLED=true
-    - datadog-ci sbom upload --service integrations-core --env ci /tmp/trivy.sbom
+    - osv-scanner --skip-git --recursive --experimental-only-packages --format=cyclonedx-1-4 --output=/tmp/sbom.json .
+    - datadog-ci sbom upload --service integrations-core --env ci /tmp/sbom.json


### PR DESCRIPTION
### What does this PR do?
- use a more recent version of the Datadog SCA product
- use osv-scanner to produce SBOMs instead of trivy

### Motivation
Requested by @juli1

### Additional Notes
[Successful job execution](https://gitlab.ddbuild.io/DataDog/integrations-core/-/jobs/463266986)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
