### PR TITLE
[Python-based kubelet] Parse resources with exponent notation

### DIFF
--- a/kubelet/changelog.d/17280.fixed
+++ b/kubelet/changelog.d/17280.fixed
@@ -1,0 +1,1 @@
+Fixes pod resources requests/limits with exponent notation correctly, e.g. `129e6` for memory is `129M` / `123Mi`

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -24,7 +24,16 @@ pytestmark = pytest.mark.skipif(sys.platform == 'win32', reason='tests for linux
 
 # Constants
 HERE = os.path.abspath(os.path.dirname(__file__))
-QUANTITIES = {'12k': 12 * 1000, '12M': 12 * (1000 * 1000), '12Ki': 12.0 * 1024, '12K': 12.0, '12test': 12.0, '1.181116006E9': 1.181116006 * (10 ** 9), '129e6': 129 * (10 ** 6), '12E': 12 * (1000 * 1000 * 1000 * 1000 * 1000 * 1000)}
+QUANTITIES = {
+    '12k': 12 * 1000,
+    '12M': 12 * (1000 * 1000),
+    '12Ki': 12.0 * 1024,
+    '12K': 12.0,
+    '12test': 12.0,
+    '1.181116006E9': 1.181116006 * (10**9),
+    '129e6': 129 * (10**6),
+    '12E': 12 * (1000 * 1000 * 1000 * 1000 * 1000 * 1000),
+}
 
 # Kubernetes versions, used to differentiate cadvisor payloads after the label change
 KUBE_POST_1_16 = '1.16'

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -24,7 +24,7 @@ pytestmark = pytest.mark.skipif(sys.platform == 'win32', reason='tests for linux
 
 # Constants
 HERE = os.path.abspath(os.path.dirname(__file__))
-QUANTITIES = {'12k': 12 * 1000, '12M': 12 * (1000 * 1000), '12Ki': 12.0 * 1024, '12K': 12.0, '12test': 12.0}
+QUANTITIES = {'12k': 12 * 1000, '12M': 12 * (1000 * 1000), '12Ki': 12.0 * 1024, '12K': 12.0, '12test': 12.0, '1.181116006E9': 1.181116006 * (10 ** 9), '129e6': 129 * (10 ** 6), '12E': 12 * (1000 * 1000 * 1000 * 1000 * 1000 * 1000)}
 
 # Kubernetes versions, used to differentiate cadvisor payloads after the label change
 KUBE_POST_1_16 = '1.16'


### PR DESCRIPTION
### What does this PR do?
* Changes the `parse_quantity` function to cover resources from pods set with exponent notation https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory : 
> Limits and requests for memory are measured in bytes. You can express memory as a plain integer or as a fixed-point number using one of these [quantity](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/) suffixes: E, P, T, G, M, k. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki. For example, the following represent roughly the same value:
`128974848, 129e6, 129M,  128974848000m, 123Mi`

### Motivation
* Customer case where the current parsing provides exabytes value for `kubernetes.memory.requests` due to the current parsing function : [CONS-6245](https://datadoghq.atlassian.net/browse/CONS-6245)

### Additional Notes
* The kubelet check is moving to a Go-based check : the Agent (Go) implementation does not suffer from this issue as it directly uses the k8s `quantity.go` to benefit from `AsApproximateFloat64` for the parsing : https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go#L135-L139
* It can be QA'd with the following manifest : 
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: exponent-pod
spec:
  containers:
    - name: redis
      image: redis:latest
      ports:
        - containerPort: 6379
      resources:
        requests:
          memory: "1.181116006E9"
          cpu: "250m"
        limits:
          memory: "1.181116006E9"
          cpu: "500m"
    - name: nginx
      image: nginx:latest
      resources:
        requests:
          memory: "1.181116006e9"
          cpu: "250m"
        limits:
          memory: "1.181116006e9"
          cpu: "500m"
```
Both `memory.limits` and `memory.requests` should be 1.1 GiB

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.


[CONS-6245]: https://datadoghq.atlassian.net/browse/CONS-6245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ