### PR TITLE
[base] add obfuscate_mongodb_string to datadog_agent stub

### DIFF
--- a/datadog_checks_base/changelog.d/17597.added
+++ b/datadog_checks_base/changelog.d/17597.added
@@ -1,0 +1,1 @@
+Add `obfuscate_mongodb_string` to datadog_agent stub

--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -128,5 +128,6 @@ class DatadogAgentStub(object):
         # Passthrough stub: obfuscation implementation is in Go code.
         return command
 
+
 # Use the stub as a singleton
 datadog_agent = DatadogAgentStub()

--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -124,6 +124,9 @@ class DatadogAgentStub(object):
     def set_process_start_time(self, time):
         self._process_start_time = time
 
+    def obfuscate_mongodb_string(self, command):
+        # Passthrough stub: obfuscation implementation is in Go code.
+        return command
 
 # Use the stub as a singleton
 datadog_agent = DatadogAgentStub()


### PR DESCRIPTION
### What does this PR do?
This PR adds `obfuscate_mongodb_string` to `datadog_agent` stub. The `obfuscate_mongodb_string` function is implemented in https://github.com/DataDog/datadog-agent/pull/25569

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
