### PR TITLE
Fix tag propagation of aurora `replication_role` tag

### DIFF
--- a/mysql/changelog.d/17555.fixed
+++ b/mysql/changelog.d/17555.fixed
@@ -1,0 +1,1 @@
+Fix tag propagation of aurora `replication_role` tag. Prior to this change, the replication_role tag was not added as a host tag for mysql aurora instances.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR fixes a bug in the `database_instance` tag propagation where aurora tags like `replication_role` were not being added to the metadata payload. This results in users losing host tags that previously existed when `database_instance` creation happened from the metrics-processor

You can see the tag now appears here after the fix:

![Screenshot 2024-05-10 at 2 09 06 PM](https://github.com/DataDog/integrations-core/assets/14317240/2714cbe0-bcfd-41ab-b6fd-ea77d06b5a74)

