### PR TITLE
Update the `oom_kill` check kernel version requirement to make it match what we test

### DIFF
--- a/oom_kill/README.md
+++ b/oom_kill/README.md
@@ -23,7 +23,7 @@ yum install -y kernel-headers-$(uname -r)
 yum install -y kernel-devel-$(uname -r)
 ```
 
-**Note**: Kernel version 4.11 or later is required for the OOM Kill check to work.
+**Note**: Kernel version 4.9 or later is required for the OOM Kill check to work.
 In addition, Windows and CentOS/RHEL versions earlier than 8 are not supported.
 
 ### Configuration
@@ -46,8 +46,8 @@ In addition to mounting `system-probe.yaml` and `oom_kill.d/conf.yaml` as descri
 1. Mount the following volumes to the Agent container:
 
     ```
-    -v /sys/kernel/debug:/sys/kernel/debug 
-    -v /lib/modules:/lib/modules 
+    -v /sys/kernel/debug:/sys/kernel/debug
+    -v /lib/modules:/lib/modules
     -v /usr/src:/usr/src
     ```
 
@@ -56,8 +56,8 @@ In addition to mounting `system-probe.yaml` and `oom_kill.d/conf.yaml` as descri
     ```
     --privileged
     ```
-    
-    From kernel version 5.8, the `--privileged` parameter can be replaces by `--cap-add CAP_BPF`. 
+
+    From kernel version 5.8, the `--privileged` parameter can be replaces by `--cap-add CAP_BPF`.
 
 **Note**: `--privileged` mode is not supported in Docker swarm.
 
@@ -92,7 +92,7 @@ spec:
       enabled: true
   override:
     nodeAgent:
-      volumes: 
+      volumes:
       - emptyDir: {}
         name: src
 ```


### PR DESCRIPTION
### What does this PR do?

Update the `oom_kill` check kernel version requirement to make it match what we really test.

### Motivation

The code of the check test for kernel `4.9`: https://github.com/DataDog/datadog-agent/blob/f181fade8a1342b39062b4876ed0a4806b4dbdf0/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill.go#L70
And the test is also validating that `oom_kill` works on this kernel: https://github.com/DataDog/datadog-agent/blob/71b3fd461d6e6ed09558621a92ed4ad8c7e5903e/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill_test.go#L48

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
