### PR TITLE
Added section to enable default metrics through jmxfetch

### DIFF
--- a/jboss_wildfly/README.md
+++ b/jboss_wildfly/README.md
@@ -98,9 +98,9 @@ The JBoss/WildFly integration does not include any events.
 
 See [service_checks.json][13] for a list of service checks provided by this integration.
 
-### Collecting Metrics with JMXFetch
+### Collecting metrics with JMXFetch
 
-You can configure the Datadog agent to collect Java application metrics through [JMXFetch][14]. To collect the default metrics configured for the JBoss/Wildfly Datadog integration, set the system property
+You can configure the Datadog Agent to collect Java application metrics through [JMXFetch][14]. To collect the default metrics configured for the JBoss/Wildfly Datadog integration, set the system property
 `Ddd.jmxfetch.jboss_wildfly.enabled=true`. 
 
 ## Troubleshooting

--- a/jboss_wildfly/README.md
+++ b/jboss_wildfly/README.md
@@ -98,6 +98,11 @@ The JBoss/WildFly integration does not include any events.
 
 See [service_checks.json][13] for a list of service checks provided by this integration.
 
+### Collecting Metrics with JMXFetch
+
+You can configure the Datadog agent to collect Java application metrics through [JMXFetch][14]. To collect the default metrics configured for the JBoss/Wildfly Datadog integration, set the system property
+`Ddd.jmxfetch.jboss_wildfly.enabled=true`. 
+
 ## Troubleshooting
 
 Need help? Contact [Datadog support][5].
@@ -116,3 +121,4 @@ Need help? Contact [Datadog support][5].
 [11]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [12]: https://github.com/DataDog/integrations-core/blob/master/jboss_wildfly/metadata.csv
 [13]: https://github.com/DataDog/integrations-core/blob/master/jboss_wildfly/assets/service_checks.json
+[14]: https://docs.datadoghq.com/integrations/java


### PR DESCRIPTION
### What does this PR do?
https://datadoghq.atlassian.net/browse/DOCS-6911
Added instructions for enabling default JBoss/Wildly-DD integration metrics via JMXFetch. 

### Motivation
JIRA ticket, request from Fred Shad, which I believe was inspired by customer feedback/support requests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
