### PR TITLE
ddev: Update IMAGES_README template

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/marketplace/IMAGES_README.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/marketplace/IMAGES_README.md
@@ -15,12 +15,7 @@ added to your /images directory and referenced in the manifest.json file.
 ```
 File type       : .jpg or .png
 File size       : ~500 KB per image, with a max of 1 MB per image
-File dimensions : The aspect ratio must be 16:9 minimum, with these constraints:
-
-                    Width: 1440px
-                    Min height: 810px
-                    Max height: 2560px
-
+File dimensions : The image must be between 1440px and 2880px width, with a 16:9 aspect ratio (eg: 1440x810)
 File name       : Use only letters, numbers, underscores, and hyphens
 Color mode      : RGB
 Color profile   : sRGB

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/marketplace/IMAGES_README.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/marketplace/IMAGES_README.md
@@ -15,7 +15,7 @@ added to your /images directory and referenced in the manifest.json file.
 ```
 File type       : .jpg or .png
 File size       : ~500 KB per image, with a max of 1 MB per image
-File dimensions : The image must be between 1440px and 2880px width, with a 16:9 aspect ratio (eg: 1440x810)
+File dimensions : The image must be between 1440px and 2880px width, with a 16:9 aspect ratio (for example: 1440x810)
 File name       : Use only letters, numbers, underscores, and hyphens
 Color mode      : RGB
 Color profile   : sRGB


### PR DESCRIPTION
### What does this PR do?
Update the `IMAGES_README` file that `ddev create` adds to the scaffolding for new integrations.

### Motivation
The image must be exactly 16:9 (as enforced by the datadog-assets tile validation, not linked here because it's not open source).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
