### PR TITLE
Update README.md

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -158,7 +158,7 @@ To configure this check for an Agent running on a host:
         port: 5432
         username: datadog
         password: '<PASSWORD>'
-        dbname: "<DB_NAME>"
+        dbname: '<DB_NAME>'
         relations:
           - relation_regex: .*
     ```

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -140,7 +140,7 @@ To configure this check for an Agent running on a host:
         port: 5432
         username: datadog
         password: '<PASSWORD>'
-        dbname: "<DB_NAME>"
+        dbname: '<DB_NAME>'
         relations:
           - relation_name: products
           - relation_name: external_seller_products

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -148,7 +148,7 @@ To configure this check for an Agent running on a host:
         port: 5432
         username: datadog
         password: '<PASSWORD>'
-        dbname: "<DB_NAME>"
+        dbname: '<DB_NAME>'
         relations:
           - relation_regex: inventory_.*
             relkind:

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -140,6 +140,7 @@ To configure this check for an Agent running on a host:
         port: 5432
         username: datadog
         password: '<PASSWORD>'
+        dbname: "<DB_NAME>"
         relations:
           - relation_name: products
           - relation_name: external_seller_products
@@ -147,6 +148,7 @@ To configure this check for an Agent running on a host:
         port: 5432
         username: datadog
         password: '<PASSWORD>'
+        dbname: "<DB_NAME>"
         relations:
           - relation_regex: inventory_.*
             relkind:
@@ -156,6 +158,7 @@ To configure this check for an Agent running on a host:
         port: 5432
         username: datadog
         password: '<PASSWORD>'
+        dbname: "<DB_NAME>"
         relations:
           - relation_regex: .*
     ```


### PR DESCRIPTION
Add dbname parameter on code example for collecting relations metrics without using autodiscovery

### What does this PR do?
Add dbname parameter on code example for collecting relations metrics without using autodiscovery
As of today, to collect relation metrics, we have 2 options: 
- use autodiscovery
- create one instance per database: But on the example here we did not added in the code the dbname parameter to specify for each instance to which db the agent should connect.

### Motivation
This was discussed in OH with Christina Duffy

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
