### PR TITLE
[PLINT-347] Add volume_type tag to cinder volumes for ceph monitoring

### DIFF
--- a/openstack_controller/changelog.d/17643.added
+++ b/openstack_controller/changelog.d/17643.added
@@ -1,0 +1,1 @@
+Added volume_type tag to cinder volumes for ceph monitoring

--- a/openstack_controller/datadog_checks/openstack_controller/metrics.py
+++ b/openstack_controller/datadog_checks/openstack_controller/metrics.py
@@ -378,7 +378,7 @@ CINDER_TRANSFER_TAGS = {'id': 'transfer_id', 'volume_id': 'volume_id', 'name': '
 CINDER_VOLUME_PREFIX = f"{CINDER_METRICS_PREFIX}.volume"
 CINDER_VOLUME_COUNT = f"{CINDER_VOLUME_PREFIX}.count"
 CINDER_VOLUME_METRICS = {f"{CINDER_VOLUME_PREFIX}.size": {}}
-CINDER_VOLUME_TAGS = {'id': 'volume_id', 'name': 'volume_name', 'status': 'volume_status'}
+CINDER_VOLUME_TAGS = {'id': 'volume_id', 'name': 'volume_name', 'status': 'volume_status', 'volume_type': 'volume_type'}
 
 IRONIC_METRICS_PREFIX = "openstack.ironic"
 IRONIC_SERVICE_CHECK = f"{IRONIC_METRICS_PREFIX}.api.up"

--- a/openstack_controller/tests/test_unit_cinder.py
+++ b/openstack_controller/tests/test_unit_cinder.py
@@ -278,6 +278,7 @@ def test_block_storage_metrics(aggregator, check, dd_run_check):
             'volume_id:9c762008-d70f-44d1-af02-98e1da79ee4b',
             'volume_name:first_volume',
             'volume_status:in-use',
+            'volume_type:lvmdriver-1',
             'keystone_server:http://127.0.0.1:8080/identity',
         ],
     )
@@ -292,6 +293,7 @@ def test_block_storage_metrics(aggregator, check, dd_run_check):
             'volume_id:259b16de-727f-4011-8388-84d17a9ae594',
             'volume_name:',
             'volume_status:in-use',
+            'volume_type:lvmdriver-1',
             'keystone_server:http://127.0.0.1:8080/identity',
         ],
     )
@@ -306,6 +308,7 @@ def test_block_storage_metrics(aggregator, check, dd_run_check):
             'volume_id:9c762008-d70f-44d1-af02-98e1da79ee4b',
             'volume_name:first_volume',
             'volume_status:in-use',
+            'volume_type:lvmdriver-1',
             'keystone_server:http://127.0.0.1:8080/identity',
         ],
     )
@@ -320,6 +323,7 @@ def test_block_storage_metrics(aggregator, check, dd_run_check):
             'volume_id:259b16de-727f-4011-8388-84d17a9ae594',
             'volume_name:',
             'volume_status:in-use',
+            'volume_type:lvmdriver-1',
             'keystone_server:http://127.0.0.1:8080/identity',
         ],
     )
@@ -647,6 +651,7 @@ def test_block_storage_volumes_pagination(
             'volume_id:9c762008-d70f-44d1-af02-98e1da79ee4b',
             'volume_name:first_volume',
             'volume_status:in-use',
+            'volume_type:lvmdriver-1',
             'keystone_server:http://127.0.0.1:8080/identity',
         ],
     )
@@ -661,6 +666,7 @@ def test_block_storage_volumes_pagination(
             'volume_id:259b16de-727f-4011-8388-84d17a9ae594',
             'volume_name:',
             'volume_status:in-use',
+            'volume_type:lvmdriver-1',
             'keystone_server:http://127.0.0.1:8080/identity',
         ],
     )
@@ -675,6 +681,7 @@ def test_block_storage_volumes_pagination(
             'volume_id:9c762008-d70f-44d1-af02-98e1da79ee4b',
             'volume_name:first_volume',
             'volume_status:in-use',
+            'volume_type:lvmdriver-1',
             'keystone_server:http://127.0.0.1:8080/identity',
         ],
     )
@@ -689,6 +696,7 @@ def test_block_storage_volumes_pagination(
             'volume_id:259b16de-727f-4011-8388-84d17a9ae594',
             'volume_name:',
             'volume_status:in-use',
+            'volume_type:lvmdriver-1',
             'keystone_server:http://127.0.0.1:8080/identity',
         ],
     )


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
To monitor Openstack resources using Ceph, we are allowing for filtering of cinder volumes by adding a volume_type tag. Customers can simply set the volume_type of a Ceph volume to 'ceph', and filter the volumes with ‘volume_type=ceph’.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
