### PR TITLE
Add TimedCache for controlled cache expiration

### DIFF
--- a/datadog_checks_base/changelog.d/17557.added
+++ b/datadog_checks_base/changelog.d/17557.added
@@ -1,0 +1,1 @@
+Add TimedCache for controlled cache expiration. The TimedCache sets TTL on initialization and expires when TTL is reached.

--- a/datadog_checks_base/datadog_checks/base/utils/db/timed_cache.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/timed_cache.py
@@ -62,7 +62,3 @@ class TimedCache:
         """Clear the entire cache and reset the last refresh time."""
         self.__cache = {}
         self.__last_refresh_time = time.time()
-
-    def __bool__(self):
-        """Return True if the cache has any items and is not expired, False otherwise."""
-        return bool(self.__cache) and not self.is_expired()

--- a/datadog_checks_base/datadog_checks/base/utils/db/timed_cache.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/timed_cache.py
@@ -1,0 +1,49 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import threading
+
+
+class TimedCache:
+    """A simple cache that clears itself every interval seconds."""
+
+    def __init__(self, interval):
+        """
+        Initialize the cache with an interval in seconds.
+
+        :param interval (int): The interval in seconds to clear the cache.
+        """
+        self.__cache = {}
+        self.__interval = interval
+        self.__timer = threading.Timer(self.__interval, self.__clear_cache)
+        self.__timer.start()
+
+    def __setitem__(self, key, value):
+        """Set an item in the cache like dict[key] = value."""
+        self.__cache[key] = value
+
+    def __getitem__(self, key):
+        """Get an item from the cache like value = dict[key]."""
+        return self.__cache[key]
+
+    def __delitem__(self, key):
+        """Delete an item from the cache like del dict[key]."""
+        del self.__cache[key]
+
+    def __bool__(self):
+        """Return True if the cache has any items, False otherwise."""
+        return bool(self.__cache)
+
+    def get(self, key, default=None):
+        """Retrieve an item from the cache, returning default if key is not found."""
+        return self.__cache.get(key, default)
+
+    def __clear_cache(self):
+        """Clear the cache and reset the timer."""
+        self.__cache.clear()
+        self.__timer = threading.Timer(self.__interval, self.__clear_cache)
+        self.__timer.start()
+
+    def stop(self):
+        """Stop the timer if it's still running."""
+        self.__timer.cancel()

--- a/datadog_checks_base/datadog_checks/base/utils/db/timed_cache.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/timed_cache.py
@@ -11,6 +11,19 @@ class TimedCache:
     Note: The cache DOES NOT automatically clear itself.
     It is up to the user to check if the cache is expired and clear it if needed.
     This is to avoid clearing the cache while it is being used in the middle of a check run.
+
+    Example:
+    ```
+    cache = TimedCache(600)  # Cache expires after 10 minutes
+    if cache.is_expired():  # Check if the cache is expired
+        cache.clear()  # Clear the cache and reset the last refresh time
+        # Do something to rebuild the cache
+
+    cache['key'] = 'value'  # Set an item in the cache
+    print(cache['key'])  # Get an item from the cache
+    print(cache.get('mykey', 1))  # Get an item from the cache with a default value
+    del cache['key']
+    ```
     """
 
     def __init__(self, ttl):

--- a/datadog_checks_base/tests/base/utils/db/test_timed_cache.py
+++ b/datadog_checks_base/tests/base/utils/db/test_timed_cache.py
@@ -1,8 +1,9 @@
 # (C) Datadog, Inc. 2024-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
 import time
+
+import pytest
 
 from datadog_checks.base.utils.db.timed_cache import TimedCache
 

--- a/datadog_checks_base/tests/base/utils/db/test_timed_cache.py
+++ b/datadog_checks_base/tests/base/utils/db/test_timed_cache.py
@@ -12,14 +12,12 @@ class TestTimedCache:
         cache = TimedCache(600)  # Using a longer interval for most tests to avoid automatic clearing during testing
         cache['test_key'] = 'test_value'
         assert cache['test_key'] == 'test_value', "The value retrieved should match the value set."
-        cache.stop()  # Important to stop the timer to clean up after the test
 
     def test_get_with_default(self):
         cache = TimedCache(600)
         assert (
             cache.get('nonexistent', 'default') == 'default'
         ), "Should return the default value when the key is not found."
-        cache.stop()
 
     def test_item_deletion(self):
         cache = TimedCache(600)
@@ -27,16 +25,17 @@ class TestTimedCache:
         del cache['test_key']
         with pytest.raises(KeyError):
             _ = cache['test_key']  # Attempting to access deleted key should raise KeyError
-        cache.stop()
 
-    def test_automatic_clearing(self):
+    def test_expire(self):
         cache = TimedCache(1)  # Set a short interval for testing auto-clearing
         cache['test_key'] = 'test_value'
+        assert cache, "The cache should not be empty immediately after setting an item."
         time.sleep(2)  # Wait enough time for the cache to clear itself
-        assert not cache, "The cache should be empty after the interval has passed."
-        with pytest.raises(KeyError):
-            _ = cache['test_key']  # After clearing, accessing the key should raise KeyError
-        cache.stop()
+        assert not cache, "The cache should be expired after the interval has passed."
+        assert cache.is_expired() is True, "The cache should be expired after the interval has passed."
+        cache.clear()
+        cache['test_key'] = 'test_value'
+        assert cache, "The cache ttl should be reset."
 
     # Optionally, you can add a test to verify that multiple items are handled correctly.
     def test_multiple_items(self):
@@ -46,4 +45,3 @@ class TestTimedCache:
             cache[k] = v
         for k, v in items.items():
             assert cache[k] == v, "Each item should be retrievable and match the set value."
-        cache.stop()

--- a/datadog_checks_base/tests/base/utils/db/test_timed_cache.py
+++ b/datadog_checks_base/tests/base/utils/db/test_timed_cache.py
@@ -1,0 +1,49 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+import time
+
+from datadog_checks.base.utils.db.timed_cache import TimedCache
+
+
+class TestTimedCache:
+    def test_set_and_get_item(self):
+        cache = TimedCache(600)  # Using a longer interval for most tests to avoid automatic clearing during testing
+        cache['test_key'] = 'test_value'
+        assert cache['test_key'] == 'test_value', "The value retrieved should match the value set."
+        cache.stop()  # Important to stop the timer to clean up after the test
+
+    def test_get_with_default(self):
+        cache = TimedCache(600)
+        assert (
+            cache.get('nonexistent', 'default') == 'default'
+        ), "Should return the default value when the key is not found."
+        cache.stop()
+
+    def test_item_deletion(self):
+        cache = TimedCache(600)
+        cache['test_key'] = 'test_value'
+        del cache['test_key']
+        with pytest.raises(KeyError):
+            _ = cache['test_key']  # Attempting to access deleted key should raise KeyError
+        cache.stop()
+
+    def test_automatic_clearing(self):
+        cache = TimedCache(1)  # Set a short interval for testing auto-clearing
+        cache['test_key'] = 'test_value'
+        time.sleep(2)  # Wait enough time for the cache to clear itself
+        assert not cache, "The cache should be empty after the interval has passed."
+        with pytest.raises(KeyError):
+            _ = cache['test_key']  # After clearing, accessing the key should raise KeyError
+        cache.stop()
+
+    # Optionally, you can add a test to verify that multiple items are handled correctly.
+    def test_multiple_items(self):
+        cache = TimedCache(600)
+        items = {'key1': 'value1', 'key2': 'value2', 'key3': 'value3'}
+        for k, v in items.items():
+            cache[k] = v
+        for k, v in items.items():
+            assert cache[k] == v, "Each item should be retrievable and match the set value."
+        cache.stop()

--- a/datadog_checks_base/tests/base/utils/db/test_timed_cache.py
+++ b/datadog_checks_base/tests/base/utils/db/test_timed_cache.py
@@ -32,7 +32,6 @@ class TestTimedCache:
         cache['test_key'] = 'test_value'
         assert cache, "The cache should not be empty immediately after setting an item."
         time.sleep(2)  # Wait enough time for the cache to clear itself
-        assert not cache, "The cache should be expired after the interval has passed."
         assert cache.is_expired() is True, "The cache should be expired after the interval has passed."
         cache.clear()
         cache['test_key'] = 'test_value'


### PR DESCRIPTION
### What does this PR do?
This PR introduces the `TimedCache` class, which adds functionality for managing a cache where the entire cache expires after a set interval, and to be manually cleared. 
This `TimedCache` is intended to be used in scenario where the check caches data for multiple check runs but wants to periodically clear the cache and re-build after sometime. It's mainly to avoid a cache to grow indefinitely. 

### Motivation
The `TimedCache` will be first used by postgres query metrics where we need to cache the `pg_stat_statements` as baseline and keep adding new queryid to the cache as new normalized queries appear. However, to avoid the baseline cache grow overtime, we will check if the cache is expired and rebuild the baseline periodically. 

### Additional Notes
The `TimedCache` is different from cachetools `TTLCache`. In `TTLCache`, every key has a TTL and expires independently. `TimedCache` has TTL on the entire cache but does not automatically clear the cache. This is to avoid losing cached values in the middle of the process. Developer should check if cache is expired at the beginning of the process and rebuild whenever needed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
