### PR TITLE
Updates to mapr e2e test setup and instructions to add librdkafka headers

### DIFF
--- a/mapr/README.md
+++ b/mapr/README.md
@@ -22,15 +22,16 @@ The MapR check is included in the [Datadog Agent][2] package but requires additi
 Installation steps for each node:
 
 1. [Install the Agent][2].
-2. Install the library _mapr-streams-library_ with the following command:
+2. Install the _librdkafka_ library, required by _mapr-streams-library_, by following [these instructions][14].
+3. Install the library _mapr-streams-library_ with the following command:
 
     `sudo -u dd-agent /opt/datadog-agent/embedded/bin/pip install --global-option=build_ext --global-option="--library-dirs=/opt/mapr/lib" --global-option="--include-dirs=/opt/mapr/include/" mapr-streams-python`.
 
     If you use Python 3 with Agent v7, replace `pip` with `pip3`.
 
-3. Add `/opt/mapr/lib/` to your `/etc/ld.so.conf` (or a file in `/etc/ld.so.conf.d/`). This is required for the _mapr-streams-library_ used by the Agent to find the MapR shared libraries.
-4. Reload the libraries by running `sudo ldconfig`.
-5. Configure the integration by specifying the ticket location.
+4. Add `/opt/mapr/lib/` to your `/etc/ld.so.conf` (or a file in `/etc/ld.so.conf.d/`). This is required for the _mapr-streams-library_ used by the Agent to find the MapR shared libraries.
+5. Reload the libraries by running `sudo ldconfig`.
+6. Configure the integration by specifying the ticket location.
 
 #### Additional notes
 
@@ -124,3 +125,4 @@ Need more help? Contact [Datadog support][13].
 [11]: https://github.com/DataDog/integrations-core/blob/master/mapr/metadata.csv
 [12]: https://github.com/DataDog/integrations-core/blob/master/mapr/assets/service_checks.json
 [13]: https://docs.datadoghq.com/help/
+[14]: https://github.com/confluentinc/librdkafka#installing-prebuilt-packages

--- a/mapr/tests/conftest.py
+++ b/mapr/tests/conftest.py
@@ -12,8 +12,16 @@ from . import common
 E2E_METADATA = {
     'post_install_commands': [
         'apt-get update',
-        'apt-get install -y gcc',
-        'pip install mapr-streams-python',
+        'apt-get install -y gcc gnupg lsb-release',
+        "sh -c 'curl https://packages.confluent.io/deb/7.0/archive.key "
+        "| gpg --dearmor -o /usr/share/keyrings/confluent.gpg'",
+        "sh -c 'echo "
+        "\"deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/confluent.gpg] "
+        "https://packages.confluent.io/clients/deb $(lsb_release -cs) main\" "
+        "> /etc/apt/sources.list.d/confluent.list'",
+        'apt-get update',
+        'apt-get install -y librdkafka-dev',
+        '/opt/datadog-agent/embedded/bin/pip install mapr-streams-python',
     ]
 }
 

--- a/mapr/tests/conftest.py
+++ b/mapr/tests/conftest.py
@@ -11,8 +11,15 @@ from . import common
 
 E2E_METADATA = {
     'post_install_commands': [
+        # mapr-streams-python is required by the integration but is not shipped with the Agent;
+        # customers are expected to install the package themselves.
+        # We do that here for the e2e testing environment.
         'apt-get update',
         'apt-get install -y gcc gnupg lsb-release',
+        # mapr-streams-python requires librdkafka headers as they're not shipped with the Agent
+        # This requires adding confluent's APT repositories. These steps are based on the docs in
+        # - https://docs.confluent.io/platform/current/installation/installing_cp/deb-ubuntu.html#get-the-software
+        # - https://github.com/confluentinc/librdkafka#installing-prebuilt-packages
         "sh -c 'curl https://packages.confluent.io/deb/7.0/archive.key "
         "| gpg --dearmor -o /usr/share/keyrings/confluent.gpg'",
         "sh -c 'echo "
@@ -21,6 +28,7 @@ E2E_METADATA = {
         "> /etc/apt/sources.list.d/confluent.list'",
         'apt-get update',
         'apt-get install -y librdkafka-dev',
+        # Finally, we can install the package
         '/opt/datadog-agent/embedded/bin/pip install mapr-streams-python',
     ]
 }


### PR DESCRIPTION
### What does this PR do?

- Fixes e2e test setup that was failing.
- Adds docs with extra step needed to be able to make the integration work.

### Motivation

Fix failing tests ([example](https://github.com/DataDog/integrations-core/actions/runs/8627672648/job/23648162655)) because of https://github.com/DataDog/datadog-agent/pull/23094. `librdkakfa` headers are no longer available in the Agent which causes the installation of mapr-streams-python to fail, as it tries to install confluent-kafka.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
