### PR TITLE
Commit to eliminate duplicate rows from availability_replicas_metrics

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -888,7 +888,7 @@ class SqlAvailabilityReplicas(BaseSqlServerMetric):
                     inner join sys.dm_hadr_database_replica_cluster_states as dhdrcs
                     on ar.replica_id = dhdrcs.replica_id
                     inner join sys.dm_hadr_database_replica_states as dhdrs
-                    on ar.replica_id = dhdrs.replica_id
+                    on ar.replica_id = dhdrs.replica_id and dhdrcs.group_database_id = dhdrs.group_database_id
                     inner join sys.availability_groups as ag
                     on ag.group_id = ar.group_id""".format(
         table=TABLE


### PR DESCRIPTION
### What does this PR do?
Fix availability_replicas_metrics from SqlAvailabilityReplicas class eliminating duplicates between sys.dm_hadr_database_replica_cluster_states and sys.dm_hadr_database_replica_states by adding join predicate based on group_database_id

### Motivation
<!-- What inspired you to submit this pull request? -->
Reduce network waits reported by DataDog DBM

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
