### PR TITLE
Changed the description of the openstack.ironic.node.up metric

### DIFF
--- a/openstack_controller/metadata.csv
+++ b/openstack_controller/metadata.csv
@@ -5,7 +5,7 @@ openstack.glance.response_time,gauge,,millisecond,,Duration that an HTTP request
 openstack.ironic.conductor.count,gauge,,,,Number of ironic conductors,0,openstack_controller,ironic conductor ct,
 openstack.ironic.conductor.up,gauge,,,,Whether an ironic conductor is up,0,openstack_controller,ironic conductor up,
 openstack.ironic.node.count,gauge,,,,Number of ironic nodes,0,openstack_controller,ironic node ct,
-openstack.ironic.node.up,gauge,,,,Number of ironic nodes up,0,openstack_controller,ironic node up,
+openstack.ironic.node.up,gauge,,,,Whether an ironic node is up,0,openstack_controller,ironic node up,
 openstack.ironic.response_time,gauge,,millisecond,,Duration that an HTTP request takes to complete when making a request to ironic endpoint,0,openstack_controller,ironic response time,
 openstack.keystone.domain.count,gauge,,,,Number of domains of the Openstack deployment,0,openstack_controller,keystone domains count,
 openstack.keystone.domain.enabled,gauge,,,,If set to 1 domain is enabled. If set to 0 domain is disabled,0,openstack_controller,keystone domain enabled,


### PR DESCRIPTION
### What does this PR do?
openstack.ironic.node.up doesn't measure how many ironic nodes are up; it measures if a given node is up. The description in the metadata.csv file is updated to clarify this.

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
