### PR TITLE
Update the ruff command for ruff 0.3.3

### DIFF
--- a/ddev/changelog.d/17257.fixed
+++ b/ddev/changelog.d/17257.fixed
@@ -1,0 +1,1 @@
+Update the ruff command for ruff 0.3.3

--- a/ddev/src/ddev/plugin/external/hatch/environment_collector.py
+++ b/ddev/src/ddev/plugin/external/hatch/environment_collector.py
@@ -131,11 +131,11 @@ class DatadogChecksEnvironmentCollector(EnvironmentCollectorInterface):
             'scripts': {
                 'style': [
                     f'black --config {settings_dir}/pyproject.toml --check --diff .',
-                    f'ruff --config {settings_dir}/pyproject.toml .',
+                    f'ruff check --config {settings_dir}/pyproject.toml .',
                 ],
                 'fmt': [
                     f'black . --config {settings_dir}/pyproject.toml',
-                    f'ruff --config {settings_dir}/pyproject.toml --fix .',
+                    f'ruff check --config {settings_dir}/pyproject.toml --fix .',
                     'python -c "print(\'\\n[NOTE] ruff may still report style errors for things '
                     'black cannot fix, these will need to be fixed manually.\')"',
                     'style',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update the ruff command for ruff 0.3.3

### Motivation
<!-- What inspired you to submit this pull request? -->

- https://github.com/DataDog/integrations-core/pull/17244

```
cmd [2] | ruff --config ./pyproject.toml --fix .
warning: `ruff <path>` is deprecated. Use `ruff check <path>` instead.
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
