### PR TITLE
Make Teleport Documentation Public

### DIFF
--- a/teleport/README.md
+++ b/teleport/README.md
@@ -1,17 +1,17 @@
 # Agent Check: Teleport
 
-## Overview
+<div class="alert alert-warning">
+Please note, this integration is in public beta and should be enabled on production workloads with caution.
+</div>
 
+## Overview
 This check monitors [Teleport][1] through the Datadog Agent.
 
 ## Setup
-
 Follow the instructions below to install and configure this check for an Agent running on a host. For containerized environments, see the [Autodiscovery Integration Templates][3] for guidance on applying these instructions.
 
 ### Installation
-
-The Teleport check is included in the [Datadog Agent][2] package.
-No additional installation is needed on your server.
+To install the Teleport integration, run the following command on a host with a running Agent: `datadog-agent integration install datadog-teleport==1.0.0`
 
 ### Prerequisites
 

--- a/teleport/README.md
+++ b/teleport/README.md
@@ -1,7 +1,7 @@
 # Agent Check: Teleport
 
 <div class="alert alert-warning">
-Please note, this integration is in public beta and should be enabled on production workloads with caution.
+This integration is in public beta and should be enabled on production workloads with caution.
 </div>
 
 ## Overview

--- a/teleport/manifest.json
+++ b/teleport/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "e47d5541-de7d-4ce6-8105-03c6dac5852a",
   "app_id": "teleport",
-  "display_on_public_website": false,
+  "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Makes the Teleport integration documentation to be publically available on the documentation website.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
