### PR TITLE
[PLINT-316] Add support for SSL verification

### DIFF
--- a/esxi/assets/configuration/spec.yaml
+++ b/esxi/assets/configuration/spec.yaml
@@ -86,4 +86,22 @@ files:
             display_default: []
             example:
               - <HOST_TAG>
+        - name: ssl_verify
+          description: Set to false to disable SSL verification when connecting to the ESXi host
+          value:
+            type: boolean
+            example: true
+        - name: ssl_cafile
+          description: |
+            Set to the absolute file path of CA certificates in PEM format
+          value:
+            type: string
+            example: "<FILE_PATH>"
+        - name: ssl_capath
+          description: |
+            Set to the absolute file path of a directory containing CA certificates
+            in PEM format
+          value:
+            type: string
+            example: "<DIRECTORY_PATH>"
         - template: instances/default

--- a/esxi/datadog_checks/esxi/check.py
+++ b/esxi/datadog_checks/esxi/check.py
@@ -239,13 +239,12 @@ class EsxiCheck(AgentCheck):
             context.check_hostname = True if self.ssl_verify else False
             context.verify_mode = ssl.CERT_REQUIRED if self.ssl_verify else ssl.CERT_NONE
 
-            if self.ssl_verify:
-                if self.ssl_capath:
-                    context.load_verify_locations(cafile=None, capath=self.ssl_capath, cadata=None)
-                elif self.ssl_cafile:
-                    context.load_verify_locations(cafile=self.ssl_cafile, capath=None, cadata=None)
-                else:
-                    context.load_default_certs(ssl.Purpose.SERVER_AUTH)
+            if self.ssl_capath:
+                context.load_verify_locations(cafile=None, capath=self.ssl_capath, cadata=None)
+            elif self.ssl_cafile:
+                context.load_verify_locations(cafile=self.ssl_cafile, capath=None, cadata=None)
+            else:
+                context.load_default_certs(ssl.Purpose.SERVER_AUTH)
 
             connection = connect.SmartConnect(host=self.host, user=self.username, pwd=self.password, sslContext=context)
             self.conn = connection

--- a/esxi/datadog_checks/esxi/check.py
+++ b/esxi/datadog_checks/esxi/check.py
@@ -3,13 +3,14 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
 import re
+import ssl
 from collections import defaultdict
 
 from pyVim import connect
 from pyVmomi import vim, vmodl
 from six import iteritems
 
-from datadog_checks.base import AgentCheck  # noqa: F401
+from datadog_checks.base import AgentCheck, is_affirmative
 from datadog_checks.base.utils.common import to_string
 
 from .constants import (
@@ -38,6 +39,9 @@ class EsxiCheck(AgentCheck):
         self.collect_per_instance_filters = self._parse_metric_regex_filters(
             self.instance.get("collect_per_instance_filters", {})
         )
+        self.ssl_verify = is_affirmative(self.instance.get('ssl_verify', True))
+        self.ssl_capath = self.instance.get("ssl_capath")
+        self.ssl_cafile = self.instance.get("ssl_cafile")
         self.tags = [f"esxi_url:{self.host}"]
 
     def _validate_excluded_host_tags(self, excluded_host_tags):
@@ -231,7 +235,19 @@ class EsxiCheck(AgentCheck):
 
     def check(self, _):
         try:
-            connection = connect.SmartConnect(host=self.host, user=self.username, pwd=self.password)
+            context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
+            context.check_hostname = True if self.ssl_verify else False
+            context.verify_mode = ssl.CERT_REQUIRED if self.ssl_verify else ssl.CERT_NONE
+
+            if self.ssl_verify:
+                if self.ssl_capath:
+                    context.load_verify_locations(cafile=None, capath=self.ssl_capath, cadata=None)
+                elif self.ssl_cafile:
+                    context.load_verify_locations(cafile=self.ssl_cafile, capath=None, cadata=None)
+                else:
+                    context.load_default_certs(ssl.Purpose.SERVER_AUTH)
+
+            connection = connect.SmartConnect(host=self.host, user=self.username, pwd=self.password, sslContext=context)
             self.conn = connection
             self.content = connection.content
 

--- a/esxi/datadog_checks/esxi/config_models/defaults.py
+++ b/esxi/datadog_checks/esxi/config_models/defaults.py
@@ -24,5 +24,9 @@ def instance_min_collection_interval():
     return 15
 
 
+def instance_ssl_verify():
+    return True
+
+
 def instance_use_guest_hostname():
     return False

--- a/esxi/datadog_checks/esxi/config_models/instance.py
+++ b/esxi/datadog_checks/esxi/config_models/instance.py
@@ -52,6 +52,9 @@ class InstanceConfig(BaseModel):
     min_collection_interval: Optional[float] = None
     password: str
     service: Optional[str] = None
+    ssl_cafile: Optional[str] = None
+    ssl_capath: Optional[str] = None
+    ssl_verify: Optional[bool] = None
     tags: Optional[tuple[str, ...]] = None
     use_guest_hostname: Optional[bool] = None
     username: str

--- a/esxi/datadog_checks/esxi/data/conf.yaml.example
+++ b/esxi/datadog_checks/esxi/data/conf.yaml.example
@@ -70,7 +70,7 @@ instances:
     #   - <HOST_TAG>
 
     ## @param ssl_verify - boolean - optional - default: true
-    ## Set to false to disable SSL verification, when connecting to vCenter
+    ## Set to false to disable SSL verification when connecting to the ESXi host
     #
     # ssl_verify: true
 

--- a/esxi/datadog_checks/esxi/data/conf.yaml.example
+++ b/esxi/datadog_checks/esxi/data/conf.yaml.example
@@ -69,6 +69,22 @@ instances:
     # excluded_host_tags:
     #   - <HOST_TAG>
 
+    ## @param ssl_verify - boolean - optional - default: true
+    ## Set to false to disable SSL verification, when connecting to vCenter
+    #
+    # ssl_verify: true
+
+    ## @param ssl_cafile - string - optional
+    ## Set to the absolute file path of CA certificates in PEM format
+    #
+    # ssl_cafile: <FILE_PATH>
+
+    ## @param ssl_capath - string - optional
+    ## Set to the absolute file path of a directory containing CA certificates
+    ## in PEM format
+    #
+    # ssl_capath: <DIRECTORY_PATH>
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/esxi/tests/common.py
+++ b/esxi/tests/common.py
@@ -5,9 +5,9 @@ from pyVmomi import vim, vmodl
 
 HOST = "127.0.0.1"
 PORT = 8989
-VCSIM_INSTANCE = {'host': f"{HOST}:{str(PORT)}", 'username': 'test', 'password': 'test'}
+VCSIM_INSTANCE = {'host': f"{HOST}:{str(PORT)}", 'username': 'test', 'password': 'test', 'ssl_verify': False}
 
-BASE_INSTANCE = {'host': 'localhost', 'username': 'test', 'password': 'test'}
+BASE_INSTANCE = {'host': 'localhost', 'username': 'test', 'password': 'test', 'ssl_verify': False}
 
 
 PERF_COUNTER_INFO = [

--- a/esxi/tests/test_integration.py
+++ b/esxi/tests/test_integration.py
@@ -158,7 +158,7 @@ def test_ssl_verify(vcsim_instance, dd_run_check, aggregator, caplog):
     dd_run_check(check)
     assert (
         "Cannot connect to ESXi host 127.0.0.1:8989: [SSL: CERTIFICATE_VERIFY_FAILED] "
-        "certificate verify failed (_ssl.c:992)" in caplog.text
+        "certificate verify failed" in caplog.text
     )
     aggregator.assert_metric('esxi.host.can_connect', 0, count=1, tags=["esxi_url:127.0.0.1:8989"])
 

--- a/esxi/tests/test_unit.py
+++ b/esxi/tests/test_unit.py
@@ -776,7 +776,7 @@ def test_ssl_disabled_cafile_ssl_capath(vcsim_instance, dd_run_check):
         load_verify_locations.assert_called_with(cafile=None, capath='/test/path', cadata=None)
         load_default_certs.assert_not_called()
 
-        
+
 @pytest.mark.parametrize(
     "resource_filters, expected_vms",
     [


### PR DESCRIPTION
### What does this PR do?
add support for SSL verification when connecting to ESXi host
### Motivation
### Additional Notes
Implementation differs from vSphere as we now use `PROTOCOL_TLS_CLIENT` since `PROTOCOL_TLS` is deprecated. we favor matching the implementation in the base check over vSphere, but use the same option names as the vSphere check 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
