### PR TITLE
Update README.md

### DIFF
--- a/sonarqube/README.md
+++ b/sonarqube/README.md
@@ -326,7 +326,7 @@ Need help? Contact [Datadog support][8].
 [2]: https://app.datadoghq.com/account/settings/agent/latest
 [3]: https://github.com/DataDog/integrations-core/blob/master/sonarqube/datadog_checks/sonarqube/data/metrics.yaml
 [4]: https://docs.sonarqube.org/latest/instance-administration/monitoring/
-[5]: https://docs.sonarqube.org/latest/instance-administration/monitoring/#header-4
+[5]: https://docs.sonarsource.com/sonarqube/latest/instance-administration/monitoring/instance/#how-do-i-activate-jmx
 [6]: https://docs.datadoghq.com/integrations/java/
 [7]: https://github.com/DataDog/integrations-core/blob/master/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
 [8]: https://docs.datadoghq.com/help/


### PR DESCRIPTION

<img width="1205" alt="SonarQube broken link" src="https://github.com/DataDog/integrations-core/assets/4161079/40d7af24-1970-489f-80d3-5e03cd7371d8">
<img width="885" alt="SonarQube Text" src="https://github.com/DataDog/integrations-core/assets/4161079/adfbd948-bdf4-4f1c-9826-912cc746b389">
In this text block "SonarQube’s JMX server is not enabled by default, " the URL to SonarQube Page was broken or not directing to the right page as maybe SonarQube updated their documentation. Changed the URL [5]
from:https://docs.sonarqube.org/latest/instance-administration/monitoring/#header-4 to: https://docs.sonarsource.com/sonarqube/latest/instance-administration/monitoring/instance/#how-do-i-activate-jmx

### What does this PR do?
Updating the link to sonarqube documentation

### Motivation
Using the integration on a Zendesk ticket noticed the link was broken

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
