### PR TITLE
[mongo] Emit mongodb_instance metadata event

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -100,6 +100,10 @@ files:
     - name: cluster_name
       description: |
         The name of the cluster to which the monitored MongoDB belongs.
+        Used to group MongoDB instances in a MongoDB cluster.
+        Please note that the cluster name must be unique for each MongoDB cluster.
+        
+        Required when `dbm` is enabled.
       value:
         type: string
     - name: database_instance_collection_interval

--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -99,7 +99,7 @@ files:
         display_default: false
     - name: cluster_name
       description: |
-        The name of the cluster to which the monitored MongoDB belongs.
+        The name of the cluster to which the monitored MongoDB instance belongs.
         Used to group MongoDB instances in a MongoDB cluster.
         Please note that the cluster name must be unique for each MongoDB cluster.
         

--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -89,6 +89,29 @@ files:
           type: string
         example:
           [ one_database, other_database ]
+    - name: dbm
+      description: |
+        Set to `true` enable Database Monitoring.
+      enabled: false
+      value:
+        type: boolean
+        example: false
+        display_default: false
+    - name: cluster_name
+      description: |
+        The name of the cluster to which the monitored MongoDB belongs.
+      value:
+        type: string
+    - name: database_instance_collection_interval
+      hidden: true
+      description: |
+        Set the database instance collection interval (in seconds). The database instance collection sends
+        basic information about the database instance along with a signal that it still exists.
+        This collection does not involve any additional queries to the database.
+      value:
+        type: number
+        example: 1800
+        display_default: false
     - name: replica_check
       description: |
         Whether or not to read from available replicas.

--- a/mongo/changelog.d/17518.added
+++ b/mongo/changelog.d/17518.added
@@ -1,1 +1,10 @@
-Emit mongodb_instance metadata event to for sharded cluster, replica-set and standalone deployment types.
+Emit mongodb_instance metadata event to for sharded cluster, replica-set and standalone deployment types. The metadata includes
+- mongodb hostname
+- mongodb version
+- replica set name
+- replica set state
+- sharding cluster role
+- cluster type
+- hosts (list of mongodb instances this mongodb connects to)
+- shards (list of shards this mongos instance connects to)
+- cluster name

--- a/mongo/changelog.d/17518.added
+++ b/mongo/changelog.d/17518.added
@@ -1,0 +1,1 @@
+Emit mongodb_instance metadata event to for sharded cluster, replica-set and standalone deployment types.

--- a/mongo/datadog_checks/mongo/api.py
+++ b/mongo/datadog_checks/mongo/api.py
@@ -11,7 +11,13 @@ from pymongo.errors import (
     ServerSelectionTimeoutError,
 )
 
-from datadog_checks.mongo.common import PRIMARY_STATE_ID, SECONDARY_STATE_ID, MongosDeployment, ReplicaSetDeployment, StandaloneDeployment
+from datadog_checks.mongo.common import (
+    PRIMARY_STATE_ID,
+    SECONDARY_STATE_ID,
+    MongosDeployment,
+    ReplicaSetDeployment,
+    StandaloneDeployment,
+)
 
 # The name of the application that created this MongoClient instance. MongoDB 3.4 and newer will print this value in
 # the server log upon establishing each connection. It is also recorded in the slow query log and profile collections.
@@ -108,7 +114,9 @@ class MongoApi(object):
         )
 
         hosts = is_master_payload.get('hosts', [])
-        return ReplicaSetDeployment(self._hostname, replset_name, replset_state, replset_key, hosts, cluster_role=cluster_role)
+        return ReplicaSetDeployment(
+            self._hostname, replset_name, replset_state, replset_key, hosts, cluster_role=cluster_role
+        )
 
     def refresh_deployment_type(self):
         # getCmdLineOpts is the runtime configuration of the mongo instance. Helpful to know whether the node is
@@ -175,7 +183,7 @@ class MongoApi(object):
 
     def _get_server_status(self):
         return self['admin'].command('serverStatus')
-    
+
     @property
     def hostname(self):
         if self._hostname:

--- a/mongo/datadog_checks/mongo/api.py
+++ b/mongo/datadog_checks/mongo/api.py
@@ -12,8 +12,6 @@ from pymongo.errors import (
 )
 
 from datadog_checks.mongo.common import (
-    PRIMARY_STATE_ID,
-    SECONDARY_STATE_ID,
     MongosDeployment,
     ReplicaSetDeployment,
     StandaloneDeployment,
@@ -99,22 +97,8 @@ class MongoApi(object):
     def _get_rs_deployment_from_status_payload(self, repl_set_payload, cluster_role):
         replset_name = repl_set_payload["set"]
         replset_state = repl_set_payload["myState"]
-
-        # The replset_key is a unique identifier for the replica set. It is used to identify the replica set from mongos shard map
-        # It is a combination of the replica set name and the list of non-arbiter and non-hidden members from the replica set config.
-        replset_key = "{}/{}".format(
-            replset_name,
-            ','.join(
-                [
-                    m['name']
-                    for m in repl_set_payload.get("members", [])
-                    if m['state'] in (PRIMARY_STATE_ID, SECONDARY_STATE_ID)
-                ]
-            ),
-        )
-
         hosts = [m['name'] for m in repl_set_payload.get("members", [])]
-        return ReplicaSetDeployment(replset_name, replset_state, replset_key, hosts, cluster_role=cluster_role)
+        return ReplicaSetDeployment(replset_name, replset_state, hosts, cluster_role=cluster_role)
 
     def refresh_deployment_type(self):
         # getCmdLineOpts is the runtime configuration of the mongo instance. Helpful to know whether the node is

--- a/mongo/datadog_checks/mongo/common.py
+++ b/mongo/datadog_checks/mongo/common.py
@@ -53,8 +53,7 @@ def get_long_state_name(state):
 
 
 class Deployment(object):
-    def __init__(self, hostname):
-        self.hostname = hostname
+    def __init__(self):
         self.use_shards = False
 
     def is_principal(self):
@@ -69,8 +68,8 @@ class Deployment(object):
 
 
 class MongosDeployment(Deployment):
-    def __init__(self, hostname, shard_map):
-        super(MongosDeployment, self).__init__(hostname)
+    def __init__(self, shard_map):
+        super(MongosDeployment, self).__init__()
         self.use_shards = True
         self.shard_map = shard_map
 
@@ -84,7 +83,11 @@ class MongosDeployment(Deployment):
 
     @property
     def cluster_type(self):
-        return "sharded"
+        return "sharded_cluster"
+
+    @property
+    def cluster_role(self):
+        return "mongos"
 
     def is_principal(self):
         # A mongos has full visibility on the data, Datadog agents should only communicate
@@ -93,8 +96,8 @@ class MongosDeployment(Deployment):
 
 
 class ReplicaSetDeployment(Deployment):
-    def __init__(self, hostname, replset_name, replset_state, replset_key, hosts, cluster_role=None):
-        super(ReplicaSetDeployment, self).__init__(hostname)
+    def __init__(self, replset_name, replset_state, replset_key, hosts, cluster_role=None):
+        super(ReplicaSetDeployment, self).__init__()
         self.replset_name = replset_name
         self.replset_state = replset_state
         self.replset_state_name = get_state_name(replset_state).lower()
@@ -113,7 +116,7 @@ class ReplicaSetDeployment(Deployment):
 
     @property
     def cluster_type(self):
-        return "sharded" if self.use_shards else "replica_set"
+        return "sharded_cluster" if self.use_shards else "replica_set"
 
 
 class StandaloneDeployment(Deployment):

--- a/mongo/datadog_checks/mongo/common.py
+++ b/mongo/datadog_checks/mongo/common.py
@@ -77,11 +77,11 @@ class MongosDeployment(Deployment):
     @property
     def shards(self):
         return list(self.shard_map.get('map', {}).values())
-    
+
     @property
     def hosts(self):
         return list(self.shard_map.get('hosts', {}).keys())
-    
+
     @property
     def cluster_type(self):
         return "sharded"
@@ -110,7 +110,7 @@ class ReplicaSetDeployment(Deployment):
         # There is only ever one primary node in a replica set.
         # In case sharding is disabled, the primary can be considered the master.
         return not self.use_shards and self.is_primary
-    
+
     @property
     def cluster_type(self):
         return "sharded" if self.use_shards else "replica_set"

--- a/mongo/datadog_checks/mongo/common.py
+++ b/mongo/datadog_checks/mongo/common.py
@@ -96,7 +96,7 @@ class MongosDeployment(Deployment):
 
 
 class ReplicaSetDeployment(Deployment):
-    def __init__(self, replset_name, replset_state, replset_key, hosts, cluster_role=None):
+    def __init__(self, replset_name, replset_state, hosts, cluster_role=None):
         super(ReplicaSetDeployment, self).__init__()
         self.replset_name = replset_name
         self.replset_state = replset_state
@@ -106,7 +106,6 @@ class ReplicaSetDeployment(Deployment):
         self.is_primary = replset_state == PRIMARY_STATE_ID
         self.is_secondary = replset_state == SECONDARY_STATE_ID
         self.is_arbiter = replset_state == ARBITER_STATE_ID
-        self.replset_key = replset_key
         self.hosts = hosts
 
     def is_principal(self):

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -102,6 +102,7 @@ class MongoConfig(object):
         # DBM config options
         self.dbm_enabled = is_affirmative(instance.get('dbm', False))
         self.database_instance_collection_interval = instance.get('database_instance_collection_interval', 1800)
+        self.cluster_name = instance.get('cluster_name', None)
 
     def _get_clean_server_name(self):
         try:

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -66,7 +66,7 @@ class MongoConfig(object):
 
         if not self.hosts:
             raise ConfigurationError('No `hosts` specified')
-        
+
         self.clean_server_name = self._get_clean_server_name()
         if self.password and not self.username:
             raise ConfigurationError('`username` must be set when a `password` is specified')

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -66,7 +66,7 @@ class MongoConfig(object):
 
         if not self.hosts:
             raise ConfigurationError('No `hosts` specified')
-
+        
         self.clean_server_name = self._get_clean_server_name()
         if self.password and not self.username:
             raise ConfigurationError('`username` must be set when a `password` is specified')
@@ -98,6 +98,10 @@ class MongoConfig(object):
         self._base_tags = list(set(instance.get('tags', [])))
         self.service_check_tags = self._compute_service_check_tags()
         self.metric_tags = self._compute_metric_tags()
+
+        # DBM config options
+        self.dbm_enabled = is_affirmative(instance.get('dbm', False))
+        self.database_instance_collection_interval = instance.get('database_instance_collection_interval', 1800)
 
     def _get_clean_server_name(self):
         try:

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -104,6 +104,9 @@ class MongoConfig(object):
         self.database_instance_collection_interval = instance.get('database_instance_collection_interval', 1800)
         self.cluster_name = instance.get('cluster_name', None)
 
+        if self.dbm_enabled and not self.cluster_name:
+            raise ConfigurationError('`cluster_name` must be set when `dbm` is enabled')
+
     def _get_clean_server_name(self):
         try:
             if not self.server:

--- a/mongo/datadog_checks/mongo/config_models/defaults.py
+++ b/mongo/datadog_checks/mongo/config_models/defaults.py
@@ -20,6 +20,14 @@ def instance_connection_scheme():
     return 'mongodb'
 
 
+def instance_database_instance_collection_interval():
+    return False
+
+
+def instance_dbm():
+    return False
+
+
 def instance_dbstats_tag_dbname():
     return True
 

--- a/mongo/datadog_checks/mongo/config_models/instance.py
+++ b/mongo/datadog_checks/mongo/config_models/instance.py
@@ -59,11 +59,14 @@ class InstanceConfig(BaseModel):
     )
     add_node_tag_to_events: Optional[bool] = None
     additional_metrics: Optional[tuple[str, ...]] = None
+    cluster_name: Optional[str] = None
     collections: Optional[tuple[str, ...]] = None
     collections_indexes_stats: Optional[bool] = None
     connection_scheme: Optional[str] = None
     custom_queries: Optional[tuple[CustomQuery, ...]] = None
     database: Optional[str] = None
+    database_instance_collection_interval: Optional[float] = None
+    dbm: Optional[bool] = None
     dbnames: Optional[tuple[str, ...]] = None
     dbstats_tag_dbname: Optional[bool] = None
     disable_generic_tags: Optional[bool] = None

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -90,7 +90,7 @@ instances:
     # dbm: false
 
     ## @param cluster_name - string - optional
-    ## The name of the cluster to which the monitored MongoDB belongs.
+    ## The name of the cluster to which the monitored MongoDB instance belongs.
     ## Used to group MongoDB instances in a MongoDB cluster.
     ## Please note that the cluster name must be unique for each MongoDB cluster.
     ##

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -91,6 +91,10 @@ instances:
 
     ## @param cluster_name - string - optional
     ## The name of the cluster to which the monitored MongoDB belongs.
+    ## Used to group MongoDB instances in a MongoDB cluster.
+    ## Please note that the cluster name must be unique for each MongoDB cluster.
+    ##
+    ## Required when `dbm` is enabled.
     #
     # cluster_name: <CLUSTER_NAME>
 

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -84,6 +84,16 @@ instances:
     #   - one_database
     #   - other_database
 
+    ## @param dbm - boolean - optional - default: false
+    ## Set to `true` enable Database Monitoring.
+    #
+    # dbm: false
+
+    ## @param cluster_name - string - optional
+    ## The name of the cluster to which the monitored MongoDB belongs.
+    #
+    # cluster_name: <CLUSTER_NAME>
+
     ## @param replica_check - boolean - optional - default: true
     ## Whether or not to read from available replicas.
     ## Disable this if any replicas are inaccessible to the Agent. This option is not supported for sharded clusters.

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -309,10 +309,9 @@ class MongoDb(AgentCheck):
         deployment = self.api_client.deployment_type
         if self._resolved_hostname not in self._database_instance_emitted:
             tags = self._get_deployment_tags(deployment)
-            mongodb_instance = {
+            mongodb_instance_metadata = {
                 "replset_name": getattr(deployment, 'replset_name', None),
                 "replset_state": getattr(deployment, 'replset_state_name', None),
-                "replset_key": getattr(deployment, 'replset_key', None),
                 "sharding_cluster_role": getattr(deployment, 'cluster_role', None),
                 "hosts": getattr(deployment, 'hosts', None),
                 "shards": getattr(deployment, 'shards', None),
@@ -332,7 +331,7 @@ class MongoDb(AgentCheck):
                 "metadata": {
                     "dbm": self._config.dbm_enabled,
                     "connection_host": self._config.clean_server_name,
-                    "mongodb_instance": mongodb_instance,
+                    "instance_metadata": {k: v for k, v in mongodb_instance_metadata.items() if v is not None},
                 },
             }
             self._database_instance_emitted[self._resolved_hostname] = database_instance

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -330,5 +330,7 @@ class MongoDb(AgentCheck):
                 "kind": "mongodb_instance",
             }
             self._database_instance_emitted[deployment.hostname] = (database_instance, mongodb_instance)
-            self.log.debug("Emitting database instance and mongodb instance metadata, %s, %s", database_instance, mongodb_instance)
+            self.log.debug(
+                "Emitting database instance and mongodb instance metadata, %s, %s", database_instance, mongodb_instance
+            )
             # self.database_monitoring_metadata(json.dumps(event, default=default_json_event_encoding))

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -3,10 +3,10 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
 
-from copy import deepcopy
-from functools import cached_property
 import json
 import time
+from copy import deepcopy
+from functools import cached_property
 
 from cachetools import TTLCache
 from packaging.version import Version

--- a/mongo/tests/conftest.py
+++ b/mongo/tests/conftest.py
@@ -125,6 +125,13 @@ def instance_integration(instance_custom_queries):
     return instance
 
 
+@pytest.fixture
+def instance_integration_cluster(instance_integration):
+    instance = copy.deepcopy(instance_integration)
+    instance["cluster_name"] = "my_cluster"
+    return instance
+
+
 @pytest.fixture(scope='session', autouse=True)
 def mock_local_tls_dns():
     with mock_local(HOSTNAME_TO_PORT_MAPPING):

--- a/mongo/tests/fixtures/getShardMap
+++ b/mongo/tests/fixtures/getShardMap
@@ -1,0 +1,38 @@
+{
+    "map": {
+        "shard01": "shard01/shard01a:27018,shard01b:27019",
+        "shard02": "shard02/shard02a:27019,shard02b:27019",
+        "shard03": "shard03/shard03a:27020,shard03b:27020",
+        "config": "configserver/config01:27017,config02:27017,config03:27017"
+    },
+    "hosts": {
+        "shard01a:27018": "shard01",
+        "shard01b:27019": "shard01",
+        "shard01c:27020": "shard01",
+        "shard03b:27020": "shard03",
+        "shard03a:27020": "shard03",
+        "shard02a:27019": "shard02",
+        "shard02b:27019": "shard02",
+        "config02:27017": "config",
+        "config01:27017": "config",
+        "config03:27017": "config"
+    },
+    "connStrings": {
+        "shard01/shard01a:27018": "shard01",
+        "shard01/shard01a:27018,shard01b:27019": "shard01",
+        "shard02/shard02a:27019,shard02b:27019": "shard02",
+        "shard03/shard03a:27020": "shard03",
+        "shard03/shard03a:27020,shard03b:27020": "shard03",
+        "configserver/config01:27017,config02:27017,config03:27017": "config"
+    },
+    "ok": 1,
+    "$clusterTime": {
+      "clusterTime": "Timestamp({ t: 1715024297, i: 1 })",
+      "signature": {
+        "hash": "Binary.createFromBase64('AAAAAAAAAAAAAAAAAAAAAAAAAAA=', 0)",
+        "keyId": "Long('0')"
+      }
+    },
+    "operationTime": "Timestamp({ t: 1715024297, i: 1 })"
+  }
+  

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -29,6 +29,47 @@ def _assert_metrics(aggregator, metrics_categories, additional_tags=None):
                 )
 
 
+def _assert_mongodb_instance_event(
+    aggregator,
+    check,
+    expected_tags,
+    dbm,
+    replset_name,
+    replset_state,
+    replset_key,
+    sharding_cluster_role,
+    hosts,
+    shards,
+    cluster_type,
+    cluster_name,
+):
+    # Gather dbm-metadata events
+    dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
+
+    # Assert that the mongodb_instance events are present with the correct metadata
+    mongodb_instance_event = next((e for e in dbm_metadata if e['kind'] == 'mongodb_instance'), None)
+    assert mongodb_instance_event is not None
+    assert mongodb_instance_event['host'] == check._resolved_hostname
+    assert mongodb_instance_event is not None
+    assert mongodb_instance_event['host'] == check._resolved_hostname
+    assert mongodb_instance_event['dbms'] == "mongodb"
+    assert mongodb_instance_event['tags'].sort() == expected_tags.sort()
+    assert mongodb_instance_event['metadata'] == {
+        'dbm': dbm,
+        'connection_host': check._config.clean_server_name,
+        "mongodb_instance": {
+            "replset_name": replset_name,
+            "replset_state": replset_state,
+            "replset_key": replset_key,
+            "sharding_cluster_role": sharding_cluster_role,
+            "hosts": hosts,
+            "shards": shards,
+            "cluster_type": cluster_type,
+            "cluster_name": cluster_name,
+        },
+    }
+
+
 def test_integration_mongos(instance_integration, aggregator, check, dd_run_check):
     mongos_check = check(instance_integration)
     mongos_check._last_states_by_server = {0: 1, 1: 2, 2: 2}
@@ -64,6 +105,38 @@ def test_integration_mongos(instance_integration, aggregator, check, dd_run_chec
         check_submission_type=True,
     )
     assert len(aggregator._events) == 0
+
+    expected_tags = ['server:mongodb://localhost:27017/', 'sharding_cluster_role:mongos']
+    _assert_mongodb_instance_event(
+        aggregator,
+        mongos_check,
+        expected_tags=expected_tags,
+        dbm=False,
+        replset_name=None,
+        replset_state=None,
+        replset_key=None,
+        sharding_cluster_role='mongos',
+        hosts=[
+            'shard01a:27018',
+            'shard01b:27019',
+            'shard01c:27020',
+            'shard03b:27020',
+            'shard03a:27020',
+            'shard02a:27019',
+            'shard02b:27019',
+            'config02:27017',
+            'config01:27017',
+            'config03:27017',
+        ],
+        shards=[
+            'shard01/shard01a:27018,shard01b:27019',
+            'shard02/shard02a:27019,shard02b:27019',
+            'shard03/shard03a:27020,shard03b:27020',
+            'configserver/config01:27017,config02:27017,config03:27017',
+        ],
+        cluster_type='sharded_cluster',
+        cluster_name=None,
+    )
 
 
 def test_integration_replicaset_primary_in_shard(instance_integration, aggregator, check, dd_run_check):
@@ -141,6 +214,32 @@ def test_integration_replicaset_primary_in_shard(instance_integration, aggregato
         count=1,
     )
 
+    expected_tags = replica_tags + [f'server:{mongo_check._config.clean_server_name}']
+    _assert_mongodb_instance_event(
+        aggregator,
+        mongo_check,
+        expected_tags=expected_tags,
+        dbm=False,
+        replset_name='mongo-mongodb-sharded-shard-0',
+        replset_state='primary',
+        replset_key=(
+            'mongo-mongodb-sharded-shard-0/mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017,'
+            'mongo-mongodb-sharded-shard0-data-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017,'
+            'mongo-mongodb-sharded-shard0-data-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017'
+        ),
+        sharding_cluster_role='shardsvr',
+        hosts=[
+            'mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+            'mongo-mongodb-sharded-shard0-arbiter-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+            'mongo-mongodb-sharded-shard0-data-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+            'mongo-mongodb-sharded-shard0-data-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+            'mongo-mongodb-sharded-shard0-data-3.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+        ],
+        shards=None,
+        cluster_type='sharded_cluster',
+        cluster_name=None,
+    )
+
 
 def test_integration_replicaset_secondary_in_shard(instance_integration, aggregator, check, dd_run_check):
     mongo_check = check(instance_integration)
@@ -179,6 +278,31 @@ def test_integration_replicaset_secondary_in_shard(instance_integration, aggrega
     )
     assert len(aggregator._events) == 0
 
+    expected_tags = replica_tags + [f'server:{mongo_check._config.clean_server_name}']
+    _assert_mongodb_instance_event(
+        aggregator,
+        mongo_check,
+        expected_tags=expected_tags,
+        dbm=False,
+        replset_name='mongo-mongodb-sharded-shard-0',
+        replset_state='secondary',
+        replset_key=(
+            'mongo-mongodb-sharded-shard-0/mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017,'
+            'mongo-mongodb-sharded-shard0-data-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017,'
+            'mongo-mongodb-sharded-shard0-data-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017'
+        ),
+        sharding_cluster_role='shardsvr',
+        hosts=[
+            'mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+            'mongo-mongodb-sharded-shard0-arbiter-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+            'mongo-mongodb-sharded-shard0-data-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+            'mongo-mongodb-sharded-shard0-data-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+        ],
+        shards=None,
+        cluster_type='sharded_cluster',
+        cluster_name=None,
+    )
+
 
 def test_integration_replicaset_arbiter_in_shard(instance_integration, aggregator, check, dd_run_check):
     for query in instance_integration['custom_queries']:
@@ -211,6 +335,31 @@ def test_integration_replicaset_arbiter_in_shard(instance_integration, aggregato
         check_submission_type=True,
     )
     assert len(aggregator._events) == 0
+
+    expected_tags = replica_tags + [f'server:{mongo_check._config.clean_server_name}']
+    _assert_mongodb_instance_event(
+        aggregator,
+        mongo_check,
+        expected_tags=expected_tags,
+        dbm=False,
+        replset_name='mongo-mongodb-sharded-shard-0',
+        replset_state='arbiter',
+        replset_key=(
+            'mongo-mongodb-sharded-shard-0/mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017,'
+            'mongo-mongodb-sharded-shard0-data-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017,'
+            'mongo-mongodb-sharded-shard0-data-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017'
+        ),
+        sharding_cluster_role='shardsvr',
+        hosts=[
+            'mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+            'mongo-mongodb-sharded-shard0-arbiter-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+            'mongo-mongodb-sharded-shard0-data-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+            'mongo-mongodb-sharded-shard0-data-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+        ],
+        shards=None,
+        cluster_type='sharded_cluster',
+        cluster_name=None,
+    )
 
 
 def test_integration_configsvr_primary(instance_integration, aggregator, check, dd_run_check):
@@ -288,6 +437,30 @@ def test_integration_configsvr_primary(instance_integration, aggregator, check, 
         count=1,
     )
 
+    expected_tags = replica_tags + [f'server:{mongo_check._config.clean_server_name}']
+    _assert_mongodb_instance_event(
+        aggregator,
+        mongo_check,
+        expected_tags=expected_tags,
+        dbm=False,
+        replset_name='mongo-mongodb-sharded-configsvr',
+        replset_state='primary',
+        replset_key=(
+            'mongo-mongodb-sharded-configsvr/mongo-mongodb-sharded-configsvr-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017,'
+            'mongo-mongodb-sharded-configsvr-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017,'
+            'mongo-mongodb-sharded-configsvr-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017'
+        ),
+        sharding_cluster_role='configsvr',
+        hosts=[
+            'mongo-mongodb-sharded-configsvr-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+            'mongo-mongodb-sharded-configsvr-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+            'mongo-mongodb-sharded-configsvr-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+        ],
+        shards=None,
+        cluster_type='sharded_cluster',
+        cluster_name=None,
+    )
+
 
 def test_integration_configsvr_secondary(instance_integration, aggregator, check, dd_run_check):
     mongo_check = check(instance_integration)
@@ -325,6 +498,30 @@ def test_integration_configsvr_secondary(instance_integration, aggregator, check
         check_submission_type=True,
     )
     assert len(aggregator._events) == 0
+
+    expected_tags = replica_tags + [f'server:{mongo_check._config.clean_server_name}']
+    _assert_mongodb_instance_event(
+        aggregator,
+        mongo_check,
+        expected_tags=expected_tags,
+        dbm=False,
+        replset_name='mongo-mongodb-sharded-configsvr',
+        replset_state='secondary',
+        replset_key=(
+            'mongo-mongodb-sharded-configsvr/mongo-mongodb-sharded-configsvr-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017,'
+            'mongo-mongodb-sharded-configsvr-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017,'
+            'mongo-mongodb-sharded-configsvr-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017'
+        ),
+        sharding_cluster_role='configsvr',
+        hosts=[
+            'mongo-mongodb-sharded-configsvr-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+            'mongo-mongodb-sharded-configsvr-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+            'mongo-mongodb-sharded-configsvr-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+        ],
+        shards=None,
+        cluster_type='sharded_cluster',
+        cluster_name=None,
+    )
 
 
 def test_integration_replicaset_primary(instance_integration, aggregator, check, dd_run_check):
@@ -399,6 +596,31 @@ def test_integration_replicaset_primary(instance_integration, aggregator, check,
             'replset:replset',
         ],
         count=1,
+    )
+
+    expected_tags = replica_tags + [f'server:{mongo_check._config.clean_server_name}']
+    _assert_mongodb_instance_event(
+        aggregator,
+        mongo_check,
+        expected_tags=expected_tags,
+        dbm=False,
+        replset_name='replset',
+        replset_state='primary',
+        replset_key=(
+            'replset/replset-data-0.mongo.default.svc.cluster.local:27017,'
+            'replset-data-1.mongo.default.svc.cluster.local:27017,'
+            'replset-data-2.mongo.default.svc.cluster.local:27017'
+        ),
+        sharding_cluster_role=None,
+        hosts=[
+            'replset-data-0.mongo.default.svc.cluster.local:27017',
+            'replset-arbiter-0.mongo.default.svc.cluster.local:27017',
+            'replset-data-1.mongo.default.svc.cluster.local:27017',
+            'replset-data-2.mongo.default.svc.cluster.local:27017',
+        ],
+        shards=None,
+        cluster_type='replica_set',
+        cluster_name=None,
     )
 
 
@@ -480,6 +702,31 @@ def test_integration_replicaset_primary_config(instance_integration, aggregator,
         count=1,
     )
 
+    expected_tags = replica_tags + [f'server:{mongo_check._config.clean_server_name}']
+    _assert_mongodb_instance_event(
+        aggregator,
+        mongo_check,
+        expected_tags=expected_tags,
+        dbm=False,
+        replset_name='replset',
+        replset_state='primary',
+        replset_key=(
+            'replset/replset-data-0.mongo.default.svc.cluster.local:27017,'
+            'replset-data-1.mongo.default.svc.cluster.local:27017,'
+            'replset-data-2.mongo.default.svc.cluster.local:27017'
+        ),
+        sharding_cluster_role=None,
+        hosts=[
+            'replset-data-0.mongo.default.svc.cluster.local:27017',
+            'replset-arbiter-0.mongo.default.svc.cluster.local:27017',
+            'replset-data-1.mongo.default.svc.cluster.local:27017',
+            'replset-data-2.mongo.default.svc.cluster.local:27017',
+        ],
+        shards=None,
+        cluster_type='replica_set',
+        cluster_name=None,
+    )
+
 
 @pytest.mark.parametrize('collect_custom_queries', [True, False])
 def test_integration_replicaset_secondary(
@@ -522,6 +769,31 @@ def test_integration_replicaset_secondary(
     )
     assert len(aggregator._events) == 0
 
+    expected_tags = replica_tags + [f'server:{mongo_check._config.clean_server_name}']
+    _assert_mongodb_instance_event(
+        aggregator,
+        mongo_check,
+        expected_tags=expected_tags,
+        dbm=False,
+        replset_name='replset',
+        replset_state='secondary',
+        replset_key=(
+            'replset/replset-data-0.mongo.default.svc.cluster.local:27017,'
+            'replset-data-1.mongo.default.svc.cluster.local:27017,'
+            'replset-data-2.mongo.default.svc.cluster.local:27017'
+        ),
+        sharding_cluster_role=None,
+        hosts=[
+            'replset-data-0.mongo.default.svc.cluster.local:27017',
+            'replset-arbiter-0.mongo.default.svc.cluster.local:27017',
+            'replset-data-1.mongo.default.svc.cluster.local:27017',
+            'replset-data-2.mongo.default.svc.cluster.local:27017',
+        ],
+        shards=None,
+        cluster_type='replica_set',
+        cluster_name=None,
+    )
+
 
 def test_integration_replicaset_arbiter(instance_integration, aggregator, check, dd_run_check):
     for query in instance_integration['custom_queries']:
@@ -550,6 +822,31 @@ def test_integration_replicaset_arbiter(instance_integration, aggregator, check,
         check_submission_type=True,
     )
     assert len(aggregator._events) == 0
+
+    expected_tags = replica_tags + [f'server:{mongo_check._config.clean_server_name}']
+    _assert_mongodb_instance_event(
+        aggregator,
+        mongo_check,
+        expected_tags=expected_tags,
+        dbm=False,
+        replset_name='replset',
+        replset_state='arbiter',
+        replset_key=(
+            'replset/replset-data-0.mongo.default.svc.cluster.local:27017,'
+            'replset-data-1.mongo.default.svc.cluster.local:27017,'
+            'replset-data-2.mongo.default.svc.cluster.local:27017'
+        ),
+        sharding_cluster_role=None,
+        hosts=[
+            'replset-data-0.mongo.default.svc.cluster.local:27017',
+            'replset-arbiter-0.mongo.default.svc.cluster.local:27017',
+            'replset-data-1.mongo.default.svc.cluster.local:27017',
+            'replset-data-2.mongo.default.svc.cluster.local:27017',
+        ],
+        shards=None,
+        cluster_type='replica_set',
+        cluster_name=None,
+    )
 
 
 def test_standalone(instance_integration, aggregator, check, dd_run_check):
@@ -584,6 +881,22 @@ def test_standalone(instance_integration, aggregator, check, dd_run_check):
         check_submission_type=True,
     )
     assert len(aggregator._events) == 0
+
+    expected_tags = [f'server:{mongo_check._config.clean_server_name}']
+    _assert_mongodb_instance_event(
+        aggregator,
+        mongo_check,
+        expected_tags=expected_tags,
+        dbm=False,
+        replset_name=None,
+        replset_state=None,
+        replset_key=None,
+        sharding_cluster_role=None,
+        hosts=None,
+        shards=None,
+        cluster_type=None,
+        cluster_name=None,
+    )
 
 
 def test_user_pass_options(check, instance_user, dd_run_check):

--- a/mongo/tests/test_integration_shard.py
+++ b/mongo/tests/test_integration_shard.py
@@ -81,7 +81,6 @@ def test_refresh_role(instance_shard, aggregator, check, dd_run_check):
         mock_deployment_type = ReplicaSetDeployment(
             "sharding01",
             9,
-            "sharding01/sharding01a:27017,sharding01b:27017,sharding01c:27017",
             ["sharding01a:27017", "sharding01b:27017", "sharding01c:27017"],
             cluster_role="TEST",
         )

--- a/mongo/tests/test_integration_shard.py
+++ b/mongo/tests/test_integration_shard.py
@@ -79,7 +79,6 @@ def test_refresh_role(instance_shard, aggregator, check, dd_run_check):
     dd_run_check(mongo_check)
     with mock.patch('datadog_checks.mongo.api.MongoApi._get_rs_deployment_from_status_payload') as get_deployment:
         mock_deployment_type = ReplicaSetDeployment(
-            "sharding01a:27017",
             "sharding01",
             9,
             "sharding01/sharding01a:27017,sharding01b:27017,sharding01c:27017",

--- a/mongo/tests/test_integration_shard.py
+++ b/mongo/tests/test_integration_shard.py
@@ -78,7 +78,7 @@ def test_refresh_role(instance_shard, aggregator, check, dd_run_check):
     mongo_check = check(instance_shard)
     dd_run_check(mongo_check)
     with mock.patch('datadog_checks.mongo.api.MongoApi._get_rs_deployment_from_status_payload') as get_deployment:
-        mock_deployment_type = ReplicaSetDeployment("sharding01", 9, cluster_role="TEST")
+        mock_deployment_type = ReplicaSetDeployment("sharding01a:27017", "sharding01", 9, "sharding01/sharding01a:27017,sharding01b:27017,sharding01c:27017", ["sharding01a:27017", "sharding01b:27017", "sharding01c:27017"], cluster_role="TEST")
         get_deployment.return_value = mock_deployment_type
         dd_run_check(mongo_check)
         assert get_deployment.call_count == 1

--- a/mongo/tests/test_integration_shard.py
+++ b/mongo/tests/test_integration_shard.py
@@ -78,7 +78,14 @@ def test_refresh_role(instance_shard, aggregator, check, dd_run_check):
     mongo_check = check(instance_shard)
     dd_run_check(mongo_check)
     with mock.patch('datadog_checks.mongo.api.MongoApi._get_rs_deployment_from_status_payload') as get_deployment:
-        mock_deployment_type = ReplicaSetDeployment("sharding01a:27017", "sharding01", 9, "sharding01/sharding01a:27017,sharding01b:27017,sharding01c:27017", ["sharding01a:27017", "sharding01b:27017", "sharding01c:27017"], cluster_role="TEST")
+        mock_deployment_type = ReplicaSetDeployment(
+            "sharding01a:27017",
+            "sharding01",
+            9,
+            "sharding01/sharding01a:27017,sharding01b:27017,sharding01c:27017",
+            ["sharding01a:27017", "sharding01b:27017", "sharding01c:27017"],
+            cluster_role="TEST",
+        )
         get_deployment.return_value = mock_deployment_type
         dd_run_check(mongo_check)
         assert get_deployment.call_count == 1

--- a/mongo/tests/test_integration_standalone.py
+++ b/mongo/tests/test_integration_standalone.py
@@ -223,4 +223,5 @@ def test_metadata(check, instance, datadog_agent):
 
     check.check(instance)
     datadog_agent.assert_metadata('test:123', version_metadata)
-    datadog_agent.assert_metadata_count(len(version_metadata) + 2)
+    datadog_agent.assert_metadata('test:123', {'resolved_hostname': check._resolved_hostname})
+    datadog_agent.assert_metadata_count(len(version_metadata) + 3)

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -45,7 +45,13 @@ def test_emits_critical_service_check_when_service_is_not_available(mock_command
     aggregator.assert_service_check('mongodb.can_connect', MongoDb.CRITICAL)
 
 
-@mock.patch('pymongo.database.Database.command', side_effect=[{'parsed': {}}])
+@mock.patch(
+    'pymongo.database.Database.command',
+    side_effect=[
+        {'host': 'test-hostname:27018'},  # serverStatus
+        {'parsed': {}},  # getCmdLineOpts
+    ],
+)
 @mock.patch('pymongo.mongo_client.MongoClient.server_info', return_value={'version': '5.0.0'})
 @mock.patch('pymongo.mongo_client.MongoClient.list_database_names', return_value=[])
 def test_emits_ok_service_check_when_service_is_available(
@@ -58,9 +64,16 @@ def test_emits_ok_service_check_when_service_is_available(
     dd_run_check(check)
     # Then
     aggregator.assert_service_check('mongodb.can_connect', MongoDb.OK)
+    assert check._resolved_hostname == 'test-hostname:27018'
 
 
-@mock.patch('pymongo.database.Database.command', side_effect=[{'parsed': {}}])
+@mock.patch(
+    'pymongo.database.Database.command',
+    side_effect=[
+        {'host': 'test-hostname:27018'},  # serverStatus
+        {'parsed': {}},  # getCmdLineOpts
+    ],
+)
 @mock.patch('pymongo.mongo_client.MongoClient.server_info', return_value={'version': '5.0.0'})
 @mock.patch('pymongo.mongo_client.MongoClient.list_database_names', return_value=[])
 def test_emits_ok_service_check_each_run_when_service_is_available(
@@ -74,9 +87,16 @@ def test_emits_ok_service_check_each_run_when_service_is_available(
     dd_run_check(check)
     # Then
     aggregator.assert_service_check('mongodb.can_connect', MongoDb.OK, count=2)
+    assert check._resolved_hostname == 'test-hostname:27018'
 
 
-@mock.patch('pymongo.database.Database.command', side_effect=[{'parsed': {}}])
+@mock.patch(
+    'pymongo.database.Database.command',
+    side_effect=[
+        {'host': 'test-hostname'},  # serverStatus
+        {'parsed': {}},  # getCmdLineOpts
+    ],
+)
 @mock.patch('pymongo.mongo_client.MongoClient.server_info', return_value={'version': '5.0.0'})
 @mock.patch('pymongo.mongo_client.MongoClient.list_database_names', return_value=[])
 def test_version_metadata(
@@ -97,13 +117,18 @@ def test_version_metadata(
             'version.minor': '0',
             'version.patch': '0',
             'version.raw': '5.0.0',
+            'resolved_hostname': 'test-hostname:27017',
         },
     )
 
 
 @mock.patch(
     'pymongo.database.Database.command',
-    side_effect=[Exception('getCmdLineOpts exception'), {'msg': 'isdbgrid'}],
+    side_effect=[
+        {'host': 'test-hostname'},  # serverStatus
+        Exception('getCmdLineOpts exception'),  # getCmdLineOpts
+        {'msg': 'isdbgrid'},  # isMaster
+    ],
 )
 @mock.patch('pymongo.mongo_client.MongoClient.server_info', return_value={'version': '5.0.0'})
 @mock.patch('pymongo.mongo_client.MongoClient.list_database_names', return_value=[])
@@ -117,17 +142,19 @@ def test_emits_ok_service_check_when_alibaba_mongos_deployment(
     dd_run_check(check)
     # Then
     aggregator.assert_service_check('mongodb.can_connect', MongoDb.OK)
-    mock_command.assert_has_calls([mock.call('getCmdLineOpts'), mock.call('isMaster')])
+    mock_command.assert_has_calls([mock.call('serverStatus'), mock.call('getCmdLineOpts'), mock.call('isMaster')])
     mock_server_info.assert_called_once()
     mock_list_database_names.assert_called_once()
+    assert check._resolved_hostname == 'test-hostname:27017'
 
 
 @mock.patch(
     'pymongo.database.Database.command',
     side_effect=[
-        Exception('getCmdLineOpts exception'),
-        {},
-        {'configsvr': True, 'set': 'replset', "myState": 1},
+        {'host': 'test-hostname'},  # serverStatus
+        Exception('getCmdLineOpts exception'),  # getCmdLineOpts
+        {},  # isMaster
+        {'configsvr': True, 'set': 'replset', "myState": 1},  # replSetGetStatus
     ],
 )
 @mock.patch('pymongo.mongo_client.MongoClient.server_info', return_value={'version': '5.0.0'})
@@ -142,7 +169,14 @@ def test_emits_ok_service_check_when_alibaba_replicaset_role_configsvr_deploymen
     dd_run_check(check)
     # Then
     aggregator.assert_service_check('mongodb.can_connect', MongoDb.OK)
-    mock_command.assert_has_calls([mock.call('getCmdLineOpts'), mock.call('isMaster'), mock.call('replSetGetStatus')])
+    mock_command.assert_has_calls(
+        [
+            mock.call('serverStatus'),
+            mock.call('getCmdLineOpts'),
+            mock.call('isMaster'),
+            mock.call('replSetGetStatus'),
+        ]
+    )
     mock_server_info.assert_called_once()
     mock_list_database_names.assert_called_once()
 
@@ -150,9 +184,10 @@ def test_emits_ok_service_check_when_alibaba_replicaset_role_configsvr_deploymen
 @mock.patch(
     'pymongo.database.Database.command',
     side_effect=[
-        Exception('getCmdLineOpts exception'),
-        {},
-        {'configsvr': True, 'set': 'replset', "myState": 3},
+        {'host': 'test-hostname'},  # serverStatus
+        Exception('getCmdLineOpts exception'),  # getCmdLineOpts
+        {},  # isMaster
+        {'configsvr': True, 'set': 'replset', "myState": 3},  # replSetGetStatus
     ],
 )
 @mock.patch('pymongo.mongo_client.MongoClient.server_info', return_value={'version': '5.0.0'})
@@ -167,7 +202,14 @@ def test_when_replicaset_state_recovering_then_database_names_not_called(
     dd_run_check(check)
     # Then
     aggregator.assert_service_check('mongodb.can_connect', MongoDb.OK)
-    mock_command.assert_has_calls([mock.call('getCmdLineOpts'), mock.call('isMaster'), mock.call('replSetGetStatus')])
+    mock_command.assert_has_calls(
+        [
+            mock.call('serverStatus'),
+            mock.call('getCmdLineOpts'),
+            mock.call('isMaster'),
+            mock.call('replSetGetStatus'),
+        ]
+    )
     mock_server_info.assert_called_once()
     mock_list_database_names.assert_not_called()
 

--- a/mongo/tests/test_unit_config.py
+++ b/mongo/tests/test_unit_config.py
@@ -95,3 +95,9 @@ def test_custom_replicaSet_is_not_allowed(instance):
     instance['options'] = {'replicaSet': 'foo'}
     with pytest.raises(ConfigurationError, match='replicaSet'):
         MongoConfig(instance, mock.Mock())
+
+
+def test_dbm_cluster_name(instance):
+    instance['dbm'] = True
+    with pytest.raises(ConfigurationError, match='`cluster_name` must be set when `dbm` is enabled'):
+        MongoConfig(instance, mock.Mock())


### PR DESCRIPTION
### What does this PR do?
In this PR, the mongo integration will emit `mongodb_instance` metadata event which contains instance level metadata including
- hostname
- version
- replica set name
- replica set state
- sharding cluster role
- cluster type
- hosts (list of mongodb instances this mongodb connects to)
- shards (list of shards this mongos instance connects to)
- cluster name

### Motivation
[DBMON-4003](https://datadoghq.atlassian.net/browse/DBMON-4003)

### Additional Notes
<!-- Anything else we should know when reviewing? -->
`mongodb_instance` ingested in staging
![image](https://github.com/DataDog/integrations-core/assets/4964070/e51e6d97-ac60-44cc-b3e7-ef749955b547)


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[DBMON-4003]: https://datadoghq.atlassian.net/browse/DBMON-4003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ