### PR TITLE
Kafka consumer : add consumer group state as tag 

### DIFF
--- a/kafka_consumer/changelog.d/17686.added
+++ b/kafka_consumer/changelog.d/17686.added
@@ -1,0 +1,1 @@
+Kafka consumer : add consumer group state as tag 

--- a/kafka_consumer/datadog_checks/kafka_consumer/client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client.py
@@ -253,14 +253,18 @@ class KafkaClient:
             return consumer_groups
         else:
             return self.config._consumer_groups
-        
+
     def get_consumer_group_state(self, consumer_group):
         consumer_group_state = ""
-        #Get the consumer group state if present
+        # Get the consumer group state if present
         consumer_groups_future = self._describe_consumer_groups(consumer_group)
         try:
             consumer_groups_result = consumer_groups_future[consumer_group].result()
-            self.log.debug("Discovered consumer group: %s in state %s", consumer_groups_result.group_id, consumer_groups_result.state)
+            self.log.debug(
+                "Discovered consumer group: %s in state %s",
+                consumer_groups_result.group_id,
+                consumer_groups_result.state,
+            )
             consumer_group_result_state = str(consumer_groups_result.state)
             consumer_group_state = consumer_group_result_state.split('.')[1]
 
@@ -285,7 +289,6 @@ class KafkaClient:
         :rtype: dict[str, future]
         """
         return self.kafka_client.describe_consumer_groups([consumer_group])
-
 
     def close_admin_client(self):
         self._kafka_client = None

--- a/kafka_consumer/datadog_checks/kafka_consumer/client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client.py
@@ -259,9 +259,10 @@ class KafkaClient:
         #Get the consumer group state if present
         consumer_groups_future = self._describe_consumer_groups(consumer_group)
         try:
-            consumer_groups_result = consumer_groups_future.result()
+            consumer_groups_result = consumer_groups_future[consumer_group].result()
             self.log.debug("Discovered consumer group: %s in state %s", consumer_groups_result.group_id, consumer_groups_result.state)
-            consumer_group_state = consumer_groups_result.state
+            consumer_group_result_state = str(consumer_groups_result.state)
+            consumer_group_state = consumer_group_result_state.split('.')[1]
 
         except Exception as e:
             self.log.error("Failed to collect consumer group: %s", e)

--- a/kafka_consumer/datadog_checks/kafka_consumer/client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client.py
@@ -258,18 +258,15 @@ class KafkaClient:
         consumer_group_state = ""
         # Get the consumer group state if present
         consumer_groups_future = self._describe_consumer_groups(consumer_group)
-        try:
-            consumer_groups_result = consumer_groups_future[consumer_group].result()
-            self.log.debug(
-                "Consumer group: %s in state %s",
-                consumer_groups_result.group_id,
-                consumer_groups_result.state,
-            )
-            consumer_group_result_state = str(consumer_groups_result.state)
-            consumer_group_state = consumer_group_result_state.split('.')[1]
+        consumer_groups_result = consumer_groups_future[consumer_group].result()
+        self.log.debug(
+            "Consumer group: %s in state %s",
+            consumer_groups_result.group_id,
+            consumer_groups_result.state,
+        )
+        consumer_group_result_state = str(consumer_groups_result.state)
+        consumer_group_state = consumer_group_result_state.split('.')[1]
 
-        except Exception as e:
-            self.log.error("Failed to collect consumer group state: %s for consumer group %s ", e, consumer_group)
         return consumer_group_state
 
     def _list_consumer_group_offsets(self, cg_tp):

--- a/kafka_consumer/datadog_checks/kafka_consumer/client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client.py
@@ -261,7 +261,7 @@ class KafkaClient:
         try:
             consumer_groups_result = consumer_groups_future[consumer_group].result()
             self.log.debug(
-                "Discovered consumer group: %s in state %s",
+                "Consumer group: %s in state %s",
                 consumer_groups_result.group_id,
                 consumer_groups_result.state,
             )
@@ -269,7 +269,7 @@ class KafkaClient:
             consumer_group_state = consumer_group_result_state.split('.')[1]
 
         except Exception as e:
-            self.log.error("Failed to collect consumer group: %s", e)
+            self.log.error("Failed to collect consumer group state: %s for consumer group %s ", e, consumer_group)
         return consumer_group_state
 
     def _list_consumer_group_offsets(self, cg_tp):

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -138,6 +138,7 @@ class KafkaCheck(AgentCheck):
         reported_contexts = 0
         self.log.debug("Reporting consumer offsets and lag metrics")
         for (consumer_group, topic, partition), consumer_offset in consumer_offsets.items():
+            consumer_group_state = self.client.get_consumer_group_state(consumer_group)
             if reported_contexts >= contexts_limit:
                 self.log.debug(
                     "Reported contexts number %s greater than or equal to contexts limit of %s, returning",
@@ -151,6 +152,7 @@ class KafkaCheck(AgentCheck):
                 'partition:%s' % partition,
                 'consumer_group:%s' % consumer_group,
                 'kafka_cluster_id:%s' % cluster_id,
+                'consumer_group_state:%s' % consumer_group_state,
             ]
             consumer_group_tags.extend(self.config._custom_tags)
 

--- a/kafka_consumer/tests/common.py
+++ b/kafka_consumer/tests/common.py
@@ -89,10 +89,21 @@ def get_cluster_id():
     client = AdminClient(config)
     return client.list_topics(timeout=5).cluster_id
 
+def get_consumer_group_state(consumer_group):
+    config = {
+        "bootstrap.servers": INSTANCE['kafka_connect_str'],
+    }
+    config.update(get_authentication_configuration(INSTANCE))
+    client = AdminClient(config)
+    consumer_groups_future = client.describe_consumer_groups([consumer_group])
+    consumer_gp_state = consumer_groups_future[consumer_group].result()
+    consumer_group_result_state = str(consumer_gp_state.state).split('.')[1]
+    return consumer_group_result_state
 
 def assert_check_kafka(aggregator, consumer_groups):
     cluster_id = get_cluster_id()
     for name, consumer_group in consumer_groups.items():
+        consumer_group_state = get_consumer_group_state(name)
         for topic, partitions in consumer_group.items():
             for partition in partitions:
                 tags = [f"topic:{topic}", f"partition:{partition}", "kafka_cluster_id:" + cluster_id] + [
@@ -104,7 +115,7 @@ def assert_check_kafka(aggregator, consumer_groups):
                 for mname in CONSUMER_METRICS:
                     aggregator.assert_metric(
                         mname,
-                        tags=tags + [f"consumer_group:{name}"],
+                        tags=tags + [f"consumer_group:{name}"] + [f"consumer_group_state:{consumer_group_state}"],
                         count=1,
                     )
 

--- a/kafka_consumer/tests/common.py
+++ b/kafka_consumer/tests/common.py
@@ -89,6 +89,7 @@ def get_cluster_id():
     client = AdminClient(config)
     return client.list_topics(timeout=5).cluster_id
 
+
 def get_consumer_group_state(consumer_group):
     config = {
         "bootstrap.servers": INSTANCE['kafka_connect_str'],
@@ -99,6 +100,7 @@ def get_consumer_group_state(consumer_group):
     consumer_gp_state = consumer_groups_future[consumer_group].result()
     consumer_group_result_state = str(consumer_gp_state.state).split('.')[1]
     return consumer_group_result_state
+
 
 def assert_check_kafka(aggregator, consumer_groups):
     cluster_id = get_cluster_id()

--- a/kafka_consumer/tests/common.py
+++ b/kafka_consumer/tests/common.py
@@ -105,7 +105,7 @@ def assert_check_kafka(aggregator, consumer_groups):
                     aggregator.assert_metric(mname)
                     t = tags + [f"consumer_group:{name}"]
                     aggregator.assert_metric_has_tags(mname, t)
-                    aggregator.assert_metric_has_tag_prefix(mname, tag_prefix='consumer_groupe_state', at_least=0)
+                    aggregator.assert_metric_has_tag_prefix(mname, tag_prefix='consumer_group_state')
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())

--- a/kafka_consumer/tests/common.py
+++ b/kafka_consumer/tests/common.py
@@ -105,6 +105,7 @@ def assert_check_kafka(aggregator, consumer_groups):
                     aggregator.assert_metric(mname)
                     t = tags + [f"consumer_group:{name}"]
                     aggregator.assert_metric_has_tags(mname, t)
+                    # Check for the tag consumer_group_state
                     aggregator.assert_metric_has_tag_prefix(mname, tag_prefix='consumer_group_state')
 
     aggregator.assert_all_metrics_covered()

--- a/kafka_consumer/tests/common.py
+++ b/kafka_consumer/tests/common.py
@@ -104,9 +104,9 @@ def assert_check_kafka(aggregator, consumer_groups):
                 for mname in CONSUMER_METRICS:
                     aggregator.assert_metric(mname)
                     t = tags + [f"consumer_group:{name}"]
-                    aggregator.assert_metric_has_tags(mname, t)
-                    # Check for the tag consumer_group_state
-                    aggregator.assert_metric_has_tag_prefix(mname, tag_prefix='consumer_group_state')
+                    if aggregator.assert_metric_has_tags(mname, t):
+                        # Check for the tag consumer_group_state
+                        aggregator.assert_metric_has_tag_prefix(mname, tag_prefix='consumer_group_state')
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())

--- a/kafka_consumer/tests/common.py
+++ b/kafka_consumer/tests/common.py
@@ -105,7 +105,7 @@ def assert_check_kafka(aggregator, consumer_groups):
                     aggregator.assert_metric(mname)
                     t = tags + [f"consumer_group:{name}"]
                     aggregator.assert_metric_has_tags(mname, t)
-                    aggregator.assert_metric_has_tag_prefix(mname, "consumer_groupe_state")
+                    aggregator.assert_metric_has_tag_prefix(mname, tag_prefix='consumer_groupe_state', at_least=0)
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())

--- a/kafka_consumer/tests/common.py
+++ b/kafka_consumer/tests/common.py
@@ -105,6 +105,7 @@ def assert_check_kafka(aggregator, consumer_groups):
                     aggregator.assert_metric(mname)
                     t = tags + [f"consumer_group:{name}"]
                     aggregator.assert_metric_has_tags(mname, t)
+                    aggregator.assert_metric_has_tag_prefix(mname, "consumer_groupe_state")
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -162,6 +162,7 @@ def test_when_consumer_lag_less_than_zero_then_emit_event(
     mock_client.get_consumer_offsets.return_value = consumer_offset
     mock_client.get_highwater_offsets.return_value = (highwater_offset, "cluster_id")
     mock_client.get_partitions_for_topic.return_value = ['partition1']
+    mock_client.get_consumer_group_state.return_value = "STABLE"
     mock_generic_client.return_value = mock_client
 
     # When
@@ -183,6 +184,7 @@ def test_when_consumer_lag_less_than_zero_then_emit_event(
             'partition:partition1',
             'topic:topic1',
             'kafka_cluster_id:cluster_id',
+            'consumer_group_state:STABLE',
         ],
     )
     aggregator.assert_metric(
@@ -194,6 +196,7 @@ def test_when_consumer_lag_less_than_zero_then_emit_event(
             'partition:partition1',
             'topic:topic1',
             'kafka_cluster_id:cluster_id',
+            'consumer_group_state:STABLE',
         ],
     )
     aggregator.assert_event(
@@ -208,6 +211,7 @@ def test_when_consumer_lag_less_than_zero_then_emit_event(
             'partition:partition1',
             'topic:topic1',
             'kafka_cluster_id:cluster_id',
+            'consumer_group_state:STABLE',
         ],
     )
 

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -383,8 +383,6 @@ def test_when_empty_string_consumer_group_then_skip(kafka_instance):
         kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [kafka_instance])
         assert kafka_consumer_check.client._get_consumer_groups() == ["my_consumer"]
 
-#def test_consumer_group_state_collection():
-
 
 def test_get_interpolated_timestamp():
     assert _get_interpolated_timestamp({0: 100, 10: 200}, 5) == 150

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -379,6 +379,8 @@ def test_when_empty_string_consumer_group_then_skip(kafka_instance):
         kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [kafka_instance])
         assert kafka_consumer_check.client._get_consumer_groups() == ["my_consumer"]
 
+#def test_consumer_group_state_collection():
+
 
 def test_get_interpolated_timestamp():
     assert _get_interpolated_timestamp({0: 100, 10: 200}, 5) == 150


### PR DESCRIPTION
### What does this PR do?
Add the consumer group state as tag

### Motivation
https://datadoghq.atlassian.net/browse/AI-3859

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
