### PR TITLE
Fix the message when tests are skipped because of the platform

### DIFF
--- a/ddev/tests/conftest.py
+++ b/ddev/tests/conftest.py
@@ -246,19 +246,19 @@ def helpers():
 def pytest_runtest_setup(item):
     for marker in item.iter_markers():
         if marker.name == 'requires_ci' and not running_in_ci():  # no cov
-            pytest.skip('Not running in CI')
+            pytest.skip('Only running in CI')
 
         if marker.name == 'requires_windows' and not PLATFORM.windows:
-            pytest.skip('Not running on Windows')
+            pytest.skip('Only running on Windows')
 
         if marker.name == 'requires_macos' and not PLATFORM.macos:
-            pytest.skip('Not running on macOS')
+            pytest.skip('Only running on macOS')
 
         if marker.name == 'requires_linux' and not PLATFORM.linux:
-            pytest.skip('Not running on Linux')
+            pytest.skip('Only running on Linux')
 
         if marker.name == 'requires_unix' and PLATFORM.windows:
-            pytest.skip('Not running on a Linux-based platform')
+            pytest.skip('Only running on a Linux-based platform')
 
 
 def pytest_configure(config):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix the message when tests are skipped because of the platform 

### Motivation
<!-- What inspired you to submit this pull request? -->

On my mac I got: 

```
tests/utils/test_json.py::test_save PASSED                               [ 94%]
tests/utils/test_platform.py::TestWindows::test_tag SKIPPED (Only running on Windows) [ 94%]
tests/utils/test_platform.py::TestWindows::test_format_for_subprocess_list SKIPPED (Not running on Windows) [ 94%]
tests/utils/test_platform.py::TestWindows::test_format_for_subprocess_list_shell SKIPPED (Not running on Windows) [ 95%]
tests/utils/test_platform.py::TestWindows::test_format_for_subprocess_string SKIPPED (Not running on Windows) [ 95%]
tests/utils/test_platform.py::TestWindows::test_format_for_subprocess_string_shell SKIPPED (Not running on Windows) [ 95%]
tests/utils/test_platform.py::TestMacOS::test_tag PASSED                 [ 95%]
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
