### PR TITLE
Decrease database instance collection interval

### DIFF
--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -102,7 +102,7 @@ class MongoConfig(object):
 
         # DBM config options
         self.dbm_enabled = is_affirmative(instance.get('dbm', False))
-        self.database_instance_collection_interval = instance.get('database_instance_collection_interval', 1800)
+        self.database_instance_collection_interval = instance.get('database_instance_collection_interval', 300)
         self.cluster_name = instance.get('cluster_name', None)
         self._operation_samples_config = instance.get('operation_samples', {})
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Based on https://github.com/DataDog/integrations-core/pull/17676

This is to help with cases where we see customers sometimes suffer from flapping host tags due to the db instance resource expiring. We should just send them more often to make this less likely.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
