### PR TITLE
[PLINT-325] Update Teleport Configuration spec

### DIFF
--- a/teleport/assets/configuration/spec.yaml
+++ b/teleport/assets/configuration/spec.yaml
@@ -7,4 +7,17 @@ files:
     - template: init_config/default
   - template: instances
     options:
+    - name: "teleport_url"
+      required: true
+      description: "The Teleport URL to connect to."
+      value:
+        type: string
+        example: "http://127.0.0.1"
+    - name: "diag_port"
+      description: "The Teleport Diagnostic Port."
+      value:
+        type: integer
+        example: 3000
+      
+
     - template: instances/default

--- a/teleport/datadog_checks/teleport/config_models/defaults.py
+++ b/teleport/datadog_checks/teleport/config_models/defaults.py
@@ -8,6 +8,10 @@
 #     ddev -x validate models -s <INTEGRATION_NAME>
 
 
+def instance_diag_port():
+    return 3000
+
+
 def instance_disable_generic_tags():
     return False
 

--- a/teleport/datadog_checks/teleport/config_models/instance.py
+++ b/teleport/datadog_checks/teleport/config_models/instance.py
@@ -34,12 +34,14 @@ class InstanceConfig(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    diag_port: Optional[int] = None
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
     metric_patterns: Optional[MetricPatterns] = None
     min_collection_interval: Optional[float] = None
     service: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None
+    teleport_url: str
 
     @model_validator(mode='before')
     def _initial_validation(cls, values):

--- a/teleport/datadog_checks/teleport/data/conf.yaml.example
+++ b/teleport/datadog_checks/teleport/data/conf.yaml.example
@@ -13,7 +13,16 @@ init_config:
 #
 instances:
 
-  -
+    ## @param teleport_url - string - required
+    ## The Teleport URL to connect to.
+    #
+  - teleport_url: http://127.0.0.1
+
+    ## @param diag_port - integer - optional - default: 3000
+    ## The Teleport Diagnostic Port.
+    #
+    # diag_port: 3000
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds `teleport_url` and `diag_port` properties to the spec.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
