### PR TITLE
[DBMON-4112] postgres - loosen up custom query exception handling

### DIFF
--- a/postgres/changelog.d/17679.fixed
+++ b/postgres/changelog.d/17679.fixed
@@ -1,0 +1,1 @@
+Adds debug info for exceptions in custom queries and preserves running of the remaining queries

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -898,7 +898,7 @@ class PostgreSql(AgentCheck):
                             check=self, operation='custom_queries', tags=['metric_prefix:{}'.format(metric_prefix)]
                         ):
                             cursor.execute(query)
-                    except (psycopg2.ProgrammingError, psycopg2.errors.QueryCanceled) as e:
+                    except Exception as e:
                         self.log.error("Error executing query for metric_prefix %s: %s", metric_prefix, str(e))
                         continue
 


### PR DESCRIPTION
### What does this PR do?

Currently any exception we get while trying to run custom checks on postgres integration will cause all subsequent checks that run to fail unless they are ProgammingError or QueryCancelled. We also lose any debugging information about the failure. We should loosen up this [exception](https://github.com/DataDog/integrations-core/blob/45d17147c1befd4127b5c34d5aaf24d1792e03bf/postgres/datadog_checks/postgres/postgres.py#L901) so that we don’t skip the rest of the checks and we have useful debugging info to help ourselves and customers debug issues

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
