### PR TITLE
Skip index fragmentation metrics for tempdb

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -197,6 +197,17 @@ files:
       value:
         type: boolean
         example: false
+    - name: include_db_fragmentation_metrics_tempdb
+      description: |
+        Configure the collection of database index fragmentation statistics in tempdb database from the
+        `sys.dm_db_index_physical_stats` DMF.
+
+        By default, we do not collect index fragmentation statistics in the tempdb database, as those queries
+        might cause blocking. This configuration parameter allows enabling the collection of this metric.
+        This parameter is ignored if 'include_db_fragmentation_metrics' is set to false.
+      value:
+        type: boolean
+        example: false
     - name: include_index_usage_metrics
       description: |
         Configure the collection of user table index usage statistics from the `sys.dm_db_index_usage_stats` DMV.

--- a/sqlserver/changelog.d/17361.added
+++ b/sqlserver/changelog.d/17361.added
@@ -1,0 +1,1 @@
+Add a new config option include_db_fragmentation_metrics_tempdb to skip index fragmentation metrics for tempdb. By default, index fragmentation metrics are NOT be collected for tempdb.

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -29,6 +29,9 @@ class SQLServerConfig:
         self.include_index_usage_metrics_tempdb: bool = is_affirmative(
             instance.get('include_index_usage_metrics_tempdb', False)
         )
+        self.include_db_fragmentation_metrics_tempdb: bool = is_affirmative(
+            instance.get('include_db_fragmentation_metrics_tempdb', False)
+        )
         self.ignore_missing_database = is_affirmative(instance.get("ignore_missing_database", False))
         if self.ignore_missing_database:
             self.log.warning(

--- a/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
@@ -68,6 +68,10 @@ def instance_include_db_fragmentation_metrics():
     return False
 
 
+def instance_include_db_fragmentation_metrics_tempdb():
+    return False
+
+
 def instance_include_fci_metrics():
     return False
 

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -173,6 +173,7 @@ class InstanceConfig(BaseModel):
     ignore_missing_database: Optional[bool] = None
     include_ao_metrics: Optional[bool] = None
     include_db_fragmentation_metrics: Optional[bool] = None
+    include_db_fragmentation_metrics_tempdb: Optional[bool] = None
     include_fci_metrics: Optional[bool] = None
     include_index_usage_metrics: Optional[bool] = None
     include_index_usage_metrics_tempdb: Optional[bool] = None

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -188,6 +188,16 @@ instances:
     #
     # include_db_fragmentation_metrics: false
 
+    ## @param include_db_fragmentation_metrics_tempdb - boolean - optional - default: false
+    ## Configure the collection of database index fragmentation statistics in tempdb database from the
+    ## `sys.dm_db_index_physical_stats` DMF.
+    ##
+    ## By default, we do not collect index fragmentation statistics in the tempdb database, as those queries
+    ## might cause blocking. This configuration parameter allows enabling the collection of this metric.
+    ## This parameter is ignored if 'include_db_fragmentation_metrics' is set to false.
+    #
+    # include_db_fragmentation_metrics_tempdb: false
+
     ## @param include_index_usage_metrics - boolean - optional - default: true
     ## Configure the collection of user table index usage statistics from the `sys.dm_db_index_usage_stats` DMV.
     ##

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -692,7 +692,7 @@ class SqlDbFragmentation(BaseSqlServerMetric):
         "DDIPS.page_count as page_count, "
         "DDIPS.avg_fragmentation_in_percent as avg_fragmentation_in_percent, I.name as index_name "
         "FROM {table} (DB_ID('{{db}}'),null,null,null,null) as DDIPS "
-        "INNER JOIN sys.indexes as I ON I.object_id = DDIPS.object_id "
+        "INNER JOIN sys.indexes as I WITH (nolock) ON I.object_id = DDIPS.object_id "
         "AND DDIPS.index_id = I.index_id "
         "WHERE DDIPS.fragment_count is not null".format(table=TABLE)
     )
@@ -712,6 +712,7 @@ class SqlDbFragmentation(BaseSqlServerMetric):
         logger.debug("%s: gathering fragmentation metrics for these databases: %s", cls.__name__, databases)
 
         for db in databases:
+            print(db)
             ctx = construct_use_statement(db)
             query = cls.QUERY_BASE.format(db=db)
             start = get_precise_time()
@@ -721,6 +722,7 @@ class SqlDbFragmentation(BaseSqlServerMetric):
                 logger.debug("%s: fetch_all executing query: %s", cls.__name__, query)
                 cursor.execute(query)
                 data = cursor.fetchall()
+                print(query, data)
             except Exception as e:
                 logger.warning("Error when trying to query db %s - skipping.  Error: %s", db, e)
                 continue

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -514,6 +514,9 @@ class SQLServer(AgentCheck):
                 self.instance.get('database', self.connection.DEFAULT_DATABASE)
             ]
 
+            if not self._config.include_db_fragmentation_metrics_tempdb:
+                db_names = [db_name for db_name in db_names if db_name != 'tempdb']
+
             if not db_fragmentation_object_names:
                 self.log.debug(
                     "No fragmentation object names specified, will return fragmentation metrics for all "


### PR DESCRIPTION
### What does this PR do?
This PR adds a new config option `include_db_fragmentation_metrics_tempdb` (default to false) to skip index fragmentation metrics for `tempdb`.
By default, index fragmentation will NOT be collected for `tempdb`.

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-3530
We have observed situations where the `sys.dm_db_index_physical_stats` DMF was blocked by `LCK_M_S` locks in `tempdb`. Additionally, there have been instances of deadlocks, with errors like `Transaction was deadlocked on lock resources with another process and has been chosen as the deadlock victim` indicating potential significant contention in `tempdb`.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
