### PR TITLE
[mongo] include namespace in samples operation_metadata

### DIFF
--- a/mongo/datadog_checks/mongo/dbm/operation_samples.py
+++ b/mongo/datadog_checks/mongo/dbm/operation_samples.py
@@ -300,6 +300,7 @@ class MongoOperationSamples(DBMAsyncJob):
             "truncated": self._get_command_truncation_state(command),
             "client": self._get_operation_client(operation),
             "user": self._get_operation_user(operation),
+            "ns": namespace,
         }
 
     def _get_operation_stats(self, operation: dict) -> OperationSampleOperationStats:
@@ -361,6 +362,7 @@ class MongoOperationSamples(DBMAsyncJob):
                     "shard": operation_metadata["shard"],
                     "collection": operation_metadata["collection"],
                     "comment": operation_metadata["comment"],
+                    "ns": operation_metadata["ns"],
                 },
                 "query_truncated": operation_metadata["truncated"],
             },

--- a/mongo/datadog_checks/mongo/dbm/types.py
+++ b/mongo/datadog_checks/mongo/dbm/types.py
@@ -148,6 +148,7 @@ class OperationSampleOperationMetadata(TypedDict, total=False):
     truncated: Optional[str]
     client: OperationSampleClient
     user: Optional[str]
+    ns: Optional[str]
 
 
 class OperationSampleActivityRecord(

--- a/mongo/tests/results/operation-samples-mongos.json
+++ b/mongo/tests/results/operation-samples-mongos.json
@@ -704,7 +704,8 @@
                 "op": "query",
                 "shard": "shard04",
                 "collection": "users",
-                "comment": "sort"
+                "comment": "sort",
+                "ns": "integration.$cmd"
             },
             "query_truncated": "not_truncated"
         },

--- a/mongo/tests/results/operation-samples-standalone.json
+++ b/mongo/tests/results/operation-samples-standalone.json
@@ -125,7 +125,8 @@
                 "op": "query",
                 "shard": null,
                 "collection": "products",
-                "comment": "find"
+                "comment": "find",
+                "ns": "integration.products"
             },
             "query_truncated": "not_truncated"
         },


### PR DESCRIPTION
### What does this PR do?
This PR includes `ns` in dbm samples `operation_metadata`

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
