### PR TITLE
Add back troubleshooting header

### DIFF
--- a/oracle/README.md
+++ b/oracle/README.md
@@ -419,6 +419,8 @@ The Oracle Database check does not include any events.
 
 See [service_checks.json][12] for a list of service checks provided by this integration.
 
+## Troubleshooting
+
 Need help? Contact [Datadog support][14].
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/oracle/images/oracle_dashboard.png


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR looks to have accidentally removed the `## Troubleshooting` header - https://github.com/DataDog/integrations-core/commit/6bb58bb3bd4aa410f86682eb814d0ff3f2428624

### Motivation
<!-- What inspired you to submit this pull request? -->
This is a required header. We plan on adding stronger validations around these kinda of things in the future. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
