### PR TITLE
Partially remove db exist check if ignore db is false

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -686,7 +686,9 @@ files:
         type: string
         example: master
     - name: ignore_missing_database
-      description: If the DB specified doesn't exist on the server then don't do the check
+      description: |
+        If the DB specified doesn't exist on the server then don't do the check
+        Note: this parameter is deprecated, please use database_autodiscovery in case when database name is uncertain. 
       value:
         type: boolean
         example: false

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -687,8 +687,8 @@ files:
         example: master
     - name: ignore_missing_database
       description: |
+        DEPRECATED - use `database_autodiscovery` instead, when database name is uncertain.
         If the DB specified doesn't exist on the server then don't do the check
-        Note: this parameter is deprecated, please use database_autodiscovery in case when database name is uncertain. 
       value:
         type: boolean
         example: false

--- a/sqlserver/changelog.d/17300.fixed
+++ b/sqlserver/changelog.d/17300.fixed
@@ -1,0 +1,1 @@
+Remove db exist check if ignore_missing_database is set to false. In this case throw SQLConnectionError instead of ConfigurationError when database does not exist. 

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -29,6 +29,12 @@ class SQLServerConfig:
         self.include_index_usage_metrics_tempdb: bool = is_affirmative(
             instance.get('include_index_usage_metrics_tempdb', False)
         )
+        self.ignore_missing_database = is_affirmative(instance.get("ignore_missing_database", False))
+        if self.ignore_missing_database:
+            self.log.warning(
+                    "The parameter 'ignore_missing_database' is deprecated"
+                    "if you are unsure about the database name please use 'database_autodiscovery'"
+                )
 
         # DBM
         self.dbm_enabled: bool = is_affirmative(instance.get('dbm', False))

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -32,9 +32,9 @@ class SQLServerConfig:
         self.ignore_missing_database = is_affirmative(instance.get("ignore_missing_database", False))
         if self.ignore_missing_database:
             self.log.warning(
-                    "The parameter 'ignore_missing_database' is deprecated"
-                    "if you are unsure about the database name please use 'database_autodiscovery'"
-                )
+                "The parameter 'ignore_missing_database' is deprecated"
+                "if you are unsure about the database name please use 'database_autodiscovery'"
+            )
 
         # DBM
         self.dbm_enabled: bool = is_affirmative(instance.get('dbm', False))

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -22,7 +22,6 @@ init_config:
     #   - query: <QUERY>
     #     columns: <COLUMNS>
     #     tags: <TAGS>
-    #     collection_interval: <COLLECTION_INTERVAL>
 
     ## @param service - string - optional
     ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
@@ -604,14 +603,6 @@ instances:
     ##              Columns without a name are ignored. To skip a column, enter:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
-    ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
-    ##     If collection_interval is not set, the query will be run every check run.
-    ##     If the collection interval is less than check collection interval, 
-    ##     the query will be run every check run.
-    ##     If the collection interval is greater than check collection interval, 
-    ##     the query will NOT BE RUN exactly at the collection interval.
-    ##     The query will be run at the next check run after the collection interval has passed.
-    ## 5. metric_prefix (optional) - The prefix to apply to each metric.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
@@ -622,8 +613,6 @@ instances:
     #       type: gauge
     #     tags:
     #     - test:<INTEGRATION>
-    #     collection_interval: 30
-    #     metric_prefix: foo_prefix
 
     ## @param stored_procedure - string - optional
     ## DEPRECATED - use `custom_queries` instead. For guidance, see:
@@ -644,6 +633,7 @@ instances:
     # proc_only_if_database: master
 
     ## @param ignore_missing_database - boolean - optional - default: false
+    ## DEPRECATED - use `database_autodiscovery` instead, when database name is uncertain.
     ## If the DB specified doesn't exist on the server then don't do the check
     #
     # ignore_missing_database: false

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -22,6 +22,7 @@ init_config:
     #   - query: <QUERY>
     #     columns: <COLUMNS>
     #     tags: <TAGS>
+    #     collection_interval: <COLLECTION_INTERVAL>
 
     ## @param service - string - optional
     ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
@@ -603,6 +604,14 @@ instances:
     ##              Columns without a name are ignored. To skip a column, enter:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
+    ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
+    ##     If collection_interval is not set, the query will be run every check run.
+    ##     If the collection interval is less than check collection interval, 
+    ##     the query will be run every check run.
+    ##     If the collection interval is greater than check collection interval, 
+    ##     the query will NOT BE RUN exactly at the collection interval.
+    ##     The query will be run at the next check run after the collection interval has passed.
+    ## 5. metric_prefix (optional) - The prefix to apply to each metric.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
@@ -613,6 +622,8 @@ instances:
     #       type: gauge
     #     tags:
     #     - test:<INTEGRATION>
+    #     collection_interval: 30
+    #     metric_prefix: foo_prefix
 
     ## @param stored_procedure - string - optional
     ## DEPRECATED - use `custom_queries` instead. For guidance, see:

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -11,7 +11,6 @@ from collections import defaultdict
 import six
 from cachetools import TTLCache
 
-from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.config import is_affirmative
 from datadog_checks.base.utils.db import QueryExecutor, QueryManager
 from datadog_checks.base.utils.db.utils import default_json_event_encoding, resolve_db_host, tracked_query

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -333,8 +333,10 @@ class SQLServer(AgentCheck):
         # Pre-process the list of metrics to collect
         try:
             if self._config.ignore_missing_database:
-                # self.connection.check_database() will try to connect to 'master'. If this is a DB hosted on Azure the function would throw.
-                # For this reason we avoid calling self.connection.check_database() for this config as it will be a false negative.
+                # self.connection.check_database() will try to connect to 'master'.
+                # If this is a DB hosted on Azure the function would throw.
+                # For this reason we avoid calling self.connection.check_database()
+                # for this config as it will be a false negative.
                 engine_edition = self.static_info_cache.get(STATIC_INFO_ENGINE_EDITION)
                 if not is_azure_sql_database(engine_edition):
                     # Do the database exist check that will allow to disable _check as a whole

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -328,7 +328,7 @@ class SQLServer(AgentCheck):
             instance_config=self.instance,
             service_check_handler=self.handle_service_check,
         )
-   
+
     def make_metric_list_to_collect(self):
         # Pre-process the list of metrics to collect
         try:

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -333,10 +333,10 @@ class SQLServer(AgentCheck):
         # Pre-process the list of metrics to collect
         try:
             if self._config.ignore_missing_database:
-                # self.connection.check_database() will try to connect to 'master'. On Azure hosted DBs this should throw 
-                # unless the database parameter was explicetly configured to be 'master'. (TODO may be cannot be master and we just skip it)
+                # self.connection.check_database() will try to connect to 'master'. If this is a DB hosted on Azure the function would throw.
+                # For this reason we avoid calling self.connection.check_database() for this config as it will be a false negative.
                 engine_edition = self.static_info_cache.get(STATIC_INFO_ENGINE_EDITION)
-                if not (is_azure_sql_database(engine_edition) and self.instance.get('database', self.connection.DEFAULT_DATABASE) != self.connection.DEFAULT_DATABASE):
+                if not is_azure_sql_database(engine_edition):
                     # Do the database exist check that will allow to disable _check as a whole
                     # as otherwise the first call to open_managed_default_connection will throw the
                     # SQLConnectionError.

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -12,6 +12,7 @@ import six
 from cachetools import TTLCache
 
 from datadog_checks.base.config import is_affirmative
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.db import QueryExecutor, QueryManager
 from datadog_checks.base.utils.db.utils import default_json_event_encoding, resolve_db_host, tracked_query
 from datadog_checks.base.utils.serialization import json
@@ -333,7 +334,8 @@ class SQLServer(AgentCheck):
         try:
             if is_affirmative(self.instance.get("ignore_missing_database", False)):
                 # Do the database exist check that will allow to disable _check as a whole
-                # as otherwise check for non existant DB will be running and throwing SQLConnectionError
+                # as otherwise the first call to open_managed_default_connection will throw the
+                # SQLConnectionError.
                 db_exists, context = self.connection.check_database()
                 if not db_exists:
                     self.do_check = False
@@ -345,7 +347,7 @@ class SQLServer(AgentCheck):
                         self.autodiscover_databases(cursor)
                     self._make_metric_list_to_collect(self._config.custom_metric)
         except SQLConnectionError as e:
-            raise e
+            raise
         except Exception as e:
             self.log.exception("Initialization exception %s", e)
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -334,7 +334,7 @@ class SQLServer(AgentCheck):
         try:
             if self._config.ignore_missing_database:
                 # self.connection.check_database() will try to connect to 'master'.
-                # If this is a DB hosted on Azure the function would throw.
+                # If this is an Azure SQL Database this function will throw.
                 # For this reason we avoid calling self.connection.check_database()
                 # for this config as it will be a false negative.
                 engine_edition = self.static_info_cache.get(STATIC_INFO_ENGINE_EDITION)

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -921,7 +921,6 @@ class SQLServer(AgentCheck):
             self._index_usage_last_check_ts = now
             self.log.debug('Collecting index usage statistics')
             # Filter out tempdb as the query might be blocking and it's index usage information is not relevant
-            self.log.error("Boris got to index collection")
             db_names = [d.name for d in self.databases] or [
                 self.instance.get('database', self.connection.DEFAULT_DATABASE)
             ]
@@ -937,7 +936,6 @@ class SQLServer(AgentCheck):
                 self.log.debug("current db is %s", current_db)
                 try:
                     for database in db_names:
-                        self.log.error("Collecting for %s", database)
                         try:
                             executor = QueryExecutor(
                                 functools.partial(self.execute_query_raw, db=database),

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -349,7 +349,7 @@ class SQLServer(AgentCheck):
                 with self.connection.open_managed_default_connection():
                     with self.connection.get_managed_cursor() as cursor:
                         self.autodiscover_databases(cursor)
-                    self._make_metric_list_to_collect(self._config.custom_metric)
+                    self._make_metric_list_to_collect(self._config.custom_metrics)
         except SQLConnectionError:
             raise
         except Exception as e:
@@ -919,6 +919,7 @@ class SQLServer(AgentCheck):
             self._index_usage_last_check_ts = now
             self.log.debug('Collecting index usage statistics')
             # Filter out tempdb as the query might be blocking and it's index usage information is not relevant
+            self.log.error("Boris got to index collection")
             db_names = [d.name for d in self.databases] or [
                 self.instance.get('database', self.connection.DEFAULT_DATABASE)
             ]
@@ -934,6 +935,7 @@ class SQLServer(AgentCheck):
                 self.log.debug("current db is %s", current_db)
                 try:
                     for database in db_names:
+                        self.log.error("Collecting for %s", database)
                         try:
                             executor = QueryExecutor(
                                 functools.partial(self.execute_query_raw, db=database),

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -339,12 +339,12 @@ class SQLServer(AgentCheck):
                 if not db_exists:
                     self.do_check = False
                     self.log.warning("Database %s does not exist. Disabling checks for this instance.", context)
-                    return 
+                    return
             if self.instance.get('stored_procedure') is None:
-                    with self.connection.open_managed_default_connection():
-                        with self.connection.get_managed_cursor() as cursor:
-                            self.autodiscover_databases(cursor)
-                        self._make_metric_list_to_collect(self._config.custom_metric)
+                with self.connection.open_managed_default_connection():
+                    with self.connection.get_managed_cursor() as cursor:
+                        self.autodiscover_databases(cursor)
+                    self._make_metric_list_to_collect(self._config.custom_metric)
         except SQLConnectionError as e:
             raise e
         except Exception as e:
@@ -968,19 +968,22 @@ class SQLServer(AgentCheck):
                             # Reference: https://github.com/mkleehammer/pyodbc/wiki/Calling-Stored-Procedures
                             call_proc = '{{CALL {}}}'.format(proc)
                             cursor.execute(call_proc)
-        
+
                         rows = cursor.fetchall()
                         self.log.debug("Row count (%s) : %s", proc, cursor.rowcount)
-        
+
                         for row in rows:
                             tags = [] if row.tags is None or row.tags == '' else row.tags.split(',')
                             tags.extend(custom_tags)
-        
+
                             if row.type.lower() in self.proc_type_mapping:
                                 self.proc_type_mapping[row.type](row.metric, row.value, tags, raw=True)
                             else:
                                 self.log.warning(
-                                    '%s is not a recognised type from procedure %s, metric %s', row.type, proc, row.metric
+                                    '%s is not a recognised type from procedure %s, metric %s',
+                                    row.type,
+                                    proc,
+                                    row.metric,
                                 )
                     except Exception as e:
                         self.log.warning("Could not call procedure %s: %s", proc, e)

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -11,8 +11,8 @@ from collections import defaultdict
 import six
 from cachetools import TTLCache
 
-from datadog_checks.base.config import is_affirmative
 from datadog_checks.base import AgentCheck
+from datadog_checks.base.config import is_affirmative
 from datadog_checks.base.utils.db import QueryExecutor, QueryManager
 from datadog_checks.base.utils.db.utils import default_json_event_encoding, resolve_db_host, tracked_query
 from datadog_checks.base.utils.serialization import json
@@ -336,6 +336,10 @@ class SQLServer(AgentCheck):
                 # Do the database exist check that will allow to disable _check as a whole
                 # as otherwise the first call to open_managed_default_connection will throw the
                 # SQLConnectionError.
+                self.warning(
+                    "The parameter 'ignore_missing_database' is deprecated"
+                    "if you are unsure about the database name please use 'database_autodiscovery'"
+                )
                 db_exists, context = self.connection.check_database()
                 if not db_exists:
                     self.do_check = False
@@ -346,7 +350,7 @@ class SQLServer(AgentCheck):
                     with self.connection.get_managed_cursor() as cursor:
                         self.autodiscover_databases(cursor)
                     self._make_metric_list_to_collect(self._config.custom_metric)
-        except SQLConnectionError as e:
+        except SQLConnectionError:
             raise
         except Exception as e:
             self.log.exception("Initialization exception %s", e)

--- a/sqlserver/tests/test_metrics.py
+++ b/sqlserver/tests/test_metrics.py
@@ -203,6 +203,7 @@ def test_check_index_usage_metrics(
 ):
     instance_docker_metrics['database'] = 'datadog_test'
     instance_docker_metrics['include_index_usage_metrics'] = True
+    instance_docker_metrics['ignore_missing_database'] = True
 
     # Cause an index seek
     bob_conn.execute_with_retries(
@@ -379,6 +380,7 @@ def test_check_incr_fraction_metrics(
     bob_conn_raw,
 ):
     instance_docker_metrics['database'] = 'datadog_test'
+    instance_docker_metrics['ignore_missing_database'] = True
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
 
     sqlserver_check.run()

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -9,7 +9,6 @@ from collections import namedtuple
 import mock
 import pytest
 
-from datadog_checks.base.errors import ConfigurationError
 from datadog_checks.dev import EnvVars
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.connection import split_sqlserver_host_port

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -42,7 +42,6 @@ def test_get_cursor(instance_docker):
 def test_missing_db(instance_docker, dd_run_check):
     instance = copy.copy(instance_docker)
     instance['ignore_missing_database'] = False
-    import mock
 
     with mock.patch(
         'datadog_checks.sqlserver.connection.Connection.open_managed_default_connection',

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -45,7 +45,10 @@ def test_missing_db(instance_docker, dd_run_check):
     instance['ignore_missing_database'] = False
     import mock
 
-    with mock.patch('datadog_checks.sqlserver.connection.Connection.open_managed_default_connection', side_effect=SQLConnectionError(Exception("couldnt connect"))):
+    with mock.patch(
+        'datadog_checks.sqlserver.connection.Connection.open_managed_default_connection',
+        side_effect=SQLConnectionError(Exception("couldnt connect")),
+    ):
         with pytest.raises(SQLConnectionError):
             check = SQLServer(CHECK_NAME, {}, [instance])
             check.initialize_connection()
@@ -58,6 +61,7 @@ def test_missing_db(instance_docker, dd_run_check):
         check.make_metric_list_to_collect()
         dd_run_check(check)
         assert check.do_check is False
+
 
 @mock.patch('datadog_checks.sqlserver.connection.Connection.open_managed_default_database')
 @mock.patch('datadog_checks.sqlserver.connection.Connection.get_cursor')
@@ -107,10 +111,10 @@ def test_db_exists(get_cursor, mock_connect, instance_docker_defaults, dd_run_ch
     check.initialize_connection()
     check.make_metric_list_to_collect()
     assert check.do_check is True
-    
+
     # check case sensitive but mismatched db
     instance['database'] = 'cASEsENSITIVE2018'
-    check = SQLServer(CHECK_NAME, {}, [instance])    
+    check = SQLServer(CHECK_NAME, {}, [instance])
     check.initialize_connection()
     check.make_metric_list_to_collect()
     assert check.do_check is False
@@ -121,6 +125,7 @@ def test_db_exists(get_cursor, mock_connect, instance_docker_defaults, dd_run_ch
     check.initialize_connection()
     check.make_metric_list_to_collect()
     assert check.do_check is True
+
 
 @mock.patch('datadog_checks.sqlserver.connection.Connection.open_managed_default_database')
 @mock.patch('datadog_checks.sqlserver.connection.Connection.get_cursor')


### PR DESCRIPTION
### What does this PR do?
Removes the database exist check in sql_integration if ignore_missing_database is set to false

### Motivation
The database exist check got introduced in https://github.com/DataDog/integrations-core/pull/357 for the reason that we don't see as valid anymore. The check is error prone and causes false positive. Nevertheless in order to avoid a breaking change we dont modify the behaviour for users that set ignore_missing_database to true. For user who set it to False we remove the check as anyway the exception when connecting to database will be thrown.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
