### PR TITLE
[mongo] send database_instance metadata before collecting metrics

### DIFF
--- a/mongo/changelog.d/17665.fixed
+++ b/mongo/changelog.d/17665.fixed
@@ -1,0 +1,1 @@
+Emit database_instance metadata before collecting metrics

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -226,9 +226,9 @@ class MongoDb(AgentCheck):
         try:
             self._refresh_metadata()
             self._refresh_deployment()
-            self._collect_metrics()
             self._send_database_instance_metadata()
-
+            self._collect_metrics()
+            
             # DBM
             if self._config.dbm_enabled:
                 self._operation_samples.run_job_loop(tags=self._get_tags(include_deployment_tags=True))


### PR DESCRIPTION
### What does this PR do?
This PR swaps the order of `_send_database_instance_metadata` and `_collect_metrics` to make sure the database_instance metadata is always sent before metrics are collected. This is to ensure the integration always emit the `database_instance` in case `_collect_metrics` fails with uncaught exceptions.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
