### PR TITLE
Fix a flaky test

### DIFF
--- a/mongo/tests/test_integration_standalone.py
+++ b/mongo/tests/test_integration_standalone.py
@@ -94,7 +94,7 @@ def test_mongo_dbstats_tag(aggregator, check, instance_dbstats_tag_dbname, dd_ru
     aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)
 
     expected_metrics = {
-        'mongodb.stats.avgobjsize': 0,
+        'mongodb.stats.avgobjsize': None,
         'mongodb.stats.storagesize': 20480.0,
     }
     expected_tags = [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix a flaky test

### Motivation
<!-- What inspired you to submit this pull request? -->

- https://github.com/DataDog/integrations-core/actions/runs/8566070893/job/23475209496
- We don't care about the value here, we just care about the tags. Values are asserted in unit tests

```
FAILED tests/test_integration_standalone.py::test_mongo_dbstats_tag - AssertionError: Needed exactly 1 candidates for 'mongodb.stats.avgobjsize', got 0
Expected:
        MetricStub(name='mongodb.stats.avgobjsize', type=None, value=0, tags=['server:mongodb://localhost:27017/'], hostname=None, device=None, flush_first_value=None)
Similar submitted:
Score   Most similar
0.80    MetricStub(name='mongodb.stats.avgobjsize', type=0, value=1987.0, tags=['server:mongodb://localhost:27017/'], hostname='', device=None, flush_first_value=False)
0.80    MetricStub(name='mongodb.stats.avgobjsize', type=0, value=99.0, tags=['server:mongodb://localhost:27017/'], hostname='', device=None, flush_first_value=False)
0.80    MetricStub(name='mongodb.stats.avgobjsize', type=0, value=37.77777777777778, tags=['server:mongodb://localhost:27017/'], hostname='', device=None, flush_first_value=False)
0.80    MetricStub(name='mongodb.stats.avgobjsize', type=0, value=27.974683544303797, tags=['server:mongodb://localhost:27017/'], hostname='', device=None, flush_first_value=False)
0.80    MetricStub(name='mongodb.stats.avgobjsize', type=0, value=27.974683544303797, tags=['server:mongodb://localhost:27017/'], hostname='', device=None, flush_first_value=False)
0.77    MetricStub(name='mongodb.asserts.msgps', type=1, value=0.0, tags=['server:mongodb://localhost:27017/'], hostname='', device=None, flush_first_value=False)
0.77    MetricStub(name='mongodb.asserts.warningps', type=1, value=0.0, tags=['server:mongodb://localhost:27017/'], hostname='', device=None, flush_first_value=False)
0.74    MetricStub(name='mongodb.asserts.regularps', type=1, value=0.0, tags=['server:mongodb://localhost:27017/'], hostname='', device=None, flush_first_value=False)
0.73    MetricStub(name='mongodb.asserts.rolloversps', type=1, value=0.0, tags=['server:mongodb://localhost:27017/'], hostname='', device=None, flush_first_value=False)
0.72    MetricStub(name='mongodb.opcounters.getmoreps', type=1, value=0.0, tags=['server:mongodb://localhost:27017/'], hostname='', device=None, flush_first_value=False)
0.72    MetricStub(name='mongodb.metrics.ttl.passesps', type=1, value=0.0, tags=['server:mongodb://localhost:27017/'], hostname='', device=None, flush_first_value=False)
0.72    MetricStub(name='mongodb.oplatencies.reads.latency', type=0, value=0.0, tags=['server:mongodb://localhost:27017/'], hostname='', device=None, flush_first_value=False)
0.71    MetricStub(name='mongodb.metrics.repl.buffer.sizebytes', type=0, value=0.0, tags=['server:mongodb://localhost:27017/'], hostname='', device=None, flush_first_value=False)
0.71    MetricStub(name='mongodb.fsynclocked', type=0, value=0.0, tags=['server:mongodb://localhost:27017/'], hostname='', device=None, flush_first_value=False)
0.71    MetricStub(name='mongodb.oplatencies.reads.latencyps', type=1, value=0.0, tags=['server:mongodb://localhost:27017/'], hostname='', device=None, flush_first_value=False)
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
