### PR TITLE
migrate index usage and index fragmentation metrics to database metrics

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -21,8 +21,6 @@ ENGINE_EDITION_AZURE_MANAGED_INSTANCE = 8
 ENGINE_EDITION_AZURE_SQL_EDGE = 9
 ENGINE_EDITION_AZURE_SYNAPSE_SERVERLESS_POOL = 11
 
-DEFAULT_INDEX_USAGE_STATS_INTERVAL = 5 * 60  # 5 minutes
-
 # Keys of the static info cache, used to cache server info which does not change
 STATIC_INFO_VERSION = 'version'
 STATIC_INFO_MAJOR_VERSION = 'major_version'

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/__init__.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/__init__.py
@@ -1,0 +1,2 @@
+from .db_fragmentation_metrics import SqlserverDBFragmentationMetrics
+from .index_usage_metrics import SqlserverIndexUsageMetrics

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/base.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/base.py
@@ -1,0 +1,115 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+
+from typing import Callable, List, Optional
+
+from datadog_checks.base.log import get_check_logger
+from datadog_checks.base.utils.db.core import QueryExecutor
+from datadog_checks.sqlserver.const import STATIC_INFO_ENGINE_EDITION, STATIC_INFO_MAJOR_VERSION
+
+
+class SqlserverDatabaseMetricsBase:
+    def __init__(
+        self,
+        instance_config,
+        new_query_executor,
+        server_static_info,
+        execute_query_handler,
+        track_operation_time=False,
+        databases=None,
+    ):
+        self.instance_config: dict = instance_config
+        self.server_static_info: dict = server_static_info
+        self.new_query_executor: Callable[
+            [List[dict], Callable, Optional[List[str]], Optional[bool]], QueryExecutor
+        ] = new_query_executor
+        self.execute_query_handler: Callable[[str, Optional[str]], List[tuple]] = execute_query_handler
+        self.track_operation_time: bool = track_operation_time
+        self._databases: Optional[List[str]] = databases
+        self._query_executors: List[QueryExecutor] = []
+        self.log = get_check_logger()
+
+    @property
+    def major_version(self) -> Optional[int]:
+        return self.server_static_info.get(STATIC_INFO_MAJOR_VERSION)
+
+    @property
+    def engine_edition(self) -> Optional[int]:
+        return self.server_static_info.get(STATIC_INFO_ENGINE_EDITION)
+
+    @property
+    def enabled(self) -> bool:
+        raise NotImplementedError
+
+    @property
+    def queries(self) -> List[dict]:
+        raise NotImplementedError
+
+    @property
+    def databases(self) -> Optional[List[str]]:
+        return self._databases
+
+    @property
+    def query_executors(self) -> List[QueryExecutor]:
+        '''
+        Returns a list of QueryExecutor objects for the database metrics.
+        '''
+        if not self._query_executors:
+            self._query_executors = self._build_query_executors()
+        return self._query_executors
+
+    def _build_query_executors(self) -> List[QueryExecutor]:
+        '''
+        Builds a list of QueryExecutor objects for the database metrics.
+        '''
+        executor = self.new_query_executor(
+            self.queries, executor=self.execute_query_handler, track_operation_time=self.track_operation_time
+        )
+        executor.compile_queries()
+        return [executor]
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"enabled={self.enabled}, "
+            f"major_version={self.major_version}, "
+            f"engine_edition={self.engine_edition})"
+        )
+
+    def metric_names(self) -> List[str]:
+        '''
+        Returns a list of metric names for the queries in the database metrics.
+        Note: This method is used for testing purposes in order to verify that the correct metrics are being collected.
+        '''
+        metric_names = []
+        for query in self.queries:
+            names = [
+                "sqlserver." + c["name"]
+                for c in query["columns"]
+                if not c["type"].startswith("tag") and c["type"] != "source"
+            ]
+            if query.get("extras"):
+                names.extend(
+                    ["sqlserver." + e["name"] for e in query["extras"] if e.get("submit_type") or e.get("type")]
+                )
+            metric_names.append(names)
+        return metric_names
+
+    def tag_names(self) -> List[str]:
+        '''
+        Returns a list of tag names for the queries in the database metrics.
+        Note: This method is used for testing purposes in order to verify that the correct tags are being collected.
+        '''
+        tag_names = []
+        for query in self.queries:
+            tag_names.append([c["name"] for c in query["columns"] if c["type"].startswith("tag")])
+        return tag_names
+
+    def execute(self) -> None:
+        if not self.enabled:
+            self.log.debug("%s: not enabled, skipping execution", str(self))
+            return
+        for query_executor in self.query_executors:
+            query_executor.execute()

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/db_fragmentation_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/db_fragmentation_metrics.py
@@ -1,0 +1,135 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import copy
+import functools
+
+from datadog_checks.base.config import is_affirmative
+from datadog_checks.base.errors import ConfigurationError
+
+from .base import SqlserverDatabaseMetricsBase
+
+DB_FRAGMENTATION_QUERY = {
+    "name": "sys.dm_db_index_physical_stats",
+    "query": """SELECT
+        DB_NAME(DDIPS.database_id) as database_name,
+        OBJECT_NAME(DDIPS.object_id, DDIPS.database_id) as object_name,
+        DDIPS.index_id as index_id,
+        I.name as index_name,
+        DDIPS.fragment_count as fragment_count,
+        DDIPS.avg_fragment_size_in_pages as avg_fragment_size_in_pages,
+        DDIPS.page_count as page_count,
+        DDIPS.avg_fragmentation_in_percent as avg_fragmentation_in_percent
+        FROM sys.dm_db_index_physical_stats (DB_ID('{db}'),null,null,null,null) as DDIPS
+        INNER JOIN sys.indexes as I WITH (NOLOCK) ON I.object_id = DDIPS.object_id
+        AND DDIPS.index_id = I.index_id
+        WHERE DDIPS.fragment_count is not null
+    """,
+    "columns": [
+        {"name": "database_name", "type": "tag"},
+        {"name": "object_name", "type": "tag"},
+        {"name": "index_id", "type": "tag"},
+        {"name": "index_name", "type": "tag"},
+        {"name": "database.fragment_count", "type": "gauge"},
+        {"name": "database.avg_fragment_size_in_pages", "type": "gauge"},
+        {"name": "database.index_page_count", "type": "gauge"},
+        {"name": "database.avg_fragmentation_in_percent", "type": "gauge"},
+    ],
+}
+
+
+class SqlserverDBFragmentationMetrics(SqlserverDatabaseMetricsBase):
+    # sys.dm_db_index_physical_stats
+    #
+    # Returns size and fragmentation information for the data and
+    # indexes of the specified table or view in SQL Server.
+    #
+    # There are reports of this query being very slow for large datasets,
+    # so debug query timing are included to help monitor it.
+    # https://dba.stackexchange.com/q/76374
+    #
+    # https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-index-physical-stats-transact-sql?view=sql-server-ver15
+    @property
+    def include_db_fragmentation_metrics(self):
+        return is_affirmative(self.instance_config.get('include_db_fragmentation_metrics', False))
+
+    @property
+    def include_db_fragmentation_metrics_tempdb(self):
+        return is_affirmative(self.instance_config.get('include_db_fragmentation_metrics_tempdb', False))
+
+    @property
+    def db_fragmentation_object_names(self):
+        return self.instance_config.get('db_fragmentation_object_names', [])
+
+    @property
+    def enabled(self):
+        if not self.include_db_fragmentation_metrics:
+            return False
+        return True
+
+    @property
+    def _default_collection_interval(self) -> int:
+        '''
+        Returns the default interval in seconds at which to collect database index fragmentation metrics.
+        '''
+        return 5 * 60  # 5 minutes
+
+    @property
+    def collection_interval(self) -> int:
+        '''
+        Returns the interval in seconds at which to collect database index fragmentation metrics.
+        Note: The index fragmentation metrics query can be expensive, so it is recommended to set a higher interval.
+        '''
+        return int(self.instance_config.get('db_fragmentation_metrics_interval', self._default_collection_interval))
+
+    @property
+    def databases(self):
+        '''
+        Returns a list of databases to collect index fragmentation metrics for.
+        By default, tempdb is excluded.
+        '''
+        if not self._databases:
+            raise ConfigurationError("No databases configured for index usage metrics")
+        if not self.include_db_fragmentation_metrics_tempdb:
+            try:
+                self._databases.remove('tempdb')
+            except ValueError:
+                pass
+        return self._databases
+
+    @property
+    def queries(self):
+        # make a copy of the query to avoid modifying the original
+        # in case different instances have different collection intervals
+        query = DB_FRAGMENTATION_QUERY.copy()
+        query['collection_interval'] = self.collection_interval
+        return [query]
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"enabled={self.enabled}, "
+            f"include_db_fragmentation_metrics={self.include_db_fragmentation_metrics}, "
+            f"db_fragmentation_object_names={self.db_fragmentation_object_names})"
+        )
+
+    def _build_query_executors(self):
+        executors = []
+        for database in self.databases:
+            queries = copy.deepcopy(self.queries)
+            for query in queries:
+                query['query'] = query['query'].format(db=database)
+                if self.db_fragmentation_object_names:
+                    query['query'] += " AND OBJECT_NAME(DDIPS.object_id, DDIPS.database_id) IN ({})".format(
+                        ','.join(["'{}'".format(name) for name in self.db_fragmentation_object_names])
+                    )
+            executor = self.new_query_executor(
+                queries,
+                executor=functools.partial(self.execute_query_handler, db=database),
+                extra_tags=['db:{}'.format(database)],
+                track_operation_time=self.track_operation_time,
+            )
+            executor.compile_queries()
+            executors.append(executor)
+        return executors

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/index_usage_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/index_usage_metrics.py
@@ -1,0 +1,117 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import functools
+
+from datadog_checks.base.config import is_affirmative
+from datadog_checks.base.errors import ConfigurationError
+
+from .base import SqlserverDatabaseMetricsBase
+
+INDEX_USAGE_STATS_QUERY = {
+    "name": "sys.dm_db_index_usage_stats",
+    "query": """
+    SELECT
+         DB_NAME(ixus.database_id) as db,
+         CASE
+            WHEN ind.name IS NULL THEN 'HeapIndex_' + OBJECT_NAME(ind.object_id)
+            ELSE ind.name
+         END AS index_name,
+         OBJECT_NAME(ind.object_id) as table_name,
+        user_seeks,
+        user_scans,
+        user_lookups,
+        user_updates
+    FROM sys.indexes ind
+             INNER JOIN sys.dm_db_index_usage_stats ixus
+             ON ixus.index_id = ind.index_id AND ixus.object_id = ind.object_id
+    WHERE OBJECTPROPERTY(ind.object_id, 'IsUserTable') = 1 AND DB_NAME(ixus.database_id) = db_name()
+    GROUP BY ixus.database_id, OBJECT_NAME(ind.object_id), ind.name, user_seeks, user_scans, user_lookups, user_updates
+""",
+    "columns": [
+        {"name": "db", "type": "tag"},
+        {"name": "index_name", "type": "tag"},
+        {"name": "table", "type": "tag"},
+        {"name": "index.user_seeks", "type": "monotonic_count"},
+        {"name": "index.user_scans", "type": "monotonic_count"},
+        {"name": "index.user_lookups", "type": "monotonic_count"},
+        {"name": "index.user_updates", "type": "monotonic_count"},
+    ],
+}
+
+
+# https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-index-usage-stats-transact-sql?view=sql-server-ver15
+class SqlserverIndexUsageMetrics(SqlserverDatabaseMetricsBase):
+    @property
+    def include_index_usage_metrics(self) -> bool:
+        return is_affirmative(self.instance_config.get('include_index_usage_metrics', True))
+
+    @property
+    def include_index_usage_metrics_tempdb(self) -> bool:
+        return is_affirmative(self.instance_config.get('include_index_usage_metrics_tempdb', False))
+
+    @property
+    def _default_collection_interval(self) -> int:
+        '''
+        Returns the default interval in seconds at which to collect index usage metrics.
+        '''
+        return 5 * 60  # 5 minutes
+
+    @property
+    def collection_interval(self) -> int:
+        '''
+        Returns the interval in seconds at which to collect index usage metrics.
+        Note: The index usage metrics query can be expensive, so it is recommended to set a higher interval.
+        '''
+        return int(self.instance_config.get('index_usage_stats_interval', self._default_collection_interval))
+
+    @property
+    def databases(self):
+        '''
+        Returns a list of databases to collect index usage metrics for.
+        By default, tempdb is excluded.
+        '''
+        if not self._databases:
+            raise ConfigurationError("No databases configured for index usage metrics")
+        if not self.include_index_usage_metrics_tempdb:
+            try:
+                self._databases.remove('tempdb')
+            except ValueError:
+                pass
+        return self._databases
+
+    @property
+    def enabled(self):
+        if not self.include_index_usage_metrics:
+            return False
+        return True
+
+    @property
+    def queries(self):
+        # make a copy of the query to avoid modifying the original
+        # in case different instances have different collection intervals
+        query = INDEX_USAGE_STATS_QUERY.copy()
+        query['collection_interval'] = self.collection_interval
+        return [query]
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"enabled={self.enabled}, "
+            f"include_index_usage_metrics={self.include_index_usage_metrics}), "
+            f"include_index_usage_metrics_tempdb={self.include_index_usage_metrics_tempdb}, "
+            f"collection_interval={self.collection_interval})"
+        )
+
+    def _build_query_executors(self):
+        executors = []
+        for database in self.databases:
+            executor = self.new_query_executor(
+                self.queries,
+                executor=functools.partial(self.execute_query_handler, db=database),
+                track_operation_time=self.track_operation_time,
+            )
+            executor.compile_queries()
+            executors.append(executor)
+        return executors

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -316,8 +316,6 @@ def get_operation_time_metrics(instance):
     if instance.get('include_task_scheduler_metrics', False):
         operation_time_metrics.append('os_schedulers_metrics')
         operation_time_metrics.append('os_tasks_metrics')
-    if instance.get('include_db_fragmentation_metrics', False):
-        operation_time_metrics.append('db_fragmentation_metrics')
     if instance.get('include_ao_metrics', False):
         operation_time_metrics.append('availability_groups_metrics')
     if instance.get('include_master_files_metrics', False):

--- a/sqlserver/tests/odbc/odbcinst.ini
+++ b/sqlserver/tests/odbc/odbcinst.ini
@@ -6,5 +6,5 @@ Driver=/usr/lib/x86_64-linux-gnu/odbc/libtdsodbc.so
 
 [ODBC Driver 18 for SQL Server]
 Description=Microsoft ODBC Driver 18 for SQL Server
-Driver=/opt/microsoft/msodbcsql18/lib64/libmsodbcsql-18.3.so.2.1
+Driver=/opt/microsoft/msodbcsql18/lib64/libmsodbcsql-18.3.so.3.1
 UsageCount=1

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -552,3 +552,17 @@ def test_format_connection_error(
     _, conn_err = format_connection_exception(error_message, driver)
     assert conn_err
     assert conn_err.value == expected_error.value
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_restore_current_database_context(instance_docker):
+    check = SQLServer(CHECK_NAME, {}, [instance_docker])
+    check.initialize_connection()
+    with check.connection.open_managed_default_connection():
+        current_db = check.connection._get_current_database_context()
+        with check.connection.restore_current_database_context():
+            with check.connection.get_managed_cursor() as cursor:
+                cursor.execute("USE tempdb")
+                assert check.connection._get_current_database_context() == "tempdb"
+        assert check.connection._get_current_database_context() == current_db

--- a/sqlserver/tests/test_database_metrics.py
+++ b/sqlserver/tests/test_database_metrics.py
@@ -1,0 +1,229 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+
+from unittest import mock
+
+import pytest
+from datadog_checks.sqlserver import SQLServer
+from datadog_checks.sqlserver.const import (
+    STATIC_INFO_ENGINE_EDITION,
+    STATIC_INFO_MAJOR_VERSION,
+)
+from datadog_checks.sqlserver.database_metrics import (
+    SqlserverDBFragmentationMetrics,
+    SqlserverIndexUsageMetrics,
+)
+
+from .common import (
+    CHECK_NAME,
+    SQLSERVER_ENGINE_EDITION,
+    SQLSERVER_MAJOR_VERSION,
+)
+
+AUTODISCOVERY_DBS = ['master', 'msdb', 'datadog_test']
+
+STATIC_SERVER_INFO = {
+    STATIC_INFO_MAJOR_VERSION: SQLSERVER_MAJOR_VERSION,
+    STATIC_INFO_ENGINE_EDITION: SQLSERVER_ENGINE_EDITION,
+}
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize('include_index_usage_metrics', [True, False])
+@pytest.mark.parametrize('include_index_usage_metrics_tempdb', [True, False])
+@pytest.mark.parametrize('index_usage_stats_interval', [None, 600])
+def test_sqlserver_index_usage_metrics(
+    aggregator,
+    dd_run_check,
+    init_config,
+    instance_docker_metrics,
+    include_index_usage_metrics,
+    include_index_usage_metrics_tempdb,
+    index_usage_stats_interval,
+):
+    instance_docker_metrics['database_autodiscovery'] = True
+    instance_docker_metrics['include_index_usage_metrics'] = include_index_usage_metrics
+    instance_docker_metrics['include_index_usage_metrics_tempdb'] = include_index_usage_metrics_tempdb
+    if index_usage_stats_interval:
+        instance_docker_metrics['index_usage_stats_interval'] = index_usage_stats_interval
+
+    mocked_results_non_tempdb = [
+        [
+            ('master', 'PK__patch_ac__09EA1DC2BD2BC49C', 'patch_action_execution_state', 36, 0, 0, 0),
+            ('master', 'PK__rds_comp__2E7CCD4A9E2910C9', 'rds_component_version', 0, 5, 0, 0),
+        ],
+        [
+            ('msdb', 'PK__backupse__21F79AAB9439648C', 'backupset', 0, 1, 0, 0),
+        ],
+        [
+            ('datadog_test', 'idx_something', 'some_table', 10, 60, 12, 18),
+            ('datadog_test', 'idx_something_else', 'some_table', 20, 30, 40, 50),
+        ],
+    ]
+    mocked_results_tempdb = [
+        ('tempdb', 'PK__dmv_view__B5A34EE25D72CBFE', 'dmv_view_run_history', 1500, 0, 0, 49),
+    ]
+    mocked_results = mocked_results_non_tempdb
+    if include_index_usage_metrics_tempdb:
+        mocked_results += [mocked_results_tempdb]
+
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
+
+    execute_query_handler_mocked = mock.MagicMock()
+    execute_query_handler_mocked.side_effect = mocked_results
+
+    index_usage_metrics = SqlserverIndexUsageMetrics(
+        instance_config=instance_docker_metrics,
+        new_query_executor=sqlserver_check._new_query_executor,
+        server_static_info=STATIC_SERVER_INFO,
+        execute_query_handler=execute_query_handler_mocked,
+        databases=AUTODISCOVERY_DBS + ['tempdb'],
+    )
+
+    expected_collection_interval = index_usage_stats_interval or index_usage_metrics._default_collection_interval
+    assert index_usage_metrics.queries[0]['collection_interval'] == expected_collection_interval
+
+    sqlserver_check._database_metrics = [index_usage_metrics]
+
+    dd_run_check(sqlserver_check)
+
+    if not include_index_usage_metrics:
+        assert index_usage_metrics.enabled is False
+    else:
+        tags = instance_docker_metrics.get('tags', [])
+        for result in mocked_results:
+            for row in result:
+                db, index_name, table, *metric_values = row
+                metrics = zip(index_usage_metrics.metric_names()[0], metric_values)
+                expected_tags = [
+                    f'db:{db}',
+                    f'index_name:{index_name}',
+                    f'table:{table}',
+                ] + tags
+                for metric_name, metric_value in metrics:
+                    aggregator.assert_metric(metric_name, value=metric_value, tags=expected_tags)
+                if not include_index_usage_metrics_tempdb:
+                    assert db != 'tempdb'
+
+    # index_usage_metrics should not be collected because the collection interval is not reached
+    aggregator.reset()
+    dd_run_check(sqlserver_check)
+    for metric_name in index_usage_metrics.metric_names()[0]:
+        aggregator.assert_metric(metric_name, count=0)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize('include_db_fragmentation_metrics', [True, False])
+@pytest.mark.parametrize('include_db_fragmentation_metrics_tempdb', [True, False])
+@pytest.mark.parametrize(
+    'db_fragmentation_object_names', [None, ['spt_fallback_db', 'spt_fallback_dev', 'spt_fallback_usg']]
+)
+@pytest.mark.parametrize('db_fragmentation_metrics_interval', [None, 600])
+def test_sqlserver_db_fragmentation_metrics(
+    aggregator,
+    dd_run_check,
+    init_config,
+    instance_docker_metrics,
+    include_db_fragmentation_metrics,
+    include_db_fragmentation_metrics_tempdb,
+    db_fragmentation_object_names,
+    db_fragmentation_metrics_interval,
+):
+    instance_docker_metrics['database_autodiscovery'] = True
+    instance_docker_metrics['include_db_fragmentation_metrics'] = include_db_fragmentation_metrics
+    instance_docker_metrics['include_db_fragmentation_metrics_tempdb'] = include_db_fragmentation_metrics_tempdb
+    if db_fragmentation_metrics_interval:
+        instance_docker_metrics['db_fragmentation_metrics_interval'] = db_fragmentation_metrics_interval
+
+    mocked_results = [
+        [
+            ('master', 'spt_fallback_db', 0, None, 0, 0.0, 0, 0.0),
+            ('master', 'spt_fallback_dev', 0, None, 0, 0.0, 0, 0.0),
+            ('master', 'spt_fallback_usg', 0, None, 0, 0.0, 0, 0.0),
+            ('master', 'spt_monitor', 0, None, 1, 1.0, 1, 0.0),
+            ('master', 'MSreplication_options', 0, None, 1, 1.0, 1, 0.0),
+        ],
+        [
+            ('msdb', 'syscachedcredentials', 1, 'PK__syscache__F6D56B562DA81DC6', 0, 0.0, 0, 0.0),
+            ('msdb', 'syscollector_blobs_internal', 1, 'PK_syscollector_blobs_internal_paremeter_name', 0, 0.0, 0, 0.0),
+        ],
+        [('datadog_test', 'ϑings', 1, 'thingsindex', 1, 1.0, 1, 0.0)],
+    ]
+    mocked_results_tempdb = [
+        [('tempdb', '#TempExample__000000000008', 1, 'PK__#TempExa__3214EC278A26D67E', 1, 1.0, 1, 0.0)],
+    ]
+
+    if db_fragmentation_object_names:
+        instance_docker_metrics['db_fragmentation_object_names'] = db_fragmentation_object_names
+        mocked_results = [
+            [
+                ('master', 'spt_fallback_db', 0, None, 0, 0.0, 0, 0.0),
+                ('master', 'spt_fallback_dev', 0, None, 0, 0.0, 0, 0.0),
+                ('master', 'spt_fallback_usg', 0, None, 0, 0.0, 0, 0.0),
+            ],
+            [],
+            [],
+        ]
+        mocked_results_tempdb = [[]]
+
+    if include_db_fragmentation_metrics_tempdb:
+        mocked_results += mocked_results_tempdb
+
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
+
+    execute_query_handler_mocked = mock.MagicMock()
+    execute_query_handler_mocked.side_effect = mocked_results
+
+    db_fragmentation_metrics = SqlserverDBFragmentationMetrics(
+        instance_config=instance_docker_metrics,
+        new_query_executor=sqlserver_check._new_query_executor,
+        server_static_info=STATIC_SERVER_INFO,
+        execute_query_handler=execute_query_handler_mocked,
+        databases=AUTODISCOVERY_DBS + ['tempdb'],
+    )
+
+    if db_fragmentation_object_names:
+        assert db_fragmentation_metrics.db_fragmentation_object_names == db_fragmentation_object_names
+
+    expected_collection_interval = (
+        db_fragmentation_metrics_interval or db_fragmentation_metrics._default_collection_interval
+    )
+    assert db_fragmentation_metrics.queries[0]['collection_interval'] == expected_collection_interval
+
+    sqlserver_check._database_metrics = [db_fragmentation_metrics]
+
+    dd_run_check(sqlserver_check)
+
+    if not include_db_fragmentation_metrics:
+        assert db_fragmentation_metrics.enabled is False
+    else:
+        tags = instance_docker_metrics.get('tags', [])
+        for result in mocked_results:
+            for row in result:
+                database_name, object_name, index_id, index_name, *metric_values = row
+                metrics = zip(db_fragmentation_metrics.metric_names()[0], metric_values)
+                expected_tags = [
+                    f'db:{database_name}',
+                    f'database_name:{database_name}',
+                    f'object_name:{object_name}',
+                    f'index_id:{index_id}',
+                    f'index_name:{index_name}',
+                ] + tags
+                for metric_name, metric_value in metrics:
+                    aggregator.assert_metric(metric_name, value=metric_value, tags=expected_tags)
+                    if db_fragmentation_object_names:
+                        for m in aggregator.metrics(metric_name):
+                            tags_by_key = dict([t.split(':') for t in m.tags if not t.startswith('dd.internal')])
+                            assert tags_by_key['object_name'].lower() in db_fragmentation_object_names
+                if not include_db_fragmentation_metrics_tempdb:
+                    assert database_name != 'tempdb'
+
+    # db_fragmentation_metrics should not be collected because the collection interval is not reached
+    aggregator.reset()
+    dd_run_check(sqlserver_check)
+    for metric_name in db_fragmentation_metrics.metric_names()[0]:
+        aggregator.assert_metric(metric_name, count=0)


### PR DESCRIPTION
### What does this PR do?
This PR adds a base class `SqlserverDatabaseMetricsBase` to be inherited by SQLServer metrics. Under the hood, this new metrics class will use `QueryExecutor` to manage the queries to be executed, the metrics values and tags to be submitted and collection interval (if configured to be different from the default collection interval).
- Migrated `SQLServer index usage metrics`, `SQLServer database fragmentation metrics` to use new database metrics.
- Increase `SQLServer database fragmentation metrics` default collection interval to 5 mins.

### Motivation
[DBMON-3867](https://datadoghq.atlassian.net/browse/DBMON-3867)
[DBMON-3528](https://datadoghq.atlassian.net/browse/DBMON-3528)
[DBMON-3643](https://datadoghq.atlassian.net/browse/DBMON-3643)
[DBMON-3529](https://datadoghq.atlassian.net/browse/DBMON-3529)
The motivation behind this change is to create a easy-to-maintain and easy-to-test interface for SQLServer metrics. 
This will help in adding new metrics and maintaining existing metrics in a more organized way.
Every types of metrics will inherit from a base class `SqlserverDatabaseMetricsBase` and will implement common methods and properties including
- `enabled`
- `queries`
- `execute` (Optional)
All the database metrics will be defined under directory `database_metrics` and will be imported in `__init__.py` file.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
