### PR TITLE
Add mongo 6 and 7 to the test environments

### DIFF
--- a/mongo/hatch.toml
+++ b/mongo/hatch.toml
@@ -7,7 +7,7 @@ dependencies = [
 
 [[envs.default.matrix]]
 python = ["3.11"]
-version = ["4.4", "5.0"]
+version = ["4.4", "5.0", "6.0", "7.0"]
 flavor = ["standalone", "shard", "auth", "tls"]
 
 [envs.default.overrides]

--- a/mongo/tests/test_e2e.py
+++ b/mongo/tests/test_e2e.py
@@ -2,10 +2,11 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
+from packaging import version
 
 from datadog_checks.mongo import MongoDb
 
-from .common import HOST, PORT1, auth, shard, standalone, tls
+from .common import HOST, MONGODB_VERSION, PORT1, auth, shard, standalone, tls
 
 BASE_METRICS = [
     'mongodb.connections.available',
@@ -38,11 +39,14 @@ BASE_METRICS = [
 ]
 
 MONGOS_METRICS = BASE_METRICS + [
-    'mongodb.stats.filesize',
     'mongodb.stats.indexsize',
     'mongodb.stats.datasize',
     'mongodb.stats.indexes',
     'mongodb.stats.objects',
+]
+
+MONGOS_METRICS_PRE_VERSION_7 = [
+    'mongodb.stats.filesize',
 ]
 
 MONGOD_METRICS = BASE_METRICS + [
@@ -71,8 +75,13 @@ def test_e2e_mongo_standalone(dd_agent_check, instance_user):
 @pytest.mark.e2e
 def test_e2e_mongo_shard(dd_agent_check, instance_authdb):
     aggregator = dd_agent_check(instance_authdb, rate=True)
+
     for metric in MONGOS_METRICS:
         aggregator.assert_metric(metric)
+
+    if version.parse(MONGODB_VERSION) < version.parse('7.0'):
+        for metric in MONGOS_METRICS_PRE_VERSION_7:
+            aggregator.assert_metric(metric)
     aggregator.assert_service_check('mongodb.can_connect', status=MongoDb.OK)
 
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add mongo 6 and 7 to the test environments

### Motivation
<!-- What inspired you to submit this pull request? -->

We do not test with the latest versions

### Additional Notes
<!-- Anything else we should know when reviewing? -->

The `mongo` command got dropped https://www.mongodb.com/docs/manual/release-notes/6.0-compatibility/#legacy-mongo-shell-removed

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
