### PR TITLE
Refactor SQLServer connector and adoprovider initialization from configuration

### DIFF
--- a/sqlserver/changelog.d/17245.fixed
+++ b/sqlserver/changelog.d/17245.fixed
@@ -1,0 +1,5 @@
+Refactor SQLServer instance connector and adoprovider initialization from configuration.
+The connector/adoprovider config takes precedence in the following order:
+- instance config
+- init config
+- the default connection/adoprovider

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -383,8 +383,8 @@ class Connection(object):
         '''
         Get the connector to use for the instance.
         The connector config value takes precedence in the following order:
-        - init_config
         - instance_config
+        - init_config
         - DEFAULT_CONNECTOR
         '''
         # First we check the valid connectors available. i.e. adodbapi, odbc
@@ -422,8 +422,8 @@ class Connection(object):
         '''
         Get the adoprovider to use for the instance.
         The adoprovider config value takes precedence in the following order:
-        - init_config
         - instance_config
+        - init_config
         - DEFAULT_ADOPROVIDER
         '''
         adoprovider_from_init_config = init_config.get('adoprovider')

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -968,7 +968,7 @@ class SQLServer(AgentCheck):
 
             try:
                 self.log.debug("Calling Stored Procedure : %s", proc)
-                if self.connection.get_connector() == 'adodbapi':
+                if self.connection.connector == 'adodbapi':
                     cursor.callproc(proc)
                 else:
                     # pyodbc does not support callproc; use execute instead.

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -477,8 +477,8 @@ def test_connection_error_reporting(
         if instance_docker['connector'] == 'odbc':
             pytest.skip("adoprovider_override is not relevant for the odbc connector")
         adoprovider_override = instance_overrides['adoprovider'].upper()
-        if adoprovider_override not in Connection.valid_adoproviders:
-            Connection.valid_adoproviders.append(adoprovider_override)
+        if adoprovider_override not in Connection.VALID_ADOPROVIDERS:
+            Connection.VALID_ADOPROVIDERS.append(adoprovider_override)
     if 'adoprovider' in instance_docker and ('driver' in instance_overrides or 'dsn' in instance_overrides):
         pytest.skip("driver or DSN overrides is not relevant for the adoprovider")
 


### PR DESCRIPTION
### What does this PR do?
This PR refactors the  SQLServer connector and adoprovider initialization from configuration to follow the order of:
- instance config
- init config
- the default connection/adoprovider

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-3722
Properly log debugging message of the defaulted connector, adoprovider and odbc driver. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
