### PR TITLE
Update pymysql from v1.1.0 to v1.1.1

### DIFF
--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -67,7 +67,7 @@ pyjwt==2.8.0; python_version > '3.0'
 pymongo[srv]==4.7.1; python_version >= '3.9'
 pymqi==1.12.10; (sys_platform != 'darwin' or platform_machine != 'arm64') and python_version > '3.0'
 pymysql==0.10.1; python_version < '3.0'
-pymysql==1.1.0; python_version > '3.0'
+pymysql==1.1.1; python_version > '3.0'
 pyodbc==5.1.0; (sys_platform != 'darwin' or platform_machine != 'arm64') and python_version > '3.0'
 pyopenssl==24.1.0; python_version > '3.0'
 pysmi==0.3.4

--- a/cacti/changelog.d/17704.security
+++ b/cacti/changelog.d/17704.security
@@ -1,0 +1,1 @@
+Update pymysql from v1.1.0 to v1.1.1

--- a/cacti/pyproject.toml
+++ b/cacti/pyproject.toml
@@ -40,7 +40,7 @@ dynamic = [
 [project.optional-dependencies]
 deps = [
     "pymysql==0.10.1; python_version < '3.0'",
-    "pymysql==1.1.0; python_version > '3.0'",
+    "pymysql==1.1.1; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/mysql/changelog.d/17704.security
+++ b/mysql/changelog.d/17704.security
@@ -1,0 +1,1 @@
+Update pymysql from v1.1.0 to v1.1.1

--- a/mysql/hatch.toml
+++ b/mysql/hatch.toml
@@ -10,7 +10,7 @@ mypy-args = [
 mypy-deps = [
   "types-cachetools==0.1.10",
   "types-enum34==1.1.1",
-  "types-pymysql==1.1.0.1",
+  "types-pymysql==1.1.1.1",
 ]
 
 [[envs.default.matrix]]

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -42,7 +42,7 @@ deps = [
     "cryptography==3.3.2; python_version < '3.0'",
     "cryptography==42.0.6; python_version > '3.0'",
     "pymysql==0.10.1; python_version < '3.0'",
-    "pymysql==1.1.0; python_version > '3.0'",
+    "pymysql==1.1.1; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/proxysql/changelog.d/17704.security
+++ b/proxysql/changelog.d/17704.security
@@ -1,0 +1,1 @@
+Update pymysql from v1.1.0 to v1.1.1

--- a/proxysql/pyproject.toml
+++ b/proxysql/pyproject.toml
@@ -40,7 +40,7 @@ dynamic = [
 [project.optional-dependencies]
 deps = [
     "pymysql==0.10.1; python_version < '3.0'",
-    "pymysql==1.1.0; python_version > '3.0'",
+    "pymysql==1.1.1; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/singlestore/changelog.d/17704.security
+++ b/singlestore/changelog.d/17704.security
@@ -1,0 +1,1 @@
+Update pymysql from v1.1.0 to v1.1.1

--- a/singlestore/hatch.toml
+++ b/singlestore/hatch.toml
@@ -9,7 +9,7 @@ mypy-args = [
     "datadog_checks/singlestore",
 ]
 mypy-deps = [
-  "types-PyMySQL==1.1.0.1",
+  "types-pymysql==1.1.1.1",
 ]
 
 [[envs.default.matrix]]

--- a/singlestore/pyproject.toml
+++ b/singlestore/pyproject.toml
@@ -40,7 +40,7 @@ dynamic = [
 [project.optional-dependencies]
 deps = [
     "pymysql==0.10.1; python_version < '3.0'",
-    "pymysql==1.1.0; python_version > '3.0'",
+    "pymysql==1.1.1; python_version > '3.0'",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?
Update pymsql from v1.1.0 to v1.1.1

### Motivation
https://github.com/DataDog/image-vuln-scans/issues/1489

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
