### PR TITLE
Quick fix for dependency confusion

### DIFF
--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -1,3 +1,6 @@
+# THIS FILE IS AUTO-GENERATED, DO NOT EDIT BY HAND
+# DO NOT PASS THIS TO PIP DIRECTLY
+--no-index
 datadog-active-directory==2.1.0; sys_platform == 'win32'
 datadog-activemq-xml==3.2.0
 datadog-activemq==3.1.0


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This part 1 of the fix to address the misunderstanding that some users may have about the `requirements-agent-release.txt`'s purpose.

It focuses on making the file unusable with `pip` directly. We also add a note to the file warning users against modifying the file or passing it to pip.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
