### PR TITLE
[Fix] Ensure open in replay is always file instead of directory

### DIFF
--- a/.github/workflows/submit-traces.yml
+++ b/.github/workflows/submit-traces.yml
@@ -36,6 +36,7 @@ jobs:
     - name: Replay
       if: steps.download.outcome == 'success'
       run: |-
+        mkdir -p captured-traces
         cd captured-traces
         for request in *; do
           # The file could be empty if there were no traces, i.e. no Agent


### PR DESCRIPTION
Example failing job:
https://github.com/DataDog/integrations-core/actions/runs/9126412076/job/25096856738#step:5:21

Ensure captured-traces directory exists during Replay job

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
