### PR TITLE
Trigger dependency build-related jobs on release branches too

### DIFF
--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
     - master
+    - 7.*.*
     paths:
     - .github/workflows/build-deps.yml
     - .builders/**
@@ -11,6 +12,7 @@ on:
   push:
     branches:
     - master
+    - 7.*.*
     paths:
     - .builders/**
     - agent_requirements.in


### PR DESCRIPTION
### What does this PR do?

It does the equivalent to what is currently already done in master w.r.t. dependency builds, uploads and lockfile updates to release branches.

### Motivation

With the new dependency build process, there's no good way to cherry pick individual dependency changes to release branches (or to update individual dependencies within a release branch, for that matter). This is because lockfiles are resolved for a predefined set of direct dependencies (as defined in agent_requirements.in); cherry picking a dependency update out of many updates would result in a new set of direct dependencies that would need separate resolution.

### Additional Notes

The auto-PR should, according to the [documentation](https://github.com/peter-evans/create-pull-request#action-inputs) for the Action that we use to generate it, inherit the base branch from the PR that triggered the workflow, which is what we want.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
