### PR TITLE
[mongo] Emit mongodb_instance event when deployment type is refreshed

### DIFF
--- a/mongo/datadog_checks/mongo/api.py
+++ b/mongo/datadog_checks/mongo/api.py
@@ -70,7 +70,6 @@ class MongoApi(object):
         self._log.debug("options: %s", options)
         self._cli = MongoClient(**options)
         self.deployment_type = None
-        self._hostname = None
 
     def __getitem__(self, item):
         return self._cli[item]
@@ -169,10 +168,9 @@ class MongoApi(object):
             hostname = self.server_status()['host'].split(':')
             if len(hostname) == 1:
                 # If there is no port, we assume the default port
-                self._hostname = "{}:27017".format(hostname[0])
+                return "{}:27017".format(hostname[0])
             else:
-                self._hostname = "{}:{}".format(hostname[0], hostname[1])
-            return self._hostname
+                return "{}:{}".format(hostname[0], hostname[1])
         except Exception as e:
             self._log.error('Unable to get hostname: %s', e)
             return None

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -181,30 +181,47 @@ class MongoDb(AgentCheck):
 
         return metrics_to_collect
 
-    def _refresh_replica_role(self):
-        if self.api_client.deployment_type is None or isinstance(self.api_client.deployment_type, ReplicaSetDeployment):
+    def _refresh_deployment(self):
+        if (
+            self.api_client.deployment_type is None  # First run
+            or isinstance(
+                self.api_client.deployment_type, ReplicaSetDeployment
+            )  # Replica set members and state can change
+            or isinstance(self.api_client.deployment_type, MongosDeployment)  # Mongos shards can change
+        ):
+            deployment_type_before = self.api_client.deployment_type
             self.log.debug("Refreshing deployment type")
             self.api_client.refresh_deployment_type()
+            if self.api_client.deployment_type != deployment_type_before:
+                self.log.debug(
+                    "Deployment type has changed from %s to %s", deployment_type_before, self.api_client.deployment_type
+                )
+                # database_instance metadata is tied to the deployment type, so we need to reset it when the deployment type changes
+                # this way new metadata will be emitted
+                self._database_instance_emitted.clear()
 
-    def _get_deployment_tags(self, deployment):
+    @property
+    def internal_resource_tags(self):
+        '''
+        Return the internal resource tags for the database instance.
+        '''
+        if not self._resolved_hostname:
+            return []
+        return [f"dd.internal.resource:database_instance:{self._resolved_hostname}"]
+
+    def _get_tags(self, include_deployment_tags=False, include_internal_resource_tags=False):
         tags = deepcopy(self._config.metric_tags)
-        if isinstance(deployment, ReplicaSetDeployment):
-            tags.extend(
-                [
-                    "replset_name:{}".format(deployment.replset_name),
-                    "replset_state:{}".format(deployment.replset_state_name),
-                ]
-            )
-            if deployment.use_shards:
-                tags.append('sharding_cluster_role:{}'.format(deployment.cluster_role))
-        elif isinstance(deployment, MongosDeployment):
-            tags.append('sharding_cluster_role:mongos')
+        if include_deployment_tags:
+            deployment = self.api_client.deployment_type
+            tags.extend(deployment.deployment_tags)
+        if include_internal_resource_tags:
+            tags.extend(self.internal_resource_tags)
         return tags
 
     def check(self, _):
         try:
             self._refresh_metadata()
-            self._refresh_replica_role()
+            self._refresh_deployment()
             self._collect_metrics()
             self._send_database_instance_metadata()
         except CRITICAL_FAILURE as e:
@@ -233,7 +250,7 @@ class MongoDb(AgentCheck):
 
     def _collect_metrics(self):
         deployment = self.api_client.deployment_type
-        tags = self._get_deployment_tags(deployment)
+        tags = self._get_tags(include_deployment_tags=True, include_internal_resource_tags=True)
 
         dbnames = self._get_db_names(self.api_client, deployment, tags)
         self.refresh_collectors(deployment, dbnames, tags)
@@ -308,16 +325,9 @@ class MongoDb(AgentCheck):
     def _send_database_instance_metadata(self):
         deployment = self.api_client.deployment_type
         if self._resolved_hostname not in self._database_instance_emitted:
-            tags = self._get_deployment_tags(deployment)
-            mongodb_instance_metadata = {
-                "replset_name": getattr(deployment, 'replset_name', None),
-                "replset_state": getattr(deployment, 'replset_state_name', None),
-                "sharding_cluster_role": getattr(deployment, 'cluster_role', None),
-                "hosts": getattr(deployment, 'hosts', None),
-                "shards": getattr(deployment, 'shards', None),
-                "cluster_type": getattr(deployment, 'cluster_type', None),
-                "cluster_name": self._config.cluster_name,
-            }
+            # DO NOT emit with internal resource tags, as the metadata event is used to CREATE the databse instance
+            tags = self._get_tags(include_deployment_tags=True, include_internal_resource_tags=False)
+            mongodb_instance_metadata = {"cluster_name": self._config.cluster_name} | deployment.instance_metadata
             database_instance = {
                 "host": self._resolved_hostname,
                 "agent_version": datadog_agent.get_version(),

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -9,12 +9,13 @@ import pytest
 
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.mongo import MongoDb
+from datadog_checks.mongo.common import SECONDARY_STATE_ID
 
 from .common import HERE, HOST, PORT1, TLS_CERTS_FOLDER, auth, tls
 from .conftest import mock_pymongo
 
 
-def _assert_metrics(aggregator, metrics_categories, additional_tags=None):
+def _assert_metrics(check_instance, aggregator, metrics_categories, additional_tags=None):
     if additional_tags is None:
         additional_tags = []
     for cat in metrics_categories:
@@ -24,9 +25,15 @@ def _assert_metrics(aggregator, metrics_categories, additional_tags=None):
                     metric['name'],
                     value=metric['value'],
                     count=1,
-                    tags=additional_tags + metric['tags'],
+                    tags=additional_tags + metric['tags'] + check_instance.internal_resource_tags,
                     metric_type=metric['type'],
                 )
+
+
+def _get_mongodb_instance_event(aggregator):
+    dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
+    mongodb_instance_event = next((e for e in dbm_metadata if e['kind'] == 'mongodb_instance'), None)
+    return mongodb_instance_event
 
 
 def _assert_mongodb_instance_event(
@@ -42,11 +49,7 @@ def _assert_mongodb_instance_event(
     cluster_type,
     cluster_name,
 ):
-    # Gather dbm-metadata events
-    dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
-
-    # Assert that the mongodb_instance events are present with the correct metadata
-    mongodb_instance_event = next((e for e in dbm_metadata if e['kind'] == 'mongodb_instance'), None)
+    mongodb_instance_event = _get_mongodb_instance_event(aggregator)
     assert mongodb_instance_event is not None
     assert mongodb_instance_event['host'] == check._resolved_hostname
     assert mongodb_instance_event is not None
@@ -80,6 +83,7 @@ def test_integration_mongos(instance_integration_cluster, aggregator, check, dd_
         dd_run_check(mongos_check)
 
     _assert_metrics(
+        mongos_check,
         aggregator,
         [
             'count-dbs',
@@ -163,9 +167,9 @@ def test_integration_replicaset_primary_in_shard(instance_integration, aggregato
         'dbstats-local',
         'fsynclock',
     ]
-    _assert_metrics(aggregator, metrics_categories, replica_tags)
+    _assert_metrics(mongo_check, aggregator, metrics_categories, replica_tags)
     # Lag metrics are tagged with the state of the member and not with the current one.
-    _assert_metrics(aggregator, ['replset-lag-from-primary-in-shard'])
+    _assert_metrics(mongo_check, aggregator, ['replset-lag-from-primary-in-shard'])
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(
         get_metadata_metrics(),
@@ -259,7 +263,7 @@ def test_integration_replicaset_secondary_in_shard(instance_integration, aggrega
         'fsynclock',
         'connection-pool',
     ]
-    _assert_metrics(aggregator, metrics_categories, replica_tags)
+    _assert_metrics(mongo_check, aggregator, metrics_categories, replica_tags)
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(
@@ -312,7 +316,7 @@ def test_integration_replicaset_arbiter_in_shard(instance_integration, aggregato
     ]
     metrics_categories = ['serverStatus', 'replset-arbiter']
 
-    _assert_metrics(aggregator, metrics_categories, replica_tags)
+    _assert_metrics(mongo_check, aggregator, metrics_categories, replica_tags)
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(
@@ -371,8 +375,8 @@ def test_integration_configsvr_primary(instance_integration, aggregator, check, 
         'dbstats-local',
         'fsynclock',
     ]
-    _assert_metrics(aggregator, metrics_categories, replica_tags)
-    _assert_metrics(aggregator, ['replset-lag-from-primary-configsvr'])
+    _assert_metrics(mongo_check, aggregator, metrics_categories, replica_tags)
+    _assert_metrics(mongo_check, aggregator, ['replset-lag-from-primary-configsvr'])
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(
@@ -465,7 +469,7 @@ def test_integration_configsvr_secondary(instance_integration, aggregator, check
         'fsynclock',
         'connection-pool',
     ]
-    _assert_metrics(aggregator, metrics_categories, replica_tags)
+    _assert_metrics(mongo_check, aggregator, metrics_categories, replica_tags)
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(
@@ -521,9 +525,9 @@ def test_integration_replicaset_primary(instance_integration, aggregator, check,
         'indexes-stats',
         'collection',
     ]
-    _assert_metrics(aggregator, metrics_categories, replica_tags)
+    _assert_metrics(mongo_check, aggregator, metrics_categories, replica_tags)
     # Lag metrics are tagged with the state of the member and not with the current one.
-    _assert_metrics(aggregator, ['replset-lag-from-primary'])
+    _assert_metrics(mongo_check, aggregator, ['replset-lag-from-primary'])
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(
@@ -617,9 +621,9 @@ def test_integration_replicaset_primary_config(instance_integration, aggregator,
         'indexes-stats',
         'collection',
     ]
-    _assert_metrics(aggregator, metrics_categories, replica_tags)
+    _assert_metrics(mongo_check, aggregator, metrics_categories, replica_tags)
     # Lag metrics are tagged with the state of the member and not with the current one.
-    _assert_metrics(aggregator, ['replset-lag-from-primary'])
+    _assert_metrics(mongo_check, aggregator, ['replset-lag-from-primary'])
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(
@@ -720,7 +724,7 @@ def test_integration_replicaset_secondary(
     if collect_custom_queries:
         metrics_categories.append('custom-queries')
 
-    _assert_metrics(aggregator, metrics_categories, replica_tags)
+    _assert_metrics(mongo_check, aggregator, metrics_categories, replica_tags)
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(
@@ -769,7 +773,7 @@ def test_integration_replicaset_arbiter(instance_integration, aggregator, check,
     replica_tags = ['replset_name:replset', 'replset_state:arbiter']
     metrics_categories = ['serverStatus', 'replset-arbiter']
 
-    _assert_metrics(aggregator, metrics_categories, replica_tags)
+    _assert_metrics(mongo_check, aggregator, metrics_categories, replica_tags)
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(
@@ -823,7 +827,7 @@ def test_standalone(instance_integration, aggregator, check, dd_run_check):
         'indexes-stats',
         'collection',
     ]
-    _assert_metrics(aggregator, metrics_categories)
+    _assert_metrics(mongo_check, aggregator, metrics_categories)
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(
@@ -872,10 +876,10 @@ def test_db_names_with_nonexistent_database(check, instance_integration, aggrega
     with open(os.path.join(HERE, "fixtures", "list_database_names"), 'r') as f:
         instance_integration['dbnames'] = json.load(f)
     instance_integration['dbnames'].append('nonexistent_database')
-    check = check(instance_integration)
+    mongo_check = check(instance_integration)
     with mock_pymongo("standalone"):
         # ensure we don't get a pymongo exception
-        dd_run_check(check, extract_message=True)
+        dd_run_check(mongo_check, extract_message=True)
 
     metrics_categories = [
         'count-dbs',
@@ -888,7 +892,7 @@ def test_db_names_with_nonexistent_database(check, instance_integration, aggrega
         'indexes-stats',
         'collection',
     ]
-    _assert_metrics(aggregator, metrics_categories)
+    _assert_metrics(mongo_check, aggregator, metrics_categories)
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(
         get_metadata_metrics(),
@@ -907,10 +911,10 @@ def test_db_names_missing_existent_database(check, instance_integration, aggrega
     with open(os.path.join(HERE, "fixtures", "list_database_names"), 'r') as f:
         instance_integration['dbnames'] = json.load(f)
     instance_integration['dbnames'].remove('local')
-    check = check(instance_integration)
+    mongo_check = check(instance_integration)
     with mock_pymongo("standalone"):
         # ensure we don't get a pymongo exception
-        dd_run_check(check, extract_message=True)
+        dd_run_check(mongo_check, extract_message=True)
 
     metrics_categories = [
         'count-dbs',
@@ -922,7 +926,7 @@ def test_db_names_missing_existent_database(check, instance_integration, aggrega
         'indexes-stats',
         'collection',
     ]
-    _assert_metrics(aggregator, metrics_categories)
+    _assert_metrics(mongo_check, aggregator, metrics_categories)
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(
         get_metadata_metrics(),
@@ -1002,3 +1006,50 @@ def test_mongod_tls_fail(check, dd_run_check, aggregator):
     with pytest.raises(Exception, match=("pymongo.errors.ConfigurationError: Private key doesn't match certificate")):
         dd_run_check(mongo_check)
     aggregator.assert_service_check('mongodb.can_connect', status=MongoDb.CRITICAL)
+
+
+def test_integration_reemit_mongodb_instance_on_deployment_change(
+    instance_integration, aggregator, check, dd_run_check
+):
+    mongo_check = check(instance_integration)
+
+    with mock_pymongo("replica-primary-in-shard"):
+        dd_run_check(mongo_check)
+
+    replica_tags = [
+        'replset_name:mongo-mongodb-sharded-shard-0',
+        'replset_state:primary',
+        'sharding_cluster_role:shardsvr',
+    ]
+
+    expected_tags = replica_tags + [f'server:{mongo_check._config.clean_server_name}']
+    _assert_mongodb_instance_event(
+        aggregator,
+        mongo_check,
+        expected_tags=expected_tags,
+        dbm=False,
+        replset_name='mongo-mongodb-sharded-shard-0',
+        replset_state='primary',
+        sharding_cluster_role='shardsvr',
+        hosts=[
+            'mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+            'mongo-mongodb-sharded-shard0-arbiter-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+            'mongo-mongodb-sharded-shard0-data-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+            'mongo-mongodb-sharded-shard0-data-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+            'mongo-mongodb-sharded-shard0-data-3.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+        ],
+        shards=None,
+        cluster_type='sharded_cluster',
+        cluster_name=None,
+    )
+    aggregator.reset()
+
+    dd_run_check(mongo_check)
+    # No new instance event should be emitted
+    assert _get_mongodb_instance_event(aggregator) is None
+
+    # Override the deployment type replset_state to secondary
+    # next check run should detect the change and re-emit the mongodb instance event
+    mongo_check.api_client.deployment_type.replset_state = SECONDARY_STATE_ID
+    dd_run_check(mongo_check)
+    assert _get_mongodb_instance_event(aggregator) is not None

--- a/mongo/tests/test_integration_shard.py
+++ b/mongo/tests/test_integration_shard.py
@@ -42,7 +42,7 @@ def test_mongo_arbiter(aggregator, check, instance_arbiter, dd_run_check):
         'replset_name:shard01',
         'replset_state:arbiter',
         'sharding_cluster_role:shardsvr',
-    ]
+    ] + check.internal_resource_tags
     for metric, value in expected_metrics.items():
         aggregator.assert_metric(metric, value, expected_tags, count=1)
 
@@ -62,7 +62,7 @@ def test_mongo_replset(instance_shard, aggregator, check, dd_run_check):
         "replset_name:shard01",
         "server:mongodb://localhost:27018/",
         "sharding_cluster_role:shardsvr",
-    ]
+    ] + mongo_check.internal_resource_tags
     for metric in replset_metrics:
         aggregator.assert_metric(metric, tags=replset_common_tags + ['replset_state:primary'])
     aggregator.assert_metric(

--- a/mongo/tests/test_integration_standalone.py
+++ b/mongo/tests/test_integration_standalone.py
@@ -99,7 +99,7 @@ def test_mongo_dbstats_tag(aggregator, check, instance_dbstats_tag_dbname, dd_ru
     }
     expected_tags = [
         'server:mongodb://localhost:27017/',
-    ]
+    ] + check.internal_resource_tags
     for metric, value in expected_metrics.items():
         aggregator.assert_metric(metric, value, expected_tags)
 


### PR DESCRIPTION
### What does this PR do?
This PR updates the logic to emit updated mongodb_instance event when deployment type is refreshed with updates. This could happen when 
- member role updated in a replica set, i.e. primary step down/secondary step up or new member joins the replica set
- new shard joins a sharded cluster -> mongos shard map updated

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4003

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
