### PR TITLE
SQLServer - Fix Always-On metrics query for replica_failover_mode and replica_failover_readiness

### DIFF
--- a/sqlserver/changelog.d/17503.fixed
+++ b/sqlserver/changelog.d/17503.fixed
@@ -1,0 +1,1 @@
+Fix Always-On metrics query for replica_failover_mode and replica_failover_readiness

--- a/sqlserver/changelog.d/17503.fixed
+++ b/sqlserver/changelog.d/17503.fixed
@@ -1,1 +1,1 @@
-Fix Always-On metrics query for replica_failover_mode and replica_failover_readiness
+Fix Always-On metrics query for replica_failover_mode and replica_failover_readiness. Previously the query returned a cartesian product of rows which could result in incorrect metrics in some cases.

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -891,7 +891,7 @@ class SqlAvailabilityReplicas(BaseSqlServerMetric):
                     inner join sys.dm_hadr_database_replica_cluster_states as dhdrcs
                     on ar.replica_id = dhdrcs.replica_id
                     inner join sys.dm_hadr_database_replica_states as dhdrs
-                    on ar.replica_id = dhdrs.replica_id
+                    on ar.replica_id = dhdrs.replica_id and dhdrcs.group_database_id = dhdrs.group_database_id
                     inner join sys.availability_groups as ag
                     on ag.group_id = ar.group_id""".format(
         table=TABLE


### PR DESCRIPTION
### What does this PR do?

User contribution from https://github.com/DataDog/integrations-core/pull/17439. Created on repo to add a changelog. Original contribution from @omarmxdbe 

- Fixes the always-on query in SQLServer to prevent duplicate rows. This affects the following 2 metrics `sqlserver.ao.replica_failover_mode` and `sqlserver.ao.replica_failover_readiness`. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
