### PR TITLE
DOCS-7515: update kafka_consumer readme

### DIFF
--- a/kafka_consumer/README.md
+++ b/kafka_consumer/README.md
@@ -4,13 +4,13 @@
 
 ## Overview
 
-This Agent check only collects metrics for message offsets. If you want to collect JMX metrics from the Kafka brokers or Java-based consumers/producers, see the kafka check.
+This Agent check only collects metrics for message offsets. If you want to collect JMX metrics from the Kafka brokers or Java-based consumers/producers, see the Kafka check.
 
 If you would benefit from visualizing the topology of your streaming data pipelines, or from investigating localized bottlenecks within your data streams setup, check out [Data Streams Monitoring][16].
 
-This check fetches the highwater offsets from the Kafka brokers, consumer offsets that are stored in Kafka or zookeeper (for old-style consumers), and the calculated consumer lag (which is the difference between the broker offset and the consumer offset).
+This check fetches the highwater offsets from the Kafka brokers, consumer offsets that are stored in Kafka or Zookeeper (for old-style consumers), and the calculated consumer lag (which is the difference between the broker offset and the consumer offset).
 
-**Note:** This integration ensures that consumer offsets are checked before broker offsets because worst case is that consumer lag is a little overstated. Doing it in reverse can understate consumer lag to the point of having negative values, which is a dire scenario usually indicating messages are being skipped.
+**Note:** This integration ensures that consumer offsets are checked before broker offsets; in the worst case, consumer lag may be a little overstated. Checking these offsets in the reverse order can understate consumer lag to the point of having negative values, which is a dire scenario usually indicating messages are being skipped.
 
 ## Setup
 
@@ -42,7 +42,19 @@ This check does not collect additional logs. To collect logs from Kafka brokers,
 
 #### Containerized
 
-For containerized environments, see the [Autodiscovery with JMX][7] guide.
+For containerized environments, see the [Autodiscovery Integration Templates][17] for guidance on applying the parameters below.
+
+##### Metric collection
+
+| Parameter            | Value                                |
+| -------------------- | ------------------------------------ |
+| `<INTEGRATION_NAME>` | `kafka_consumer`                     |
+| `<INIT_CONFIG>`      | blank or `{}`                        |
+| `<INSTANCE_CONFIG>`  | `{"kafka_connect_str": <KAFKA_CONNECT_STR>}` <br/>For example, `{"kafka_connect_str": "server:9092"}` |
+
+##### Log collection
+
+This check does not collect additional logs. To collect logs from Kafka brokers, see [log collection instructions for Kafka][6].
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->
@@ -131,3 +143,4 @@ sudo service datadog-agent restart
 [14]: https://www.datadoghq.com/blog/collecting-kafka-performance-metrics
 [15]: https://www.datadoghq.com/blog/monitor-kafka-with-datadog
 [16]: https://www.datadoghq.com/product/data-streams-monitoring/
+[17]: https://docs.datadoghq.com/containers/kubernetes/integrations/


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates the `kafka_consumer` readme to use non-JMX containerized instructions.

### Motivation
Flagged by support, kafka_consumer is not a JMX check.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
