### PR TITLE
Fix default value for pg_stat_statements_view

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -402,6 +402,7 @@ files:
       value:
         type: string
         example: show_pg_stat_statements()
+        display_default: pg_stat_statements
     - name: query_metrics
       description: Configure collection of query metrics
       options:

--- a/postgres/changelog.d/17400.fixed
+++ b/postgres/changelog.d/17400.fixed
@@ -1,0 +1,1 @@
+Fix default value for pg_stat_statements_view

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -109,7 +109,7 @@ def instance_min_collection_interval():
 
 
 def instance_pg_stat_statements_view():
-    return 'show_pg_stat_statements()'
+    return 'pg_stat_statements'
 
 
 def instance_port():

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -311,7 +311,7 @@ instances:
     #
     # dbm: false
 
-    ## @param pg_stat_statements_view - string - optional - default: show_pg_stat_statements()
+    ## @param pg_stat_statements_view - string - optional - default: pg_stat_statements
     ## Set this value if you want to define a custom view or function to allow the datadog user to query the
     ## `pg_stat_statements` table, which is useful for restricting the permissions given to the datadog agent.
     ## Please note this is an ALPHA feature and is subject to change or deprecation without notice.


### PR DESCRIPTION
### What does this PR do?
Fixes the default value for pg_stat_statements_view in the example config

### Motivation
<!-- What inspired you to submit this pull request? -->
Some customers are confused by the current default, which is not the correct default.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
