### PR TITLE
Revert "Run PR test with access to tokens"

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,7 @@
 name: PR
 
 on:
-  pull_request_target:
+  pull_request:
     paths-ignore:
     - datadog_checks_base/datadog_checks/**
     - datadog_checks_dev/datadog_checks/dev/*.py


### PR DESCRIPTION
Reverts DataDog/integrations-core#17652

Discussed offline, we must revert temporarily