### PR TITLE
Reuse our own package indices when retrieving wheels for resolution

### DIFF
--- a/.builders/build.py
+++ b/.builders/build.py
@@ -219,12 +219,19 @@ def build_image():
             final_requirements = mount_dir / 'frozen.txt'
             final_requirements.touch()
 
+            script_args = ['--python', args.python]
+
+            # Assumption: if a digest was provided we're not changing the build image and therefore
+            # we're fine with reusing wheels we've built previously
+            if args.digest or True:
+                script_args.append('--use-built-index')
+
             check_process([
                 'docker', 'run', '--rm',
                 '-v', f'{mount_dir}:{internal_mount_dir}',
                 # Anything created within directories mounted to the container cannot be removed by the host
                 '-e', 'PYTHONDONTWRITEBYTECODE=1',
-                image_name, '--python', args.python,
+                image_name, *script_args,
             ])
 
             output_dir = Path(args.output_dir)

--- a/.builders/scripts/build_wheels.py
+++ b/.builders/scripts/build_wheels.py
@@ -10,6 +10,10 @@ from tempfile import TemporaryDirectory
 from dotenv import dotenv_values
 from utils import extract_metadata, normalize_project_name
 
+INDEX_BASE_URL = 'https://storage.googleapis.com/dd-agent-int-deps'
+CUSTOM_EXTERNAL_INDEX = f'{INDEX_BASE_URL}/external'
+CUSTOM_BUILT_INDEX = f'{INDEX_BASE_URL}/built'
+
 if sys.platform == 'win32':
     PY3_PATH = Path('C:\\py3\\Scripts\\python.exe')
     PY2_PATH = Path('C:\\py2\\Scripts\\python.exe')
@@ -54,6 +58,7 @@ def check_process(*args, **kwargs) -> subprocess.CompletedProcess:
 def main():
     parser = argparse.ArgumentParser(prog='wheel-builder', allow_abbrev=False)
     parser.add_argument('--python', required=True)
+    parser.add_argument('--use-built-index', action='store_true', default=False)
     args = parser.parse_args()
 
     python_version = args.python
@@ -107,7 +112,11 @@ def main():
             str(python_path), '-m', 'pip', 'wheel',
             '-r', str(MOUNT_DIR / 'requirements.in'),
             '--wheel-dir', str(staged_wheel_dir),
+            '--extra-index-url', CUSTOM_EXTERNAL_INDEX,
         ]
+        if args.use_built_index:
+            command_args.extend(['--extra-index-url', CUSTOM_BUILT_INDEX])
+
         check_process(command_args, env=env_vars)
 
         # Repair wheels

--- a/.builders/scripts/repair_wheels.py
+++ b/.builders/scripts/repair_wheels.py
@@ -66,7 +66,7 @@ def wheel_was_built(wheel: Path) -> bool:
 
 class WheelName(NamedTuple):
     """Helper class to manipulate wheel names."""
-    # Note: this assumes no build number is ever used to avoid extra parsing logic
+    # Note: this implementation ignores build tags (it drops them on parsing)
     name: str
     version: str
     python_tag: str
@@ -76,7 +76,10 @@ class WheelName(NamedTuple):
     @classmethod
     def parse(cls, wheel_name: str):
         name, _ext = os.path.splitext(wheel_name)
-        return cls(*name.split('-'))
+        parts = name.split('-')
+        if len(parts) == 6:
+            parts.pop(2)
+        return cls(*parts)
 
     def __str__(self):
         return '-'.join([

--- a/.builders/upload.py
+++ b/.builders/upload.py
@@ -135,7 +135,7 @@ def upload(targets_dir):
                     continue
             else:
                 # https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-name-convention
-                name, version, python_tag, abi_tag, platform_tag = wheel.stem.split('-')
+                name, version, *_build_tag, python_tag, abi_tag, platform_tag = wheel.stem.split('-')
                 existing_wheels = list(bucket.list_blobs(
                     match_glob=(f'{artifact_type}/{project_name}/'
                                 f'{name}-{version}*-{python_tag}-{abi_tag}-{platform_tag}.whl'),


### PR DESCRIPTION
### What does this PR do?

Incorporates our custom indices to the sources for used in resolution+retrieval+build process (through `pip wheel`), by adding them with `--extra-index-url`.
- Adds our custom "external" index always.
- Adds our custom "built" index when the build images haven't changed.

A few other changes were required to account for the introduction of build tags through our own index in parts of the process where we didn't have any.

### Motivation

- Protection from 3rd parties through PyPI.
- Optimization by avoiding rebuilds that may be unnecessary.

### Additional Notes

- I think adding the "external" index via `--extra-index-url` is always safe, regardless of the lack of priority guarantees between PyPI and the additional index. `pip` will consider artifacts from both indices and choose the "best" fit (highest compatible version, prefer binary by default).
- Adding the "built" index conditionally *should* be safe enough, though there may be some edge cases. The main reason we can't always provide the "built" index is that we want to be able to update the build for an existing version (library dependencies, compilation flags, etc.); providing it when nothing in the build images or scripts has changed sounds like a good compromise.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
