### PR TITLE
Assign ownership to BARX for relevant parts of new deps building system

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,13 @@ manifest.json         @DataDog/documentation @DataDog/agent-integrations
 **/assets             @DataDog/documentation @DataDog/agent-integrations
 **/assets/logs        @DataDog/logs-backend @DataDog/documentation @DataDog/agent-integrations
 
+# Dependencies
+/.deps/                            @DataDog/agent-integrations @DataDog/agent-build-and-releases
+/.builders/                        @DataDog/agent-build-and-releases
+/.builders/images/                 @DataDog/agent-integrations @DataDog/agent-build-and-releases
+/.builders/patches/                @DataDog/agent-integrations @DataDog/agent-build-and-releases
+/.github/workflows/build-deps.yml  @DataDog/agent-build-and-releases
+
 # Checks base
 /datadog_checks_base/                                          @DataDog/agent-integrations
 /datadog_checks_base/datadog_checks/base/checks/openmetrics/   @DataDog/agent-integrations @DataDog/container-integrations


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation

[BARX-307](https://datadoghq.atlassian.net/browse/BARX-307)

### Additional Notes

The rationale for the ownership assignment is:

- agent-integrations is responsible for dependency updates and as such need to own or co-own all the files that might be involved (any patching or additional non-Python dependency that might be required at some point).
- agent-build-and-releases is responsible for the build and upload machinery itself, and should be giving a hand whenever dependencies require changes in the build images, etc.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[BARX-307]: https://datadoghq.atlassian.net/browse/BARX-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ