### PR TITLE
Make default maximums more prominent in the config

### DIFF
--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -679,7 +679,9 @@ instances:
     # collect_node_metrics: true
 
     ## @param nodes - list of strings - optional
-    ## Use the `nodes` parameters to specify the nodes you'd like to collect metrics on (up to 100 nodes).
+    ## Use the `nodes` parameters to specify the nodes you'd like to collect metrics on.
+    ## The default maximum number of nodes is 100. Exceeding this limit can cause data loss. 
+    ## To increase the maximum, contact customer support.
     #
     # nodes:
     #   - <NODE_NAME_1>
@@ -696,7 +698,9 @@ instances:
     #   - <REGEX>
 
     ## @param queues - list of strings - optional
-    ## Use the `queues` parameters to specify the queues you'd like to collect metrics on (up to 200 queues).
+    ## Use the `queues` parameters to specify the queues you'd like to collect metrics on.
+    ## The default maximum number of queues is 200. Exceeding this limit can cause 
+    ## data loss. To increase the maximum, contact customer support.
     #
     # queues:
     #   - <QUEUE_NAME_1>
@@ -720,7 +724,9 @@ instances:
     #   - <REGEX>
 
     ## @param exchanges - list of strings - optional
-    ## Use the `exchanges` parameters to specify the exchanges you'd like to collect metrics on (up to 50 exchanges).
+    ## Use the `exchanges` parameters to specify the exchanges you'd like to collect metrics on.
+    ## The default maximum number of exchanges is 50. Exceeding this limit can cause 
+    ## data loss. To increase the maximum, contact customer support.
     #
     # exchanges:
     #   - <EXCHANGE_1>


### PR DESCRIPTION
### What does this PR do?
Make the default maximums more prominent in the config, as customers aren't noticing the limits and are experiencing data loss.

### Motivation
DOCS-7477

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
