### PR TITLE
Decrease database instance collection interval

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -876,7 +876,7 @@ files:
         This collection does not involve any additional queries to the database.
       value:
         type: number
-        example: 1800
+        example: 300
         display_default: false
     - name: propagate_agent_tags
       description: |

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -164,7 +164,7 @@ class PostgresConfig:
         }
         self.log_unobfuscated_queries = is_affirmative(instance.get('log_unobfuscated_queries', False))
         self.log_unobfuscated_plans = is_affirmative(instance.get('log_unobfuscated_plans', False))
-        self.database_instance_collection_interval = instance.get('database_instance_collection_interval', 1800)
+        self.database_instance_collection_interval = instance.get('database_instance_collection_interval', 300)
 
     def _build_tags(self, custom_tags, agent_tags, propagate_agent_tags=True):
         # Clean up tags in case there was a None entry in the instance

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -745,7 +745,7 @@ def test_database_instance_metadata(aggregator, pg_instance, dbm_enabled, report
     assert event['dbms'] == "postgres"
     assert event['tags'].sort() == expected_tags.sort()
     assert event['integration_version'] == __version__
-    assert event['collection_interval'] == 1800
+    assert event['collection_interval'] == 300
     assert event['metadata'] == {
         'dbm': dbm_enabled,
         'connection_host': pg_instance['host'],


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Reduces collection interval from 30 minutes to 5 minutes for database instances.

### Motivation
<!-- What inspired you to submit this pull request? -->
This change makes it less likely that a database instance will be incorrectly deleted from our stores, and improves the responsiveness of updates to database instances. This is intended to counteract bugs where databases are disappearing and causing tag flapping, as well as improving user experience with seeing the database instances they expect.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Database instance events are fairly lightweight so no noticeable performance impact is expected.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [x] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
