### PR TITLE
Fix ddev builds

### DIFF
--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -94,7 +94,7 @@ jobs:
       CARGO: cargo
       CARGO_BUILD_TARGET: ${{ matrix.job.target }}
       PYAPP_REPO: pyapp
-      PYAPP_VERSION: "0.11.1"
+      PYAPP_VERSION: "0.15.1"
       PYAPP_PIP_EXTERNAL: "1"
 
     steps:

--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -70,9 +70,6 @@ jobs:
         - target: x86_64-unknown-linux-musl
           os: ubuntu-22.04
           cross: true
-        - target: i686-unknown-linux-gnu
-          os: ubuntu-22.04
-          cross: true
         - target: powerpc64le-unknown-linux-gnu
           os: ubuntu-22.04
           cross: true


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes the builds by:

- upgrading pyapp
- removing the 32-bit linux build, as recommended by @ofek 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
