### PR TITLE
[PLINT-376] Adding glance image member metrics

### DIFF
--- a/openstack_controller/assets/configuration/spec.yaml
+++ b/openstack_controller/assets/configuration/spec.yaml
@@ -606,7 +606,12 @@ files:
                   - type: object
                     properties:
                       - name: images
-                        type: boolean
+                        anyOf:
+                          - type: boolean
+                          - type: object
+                            properties:
+                              - name: members
+                                type: boolean
             example:
               compute: false
         - name: projects

--- a/openstack_controller/datadog_checks/openstack_controller/api/api_rest.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api/api_rest.py
@@ -493,3 +493,10 @@ class ApiRest(Api):
             'id',
             next_signifier='next',
         )
+
+    def get_glance_members(self, image_id):
+        response = self.http.get(
+            '{}/v2/images/{}/members'.format(self._catalog.get_endpoint_by_type(Component.Types.IMAGE.value), image_id)
+        )
+        response.raise_for_status()
+        return response.json().get('members', [])

--- a/openstack_controller/datadog_checks/openstack_controller/api/api_sdk.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api/api_sdk.py
@@ -299,3 +299,6 @@ class ApiSdk(Api):
             image.to_dict(original_names=True)
             for image in self.call_paginated_api(self.connection.image.images, limit=self.config.paginated_limit)
         ]
+
+    def get_glance_members(self, image_id):
+        return [member.to_dict(original_names=True) for member in self.connection.image.members(image_id)]

--- a/openstack_controller/datadog_checks/openstack_controller/components/image.py
+++ b/openstack_controller/datadog_checks/openstack_controller/components/image.py
@@ -9,6 +9,9 @@ from datadog_checks.openstack_controller.metrics import (
     GLANCE_IMAGE_METRICS,
     GLANCE_IMAGE_PREFIX,
     GLANCE_IMAGE_TAGS,
+    GLANCE_MEMBER_COUNT,
+    GLANCE_MEMBER_PREFIX,
+    GLANCE_MEMBER_TAGS,
     GLANCE_RESPONSE_TIME,
     GLANCE_SERVICE_CHECK,
     get_metrics_and_tags,
@@ -52,3 +55,18 @@ class Image(Component):
                 self.check.gauge(GLANCE_IMAGE_COUNT, 1, tags=tags + image['tags'])
                 for metric, value in image['metrics'].items():
                     self.check.gauge(metric, value, tags=tags + image['tags'])
+                self._report_members(config, tags, item['id'])
+
+    @Component.http_error()
+    def _report_members(self, config, tags, image_id):
+        report_members = config.get('members', True)
+        if report_members:
+            data = self.check.api.get_glance_members(image_id)
+            for item in data:
+                member = get_metrics_and_tags(
+                    item,
+                    tags=GLANCE_MEMBER_TAGS,
+                    prefix=GLANCE_MEMBER_PREFIX,
+                    metrics=[GLANCE_MEMBER_COUNT],
+                )
+                self.check.gauge(GLANCE_MEMBER_COUNT, 1, tags=tags + member['tags'])

--- a/openstack_controller/datadog_checks/openstack_controller/config_models/instance.py
+++ b/openstack_controller/datadog_checks/openstack_controller/config_models/instance.py
@@ -117,12 +117,20 @@ class IdentityItem(BaseModel):
     users: Optional[bool] = None
 
 
+class Image(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    members: Optional[bool] = None
+
+
 class ImageItem(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
         frozen=True,
     )
-    images: Optional[bool] = None
+    images: Optional[Union[bool, Image]] = None
 
 
 class IncludeItem3(BaseModel):

--- a/openstack_controller/datadog_checks/openstack_controller/metrics.py
+++ b/openstack_controller/datadog_checks/openstack_controller/metrics.py
@@ -547,6 +547,13 @@ GLANCE_IMAGE_TAGS = {
     'status': 'status',
     'container_format': 'container_format',
 }
+GLANCE_MEMBER_PREFIX = f"{GLANCE_IMAGE_PREFIX}.member"
+GLANCE_MEMBER_COUNT = f"{GLANCE_MEMBER_PREFIX}.count"
+GLANCE_MEMBER_TAGS = {
+    'member_id': 'member_id',
+    'image_id': 'image_id',
+    'status': 'status',
+}
 
 
 def is_interface_metric(label):

--- a/openstack_controller/metadata.csv
+++ b/openstack_controller/metadata.csv
@@ -1,6 +1,7 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
 openstack.cinder.response_time,gauge,,millisecond,,Duration that an HTTP request takes to complete when making a request to cinder endpoint,0,openstack_controller,cinder response time,
 openstack.glance.image.count,gauge,,,,Number of public virtual machine images,0,openstack_controller,glance image ct,
+openstack.glance.image.member.count,gauge,,,,Number of members associated with an image,0,openstack_controller,glance image member ct,
 openstack.glance.image.size,gauge,,,,Size of image file in bytes,0,openstack_controller,glance image size,
 openstack.glance.image.up,gauge,,,,Whether a glance image is up,0,openstack_controller,glance image up,
 openstack.glance.response_time,gauge,,millisecond,,Duration that an HTTP request takes to complete when making a request to glance endpoint,0,openstack_controller,glance response time,

--- a/openstack_controller/tests/conftest.py
+++ b/openstack_controller/tests/conftest.py
@@ -590,7 +590,19 @@ def connection_image(request, mock_responses):
             for node in mock_responses('GET', '/image/v2/images')['images']
         ]
 
-    return mock.MagicMock(images=mock.MagicMock(side_effect=images))
+    def members(image_id):
+        if http_error and 'members' in http_error:
+            raise requests.exceptions.HTTPError(response=http_error['members'])
+        return [
+            mock.MagicMock(
+                to_dict=mock.MagicMock(
+                    return_value=node,
+                )
+            )
+            for node in mock_responses('GET', f'/image/v2/images/{image_id}/members')['members']
+        ]
+
+    return mock.MagicMock(images=mock.MagicMock(side_effect=images), members=mock.MagicMock(side_effect=members))
 
 
 @pytest.fixture

--- a/openstack_controller/tests/fixtures/GET/image/v2/images/28c293db-48c5-4c8b-a711-09b2c11fa8e5/members/response.json
+++ b/openstack_controller/tests/fixtures/GET/image/v2/images/28c293db-48c5-4c8b-a711-09b2c11fa8e5/members/response.json
@@ -1,0 +1,21 @@
+{
+    "members": [
+        {
+            "created_at": "2013-10-07T17:58:03Z",
+            "image_id": "28c293db-48c5-4c8b-a711-09b2c11fa8e5",
+            "member_id": "123456789",
+            "schema": "/v2/schemas/member",
+            "status": "pending",
+            "updated_at": "2013-10-07T17:58:03Z"
+        },
+        {
+            "created_at": "2013-10-07T17:58:55Z",
+            "image_id": "28c293db-48c5-4c8b-a711-09b2c11fa8e5",
+            "member_id": "987654321",
+            "schema": "/v2/schemas/member",
+            "status": "accepted",
+            "updated_at": "2013-10-08T12:08:55Z"
+        }
+    ],
+    "schema": "/v2/schemas/members"
+}

--- a/openstack_controller/tests/metrics.py
+++ b/openstack_controller/tests/metrics.py
@@ -4627,3 +4627,30 @@ IMAGES_METRICS_GLANCE = [
         ],
     },
 ]
+
+MEMBERS_METRICS_GLANCE = [
+    {
+        'name': 'openstack.glance.image.member.count',
+        'count': 1,
+        'value': 1,
+        'hostname': '',
+        'tags': [
+            'member_id:123456789',
+            'image_id:28c293db-48c5-4c8b-a711-09b2c11fa8e5',
+            'status:pending',
+            'keystone_server:http://127.0.0.1:8080/identity',
+        ],
+    },
+    {
+        'name': 'openstack.glance.image.member.count',
+        'count': 1,
+        'value': 1,
+        'hostname': '',
+        'tags': [
+            'member_id:987654321',
+            'image_id:28c293db-48c5-4c8b-a711-09b2c11fa8e5',
+            'status:accepted',
+            'keystone_server:http://127.0.0.1:8080/identity',
+        ],
+    },
+]

--- a/openstack_controller/tests/test_unit_glance.py
+++ b/openstack_controller/tests/test_unit_glance.py
@@ -367,6 +367,34 @@ def test_disable_glance_members_metrics(aggregator, dd_run_check, instance, open
 
 
 @pytest.mark.parametrize(
+    ('instance', 'metrics'),
+    [
+        pytest.param(
+            configs.REST,
+            MEMBERS_METRICS_GLANCE,
+            id='api rest',
+        ),
+        pytest.param(
+            configs.SDK,
+            MEMBERS_METRICS_GLANCE,
+            id='api sdk',
+        ),
+    ],
+)
+@pytest.mark.usefixtures('mock_http_get', 'mock_http_post', 'openstack_connection')
+def test_images_members_metrics(aggregator, check, dd_run_check, metrics):
+    dd_run_check(check)
+    for metric in metrics:
+        aggregator.assert_metric(
+            metric['name'],
+            count=metric['count'],
+            value=metric['value'],
+            tags=metric['tags'],
+            hostname=metric.get('hostname'),
+        )
+
+
+@pytest.mark.parametrize(
     ('instance'),
     [
         pytest.param(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adding metric openstack.glance.image.member.count

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
