### PR TITLE
Collect all metrics by default for the OpenMetrics integration in the serve payload script

### DIFF
--- a/ddev/changelog.d/17316.added
+++ b/ddev/changelog.d/17316.added
@@ -1,0 +1,1 @@
+Collect all metrics by default for the OpenMetrics integration in the serve payload script

--- a/ddev/src/ddev/cli/meta/scripts/serve_openmetrics_payload.py
+++ b/ddev/src/ddev/cli/meta/scripts/serve_openmetrics_payload.py
@@ -78,6 +78,9 @@ def serve_openmetrics_payload(
             ],
         }
 
+        if integration == 'openmetrics':
+            check_config['instances'][0]['metrics'] = [".*"]
+
     metadata = {
         "docker_volumes": [
             f"{HERE}/scripts/serve.py:/tmp/serve.py",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Collect all metrics by default for the OpenMetrics integration in the serve payload script

### Motivation
<!-- What inspired you to submit this pull request? -->

This is not needed for OM-based integrations because we override the `metrics` option for them, but not for the default OM integration. That way we can collect everything by default

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
