### PR TITLE
Remove empty process_signatures field

### DIFF
--- a/pan_firewall/manifest.json
+++ b/pan_firewall/manifest.json
@@ -39,7 +39,6 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
-      "process_signatures": [],
       "source_type_id": 10155,
       "auto_install": true
     },

--- a/tokumx/manifest.json
+++ b/tokumx/manifest.json
@@ -42,7 +42,6 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
-      "process_signatures": [],
       "source_type_id": 74,
       "auto_install": true
     },


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates 2 manifest to remove their empty "process signatures" field. These are the only two integrations that list the field with an empty list. 

### Motivation
<!-- What inspired you to submit this pull request? -->
Cleans up two unused fields while we work on finalizing a migration of certain fields over to APW! 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
