### PR TITLE
Persist the target image digest

### DIFF
--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -170,11 +170,17 @@ jobs:
       if: github.event_name == 'push' && steps.changed-files.outputs.builders_any_changed == 'true'
       run: ${DOCKER} push ${{ env.BUILDER_IMAGE }}
 
-    - name: Save image digest
+    - name: Save new image digest
       if: github.event_name == 'push' && steps.changed-files.outputs.builders_any_changed == 'true'
       run: >-
         ${DOCKER} inspect --format "{{index .RepoDigests 0}}" ${{ env.BUILDER_IMAGE }}
         | cut -d '@' -f 2
+        > ${{ env.OUT_DIR }}/image_digest
+
+    - name: Persist current image digest
+      if: github.event_name == 'push' && steps.changed-files.outputs.builders_any_changed != 'true'
+      run: >-
+        jq -r '.["${{ matrix.job.image }}"]' .deps/image_digests.json
         > ${{ env.OUT_DIR }}/image_digest
 
     - name: Upload artifacts


### PR DESCRIPTION
### Motivation

The fix yesterday https://github.com/DataDog/integrations-core/pull/17331 also introduced another issue [`34105da` (#17333)](https://github.com/DataDog/integrations-core/pull/17333/commits/34105da07d6f36f79d9457e97d84f35bd4ddc681) which is why the conditional was set up like that originally.

Now both cases are handled; we either get the new digest from registry or we copy the existing one.