### PR TITLE
Add option to use configured host as hostname for esxi hosts

### DIFF
--- a/esxi/assets/configuration/spec.yaml
+++ b/esxi/assets/configuration/spec.yaml
@@ -42,6 +42,14 @@ files:
           value:
             type: boolean
             example: false
+        - name: use_configured_hostname
+          description: |
+            If true, the check will use the configured `host` parameter for ESXi hostnames instead of the Host name.
+            You may need to use this if you install both the vSphere check and ESXi check to avoid duplicate entries
+            for hosts in the web application UI.
+          value:
+            type: boolean
+            example: true
         - name: collect_per_instance_filters
           description: |
             Use this option to collect metrics tagged with instance values.

--- a/esxi/changelog.d/17544.added
+++ b/esxi/changelog.d/17544.added
@@ -1,0 +1,1 @@
+Add option to use configured host as hostname.

--- a/esxi/datadog_checks/esxi/config_models/defaults.py
+++ b/esxi/datadog_checks/esxi/config_models/defaults.py
@@ -28,5 +28,9 @@ def instance_ssl_verify():
     return True
 
 
+def instance_use_configured_hostname():
+    return True
+
+
 def instance_use_guest_hostname():
     return False

--- a/esxi/datadog_checks/esxi/config_models/instance.py
+++ b/esxi/datadog_checks/esxi/config_models/instance.py
@@ -78,6 +78,7 @@ class InstanceConfig(BaseModel):
     ssl_capath: Optional[str] = None
     ssl_verify: Optional[bool] = None
     tags: Optional[tuple[str, ...]] = None
+    use_configured_hostname: Optional[bool] = None
     use_guest_hostname: Optional[bool] = None
     username: str
 

--- a/esxi/datadog_checks/esxi/data/conf.yaml.example
+++ b/esxi/datadog_checks/esxi/data/conf.yaml.example
@@ -39,6 +39,13 @@ instances:
     #
     # use_guest_hostname: false
 
+    ## @param use_configured_hostname - boolean - optional - default: true
+    ## If true, the check will use the configured `host` parameter for ESXi hostnames instead of the Host name.
+    ## You may need to use this if you install both the vSphere check and ESXi check to avoid duplicate entries
+    ## for hosts in the web application UI.
+    #
+    # use_configured_hostname: true
+
     ## @param collect_per_instance_filters - mapping - optional
     ## Use this option to collect metrics tagged with instance values.
     ## Some ESXi metrics can be tagged with instance values.

--- a/esxi/tests/test_unit.py
+++ b/esxi/tests/test_unit.py
@@ -1201,7 +1201,7 @@ def test_vm_metrics_filters(vcsim_instance, dd_run_check, metric_filters, expect
 
 
 @pytest.mark.usefixtures("service_instance")
-def test_use_configured_hostname(vcsim_instance, dd_run_check, aggregator):
+def test_use_configured_hostname(vcsim_instance, dd_run_check, aggregator, datadog_agent):
     instance = copy.deepcopy(vcsim_instance)
     instance['use_configured_hostname'] = True
     check = EsxiCheck('esxi', {}, [instance])
@@ -1211,3 +1211,15 @@ def test_use_configured_hostname(vcsim_instance, dd_run_check, aggregator):
     aggregator.assert_metric("esxi.cpu.usage.avg", value=26, tags=base_tags, hostname="127.0.0.1:8989")
     aggregator.assert_metric("esxi.mem.granted.avg", value=80, tags=base_tags, hostname="127.0.0.1:8989")
     aggregator.assert_metric("esxi.host.can_connect", 1, count=1, tags=base_tags)
+
+    datadog_agent.assert_external_tags(
+        '127.0.0.1:8989',
+        {
+            'esxi': [
+                'esxi_datacenter:dc2',
+                'esxi_folder:folder_1',
+                'esxi_type:host',
+                'esxi_url:127.0.0.1:8989',
+            ]
+        },
+    )

--- a/esxi/tests/test_unit.py
+++ b/esxi/tests/test_unit.py
@@ -1198,3 +1198,16 @@ def test_vm_metrics_filters(vcsim_instance, dd_run_check, metric_filters, expect
     aggregator.assert_metric('esxi.host.count')
     aggregator.assert_metric('esxi.vm.count')
     aggregator.assert_all_metrics_covered()
+
+
+@pytest.mark.usefixtures("service_instance")
+def test_use_configured_hostname(vcsim_instance, dd_run_check, aggregator):
+    instance = copy.deepcopy(vcsim_instance)
+    instance['use_configured_hostname'] = True
+    check = EsxiCheck('esxi', {}, [instance])
+    dd_run_check(check)
+
+    base_tags = ["esxi_url:127.0.0.1:8989"]
+    aggregator.assert_metric("esxi.cpu.usage.avg", value=26, tags=base_tags, hostname="127.0.0.1:8989")
+    aggregator.assert_metric("esxi.mem.granted.avg", value=80, tags=base_tags, hostname="127.0.0.1:8989")
+    aggregator.assert_metric("esxi.host.can_connect", 1, count=1, tags=base_tags)


### PR DESCRIPTION
### What does this PR do?
Add an option `use_configured_hostname` to allow users to set the hostname of ESXi hosts to be the configured `host` instead of the name found from pyvmomi
### Motivation
If a customer enables both the ESXi and vSphere integration, they could have duplicated hosts without this option
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
