### PR TITLE
[sqlserver] send database_instance metadata before collecting metrics

### DIFF
--- a/sqlserver/changelog.d/17675.fixed
+++ b/sqlserver/changelog.d/17675.fixed
@@ -1,1 +1,2 @@
 Emit database_instance metadata before collecting metrics
+Decreased database instance collection interval from 1800 seconds to 300 seconds to improve reliability

--- a/sqlserver/changelog.d/17675.fixed
+++ b/sqlserver/changelog.d/17675.fixed
@@ -1,0 +1,1 @@
+Emit database_instance metadata before collecting metrics

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -98,7 +98,7 @@ class SQLServerConfig:
         )
         self.log_unobfuscated_queries: bool = is_affirmative(instance.get('log_unobfuscated_queries', False))
         self.log_unobfuscated_plans: bool = is_affirmative(instance.get('log_unobfuscated_plans', False))
-        self.database_instance_collection_interval: int = instance.get('database_instance_collection_interval', 1800)
+        self.database_instance_collection_interval: int = instance.get('database_instance_collection_interval', 300)
         self.stored_procedure_characters_limit: int = instance.get('stored_procedure_characters_limit', PROC_CHAR_LIMIT)
         self.connection_host: str = instance['host']
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -747,13 +747,14 @@ class SQLServer(AgentCheck):
                     [QUERY_SERVER_STATIC_INFO], executor=self.execute_query_raw
                 )
                 self.server_state_queries.compile_queries()
+
+            self._send_database_instance_metadata()
             if self._config.proc:
                 self.do_stored_procedure_check()
             else:
                 self.collect_metrics()
             if self._config.autodiscovery and self._config.autodiscovery_db_service_check:
                 self._check_database_conns()
-            self._send_database_instance_metadata()
             if self._config.dbm_enabled:
                 self.statement_metrics.run_job_loop(self.tags)
                 self.procedure_metrics.run_job_loop(self.tags)

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -758,7 +758,7 @@ def test_database_instance_metadata(aggregator, dd_run_check, instance_docker, d
     assert event['dbms'] == "sqlserver"
     assert event['tags'] == ['optional:tag1']
     assert event['integration_version'] == __version__
-    assert event['collection_interval'] == 1800
+    assert event['collection_interval'] == 300
     assert event['metadata'] == {
         'dbm': dbm_enabled,
         'connection_host': instance_docker['host'],


### PR DESCRIPTION
### What does this PR do?
This PR swaps the order of _send_database_instance_metadata and _collect_metrics to make sure the database_instance metadata is always sent before metrics are collected. This is to ensure the integration always emit the database_instance in case _collect_metrics fails with uncaught exceptions.

### Motivation
Keep consistency with the rest of the dbms integrations. As fixed recently in #17590 and #17665

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
