### PR TITLE
Tag metrics with nginx host and port.

### DIFF
--- a/nginx/changelog.d/17233.added
+++ b/nginx/changelog.d/17233.added
@@ -1,0 +1,1 @@
+Tag metrics with nginx host and port.

--- a/nginx/tests/common.py
+++ b/nginx/tests/common.py
@@ -17,6 +17,8 @@ HOST = get_docker_hostname()
 PORT = '8080'
 PORT_SSL = '8081'
 TAGS = ['foo:foo', 'bar:bar']
+TAGS_WITH_HOST = TAGS + ['nginx_host:{}'.format(HOST)]
+TAGS_WITH_HOST_AND_PORT = TAGS_WITH_HOST + ['port:{}'.format(PORT)]
 USING_VTS = os.getenv('NGINX_IMAGE', '').endswith('nginx-vts')
 USING_LATEST = os.getenv('NGINX_IMAGE', '').endswith('latest')
 NGINX_VERSION = os.getenv('NGINX_VERSION', os.environ.get('NGINX_IMAGE'))
@@ -104,7 +106,7 @@ def assert_num_metrics(aggregator, num_expected):
 
 def mock_http_responses(url, **_params):
     mapping = {
-        'http://nginx:9999/vts_status': 'vts.json',
+        'http://localhost:8080/vts_status': 'vts.json',
     }
 
     metrics_file = mapping.get(url)

--- a/nginx/tests/conftest.py
+++ b/nginx/tests/conftest.py
@@ -87,8 +87,8 @@ def instance_vts():
 @pytest.fixture(scope='session')
 def mocked_instance_vts():
     return {
-        'nginx_status_url': 'http://nginx:9999/vts_status',
         'tags': TAGS,
+        'nginx_status_url': 'http://{}:{}/vts_status'.format(HOST, PORT),
         'use_vts': True,
         'disable_generic_tags': True,
     }

--- a/nginx/tests/test_e2e.py
+++ b/nginx/tests/test_e2e.py
@@ -13,22 +13,12 @@ from . import common
 def test_e2e(dd_agent_check, instance):
     aggregator = dd_agent_check(instance, rate=True)
 
-    aggregator.assert_metric('nginx.net.writing', count=2, tags=common.TAGS)
-    aggregator.assert_metric('nginx.net.waiting', count=2, tags=common.TAGS)
-    aggregator.assert_metric('nginx.net.reading', count=2, tags=common.TAGS)
-    aggregator.assert_metric('nginx.net.conn_dropped_per_s', count=1, tags=common.TAGS)
-    aggregator.assert_metric('nginx.net.conn_opened_per_s', count=1, tags=common.TAGS)
-    aggregator.assert_metric('nginx.net.request_per_s', count=1, tags=common.TAGS)
+    for m in ('nginx.net.conn_dropped_per_s', 'nginx.net.conn_opened_per_s', 'nginx.net.request_per_s'):
+        aggregator.assert_metric(m, count=1, tags=common.TAGS_WITH_HOST_AND_PORT)
+    for m in ('nginx.net.writing', 'nginx.net.reading', 'nginx.net.waiting', 'nginx.net.connections'):
+        aggregator.assert_metric(m, count=2, tags=common.TAGS_WITH_HOST_AND_PORT)
 
-    aggregator.assert_metric('nginx.net.connections', count=2, tags=common.TAGS)
-
-    aggregator.assert_all_metrics_covered()
-
-    tags = common.TAGS + [
-        'nginx_host:{}'.format(common.HOST),
-        'port:{}'.format(common.PORT),
-    ]
-    aggregator.assert_service_check('nginx.can_connect', status=Nginx.OK, tags=tags)
+    aggregator.assert_service_check('nginx.can_connect', status=Nginx.OK, tags=common.TAGS_WITH_HOST_AND_PORT)
 
 
 @pytest.mark.e2e
@@ -36,44 +26,47 @@ def test_e2e(dd_agent_check, instance):
 def test_e2e_vts(dd_agent_check, instance_vts):
     aggregator = dd_agent_check(instance_vts, rate=True)
 
-    aggregator.assert_metric('nginx.net.writing', count=2, tags=common.TAGS)
-    aggregator.assert_metric('nginx.net.waiting', count=2, tags=common.TAGS)
-    aggregator.assert_metric('nginx.net.reading', count=2, tags=common.TAGS)
-    aggregator.assert_metric('nginx.net.conn_dropped_per_s', count=1, tags=common.TAGS)
-    aggregator.assert_metric('nginx.net.conn_opened_per_s', count=1, tags=common.TAGS)
-    aggregator.assert_metric('nginx.net.request_per_s', count=1, tags=common.TAGS)
+    for m in (
+        'nginx.net.writing',
+        'nginx.net.reading',
+        'nginx.net.waiting',
+        'nginx.connections.active',
+        'nginx.requests.total',
+        'nginx.timestamp',
+        'nginx.load_timestamp',
+        'nginx.connections.accepted',
+    ):
+        aggregator.assert_metric(m, count=2, tags=common.TAGS_WITH_HOST_AND_PORT)
+    for m in (
+        'nginx.net.conn_dropped_per_s',
+        'nginx.net.conn_opened_per_s',
+        'nginx.net.request_per_s',
+        'nginx.connections.accepted_count',
+        'nginx.requests.total_count',
+    ):
+        aggregator.assert_metric(m, count=1, tags=common.TAGS_WITH_HOST_AND_PORT)
 
-    tags_server_zone = common.TAGS + ['server_zone:*']
-
-    aggregator.assert_metric('nginx.connections.active', count=2, tags=common.TAGS)
-    aggregator.assert_metric('nginx.server_zone.sent', count=2, tags=tags_server_zone)
-    aggregator.assert_metric('nginx.server_zone.sent_count', count=1, tags=tags_server_zone)
-    aggregator.assert_metric('nginx.server_zone.received', count=2, tags=tags_server_zone)
-    aggregator.assert_metric('nginx.server_zone.received_count', count=1, tags=tags_server_zone)
-    aggregator.assert_metric('nginx.requests.total_count', count=1, tags=common.TAGS)
-    aggregator.assert_metric('nginx.requests.total', count=2, tags=common.TAGS)
-    aggregator.assert_metric('nginx.timestamp', count=2, tags=common.TAGS)
-    aggregator.assert_metric('nginx.server_zone.requests_count', count=1, tags=tags_server_zone)
-    aggregator.assert_metric('nginx.load_timestamp', count=2, tags=common.TAGS)
-    aggregator.assert_metric('nginx.server_zone.requests', count=2, tags=tags_server_zone)
-    aggregator.assert_metric('nginx.connections.accepted', count=2, tags=common.TAGS)
-    aggregator.assert_metric('nginx.connections.accepted_count', count=1, tags=common.TAGS)
-
-    aggregator.assert_metric('nginx.server_zone.responses.1xx_count', count=1, tags=tags_server_zone)
-    aggregator.assert_metric('nginx.server_zone.responses.2xx_count', count=1, tags=tags_server_zone)
-    aggregator.assert_metric('nginx.server_zone.responses.3xx_count', count=1, tags=tags_server_zone)
-    aggregator.assert_metric('nginx.server_zone.responses.4xx_count', count=1, tags=tags_server_zone)
-    aggregator.assert_metric('nginx.server_zone.responses.5xx_count', count=1, tags=tags_server_zone)
-    aggregator.assert_metric('nginx.server_zone.responses.1xx', count=2, tags=tags_server_zone)
-    aggregator.assert_metric('nginx.server_zone.responses.2xx', count=2, tags=tags_server_zone)
-    aggregator.assert_metric('nginx.server_zone.responses.3xx', count=2, tags=tags_server_zone)
-    aggregator.assert_metric('nginx.server_zone.responses.4xx', count=2, tags=tags_server_zone)
-    aggregator.assert_metric('nginx.server_zone.responses.5xx', count=2, tags=tags_server_zone)
+    tags_server_zone = common.TAGS_WITH_HOST_AND_PORT + ['server_zone:*']
+    for m, count in (
+        ('nginx.server_zone.sent', 2),
+        ('nginx.server_zone.sent_count', 1),
+        ('nginx.server_zone.received', 2),
+        ('nginx.server_zone.received_count', 1),
+        ('nginx.server_zone.requests_count', 1),
+        ('nginx.server_zone.requests', 2),
+        ('nginx.server_zone.responses.1xx_count', 1),
+        ('nginx.server_zone.responses.2xx_count', 1),
+        ('nginx.server_zone.responses.3xx_count', 1),
+        ('nginx.server_zone.responses.4xx_count', 1),
+        ('nginx.server_zone.responses.5xx_count', 1),
+        ('nginx.server_zone.responses.1xx', 2),
+        ('nginx.server_zone.responses.2xx', 2),
+        ('nginx.server_zone.responses.3xx', 2),
+        ('nginx.server_zone.responses.4xx', 2),
+        ('nginx.server_zone.responses.5xx', 2),
+    ):
+        aggregator.assert_metric(m, count=count, tags=tags_server_zone)
 
     aggregator.assert_all_metrics_covered()
 
-    tags = common.TAGS + [
-        'nginx_host:{}'.format(common.HOST),
-        'port:{}'.format(common.PORT),
-    ]
-    aggregator.assert_service_check('nginx.can_connect', status=Nginx.OK, tags=tags)
+    aggregator.assert_service_check('nginx.can_connect', status=Nginx.OK, tags=common.TAGS_WITH_HOST_AND_PORT)

--- a/nginx/tests/test_nginx.py
+++ b/nginx/tests/test_nginx.py
@@ -7,7 +7,7 @@ import mock
 import pytest
 import requests
 
-from .common import FIXTURES_PATH, HOST, NGINX_VERSION, PORT, PORT_SSL, TAGS, USING_VTS
+from .common import FIXTURES_PATH, HOST, NGINX_VERSION, PORT_SSL, TAGS_WITH_HOST, TAGS_WITH_HOST_AND_PORT, USING_VTS
 from .utils import mocked_perform_request, requires_static_version
 
 pytestmark = [pytest.mark.skipif(USING_VTS, reason='Using VTS'), pytest.mark.integration]
@@ -20,9 +20,8 @@ def test_connect(check, instance, aggregator):
     """
     check = check(instance)
     check.check(instance)
-    tags = TAGS + ['nginx_host:{}'.format(HOST), 'port:{}'.format(PORT)]
-    aggregator.assert_metric("nginx.net.connections", tags=tags, count=1)
-    aggregator.assert_service_check('nginx.can_connect', tags=tags)
+    aggregator.assert_metric("nginx.net.connections", tags=TAGS_WITH_HOST_AND_PORT, count=1)
+    aggregator.assert_service_check('nginx.can_connect', tags=TAGS_WITH_HOST_AND_PORT)
 
 
 @pytest.mark.usefixtures('dd_environment')
@@ -42,7 +41,7 @@ def test_generic_tags(check, instance, aggregator, disable_generic_tags, host_ta
     instance['disable_generic_tags'] = disable_generic_tags
     check = check(instance)
     check.check(instance)
-    tags = TAGS + ['nginx_host:{}'.format(HOST), 'port:{}'.format(PORT)]
+    tags = TAGS_WITH_HOST_AND_PORT
     aggregator.assert_metric("nginx.net.connections", tags=tags, count=1)
     aggregator.assert_service_check('nginx.can_connect', tags=tags + host_tag)
 
@@ -55,9 +54,7 @@ def test_connect_ssl(check, instance_ssl, aggregator):
     instance_ssl['ssl_validation'] = False
     check_no_ssl = check(instance_ssl)
     check_no_ssl.check(instance_ssl)
-    aggregator.assert_metric(
-        "nginx.net.connections", tags=TAGS + ['nginx_host:{}'.format(HOST), 'port:{}'.format(PORT_SSL)], count=1
-    )
+    aggregator.assert_metric("nginx.net.connections", tags=TAGS_WITH_HOST + ['port:{}'.format(PORT_SSL)], count=1)
 
     # assert ssl validation throws an error
     with pytest.raises(requests.exceptions.SSLError):

--- a/nginx/tests/test_plus_api.py
+++ b/nginx/tests/test_plus_api.py
@@ -14,6 +14,9 @@ from .utils import mocked_perform_request
 pytestmark = [pytest.mark.unit]
 
 
+BASE_TAGS = ['bar:bar', 'foo:foo', 'nginx_host:localhost', 'port:8080']
+
+
 def test_plus_api_v2(check, instance_plus_v7, aggregator):
     instance = deepcopy(instance_plus_v7)
     instance['plus_api_version'] = 2
@@ -78,14 +81,12 @@ def test_plus_api_v5(check, instance_plus_v7, aggregator):
     # total number of metrics should be higher than v4 w/ resolvers and http location zones data
     assert_num_metrics(aggregator, 1261)
 
-    base_tags = ['bar:bar', 'foo:foo']
-
     # resolvers endpoint
-    resolvers_tags = base_tags + ['resolver:resolver-http']
+    resolvers_tags = BASE_TAGS + ['resolver:resolver-http']
     aggregator.assert_metric('nginx.resolver.responses.noerror', value=0, tags=resolvers_tags, count=1)
 
     # http location zones endpoint w/out code data
-    location_zone_tags = base_tags + ['location_zone:swagger']
+    location_zone_tags = BASE_TAGS + ['location_zone:swagger']
     location_zone_code_tags = location_zone_tags + ['code:404']
 
     aggregator.assert_metric(
@@ -118,7 +119,7 @@ def test_plus_api_v5(check, instance_plus_v7, aggregator):
     )
 
     # no limit conns endpoint
-    conn_tags = base_tags + ['limit_conn:addr']
+    conn_tags = BASE_TAGS + ['limit_conn:addr']
     aggregator.assert_metric(
         'nginx.stream.limit_conn.rejected', value=0, metric_type=aggregator.MONOTONIC_COUNT, tags=conn_tags, count=0
     )
@@ -135,14 +136,12 @@ def test_plus_api_v6(check, instance_plus_v7, aggregator):
     # total number of metrics should be higher than v5 w/ http limit conns, http limit reqs, and stream limit conns
     assert_num_metrics(aggregator, 1277)
 
-    base_tags = ['bar:bar', 'foo:foo']
-
     # same tests for v3
     aggregator.assert_metric_has_tag('nginx.stream.zone_sync.zone.records_total', 'zone:zone1', count=1)
     aggregator.assert_metric_has_tag('nginx.stream.zone_sync.zone.records_total', 'zone:zone2', count=1)
 
     # stream limit conns endpoint
-    conn_tags = base_tags + ['limit_conn:addr']
+    conn_tags = BASE_TAGS + ['limit_conn:addr']
     aggregator.assert_metric(
         'nginx.stream.limit_conn.rejected', value=0, metric_type=aggregator.MONOTONIC_COUNT, tags=conn_tags, count=1
     )
@@ -157,7 +156,7 @@ def test_plus_api_v6(check, instance_plus_v7, aggregator):
     )
 
     # http limit reqs endpoint
-    limit_req_tags = base_tags + ['limit_req:one']
+    limit_req_tags = BASE_TAGS + ['limit_req:one']
     aggregator.assert_metric(
         'nginx.limit_req.delayed_dry_run',
         value=322948,
@@ -167,7 +166,7 @@ def test_plus_api_v6(check, instance_plus_v7, aggregator):
     )
 
     # http server zones endpoint does not have code information
-    code_tags = base_tags + ['code:200', 'server_zone:hg.nginx.org']
+    code_tags = BASE_TAGS + ['code:200', 'server_zone:hg.nginx.org']
     aggregator.assert_metric(
         'nginx.server_zone.responses.code',
         value=803845,
@@ -190,14 +189,12 @@ def test_plus_api_v7(check, instance_plus_v7, aggregator, only_query_enabled_end
     # with codes data for http upstream, http server zones, and http location zone
     assert_num_metrics(aggregator, 1352)
 
-    base_tags = ['bar:bar', 'foo:foo']
-
     # same tests for v3
     aggregator.assert_metric_has_tag('nginx.stream.zone_sync.zone.records_total', 'zone:zone1', count=1)
     aggregator.assert_metric_has_tag('nginx.stream.zone_sync.zone.records_total', 'zone:zone2', count=1)
 
     # http location zones endpoint
-    location_zone_tags = base_tags + ['location_zone:swagger']
+    location_zone_tags = BASE_TAGS + ['location_zone:swagger']
     location_zone_code_tags = location_zone_tags + ['code:404']
 
     aggregator.assert_metric(
@@ -216,7 +213,7 @@ def test_plus_api_v7(check, instance_plus_v7, aggregator, only_query_enabled_end
     )
 
     # http server zones endpoint
-    code_tags = base_tags + ['code:200', 'server_zone:hg.nginx.org']
+    code_tags = BASE_TAGS + ['code:200', 'server_zone:hg.nginx.org']
     aggregator.assert_metric(
         'nginx.server_zone.responses.code',
         value=803845,
@@ -226,7 +223,7 @@ def test_plus_api_v7(check, instance_plus_v7, aggregator, only_query_enabled_end
     )
 
     # http limit reqs endpoint
-    limit_req_tags = base_tags + ['limit_req:one']
+    limit_req_tags = BASE_TAGS + ['limit_req:one']
     aggregator.assert_metric(
         'nginx.limit_req.delayed_dry_run',
         value=322948,
@@ -236,7 +233,7 @@ def test_plus_api_v7(check, instance_plus_v7, aggregator, only_query_enabled_end
     )
 
     # http upstreams endpoint
-    upstream_tags = base_tags + ['server:10.0.0.42:8084', 'upstream:demo-backend']
+    upstream_tags = BASE_TAGS + ['server:10.0.0.42:8084', 'upstream:demo-backend']
     aggregator.assert_metric(
         'nginx.upstream.peers.health_checks.unhealthy_count',
         value=0,
@@ -252,7 +249,7 @@ def test_plus_api_v7(check, instance_plus_v7, aggregator, only_query_enabled_end
         count=1,
     )
 
-    upstream_code_tags = base_tags + ['code:200', 'server:10.0.0.42:8084', 'upstream:demo-backend']
+    upstream_code_tags = BASE_TAGS + ['code:200', 'server:10.0.0.42:8084', 'upstream:demo-backend']
     aggregator.assert_metric(
         'nginx.upstream.peers.responses.code',
         value=12960954,
@@ -262,7 +259,7 @@ def test_plus_api_v7(check, instance_plus_v7, aggregator, only_query_enabled_end
     )
 
     # resolvers endpoint
-    resolvers_tags = base_tags + ['resolver:resolver-http']
+    resolvers_tags = BASE_TAGS + ['resolver:resolver-http']
     aggregator.assert_metric(
         'nginx.resolver.responses.noerror',
         value=0,
@@ -272,7 +269,7 @@ def test_plus_api_v7(check, instance_plus_v7, aggregator, only_query_enabled_end
     )
 
     # stream limit conns endpoint
-    conn_tags = base_tags + ['limit_conn:addr']
+    conn_tags = BASE_TAGS + ['limit_conn:addr']
     aggregator.assert_metric(
         'nginx.stream.limit_conn.rejected', value=0, metric_type=aggregator.MONOTONIC_COUNT, tags=conn_tags, count=1
     )
@@ -304,14 +301,12 @@ def test_plus_api_v7_no_stream(check, instance, aggregator):
     # Number of metrics should be low since stream is disabled
     assert_num_metrics(aggregator, 1025)
 
-    base_tags = ['bar:bar', 'foo:foo']
-
     # test that stream metrics are not emitted
     aggregator.assert_metric('nginx.stream.zone_sync.zone.records_total', count=0)
     aggregator.assert_metric('nginx.stream.limit_conn.rejected', count=0)
 
     # http server zones endpoint
-    code_tags = base_tags + ['code:200', 'server_zone:hg.nginx.org']
+    code_tags = BASE_TAGS + ['code:200', 'server_zone:hg.nginx.org']
     aggregator.assert_metric(
         'nginx.server_zone.responses.code',
         value=803845,
@@ -321,7 +316,7 @@ def test_plus_api_v7_no_stream(check, instance, aggregator):
     )
 
     # http upstreams endpoint
-    upstream_tags = base_tags + ['server:10.0.0.42:8084', 'upstream:demo-backend']
+    upstream_tags = BASE_TAGS + ['server:10.0.0.42:8084', 'upstream:demo-backend']
     aggregator.assert_metric(
         'nginx.upstream.peers.health_checks.unhealthy_count',
         value=0,

--- a/nginx/tests/test_plus_api.py
+++ b/nginx/tests/test_plus_api.py
@@ -8,13 +8,10 @@ import pytest
 
 from datadog_checks.nginx.metrics import COUNT_METRICS
 
-from .common import assert_all_metrics_and_metadata, assert_num_metrics
+from .common import TAGS_WITH_HOST_AND_PORT, assert_all_metrics_and_metadata, assert_num_metrics
 from .utils import mocked_perform_request
 
 pytestmark = [pytest.mark.unit]
-
-
-BASE_TAGS = ['bar:bar', 'foo:foo', 'nginx_host:localhost', 'port:8080']
 
 
 def test_plus_api_v2(check, instance_plus_v7, aggregator):
@@ -82,11 +79,11 @@ def test_plus_api_v5(check, instance_plus_v7, aggregator):
     assert_num_metrics(aggregator, 1261)
 
     # resolvers endpoint
-    resolvers_tags = BASE_TAGS + ['resolver:resolver-http']
+    resolvers_tags = TAGS_WITH_HOST_AND_PORT + ['resolver:resolver-http']
     aggregator.assert_metric('nginx.resolver.responses.noerror', value=0, tags=resolvers_tags, count=1)
 
     # http location zones endpoint w/out code data
-    location_zone_tags = BASE_TAGS + ['location_zone:swagger']
+    location_zone_tags = TAGS_WITH_HOST_AND_PORT + ['location_zone:swagger']
     location_zone_code_tags = location_zone_tags + ['code:404']
 
     aggregator.assert_metric(
@@ -119,7 +116,7 @@ def test_plus_api_v5(check, instance_plus_v7, aggregator):
     )
 
     # no limit conns endpoint
-    conn_tags = BASE_TAGS + ['limit_conn:addr']
+    conn_tags = TAGS_WITH_HOST_AND_PORT + ['limit_conn:addr']
     aggregator.assert_metric(
         'nginx.stream.limit_conn.rejected', value=0, metric_type=aggregator.MONOTONIC_COUNT, tags=conn_tags, count=0
     )
@@ -141,7 +138,7 @@ def test_plus_api_v6(check, instance_plus_v7, aggregator):
     aggregator.assert_metric_has_tag('nginx.stream.zone_sync.zone.records_total', 'zone:zone2', count=1)
 
     # stream limit conns endpoint
-    conn_tags = BASE_TAGS + ['limit_conn:addr']
+    conn_tags = TAGS_WITH_HOST_AND_PORT + ['limit_conn:addr']
     aggregator.assert_metric(
         'nginx.stream.limit_conn.rejected', value=0, metric_type=aggregator.MONOTONIC_COUNT, tags=conn_tags, count=1
     )
@@ -156,7 +153,7 @@ def test_plus_api_v6(check, instance_plus_v7, aggregator):
     )
 
     # http limit reqs endpoint
-    limit_req_tags = BASE_TAGS + ['limit_req:one']
+    limit_req_tags = TAGS_WITH_HOST_AND_PORT + ['limit_req:one']
     aggregator.assert_metric(
         'nginx.limit_req.delayed_dry_run',
         value=322948,
@@ -166,7 +163,7 @@ def test_plus_api_v6(check, instance_plus_v7, aggregator):
     )
 
     # http server zones endpoint does not have code information
-    code_tags = BASE_TAGS + ['code:200', 'server_zone:hg.nginx.org']
+    code_tags = TAGS_WITH_HOST_AND_PORT + ['code:200', 'server_zone:hg.nginx.org']
     aggregator.assert_metric(
         'nginx.server_zone.responses.code',
         value=803845,
@@ -194,7 +191,7 @@ def test_plus_api_v7(check, instance_plus_v7, aggregator, only_query_enabled_end
     aggregator.assert_metric_has_tag('nginx.stream.zone_sync.zone.records_total', 'zone:zone2', count=1)
 
     # http location zones endpoint
-    location_zone_tags = BASE_TAGS + ['location_zone:swagger']
+    location_zone_tags = TAGS_WITH_HOST_AND_PORT + ['location_zone:swagger']
     location_zone_code_tags = location_zone_tags + ['code:404']
 
     aggregator.assert_metric(
@@ -213,7 +210,7 @@ def test_plus_api_v7(check, instance_plus_v7, aggregator, only_query_enabled_end
     )
 
     # http server zones endpoint
-    code_tags = BASE_TAGS + ['code:200', 'server_zone:hg.nginx.org']
+    code_tags = TAGS_WITH_HOST_AND_PORT + ['code:200', 'server_zone:hg.nginx.org']
     aggregator.assert_metric(
         'nginx.server_zone.responses.code',
         value=803845,
@@ -223,7 +220,7 @@ def test_plus_api_v7(check, instance_plus_v7, aggregator, only_query_enabled_end
     )
 
     # http limit reqs endpoint
-    limit_req_tags = BASE_TAGS + ['limit_req:one']
+    limit_req_tags = TAGS_WITH_HOST_AND_PORT + ['limit_req:one']
     aggregator.assert_metric(
         'nginx.limit_req.delayed_dry_run',
         value=322948,
@@ -233,7 +230,7 @@ def test_plus_api_v7(check, instance_plus_v7, aggregator, only_query_enabled_end
     )
 
     # http upstreams endpoint
-    upstream_tags = BASE_TAGS + ['server:10.0.0.42:8084', 'upstream:demo-backend']
+    upstream_tags = TAGS_WITH_HOST_AND_PORT + ['server:10.0.0.42:8084', 'upstream:demo-backend']
     aggregator.assert_metric(
         'nginx.upstream.peers.health_checks.unhealthy_count',
         value=0,
@@ -249,7 +246,7 @@ def test_plus_api_v7(check, instance_plus_v7, aggregator, only_query_enabled_end
         count=1,
     )
 
-    upstream_code_tags = BASE_TAGS + ['code:200', 'server:10.0.0.42:8084', 'upstream:demo-backend']
+    upstream_code_tags = TAGS_WITH_HOST_AND_PORT + ['code:200', 'server:10.0.0.42:8084', 'upstream:demo-backend']
     aggregator.assert_metric(
         'nginx.upstream.peers.responses.code',
         value=12960954,
@@ -259,7 +256,7 @@ def test_plus_api_v7(check, instance_plus_v7, aggregator, only_query_enabled_end
     )
 
     # resolvers endpoint
-    resolvers_tags = BASE_TAGS + ['resolver:resolver-http']
+    resolvers_tags = TAGS_WITH_HOST_AND_PORT + ['resolver:resolver-http']
     aggregator.assert_metric(
         'nginx.resolver.responses.noerror',
         value=0,
@@ -269,7 +266,7 @@ def test_plus_api_v7(check, instance_plus_v7, aggregator, only_query_enabled_end
     )
 
     # stream limit conns endpoint
-    conn_tags = BASE_TAGS + ['limit_conn:addr']
+    conn_tags = TAGS_WITH_HOST_AND_PORT + ['limit_conn:addr']
     aggregator.assert_metric(
         'nginx.stream.limit_conn.rejected', value=0, metric_type=aggregator.MONOTONIC_COUNT, tags=conn_tags, count=1
     )
@@ -306,7 +303,7 @@ def test_plus_api_v7_no_stream(check, instance, aggregator):
     aggregator.assert_metric('nginx.stream.limit_conn.rejected', count=0)
 
     # http server zones endpoint
-    code_tags = BASE_TAGS + ['code:200', 'server_zone:hg.nginx.org']
+    code_tags = TAGS_WITH_HOST_AND_PORT + ['code:200', 'server_zone:hg.nginx.org']
     aggregator.assert_metric(
         'nginx.server_zone.responses.code',
         value=803845,
@@ -316,7 +313,7 @@ def test_plus_api_v7_no_stream(check, instance, aggregator):
     )
 
     # http upstreams endpoint
-    upstream_tags = BASE_TAGS + ['server:10.0.0.42:8084', 'upstream:demo-backend']
+    upstream_tags = TAGS_WITH_HOST_AND_PORT + ['server:10.0.0.42:8084', 'upstream:demo-backend']
     aggregator.assert_metric(
         'nginx.upstream.peers.health_checks.unhealthy_count',
         value=0,

--- a/nginx/tests/test_vts.py
+++ b/nginx/tests/test_vts.py
@@ -6,7 +6,7 @@ import pytest
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.nginx import VTS_METRIC_MAP
 
-from .common import TAGS, USING_VTS, VTS_MOCKED_METRICS, mock_http_responses
+from .common import TAGS_WITH_HOST_AND_PORT, USING_VTS, VTS_MOCKED_METRICS, mock_http_responses
 
 pytestmark = [pytest.mark.skipif(not USING_VTS, reason='Not using VTS')]
 
@@ -44,7 +44,7 @@ def test_vts(check, instance_vts, aggregator):
     for mapped in VTS_METRIC_MAP.values():
         if mapped in skip_metrics:
             continue
-        aggregator.assert_metric(mapped, tags=TAGS)
+        aggregator.assert_metric(mapped, tags=TAGS_WITH_HOST_AND_PORT)
 
 
 @pytest.mark.unit
@@ -55,7 +55,7 @@ def test_vts_unit(dd_run_check, aggregator, mocked_instance_vts, check, mocker):
 
     for mapped in VTS_MOCKED_METRICS:
         aggregator.assert_metric(mapped)
-        for tag in TAGS:
+        for tag in TAGS_WITH_HOST_AND_PORT:
             aggregator.assert_metric_has_tag(mapped, tag)
 
     aggregator.assert_metrics_using_metadata(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Second take on [nginx: metrics should have same tags as service checks](https://github.com/DataDog/integrations-core/pull/16797), but this time we don't submit `host` tag with metrics ever.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
