### PR TITLE
[ECOS-141] Removed deprecated Monitoring and Web categories #678 

### DIFF
--- a/agent_metrics/manifest.json
+++ b/agent_metrics/manifest.json
@@ -14,8 +14,7 @@
     "classifier_tags": [
       "Supported OS::Linux",
       "Supported OS::macOS",
-      "Supported OS::Windows",
-      "Category::Monitoring"
+      "Supported OS::Windows"
     ]
   },
   "author": {

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/snmp_tile/snmp_{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/snmp_tile/snmp_{check_name}/manifest.json
@@ -15,7 +15,6 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS",
-      "Category::Monitoring",
       "Category::Notifications",
       "Category::Network"
     ]

--- a/dns_check/manifest.json
+++ b/dns_check/manifest.json
@@ -15,8 +15,7 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Category::Network",
-      "Category::Web"
+      "Category::Network"
     ]
   },
   "author": {

--- a/external_dns/manifest.json
+++ b/external_dns/manifest.json
@@ -15,7 +15,6 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Category::Web",
       "Category::Network"
     ]
   },

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -15,7 +15,6 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Category::Web",
       "Category::Network"
     ]
   },

--- a/network/manifest.json
+++ b/network/manifest.json
@@ -15,7 +15,6 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Category::Web",
       "Category::Network"
     ]
   },

--- a/ntp/manifest.json
+++ b/ntp/manifest.json
@@ -15,7 +15,6 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Category::Web",
       "Category::Network"
     ]
   },

--- a/snmp_aruba/manifest.json
+++ b/snmp_aruba/manifest.json
@@ -15,7 +15,6 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS",
-      "Category::Monitoring",
       "Category::Notifications",
       "Category::Network"
     ]

--- a/tcp_check/manifest.json
+++ b/tcp_check/manifest.json
@@ -15,8 +15,7 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Category::Network",
-      "Category::Web"
+      "Category::Network"
     ]
   },
   "author": {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Remove deprecated `Monitoring` and `Web` categories from integration manifests so we can complete the deprecation process

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
