### PR TITLE
[PLINT-313] Add support for metric filters

### DIFF
--- a/esxi/assets/configuration/spec.yaml
+++ b/esxi/assets/configuration/spec.yaml
@@ -111,6 +111,30 @@ files:
                   type: string
                 - name: property
                   type: string
+        - name: metric_filters
+          description: |
+            Use this option to control what metrics to submit for each resource type
+            For each resource type (vm, host) collected,
+            you can choose which metric you want to collect using a list of regex.
+            If you do not specify a regex for the resource, all metrics will be collected.
+            See https://github.com/DataDog/integrations-core/blob/master/esxi/datadog_checks/esxi/metrics.py
+            for the list of collected metrics (do not prefix them with `esxi`)
+          value:
+            example:
+              vm:
+                - <VM_REGEX>
+              host:
+                - <HOST_REGEX>
+            type: object
+            properties:
+              - name: vm
+                type: array
+                items:
+                  type: string
+              - name: host
+                type: array
+                items:
+                  type: string
         - name: excluded_host_tags
           description: |
             Use this option to send a subset of host tags as metric tags.

--- a/esxi/datadog_checks/esxi/check.py
+++ b/esxi/datadog_checks/esxi/check.py
@@ -29,6 +29,7 @@ from .resource_filters import create_resource_filter
 from .utils import (
     get_mapped_instance_tag,
     get_tags_recursively,
+    is_metric_excluded_by_filters,
     is_resource_collected_by_filters,
     should_collect_per_instance_values,
 )
@@ -48,6 +49,7 @@ class EsxiCheck(AgentCheck):
             self.instance.get("collect_per_instance_filters", {})
         )
         self.resource_filters = self._parse_resource_filters(self.instance.get("resource_filters", []))
+        self.metric_filters = self._parse_metric_regex_filters(self.instance.get("metric_filters", {}))
         self.tags = [f"esxi_url:{self.host}"]
 
     def _validate_excluded_host_tags(self, excluded_host_tags):
@@ -218,10 +220,12 @@ class EsxiCheck(AgentCheck):
         counter_keys_and_names = {}
         for counter in self.content.perfManager.perfCounter:
             full_name = f"{counter.groupInfo.key}.{counter.nameInfo.key}.{SHORT_ROLLUP[counter.rollupType]}"
-            if full_name in avaliable_metrics:
+            if full_name in avaliable_metrics and not is_metric_excluded_by_filters(
+                full_name, type(entity), self.metric_filters
+            ):
                 counter_keys_and_names[counter.key] = full_name
             else:
-                self.log.trace("Skipping metric %s as it is not recognized", full_name)
+                self.log.trace("Skipping metric %s as it is not recognized or filtered", full_name)
 
         available_counter_ids = [m.counterId for m in self.content.perfManager.QueryAvailablePerfMetric(entity=entity)]
         counter_ids = [

--- a/esxi/datadog_checks/esxi/config_models/instance.py
+++ b/esxi/datadog_checks/esxi/config_models/instance.py
@@ -28,6 +28,15 @@ class CollectPerInstanceFilters(BaseModel):
     vm: Optional[tuple[str, ...]] = None
 
 
+class MetricFilters(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    host: Optional[tuple[str, ...]] = None
+    vm: Optional[tuple[str, ...]] = None
+
+
 class MetricPatterns(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -59,6 +68,7 @@ class InstanceConfig(BaseModel):
     empty_default_hostname: Optional[bool] = None
     excluded_host_tags: Optional[tuple[str, ...]] = None
     host: str
+    metric_filters: Optional[MetricFilters] = None
     metric_patterns: Optional[MetricPatterns] = None
     min_collection_interval: Optional[float] = None
     password: str

--- a/esxi/datadog_checks/esxi/data/conf.yaml.example
+++ b/esxi/datadog_checks/esxi/data/conf.yaml.example
@@ -84,6 +84,20 @@ instances:
     #     patterns:
     #     - <GUEST_HOSTNAME_REGEX>
 
+    ## @param metric_filters - mapping - optional
+    ## Use this option to control what metrics to submit for each resource type
+    ## For each resource type (vm, host) collected,
+    ## you can choose which metric you want to collect using a list of regex.
+    ## If you do not specify a regex for the resource, all metrics will be collected.
+    ## See https://github.com/DataDog/integrations-core/blob/master/esxi/datadog_checks/esxi/metrics.py
+    ## for the list of collected metrics (do not prefix them with `esxi`)
+    #
+    # metric_filters:
+    #   vm:
+    #   - <VM_REGEX>
+    #   host:
+    #   - <HOST_REGEX>
+
     ## @param excluded_host_tags - list of strings - optional - default: []
     ## Use this option to send a subset of host tags as metric tags.
     ## The ESXi integration collects tags for every ESXi host or VM in your environment.

--- a/esxi/datadog_checks/esxi/metrics.py
+++ b/esxi/datadog_checks/esxi/metrics.py
@@ -404,3 +404,6 @@ RESOURCE_NAME_TO_METRICS = {
     "vm": VM_METRICS,
     "host": HOST_METRICS,
 }
+
+
+REFERENCE_METRIC = "cpu.usage.avg"

--- a/esxi/datadog_checks/esxi/utils.py
+++ b/esxi/datadog_checks/esxi/utils.py
@@ -8,6 +8,7 @@ from six import iteritems
 from datadog_checks.base import to_string
 
 from .constants import METRIC_TO_INSTANCE_TAG_MAPPING, RESOURCE_TYPE_TO_NAME
+from .metrics import REFERENCE_METRIC
 
 
 def get_tags_recursively(mor, infrastructure_data, include_only=None):
@@ -106,3 +107,17 @@ def is_resource_collected_by_filters(mor, infrastructure_data, resource_filters)
 
     # Otherwise, do not collect it
     return False
+
+
+def is_metric_excluded_by_filters(metric_name, mor_type, metric_filters):
+    if metric_name.startswith(REFERENCE_METRIC):
+        # Always collect at least one metric for reference
+        return False
+    filters = metric_filters.get(RESOURCE_TYPE_TO_NAME[mor_type])
+    if not filters:
+        # No filters means collect everything
+        return False
+    if match_any_regex(metric_name, filters):
+        return False
+
+    return True


### PR DESCRIPTION
### What does this PR do?
Add the ability to filter metrics, mirroring the behavior of the vSphere check 
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
