### PR TITLE
Do not open the editor if no changelog should be generated in the changelog new command

### DIFF
--- a/ddev/changelog.d/17348.fixed
+++ b/ddev/changelog.d/17348.fixed
@@ -1,0 +1,1 @@
+Do not open the editor if no changelog should be generated in the changelog new command

--- a/ddev/src/ddev/cli/release/changelog/new.py
+++ b/ddev/src/ddev/cli/release/changelog/new.py
@@ -42,7 +42,7 @@ def new(app: Application, entry_type: str | None, targets: tuple[str], message: 
         towncrier(check.path, *create_command)
         edited += 1
 
-    if edited == 0:
+    if not edited:
         app.display_info('No changelog entries to create')
     else:
         app.display_success(f'Added {edited} changelog entr{"ies" if edited > 1 else "y"}')

--- a/ddev/src/ddev/cli/release/changelog/new.py
+++ b/ddev/src/ddev/cli/release/changelog/new.py
@@ -32,11 +32,27 @@ def new(app: Application, entry_type: str | None, targets: tuple[str], message: 
     """
     from datadog_checks.dev.tooling.commands.release.changelog import towncrier
 
+    create_command = None
+
+    edited = 0
+    for check in app.repo.integrations.iter_changed_code(targets):
+        if not create_command:
+            create_command = __get_create_command(app, entry_type, message)
+
+        towncrier(check.path, *create_command)
+        edited += 1
+
+    if edited == 0:
+        app.display_info('No changelog entries to create')
+    else:
+        app.display_success(f'Added {edited} changelog entr{"ies" if edited > 1 else "y"}')
+
+
+def __get_create_command(app, entry_type, message):
     from ddev.release.constants import ENTRY_TYPES
 
     latest_commit = app.repo.git.latest_commit
     pr = app.github.get_pull_request(latest_commit.sha)
-    message_based_on_git = ''
     if pr is not None:
         pr_number = pr.number
         message_based_on_git = pr.title
@@ -44,20 +60,14 @@ def new(app: Application, entry_type: str | None, targets: tuple[str], message: 
         pr_number = app.github.get_next_issue_number()
         message_based_on_git = latest_commit.subject
 
-    if entry_type is not None:
-        if entry_type not in ENTRY_TYPES:
-            app.abort(f'Unknown entry type: {entry_type}')
-    else:
+    if entry_type is None:
         entry_type = click.prompt('Entry type?', type=click.Choice(ENTRY_TYPES, case_sensitive=False))
+    elif entry_type not in ENTRY_TYPES:
+        app.abort(f'Unknown entry type: {entry_type}')
 
-    create_cmd = [
+    return [
         'create',
         '--content',
         message or click.edit(text=message_based_on_git, require_save=False) or message_based_on_git,
         f'{pr_number}.{entry_type}',
     ]
-    edited = 0
-    for check in app.repo.integrations.iter_changed_code(targets):
-        towncrier(check.path, *create_cmd)
-        edited += 1
-    app.display_success(f'Added {edited} changelog entr{"ies" if edited > 1 else "y"}')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Do not open the editor if no changelog should be generated in the changelog new command

### Motivation
<!-- What inspired you to submit this pull request? -->

I ran the `changelog new` command for a PR that only changed a `conftest.py` file. No changelog files were generated (which is expected) but I got confused because ddev opened the editor and the success message was misleading. I thought there was a bug in the command before figuring out it's actually the expected behaviour.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
