### PR TITLE
Add bufferpool-wait-time-ns-total and bufferpool-wait-ratio for kafka producer

### DIFF
--- a/kafka/changelog.d/17612.added
+++ b/kafka/changelog.d/17612.added
@@ -1,0 +1,1 @@
+Add bufferpool-wait-time-ns-total and bufferpool-wait-ratio metrics for kafka producer

--- a/kafka/datadog_checks/kafka/data/metrics.yaml
+++ b/kafka/datadog_checks/kafka/data/metrics.yaml
@@ -87,6 +87,12 @@ jmx_metrics:
           bufferpool-wait-time:
             metric_type: gauge
             alias: kafka.producer.bufferpool_wait_time
+          bufferpool-wait-ratio:
+            metric_type: gauge
+            alias: kafka.producer.bufferpool_wait_ratio
+          bufferpool-wait-time-ns-total:
+            metric_type: gauge
+            alias: kafka.producer.bufferpool_wait_time_ns_total
           batch-size-avg:
             metric_type: gauge
             alias: kafka.producer.batch_size_avg

--- a/kafka/metadata.csv
+++ b/kafka/metadata.csv
@@ -27,7 +27,7 @@ kafka.producer.batch_size_max,gauge,10,byte,,The max number of bytes sent per pa
 kafka.producer.buffer_bytes_total,gauge,10,byte,,The maximum amount of buffer memory the client can use (whether or not it is currently used).,1,kafka,buffer bytes,
 kafka.producer.bufferpool_wait_ratio,gauge,10,,,The fraction of time an appender waits for space allocation.,-1,kafka,bufferpool wait ratio,
 kafka.producer.bufferpool_wait_time,gauge,10,,,The fraction of time an appender waits for space allocation.,-1,kafka,bufferpool wait time,
-kafka.producer.bufferpool_wait_time_ns_total,gauge,10,,,The total time in nanoseconds an appender waits for space allocation.,-1,kafka,bufferpool wait time ns total,
+kafka.producer.bufferpool_wait_time_ns_total,gauge,10,,,The total time in nanoseconds an appender waits for space allocation.,0,kafka,bufferpool wait time ns total,
 kafka.producer.bytes_out,gauge,10,byte,second,Producer bytes out rate.,1,kafka,prod bytes out,
 kafka.producer.compression_rate,gauge,10,fraction,,The average compression rate of record batches for a topic,1,kafka,compression rate,
 kafka.producer.compression_rate_avg,rate,10,fraction,,The average compression rate of record batches.,0,kafka,avg compression rate,

--- a/kafka/metadata.csv
+++ b/kafka/metadata.csv
@@ -27,7 +27,7 @@ kafka.producer.batch_size_max,gauge,10,byte,,The max number of bytes sent per pa
 kafka.producer.buffer_bytes_total,gauge,10,byte,,The maximum amount of buffer memory the client can use (whether or not it is currently used).,1,kafka,buffer bytes,
 kafka.producer.bufferpool_wait_ratio,gauge,10,,,The fraction of time an appender waits for space allocation.,-1,kafka,bufferpool wait ratio,
 kafka.producer.bufferpool_wait_time,gauge,10,,,The fraction of time an appender waits for space allocation.,-1,kafka,bufferpool wait time,
-kafka.producer.bufferpool_wait_time_ns_total,gauge,10,,,The total time in nanoseconds an appender waits for space allocation.,0,kafka,bufferpool wait time ns total,
+kafka.producer.bufferpool_wait_time_ns_total,gauge,10,nanosecond,,The total time in nanoseconds an appender waits for space allocation.,0,kafka,bufferpool wait time ns total,
 kafka.producer.bytes_out,gauge,10,byte,second,Producer bytes out rate.,1,kafka,prod bytes out,
 kafka.producer.compression_rate,gauge,10,fraction,,The average compression rate of record batches for a topic,1,kafka,compression rate,
 kafka.producer.compression_rate_avg,rate,10,fraction,,The average compression rate of record batches.,0,kafka,avg compression rate,

--- a/kafka/metadata.csv
+++ b/kafka/metadata.csv
@@ -25,7 +25,9 @@ kafka.producer.available_buffer_bytes,gauge,10,byte,,The total amount of buffer 
 kafka.producer.batch_size_avg,gauge,10,byte,,The average number of bytes sent per partition per-request.,0,kafka,avg batch size,cpu
 kafka.producer.batch_size_max,gauge,10,byte,,The max number of bytes sent per partition per-request.,0,kafka,max batch size,
 kafka.producer.buffer_bytes_total,gauge,10,byte,,The maximum amount of buffer memory the client can use (whether or not it is currently used).,1,kafka,buffer bytes,
+kafka.producer.bufferpool_wait_ratio,gauge,10,,,The fraction of time an appender waits for space allocation.,-1,kafka,bufferpool wait ratio,
 kafka.producer.bufferpool_wait_time,gauge,10,,,The fraction of time an appender waits for space allocation.,-1,kafka,bufferpool wait time,
+kafka.producer.bufferpool_wait_time_ns_total,gauge,10,,,The total time in nanoseconds an appender waits for space allocation.,-1,kafka,bufferpool wait time ns total,
 kafka.producer.bytes_out,gauge,10,byte,second,Producer bytes out rate.,1,kafka,prod bytes out,
 kafka.producer.compression_rate,gauge,10,fraction,,The average compression rate of record batches for a topic,1,kafka,compression rate,
 kafka.producer.compression_rate_avg,rate,10,fraction,,The average compression rate of record batches.,0,kafka,avg compression rate,


### PR DESCRIPTION
### What does this PR do?
Updates the metrics.yaml for the kafka integration to collect the bufferpool-wait-time-ns-total and bufferpool-wait-ratio attributes from the kafka producer

### Motivation
https://datadoghq.atlassian.net/browse/AI-3858


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
