### PR TITLE
Reorder code owner for mongo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -222,10 +222,10 @@ datadog_checks_base/tests/**/test_db_statements.py  @DataDog/database-monitoring
 /oracle/*.md                                        @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation
 /oracle/manifest.json                               @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation
 /oracle/assets/logs/                                @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
-/mongo/                                             @DataDog/database-monitoring-agent @DataDog/agent-integrations
-/mongo/*.md                                         @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation
-/mongo/manifest.json                                @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation
-/mongo/assets/logs/                                 @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-backend
+/mongo/                                             @DataDog/agent-integrations @DataDog/database-monitoring-agent
+/mongo/*.md                                         @DataDog/agent-integrations @DataDog/database-monitoring @DataDog/documentation
+/mongo/manifest.json                                @DataDog/agent-integrations @DataDog/database-monitoring @DataDog/documentation
+/mongo/assets/logs/                                 @DataDog/agent-integrations @DataDog/database-monitoring @DataDog/documentation @DataDog/logs-backend
 
 # APM Integrations
 /langchain/         @DataDog/ml-observability @DataDog/agent-integrations @DataDog/documentation


### PR DESCRIPTION
### What does this PR do?
This PR reorders the code owner of mongo integration as `agent-integrations` remains the primary codeowner of mongo integration. 

### Motivation
The ensures the correct primary code owner of mongo integration until DBM for MongoDB is GA.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
