### PR TITLE
[datadog-cluster-agent] Add CWS Instrumentation metrics

### DIFF
--- a/datadog_cluster_agent/changelog.d/17530.added
+++ b/datadog_cluster_agent/changelog.d/17530.added
@@ -1,0 +1,1 @@
+[datadog-cluster-agent] Add CWS Instrumentation metrics

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
@@ -6,6 +6,8 @@ from datadog_checks.base import OpenMetricsBaseCheck
 
 DEFAULT_METRICS = {
     'admission_webhooks_certificate_expiry': 'admission_webhooks.certificate_expiry',
+    'admission_webhooks_cws_exec_instrumentation_attempts': 'admission_webhooks.cws_exec_instrumentation_attempts',
+    'admission_webhooks_cws_pod_instrumentation_attempts': 'admission_webhooks.cws_pod_instrumentation_attempts',
     'admission_webhooks_library_injection_attempts': 'admission_webhooks.library_injection_attempts',
     'admission_webhooks_library_injection_errors': 'admission_webhooks.library_injection_errors',
     'admission_webhooks_mutation_attempts': 'admission_webhooks.mutation_attempts',

--- a/datadog_cluster_agent/metadata.csv
+++ b/datadog_cluster_agent/metadata.csv
@@ -1,5 +1,9 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
 datadog.cluster_agent.admission_webhooks.certificate_expiry,gauge,,hour,,Time left before the certificate expires,0,datadog_cluster_agent,admission webhooks certificate expiry,
+datadog.cluster_agent.admission_webhooks.cws_exec_instrumentation_attempts.count,count,,,,CWS exec Instrumentation attempts count,0,datadog_cluster_agent,cws exec instrumentation attempts,
+datadog.cluster_agent.admission_webhooks.cws_exec_instrumentation_attempts.sum,count,,,,CWS exec Instrumentation attempts sum,0,datadog_cluster_agent,cws exec instrumentation attempts,
+datadog.cluster_agent.admission_webhooks.cws_pod_instrumentation_attempts.count,count,,,,CWS pod Instrumentation attempts count,0,datadog_cluster_agent,cws pod instrumentation attempts,
+datadog.cluster_agent.admission_webhooks.cws_pod_instrumentation_attempts.sum,count,,,,CWS pod Instrumentation attempts sum,0,datadog_cluster_agent,cws pod instrumentation attempts,
 datadog.cluster_agent.admission_webhooks.library_injection_attempts,count,,,,"Number of library injection attempts by language",0,datadog_cluster_agent,library injection attempts,
 datadog.cluster_agent.admission_webhooks.library_injection_errors,count,,,,"Number of library injection failures by language",0,datadog_cluster_agent,library injection errors,
 datadog.cluster_agent.admission_webhooks.mutation_attempts,gauge,,,,Number of pod mutation attempts by mutation type,0,datadog_cluster_agent,admission webhooks mutation attempts,

--- a/datadog_cluster_agent/tests/fixtures/metrics.txt
+++ b/datadog_cluster_agent/tests/fixtures/metrics.txt
@@ -424,6 +424,30 @@ admission_webhooks_library_injection_attempts{injected="true",language="java"} 4
 # HELP admission_webhooks_library_injection_errors Number of library injection failures by language
 # TYPE admission_webhooks_library_injection_errors counter
 admission_webhooks_library_injection_errors{language="java"} 1
+# HELP admission_webhooks_cws_exec_instrumentation_attempts Distribution of exec requests instrumentation attempts by CWS Instrumentation mode
+# TYPE admission_webhooks_cws_exec_instrumentation_attempts histogram
+admission_webhooks_cws_exec_instrumentation_attempts_bucket{injected="false",mode="init_container",reason="already_instrumented",le="0"} 0
+admission_webhooks_cws_exec_instrumentation_attempts_bucket{injected="false",mode="init_container",reason="already_instrumented",le="+Inf"} 1
+admission_webhooks_cws_exec_instrumentation_attempts_sum{injected="false",mode="init_container",reason="already_instrumented"} 1
+admission_webhooks_cws_exec_instrumentation_attempts_count{injected="false",mode="init_container",reason="already_instrumented"} 1
+admission_webhooks_cws_exec_instrumentation_attempts_bucket{injected="false",mode="init_container",reason="pod_not_instrumented",le="0"} 0
+admission_webhooks_cws_exec_instrumentation_attempts_bucket{injected="false",mode="init_container",reason="pod_not_instrumented",le="+Inf"} 2
+admission_webhooks_cws_exec_instrumentation_attempts_sum{injected="false",mode="init_container",reason="pod_not_instrumented"} 2
+admission_webhooks_cws_exec_instrumentation_attempts_count{injected="false",mode="init_container",reason="pod_not_instrumented"} 2
+admission_webhooks_cws_exec_instrumentation_attempts_bucket{injected="true",mode="init_container",reason="",le="0"} 0
+admission_webhooks_cws_exec_instrumentation_attempts_bucket{injected="true",mode="init_container",reason="",le="+Inf"} 1
+admission_webhooks_cws_exec_instrumentation_attempts_sum{injected="true",mode="init_container",reason=""} 1
+admission_webhooks_cws_exec_instrumentation_attempts_count{injected="true",mode="init_container",reason=""} 1
+# HELP admission_webhooks_cws_pod_instrumentation_attempts Distribution of pod requests instrumentation attempts by CWS Instrumentation mode
+# TYPE admission_webhooks_cws_pod_instrumentation_attempts histogram
+admission_webhooks_cws_pod_instrumentation_attempts_bucket{injected="false",mode="init_container",reason="already_instrumented",le="0"} 0
+admission_webhooks_cws_pod_instrumentation_attempts_bucket{injected="false",mode="init_container",reason="already_instrumented",le="+Inf"} 1
+admission_webhooks_cws_pod_instrumentation_attempts_sum{injected="false",mode="init_container",reason="already_instrumented"} 1
+admission_webhooks_cws_pod_instrumentation_attempts_count{injected="false",mode="init_container",reason="already_instrumented"} 1
+admission_webhooks_cws_pod_instrumentation_attempts_bucket{injected="true",mode="init_container",reason="",le="0"} 0
+admission_webhooks_cws_pod_instrumentation_attempts_bucket{injected="true",mode="init_container",reason="",le="+Inf"} 1
+admission_webhooks_cws_pod_instrumentation_attempts_sum{injected="true",mode="init_container",reason=""} 1
+admission_webhooks_cws_pod_instrumentation_attempts_count{injected="true",mode="init_container",reason=""} 1
 # HELP kubernetes_apiserver_emitted_events Number of events emitted by the check.
 # TYPE kubernetes_apiserver_emitted_events counter
 kubernetes_apiserver_emitted_events{kind="ConfigMap",type="Normal"} 7

--- a/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
+++ b/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
@@ -14,6 +14,10 @@ NAMESPACE = 'datadog.cluster_agent'
 
 METRICS = [
     'admission_webhooks.certificate_expiry',
+    'admission_webhooks.cws_exec_instrumentation_attempts.count',
+    'admission_webhooks.cws_exec_instrumentation_attempts.sum',
+    'admission_webhooks.cws_pod_instrumentation_attempts.count',
+    'admission_webhooks.cws_pod_instrumentation_attempts.sum',
     'admission_webhooks.library_injection_attempts',
     'admission_webhooks.library_injection_errors',
     'admission_webhooks.mutation_attempts',


### PR DESCRIPTION
### What does this PR do?

Add CWS Instrumentation histogram metric in the datadog_cluster_agent check.

### Motivation

Keep the integration up-to-date and collect new metrics introduced in this [PR](https://github.com/DataDog/datadog-agent/pull/25433).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
