### PR TITLE
Relax assertion about metric count to make test less flaky

### DIFF
--- a/mongo/tests/test_integration_standalone.py
+++ b/mongo/tests/test_integration_standalone.py
@@ -101,7 +101,7 @@ def test_mongo_dbstats_tag(aggregator, check, instance_dbstats_tag_dbname, dd_ru
         'server:mongodb://localhost:27017/',
     ]
     for metric, value in expected_metrics.items():
-        aggregator.assert_metric(metric, value, expected_tags, count=1)
+        aggregator.assert_metric(metric, value, expected_tags)
 
 
 def test_mongo_1valid_and_1invalid_custom_queries(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
We've been seeing this test fail *sometimes* where the number of samples for one of the metrics was greater than 1.

Using the default `at_least=1` seems appropriate here from the point of view of behavior.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
