### PR TITLE
fix(devcontainer): patch /etc/init.d/docker to support DiD

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,3 +12,4 @@ RUN echo \
   $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 RUN apt update
 RUN DEBIAN_FRONTEND=noninteractive apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+RUN sed -i 's\ulimit -Hn 524288\ulimit -n 524288\g' /etc/init.d/docker


### PR DESCRIPTION
### What does this PR do?
In `.devcontainer/dockerfile`, patch `/etc/init.d/docker` to change the `ulimit` command arguments and allows to run docker-in-docker commands.

I followed the workaround instruction defined [here](https://forums.docker.com/t/etc-init-d-docker-62-ulimit-error-setting-limit-invalid-argument-problem/139424). The issue seems to be linked to an change in the base image used by the upstream python devcontainer container image.

```
Container where the error was received: Debian GNU/Linux 11 (bullseye)
This error started to be received approximately as of Friday, January 19, 21:00:00UTC 2024.
```

### Motivation

Be able to use .devcontainer with this repository.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
