### PR TITLE
[Backport 7.54.x] Trigger dependency build-related jobs on release branches too

### DIFF
--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
     - master
+    - 7.*.*
     paths:
     - .github/workflows/build-deps.yml
     - .builders/**
@@ -11,6 +12,7 @@ on:
   push:
     branches:
     - master
+    - 7.*.*
     paths:
     - .builders/**
     - agent_requirements.in


### PR DESCRIPTION

### Motivation

Required to trigger dependency resolutions that target this release branch.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
