### PR TITLE
Set statement_timeout at session level & use reset_val as setting when source is session

### DIFF
--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -27,8 +27,15 @@ DEFAULT_SCHEMAS_COLLECTION_INTERVAL = 600
 DEFAULT_RESOURCES_COLLECTION_INTERVAL = 300
 DEFAULT_SETTINGS_IGNORED_PATTERNS = ["plpgsql%"]
 
+# PG_SETTINGS_QURERY is used to collect all the settings from the pg_settings table
+# Edge case: If source is 'session', it uses reset_val
+# (which represents the value that the setting would revert to on session end or reset),
+# otherwise, it uses the current setting value.
 PG_SETTINGS_QUERY = """
-SELECT name, setting FROM pg_settings
+SELECT
+name,
+case when source = 'session' then reset_val else setting end as setting
+FROM pg_settings
 """
 
 DATABASE_INFORMATION_QUERY = """

--- a/postgres/tests/compose/etc/postgresql/postgresql.conf
+++ b/postgres/tests/compose/etc/postgresql/postgresql.conf
@@ -4,6 +4,7 @@ pg_stat_statements.max=10000
 pg_stat_statements.track=all
 track_io_timing=on
 track_functions=pl
+statement_timeout = 10000
 
 wal_level = logical
 max_wal_senders = 10

--- a/postgres/tests/compose/etc/postgresql_logical_replica/postgresql.conf
+++ b/postgres/tests/compose/etc/postgresql_logical_replica/postgresql.conf
@@ -5,3 +5,4 @@ pg_stat_statements.max=100
 pg_stat_statements.track=all
 track_io_timing=on
 track_functions=pl
+statement_timeout = 10000

--- a/postgres/tests/compose/etc/postgresql_replica/postgresql.conf
+++ b/postgres/tests/compose/etc/postgresql_replica/postgresql.conf
@@ -5,6 +5,7 @@ pg_stat_statements.max=10000
 pg_stat_statements.track=all
 track_io_timing=on
 track_functions=pl
+statement_timeout = 10000
 
 hot_standby = on
 hot_standby_feedback = on

--- a/postgres/tests/compose/etc/postgresql_replica2/postgresql.conf
+++ b/postgres/tests/compose/etc/postgresql_replica2/postgresql.conf
@@ -5,6 +5,7 @@ pg_stat_statements.max=100
 pg_stat_statements.track=all
 track_io_timing=on
 track_functions=pl
+statement_timeout = 10000
 
 hot_standby = on
 hot_standby_feedback = off

--- a/postgres/tests/test_connections.py
+++ b/postgres/tests/test_connections.py
@@ -355,3 +355,18 @@ def test_conn_terminated_prematurely(pg_instance):
 
     # new check run will re-open connection
     check.check(pg_instance)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_conn_statement_timeout(pg_instance):
+    """
+    Test db connection statement timeout is set at the session level
+    """
+    pg_instance["query_timeout"] = 500
+    check = PostgreSql('postgres', {}, [pg_instance])
+    check._connect()
+    with pytest.raises(psycopg2.errors.QueryCanceled):
+        with check.db() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute("SELECT pg_sleep(1)")

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -45,6 +45,10 @@ def test_collect_metadata(integration_check, dbm_instance, aggregator):
     assert event['kind'] == "pg_settings"
     assert len(event["metadata"]) > 0
     assert all(not k['name'].startswith('max_wal') for k in event['metadata'])
+    statement_timeout_setting = next((k for k in event['metadata'] if k['name'] == 'statement_timeout'), None)
+    assert statement_timeout_setting is not None
+    # statement_timeout should be server level setting not session level
+    assert statement_timeout_setting['setting'] == '10000'
 
 
 def test_collect_schemas(integration_check, dbm_instance, aggregator):


### PR DESCRIPTION
### What does this PR do?
This PR
- Sets statement_timeout at session level instead of connection level after database connection is established
- Use `reset_val` in pg_settings query when `source` equals to `session`.
![image](https://github.com/DataDog/integrations-core/assets/4964070/e4b8737e-0b57-4382-8f94-f1f9f327402c)

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-3728
Prior to the change, the `statement_timeout` setting collected from `pg_settings` is set by datadog integration connection (default to 5s). This does not reflect the database level `statement_timeout` setting and is often misleading. In this PR, we set the statement_timeout after the connection is established. This way we can do a simple check `case when source = 'session' then reset_val else setting end as setting` to retrieve the server level setting. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
