### PR TITLE
[PLINT-361] Add esxi_host tag 

### DIFF
--- a/esxi/datadog_checks/esxi/check.py
+++ b/esxi/datadog_checks/esxi/check.py
@@ -10,6 +10,7 @@ from pyVmomi import vim, vmodl
 from six import iteritems
 
 from datadog_checks.base import AgentCheck  # noqa: F401
+from datadog_checks.base.utils.common import to_string
 
 from .constants import (
     ALL_RESOURCES,
@@ -284,17 +285,31 @@ class EsxiCheck(AgentCheck):
 
             tags = []
             parent = resource_props.get('parent')
-            runtime_host = resource_props.get('runtime.host')
+
+            if resource_type == "vm":
+                runtime_host = resource_props.get('runtime.host')
+                runtime_host_props = {}
+                if runtime_host:
+                    if runtime_host in all_resources_with_metrics:
+                        runtime_host_props = all_resources_with_metrics.get(runtime_host, {})
+                    else:
+                        self.log.debug("Missing runtime.host details for VM %s", hostname)
+
+                runtime_hostname = to_string(runtime_host_props.get("name", "unknown"))
+                tags.append('esxi_host:{}'.format(runtime_hostname))
+
+                if runtime_host is not None:
+                    tags.extend(
+                        get_tags_recursively(
+                            runtime_host,
+                            resource_map,
+                            include_only=['esxi_cluster'],
+                        )
+                    )
+
             if parent is not None:
                 tags.extend(get_tags_recursively(parent, resource_map))
-            if runtime_host is not None:
-                tags.extend(
-                    get_tags_recursively(
-                        runtime_host,
-                        resource_map,
-                        include_only=['esxi_cluster'],
-                    )
-                )
+
             tags.append('esxi_type:{}'.format(resource_type))
 
             metric_tags = self.tags

--- a/esxi/tests/test_integration.py
+++ b/esxi/tests/test_integration.py
@@ -101,6 +101,7 @@ def test_vcsim_external_host_tags(vcsim_instance, datadog_agent, dd_run_check):
                 'esxi_folder:ha-folder-root',
                 'esxi_folder:vm',
                 'esxi_type:vm',
+                'esxi_host:localhost.localdomain',
                 'esxi_url:127.0.0.1:8989',
             ]
         },
@@ -113,6 +114,7 @@ def test_vcsim_external_host_tags(vcsim_instance, datadog_agent, dd_run_check):
                 'esxi_folder:ha-folder-root',
                 'esxi_folder:vm',
                 'esxi_type:vm',
+                'esxi_host:localhost.localdomain',
                 'esxi_url:127.0.0.1:8989',
             ]
         },
@@ -138,6 +140,7 @@ def test_esxi_resource_count_metrics(vcsim_instance, dd_run_check, aggregator):
         'esxi_folder:ha-folder-root',
         'esxi_folder:vm',
         'esxi_type:vm',
+        'esxi_host:localhost.localdomain',
         'esxi_url:127.0.0.1:8989',
     ]
 


### PR DESCRIPTION
### What does this PR do?
Adds an `esxi_host` tag to as a VM host tag, signifying what esxi host the VM is running on 

### Motivation
While we are already submitting the `esxi_url` tag, this is most likely different than the host's name. 

### Additional Notes
This will be the same for all VMs 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
