### PR TITLE
Only collect property metrics for resources that support it and lower log line level

### DIFF
--- a/vsphere/changelog.d/17446.fixed
+++ b/vsphere/changelog.d/17446.fixed
@@ -1,0 +1,1 @@
+Only collect property metrics for resources that support it and lower level for log line

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -26,6 +26,7 @@ from datadog_checks.vsphere.constants import (
     HOST_RESOURCES,
     MAX_QUERY_METRICS_OPTION,
     PROPERTY_COUNT_METRICS,
+    PROPERTY_METRICS_BY_RESOURCE_TYPE,
     REALTIME_METRICS_INTERVAL_ID,
     UNLIMITED_HIST_METRICS_PER_QUERY,
 )
@@ -889,7 +890,12 @@ class VSphereCheck(AgentCheck):
 
         all_properties = mor_props.get('properties', None)
         if not all_properties:
-            self.log.debug('Could not retrieve properties for resource %s hostname=%s', mor_name, hostname)
+            self.log.debug(
+                'Could not retrieve properties for %s resource %s hostname=%s',
+                resource_metric_suffix,
+                mor_name,
+                hostname,
+            )
             return
 
         base_tags = self._config.base_tags + resource_tags
@@ -985,7 +991,14 @@ class VSphereCheck(AgentCheck):
 
             # Submit property metrics after the cache is refreshed
             if self._config.collect_property_metrics:
-                for resource_type in self._config.collected_resource_types:
+
+                resources_with_property_metrics = [
+                    resource
+                    for resource in self._config.collected_resource_types
+                    if MOR_TYPE_AS_STRING[resource] in PROPERTY_METRICS_BY_RESOURCE_TYPE.keys()
+                ]
+
+                for resource_type in resources_with_property_metrics:
                     for mor in self.infrastructure_cache.get_mors(resource_type):
                         mor_props = self.infrastructure_cache.get_mor_props(mor)
                         resource_tags = mor_props.get('tags', [])

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -889,7 +889,7 @@ class VSphereCheck(AgentCheck):
 
         all_properties = mor_props.get('properties', None)
         if not all_properties:
-            self.log.warning('Could not retrieve properties for resource %s hostname=%s', mor_name, hostname)
+            self.log.debug('Could not retrieve properties for resource %s hostname=%s', mor_name, hostname)
             return
 
         base_tags = self._config.base_tags + resource_tags

--- a/vsphere/tests/common.py
+++ b/vsphere/tests/common.py
@@ -890,6 +890,19 @@ VM_PROPERTIES_EX = mock.MagicMock(
                     ),
                 ],
             ),
+            vim.ObjectContent(
+                obj=vim.Datacenter(moId="dc2"),
+                propSet=[
+                    vmodl.DynamicProperty(
+                        name='name',
+                        val='dc2',
+                    ),
+                    vmodl.DynamicProperty(
+                        name='parent',
+                        val=vim.Folder(moId="folder_1"),
+                    ),
+                ],
+            ),
         ],
     )
 )

--- a/vsphere/tests/test_unit.py
+++ b/vsphere/tests/test_unit.py
@@ -2764,9 +2764,11 @@ def test_host_property_metrics(aggregator, realtime_instance, dd_run_check, capl
     aggregator.assert_metric('vsphere.cpu.costop.sum', count=1, hostname='host2')
 
 
-def test_cluster_property_metrics(aggregator, historical_instance, dd_run_check, service_instance, vm_properties_ex):
+def test_cluster_property_metrics(
+    aggregator, historical_instance, dd_run_check, service_instance, vm_properties_ex, caplog
+):
     historical_instance['collect_property_metrics'] = True
-
+    caplog.set_level(logging.DEBUG)
     service_instance.content.propertyCollector.RetrievePropertiesEx = vm_properties_ex
     base_tags = ['vcenter_server:FAKE', 'vsphere_type:cluster']
     base_tags_cluster_1 = base_tags + ['vsphere_cluster:c1']
@@ -2814,6 +2816,7 @@ def test_cluster_property_metrics(aggregator, historical_instance, dd_run_check,
     aggregator.assert_metric(
         'vsphere.cluster.configuration.drsConfig.vmotionRate', count=1, value=1, tags=base_tags_cluster_2
     )
+    assert "Could not retrieve properties" not in caplog.text
 
 
 def test_datastore_property_metrics(aggregator, historical_instance, dd_run_check, service_instance, vm_properties_ex):
@@ -3016,8 +3019,10 @@ def test_property_metrics_metric_filters(
     aggregator.assert_metric('datadog.vsphere.refresh_infrastructure_cache.time')
     aggregator.assert_metric('datadog.vsphere.refresh_metrics_metadata_cache.time')
     aggregator.assert_metric('datadog.vsphere.query_metrics.time')
+    aggregator.assert_metric('vsphere.datacenter.count')
     aggregator.assert_metric('vsphere.cpu.totalmhz.avg')
     aggregator.assert_metric('vsphere.datastore.busResets.sum')
+    aggregator.assert_metric('vsphere.vmop.numChangeDS.latest')
     aggregator.assert_all_metrics_covered()
 
 


### PR DESCRIPTION
### What does this PR do?
Only collect property metrics for resources that support it and lower log line _level

### Motivation
The `Could not retrieve properties for resource` message was appearing often in logs. It is not a critical failure (worthy of a warning log) and often avoidable. The most common reason this happens is when attempting to collect property metrics for datacenters, which don't support property metrics. After this change, we don't try to collect property metrics for datacenters. 

The PR also lowers the log level so if the issue does happen again, it does not spam the agent logs anymore

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
