### PR TITLE
Tweak codeowners to properly set build-deps.yml's owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,6 @@ manifest.json         @DataDog/documentation @DataDog/agent-integrations
 /.builders/                        @DataDog/agent-build-and-releases
 /.builders/images/                 @DataDog/agent-integrations @DataDog/agent-build-and-releases
 /.builders/patches/                @DataDog/agent-integrations @DataDog/agent-build-and-releases
-/.github/workflows/build-deps.yml  @DataDog/agent-build-and-releases
 
 # Checks base
 /datadog_checks_base/                                          @DataDog/agent-integrations
@@ -295,6 +294,7 @@ datadog_checks_base/datadog_checks/base/checks/windows/              @DataDog/wi
 docs/developer/process/integration-release.md                         @DataDog/software-integrity-and-trust @DataDog/agent-integrations @trishankatdatadog
 # As well as the pipelines.
 /.github/workflows/                                                   @DataDog/agent-integrations
+/.github/workflows/build-deps.yml                                     @DataDog/agent-build-and-releases
 /.gitlab-ci.yml                                                       @DataDog/agent-integrations
 /.gitlab/software_composition_analysis.yaml                           @DataDog/software-integrity-and-trust
 # Dev container


### PR DESCRIPTION
### What does this PR do?

Moves ownership for build-deps.yml to a place on the CODEOWNERS file that ensures it is honored.

### Motivation

Automatically asked reviewers for #17449 didn't match what I expected (as intended with the change #17387).

### Additional Notes

Codeowners precedence is actually order based, not specificity based (my initial assumption).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
