### PR TITLE
[PLINT-314] Add support for per instance filters

### DIFF
--- a/esxi/assets/configuration/spec.yaml
+++ b/esxi/assets/configuration/spec.yaml
@@ -42,4 +42,29 @@ files:
           value:
             type: boolean
             example: false
+        - name: collect_per_instance_filters
+          description: |
+            Use this option to collect metrics tagged with instance values.
+            Some ESXi metrics can be tagged with instance values.
+            For each resource type (vm, host) to collect,
+            you can choose which metrics you want to collect the instance value as tags using a list of regex.
+            See https://github.com/DataDog/integrations-core/blob/master/esxi/datadog_checks/esxi/metrics.py
+            for the list of collected metrics (do not prefix them with `esxi`)
+            /!\ Use with parsimony, collecting per-instance metrics might be very expensive for big environments.
+          value:
+            example:
+              vm:
+                - <VM_REGEX>
+              host:
+                - <HOST_REGEX>
+            type: object
+            properties:
+              - name: vm
+                type: array
+                items:
+                  type: string
+              - name: host
+                type: array
+                items:
+                  type: string
         - template: instances/default

--- a/esxi/datadog_checks/esxi/check.py
+++ b/esxi/datadog_checks/esxi/check.py
@@ -140,7 +140,6 @@ class EsxiCheck(AgentCheck):
             if should_collect_per_instance_values(self.collect_per_instance_filters, metric_name, resource_type):
                 metric_id.instance = "*"
 
-
         spec = vim.PerformanceManager.QuerySpec(maxSample=1, entity=entity, metricId=metric_ids)
         result_stats = self.content.perfManager.QueryPerf([spec])
 

--- a/esxi/datadog_checks/esxi/check.py
+++ b/esxi/datadog_checks/esxi/check.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2024-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
 from collections import defaultdict
 import logging
 import re

--- a/esxi/datadog_checks/esxi/check.py
+++ b/esxi/datadog_checks/esxi/check.py
@@ -1,7 +1,10 @@
 # (C) Datadog, Inc. 2024-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
+from collections import defaultdict
+import logging
+import re
+from six import iteritems
 from pyVim import connect
 from pyVmomi import vim, vmodl
 
@@ -9,7 +12,7 @@ from datadog_checks.base import AgentCheck  # noqa: F401
 
 from .constants import ALL_RESOURCES, HOST_RESOURCE, MAX_PROPERTIES, RESOURCE_TYPE_TO_NAME, SHORT_ROLLUP, VM_RESOURCE
 from .metrics import RESOURCE_NAME_TO_METRICS
-from .utils import get_tags_recursively
+from .utils import get_mapped_instance_tag, get_tags_recursively, should_collect_per_instance_values
 
 
 class EsxiCheck(AgentCheck):
@@ -21,7 +24,25 @@ class EsxiCheck(AgentCheck):
         self.username = self.instance.get("username")
         self.password = self.instance.get("password")
         self.use_guest_hostname = self.instance.get("use_guest_hostname", False)
+        self.collect_per_instance_filters = self._parse_metric_regex_filters(
+            self.instance.get("collect_per_instance_filters", {})
+        )
         self.tags = [f"esxi_url:{self.host}"]
+
+    def _parse_metric_regex_filters(self, all_metric_filters):
+        allowed_resource_types = RESOURCE_TYPE_TO_NAME.values()
+        metric_filters = {}
+        for resource_type, filters in iteritems(all_metric_filters):
+            if resource_type not in allowed_resource_types:
+                self.log.warning(
+                    "Ignoring metric_filter for resource '%s'. It should be one of '%s'",
+                    resource_type,
+                    ", ".join(allowed_resource_types),
+                )
+                continue
+            metric_filters[resource_type] = filters
+
+        return {k: [re.compile(r) for r in v] for k, v in iteritems(metric_filters)}
 
     def get_resources(self):
         self.log.debug("Retrieving resources")
@@ -91,16 +112,62 @@ class EsxiCheck(AgentCheck):
         return counter_keys_and_names, metric_ids
 
     def collect_metrics_for_entity(self, metric_ids, counter_keys_and_names, entity, entity_name):
+        resource_type = type(entity)
+        resource_name = RESOURCE_TYPE_TO_NAME[resource_type]
+        for metric_id in metric_ids:
+            metric_name = counter_keys_and_names.get(metric_id.counterId)
+            if should_collect_per_instance_values(self.collect_per_instance_filters, metric_name, resource_type):
+                metric_id.instance = "*"
 
-        resource_name = RESOURCE_TYPE_TO_NAME[type(entity)]
         spec = vim.PerformanceManager.QuerySpec(maxSample=1, entity=entity, metricId=metric_ids)
         result_stats = self.content.perfManager.QueryPerf([spec])
+
+        # `have_instance_value` is used later to avoid collecting aggregated metrics
+        # when instance metrics are collected.
+        have_instance_value = defaultdict(set)
+        if self.collect_per_instance_filters:
+            for results_for_entity in result_stats:
+                metric_resource_type = type(results_for_entity.entity)
+                for metric_result in results_for_entity.value:
+                    if metric_result.id.instance:
+                        counter_id = counter_keys_and_names.get(metric_result.id.counterId)
+                        if counter_id:
+                            have_instance_value[metric_resource_type].add(counter_id)
 
         for results_for_entity in result_stats:
             for metric_result in results_for_entity.value:
                 metric_name = counter_keys_and_names.get(metric_result.id.counterId)
-                if len(metric_result.value) == 0:
+                if self.log.isEnabledFor(logging.DEBUG):
+                    # Use isEnabledFor to avoid unnecessary processing
                     self.log.debug(
+                        "Processing metric `%s`: resource_type=`%s`, result=`%s`",
+                        metric_name,
+                        resource_type,
+                        str(metric_result).replace("\n", "\\n"),
+                    )
+
+                if not metric_name:
+                    # Fail-safe
+                    self.log.debug(
+                        "Skipping value for counter %s, because the integration doesn't have metadata about it",
+                        metric_result.id.counterId,
+                    )
+                    continue
+
+                additional_tags = []
+                if should_collect_per_instance_values(
+                    self.collect_per_instance_filters, metric_name, resource_type
+                ) and (metric_name in have_instance_value[resource_type]):
+                    instance_value = metric_result.id.instance
+                    # When collecting per instance values, it's possible that both aggregated metric and per instance
+                    # metrics are received. In that case, the metric with no instance value is skipped.
+                    if not instance_value:
+                        continue
+                    instance_tag_key = get_mapped_instance_tag(metric_name)
+                    additional_tags.append(f'{instance_tag_key}:{instance_value}')
+
+                if len(metric_result.value) == 0:
+                    self.log.warning(
                         "Skipping metric %s for %s because no value was returned by the %s",
                         metric_name,
                         entity_name,
@@ -121,15 +188,16 @@ class EsxiCheck(AgentCheck):
                     continue
                 else:
                     most_recent_val = valid_values[-1]
+                    all_tags = self.tags + additional_tags
 
                     self.log.debug(
                         "Submit metric: name=`%s`, value=`%s`, hostname=`%s`, tags=`%s`",
                         metric_name,
                         most_recent_val,
                         entity_name,
-                        self.tags,
+                        all_tags,
                     )
-                    self.gauge(metric_name, most_recent_val, hostname=entity_name, tags=self.tags)
+                    self.gauge(metric_name, most_recent_val, hostname=entity_name, tags=all_tags)
 
     def check(self, _):
         try:

--- a/esxi/datadog_checks/esxi/check.py
+++ b/esxi/datadog_checks/esxi/check.py
@@ -1,13 +1,13 @@
 # (C) Datadog, Inc. 2024-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
-from collections import defaultdict
 import logging
 import re
-from six import iteritems
+from collections import defaultdict
+
 from pyVim import connect
 from pyVmomi import vim, vmodl
+from six import iteritems
 
 from datadog_checks.base import AgentCheck  # noqa: F401
 

--- a/esxi/datadog_checks/esxi/config_models/instance.py
+++ b/esxi/datadog_checks/esxi/config_models/instance.py
@@ -19,6 +19,15 @@ from datadog_checks.base.utils.models import validation
 from . import defaults, validators
 
 
+class CollectPerInstanceFilters(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    host: Optional[tuple[str, ...]] = None
+    vm: Optional[tuple[str, ...]] = None
+
+
 class MetricPatterns(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -34,6 +43,7 @@ class InstanceConfig(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    collect_per_instance_filters: Optional[CollectPerInstanceFilters] = None
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
     host: str

--- a/esxi/datadog_checks/esxi/constants.py
+++ b/esxi/datadog_checks/esxi/constants.py
@@ -35,3 +35,25 @@ RESOURCE_TYPE_TO_NAME = {
     HOST_RESOURCE: 'host',
     VM_RESOURCE: 'vm',
 }
+
+
+METRIC_TO_INSTANCE_TAG_MAPPING = {
+    # Structure:
+    # prefix: tag key used for instance value
+    'cpu.': 'cpu_core',
+    # Examples: 0, 15
+    'datastore.': 'vmfs_uuid',
+    # Examples: fd3f776b-2ca26041, 5deed40f-cef2b3f6-0bcd-000c2927ce06
+    'disk.': 'device_path',
+    # Examples: mpx.vmhba0:C0:T1:L0, mpx.vmhba0:C0:T1:L0
+    'net.': 'nic',
+    # Examples: vmnic1, 4000
+    'storageAdapter.': 'storage_adapter',
+    # Examples: vmhba1, vmhba64
+    'storagePath.': 'storage_path',
+    # Examples: ide.vmhba64-ide.0:0-mpx.vmhba64:C0:T0:L0, pscsi.vmhba0-pscsi.0:1-mpx.vmhba0:C0:T1:L0
+    'sys.resource': 'resource_path',
+    # Examples: host/system/vmotion, host/system
+    'virtualDisk.': 'disk',
+    # Examples: scsi0:0, scsi0:0
+}

--- a/esxi/datadog_checks/esxi/data/conf.yaml.example
+++ b/esxi/datadog_checks/esxi/data/conf.yaml.example
@@ -39,6 +39,21 @@ instances:
     #
     # use_guest_hostname: false
 
+    ## @param collect_per_instance_filters - mapping - optional
+    ## Use this option to collect metrics tagged with instance values.
+    ## Some ESXi metrics can be tagged with instance values.
+    ## For each resource type (vm, host) to collect,
+    ## you can choose which metrics you want to collect the instance value as tags using a list of regex.
+    ## See https://github.com/DataDog/integrations-core/blob/master/esxi/datadog_checks/esxi/metrics.py
+    ## for the list of collected metrics (do not prefix them with `esxi`)
+    ## /!\ Use with parsimony, collecting per-instance metrics might be very expensive for big environments.
+    #
+    # collect_per_instance_filters:
+    #   vm:
+    #   - <VM_REGEX>
+    #   host:
+    #   - <HOST_REGEX>
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/esxi/datadog_checks/esxi/utils.py
+++ b/esxi/datadog_checks/esxi/utils.py
@@ -9,6 +9,7 @@ from datadog_checks.base import to_string
 
 from .constants import METRIC_TO_INSTANCE_TAG_MAPPING, RESOURCE_TYPE_TO_NAME
 
+
 def get_tags_recursively(mor, infrastructure_data, include_only=None):
     """Go up the resources hierarchy from the given mor. Note that a host running a VM is not considered to be a
     parent of that VM.

--- a/esxi/datadog_checks/esxi/utils.py
+++ b/esxi/datadog_checks/esxi/utils.py
@@ -1,9 +1,10 @@
 # (C) Datadog, Inc. 2024-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
+from six import iteritems
 from pyVmomi import vim
 
+from .constants import METRIC_TO_INSTANCE_TAG_MAPPING, RESOURCE_TYPE_TO_NAME
 from datadog_checks.base import to_string
 
 
@@ -51,3 +52,28 @@ def get_tags_recursively(mor, infrastructure_data, include_only=None):
                 continue
             filtered_tags.append(tag)
     return filtered_tags
+
+
+def match_any_regex(string, regexes):
+    for regex in regexes:
+        if regex.match(string):
+            return True
+    return False
+
+
+def should_collect_per_instance_values(collect_per_instance_filters, metric_name, resource_type):
+    filters = collect_per_instance_filters.get(RESOURCE_TYPE_TO_NAME[resource_type], [])
+    metric_matched = match_any_regex(metric_name, filters)
+    return metric_matched
+
+
+def get_mapped_instance_tag(metric_name):
+    """
+    When collecting per-instance metric, the `instance` tag can mean a lot of different things. The meaning of the
+    tag cannot be guessed by looking at the api results and has to be inferred using documentation or experience.
+    This method acts as a utility to map a metric_name to the meaning of its instance tag.
+    """
+    for prefix, tag_key in iteritems(METRIC_TO_INSTANCE_TAG_MAPPING):
+        if metric_name.startswith(prefix):
+            return tag_key
+    return 'instance'

--- a/esxi/datadog_checks/esxi/utils.py
+++ b/esxi/datadog_checks/esxi/utils.py
@@ -5,9 +5,9 @@
 from pyVmomi import vim
 from six import iteritems
 
-from .constants import METRIC_TO_INSTANCE_TAG_MAPPING, RESOURCE_TYPE_TO_NAME
 from datadog_checks.base import to_string
 
+from .constants import METRIC_TO_INSTANCE_TAG_MAPPING, RESOURCE_TYPE_TO_NAME
 
 def get_tags_recursively(mor, infrastructure_data, include_only=None):
     """Go up the resources hierarchy from the given mor. Note that a host running a VM is not considered to be a

--- a/esxi/datadog_checks/esxi/utils.py
+++ b/esxi/datadog_checks/esxi/utils.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2024-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
 from six import iteritems
 from pyVmomi import vim
 

--- a/esxi/datadog_checks/esxi/utils.py
+++ b/esxi/datadog_checks/esxi/utils.py
@@ -2,8 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from six import iteritems
 from pyVmomi import vim
+from six import iteritems
 
 from .constants import METRIC_TO_INSTANCE_TAG_MAPPING, RESOURCE_TYPE_TO_NAME
 from datadog_checks.base import to_string

--- a/esxi/tests/conftest.py
+++ b/esxi/tests/conftest.py
@@ -90,6 +90,10 @@ def service_instance(
     retrieve_properties_ex,
 ):
     mock_si = MagicMock()
+    mock_si.content.about.version = '6.5.0'
+    mock_si.content.about.build = '123456789'
+    mock_si.content.about.apiType = 'HostAgent'
+    mock_si.content.about.fullName = 'VMware ESXi 6.5.0 build-123456789'
     mock_si.content.perfManager.perfCounter = PERF_COUNTER_INFO
     mock_si.content.perfManager.QueryAvailablePerfMetric = MagicMock(side_effect=query_available_perf_metric)
     mock_si.content.perfManager.QueryPerf = MagicMock(side_effect=query_perf)

--- a/esxi/tests/test_unit.py
+++ b/esxi/tests/test_unit.py
@@ -523,6 +523,7 @@ def test_invalid_instance_filters(dd_run_check, vcsim_instance, caplog):
     dd_run_check(check)
     assert "Ignoring metric_filter for resource 'cluster'. It should be one of 'host, vm'" in caplog.text
 
+
 @pytest.mark.parametrize(
     'excluded_tags, expected_warning',
     [


### PR DESCRIPTION
### What does this PR do?
Adds support for per instance filters in the ESXi integration. per-instance metrics are more granular, non-aggregated metrics that have additional tags and tag values that we collect and send

### Motivation
vSphere has this option, much of this logic is copied from the vSphere integration
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
