### PR TITLE
Do not fail if no tags are provided in the config

### DIFF
--- a/ibm_ace/changelog.d/17336.fixed
+++ b/ibm_ace/changelog.d/17336.fixed
@@ -1,0 +1,1 @@
+Do not fail if no tags are provided in the config

--- a/ibm_ace/datadog_checks/ibm_ace/check.py
+++ b/ibm_ace/datadog_checks/ibm_ace/check.py
@@ -32,7 +32,11 @@ class IbmAceCheck(AgentCheck, ConfigMixin):
                 self.disconnect()
 
     def initialize_config(self):
-        tags = [f'mq_server:{self.config.mq_server}', f'mq_port:{self.config.mq_port}', *self.config.tags]
+        tags = [f'mq_server:{self.config.mq_server}', f'mq_port:{self.config.mq_port}']
+
+        if self.config.tags:
+            tags.extend(self.config.tags)
+
         self._tags = tuple(tags)
 
         cd = pymqi.CD()

--- a/ibm_ace/tests/test_integration.py
+++ b/ibm_ace/tests/test_integration.py
@@ -33,6 +33,30 @@ def test(dd_run_check, aggregator, instance, global_tags):
     aggregator.assert_metrics_using_metadata(metadata_metrics, check_metric_type=False)
 
 
+@pytest.mark.usefixtures('dd_environment')
+def test_without_extra_tags(dd_run_check, aggregator, instance):
+    instance.pop('tags')
+
+    tags = [f'mq_server:{instance["mq_server"]}', f'mq_port:{instance["mq_port"]}']
+
+    from datadog_checks.ibm_ace import IbmAceCheck
+
+    check = IbmAceCheck('ibm_ace', {}, [instance])
+    dd_run_check(check)
+
+    for subscription_type, num_messages in (('resource_statistics', 1), ('message_flows', 2)):
+        local_tags = [f'subscription:{subscription_type}', *tags]
+        aggregator.assert_service_check('ibm_ace.mq.subscription', ServiceCheck.OK, tags=local_tags)
+        aggregator.assert_metric('ibm_ace.messages.current', num_messages, tags=local_tags)
+
+    metadata_metrics = get_metadata_metrics()
+    for metric in metadata_metrics:
+        aggregator.assert_metric(metric, at_least=0)
+
+    aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(metadata_metrics, check_metric_type=False)
+
+
 def test_critical_service_check(dd_agent_check, instance, global_tags):
     try:
         aggregator = dd_agent_check(instance)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Do not fail if no tags are provided in the config

### Motivation
<!-- What inspired you to submit this pull request? -->

This field is optional and defaults to `None`. The problem is if we run the check without specifying any tags in the instance config, we end up failing here: https://github.com/DataDog/integrations-core/blob/master/ibm_ace/datadog_checks/ibm_ace/check.py#L35

With this kind of error: 

```
      Error: Value after * must be an iterable, not NoneType
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.11/site-packages/datadog_checks/base/checks/base.py", line 1210, in run
          initialization()
        File "/opt/datadog-agent/embedded/lib/python3.11/site-packages/datadog_checks/ibm_ace/check.py", line 35, in initialize_config
          tags = [f'mq_server:{self.config.mq_server}', f'mq_port:{self.config.mq_port}', *self.config.tags]
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
