### PR TITLE
Fix token auth for teamcity integration

### DIFF
--- a/teamcity/changelog.d/17478.fixed
+++ b/teamcity/changelog.d/17478.fixed
@@ -1,0 +1,1 @@
+check for auth_token key and skip adding guestAuth or httpAuth to url if present

--- a/teamcity/datadog_checks/teamcity/teamcity_openmetrics.py
+++ b/teamcity/datadog_checks/teamcity/teamcity_openmetrics.py
@@ -13,14 +13,15 @@ class TeamCityOpenMetrics(OpenMetricsBaseCheckV2):
     __NAMESPACE__ = 'teamcity'
     DEFAULT_METRIC_LIMIT = 0
 
-    DEFAULT_METRICS_URL = "/{}/app/metrics"
-    EXPERIMENTAL_METRICS_URL = "/{}/app/metrics?experimental=true"
+    DEFAULT_METRICS_URL = "/app/metrics"
+    EXPERIMENTAL_METRICS_URL = "/app/metrics?experimental=true"
 
     def __init__(self, name, init_config, instances):
         super(TeamCityOpenMetrics, self).__init__(name, init_config, instances)
         self.basic_http_auth = is_affirmative(
             self.instance.get('basic_http_authentication', bool(self.instance.get('password')))
         )
+        self.token_auth = is_affirmative(self.instance.get('auth_token'))
         self.auth_type = 'httpAuth' if self.basic_http_auth else 'guestAuth'
         parsed_endpoint = urlparse(self.instance.get('server'))
         self.server_url = "{}://{}".format(parsed_endpoint.scheme, parsed_endpoint.netloc)
@@ -29,9 +30,12 @@ class TeamCityOpenMetrics(OpenMetricsBaseCheckV2):
         experimental_metrics = is_affirmative(self.instance.get('experimental_metrics', False))
 
         if experimental_metrics:
-            self.metrics_endpoint = self.EXPERIMENTAL_METRICS_URL.format(self.auth_type)
+            self.metrics_endpoint = self.EXPERIMENTAL_METRICS_URL
         else:
-            self.metrics_endpoint = self.DEFAULT_METRICS_URL.format(self.auth_type)
+            self.metrics_endpoint = self.DEFAULT_METRICS_URL
+
+        if not self.token_auth:
+            self.metrics_endpoint = '/{}{}'.format(self.auth_type, self.metrics_endpoint)
 
     def configure_scrapers(self):
         config = deepcopy(self.instance)

--- a/teamcity/datadog_checks/teamcity/teamcity_rest.py
+++ b/teamcity/datadog_checks/teamcity/teamcity_rest.py
@@ -46,6 +46,7 @@ class TeamCityRest(AgentCheck):
         self.basic_http_auth = is_affirmative(
             self.instance.get('basic_http_authentication', bool(self.instance.get('password', False)))
         )
+        self.token_auth = is_affirmative(self.instance.get('auth_token'))
 
         self.monitored_projects = self.instance.get('projects', {})
         self.default_build_configs_limit = self.instance.get('default_build_configs_limit', DEFAULT_BUILD_CONFIGS_LIMIT)
@@ -67,7 +68,9 @@ class TeamCityRest(AgentCheck):
 
         server = self.instance.get('server')
         self.server_url = normalize_server_url(server)
-        self.base_url = "{}/{}".format(self.server_url, self.auth_type)
+        self.base_url = self.server_url
+        if not self.token_auth:
+            self.base_url = "{}/{}".format(self.server_url, self.auth_type)
 
         instance_tags = [
             'server:{}'.format(sanitize_server_url(self.server_url)),


### PR DESCRIPTION
### What does this PR do?
Skip adding auth type to URL if using token auth.

### Motivation
As currently implemented, the teamcity integration automatically adds either 'guestAuth' or 'httpAuth' to the URL, and doesn't offer any mechanism to skip adding them. However, these paths don't work when using token auth, making it impossible to use this integration with a TeamCity server that doesn't allow either anonymous access or basic auth.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
