### PR TITLE
[mongo] Only emit database_instance when dbm is enabled

### DIFF
--- a/mongo/changelog.d/17697.fixed
+++ b/mongo/changelog.d/17697.fixed
@@ -1,0 +1,1 @@
+Only emit database_instance metadata when dbm is enabled

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -226,11 +226,11 @@ class MongoDb(AgentCheck):
         try:
             self._refresh_metadata()
             self._refresh_deployment()
-            self._send_database_instance_metadata()
             self._collect_metrics()
 
             # DBM
             if self._config.dbm_enabled:
+                self._send_database_instance_metadata()
                 self._operation_samples.run_job_loop(tags=self._get_tags(include_deployment_tags=True))
         except CRITICAL_FAILURE as e:
             self.service_check(SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=self._config.service_check_tags)


### PR DESCRIPTION
### What does this PR do?
This PR changed emitting `database_instance` metadata for mongo only when `dbm` is enabled.

### Motivation
We've observed conflict mongo database_instance collected from `serverStatus.host` for mongo on k8s. The database_instance conflict causes tag flip when 2 mongodb instances emit the same database_instance.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
