### PR TITLE
fix: Confluent Platform Intergration - Correct Mbean regex stream thread metric

### DIFF
--- a/confluent_platform/datadog_checks/confluent_platform/data/metrics.yaml
+++ b/confluent_platform/datadog_checks/confluent_platform/data/metrics.yaml
@@ -1603,8 +1603,12 @@ jmx_metrics:
   #   - Confluent Streams Thread: https://docs.confluent.io/current/streams/monitoring.html#built-in-metrics
   - include:
       domain: kafka.streams
-      bean_regex: kafka\.streams:type=stream-metrics,client-id=.*
+      bean_regex: kafka\.streams:type=stream-thread-metrics,thread-id=.*
       attribute:
+        blocked-time-ns-total:
+          # The total time the Kafka Streams thread spent blocked on Kafka since it was started, in nanoseconds (ns).
+          alias: confluent.$domain.stream.$attribute
+          metric_type: gauge
         commit-latency-avg:
           # The average value of commit-latency.
           alias: confluent.$domain.stream.$attribute


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixed the JMX Mbean regex to collect stream thread metrics of ksqldb in Confluent Platform.
And added the blocked-time-ns-total metric. (described in confluent docs as being very useful for debugging Kafka Streams application performance)

### Motivation
<!-- What inspired you to submit this pull request? -->
I am maintaining a confluent platform, and while configuring the ksqldb dashboard, I discovered that stream thread metrics were not collected.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
