### PR TITLE
Add optional display_name tag

### DIFF
--- a/windows_service/assets/configuration/spec.yaml
+++ b/windows_service/assets/configuration/spec.yaml
@@ -64,4 +64,10 @@ files:
             value:
               type: boolean
               example: false
+          - name: collect_display_name_as_tag
+            description: |
+              Whether or not to submit the Windows Service Display Name as the `display_name` tag.
+            value:
+              type: boolean
+              example: false
           - template: instances/default

--- a/windows_service/assets/configuration/spec.yaml
+++ b/windows_service/assets/configuration/spec.yaml
@@ -67,6 +67,12 @@ files:
           - name: collect_display_name_as_tag
             description: |
               Whether or not to submit the Windows Service Display Name as the `display_name` tag.
+              `display_name` will be formatted according to Datadog's tagging requirements:
+              https://docs.datadoghq.com/getting_started/tagging/#define-tags
+
+              Example of the default `windows_service` tag and `display_name` tag:
+              windows_service:wuauserv
+              display_name:windows_update
             value:
               type: boolean
               example: false

--- a/windows_service/changelog.d/17657.added
+++ b/windows_service/changelog.d/17657.added
@@ -1,0 +1,1 @@
+Add optional display_name tag

--- a/windows_service/datadog_checks/windows_service/config_models/defaults.py
+++ b/windows_service/datadog_checks/windows_service/config_models/defaults.py
@@ -8,6 +8,10 @@
 #     ddev -x validate models -s <INTEGRATION_NAME>
 
 
+def instance_collect_display_name_as_tag():
+    return False
+
+
 def instance_disable_generic_tags():
     return False
 

--- a/windows_service/datadog_checks/windows_service/config_models/instance.py
+++ b/windows_service/datadog_checks/windows_service/config_models/instance.py
@@ -35,6 +35,7 @@ class InstanceConfig(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    collect_display_name_as_tag: Optional[bool] = None
     disable_generic_tags: Optional[bool] = None
     disable_legacy_service_tag: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None

--- a/windows_service/datadog_checks/windows_service/data/conf.yaml.example
+++ b/windows_service/datadog_checks/windows_service/data/conf.yaml.example
@@ -61,6 +61,11 @@ instances:
     #
     # windows_service_startup_type_tag: false
 
+    ## @param collect_display_name_as_tag - boolean - optional - default: false
+    ## Whether or not to submit the Windows Service Display Name as the `display_name` tag.
+    #
+    # collect_display_name_as_tag: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/windows_service/datadog_checks/windows_service/data/conf.yaml.example
+++ b/windows_service/datadog_checks/windows_service/data/conf.yaml.example
@@ -63,6 +63,12 @@ instances:
 
     ## @param collect_display_name_as_tag - boolean - optional - default: false
     ## Whether or not to submit the Windows Service Display Name as the `display_name` tag.
+    ## `display_name` will be formatted according to Datadog's tagging requirements:
+    ## https://docs.datadoghq.com/getting_started/tagging/#define-tags
+    ##
+    ## Example of the default `windows_service` tag and `display_name` tag:
+    ## windows_service:wuauserv
+    ## display_name:windows_update
     #
     # collect_display_name_as_tag: false
 

--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -316,7 +316,7 @@ class WindowsService(AgentCheck):
 
                 if instance.get('windows_service_startup_type_tag', False):
                     tags.append('windows_service_startup_type:{}'.format(startup_type_string))
-                
+
                 if instance.get('collect_display_name_as_tag', False):
                     tags.append('display_name:{}'.format(service))
 

--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -259,7 +259,7 @@ class WindowsService(AgentCheck):
         # See test_name_regex_order()
         service_filters = sorted(service_filters, reverse=True, key=lambda x: len(x.name or ""))
 
-        for short_name, _, service_status in service_statuses:
+        for short_name, display_name, service_status in service_statuses:
             service_view = ServiceView(scm_handle, short_name)
 
             if 'ALL' not in services:
@@ -284,6 +284,9 @@ class WindowsService(AgentCheck):
 
             tags = ['windows_service:{}'.format(short_name)]
             tags.extend(custom_tags)
+
+            if instance.get('collect_display_name_as_tag', False):
+                tags.append('display_name:{}'.format(display_name))
 
             if instance.get('windows_service_startup_type_tag', False):
                 try:
@@ -313,6 +316,9 @@ class WindowsService(AgentCheck):
 
                 if instance.get('windows_service_startup_type_tag', False):
                     tags.append('windows_service_startup_type:{}'.format(startup_type_string))
+                
+                if instance.get('collect_display_name_as_tag', False):
+                    tags.append('display_name:{}'.format(service))
 
                 if not instance.get('disable_legacy_service_tag', False):
                     self._log_deprecation('service_tag', 'windows_service')

--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -309,6 +309,7 @@ class WindowsService(AgentCheck):
                 # if a name doesn't match anything (wrong name or no permission to access the service), report UNKNOWN
                 status = self.UNKNOWN
                 startup_type_string = ServiceView.STARTUP_TYPE_UNKNOWN
+                display_name = "Not_Found"
 
                 tags = ['windows_service:{}'.format(service)]
 
@@ -318,7 +319,7 @@ class WindowsService(AgentCheck):
                     tags.append('windows_service_startup_type:{}'.format(startup_type_string))
 
                 if instance.get('collect_display_name_as_tag', False):
-                    tags.append('display_name:{}'.format(service))
+                    tags.append('display_name:{}'.format(display_name))
 
                 if not instance.get('disable_legacy_service_tag', False):
                     self._log_deprecation('service_tag', 'windows_service')

--- a/windows_service/tests/test_windows_service.py
+++ b/windows_service/tests/test_windows_service.py
@@ -221,6 +221,45 @@ def test_startup_type_tag(aggregator, check, instance_basic):
     )
 
 
+def test_display_name_tag(aggregator, check, instance_basic):
+    instance_basic['collect_display_name_as_tag'] = True
+    c = check(instance_basic)
+    c.check(instance_basic)
+    aggregator.assert_service_check(
+        c.SERVICE_CHECK_NAME,
+        status=c.OK,
+        tags=[
+            'service:EventLog',
+            'windows_service:EventLog',
+            'display_name:Windows Event Log',
+            'optional:tag1',
+        ],
+        count=1,
+    )
+    aggregator.assert_service_check(
+        c.SERVICE_CHECK_NAME,
+        status=c.OK,
+        tags=[
+            'service:Dnscache',
+            'windows_service:Dnscache',
+            'display_name:DNS Client',
+            'optional:tag1',
+        ],
+        count=1,
+    )
+    aggregator.assert_service_check(
+        c.SERVICE_CHECK_NAME,
+        status=c.UNKNOWN,
+        tags=[
+            'service:NonExistentService',
+            'windows_service:NonExistentService',
+            'display_name:NonExistentService',
+            'optional:tag1',
+        ],
+        count=1,
+    )
+
+
 def test_openservice_failure(aggregator, check, instance_basic_dict, caplog):
     # dict type
     instance_basic_dict['services'].append({'startup_type': 'automatic'})

--- a/windows_service/tests/test_windows_service.py
+++ b/windows_service/tests/test_windows_service.py
@@ -253,7 +253,7 @@ def test_display_name_tag(aggregator, check, instance_basic):
         tags=[
             'service:NonExistentService',
             'windows_service:NonExistentService',
-            'display_name:NonExistentService',
+            'display_name:Not_Found',
             'optional:tag1',
         ],
         count=1,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add a new tag to each windows_service service check that includes the Windows Service Display Name as the tag `display_name`.
Add a `collect_display_name_as_tag` option to control presence/absence of the tag.

### Motivation
<!-- What inspired you to submit this pull request? -->
Customer Requests: https://datadoghq.atlassian.net/browse/WINA-795

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
