### PR TITLE
Break circular dependency between sqlserver check and connection

### DIFF
--- a/sqlserver/changelog.d/17275.fixed
+++ b/sqlserver/changelog.d/17275.fixed
@@ -1,0 +1,1 @@
+Break circular dependency between sqlserver check and connection

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -147,9 +147,9 @@ class Connection(object):
 
     VALID_ADOPROVIDERS = ['SQLOLEDB', 'MSOLEDBSQL', 'MSOLEDBSQL19', 'SQLNCLI11']
 
-    def __init__(self, check, init_config, instance_config, service_check_handler):
+    def __init__(self, host, init_config, instance_config, service_check_handler):
+        self.host = host
         self.instance = instance_config
-        self._check = check
         self.service_check_handler = service_check_handler
         self.log = get_check_logger()
 
@@ -298,7 +298,7 @@ class Connection(object):
                 conn_warn_msg.value,
                 tcp_connection_status,
                 exception_msg,
-                host=self._check.resolved_hostname,
+                host=host,
                 connection_host=host,
                 database=database,
                 code=conn_warn_msg.value,

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -322,7 +322,12 @@ class SQLServer(AgentCheck):
         return self._agent_hostname
 
     def initialize_connection(self):
-        self.connection = Connection(self, self.init_config, self.instance, self.handle_service_check)
+        self.connection = Connection(
+            host=self.resolved_hostname,
+            init_config=self.init_config,
+            instance_config=self.instance,
+            service_check_handler=self.handle_service_check,
+        )
 
     def make_metric_list_to_collect(self):
         # Pre-process the list of metrics to collect

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -71,7 +71,7 @@ def test_warn_trusted_connection_username_pass(instance_minimal_defaults, cs, us
     instance_minimal_defaults["username"] = username
     instance_minimal_defaults["password"] = password
     check = SQLServer(CHECK_NAME, {}, [instance_minimal_defaults])
-    connection = Connection(check, {}, instance_minimal_defaults, None)
+    connection = Connection(check.resolved_hostname, {}, instance_minimal_defaults, None)
     connection.log = mock.MagicMock()
     connection._connection_options_validation('somekey', 'somedb')
     if expect_warning:
@@ -94,7 +94,7 @@ def test_warn_trusted_connection_username_pass(instance_minimal_defaults, cs, us
 def test_will_warn_parameters_for_the_wrong_connection(instance_minimal_defaults, connector, param):
     instance_minimal_defaults.update({'connector': connector, param: 'foo'})
     check = SQLServer(CHECK_NAME, {}, [instance_minimal_defaults])
-    connection = Connection(check, {}, instance_minimal_defaults, None)
+    connection = Connection(check.resolved_hostname, {}, instance_minimal_defaults, None)
     connection.log = mock.MagicMock()
     connection._connection_options_validation('somekey', 'somedb')
     connection.log.warning.assert_called_once_with(
@@ -127,7 +127,7 @@ def test_will_warn_parameters_for_the_wrong_connection(instance_minimal_defaults
 def test_will_fail_for_duplicate_parameters(instance_minimal_defaults, connector, cs, param, should_fail):
     instance_minimal_defaults.update({'connector': connector, param: 'foo', 'connection_string': cs + "=foo"})
     check = SQLServer(CHECK_NAME, {}, [instance_minimal_defaults])
-    connection = Connection(check, {}, instance_minimal_defaults, None)
+    connection = Connection(check.resolved_hostname, {}, instance_minimal_defaults, None)
     if should_fail:
         match = (
             "%s has been provided both in the connection string and as a configuration option (%s), "
@@ -159,7 +159,7 @@ def test_will_fail_for_wrong_parameters_in_the_connection_string(instance_minima
     instance_minimal_defaults.update({'connector': connector, 'connection_string': cs + '=foo'})
     other_connector = 'odbc' if connector != 'odbc' else 'adodbapi'
     check = SQLServer(CHECK_NAME, {}, [instance_minimal_defaults])
-    connection = Connection(check, {}, instance_minimal_defaults, None)
+    connection = Connection(check.resolved_hostname, {}, instance_minimal_defaults, None)
     match = (
         "%s has been provided in the connection string. "
         "This option is only available for %s connections, however %s has been selected"
@@ -223,7 +223,7 @@ def test_managed_auth_config_valid(instance_minimal_defaults, name, managed_iden
             instance_minimal_defaults[k] = v
     instance_minimal_defaults.update({'connector': 'odbc'})
     check = SQLServer(CHECK_NAME, {}, [instance_minimal_defaults])
-    connection = Connection(check, {}, instance_minimal_defaults, None)
+    connection = Connection(check.resolved_hostname, {}, instance_minimal_defaults, None)
     if should_fail:
         with pytest.raises(ConfigurationError, match=re.escape(expected_err)):
             connection._connection_options_validation('somekey', 'somedb')
@@ -284,7 +284,7 @@ def test_config_with_and_without_port(instance_minimal_defaults, host, port, exp
     instance_minimal_defaults["host"] = host
     instance_minimal_defaults["port"] = port
     check = SQLServer(CHECK_NAME, {}, [instance_minimal_defaults])
-    connection = Connection(check, {}, instance_minimal_defaults, None)
+    connection = Connection(check.resolved_hostname, {}, instance_minimal_defaults, None)
     _, result_host, _, _, _, _ = connection._get_access_info('somekey', 'somedb')
     assert result_host == expected_host
 
@@ -366,7 +366,7 @@ def test_connection_failure(aggregator, dd_run_check, instance_docker):
     try:
         # Break the connection
         check.connection = Connection(
-            check, {}, {'host': '', 'username': '', 'password': ''}, check.handle_service_check
+            check.resolved_hostname, {}, {'host': '', 'username': '', 'password': ''}, check.handle_service_check
         )
         dd_run_check(check)
     except Exception:
@@ -491,7 +491,7 @@ def test_connection_error_reporting(
     expected_error_pattern = matching_patterns[0]
 
     check = SQLServer(CHECK_NAME, {}, [instance_docker])
-    connection = Connection(check, check.init_config, check.instance, check.handle_service_check)
+    connection = Connection(check.resolved_hostname, check.init_config, check.instance, check.handle_service_check)
     with pytest.raises(SQLConnectionError) as excinfo:
         with connection.open_managed_default_connection():
             pytest.fail("connection should not have succeeded")


### PR DESCRIPTION
### What does this PR do?
This PR breaks circular dependencies between `SQLServer` check class and `Connection` class. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
