### PR TITLE
Collect postgres table owner in database-monitoring schema payloads

### DIFF
--- a/postgres/changelog.d/17314.added
+++ b/postgres/changelog.d/17314.added
@@ -1,0 +1,1 @@
+Collect the postgres table owner field in postgres schema payloads, which will be displayed in the database-monitoring schemas feature. 

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -401,8 +401,10 @@ class PostgresMetadata(DBMAsyncJob):
             this_payload = {}
             name = table["name"]
             table_id = table["id"]
+            table_owner = table["owner"]
             this_payload.update({"id": str(table["id"])})
             this_payload.update({"name": name})
+            this_payload.update({"owner": table_owner})
             if table["hasindexes"]:
                 cursor.execute(PG_INDEXES_QUERY.format(tablename=name))
                 rows = cursor.fetchall()

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -91,7 +91,7 @@ def test_collect_schemas(integration_check, dbm_instance, aggregator):
         if table['name'] == "persons":
             # check that foreign keys, indexes get reported
             keys = list(table.keys())
-            assert_fields(keys, ["foreign_keys", "columns", "toast_table", "id", "name"])
+            assert_fields(keys, ["foreign_keys", "columns", "toast_table", "id", "name", "owner"])
             assert_fields(list(table['foreign_keys'][0].keys()), ['name', 'definition'])
             assert_fields(
                 list(table['columns'][0].keys()),
@@ -104,7 +104,7 @@ def test_collect_schemas(integration_check, dbm_instance, aggregator):
             )
         if table['name'] == "cities":
             keys = list(table.keys())
-            assert_fields(keys, ["indexes", "columns", "toast_table", "id", "name"])
+            assert_fields(keys, ["indexes", "columns", "toast_table", "id", "name", "owner"])
             assert_fields(list(table['indexes'][0].keys()), ['name', 'definition'])
         if float(POSTGRES_VERSION) >= 11:
             if table['name'] in ('test_part', 'test_part_no_activity'):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds the postgres table `owner`, which we already have support for in our backend. We were [always collecting this](https://github.com/DataDog/integrations-core/blob/master/postgres/datadog_checks/postgres/metadata.py#L62) in our queries, but never sending it to the backend to be used in our schemas UI. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
