### PR TITLE
[mongo] Add cluster_name to metrics tags

### DIFF
--- a/mongo/changelog.d/17576.added
+++ b/mongo/changelog.d/17576.added
@@ -1,0 +1,1 @@
+Adds tag `cluster_name` to metrics

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -95,10 +95,6 @@ class MongoConfig(object):
         self.coll_names = instance.get('collections', [])
         self.custom_queries = instance.get("custom_queries", [])
 
-        self._base_tags = list(set(instance.get('tags', [])))
-        self.service_check_tags = self._compute_service_check_tags()
-        self.metric_tags = self._compute_metric_tags()
-
         # DBM config options
         self.dbm_enabled = is_affirmative(instance.get('dbm', False))
         self.database_instance_collection_interval = instance.get('database_instance_collection_interval', 1800)
@@ -106,6 +102,10 @@ class MongoConfig(object):
 
         if self.dbm_enabled and not self.cluster_name:
             raise ConfigurationError('`cluster_name` must be set when `dbm` is enabled')
+
+        self._base_tags = list(set(instance.get('tags', [])))
+        self.service_check_tags = self._compute_service_check_tags()
+        self.metric_tags = self._compute_metric_tags()
 
     def _get_clean_server_name(self):
         try:
@@ -138,4 +138,7 @@ class MongoConfig(object):
         return service_check_tags
 
     def _compute_metric_tags(self):
-        return self._base_tags + ['server:%s' % self.clean_server_name]
+        tags = self._base_tags + ['server:%s' % self.clean_server_name]
+        if self.cluster_name:
+            tags.append('cluster_name:%s' % self.cluster_name)
+        return tags

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -96,7 +96,7 @@ def test_integration_mongos(instance_integration_cluster, aggregator, check, dd_
             'jumbo',
             'sessions',
         ],
-        ['sharding_cluster_role:mongos'],
+        ['sharding_cluster_role:mongos', 'cluster_name:my_cluster'],
     )
 
     aggregator.assert_all_metrics_covered()
@@ -112,7 +112,7 @@ def test_integration_mongos(instance_integration_cluster, aggregator, check, dd_
     )
     assert len(aggregator._events) == 0
 
-    expected_tags = ['server:mongodb://localhost:27017/', 'sharding_cluster_role:mongos']
+    expected_tags = ['server:mongodb://localhost:27017/', 'sharding_cluster_role:mongos', 'cluster_name:my_cluster']
     _assert_mongodb_instance_event(
         aggregator,
         mongos_check,


### PR DESCRIPTION
### What does this PR do?
This PR adds tag `cluster_name` to mongo metrics when `cluster_name` is configured in conf.yaml. 

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4005

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
