### PR TITLE
Add a comment to the PR when the `removed` fragment is used

### DIFF
--- a/.github/workflows/pr-quick-check.yml
+++ b/.github/workflows/pr-quick-check.yml
@@ -63,14 +63,16 @@ jobs:
       id: changes
       with:
         filters: |
-          changed_fragments:
+          major_bump_fragments:
             - '*/changelog.d/*.changed'
+            - '*/changelog.d/*.removed'
+            - '*/changelog.d/*.major'
 
     - name: Comment
-      if: ${{ steps.changes.outputs.changed_fragments == 'true' }}
+      if: ${{ steps.changes.outputs.major_bump_fragments == 'true' }}
       uses: actions/github-script@0.3.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
-          github.issues.createComment({ issue_number, owner, repo, body: "The changelog type `changed` was used in this Pull Request, so the next release will bump major version. Please make sure this is a breaking change, or use the `fixed` or `added` type instead." });
+          github.issues.createComment({ issue_number, owner, repo, body: "The changelog type `changed` or `removed` was used in this Pull Request, so the next release will bump major version. Please make sure this is a breaking change, or use the `fixed` or `added` type instead." });


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add a comment to the PR when the `removed` fragment is used

### Motivation
<!-- What inspired you to submit this pull request? -->

This is also a major bump https://github.com/DataDog/integrations-core/blob/6194881ba79a1646a93a012a7501e7e2e490b2d5/datadog_checks_dev/datadog_checks/dev/tooling/constants.py#L39-L53

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
