### PR TITLE
[containers] Use global time picker for container overview dashboard widgets 

### DIFF
--- a/container/assets/dashboards/containers.json
+++ b/container/assets/dashboards/containers.json
@@ -18,7 +18,7 @@
         {
             "id": 4,
             "definition": {
-                "title": "Running containers",
+                "title": "Running containers in the past minute",
                 "title_size": "16",
                 "title_align": "center",
                 "time": {
@@ -56,7 +56,7 @@
         {
             "id": 11,
             "definition": {
-                "title": "Running container change",
+                "title": "Running container changes in the past 5 minutes",
                 "title_size": "16",
                 "title_align": "center",
                 "time": {
@@ -135,9 +135,7 @@
                                 "value",
                                 "sum"
                             ],
-                            "time": {
-                                "live_span": "1h"
-                            },
+                            "time": {},
                             "type": "timeseries",
                             "requests": [
                                 {
@@ -178,9 +176,7 @@
                                 "value",
                                 "sum"
                             ],
-                            "time": {
-                                "live_span": "1h"
-                            },
+                            "time": {},
                             "type": "timeseries",
                             "requests": [
                                 {
@@ -221,9 +217,7 @@
                                 "value",
                                 "sum"
                             ],
-                            "time": {
-                                "live_span": "1h"
-                            },
+                            "time": {},
                             "type": "timeseries",
                             "requests": [
                                 {
@@ -261,9 +255,7 @@
                             "title": "Most CPU-intensive containers",
                             "title_size": "16",
                             "title_align": "left",
-                            "time": {
-                                "live_span": "1h"
-                            },
+                            "time": {},
                             "type": "toplist",
                             "requests": [
                                 {
@@ -300,9 +292,7 @@
                             "title_size": "16",
                             "title_align": "left",
                             "show_legend": false,
-                            "time": {
-                                "live_span": "1h"
-                            },
+                            "time": {},
                             "type": "heatmap",
                             "custom_links": [],
                             "requests": [
@@ -342,9 +332,7 @@
                                 "value",
                                 "sum"
                             ],
-                            "time": {
-                                "live_span": "1h"
-                            },
+                            "time": {},
                             "type": "timeseries",
                             "requests": [
                                 {
@@ -387,9 +375,7 @@
                                 "value",
                                 "sum"
                             ],
-                            "time": {
-                                "live_span": "1h"
-                            },
+                            "time": {},
                             "type": "timeseries",
                             "requests": [
                                 {
@@ -432,9 +418,7 @@
                                 "value",
                                 "sum"
                             ],
-                            "time": {
-                                "live_span": "1h"
-                            },
+                            "time": {},
                             "type": "timeseries",
                             "requests": [
                                 {
@@ -468,9 +452,7 @@
                             "title": "Most RAM-intensive containers",
                             "title_size": "16",
                             "title_align": "left",
-                            "time": {
-                                "live_span": "1h"
-                            },
+                            "time": {},
                             "type": "toplist",
                             "requests": [
                                 {
@@ -507,9 +489,7 @@
                             "title_size": "16",
                             "title_align": "left",
                             "show_legend": false,
-                            "time": {
-                                "live_span": "1h"
-                            },
+                            "time": {},
                             "type": "heatmap",
                             "custom_links": [],
                             "requests": [
@@ -589,9 +569,7 @@
                                 "value",
                                 "sum"
                             ],
-                            "time": {
-                                "live_span": "1h"
-                            },
+                            "time": {},
                             "type": "timeseries",
                             "requests": [
                                 {
@@ -624,9 +602,7 @@
                             "title_size": "16",
                             "title_align": "left",
                             "show_legend": false,
-                            "time": {
-                                "live_span": "1h"
-                            },
+                            "time": {},
                             "type": "heatmap",
                             "custom_links": [],
                             "requests": [
@@ -645,9 +621,7 @@
                             "title": "Most tx-intensive containers",
                             "title_size": "16",
                             "title_align": "left",
-                            "time": {
-                                "live_span": "1h"
-                            },
+                            "time": {},
                             "type": "toplist",
                             "requests": [
                                 {
@@ -704,9 +678,7 @@
                                 "value",
                                 "sum"
                             ],
-                            "time": {
-                                "live_span": "1h"
-                            },
+                            "time": {},
                             "type": "timeseries",
                             "requests": [
                                 {
@@ -747,9 +719,7 @@
                                 "value",
                                 "sum"
                             ],
-                            "time": {
-                                "live_span": "1h"
-                            },
+                            "time": {},
                             "type": "timeseries",
                             "requests": [
                                 {
@@ -790,9 +760,7 @@
                                 "value",
                                 "sum"
                             ],
-                            "time": {
-                                "live_span": "1h"
-                            },
+                            "time": {},
                             "type": "timeseries",
                             "requests": [
                                 {
@@ -833,9 +801,7 @@
                                 "value",
                                 "sum"
                             ],
-                            "time": {
-                                "live_span": "1h"
-                            },
+                            "time": {},
                             "type": "timeseries",
                             "requests": [
                                 {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update widgets in the container overview dashboard to use the global time picker.

### Motivation
<!-- What inspired you to submit this pull request? -->
Minor improvement to current OOTB dashboard.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
