### PR TITLE
add dd_security_events to docs

### DIFF
--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -467,7 +467,7 @@ Checks
 
 Starting with Agent 7.54, you can automatically send Security Events to Datadog as Logs by using the `dd_security_events` flag. These Logs can be used with [Datadog's Cloud SIEM][29] to automatically detect threats and suspicious activity in real-time. These default security events are compatible with Datadog's out-of-the-box Windows detection rules to create security signals when a user clears the Security Logs, disables the Windows firewall, changes the Directory Services Restore Mode (DSRM) password, and more.
 
-1. Collecting logs is disabled by default in the Datadog Agent. Enable it in your `datadog.yaml` file:
+1. Enable collecting logs in your `datadog.yaml` file. It is disabled by default in the Datadog Agent.
 
    ```yaml
    logs_enabled: true

--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -475,7 +475,7 @@ Starting with Agent 7.54, you can automatically send Security Events to Datadog 
 
 2. In the integration configuration file, (`win32_event_log.d/conf.yaml`) set the `dd_security_events` flag to `low` or `high` to start sending Security Events to Datadog.
 
-   - `low`: sends only the most important and crtical Security events, including 1102 (Audit log cleared), 4649 (Replay attack detected), and 4719 (System audit policy was changed).
+   - `low`: sends only the most important and critical Security events, including 1102 (Audit log cleared), 4649 (Replay attack detected), and 4719 (System audit policy was changed).
    - `high`: sends a higher volume of Security events, including 4714 (Encrypted data recovery policy was changed), 4739 (Domain policy was changed), and 4764 (Security-disabled group was deleted).
 
 

--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -557,4 +557,4 @@ Additional helpful documentation, links, and articles:
 [26]: https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=configurationfile
 [27]: https://www.datadoghq.com/blog/monitor-windows-event-logs-with-datadog/
 [28]: https://docs.datadoghq.com/integrations/guide/add-event-log-files-to-the-win32-ntlogevent-wmi-class/
-[29]: https://www.datadoghq.com/product/cloud-siem/
+[29]: https://docs.datadoghq.com/security/cloud_siem/

--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -473,7 +473,7 @@ Starting with Agent 7.54, you can automatically send Security Events to Datadog 
    logs_enabled: true
    ```
 
-2. In the integration configuration file (`win32_event_log.d/conf.yaml`) set the `dd_security_events` flag to `low` or `high` to start sending Security Events to Datadog.
+2. In the integration configuration file, (`win32_event_log.d/conf.yaml`) set the `dd_security_events` flag to `low` or `high` to start sending Security Events to Datadog.
 
    - `low`: sends only the most important and crtical Security events, including 1102 (Audit log cleared), 4649 (Replay attack detected), and 4719 (System audit policy was changed).
    - `high`: sends a higher volume of Security events, including 4714 (Encrypted data recovery policy was changed), 4739 (Domain policy was changed), and 4764 (Security-disabled group was deleted).

--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -465,7 +465,7 @@ Checks
 
 ## Send Default Security logs
 
-Starting with Agent 7.54, you can automatically send Security Events to Datadog as Logs by using the `dd_security_events` flag. These Logs can be used with [Datadog's Cloud SIEM][29] to automatically detect threats and suspicious activity in real-time. These default security events are compatible with Datadog's out-of-the-box Windows detection rules to create security signals when a user clears the Security Logs, disables the Windows firewall, changes the Directory Services Restore Mode (DSRM) password, and more.
+Starting with Agent 7.54, you can automatically send Security Events to Datadog as logs by using the `dd_security_events` flag. These logs can be used with [Datadog's Cloud SIEM][29] to automatically detect threats and suspicious activity in real-time. These default security events are compatible with Datadog's out-of-the-box Windows detection rules to create security signals when a user clears the Security logs, disables the Windows firewall, changes the Directory Services Restore Mode (DSRM) password, and more.
 
 1. Enable collecting logs in your `datadog.yaml` file. It is disabled by default in the Datadog Agent.
 

--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -475,8 +475,8 @@ Starting with Agent 7.54, you can automatically send Security Events to Datadog 
 
 2. In the integration configuration file, (`win32_event_log.d/conf.yaml`) set the `dd_security_events` flag to `low` or `high` to start sending Security Events to Datadog.
 
-   - `low`: sends only the most important and critical Security events, including 1102 (Audit log cleared), 4649 (Replay attack detected), and 4719 (System audit policy was changed).
-   - `high`: sends a higher volume of Security events, including 4714 (Encrypted data recovery policy was changed), 4739 (Domain policy was changed), and 4764 (Security-disabled group was deleted).
+   - `low`: sends only the most important and critical Security events, including Audit log cleared (1102), Replay attack detected (4649), and System audit policy was changed (4719). For a full list of events collected on the `low` setting, [see here][30]. 
+   - `high`: sends a higher volume of Security events, including Encrypted data recovery policy was changed (4714), Domain policy was changed (4739), and Security-disabled group was deleted (4764). For a full list of events collected on the `high` setting, [see here][31]. 
 
 
 3. [Restart the Agent][4].
@@ -558,3 +558,5 @@ Additional helpful documentation, links, and articles:
 [27]: https://www.datadoghq.com/blog/monitor-windows-event-logs-with-datadog/
 [28]: https://docs.datadoghq.com/integrations/guide/add-event-log-files-to-the-win32-ntlogevent-wmi-class/
 [29]: https://docs.datadoghq.com/security/cloud_siem/
+[30]: https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/dist/conf.d/win32_event_log.d/profiles/dd_security_events_low.yaml.example
+[31]: https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/dist/conf.d/win32_event_log.d/profiles/dd_security_events_high.yaml.example

--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -24,7 +24,7 @@ Windows Event Logs can be collected as one or both of the following methods.
 - As [Datadog Events][16]
 - As [Datadog Logs][17]
 
-Both methods are configured in `win32_event_log.d/conf.yaml` in the `conf.d/` folder at the root of your [Agent's configuration directory][2]. See the [sample win32_event_log.d/conf.yaml][3] for all available configuration options.
+Both methods are configured in `win32_event_log.d/conf.yaml` in the `conf.d/` folder at the root of your [Agent's configuration directory][2]. See the [sample win32_event_log.d/conf.yaml][3] for all available configuration options. For a quickstart option to send Security event logs, see [Send default Security logs](#send-default-security-logs).
 
 #### List Windows Event channels
 

--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -26,7 +26,6 @@ Windows Event Logs can be collected as one or both of the following methods.
 
 Both methods are configured in `win32_event_log.d/conf.yaml` in the `conf.d/` folder at the root of your [Agent's configuration directory][2]. See the [sample win32_event_log.d/conf.yaml][3] for all available configuration options.
 
-
 #### List Windows Event channels
 
 First, identify the Windows Event Log channels you want to monitor. 
@@ -464,6 +463,25 @@ Checks
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->
 
+## Send Default Security Logs
+
+Starting with Agent 7.54, you can automatically send Security Events to Datadog as Logs by using the `dd_security_events` flag. These Logs can be used with [Datadog's Cloud SIEM][29] to automatically detect threats and suspicious activity in real-time. These default security events are compatible with Datadog's out-of-the-box Windows detection rules to create security signals when a user clears the Security Logs, disables the Windows firewall, changes the Directory Services Restore Mode (DSRM) password, and more.
+
+1. Collecting logs is disabled by default in the Datadog Agent. Enable it in your `datadog.yaml` file:
+
+   ```yaml
+   logs_enabled: true
+   ```
+
+2. In the integration configuration file (`win32_event_log.d/conf.yaml`) set the `dd_security_events` flag to `low` or `high` to start sending Security Events to Datadog.
+
+   - `low`: sends only the most important and crtical Security events, including 1102 (Audit log cleared), 4649 (Replay attack detected), and 4719 (System audit policy was changed).
+   - `high`: sends a higher volume of Security events, including 4714 (Encrypted data recovery policy was changed), 4739 (Domain policy was changed), and 4764 (Security-disabled group was deleted).
+
+
+3. [Restart the Agent][4].
+
+
 ## Data Collected
 
 ### Metrics
@@ -539,3 +557,4 @@ Additional helpful documentation, links, and articles:
 [26]: https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=configurationfile
 [27]: https://www.datadoghq.com/blog/monitor-windows-event-logs-with-datadog/
 [28]: https://docs.datadoghq.com/integrations/guide/add-event-log-files-to-the-win32-ntlogevent-wmi-class/
+[29]: https://www.datadoghq.com/product/cloud-siem/

--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -463,7 +463,7 @@ Checks
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->
 
-## Send Default Security Logs
+## Send Default Security logs
 
 Starting with Agent 7.54, you can automatically send Security Events to Datadog as Logs by using the `dd_security_events` flag. These Logs can be used with [Datadog's Cloud SIEM][29] to automatically detect threats and suspicious activity in real-time. These default security events are compatible with Datadog's out-of-the-box Windows detection rules to create security signals when a user clears the Security Logs, disables the Windows firewall, changes the Directory Services Restore Mode (DSRM) password, and more.
 


### PR DESCRIPTION
### What does this PR do?
Documentation for new feature to send default Security Events to Datadog as Logs.

### Motivation
New feature to send default Security Events to Datadog as Logs.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
