### PR TITLE
Add postgresql.running metric

### DIFF
--- a/postgres/changelog.d/17418.added
+++ b/postgres/changelog.d/17418.added
@@ -1,0 +1,1 @@
+Add new postgresql.running metric

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -650,6 +650,9 @@ class PostgreSql(AgentCheck):
             )
             self._dynamic_queries.append(self._new_query_executor(queries, db=db))
 
+    def _emit_running_metric(self):
+        self.gauge("postgresql.running", 1, tags=self.tags_without_db, hostname=self.resolved_hostname)
+
     def _collect_stats(self, instance_tags):
         """Query pg_stat_* for various metrics
         If relations is not an empty list, gather per-relation metrics
@@ -1027,6 +1030,7 @@ class PostgreSql(AgentCheck):
                 self.tags_without_db.append(replication_role_tag)
 
             self.log.debug("Running check against version %s: is_aurora: %s", str(self.version), str(self.is_aurora))
+            self._emit_running_metric()
             self._collect_stats(tags)
             self._collect_custom_queries(tags)
             if self._config.dbm_enabled:

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -124,6 +124,7 @@ postgresql.rows_hot_updated,gauge,,row,second,"Enabled with `relations`. The num
 postgresql.rows_inserted,gauge,,row,second,Enabled with `relations`. The number of rows inserted by queries in this database. This metric is tagged with db.,0,postgres,rows insrt,
 postgresql.rows_returned,gauge,,row,second,The number of rows returned by queries in this database. This metric is tagged with db.,0,postgres,rows ret,
 postgresql.rows_updated,gauge,,row,second,Enabled with `relations`. The number of rows updated by queries in this database. This metric is tagged with db.,0,postgres,rows updt,
+postgresql.running,gauge,,,,The number of instances running.,0,postgres,running,
 postgresql.seq_rows_read,gauge,,row,second,"Enabled with `relations`. The number of live rows fetched by sequential scans. This metric is tagged with db, schema, table.",0,postgres,seq rows rd,
 postgresql.seq_scans,gauge,,scan,second,"Enabled with `relations`. The number of sequential scans initiated on this table. This metric is tagged with db, schema, table.",0,postgres,seq scans,
 postgresql.sessions.abandoned,count,,session,,Number of database sessions to this database that were terminated because connection to the client was lost. This metric is tagged with db.,-1,postgres,postgres sessions abandoned,

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -203,6 +203,7 @@ def check_common_metrics(aggregator, expected_tags, count=1):
         if POSTGRES_VERSION is None or float(POSTGRES_VERSION) >= 14.0:
             for metric_name, _ in NEWER_14_METRICS.values():
                 aggregator.assert_metric(metric_name, count=count, tags=db_tags)
+    aggregator.assert_metric('postgresql.running', count=count, value=1, tags=expected_tags)
 
 
 def check_db_count(aggregator, expected_tags, count=1):


### PR DESCRIPTION
### What does this PR do?
Add a `postgresql.running` metric.

### Motivation
We want to be able to aggregate the number of database instances per version, system_identifier or any other arbitrary tags. The metrics currently available don't allow this.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
