### PR TITLE
Hide dbm config option for mongo

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -90,6 +90,7 @@ files:
         example:
           [ one_database, other_database ]
     - name: dbm
+      hidden: true
       description: |
         Set to `true` enable Database Monitoring.
         
@@ -101,6 +102,7 @@ files:
         example: false
         display_default: false
     - name: cluster_name
+      hidden: true
       description: |
         The name of the cluster to which the monitored MongoDB instance belongs.
         Used to group MongoDB instances in a MongoDB cluster.

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -84,23 +84,6 @@ instances:
     #   - one_database
     #   - other_database
 
-    ## @param dbm - boolean - optional - default: false
-    ## Set to `true` enable Database Monitoring.
-    ##
-    ## NOTE: Database Monitoring for MongoDB is currently in private beta.
-    ## If you are interested in participating, please reach out to your Datadog Customer Success Manager.
-    #
-    # dbm: false
-
-    ## @param cluster_name - string - optional
-    ## The name of the cluster to which the monitored MongoDB instance belongs.
-    ## Used to group MongoDB instances in a MongoDB cluster.
-    ## Please note that the cluster name must be unique for each MongoDB cluster.
-    ##
-    ## Required when `dbm` is enabled.
-    #
-    # cluster_name: <CLUSTER_NAME>
-
     ## @param replica_check - boolean - optional - default: true
     ## Whether or not to read from available replicas.
     ## Disable this if any replicas are inaccessible to the Agent. This option is not supported for sharded clusters.


### PR DESCRIPTION
### What does this PR do?
This PR hides `dbm` config option in `conf.yaml.example` for mongo.

### Motivation
<!-- What inspired you to submit this pull request? -->
https://datadoghq.atlassian.net/browse/DBMON-4088

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
