### PR TITLE
Bring back the comment when contributors use the `changed` changelog fragment

### DIFF
--- a/.github/workflows/pr-quick-check.yml
+++ b/.github/workflows/pr-quick-check.yml
@@ -58,3 +58,19 @@ jobs:
         --pr-file "$GITHUB_EVENT_PATH"
         ${{ github.event.pull_request.base.repo.private && '--private' || '' }}
         --repo "${{ inputs.repo }}"
+
+    - uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          changed_fragments:
+            - '*/changelog.d/*.changed'
+
+    - name: Comment
+      if: ${{ steps.changes.outputs.changed_fragments == 'true' }}
+      uses: actions/github-script@0.3.0
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
+          github.issues.createComment({ issue_number, owner, repo, body: "The changelog type `changed` was used in this Pull Request, so the next release will bump major version. Please make sure this is a breaking change, or use the `fixed` or `added` type instead." });


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bring back the comment when contributors use the changed changelog fragment. 

Example [here](https://github.com/DataDog/integrations-core/pull/17289#issuecomment-2022317426) triggered on this PR changing something in `ddev` with a `changed` fragment. (I reverted the modification)

### Motivation
<!-- What inspired you to submit this pull request? -->

- It got dropped when we changed the way to manage changelogs and I think it was useful and saves us some friction on a lot of PRs.

https://github.com/DataDog/integrations-core/blob/7.45.x/.github/workflows/changelog-label-check.yml#L22-L29

- I reviewed a couple of PRs where people used `changed` without knowing what it would do.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- We have to use an action to filter jobs on path that were modified, the built-it path option only works for workflows

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
