### PR TITLE
Fix how we collect test results to publish them

### DIFF
--- a/.github/workflows/test-results-master.yml
+++ b/.github/workflows/test-results-master.yml
@@ -23,8 +23,9 @@ jobs:
 
     - uses: actions/download-artifact@v4
       with:
-        name: test-results
+        pattern: test-results-*
         path: test-results
+        merge-multiple: true
 
     - name: Publish test results
       uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/test-results-pr.yml
+++ b/.github/workflows/test-results-pr.yml
@@ -43,5 +43,5 @@ jobs:
         commit: ${{ github.event.workflow_run.head_sha }}
         event_file: artifacts/github-event/event.json
         event_name: ${{ github.event.workflow_run.event }}
-        files: "artifacts/test-results/*/*.xml"
+        files: "artifacts/test-results-*/*/*.xml"
         compare_to_earlier_commit: false


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
When we collect test results for publishing we should account for the fact that our test result artifacts now have names that include more than just "test-result"

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
