### PR TITLE
[SNMP] Update tests with new device_id and device_ip tags

### DIFF
--- a/snmp/tests/test_e2e_core.py
+++ b/snmp/tests/test_e2e_core.py
@@ -88,7 +88,11 @@ def test_e2e_user_profiles(dd_agent_check):
         'ups_name:testIdentName',
         'device_namespace:default',
     ]
-    tags = profile_tags + ["snmp_device:{}".format(device_ip)]
+    tags = profile_tags + [
+        "snmp_device:{}".format(device_ip),
+        "device_ip:{}".format(device_ip),
+        "device_id:default:{}".format(device_ip),
+    ]
 
     aggregator.assert_metric('snmp.upsAdvBatteryNumOfBattPacks', metric_type=aggregator.GAUGE, tags=tags, count=2)
     aggregator.assert_metric(
@@ -116,6 +120,8 @@ def test_e2e_user_profiles(dd_agent_check):
         'sys_object_id': '1.3.6.1.4.1.318.1.999',
         'tags': [
             'device_namespace:default',
+            "device_id:default:" + device_ip,
+            "device_ip:" + device_ip,
             'firmware_version:2.0.3-test',
             'model:APC Smart-UPS 600',
             'serial_num:test_serial',
@@ -146,7 +152,11 @@ def test_e2e_user_profiles_that_extend_profile_with_same_name(dd_agent_check):
         'snmp_profile:palo-alto',
         'device_namespace:default',
     ]
-    tags = profile_tags + ["snmp_device:{}".format(device_ip)]
+    tags = profile_tags + [
+        "snmp_device:{}".format(device_ip),
+        "device_ip:{}".format(device_ip),
+        "device_id:default:{}".format(device_ip),
+    ]
 
     aggregator.assert_metric('snmp.panSessionUtilization', metric_type=aggregator.GAUGE, tags=tags, count=2)
     aggregator.assert_metric('snmp.panSessionUtilization_user', metric_type=aggregator.GAUGE, tags=tags, count=2)
@@ -166,6 +176,8 @@ def test_e2e_user_profiles_that_extend_profile_with_same_name(dd_agent_check):
         'sys_object_id': '1.3.6.1.4.1.25461.2.3.18',
         'tags': [
             'device_namespace:default',
+            "device_id:default:" + device_ip,
+            "device_ip:" + device_ip,
             'snmp_device:' + device_ip,
             'snmp_profile:palo-alto',
         ],
@@ -190,7 +202,13 @@ def assert_apc_ups_metrics(dd_agent_check, config):
         'device_vendor:apc',
         'device_namespace:default',
     ]
-    tags = profile_tags + ["snmp_device:{}".format(instance['ip_address'])]
+    device_ip = instance['ip_address']
+
+    tags = profile_tags + [
+        "snmp_device:{}".format(device_ip),
+        "device_ip:{}".format(device_ip),
+        "device_id:default:{}".format(device_ip),
+    ]
 
     common.assert_common_metrics(aggregator, tags, is_e2e=True, loader='core')
     aggregator.assert_metric(
@@ -237,7 +255,13 @@ def test_e2e_memory_cpu_f5_big_ip(dd_agent_check):
         'snmp_host:f5-big-ip-adc-good-byol-1-vm.c.datadog-integrations-lab.internal',
         'snmp_profile:f5-big-ip',
     ]
-    tags += ['snmp_device:{}'.format(instance['ip_address'])]
+    device_ip = instance['ip_address']
+
+    tags += [
+        "snmp_device:{}".format(device_ip),
+        "device_ip:{}".format(device_ip),
+        "device_id:default:{}".format(device_ip),
+    ]
 
     common.assert_common_metrics(aggregator, tags, is_e2e=True, loader='core')
 
@@ -283,6 +307,8 @@ def test_e2e_core_discovery(dd_agent_check):
         # autodiscovery
         'autodiscovery_subnet:' + network,
         'snmp_device:' + ip_address,
+        "device_ip:" + ip_address,
+        "device_id:default:" + ip_address,
     ]
 
     tags_with_loader = tags + ['loader:core']
@@ -356,6 +382,7 @@ def test_e2e_regex_match(dd_agent_check):
     ]
     config['init_config']['loader'] = 'core'
     aggregator = common.dd_agent_check_wrapper(dd_agent_check, config, rate=True)
+    device_ip = instance['ip_address']
 
     # raw sysName: 41ba948911b9
     aggregator.assert_metric(
@@ -366,7 +393,9 @@ def test_e2e_regex_match(dd_agent_check):
             'letter1:4',
             'letter2:1',
             'loader:core',
-            'snmp_device:' + instance['ip_address'],
+            'snmp_device:' + device_ip,
+            'device_ip:' + device_ip,
+            'device_id:default:' + device_ip,
             'device_namespace:default',
         ],
     )
@@ -391,6 +420,8 @@ def test_e2e_meraki_cloud_controller(dd_agent_check):
         'device_vendor:meraki',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        "device_ip:" + ip_address,
+        "device_id:default:" + ip_address,
     ]
 
     common.assert_common_metrics(aggregator, tags=common_tags, is_e2e=True, loader='core')
@@ -485,8 +516,14 @@ def test_e2e_core_detect_metrics_using_apc_ups_metrics(dd_agent_check):
         # metric_tags from _base.yaml
         'snmp_host:APC_UPS_NAME',
     ]
+    device_ip = instance['ip_address']
 
-    tags = global_metric_tags + ['device_namespace:default', "snmp_device:{}".format(instance['ip_address'])]
+    tags = global_metric_tags + [
+        'device_namespace:default',
+        "snmp_device:{}".format(device_ip),
+        "device_ip:{}".format(device_ip),
+        "device_id:default:{}".format(device_ip),
+    ]
 
     common.assert_common_metrics(aggregator, tags, is_e2e=True, loader='core')
 
@@ -534,12 +571,15 @@ def test_e2e_core_cisco_csr(dd_agent_check):
     config['init_config']['loader'] = 'core'
     instance = config['instances'][0]
     aggregator = common.dd_agent_check_wrapper(dd_agent_check, config, rate=True)
+    device_ip = instance['ip_address']
 
     global_tags = [
         'snmp_profile:cisco-csr1000v',
         'device_vendor:cisco',
         'device_namespace:default',
-        "snmp_device:{}".format(instance['ip_address']),
+        "snmp_device:{}".format(device_ip),
+        "device_ip:{}".format(device_ip),
+        "device_id:default:{}".format(device_ip),
     ]
 
     common.assert_common_metrics(aggregator, global_tags, is_e2e=True, loader='core')
@@ -570,12 +610,15 @@ def test_e2e_cisco_nexus(dd_agent_check):
     config['init_config']['loader'] = 'core'
     instance = config['instances'][0]
     aggregator = common.dd_agent_check_wrapper(dd_agent_check, config, rate=True)
+    device_ip = instance['ip_address']
 
     common_tags = [
         'snmp_profile:cisco-nexus',
         'device_vendor:cisco',
         'device_namespace:default',
-        "snmp_device:{}".format(instance['ip_address']),
+        "snmp_device:{}".format(device_ip),
+        "device_ip:{}".format(device_ip),
+        "device_id:default:{}".format(device_ip),
         'snmp_host:Nexus-eu1.companyname.managed',
     ]
 
@@ -786,6 +829,8 @@ def test_e2e_cisco_legacy_wlc(dd_agent_check):
         'device_vendor:cisco',
         'snmp_host:DDOGWLC',
         'snmp_device:' + ip_address,
+        "device_ip:" + ip_address,
+        "device_id:default:" + ip_address,
     ]
     common.assert_common_metrics(aggregator, tags, is_e2e=True, loader='core')
 

--- a/snmp/tests/test_e2e_core_metadata.py
+++ b/snmp/tests/test_e2e_core_metadata.py
@@ -79,6 +79,8 @@ def test_e2e_core_metadata_f5(dd_agent_check):
                     u'status': 1,
                     u'sys_object_id': u'1.3.6.1.4.1.3375.2.1.3.4.43',
                     u'tags': [
+                        u'device_id:' + device_id,
+                        u'device_ip:' + device_ip,
                         u'device_namespace:default',
                         u'device_vendor:f5',
                         u'snmp_device:' + device_ip,
@@ -192,13 +194,16 @@ def test_e2e_core_metadata_cisco_3850(dd_agent_check):
     pprint.pprint(event1['devices'])
     assert len(event1['devices']) == 1
     actual_device = event1['devices'][0]
+
+    device_id = 'default:' + device_ip
+
     device = {
         u'description': u'Cisco IOS Software, IOS-XE Software, Catalyst L3 Switch '
         u'Software (CAT3K_CAA-UNIVERSALK9-M), Version 03.06.06E RELEASE '
         u'SOFTWARE (fc1) Technical Support: '
         u'http://www.cisco.com/techsupport Copyright (c) 1986-2016 by '
         u'Cisco Systems, Inc. Compiled Sat 17-Dec-',
-        u'id': u'default:' + device_ip,
+        u'id': device_id,
         u'id_tags': [u'device_namespace:default', u'snmp_device:' + device_ip],
         u'ip_address': device_ip,
         u'location': u'4th floor',
@@ -208,6 +213,8 @@ def test_e2e_core_metadata_cisco_3850(dd_agent_check):
         u'status': 1,
         u'sys_object_id': u'1.3.6.1.4.1.9.1.1745',
         u'tags': [
+            u'device_id:' + device_id,
+            u'device_ip:' + device_ip,
             u'device_namespace:default',
             u'device_vendor:cisco',
             u'snmp_device:' + device_ip,
@@ -252,9 +259,10 @@ def test_e2e_core_metadata_cisco_catalyst(dd_agent_check):
     aggregator = dd_agent_check(config, rate=False)
 
     device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
 
     device = {
-        u'id': u'default:' + device_ip,
+        u'id': device_id,
         u'id_tags': [
             u'device_namespace:default',
             u'snmp_device:' + device_ip,
@@ -265,6 +273,8 @@ def test_e2e_core_metadata_cisco_catalyst(dd_agent_check):
         u'status': 1,
         u'sys_object_id': u'1.3.6.1.4.1.9.1.241',
         u'tags': [
+            u'device_id:' + device_id,
+            u'device_ip:' + device_ip,
             u'device_namespace:default',
             u'device_vendor:cisco',
             u'snmp_device:' + device_ip,
@@ -291,9 +301,10 @@ def test_e2e_core_metadata_hp_ilo4(dd_agent_check):
     aggregator = dd_agent_check(config, rate=False)
 
     device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
 
     device = {
-        u'id': u'default:' + device_ip,
+        u'id': device_id,
         u'id_tags': [
             u'device_namespace:default',
             u'snmp_device:' + device_ip,
@@ -309,6 +320,8 @@ def test_e2e_core_metadata_hp_ilo4(dd_agent_check):
         u'sys_object_id': u'1.3.6.1.4.1.232.9.4.10',
         u'version': u'A04-08/12/2018',
         u'tags': [
+            u'device_id:' + device_id,
+            u'device_ip:' + device_ip,
             u'device_namespace:default',
             u'device_vendor:hp',
             u'snmp_device:' + device_ip,
@@ -335,9 +348,10 @@ def test_e2e_core_metadata_hpe_proliant(dd_agent_check):
     aggregator = dd_agent_check(config, rate=False)
 
     device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
 
     device = {
-        u'id': u'default:' + device_ip,
+        u'id': device_id,
         u'id_tags': [
             u'device_namespace:default',
             u'snmp_device:' + device_ip,
@@ -353,6 +367,8 @@ def test_e2e_core_metadata_hpe_proliant(dd_agent_check):
         u'version': u'A04-08/12/2019',
         u'sys_object_id': u'1.3.6.1.4.1.232.1.2',
         u'tags': [
+            u'device_id:' + device_id,
+            u'device_ip:' + device_ip,
             u'device_namespace:default',
             u'device_vendor:hp',
             u'snmp_device:' + device_ip,
@@ -379,13 +395,14 @@ def test_e2e_core_metadata_apc_ups(dd_agent_check):
     aggregator = dd_agent_check(config, rate=False)
 
     device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
 
     device = {
         'description': 'APC Web/SNMP Management Card (MB:v3.9.2 PF:v3.9.2 '
         'PN:apc_hw02_aos_392.bin AF1:v3.7.2 AN1:apc_hw02_sumx_372.bin '
         'MN:AP9619 HR:A10 SN: 5A1827E00000 MD:12/04/2007) (Embedded '
         'PowerNet SNMP Agent SW v2.2 compatible)',
-        'id': 'default:' + device_ip,
+        'id': device_id,
         'id_tags': [
             'device_namespace:default',
             'snmp_device:' + device_ip,
@@ -400,6 +417,8 @@ def test_e2e_core_metadata_apc_ups(dd_agent_check):
         'status': 1,
         'sys_object_id': '1.3.6.1.4.1.318.1.1.1',
         'tags': [
+            u'device_id:' + device_id,
+            u'device_ip:' + device_ip,
             'device_namespace:default',
             'device_vendor:apc',
             'firmware_version:2.0.3-test',
@@ -430,11 +449,12 @@ def test_e2e_core_metadata_juniper_ex(dd_agent_check):
     aggregator = dd_agent_check(config, rate=False)
 
     device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
 
     expected_device = {
         u'description': u'Juniper Networks, Inc. ex2200-24t-4g internet router, kernel '
         + u'JUNOS 10.2R1.8 #0: 2010-05-27 20:13:49 UTC',
-        u'id': u'default:' + device_ip,
+        u'id': device_id,
         u'id_tags': [
             u'device_namespace:default',
             u'snmp_device:' + device_ip,
@@ -449,6 +469,8 @@ def test_e2e_core_metadata_juniper_ex(dd_agent_check):
         u'sys_object_id': u'1.3.6.1.4.1.2636.1.1.1.2.30',
         u'serial_number': u'dXPEdPBE5yKtjW9xx3',
         u'tags': [
+            u'device_id:' + device_id,
+            u'device_ip:' + device_ip,
             u'device_namespace:default',
             u'device_vendor:juniper-networks',
             u'snmp_device:' + device_ip,
@@ -475,11 +497,12 @@ def test_e2e_core_metadata_juniper_mx(dd_agent_check):
     aggregator = dd_agent_check(config, rate=False)
 
     device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
 
     expected_device = {
         u'description': u'Juniper Networks, Inc. mx480 internet router, kernel JUNOS 11.2R1.10 '
         + u'#0: 2011-07-29 07:15:34 UTC',
-        u'id': u'default:' + device_ip,
+        u'id': device_id,
         u'id_tags': [
             u'device_namespace:default',
             u'snmp_device:' + device_ip,
@@ -494,6 +517,8 @@ def test_e2e_core_metadata_juniper_mx(dd_agent_check):
         u'sys_object_id': u'1.3.6.1.4.1.2636.1.1.1.2.25',
         u'serial_number': u'dXPEdPBE5yKtjW9xx4',
         u'tags': [
+            u'device_id:' + device_id,
+            u'device_ip:' + device_ip,
             u'device_namespace:default',
             u'device_vendor:juniper-networks',
             u'snmp_device:' + device_ip,
@@ -520,11 +545,12 @@ def test_e2e_core_metadata_juniper_srx(dd_agent_check):
     aggregator = dd_agent_check(config, rate=False)
 
     device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
 
     expected_device = {
         u'description': u'Juniper Networks, Inc. srx3400 internet router, kernel JUNOS '
         + u'10.4R3.4 #0: 2011-03-19 22:06:23 UTC',
-        u'id': u'default:' + device_ip,
+        u'id': device_id,
         u'id_tags': [
             u'device_namespace:default',
             u'snmp_device:' + device_ip,
@@ -539,6 +565,8 @@ def test_e2e_core_metadata_juniper_srx(dd_agent_check):
         u'sys_object_id': u'1.3.6.1.4.1.2636.1.1.1.2.35',
         u'serial_number': u'dXPEdPBE5yKtjW9xx5',
         u'tags': [
+            u'device_id:' + device_id,
+            u'device_ip:' + device_ip,
             u'device_namespace:default',
             u'device_vendor:juniper-networks',
             u'snmp_device:' + device_ip,
@@ -564,10 +592,11 @@ def test_e2e_core_metadata_aruba_switch(dd_agent_check):
     aggregator = dd_agent_check(config, rate=False)
 
     device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
 
     device = {
         'description': 'ArubaOS (MODEL: Aruba7210), Version 8.6.0.4 (74969)',
-        'id': 'default:' + device_ip,
+        'id': device_id,
         'id_tags': [
             'device_namespace:default',
             'snmp_device:' + device_ip,
@@ -583,6 +612,8 @@ def test_e2e_core_metadata_aruba_switch(dd_agent_check):
         'status': 1,
         'sys_object_id': '1.3.6.1.4.1.14823.1.1.36',
         'tags': [
+            'device_id:' + device_id,
+            'device_ip:' + device_ip,
             'device_namespace:default',
             'device_vendor:aruba',
             'snmp_device:' + device_ip,
@@ -609,10 +640,11 @@ def test_e2e_core_metadata_aruba_access_point(dd_agent_check):
     aggregator = dd_agent_check(config, rate=False)
 
     device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
 
     device = {
         'description': 'ArubaOS (MODEL: 335), Version 6.5.4.3-6.5.4.3',
-        'id': 'default:' + device_ip,
+        'id': device_id,
         'id_tags': [
             'device_namespace:default',
             'snmp_device:' + device_ip,
@@ -626,6 +658,8 @@ def test_e2e_core_metadata_aruba_access_point(dd_agent_check):
         'status': 1,
         'sys_object_id': '1.3.6.1.4.1.14823.1.2.80',
         'tags': [
+            'device_id:' + device_id,
+            'device_ip:' + device_ip,
             'device_namespace:default',
             'device_vendor:aruba',
             'snmp_device:' + device_ip,
@@ -652,10 +686,11 @@ def test_e2e_core_metadata_arista(dd_agent_check):
     aggregator = dd_agent_check(config, rate=False)
 
     device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
 
     device = {
         'description': 'Arista Networks EOS version 4.20.11.1M running on an Arista Networks DCS-7504',
-        'id': 'default:' + device_ip,
+        'id': device_id,
         'id_tags': [
             'device_namespace:default',
             'snmp_device:' + device_ip,
@@ -671,6 +706,8 @@ def test_e2e_core_metadata_arista(dd_agent_check):
         'status': 1,
         'sys_object_id': '1.3.6.1.4.1.30065.1.3011.7504',
         'tags': [
+            'device_id:' + device_id,
+            'device_ip:' + device_ip,
             'device_namespace:default',
             'device_vendor:arista',
             'snmp_device:' + device_ip,
@@ -697,10 +734,11 @@ def test_e2e_core_metadata_palo_alto(dd_agent_check):
     aggregator = dd_agent_check(config, rate=False)
 
     device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
 
     device = {
         'description': 'Palo Alto Networks PA-3000 series firewall',
-        'id': 'default:' + device_ip,
+        'id': device_id,
         'id_tags': [
             'device_namespace:default',
             'snmp_device:' + device_ip,
@@ -715,6 +753,8 @@ def test_e2e_core_metadata_palo_alto(dd_agent_check):
         'status': 1,
         'sys_object_id': '1.3.6.1.4.1.25461.2.3.18',
         'tags': [
+            'device_id:' + device_id,
+            'device_ip:' + device_ip,
             'device_namespace:default',
             'snmp_device:' + device_ip,
             'snmp_profile:palo-alto',
@@ -739,10 +779,11 @@ def test_e2e_core_metadata_netapp(dd_agent_check):
     aggregator = dd_agent_check(config, rate=False)
 
     device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
 
     device = {
         'description': 'NetApp Release 9.3P7: Wed Jul 25 10:11:10 UTC 2018',
-        'id': 'default:' + device_ip,
+        'id': device_id,
         'id_tags': [
             'device_namespace:default',
             'snmp_device:' + device_ip,
@@ -758,6 +799,8 @@ def test_e2e_core_metadata_netapp(dd_agent_check):
         'status': 1,
         'sys_object_id': '1.3.6.1.4.1.789.2.5',
         'tags': [
+            'device_id:' + device_id,
+            'device_ip:' + device_ip,
             'device_namespace:default',
             'device_vendor:netapp',
             'snmp_device:' + device_ip,
@@ -784,10 +827,11 @@ def test_e2e_core_metadata_checkpoint(dd_agent_check):
     aggregator = dd_agent_check(config, rate=False)
 
     device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
 
     device = {
         'description': 'Linux host1 3.10.0-957.21.3cpx86_64 #1 SMP Tue Jan 28 17:26:12 IST 2020 x86_64',
-        'id': 'default:' + device_ip,
+        'id': device_id,
         'id_tags': [
             'device_namespace:default',
             'snmp_device:' + device_ip,
@@ -803,6 +847,8 @@ def test_e2e_core_metadata_checkpoint(dd_agent_check):
         'status': 1,
         'sys_object_id': '1.3.6.1.4.1.2620.1.1',
         'tags': [
+            'device_id:' + device_id,
+            'device_ip:' + device_ip,
             'device_namespace:default',
             'device_vendor:checkpoint',
             'snmp_device:' + device_ip,
@@ -830,10 +876,11 @@ def test_e2e_core_metadata_checkpoint_firewall(dd_agent_check):
     aggregator = dd_agent_check(config, rate=False)
 
     device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
 
     device = {
         'description': 'Linux host1 3.10.0-957.21.3cpx86_64 #1 SMP Tue Jan 28 17:26:12 IST 2020 x86_64',
-        'id': 'default:' + device_ip,
+        'id': device_id,
         'id_tags': [
             'device_namespace:default',
             'snmp_device:' + device_ip,
@@ -849,6 +896,8 @@ def test_e2e_core_metadata_checkpoint_firewall(dd_agent_check):
         'status': 1,
         'sys_object_id': '1.3.6.1.4.1.2620.1.1',
         'tags': [
+            'device_id:' + device_id,
+            'device_ip:' + device_ip,
             'device_namespace:default',
             'device_vendor:checkpoint',
             'snmp_device:' + device_ip,
@@ -875,9 +924,10 @@ def test_e2e_core_metadata_fortinet_fortigate(dd_agent_check):
     aggregator = dd_agent_check(config, rate=False)
 
     device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
 
     device = {
-        'id': 'default:' + device_ip,
+        'id': device_id,
         'id_tags': [
             'device_namespace:default',
             'snmp_device:' + device_ip,
@@ -893,6 +943,8 @@ def test_e2e_core_metadata_fortinet_fortigate(dd_agent_check):
         'status': 1,
         'sys_object_id': '1.3.6.1.4.1.12356.101.1.1',
         'tags': [
+            'device_id:' + device_id,
+            'device_ip:' + device_ip,
             'device_namespace:default',
             'device_vendor:fortinet',
             'snmp_device:' + device_ip,
@@ -919,9 +971,10 @@ def test_e2e_core_metadata_dell_idrac(dd_agent_check):
     aggregator = dd_agent_check(config, rate=False)
 
     device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
 
     device = {
-        u'id': u'default:' + device_ip,
+        u'id': device_id,
         u'id_tags': [
             u'device_namespace:default',
             u'snmp_device:' + device_ip,
@@ -936,6 +989,8 @@ def test_e2e_core_metadata_dell_idrac(dd_agent_check):
         u'version': u'2.5.4',
         u'sys_object_id': u'1.3.6.1.4.1.674.10892.2',
         u'tags': [
+            'device_id:' + device_id,
+            'device_ip:' + device_ip,
             u'device_namespace:default',
             u'device_vendor:dell',
             u'snmp_device:' + device_ip,
@@ -961,10 +1016,11 @@ def test_e2e_core_metadata_isilon(dd_agent_check):
     aggregator = dd_agent_check(config, rate=False)
 
     device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
 
     device = {
         'description': 'device-name-3 263829375 Isilon OneFS v8.2.0.0',
-        'id': 'default:' + device_ip,
+        'id': device_id,
         'id_tags': [
             'device_namespace:default',
             'snmp_device:' + device_ip,
@@ -979,6 +1035,8 @@ def test_e2e_core_metadata_isilon(dd_agent_check):
         'status': 1,
         'sys_object_id': '1.3.6.1.4.1.12325.1.1.2.1.1',
         'tags': [
+            'device_id:' + device_id,
+            'device_ip:' + device_ip,
             'cluster_name:testcluster1',
             'device_namespace:default',
             'device_vendor:dell',
@@ -1057,12 +1115,13 @@ def test_e2e_core_metadata_cisco_asr_1001x(dd_agent_check):
     aggregator = dd_agent_check(config, rate=False)
 
     device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
 
     device = {
         u'description': u'Cisco IOS Software [Bengaluru], ASR1000 Software '
         '(X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 17.6.4, RELEASE '
         'SOFTWARE (fc1)',
-        u'id': u'default:' + device_ip,
+        u'id': device_id,
         u'id_tags': [
             u'device_namespace:default',
             u'snmp_device:' + device_ip,
@@ -1074,6 +1133,8 @@ def test_e2e_core_metadata_cisco_asr_1001x(dd_agent_check):
         u'status': 1,
         u'sys_object_id': u'1.3.6.1.4.1.9.1.1861',
         u'tags': [
+            'device_id:' + device_id,
+            'device_ip:' + device_ip,
             u'device_namespace:default',
             u'device_vendor:cisco',
             u'snmp_device:' + device_ip,
@@ -1099,10 +1160,11 @@ def test_e2e_core_metadata_cisco_asr_9001(dd_agent_check):
     aggregator = dd_agent_check(config, rate=False)
 
     device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
 
     device = {
         u'description': u'Cisco IOS XR Software (Cisco ASR9K Series),  Version ' '6.4.2[Default]',
-        u'id': u'default:' + device_ip,
+        u'id': device_id,
         u'id_tags': [
             u'device_namespace:default',
             u'snmp_device:' + device_ip,
@@ -1114,6 +1176,8 @@ def test_e2e_core_metadata_cisco_asr_9001(dd_agent_check):
         u'status': 1,
         u'sys_object_id': u'1.3.6.1.4.1.9.1.1639',
         u'tags': [
+            'device_id:' + device_id,
+            'device_ip:' + device_ip,
             u'device_namespace:default',
             u'device_vendor:cisco',
             u'snmp_device:' + device_ip,
@@ -1139,11 +1203,12 @@ def test_e2e_core_metadata_cisco_asr_9901(dd_agent_check):
     aggregator = dd_agent_check(config, rate=False)
 
     device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
 
     device = {
         u'description': u'Cisco IOS XR Software (ASR9K), Version 7.1.3  Copyright (c) '
         '2013-2020 by Cisco Systems, Inc.',
-        u'id': u'default:' + device_ip,
+        u'id': device_id,
         u'id_tags': [
             u'device_namespace:default',
             u'snmp_device:' + device_ip,
@@ -1155,6 +1220,8 @@ def test_e2e_core_metadata_cisco_asr_9901(dd_agent_check):
         u'status': 1,
         u'sys_object_id': u'1.3.6.1.4.1.9.1.2658',
         u'tags': [
+            'device_id:' + device_id,
+            'device_ip:' + device_ip,
             u'device_namespace:default',
             u'device_vendor:cisco',
             u'snmp_device:' + device_ip,
@@ -1281,10 +1348,11 @@ def test_e2e_core_metadata_cisco_wlc(dd_agent_check):
     aggregator = dd_agent_check(config, rate=False)
 
     device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
 
     device = {
         u'description': u'Cisco Controller',
-        u'id': u'default:' + device_ip,
+        u'id': device_id,
         u'id_tags': [
             u'device_namespace:default',
             u'snmp_device:' + device_ip,
@@ -1296,6 +1364,8 @@ def test_e2e_core_metadata_cisco_wlc(dd_agent_check):
         u'status': 1,
         u'sys_object_id': u'1.3.6.1.4.1.9.1.1069',
         u'tags': [
+            'device_id:' + device_id,
+            'device_ip:' + device_ip,
             u'device_namespace:default',
             u'device_vendor:cisco',
             u'snmp_device:' + device_ip,

--- a/snmp/tests/test_e2e_core_profiles/test_profile_3com.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_3com.py
@@ -30,6 +30,8 @@ def test_e2e_profile_3com(dd_agent_check):
         'snmp_host:3com.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST METRICS ---
@@ -47,6 +49,8 @@ def test_e2e_profile_3com(dd_agent_check):
         'status': 1,
         'sys_object_id': '1.3.6.1.4.1.43.1.999',
         'tags': [
+            'device_id:default:' + ip_address,
+            'device_ip:' + ip_address,
             'device_namespace:default',
             'snmp_device:' + ip_address,
             'snmp_host:3com.device.name',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_3com_huawei.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_3com_huawei.py
@@ -30,6 +30,8 @@ def test_e2e_profile_3com_huawei(dd_agent_check):
         'snmp_host:3com-huawei.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST METRICS ---
@@ -77,6 +79,8 @@ def test_e2e_profile_3com_huawei(dd_agent_check):
         'status': 1,
         'sys_object_id': '1.3.6.1.4.1.43.45.1.2.999',
         'tags': [
+            'device_id:default:' + ip_address,
+            'device_ip:' + ip_address,
             'device_namespace:default',
             'snmp_device:' + ip_address,
             'snmp_host:3com-huawei.device.name',

--- a/snmp/tests/test_e2e_core_profiles/test_profile__checkpoint_firewall_cpu_memory.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile__checkpoint_firewall_cpu_memory.py
@@ -29,6 +29,8 @@ def test_e2e_profile__checkpoint_firewall_cpu_memory(dd_agent_check):
         'snmp_host:_checkpoint-firewall-cpu-memory.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile__cisco_generic.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile__cisco_generic.py
@@ -36,6 +36,8 @@ def test_e2e_profile__cisco_generic(dd_agent_check):
         'snmp_host:_cisco-generic.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile__cisco_ipsec_flow_monitor.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile__cisco_ipsec_flow_monitor.py
@@ -27,6 +27,8 @@ def test_e2e_profile__cisco_ipsec_flow_monitor(dd_agent_check):
         'snmp_host:_cisco-ipsec-flow-monitor.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile__dell_rac.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile__dell_rac.py
@@ -29,6 +29,8 @@ def test_e2e_profile__dell_rac(dd_agent_check):
         'snmp_host:_dell-rac.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile__generic_bgp4.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile__generic_bgp4.py
@@ -29,6 +29,8 @@ def test_e2e_profile__generic_bgp4(dd_agent_check):
         'snmp_host:_generic-bgp4.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile__generic_entity_sensor.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile__generic_entity_sensor.py
@@ -29,6 +29,8 @@ def test_e2e_profile__generic_entity_sensor(dd_agent_check):
         'snmp_host:_generic-entity-sensor.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile__generic_rtp.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile__generic_rtp.py
@@ -27,6 +27,8 @@ def test_e2e_profile__generic_rtp(dd_agent_check):
         'snmp_host:_generic-rtp.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile__generic_sip.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile__generic_sip.py
@@ -27,6 +27,8 @@ def test_e2e_profile__generic_sip(dd_agent_check):
         'snmp_host:_generic-sip.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile__generic_ucd.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile__generic_ucd.py
@@ -29,6 +29,8 @@ def test_e2e_profile__generic_ucd(dd_agent_check):
         'snmp_host:_generic-ucd.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile__generic_ups.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile__generic_ups.py
@@ -29,6 +29,8 @@ def test_e2e_profile__generic_ups(dd_agent_check):
         'snmp_host:_generic-ups.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'ups_ident_manufacturer:quaintly forward driving Jaded',
         'ups_ident_model:but zombies acted kept forward zombies quaintly acted Jaded',

--- a/snmp/tests/test_e2e_core_profiles/test_profile__hp_compaq_health.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile__hp_compaq_health.py
@@ -29,6 +29,8 @@ def test_e2e_profile__hp_compaq_health(dd_agent_check):
         'snmp_host:_hp-compaq-health.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_a10_thunder.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_a10_thunder.py
@@ -30,6 +30,8 @@ def test_e2e_profile_a10_thunder(dd_agent_check):
         'snmp_host:a10-thunder.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'ax_sys_a_fle_x_engine_version:their quaintly acted Jaded driving their ' 'forward',
         'ax_sys_firmware_version:oxen their quaintly kept quaintly zombies',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_alcatel_lucent_ent.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_alcatel_lucent_ent.py
@@ -30,6 +30,8 @@ def test_e2e_profile_alcatel_lucent_ent(dd_agent_check):
         'snmp_host:alcatel-lucent-ent.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_alcatel_lucent_ind.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_alcatel_lucent_ind.py
@@ -30,6 +30,8 @@ def test_e2e_profile_alcatel_lucent_ind(dd_agent_check):
         'snmp_host:alcatel-lucent-ind.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_alcatel_lucent_omni_access_wlc.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_alcatel_lucent_omni_access_wlc.py
@@ -30,6 +30,8 @@ def test_e2e_profile_alcatel_lucent_omni_access_wlc(dd_agent_check):
         'snmp_host:alcatel-lucent-omni-access-wlc.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'wlsx_model_name:quaintly Jaded oxen oxen',
         'wlsx_switch_license_serial_number:quaintly oxen their',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_anue.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_anue.py
@@ -30,6 +30,8 @@ def test_e2e_profile_anue(dd_agent_check):
         'snmp_host:anue-packet-broker.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_apc_netbotz.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_apc_netbotz.py
@@ -29,6 +29,8 @@ def test_e2e_profile_apc_netbotz(dd_agent_check):
         'snmp_host:apc-netbotz.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_apc_pdu.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_apc_pdu.py
@@ -31,6 +31,8 @@ def test_e2e_profile_apc_pdu(dd_agent_check):
         'snmp_host:apc-pdu.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'powernet_r_pdu_ident_firmware_rev:kept zombies forward acted zombies but kept forward',
         'powernet_r_pdu_ident_hardware_rev:zombies forward their',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_arista_switch.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_arista_switch.py
@@ -33,6 +33,8 @@ def test_e2e_profile_arista_switch(dd_agent_check):
         'snmp_host:arista-switch.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_aruba_clearpass.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_aruba_clearpass.py
@@ -31,6 +31,8 @@ def test_e2e_profile_aruba_clearpass(dd_agent_check):
         'snmp_host:aruba-clearpass.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'cppm_system_version:5.0.1',
         'cppm_cluster_node_type:Master',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_aruba_cx_switch.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_aruba_cx_switch.py
@@ -31,6 +31,8 @@ def test_e2e_profile_aruba_cx_switch(dd_agent_check):
         'snmp_host:aruba-cx-switch.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_aruba_mobility_controller.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_aruba_mobility_controller.py
@@ -30,6 +30,8 @@ def test_e2e_profile_aruba_mobility_controller(dd_agent_check):
         'snmp_host:aruba-mobility-controller.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_aruba_switch.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_aruba_switch.py
@@ -32,6 +32,8 @@ def test_e2e_profile_aruba_switch(dd_agent_check):
         'snmp_host:aruba-switch.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
         'device_vendor:aruba',
     ] + []
 

--- a/snmp/tests/test_e2e_core_profiles/test_profile_aruba_wireless_controller.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_aruba_wireless_controller.py
@@ -30,6 +30,8 @@ def test_e2e_profile_aruba_wireless_controller(dd_agent_check):
         'snmp_host:aruba-wireless-controller.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'wlsx_model_name:their driving kept their kept',
         'wlsx_switch_license_serial_number:forward kept forward',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_audiocodes_mediant_sbc.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_audiocodes_mediant_sbc.py
@@ -30,6 +30,8 @@ def test_e2e_profile_audiocodes_mediant_sbc(dd_agent_check):
         'snmp_host:audiocodes-mediant-sbc.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_avaya_aura_media_server.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_avaya_aura_media_server.py
@@ -31,6 +31,8 @@ def test_e2e_profile_avaya_aura_media_server(dd_agent_check):
         'snmp_host:avaya-aura-media-server.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_avaya_cajun_switch.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_avaya_cajun_switch.py
@@ -29,6 +29,8 @@ def test_e2e_profile_avaya_cajun_switch(dd_agent_check):
         'snmp_host:avaya-cajun-switch.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + ['avaya_gen_cpu_utilization_enable_monitoring:enabled']
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_avaya_media_gateway.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_avaya_media_gateway.py
@@ -32,6 +32,8 @@ def test_e2e_profile_avaya_media_gateway(dd_agent_check):
         'snmp_host:avaya-media-gateway.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_id:default:' + ip_address,
+        'device_ip:' + ip_address,
     ] + [
         'avaya_cmg_active_controller_address:112.163.176.135',
         'avaya_cmg_hw_type:avaya_g250-a14',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_avaya_nortel_ethernet_routing_switch.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_avaya_nortel_ethernet_routing_switch.py
@@ -30,6 +30,8 @@ def test_e2e_profile_avaya_nortel_ethernet_routing_switch(dd_agent_check):
         'snmp_host:avaya-nortel-ethernet-routing-switch.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + ['avaya_s5_chas_ser_num:oxen', 'avaya_s5_chas_ver:Jaded driving']
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_avocent_acs.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_avocent_acs.py
@@ -31,6 +31,8 @@ def test_e2e_profile_avocent_acs(dd_agent_check):
         'snmp_host:avocent-acs.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_avtech_roomalert_32s.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_avtech_roomalert_32s.py
@@ -29,6 +29,8 @@ def test_e2e_profile_avtech_roomalert_32s(dd_agent_check):
         'snmp_host:avtech-roomalert-32s.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_avtech_roomalert_3e.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_avtech_roomalert_3e.py
@@ -29,6 +29,8 @@ def test_e2e_profile_avtech_roomalert3e(dd_agent_check):
         'snmp_host:avtech-roomalert-3e.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_avtech_roomalert_3s.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_avtech_roomalert_3s.py
@@ -29,6 +29,8 @@ def test_e2e_profile_avtech_roomalert_3s(dd_agent_check):
         'snmp_host:avtech-roomalert-3s.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_barracuda_cloudgen.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_barracuda_cloudgen.py
@@ -31,6 +31,8 @@ def test_e2e_profile_barracuda_cloudgen(dd_agent_check):
         'snmp_host:barracuda-cloudgen.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_bluecat_server.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_bluecat_server.py
@@ -32,6 +32,8 @@ def test_e2e_profile_bluecat_server(dd_agent_check):
         'snmp_host:bluecat-server.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'bcn_sys_id_product:1.3.6.1.4.1.13315.2.1',
         'bcn_sys_id_os_release:OS v1.2.3',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_brocade_fc_switch.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_brocade_fc_switch.py
@@ -30,6 +30,8 @@ def test_e2e_profile_brocade_fc_switch(dd_agent_check):
         'snmp_host:brocade-fc-switch.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_brother_net_printer.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_brother_net_printer.py
@@ -29,6 +29,8 @@ def test_e2e_profile_brother_net_printer(dd_agent_check):
         'snmp_host:brother-net-printer.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + ['br_info_serial_number:acted oxen quaintly Jaded oxen kept']
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_chatsworth_pdu.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_chatsworth_pdu.py
@@ -29,6 +29,8 @@ def test_e2e_profile_chatsworth_pdu(dd_agent_check):
         'snmp_host:chatsworth_pdu.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
         'device_vendor:chatsworth',
     ] + [
         'legacy_pdu_macaddress:00:0E:D3:AA:CC:EE',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_checkpoint.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_checkpoint.py
@@ -34,6 +34,8 @@ def test_e2e_profile_checkpoint(dd_agent_check):
         'snmp_host:checkpoint.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
         'device_vendor:checkpoint',
     ] + []
 

--- a/snmp/tests/test_e2e_core_profiles/test_profile_chrysalis_luna_hsm.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_chrysalis_luna_hsm.py
@@ -31,6 +31,8 @@ def test_e2e_profile_chrysalis_luna_hsm(dd_agent_check):
         'snmp_host:chrysalis-luna-hsm.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_cisco.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_cisco.py
@@ -37,6 +37,8 @@ def test_e2e_profile_cisco(dd_agent_check):
         "snmp_host:cisco3620",
         "device_namespace:default",
         "snmp_device:" + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST METRICS ---
@@ -62,6 +64,8 @@ def test_e2e_profile_cisco(dd_agent_check):
         "status": 1,
         "sys_object_id": "1.3.6.1.4.1.9.1.122",
         "tags": [
+            "device_ip:" + ip_address,
+            "device_id:default:" + ip_address,
             "device_namespace:default",
             "snmp_device:" + ip_address,
             "snmp_host:cisco3620",

--- a/snmp/tests/test_e2e_core_profiles/test_profile_cisco_access_point.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_cisco_access_point.py
@@ -31,6 +31,8 @@ def test_e2e_profile_cisco_access_point(dd_agent_check):
         'snmp_host:cisco-access-point.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_cisco_firepower.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_cisco_firepower.py
@@ -30,6 +30,8 @@ def test_e2e_profile_cisco_firepower(dd_agent_check):
         'snmp_host:cisco-firepower.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_cisco_firepower_asa.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_cisco_firepower_asa.py
@@ -30,6 +30,8 @@ def test_e2e_profile_cisco_firepower_asa(dd_agent_check):
         'snmp_host:cisco-firepower-asa.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_cisco_ironport_email.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_cisco_ironport_email.py
@@ -30,6 +30,8 @@ def test_e2e_profile_cisco_ironport_email(dd_agent_check):
         'snmp_host:cisco-ironport-email.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'ironport_cache_admin:forward Jaded Jaded oxen',
         'ironport_cache_software:but driving Jaded but kept but Jaded',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_cisco_ise.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_cisco_ise.py
@@ -32,6 +32,8 @@ def test_e2e_profile_cisco_ise(dd_agent_check):
         'snmp_host:cisco-ise.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_cisco_load_balancer.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_cisco_load_balancer.py
@@ -31,6 +31,8 @@ def test_e2e_profile_cisco_load_balancer(dd_agent_check):
         'snmp_host:cisco-load-balancer.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_cisco_sb.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_cisco_sb.py
@@ -30,6 +30,8 @@ def test_e2e_profile_cisco_sb(dd_agent_check):
         'snmp_host:cisco-sb.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_cisco_ucs.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_cisco_ucs.py
@@ -30,6 +30,8 @@ def test_e2e_profile_cisco_ucs(dd_agent_check):
         'snmp_host:cisco-ucs.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_cisco_wan_optimizer.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_cisco_wan_optimizer.py
@@ -31,6 +31,8 @@ def test_e2e_profile_cisco_wan_optimizer(dd_agent_check):
         'snmp_host:cisco-wan-optimizer.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_citrix_netscaler.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_citrix_netscaler.py
@@ -30,6 +30,8 @@ def test_e2e_profile_citrix_netscaler(dd_agent_check):
         'snmp_host:citrix-netscaler.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_citrix_netscaler_sdx.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_citrix_netscaler_sdx.py
@@ -29,6 +29,8 @@ def test_e2e_profile_citrix_netscaler_sdx(dd_agent_check):
         'snmp_host:citrix-netscaler-sdx.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'netscaler_sdx_system_bios_version:zombies',
         'netscaler_sdx_system_gateway:acted quaintly oxen',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_cradlepoint.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_cradlepoint.py
@@ -30,6 +30,8 @@ def test_e2e_profile_cradlepoint(dd_agent_check):
         'snmp_host:cradlepoint.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_cyberpower_pdu.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_cyberpower_pdu.py
@@ -29,6 +29,8 @@ def test_e2e_profile_cyberpower_pdu(dd_agent_check):
         'snmp_host:cyberpower-pdu.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'e_pdu_ident_model_number:their oxen forward kept driving',
         'e_pdu_ident_name:zombies oxen their oxen Jaded driving driving kept acted',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_dell.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_dell.py
@@ -32,6 +32,8 @@ def test_e2e_profile_dell(dd_agent_check):
         "snmp_host:dell.example",
         "device_namespace:default",
         "snmp_device:" + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST METRICS ---
@@ -51,6 +53,8 @@ def test_e2e_profile_dell(dd_agent_check):
         "status": 1,
         "sys_object_id": "1.3.6.1.4.1.674.1",
         "tags": [
+            "device_ip:" + ip_address,
+            "device_id:default:" + ip_address,
             "device_namespace:default",
             "snmp_device:" + ip_address,
             "snmp_host:dell.example",

--- a/snmp/tests/test_e2e_core_profiles/test_profile_dell_emc_data_domain.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_dell_emc_data_domain.py
@@ -30,6 +30,8 @@ def test_e2e_profile_dell_emc_data_domain(dd_agent_check):
         'snmp_host:dell-emc-data-domain.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_dell_force10.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_dell_force10.py
@@ -30,6 +30,8 @@ def test_e2e_profile_dell_force10(dd_agent_check):
         'snmp_host:dell-force10.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_dell_os10.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_dell_os10.py
@@ -31,6 +31,8 @@ def test_e2e_profile_dell_os10(dd_agent_check):
         'snmp_host:dell-os10.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_dell_powerconnect.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_dell_powerconnect.py
@@ -30,6 +30,8 @@ def test_e2e_profile_dell_powerconnect(dd_agent_check):
         'snmp_host:dell-powerconnect.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_dell_sonicwall.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_dell_sonicwall.py
@@ -30,6 +30,8 @@ def test_e2e_profile_dell_sonicwall(dd_agent_check):
         'snmp_host:dell-sonicwall.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_dialogic_media_gateway.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_dialogic_media_gateway.py
@@ -30,6 +30,8 @@ def test_e2e_profile_dialogic_media_gateway(dd_agent_check):
         'snmp_host:dialogic-media-gateway.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_dlink_dgs_switch.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_dlink_dgs_switch.py
@@ -30,6 +30,8 @@ def test_e2e_profile_dlink_dgs_switch(dd_agent_check):
         'snmp_host:dlink-dgs-switch.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_eaton_epdu.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_eaton_epdu.py
@@ -29,6 +29,8 @@ def test_e2e_profile_eaton_epdu(dd_agent_check):
         'snmp_host:eaton-epdu.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_exagrid.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_exagrid.py
@@ -31,6 +31,8 @@ def test_e2e_profile_exagrid(dd_agent_check):
         'snmp_host:exagrid.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_extreme_switching.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_extreme_switching.py
@@ -31,6 +31,8 @@ def test_e2e_profile_extreme_switching(dd_agent_check):
         'snmp_host:extreme-switching.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_f5_big_ip.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_f5_big_ip.py
@@ -37,6 +37,8 @@ def test_e2e_profile_f5_big_ip(dd_agent_check):
         'snmp_host:f5-big-ip-adc-good-byol-1-vm.c.datadog-integrations-lab.internal',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
         'device_vendor:f5',
     ] + []
 

--- a/snmp/tests/test_e2e_core_profiles/test_profile_features.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_features.py
@@ -26,6 +26,8 @@ def test_e2e_features(dd_agent_check):
         'snmp_host:features.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_fireeye.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_fireeye.py
@@ -30,6 +30,8 @@ def test_e2e_profile_fireeye(dd_agent_check):
         'snmp_host:fireeye.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'fe_hardware_model:but but their driving acted forward forward their zombies',
         'fe_serial_number:zombies driving quaintly Jaded their zombies driving but ' 'Jaded',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_fortinet.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_fortinet.py
@@ -30,6 +30,8 @@ def test_e2e_profile_fortinet(dd_agent_check):
         "snmp_host:fortinet.example",
         "device_namespace:default",
         "snmp_device:" + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST METRICS ---
@@ -47,6 +49,8 @@ def test_e2e_profile_fortinet(dd_agent_check):
         "status": 1,
         "sys_object_id": "1.3.6.1.4.1.12356.103.1",
         "tags": [
+            "device_ip:" + ip_address,
+            "device_id:default:" + ip_address,
             "device_namespace:default",
             "snmp_device:" + ip_address,
             "snmp_host:fortinet.example",

--- a/snmp/tests/test_e2e_core_profiles/test_profile_fortinet_appliance.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_fortinet_appliance.py
@@ -30,6 +30,8 @@ def test_e2e_profile_fortinet_appliance(dd_agent_check):
         'snmp_host:fortinet.appliance.example',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_fortinet_fortigate.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_fortinet_fortigate.py
@@ -32,6 +32,8 @@ def test_e2e_profile_fortinet_fortigate(dd_agent_check):
         'snmp_host:fortinet-fortigate.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
         'device_vendor:fortinet',
     ] + []
 

--- a/snmp/tests/test_e2e_core_profiles/test_profile_fortinet_fortiswitch.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_fortinet_fortiswitch.py
@@ -30,6 +30,8 @@ def test_e2e_profile_fortinet_fortiswitch(dd_agent_check):
         'snmp_host:fortinet.fortiswitch.example',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'fs_sys_serial:their acted quaintly Jaded zombies forward oxen but driving',
         'fs_sys_version:but forward quaintly zombies forward kept quaintly',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_generic_lldp.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_generic_lldp.py
@@ -29,6 +29,8 @@ def test_e2e_profile_generic_lldp(dd_agent_check):
         'snmp_host:_generic-lldp-mib.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_generic_ospf.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_generic_ospf.py
@@ -29,6 +29,8 @@ def test_e2e_profile_generic_ospf(dd_agent_check):
         'snmp_host:_generic-ospf.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_generic_ups.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_generic_ups.py
@@ -30,6 +30,8 @@ def test_e2e_profile_generic_ups(dd_agent_check):
         'snmp_host:generic-ups.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_gigamon.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_gigamon.py
@@ -30,6 +30,8 @@ def test_e2e_profile_gigamon(dd_agent_check):
         'snmp_host:gigamon.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_hp_h3c_switch.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_hp_h3c_switch.py
@@ -30,6 +30,8 @@ def test_e2e_profile_hp_h3c_switch(dd_agent_check):
         'snmp_host:hp-h3c-switch.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_hp_icf_switch.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_hp_icf_switch.py
@@ -30,6 +30,8 @@ def test_e2e_profile_hp_icf_switch(dd_agent_check):
         'snmp_host:hp-icf-switch.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_hp_ilo.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_hp_ilo.py
@@ -29,6 +29,8 @@ def test_e2e_profile_hp_ilo(dd_agent_check):
         'snmp_host:hp-ilo.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST METRICS ---
@@ -172,6 +174,8 @@ def test_e2e_profile_hp_ilo(dd_agent_check):
         'sys_object_id': '1.3.6.1.4.1.232.9.4.11',
         'version': 'A04-08/12/2018',
         'tags': [
+            'device_id:default:' + ip_address,
+            'device_ip:' + ip_address,
             'device_namespace:default',
             'snmp_device:' + ip_address,
             'snmp_host:hp-ilo.device.name',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_hpe_bladesystem_enclosure.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_hpe_bladesystem_enclosure.py
@@ -31,6 +31,8 @@ def test_e2e_profile_hpe_bladesystem_enclosure(dd_agent_check):
         'snmp_host:hpe-bladesystem-enclosure.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_hpe_msa.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_hpe_msa.py
@@ -30,6 +30,8 @@ def test_e2e_profile_hpe_msa(dd_agent_check):
         'snmp_host:hpe-msa.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'hpe_fibrechannel_cpq_si_product_name:forward driving forward but',
         'hpe_fibrechannel_cpq_si_sys_product_id:kept',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_hpe_nimble.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_hpe_nimble.py
@@ -30,6 +30,8 @@ def test_e2e_profile_hpe_nimble(dd_agent_check):
         'snmp_host:hpe-nimble.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_huawei.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_huawei.py
@@ -29,6 +29,8 @@ def test_e2e_profile_huawei(dd_agent_check):
         'snmp_host:huawei.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + ['huawei_hw_entity_system_model:Jaded but Jaded']
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_huawei_access_controllers.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_huawei_access_controllers.py
@@ -30,6 +30,8 @@ def test_e2e_profile_huawei_access_controllers(dd_agent_check):
         'snmp_host:huawei-access-controllers.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_huawei_routers.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_huawei_routers.py
@@ -29,6 +29,8 @@ def test_e2e_profile_huawei_routers(dd_agent_check):
         'snmp_host:huawei-routers.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_huawei_switches.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_huawei_switches.py
@@ -29,6 +29,8 @@ def test_e2e_profile_huawei_switches(dd_agent_check):
         'snmp_host:huawei-switches.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_ibm_datapower_gateway.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_ibm_datapower_gateway.py
@@ -29,6 +29,8 @@ def test_e2e_profile_ibm_datapower_gateway(dd_agent_check):
         'snmp_host:ibm-datapower-gateway.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_ibm_lenovo_server.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_ibm_lenovo_server.py
@@ -32,6 +32,8 @@ def test_e2e_profile_ibm_lenovo_server(dd_agent_check):
         'snmp_host:ibm-lenovo-server.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'ibm_imm_machine_level_product_name:Jaded acted their but acted kept driving ' 'Jaded Jaded',
         'ibm_imm_machine_level_serial_number:driving quaintly quaintly but driving',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_infinera_coriant_groove.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_infinera_coriant_groove.py
@@ -30,6 +30,8 @@ def test_e2e_profile_infinera_coriant_groove(dd_agent_check):
         'snmp_host:infinera-coriant-groove.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_infoblox_ipam.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_infoblox_ipam.py
@@ -32,6 +32,8 @@ def test_e2e_profile_infoblox_ipam(dd_agent_check):
         'snmp_host:infoblox-ipam.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'ib_hardware_type:Jaded oxen Jaded forward but zombies forward their',
         'ib_nios_version:zombies driving forward oxen but acted oxen',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_ixsystems_truenas.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_ixsystems_truenas.py
@@ -32,6 +32,8 @@ def test_e2e_profile_ixsystems_truenas(dd_agent_check):
         'snmp_host:ixsystems-truenas.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_juniper.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_juniper.py
@@ -35,6 +35,8 @@ def test_e2e_profile_juniper(dd_agent_check):
         "snmp_host:jnxM40",
         "device_namespace:default",
         "snmp_device:" + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST METRICS ---
@@ -59,6 +61,8 @@ def test_e2e_profile_juniper(dd_agent_check):
         "status": 1,
         "sys_object_id": "1.3.6.1.4.1.2636.1.1.1.2.1",
         "tags": [
+            "device_ip:" + ip_address,
+            "device_id:default:" + ip_address,
             "device_namespace:default",
             "snmp_device:" + ip_address,
             "snmp_host:jnxM40",
@@ -81,6 +85,8 @@ def test_e2e_profile_juniper_variation(dd_agent_check):
         "snmp_host:jnxVariationM40",
         "device_namespace:default",
         "snmp_device:" + ip_address,
+        "device_ip:" + ip_address,
+        "device_id:default:" + ip_address,
     ]
 
     # --- TEST METRICS ---
@@ -105,6 +111,8 @@ def test_e2e_profile_juniper_variation(dd_agent_check):
         "status": 1,
         "sys_object_id": "1.3.6.1.4.1.2636.1.1.1.4.1",
         "tags": [
+            "device_ip:" + ip_address,
+            "device_id:default:" + ip_address,
             "device_namespace:default",
             "snmp_device:" + ip_address,
             "snmp_host:jnxVariationM40",

--- a/snmp/tests/test_e2e_core_profiles/test_profile_juniper_pulse_secure.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_juniper_pulse_secure.py
@@ -32,6 +32,8 @@ def test_e2e_profile_juniper_pulse_secure(dd_agent_check):
         'snmp_host:juniper-pulse-secure.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'juniper_ive_esap_version:but Jaded acted quaintly forward oxen acted kept',
         'juniper_ive_product_name:kept their Jaded oxen but acted quaintly',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_juniper_qfx.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_juniper_qfx.py
@@ -37,6 +37,8 @@ def test_e2e_profile_juniper_qfx(dd_agent_check):
         'snmp_host:juniper-qfx.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_kyocera_printer.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_kyocera_printer.py
@@ -29,6 +29,8 @@ def test_e2e_profile_kyocera_printer(dd_agent_check):
         'snmp_host:kyocera-printer.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + ['kcprt_general_model_name:kept but oxen Jaded', 'kcprt_serial_number:kept kept']
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_linksys.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_linksys.py
@@ -30,6 +30,8 @@ def test_e2e_profile_linksys(dd_agent_check):
         'snmp_host:linksys.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_mcafee_web_gateway.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_mcafee_web_gateway.py
@@ -30,6 +30,8 @@ def test_e2e_profile_mcafee_web_gateway(dd_agent_check):
         'snmp_host:mcafee-web-gateway.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'mcafee_mwg_k_build_number:9',
         'mcafee_mwg_k_company_name:driving zombies kept',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_meraki.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_meraki.py
@@ -29,6 +29,8 @@ def test_e2e_profile_meraki(dd_agent_check):
         'device_namespace:default',
         'device_vendor:meraki',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
         'snmp_host:dashboard.meraki.com',
         'snmp_profile:meraki',
     ]
@@ -51,6 +53,8 @@ def test_e2e_profile_meraki(dd_agent_check):
         'status': 1,
         'sys_object_id': '1.3.6.1.4.1.29671.2.1',
         'tags': [
+            'device_id:default:' + ip_address,
+            'device_ip:' + ip_address,
             'device_namespace:default',
             'device_vendor:meraki',
             'snmp_device:' + ip_address,

--- a/snmp/tests/test_e2e_core_profiles/test_profile_meraki_cloud_controller.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_meraki_cloud_controller.py
@@ -38,6 +38,8 @@ def test_e2e_profile_meraki_cloud_controller(dd_agent_check):
         'snmp_host:dashboard.meraki.com',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
         'device_vendor:meraki',
     ] + []
 

--- a/snmp/tests/test_e2e_core_profiles/test_profile_mikrotik_router.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_mikrotik_router.py
@@ -30,6 +30,8 @@ def test_e2e_profile_mikrotik_router(dd_agent_check):
         'snmp_host:mikrotik-router.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_nasuni_filer.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_nasuni_filer.py
@@ -31,6 +31,8 @@ def test_e2e_profile_nasuni_filer(dd_agent_check):
         'snmp_host:nasuni-filer.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'filer_bios_version:quaintly zombies zombies but',
         'filer_cpu_arch:their zombies',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_nec_univerge.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_nec_univerge.py
@@ -31,6 +31,8 @@ def test_e2e_profile_nec_univerge(dd_agent_check):
         'snmp_host:nec-univerge.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_netgear.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_netgear.py
@@ -30,6 +30,8 @@ def test_e2e_profile_netgear(dd_agent_check):
         'snmp_host:netgear.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_netgear_access_point.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_netgear_access_point.py
@@ -30,6 +30,8 @@ def test_e2e_profile_netgear_access_point(dd_agent_check):
         'snmp_host:netgear-access-point.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_netgear_readynas.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_netgear_readynas.py
@@ -30,6 +30,8 @@ def test_e2e_profile_netgear_readynas(dd_agent_check):
         'snmp_host:netgear-readynas.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_netgear_switch.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_netgear_switch.py
@@ -29,6 +29,8 @@ def test_e2e_profile_netgear_switch(dd_agent_check):
         'snmp_host:netgear-switch.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'agent_inventory_machine_model:their quaintly but acted oxen oxen their Jaded acted',
         'agent_inventory_software_version:kept but their zombies quaintly but driving',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_nvidia_cumulus_linux_switch.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_nvidia_cumulus_linux_switch.py
@@ -32,6 +32,8 @@ def test_e2e_profile_nvidia_cumulus_linux_switch(dd_agent_check):
         'snmp_host:nvidia-cumulus-linux-switch.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_nvidia_mellanox_switchx.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_nvidia_mellanox_switchx.py
@@ -32,6 +32,8 @@ def test_e2e_profile_nvidia_mellanox_switchx(dd_agent_check):
         'snmp_host:nvidia-mellanox-switchx.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_omron_cj_ethernet_ip.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_omron_cj_ethernet_ip.py
@@ -30,6 +30,8 @@ def test_e2e_profile_omron_cj_ethernet_ip(dd_agent_check):
         'snmp_host:omron-cj-ethernet-ip.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_opengear_console_manager.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_opengear_console_manager.py
@@ -33,6 +33,8 @@ def test_e2e_profile_opengear_console_manager(dd_agent_check):
         'snmp_host:opengear-console-manager.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_opengear_infrastructure_manager.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_opengear_infrastructure_manager.py
@@ -31,6 +31,8 @@ def test_e2e_profile_opengear_infrastructure_manager(dd_agent_check):
         'snmp_host:opengear-infrastructure-manager.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_palo_alto_cloudgenix.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_palo_alto_cloudgenix.py
@@ -30,6 +30,8 @@ def test_e2e_profile_palo_alto_cloudgenix(dd_agent_check):
         'snmp_host:palo-alto-cloudgenix.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_peplink.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_peplink.py
@@ -31,6 +31,8 @@ def test_e2e_profile_peplink(dd_agent_check):
         'snmp_host:peplink.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'peplink_bal_firmware:driving their acted',
         'peplink_bal_serial_number:zombies their',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_pf_sense.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_pf_sense.py
@@ -32,6 +32,8 @@ def test_e2e_profile_pf_sense(dd_agent_check):
         'snmp_host:pf-sense.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ]
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_raritan_dominion.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_raritan_dominion.py
@@ -30,6 +30,8 @@ def test_e2e_profile_raritan_dominion(dd_agent_check):
         'snmp_host:raritan-dominion.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_riverbed_interceptor.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_riverbed_interceptor.py
@@ -30,6 +30,8 @@ def test_e2e_profile_riverbed_interceptor(dd_agent_check):
         'snmp_host:riverbed-interceptor.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'riverbed_interceptor_model:kept zombies Jaded but driving their but',
         'riverbed_interceptor_serial_number:but zombies quaintly acted but',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_riverbed_steelhead.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_riverbed_steelhead.py
@@ -30,6 +30,8 @@ def test_e2e_profile_riverbed_steelhead(dd_agent_check):
         'snmp_host:riverbed-steelhead.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_ruckus_unleashed.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_ruckus_unleashed.py
@@ -30,6 +30,8 @@ def test_e2e_profile_ruckus_unleashed(dd_agent_check):
         'snmp_host:ruckus-unleashed.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'ruckus_unleashed_system_licensed_aps:34750',
         'ruckus_unleashed_system_serial_number:acted but',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_ruckus_wap.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_ruckus_wap.py
@@ -31,6 +31,8 @@ def test_e2e_profile_ruckus_wap(dd_agent_check):
         'snmp_host:ruckus-wap.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_server_iron_switch.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_server_iron_switch.py
@@ -31,6 +31,8 @@ def test_e2e_profile_server_iron_switch(dd_agent_check):
         'snmp_host:server-iron-switch.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_servertech_pdu3.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_servertech_pdu3.py
@@ -29,6 +29,8 @@ def test_e2e_profile_servertech_pdu3(dd_agent_check):
         'snmp_host:servertech-pdu3.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'servertech_sentry3_system_nic_serial_number:oxen',
         'servertech_sentry3_system_version:zombies acted kept quaintly but but',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_servertech_pdu4.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_servertech_pdu4.py
@@ -29,6 +29,8 @@ def test_e2e_profile_servertech_pdu4(dd_agent_check):
         'snmp_host:servertech-pdu4.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_silverpeak_edgeconnect.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_silverpeak_edgeconnect.py
@@ -30,6 +30,8 @@ def test_e2e_profile_silverpeak_edgeconnect(dd_agent_check):
         'snmp_host:silverpeak-edgeconnect.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_sinetica_eagle_i.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_sinetica_eagle_i.py
@@ -29,6 +29,8 @@ def test_e2e_profile_sinetica_eagle_i(dd_agent_check):
         'snmp_host:sinetica-eagle-i.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'hawk_i2_inv_fw_revision:oxen Jaded',
         'hawk_i2_inv_hw_revision:acted',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_sophos_xgs_firewall.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_sophos_xgs_firewall.py
@@ -30,6 +30,8 @@ def test_e2e_profile_sophos_xgs_firewall(dd_agent_check):
         'snmp_host:sophos-xgs-firewall.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'sfos_device_fw_version:forward zombies zombies oxen their',
         'sfos_device_type:Jaded forward kept acted but quaintly but',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_synology_disk_station.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_synology_disk_station.py
@@ -30,6 +30,8 @@ def test_e2e_profile_synology_disk_station(dd_agent_check):
         'snmp_host:synology-disk-station.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'synology_model_name:quaintly quaintly their Jaded quaintly acted',
         'synology_serial_number:kept',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_tp_link.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_tp_link.py
@@ -30,6 +30,8 @@ def test_e2e_profile_tp_link(dd_agent_check):
         'snmp_host:tp-link.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_tripplite.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_tripplite.py
@@ -29,6 +29,8 @@ def test_e2e_profile_tripplite(dd_agent_check):
         'snmp_host:tripplite.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_tripplite_pdu.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_tripplite_pdu.py
@@ -29,6 +29,8 @@ def test_e2e_profile_tripplite_pdu(dd_agent_check):
         'snmp_host:tripplite-pdu.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_tripplite_ups.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_tripplite_ups.py
@@ -30,6 +30,8 @@ def test_e2e_profile_tripplite_ups(dd_agent_check):
         'snmp_host:tripplite-ups.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'tl_ups_ident_id:2',
         'tl_ups_ident_serial_num:zombies acted',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_ubiquiti_unifi.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_ubiquiti_unifi.py
@@ -30,6 +30,8 @@ def test_e2e_profile_ubiquiti_unifi(dd_agent_check):
         'snmp_host:ubiquiti-unifi.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_ubiquiti_unifi_security_gateway.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_ubiquiti_unifi_security_gateway.py
@@ -31,6 +31,8 @@ def test_e2e_profile_ubiquiti_unifi_security_gateway(dd_agent_check):
         'snmp_host:ubiquiti-unifi-security-gateway.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_velocloud_edge.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_velocloud_edge.py
@@ -31,6 +31,8 @@ def test_e2e_profile_velocloud_edge(dd_agent_check):
         'snmp_host:velocloud-edge.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_vertiv_liebert_ac.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_vertiv_liebert_ac.py
@@ -29,6 +29,8 @@ def test_e2e_profile_vertiv_liebert_ac(dd_agent_check):
         'snmp_host:vertiv-liebert-ac.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'lgp_agent_ident_model:forward acted quaintly quaintly zombies Jaded quaintly '
         'oxen zombies forward acted quaintly quaintly zombies Jaded quaintly oxen '

--- a/snmp/tests/test_e2e_core_profiles/test_profile_vertiv_watchdog.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_vertiv_watchdog.py
@@ -29,6 +29,8 @@ def test_e2e_profile_vertiv_watchdog(dd_agent_check):
         'snmp_host:vertiv-watchdog.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'vertiv_product_friendly_name:forward zombies zombies',
         'vertiv_product_mac_address:acted but forward',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_vmware_esx.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_vmware_esx.py
@@ -31,6 +31,8 @@ def test_e2e_profile_vmware_esx(dd_agent_check):
         'snmp_host:vmware-esx.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_watchguard.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_watchguard.py
@@ -31,6 +31,8 @@ def test_e2e_profile_watchguard(dd_agent_check):
         'snmp_host:watchguard.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_western_digital_mycloud_ex2_ultra.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_western_digital_mycloud_ex2_ultra.py
@@ -31,6 +31,8 @@ def test_e2e_profile_western_digital_mycloud_ex2_ultra(dd_agent_check):
         'snmp_host:western-digital-mycloud-ex2-ultra.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'wdmycloudex2_agent_ver:oxen quaintly zombies driving oxen their oxen',
         'wdmycloudex2_host_name:but oxen quaintly but Jaded',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_zebra_printer.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_zebra_printer.py
@@ -29,6 +29,8 @@ def test_e2e_profile_zebra_printer(dd_agent_check):
         'snmp_host:zebra-printer.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + []
 
     # --- TEST EXTENDED METRICS ---

--- a/snmp/tests/test_e2e_core_profiles/test_profile_zyxel_switch.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_zyxel_switch.py
@@ -30,6 +30,8 @@ def test_e2e_profile_zyxel_switch(dd_agent_check):
         'snmp_host:zyxel-switch.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
+        'device_ip:' + ip_address,
+        'device_id:default:' + ip_address,
     ] + [
         'zyxel_sys_product_model:but Jaded acted but acted Jaded zombies',
         'zyxel_sys_product_serial_number:oxen quaintly Jaded their oxen',

--- a/snmp/tests/test_e2e_core_profiles/utils.py
+++ b/snmp/tests/test_e2e_core_profiles/utils.py
@@ -357,7 +357,10 @@ def assert_extend_juniper_virtualchassis(aggregator, common_tags):
 
 def assert_all_profile_metrics_and_tags_covered(profile, aggregator):
     metric_and_tags = collect_profile_metrics_and_tags(profile)
-    global_tags = set(metric_and_tags["global_tags"] + ['device_namespace', 'snmp_device', 'snmp_host', 'snmp_profile'])
+    global_tags = set(
+        metric_and_tags["global_tags"]
+        + ['device_namespace', 'snmp_device', 'snmp_host', 'snmp_profile', 'device_id', 'device_ip']
+    )
 
     for metric, metric_info in metric_and_tags["table_metrics"].items():
         collected_metric_tag_keys = get_collected_metric_tag_keys(aggregator, metric) - ASSERT_ALL_PROFILE_EXCLUDED_TAGS

--- a/snmp/tests/test_e2e_snmp_listener.py
+++ b/snmp/tests/test_e2e_snmp_listener.py
@@ -133,7 +133,7 @@ def test_e2e_snmp_listener(dd_agent_check, container_ip, autodiscovery_ready):
         common_tags = [
             'snmp_device:{}'.format(snmp_device),
             'device_ip:{}'.format(snmp_device),
-            'device_id:test-auth-proto-{}:{}'.format(auth_proto,snmp_device),
+            'device_id:test-auth-proto-{}:{}'.format(auth_proto, snmp_device),
             'autodiscovery_subnet:{}.0/27'.format(subnet_prefix),
             'snmp_host:41ba948911b9',
             'snmp_profile:generic-device',

--- a/snmp/tests/test_e2e_snmp_listener.py
+++ b/snmp/tests/test_e2e_snmp_listener.py
@@ -55,6 +55,8 @@ def test_e2e_snmp_listener(dd_agent_check, container_ip, autodiscovery_ready):
     common_tags = [
         'snmp_profile:generic-device',
         'snmp_device:{}'.format(snmp_device),
+        'device_ip:{}'.format(snmp_device),
+        'device_id:default:{}'.format(snmp_device),
         'autodiscovery_subnet:{}.0/29'.format(subnet_prefix),
         'tag1:val1',
         'tag2:val2',
@@ -130,6 +132,8 @@ def test_e2e_snmp_listener(dd_agent_check, container_ip, autodiscovery_ready):
     for auth_proto in ['sha', 'sha256']:
         common_tags = [
             'snmp_device:{}'.format(snmp_device),
+            'device_ip:{}'.format(snmp_device),
+            'device_id:test-auth-proto-{}:{}'.format(auth_proto,snmp_device),
             'autodiscovery_subnet:{}.0/27'.format(subnet_prefix),
             'snmp_host:41ba948911b9',
             'snmp_profile:generic-device',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update tests with new device_id and device_ip tags added in DataDog/datadog-agent#24902

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
