### PR TITLE
Fix exception handling in Teleport tests

### DIFF
--- a/teleport/tests/test_common.py
+++ b/teleport/tests/test_common.py
@@ -12,7 +12,7 @@ pytestmark = [pytest.mark.unit]
 
 
 def test_connect_exception(dd_run_check, aggregator, caplog):
-    with pytest.raises(Exception, match="Failed to resolve 'invalid-hostname'"):
+    with pytest.raises(Exception, match="Failed to resolve 'invalid-hostname'|Max retries exceeded"):
         check = TeleportCheck("teleport", {}, [BAD_HOSTNAME_INSTANCE])
         dd_run_check(check)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update the match field in the exception we receive to support different exceptions messages raised by different `requests` versions.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
