### PR TITLE
Trigger the agent build when anything changes under .deps

### DIFF
--- a/.deps/resolved/macos_py3.txt
+++ b/.deps/resolved/macos_py3.txt
@@ -132,4 +132,3 @@ websocket-client @ https://storage.googleapis.com/dd-agent-int-deps/external/web
 wrapt @ https://storage.googleapis.com/dd-agent-int-deps/external/wrapt/wrapt-1.16.0-cp311-cp311-win_amd64.whl#sha256=aefbc4cb0a54f91af643660a0a150ce2c090d3652cf4052a5397fb2de549cd89
 xmltodict @ https://storage.googleapis.com/dd-agent-int-deps/external/xmltodict/xmltodict-0.13.0-py2.py3-none-any.whl#sha256=aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852
 zipp @ https://storage.googleapis.com/dd-agent-int-deps/external/zipp/zipp-3.17.0-py3-none-any.whl#sha256=0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31
-

--- a/.deps/resolved/macos_py3.txt
+++ b/.deps/resolved/macos_py3.txt
@@ -132,3 +132,4 @@ websocket-client @ https://storage.googleapis.com/dd-agent-int-deps/external/web
 wrapt @ https://storage.googleapis.com/dd-agent-int-deps/external/wrapt/wrapt-1.16.0-cp311-cp311-win_amd64.whl#sha256=aefbc4cb0a54f91af643660a0a150ce2c090d3652cf4052a5397fb2de549cd89
 xmltodict @ https://storage.googleapis.com/dd-agent-int-deps/external/xmltodict/xmltodict-0.13.0-py2.py3-none-any.whl#sha256=aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852
 zipp @ https://storage.googleapis.com/dd-agent-int-deps/external/zipp/zipp-3.17.0-py3-none-any.whl#sha256=0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,7 +53,7 @@ trigger-agent-build:
   rules:
     - if: ($CI_COMMIT_BRANCH =~ /^7.[0-9]{2}.x/)
       changes:
-        - datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+        - .deps/*
       when: always
     - if: ($CI_COMMIT_BRANCH !~ /^7.[0-9]{2}.x/)
       when: always
@@ -65,7 +65,7 @@ trigger-agent-build:
     - export AGENT_REQUIREMENTS_CHANGED="false"
     - git fetch origin master
     - BASE_REF=$(git merge-base HEAD FETCH_HEAD)
-    - git --no-pager diff --exit-code --name-only HEAD $BASE_REF -- datadog_checks_base/datadog_checks/base/data/agent_requirements.in || export AGENT_REQUIREMENTS_CHANGED="true" || true
+    - git --no-pager diff --exit-code --name-only HEAD $BASE_REF -- .deps || export AGENT_REQUIREMENTS_CHANGED="true" || true
     - export RELEASE_BRANCH=""
     - |
       if [[ "$AGENT_REQUIREMENTS_CHANGED" = "true" ]]; then

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,8 +70,7 @@ trigger-agent-build:
     - |
       if [[ "$AGENT_REQUIREMENTS_CHANGED" = "true" ]]; then
           export RELEASE_BRANCH=$(git tag -l '7\.*' --points-at $BASE_REF | cat | sed 's/\..-.*/\.x/')
-          export RELEASE_BRANCH="alopez/omnibus-python-deps" # Temporarily set for testing against branch with the change
-          echo "Locked dependendencies have been modified, triggering an agent build pipeline."
+          echo "File agent_requirements.in has been modified, triggering an agent build pipeline."
           DATADOG_AGENT_PIPELINE_URL=$DATADOG_AGENT_PIPELINE_URL RELEASE_BRANCH=$RELEASE_BRANCH python -u /trigger_agent_build.py --output-file pipeline_id.txt
 
           # Get slack user

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,15 +62,15 @@ trigger-agent-build:
   script:
     - export SLACK_CACHE_DIR="${PWD}/.slack-cache"
     - DATADOG_AGENT_PIPELINE_URL=$(aws ssm get-parameter --region us-east-1 --name ci.integrations-core.datadog-agent-pipeline-url --with-decryption --query "Parameter.Value" --out text)
-    - export AGENT_REQUIREMENTS_CHANGED="false"
+    - export DEPENDENCIES_CHANGED="false"
     - git fetch origin master
     - BASE_REF=$(git merge-base HEAD FETCH_HEAD)
-    - git --no-pager diff --exit-code --name-only HEAD $BASE_REF -- .deps || export AGENT_REQUIREMENTS_CHANGED="true" || true
+    - git --no-pager diff --exit-code --name-only HEAD $BASE_REF -- .deps || export DEPENDENCIES_CHANGED="true" || true
     - export RELEASE_BRANCH=""
     - |
-      if [[ "$AGENT_REQUIREMENTS_CHANGED" = "true" ]]; then
+      if [[ "$DEPENDENCIES_CHANGED" = "true" ]]; then
           export RELEASE_BRANCH=$(git tag -l '7\.*' --points-at $BASE_REF | cat | sed 's/\..-.*/\.x/')
-          echo "File agent_requirements.in has been modified, triggering an agent build pipeline."
+          echo "Dependency files under .deps have been modified, triggering an agent build pipeline."
           DATADOG_AGENT_PIPELINE_URL=$DATADOG_AGENT_PIPELINE_URL RELEASE_BRANCH=$RELEASE_BRANCH python -u /trigger_agent_build.py --output-file pipeline_id.txt
 
           # Get slack user

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,7 +70,8 @@ trigger-agent-build:
     - |
       if [[ "$AGENT_REQUIREMENTS_CHANGED" = "true" ]]; then
           export RELEASE_BRANCH=$(git tag -l '7\.*' --points-at $BASE_REF | cat | sed 's/\..-.*/\.x/')
-          echo "File agent_requirements.in has been modified, triggering an agent build pipeline."
+          export RELEASE_BRANCH="alopez/omnibus-python-deps" # Temporarily set for testing against branch with the change
+          echo "Locked dependendencies have been modified, triggering an agent build pipeline."
           DATADOG_AGENT_PIPELINE_URL=$DATADOG_AGENT_PIPELINE_URL RELEASE_BRANCH=$RELEASE_BRANCH python -u /trigger_agent_build.py --output-file pipeline_id.txt
 
           # Get slack user


### PR DESCRIPTION
### What does this PR do?

Changes triggering of agent builds to when the lockfiles are changed, since that will become the source of truth for installing dependencies from the Agent build once https://github.com/DataDog/datadog-agent/pull/23094 is in place.

### Motivation

[BARX-288](https://datadoghq.atlassian.net/browse/BARX-288)

The goal is to catch possible issues with PR's that modify the dependency lockfiles that will be used by the Agent.

### Additional Notes

Tested a successful trigger in [e366bf7](https://github.com/DataDog/integrations-core/pull/17232/commits/e366bf7e5c452b8dd901bb9370b37adac192c3d8).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.


[BARX-288]: https://datadoghq.atlassian.net/browse/BARX-288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ