### PR TITLE
Add fastpath tag to lock metrics

### DIFF
--- a/postgres/changelog.d/17451.added
+++ b/postgres/changelog.d/17451.added
@@ -1,0 +1,1 @@
+Add fastpath tag to lock metrics

--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -36,6 +36,7 @@ LOCK_METRICS = {
         ('datname', 'db'),
         ('relname', 'table'),
         ('granted', 'granted'),
+        ('fastpath', 'fastpath'),
     ],
     'metrics': {'lock_count': ('postgresql.locks', AgentCheck.gauge)},
     'query': """
@@ -45,6 +46,7 @@ SELECT mode,
        pd.datname,
        pc.relname,
        granted,
+       fastpath,
        count(*) AS {metrics_columns}
   FROM pg_locks l
   JOIN pg_database pd ON (l.database = pd.oid)
@@ -53,7 +55,7 @@ SELECT mode,
  WHERE {relations}
    AND l.mode IS NOT NULL
    AND pc.relname NOT LIKE 'pg^_%%' ESCAPE '^'
- GROUP BY pd.datname, pc.relname, pn.nspname, locktype, mode, granted""",
+ GROUP BY pd.datname, pc.relname, pn.nspname, locktype, mode, granted, fastpath""",
     'relation': True,
     'name': 'lock_metrics',
 }

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -282,6 +282,7 @@ def test_vacuum_age(aggregator, integration_check, pg_instance):
                 'lock_mode:AccessExclusiveLock',
                 'lock_type:relation',
                 'granted:True',
+                'fastpath:False',
                 'table:persons',
                 'schema:public',
             ],


### PR DESCRIPTION
### What does this PR do?
Add `fastpath` as a tag to pg_locks metrics.

### Motivation
We want to be able to see unexpected increase in locks that were not granted with fastpath and if there's any correlation with an increase in Lock wait event. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
