### PR TITLE
Update the description for the tls_ca_cert config option to use openssl rehash instead of c_rehash

### DIFF
--- a/argo_rollouts/changelog.d/17476.fixed
+++ b/argo_rollouts/changelog.d/17476.fixed
@@ -1,0 +1,1 @@
+Update the description for the tls_ca_cert config option to use openssl rehash instead of c_rehash

--- a/argo_rollouts/datadog_checks/argo_rollouts/data/conf.yaml.example
+++ b/argo_rollouts/datadog_checks/argo_rollouts/data/conf.yaml.example
@@ -511,8 +511,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/argo_workflows/changelog.d/17476.fixed
+++ b/argo_workflows/changelog.d/17476.fixed
@@ -1,0 +1,1 @@
+Update the description for the tls_ca_cert config option to use openssl rehash instead of c_rehash

--- a/argo_workflows/datadog_checks/argo_workflows/data/conf.yaml.example
+++ b/argo_workflows/datadog_checks/argo_workflows/data/conf.yaml.example
@@ -511,8 +511,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 

--- a/tekton/changelog.d/17476.fixed
+++ b/tekton/changelog.d/17476.fixed
@@ -1,0 +1,1 @@
+Update the description for the tls_ca_cert config option to use openssl rehash instead of c_rehash

--- a/tekton/datadog_checks/tekton/data/conf.yaml.example
+++ b/tekton/datadog_checks/tekton/data/conf.yaml.example
@@ -516,8 +516,8 @@ instances:
     ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
     #
     # tls_ca_cert: <CA_CERT_PATH>
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

https://github.com/DataDog/integrations-core/pull/16981 but for the latest integrations

### Motivation
<!-- What inspired you to submit this pull request? -->

My PR was a bit behind and these integrations were not merged yet 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
