### PR TITLE
Lower log level for missing metric

### DIFF
--- a/esxi/changelog.d/17459.fixed
+++ b/esxi/changelog.d/17459.fixed
@@ -1,0 +1,1 @@
+Lower log level for missing metric

--- a/esxi/datadog_checks/esxi/check.py
+++ b/esxi/datadog_checks/esxi/check.py
@@ -294,7 +294,7 @@ class EsxiCheck(AgentCheck):
                     additional_tags.append(f'{instance_tag_key}:{instance_value}')
 
                 if len(metric_result.value) == 0:
-                    self.log.warning(
+                    self.log.debug(
                         "Skipping metric %s for %s because no value was returned by the %s",
                         metric_name,
                         entity_name,


### PR DESCRIPTION
### What does this PR do?
Lower log level for missing metric
### Motivation
a missing metric value should not be a warning

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
