### PR TITLE
fix missing file stats metrics for sqlserver newer than 2012 and not Azure SQL Database/Azure SQL Managed Instance

### DIFF
--- a/sqlserver/changelog.d/17299.fixed
+++ b/sqlserver/changelog.d/17299.fixed
@@ -1,0 +1,1 @@
+Fix missing file stats metrics `sqlserver.files.write_io_stall_queued` and `sqlserver.files.read_io_stall_queued` for sqlserver newer than 2012 and not Azure SQL Database/Azure SQL Managed Instance

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -335,7 +335,7 @@ def get_query_file_stats(sqlserver_major_version, sqlserver_engine_edition):
         "io_stall": {"name": "files.io_stall", "type": "monotonic_count"},
     }
 
-    if sqlserver_major_version <= 2012 or not is_azure_database(sqlserver_engine_edition):
+    if sqlserver_major_version <= 2012 and not is_azure_database(sqlserver_engine_edition):
         column_definitions.pop("io_stall_queued_read_ms")
         column_definitions.pop("io_stall_queued_write_ms")
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes 2 missing metrics `sqlserver.files.write_io_stall_queued` and `sqlserver.files.read_io_stall_queued` for sqlserver major version > 2012 and not Azure SQL Database/Azure SQL Managed Instance.
<img width="1760" alt="image" src="https://github.com/DataDog/integrations-core/assets/4964070/8a8c51de-fe89-41e3-bfb0-c1a939170ab9">


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
