### PR TITLE
Bump pytest and require flaky minimum version

### DIFF
--- a/datadog_checks_dev/changelog.d/17269.fixed
+++ b/datadog_checks_dev/changelog.d/17269.fixed
@@ -1,0 +1,1 @@
+Bump pytest and require flaky minimum version

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -34,12 +34,12 @@ classifiers = [
 dependencies = [
     "contextlib2; python_version < '3.0'",
     "coverage>=5.0.3",
-    "flaky",
+    "flaky>=3.8.0",
     "mock",
     "psutil",
     "py>=1.8.2; python_version < '3.0'",  # https://github.com/ionelmc/pytest-benchmark/issues/226
     "pytest==4.6.11; python_version < '3.0'",
-    "pytest==8.0.2; python_version > '3.0'",
+    "pytest==8.1.1; python_version > '3.0'",
     "pytest-asyncio>=0.23.4; python_version > '3.0'",
     "pytest-benchmark[histogram]<4.0.0; python_version < '3.0'",
     "pytest-benchmark[histogram]>=4.0.0; python_version > '3.0'",

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 dependencies = [
     "contextlib2; python_version < '3.0'",
     "coverage>=5.0.3",
-    "flaky>=3.8.0",
+    "flaky>=3.8.0; python_version > '3.0",
     "mock",
     "psutil",
     "py>=1.8.2; python_version < '3.0'",  # https://github.com/ionelmc/pytest-benchmark/issues/226

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -34,8 +34,8 @@ classifiers = [
 dependencies = [
     "contextlib2; python_version < '3.0'",
     "coverage>=5.0.3",
-    "flaky; python_version < '3.0",
-    "flaky>=3.8.0; python_version > '3.0",
+    "flaky; python_version < '3.0'",
+    "flaky>=3.8.0; python_version > '3.0'",
     "mock",
     "psutil",
     "py>=1.8.2; python_version < '3.0'",  # https://github.com/ionelmc/pytest-benchmark/issues/226

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
 dependencies = [
     "contextlib2; python_version < '3.0'",
     "coverage>=5.0.3",
+    "flaky; python_version < '3.0",
     "flaky>=3.8.0; python_version > '3.0",
     "mock",
     "psutil",

--- a/ddev/changelog.d/17269.fixed
+++ b/ddev/changelog.d/17269.fixed
@@ -1,0 +1,1 @@
+Bump pytest and require flaky minimum version

--- a/ddev/changelog.d/17269.fixed
+++ b/ddev/changelog.d/17269.fixed
@@ -1,1 +1,0 @@
-Bump pytest and require flaky minimum version


### PR DESCRIPTION
That version of flaky fixes a problem with 8.1.1 of pytest

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
