### PR TITLE
Revert "[mongo] Add cluster_name to metrics tags (#17576)"

### DIFF
--- a/mongo/changelog.d/17576.added
+++ b/mongo/changelog.d/17576.added
@@ -1,1 +1,0 @@
-Adds tag `cluster_name` to metrics

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -95,6 +95,10 @@ class MongoConfig(object):
         self.coll_names = instance.get('collections', [])
         self.custom_queries = instance.get("custom_queries", [])
 
+        self._base_tags = list(set(instance.get('tags', [])))
+        self.service_check_tags = self._compute_service_check_tags()
+        self.metric_tags = self._compute_metric_tags()
+
         # DBM config options
         self.dbm_enabled = is_affirmative(instance.get('dbm', False))
         self.database_instance_collection_interval = instance.get('database_instance_collection_interval', 1800)
@@ -102,10 +106,6 @@ class MongoConfig(object):
 
         if self.dbm_enabled and not self.cluster_name:
             raise ConfigurationError('`cluster_name` must be set when `dbm` is enabled')
-
-        self._base_tags = list(set(instance.get('tags', [])))
-        self.service_check_tags = self._compute_service_check_tags()
-        self.metric_tags = self._compute_metric_tags()
 
     def _get_clean_server_name(self):
         try:
@@ -138,7 +138,4 @@ class MongoConfig(object):
         return service_check_tags
 
     def _compute_metric_tags(self):
-        tags = self._base_tags + ['server:%s' % self.clean_server_name]
-        if self.cluster_name:
-            tags.append('cluster_name:%s' % self.cluster_name)
-        return tags
+        return self._base_tags + ['server:%s' % self.clean_server_name]

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -96,7 +96,7 @@ def test_integration_mongos(instance_integration_cluster, aggregator, check, dd_
             'jumbo',
             'sessions',
         ],
-        ['sharding_cluster_role:mongos', 'cluster_name:my_cluster'],
+        ['sharding_cluster_role:mongos'],
     )
 
     aggregator.assert_all_metrics_covered()
@@ -112,7 +112,7 @@ def test_integration_mongos(instance_integration_cluster, aggregator, check, dd_
     )
     assert len(aggregator._events) == 0
 
-    expected_tags = ['server:mongodb://localhost:27017/', 'sharding_cluster_role:mongos', 'cluster_name:my_cluster']
+    expected_tags = ['server:mongodb://localhost:27017/', 'sharding_cluster_role:mongos']
     _assert_mongodb_instance_event(
         aggregator,
         mongos_check,


### PR DESCRIPTION
### What does this PR do?
This reverts commit 58abe3d64d6672c4f8f4c778d6ec5f4d3fb05b71. The `cluster_name` tag conflicts with k8s cluster_name.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
