### PR TITLE
Declare sonarqube as Python 2 compatible

### DIFF
--- a/sonarqube/changelog.d/17323.fixed
+++ b/sonarqube/changelog.d/17323.fixed
@@ -1,0 +1,1 @@
+Declare the integration as  Python 2 compatible

--- a/sonarqube/pyproject.toml
+++ b/sonarqube/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.11",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Declare sonarqube as Python 2 compatible

### Motivation
<!-- What inspired you to submit this pull request? -->

We test it on Py2 https://github.com/DataDog/integrations-core/blob/81b91a54328f174c5c1e92cb818640cba1ddfec3/sonarqube/hatch.toml#L4 and it works fine

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
