### PR TITLE
Manually change the permissions to allow for the runner to create file

### DIFF
--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -33,24 +33,24 @@ env:
   SOURCE_DATE_EPOCH: "1580601600"
 
 jobs:
-  test:
-    name: Run tests
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Install dependencies
-        run: |
-          pip install -r .builders/deps/host_dependencies.txt
-          pip install -r .builders/test_dependencies.txt
-      - name: Run tests
-        run: |
-          cd .builders
-          pytest -vvv
+  # test:
+  #   name: Run tests
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+  #     - name: Set up Python ${{ env.PYTHON_VERSION }}
+  #       uses: actions/setup-python@v5
+  #       with:
+  #         python-version: ${{ env.PYTHON_VERSION }}
+  #     - name: Install dependencies
+  #       run: |
+  #         pip install -r .builders/deps/host_dependencies.txt
+  #         pip install -r .builders/test_dependencies.txt
+  #     - name: Run tests
+  #       run: |
+  #         cd .builders
+  #         pytest -vvv
 
   build:
     name: Target ${{ matrix.job.image }} on ${{ matrix.job.os }}
@@ -96,6 +96,7 @@ jobs:
     - name: Checkout code
       if: github.event_name == 'pull_request'
       uses: actions/checkout@v4
+
 
     - name: Set up Python ${{ env.PYTHON_VERSION }}
       if: matrix.job.image != 'linux-aarch64'
@@ -167,6 +168,11 @@ jobs:
         digest=$(jq -r '.["${{ matrix.job.image }}"]' .deps/image_digests.json)
         python .builders/build.py ${{ matrix.job.image }} --python 3 ${{ env.OUT_DIR }}/py3 --digest $digest
         python .builders/build.py ${{ matrix.job.image }} --python 2 ${{ env.OUT_DIR }}/py2 --digest $digest
+
+    - name: Change permissions
+      if: matrix.job.image == 'linux-aarch64'
+      run: |
+        sudo chmod 777 ${{ env.OUT_DIR }}
 
     - name: Publish image
       if: github.event_name == 'push' && steps.changed-files.outputs.builders_any_changed == 'true'

--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -33,24 +33,24 @@ env:
   SOURCE_DATE_EPOCH: "1580601600"
 
 jobs:
-  # test:
-  #   name: Run tests
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
-  #     - name: Set up Python ${{ env.PYTHON_VERSION }}
-  #       uses: actions/setup-python@v5
-  #       with:
-  #         python-version: ${{ env.PYTHON_VERSION }}
-  #     - name: Install dependencies
-  #       run: |
-  #         pip install -r .builders/deps/host_dependencies.txt
-  #         pip install -r .builders/test_dependencies.txt
-  #     - name: Run tests
-  #       run: |
-  #         cd .builders
-  #         pytest -vvv
+  test:
+    name: Run tests
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install dependencies
+        run: |
+          pip install -r .builders/deps/host_dependencies.txt
+          pip install -r .builders/test_dependencies.txt
+      - name: Run tests
+        run: |
+          cd .builders
+          pytest -vvv
 
   build:
     name: Target ${{ matrix.job.image }} on ${{ matrix.job.os }}
@@ -96,7 +96,6 @@ jobs:
     - name: Checkout code
       if: github.event_name == 'pull_request'
       uses: actions/checkout@v4
-
 
     - name: Set up Python ${{ env.PYTHON_VERSION }}
       if: matrix.job.image != 'linux-aarch64'


### PR DESCRIPTION
In the Aarch runner the directories were all listed under root. Because of this, the runner user that the runner run as doesn't have the correct permissions to create the file and thus the job always fails with a permission denied error:

```
/home/runner/work/_temp/6822cb3e-4435-4ce9-8eb5-3746fd134886.sh: line 1: output/linux-aarch64/image_digest: Permission denied
```

https://github.com/DataDog/integrations-core/actions/runs/9291550932/job/25620772401

Inspecting the permissions in the runner:
```
Run ls -la output/linux-aarch64/
total 16
drwxr-xr-x 4 root root 4096 May 30 20:23 .
drwxr-xr-x 3 root root 4096 May 30 20:22 ..
drwxr-xr-x 3 root root 4096 May 30 20:23 py2
drwxr-xr-x 3 root root 4096 May 30 20:22 py3
```

It's different when compared to the linux-x86_64 runner:
```
Run ls -la output/linux-x86_64/
total 16
drwxr-xr-x 4 runner docker 4096 May 30 20:22 .
drwxr-xr-x 3 runner docker 4096 May 30 20:22 ..
drwxr-xr-x 3 runner docker 4096 May 30 20:22 py2
drwxr-xr-x 3 runner docker 4096 May 30 20:22 py3
```


