### PR TITLE
[SQLServer] Filter query metrics by database_name if check is configured to a single non-master db

### DIFF
--- a/sqlserver/changelog.d/17717.fixed
+++ b/sqlserver/changelog.d/17717.fixed
@@ -1,0 +1,1 @@
+Filter query metrics by database_name if check is configured to a single non-master db

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -1014,3 +1014,60 @@ def test_metrics_lookback_multiplier(instance_docker):
 
     check.statement_metrics._load_raw_query_metrics_rows(mock_cursor)
     mock_cursor.execute.assert_called_with(ANY, (6,))
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize(
+    "configured_database,database_autodiscovery,filter_to_configured_database",
+    [
+        pytest.param(None, False, False, id="no_database_configured"),  # should default to master
+        pytest.param(
+            "datadog_test", False, True, id="configured_database_datadog_test"
+        ),  # should use configured database datadog_test
+        pytest.param("master", False, False, id="configured_database_master"),  # should use configured database master
+        pytest.param(None, True, False, id="autodiscovered_database"),  # should use autodiscovered database
+    ],
+)
+def test_statement_with_metrics_filtered_to_configured_database(
+    aggregator,
+    dd_run_check,
+    dbm_instance,
+    bob_conn,
+    configured_database,
+    database_autodiscovery,
+    filter_to_configured_database,
+):
+    if configured_database:
+        dbm_instance['database'] = configured_database
+    dbm_instance['database_autodiscovery'] = database_autodiscovery
+    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
+
+    def _execute_queries():
+        bob_conn.execute_with_retries("SELECT * FROM ϑings", (), database="datadog_test")
+        bob_conn.execute_with_retries("SELECT count(*) from sys.databases", (), database="master")
+
+    dd_run_check(check)
+    _execute_queries()
+    dd_run_check(check)
+    aggregator.reset()
+    _execute_queries()
+    dd_run_check(check)
+
+    # dbm-metrics
+    dbm_metrics = aggregator.get_event_platform_events("dbm-metrics")
+    assert len(dbm_metrics) == 1, "should have collected exactly one dbm-metrics payload"
+    payload = dbm_metrics[0]
+    # metrics rows
+    sqlserver_rows = payload.get('sqlserver_rows', [])
+    assert sqlserver_rows, "should have collected some sqlserver query metrics rows"
+    if filter_to_configured_database:
+        assert all(
+            row['database_name'] == configured_database for row in sqlserver_rows
+        ), "should have only collected metrics for configured database"
+    else:
+        # {"master", "datadog_test"} should be present in the metrics database names
+        assert {row['database_name'] for row in sqlserver_rows} - {
+            "master",
+            "datadog_test",
+        }, "should have collected metrics for master and datadog_test databases"


### PR DESCRIPTION
### What does this PR do?
This PR adds filters to sqlserver query metrics to exclude metrics from databases that are not configured to be monitored. When the check is configured to only monitor a single non-master database (with database_autodiscovery disabled), query metrics from unmonitored databases are filtered out. 

Prior to the fix, query metrics from multiple databases are collected on Azure SQL Database, which is supposed to have access contained to a single database.
<img width="1339" alt="image" src="https://github.com/DataDog/integrations-core/assets/4964070/84b58b5d-48a1-46be-aa50-36141d933054">

With the fix, query metrics from unmonitored databases are not included, even when using admin user to monitor (although highly not recommended).
<img width="1332" alt="image" src="https://github.com/DataDog/integrations-core/assets/4964070/18bebd92-e672-4842-94b8-5fdc1fb2c404">

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4135
This change is to ensure not including query metrics from unmonitored databases. On Azure SQL Database, if the check is configured to use an admin user, additional query metrics from database `master` and other databases (db name cannot be resolved hence all grouped under tag `db:N/A`) can be retrieved from `sys.dm_exec_query_stats`. This has caused query metrics inflation as the access in Azure SQL Database should be contained to a single database.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
