### PR TITLE
Dependency and changelog update in one commit

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -85,5 +85,5 @@ jobs:
         git config --global user.email "agent-integrations-dependency-bot@datadoghq.com"
         git config --global user.name "Agent Integrations Dependency Bot"
         git add .
-        git commit -am "Update changelogs"
-        git push origin HEAD
+        git commit --amend
+        git push origin HEAD --force


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
#### Before
When the bot updates the dependencies, it makes 2 commits: one to bump the deps, separate one to update changelogs.

Github PR UI only shows checks for the second commit, which don't include tests (changelogs don't trigger tests). So it's harder to see at a glance if the dependency update bump was fine.

### Motivation
<!-- What inspired you to submit this pull request? -->
This way GitHub PR UI shows tests for affected integrations as well.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
