### PR TITLE
Add mariadb 10.6

### DIFF
--- a/mysql/hatch.toml
+++ b/mysql/hatch.toml
@@ -29,11 +29,12 @@ replication = ["group"]
 python = ["3.11"]
 flavor = ["mariadb"]
 version = [
-  "10.2",  # EOL 23 May 2022
-  "10.5",  # EOL 24 June 2025
-  "10.8",
-  "10.9",
-  "10.11",
+  "10.2",  # EOL 23 May 2022 (ended)
+  "10.5",  # EOL 24 June 2025 (LTS version)
+  "10.6",  # EOL 06 July 2026 (LTS version)
+  "10.8",  # EOL 20 May 2023 (ended)
+  "10.9",  # EOL 22 Aug 2023 (ended)
+  "10.11", # EOL 16 Feb 2028 (LTS version)
 ]
 
 [envs.default.overrides]


### PR DESCRIPTION
### What does this PR do?
Inspired by https://github.com/DataDog/integrations-core/pull/16886, I'm adding the 10.6 version of MariaDB into the tests.

### Motivation
10.6 is one of the LTS versions, so it should be much more used than other versions, and thus should be tested.

### Additional Notes
I've also added details on the existing versions.

Depending on the cost to maintain them, you might want to drop the 10.8 & 10.9 versions: they are not LTS, and there is the 10.11 afterwards already included.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
