### PR TITLE
Update README.md

### DIFF
--- a/openmetrics/README.md
+++ b/openmetrics/README.md
@@ -68,7 +68,7 @@ By default, the integration skips metrics that come without a type on a Promethe
 
 ```yaml
   metrics:
-    - "metric_without_type":
+    - "<NAME_OF_METRIC_WITHOUT_TYPE>":
         "type": "gauge"
 ```
 


### PR DESCRIPTION
Slight change of missing untyped metric configuration.  Indeed customers are often trying to directly add "metric_without_type" instead of the untyped metric name.

### What does this PR do?
Slight change of missing untyped metric configuration. 
Indeed customers are often trying to directly add "metric_without_type" instead of the untyped metric name.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
