### PR TITLE
Fix NoneType error in schema collection when partition tables have no activities

### DIFF
--- a/postgres/changelog.d/17235.fixed
+++ b/postgres/changelog.d/17235.fixed
@@ -1,0 +1,1 @@
+Fix NoneType error in schema collection when partition tables have no activities

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -141,7 +141,7 @@ WHERE  inhparent = {parent_oid};
 
 PARTITION_ACTIVITY_QUERY = """
 SELECT pi.inhparent :: regclass         AS parent_table_name,
-       SUM(psu.seq_scan + psu.idx_scan) AS total_activity
+       COALESCE(SUM(psu.seq_scan + psu.idx_scan), 0) AS total_activity
 FROM   pg_catalog.pg_stat_user_tables psu
        join pg_class pc
          ON psu.relname = pc.relname

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -141,7 +141,7 @@ WHERE  inhparent = {parent_oid};
 
 PARTITION_ACTIVITY_QUERY = """
 SELECT pi.inhparent :: regclass         AS parent_table_name,
-       COALESCE(SUM(psu.seq_scan + psu.idx_scan), 0) AS total_activity
+       SUM(COALESCE(psu.seq_scan, 0) + COALESCE(psu.idx_scan, 0)) AS total_activity
 FROM   pg_catalog.pg_stat_user_tables psu
        join pg_class pc
          ON psu.relname = pc.relname

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -208,7 +208,7 @@ def check_db_count(aggregator, expected_tags, count=1):
     table_count = 7
     # We create 2 additional partition tables when partition is available + 2 parent tables
     if float(POSTGRES_VERSION) >= 11.0:
-        table_count = 11
+        table_count = 14
     aggregator.assert_metric(
         'postgresql.table.count',
         value=table_count,

--- a/postgres/tests/compose/resources/03_load_data.sh
+++ b/postgres/tests/compose/resources/03_load_data.sh
@@ -40,6 +40,9 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" datadog_test <<-EOSQL
     INSERT INTO test_part (filler) SELECT array_to_string(ARRAY(SELECT chr((65 + round(random() * 50)) :: integer) FROM generate_series(1,3000)), '');
     VACUUM ANALYZE test_part;
     CREATE TABLE test_part_no_children (id SERIAL PRIMARY KEY, filler text) PARTITION BY RANGE (id);
+    CREATE TABLE test_part_no_activity (id SERIAL PRIMARY KEY, filler text) PARTITION BY RANGE (id);
+    CREATE TABLE test_part_no_activity1 PARTITION OF test_part_no_activity FOR VALUES FROM (MINVALUE) TO (500);
+    CREATE TABLE test_part_no_activity2 PARTITION OF test_part_no_activity FOR VALUES FROM (500) TO (MAXVALUE);
 EOSQL
 fi
 

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -75,7 +75,7 @@ def test_collect_schemas(integration_check, dbm_instance, aggregator):
     tables_set = {'persons', "personsdup1", "personsdup2", "pgtable", "pg_newtable", "cities"}
     # if version isn't 9 or 10, check that partition master is in tables
     if float(POSTGRES_VERSION) >= 11:
-        tables_set.update({'test_part', 'test_part_no_children'})
+        tables_set.update({'test_part', 'test_part_no_children', 'test_part_no_activity'})
     tables_not_reported_set = {'test_part1', 'test_part2'}
 
     tables_got = []
@@ -102,7 +102,7 @@ def test_collect_schemas(integration_check, dbm_instance, aggregator):
             assert_fields(keys, ["indexes", "columns", "toast_table", "id", "name"])
             assert_fields(list(table['indexes'][0].keys()), ['name', 'definition'])
         if float(POSTGRES_VERSION) >= 11:
-            if table['name'] == 'test_part':
+            if table['name'] in ('test_part', 'test_part_no_activity'):
                 keys = list(table.keys())
                 assert_fields(keys, ["indexes", "num_partitions", "partition_key"])
                 assert table['num_partitions'] == 2


### PR DESCRIPTION
### What does this PR do?
This PR fixes `NoneType` error in schema collection when partition tables have no activities.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
