### PR TITLE
Add context_info to SQL Server activity samples (DBMON-4106)

### DIFF
--- a/sqlserver/changelog.d/17648.added
+++ b/sqlserver/changelog.d/17648.added
@@ -1,1 +1,0 @@
-Add context_info to SQL Server activity samples

--- a/sqlserver/changelog.d/17648.added
+++ b/sqlserver/changelog.d/17648.added
@@ -1,0 +1,1 @@
+Add context_info to SQL Server activity samples

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import base64
 import binascii
 import datetime
 import re
@@ -136,6 +137,7 @@ DM_EXEC_REQUESTS_COLS = [
     "row_count",
     "query_hash",
     "query_plan_hash",
+    "context_info",
 ]
 
 
@@ -333,6 +335,10 @@ class SqlserverActivity(DBMAsyncJob):
         # remove deobfuscated sql text from event
         if 'statement_text' in row:
             del row['statement_text']
+        # convert `context_info` to string, since the default decoding format 
+        # for json is utf-8, and `context_info` need not comply to utf-8
+        if 'context_info' in row:
+            row['context_info'] = row['context_info'].hex()
         return row
 
     @staticmethod

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-import base64
 import binascii
 import datetime
 import re
@@ -335,7 +334,7 @@ class SqlserverActivity(DBMAsyncJob):
         # remove deobfuscated sql text from event
         if 'statement_text' in row:
             del row['statement_text']
-        # convert `context_info` to string, since the default decoding format 
+        # convert `context_info` to string, since the default decoding format
         # for json is utf-8, and `context_info` need not comply to utf-8
         if 'context_info' in row:
             row['context_info'] = row['context_info'].hex()

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -99,7 +99,7 @@ def test_collect_load_activity(
     def run_test_query(c, q):
         cur = c.cursor()
         cur.execute("USE {}".format(database))
-        # 0xFF can't be decoded to Unicode, which makes it good test data, 
+        # 0xFF can't be decoded to Unicode, which makes it good test data,
         # since Unicode is a default format
         cur.execute("SET CONTEXT_INFO 0xff")
         cur.execute(q)

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -99,6 +99,9 @@ def test_collect_load_activity(
     def run_test_query(c, q):
         cur = c.cursor()
         cur.execute("USE {}".format(database))
+        # 0xFF can't be decoded to Unicode, which makes it food test data, 
+        # since Unicode is a default format
+        cur.execute("SET CONTEXT_INFO 0xff")
         cur.execute(q)
 
     # run the test query once before the blocking test to ensure that if it's
@@ -164,6 +167,7 @@ def test_collect_load_activity(
         assert blocked_row['procedure_name'], "missing procedure name"
     assert re.match(match_pattern, blocked_row['text'], re.IGNORECASE), "incorrect blocked query"
     assert blocked_row['database_name'] == "datadog_test", "incorrect database_name"
+    assert blocked_row['context_info'] == "ff", "incorrect context_info"
     assert blocked_row['id'], "missing session id"
     assert blocked_row['now'], "missing current timestamp"
     assert blocked_row['last_request_start_time'], "missing last_request_start_time"

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -99,7 +99,7 @@ def test_collect_load_activity(
     def run_test_query(c, q):
         cur = c.cursor()
         cur.execute("USE {}".format(database))
-        # 0xFF can't be decoded to Unicode, which makes it food test data, 
+        # 0xFF can't be decoded to Unicode, which makes it good test data, 
         # since Unicode is a default format
         cur.execute("SET CONTEXT_INFO 0xff")
         cur.execute(q)


### PR DESCRIPTION
### What does this PR do?
Adding the `context_info` field to SQL Server activity samples.

### Motivation
APM tracers will populate this field needed for the full mode APM/DBM link. The details are [here](https://docs.google.com/document/d/1AAo50nJNcb5r7BU9Hqc0i_V-KsmnLw8lgpwV--qamto/edit?usp=sharing).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
