### PR TITLE
DOCS-7626 Google Kubernetes Engine Doc Update

### DIFF
--- a/gke/README.md
+++ b/gke/README.md
@@ -92,7 +92,7 @@ Because Autopilot does not allow `socket` mode, Datadog recommends using `servic
 
 [101]: https://github.com/DataDog/helm-charts/tree/master/charts/datadog#values
 [102]: https://docs.datadoghq.com/containers/cluster_agent/admission_controller/?tab=operator
-[103]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L922
+[103]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L1046
 
 
 <!-- xxz tab xxx -->

--- a/gke/README.md
+++ b/gke/README.md
@@ -41,6 +41,7 @@ Choose a mode of operation. A *mode of operation* refers to the level of flexibi
 
 Deploy a [containerized version of the Datadog Agent][7] on your Kubernetes cluster. See [Install the Datadog Agent on Kubernetes][8].
 
+
 <!-- xxz tab xxx -->
 <!-- xxx tab "Autopilot" xxx -->
 
@@ -67,7 +68,7 @@ Deploy a [containerized version of the Datadog Agent][7] on your Kubernetes clus
       datadog/datadog
   ```
 
-  **Note**: If you also wish to enable logs or traces, add lines to this command setting `datadog.logs.enabled` (for logs) and `datadog.apm.enabled` (for traces) to `true`. For example:
+  **Note**: If you also wish to enable logs or traces, add lines to this command setting `datadog.logs.enabled` (for logs) and `datadog.apm.portEnabled` (for traces) to `true`. For example:
 
   ```bash
   helm install --name <RELEASE_NAME> \
@@ -77,23 +78,32 @@ Deploy a [containerized version of the Datadog Agent][7] on your Kubernetes clus
       --set clusterAgent.metricsProvider.enabled=true \
       --set providers.gke.autopilot=true \
       --set datadog.logs.enabled=true \
-      --set datadog.apm.enabled=true \
+      --set datadog.apm.portEnabled=true \
       datadog/datadog
   ```
 
-  See the [Datadog helm-charts repository][9] for a full list of configurable values.
+  See the [Datadog `helm-charts` repository][101] for a full list of configurable values.
 
 #### Admission Controller
  
-To use [Admission Controller](https://docs.datadoghq.com/containers/cluster_agent/admission_controller/?tab=operator) with Autopilot, set the [`configMode`](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L922) of the Admission Controller to either `service` or `hostip`. 
+To use [Admission Controller][102] with Autopilot, set the [`configMode`][103] of the Admission Controller to either `service` or `hostip`. 
 
 Because Autopilot does not allow `socket` mode, Datadog recommends using `service` (with `hostip` as a fallback) to provide a more robust layer of abstraction for the controller. 
+
+[101]: https://github.com/DataDog/helm-charts/tree/master/charts/datadog#values
+[102]: https://docs.datadoghq.com/containers/cluster_agent/admission_controller/?tab=operator
+[103]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L922
+
+
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->
 
 ## Further Reading
 
-- [Announcing support for GKE Autopilot][10]
+- [Monitor GKE Autopilot with Datadog][10]
+- [Monitor GKE with Datadog][11]
+- [Monitor your T2A-powered GKE workloads with Datadog][12]
+- [New GKE dashboards and metrics provide deeper visibility into your environment][13]
 
 [1]: https://cloud.google.com/resource-manager/docs/creating-managing-projects
 [2]: https://console.cloud.google.com/apis/api/container.googleapis.com
@@ -105,3 +115,6 @@ Because Autopilot does not allow `socket` mode, Datadog recommends using `servic
 [8]: https://docs.datadoghq.com/containers/kubernetes/installation?tab=operator
 [9]: https://github.com/DataDog/helm-charts/tree/master/charts/datadog#values
 [10]: https://www.datadoghq.com/blog/gke-autopilot-monitoring/
+[11]: https://www.datadoghq.com/blog/monitor-google-kubernetes-engine/
+[12]: https://www.datadoghq.com/blog/monitor-tau-t2a-gke-workloads-with-datadog-arm-support/
+[13]: https://www.datadoghq.com/blog/gke-dashboards-integration-improvements/


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Replace [deprecated parameter `datadog.apm.enabled`](https://github.com/DataDog/helm-charts/tree/main/charts/datadog#values:~:text=datadog.apm.enabled,apm.portEnabled%20instead) with replacement parameter `datadog.apm.portEnabled`. 

Also updates some broken links in the Autopilot tab + adds more Monitor blog posts.

<img width="922" alt="Screenshot 2024-04-08 at 3 52 52 PM" src="https://github.com/DataDog/integrations-core/assets/76412946/ff4cdb2c-a5a1-4c37-a247-30d817e78ae5">

### Motivation
<!-- What inspired you to submit this pull request? -->

[Hotjar user feedback](https://datadoghq.atlassian.net/browse/DOCS-7626).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
