### PR TITLE
Simplify submit-trace action and adjust it to new artifact upload

### DIFF
--- a/.github/workflows/submit-traces.yml
+++ b/.github/workflows/submit-traces.yml
@@ -2,11 +2,6 @@ name: Submit traces
 
 on:
   workflow_call:
-    inputs:
-      artifact-name:
-        required: false
-        default: "traces"
-        type: string
 
 defaults:
   run:
@@ -34,7 +29,7 @@ jobs:
     - uses: actions/download-artifact@v4
       id: download
       with:
-        name: "${{ inputs.artifact-name }}"
+        pattern: "traces-*"
         path: captured-traces
       continue-on-error: true
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

1. Adjusts submit-traces action to the new artifact naming convention
2. Simplifies the action by dropping an unused input

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
