### PR TITLE
Use a forced metric type of gauge for ccmRejectedPhones and ccmUnregisteredPhones.

### DIFF
--- a/snmp/changelog.d/17722.fixed
+++ b/snmp/changelog.d/17722.fixed
@@ -1,0 +1,1 @@
+Use a forced metric type of gauge for ccmRejectedPhones and ccmUnregisteredPhones so they are not incorrectly inferred to be rate types.

--- a/snmp/datadog_checks/snmp/data/default_profiles/_cisco-voice.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_cisco-voice.yaml
@@ -74,10 +74,12 @@ metrics:
       name: ccmRegisteredPhones
       OID: 1.3.6.1.4.1.9.9.156.1.5.5.0
   - MIB: CISCO-CCM-MIB
+    metric_type: gauge
     symbol:
       name: ccmRejectedPhones
       OID: 1.3.6.1.4.1.9.9.156.1.5.7.0
   - MIB: CISCO-CCM-MIB
+    metric_type: gauge
     symbol:
       name: ccmUnregisteredPhones
       OID: 1.3.6.1.4.1.9.9.156.1.5.6.0

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -182,12 +182,7 @@ def test_cisco_voice(aggregator):
     for cvp in cvp_gauges:
         aggregator.assert_metric('snmp.{}'.format(cvp), metric_type=aggregator.GAUGE, tags=tags)
 
-    ccms_counts = ["ccmRejectedPhones", "ccmUnregisteredPhones"]
-
-    ccms_gauges = ["ccmRegisteredGateways", "ccmRegisteredPhones"]
-
-    for ccm in ccms_counts:
-        aggregator.assert_metric('snmp.{}'.format(ccm), metric_type=aggregator.RATE, tags=tags)
+    ccms_gauges = ["ccmRegisteredGateways", "ccmRegisteredPhones", "ccmRejectedPhones", "ccmUnregisteredPhones"]
 
     for ccm in ccms_gauges:
         aggregator.assert_metric('snmp.{}'.format(ccm), metric_type=aggregator.GAUGE, tags=tags)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Use a forced metric type of gauge for ccmRejectedPhones and ccmUnregisteredPhones in the _cisco-voice.yaml default profile.  Without this those two metrics are incorrectly inferred to be rates. 

### Motivation
<!-- What inspired you to submit this pull request? -->
A customer reported the issue.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
To test:
1) ddev env start snmp py3.11-false -e DD_TAGS="ndm_qa:test-17722" -e DD_SITE=datad0g.com -e DD_DD_URL=https://app.datad0g.com -e DD_API_KEY=$DATADOG_STAGING_ORG2_API_KEY
2) ddev env config edit snmp py3.11-false
Change community_string from public to cisco_icm
3) ddev env reload snmp py3.11-false
4) Go to https://dd.datad0g.com/metric/explorer and confirm that ccmRejectedPhones and ccmUnregisteredPhones metrics show up as non-zero.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
