### PR TITLE
Fix trailing `,` in manifest generation

### DIFF
--- a/datadog_checks_dev/changelog.d/17538.fixed
+++ b/datadog_checks_dev/changelog.d/17538.fixed
@@ -1,0 +1,1 @@
+Fix trailing `,` in manifest.json generation template

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
@@ -154,7 +154,7 @@ def create(ctx, name, integration_type, location, non_interactive, quiet, dry_ru
             eula = 'assets/eula.pdf'
             template_fields['terms'] = f'\n  "terms": {{\n    "eula": "{eula}"\n  }},'
             template_fields['author_info'] = (
-                f'\n  "author": {{\n    "name": "{author_name}",\n    "homepage": "{homepage}",\n    "vendor_id": "{TODO_FILL_IN}",\n    "sales_email": "{sales_email}",\n    "support_email": "{support_email}"\n  }},'  # noqa
+                f'\n  "author": {{\n    "name": "{author_name}",\n    "homepage": "{homepage}",\n    "vendor_id": "{TODO_FILL_IN}",\n    "sales_email": "{sales_email}",\n    "support_email": "{support_email}"\n  }}'  # noqa
             )
 
             template_fields['pricing_plan'] = '\n  "pricing": [],'
@@ -174,7 +174,7 @@ def create(ctx, name, integration_type, location, non_interactive, quiet, dry_ru
     "name": "Datadog",
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
-  },"""
+  }"""
             else:
                 prompt_and_update_if_missing(template_fields, 'email', 'Email used for support requests')
                 prompt_and_update_if_missing(template_fields, 'author', 'Your name')
@@ -186,7 +186,7 @@ def create(ctx, name, integration_type, location, non_interactive, quiet, dry_ru
     "name": "{template_fields['author']}",
     "homepage": "",
     "sales_email": ""
-  }},"""
+  }}"""
             template_fields['terms'] = ''
             template_fields['integration_id'] = kebab_case_name(name)
             template_fields['package_url'] = (


### PR DESCRIPTION
### What does this PR do?
Fix trailing comma in the manifest
