### PR TITLE
Add dd_security_events option to spec

### DIFF
--- a/win32_event_log/assets/configuration/spec.yaml
+++ b/win32_event_log/assets/configuration/spec.yaml
@@ -96,7 +96,7 @@ files:
         The `dd_security_events` option cannot be used with the `path` option.
       value:
         type: string
-        display_default: None
+        display_default:
         example: high
         enum:
         - high

--- a/win32_event_log/assets/configuration/spec.yaml
+++ b/win32_event_log/assets/configuration/spec.yaml
@@ -80,8 +80,27 @@ files:
         channel (you cannot subscribe to Analytic or Debug channels).
 
         The path is required if `legacy_mode` is set to `false`.
+
+        The `path` option cannot be used with the `dd_security_events` option.
       value:
         type: string
+    - name: dd_security_events
+      description: |
+        Starting with Agent 7.54, you can automatically send Security Events to Datadog as Logs
+        by using the `dd_security_events` option.
+
+        Supported values:
+          - `low`: sends only the most important and crtical Security events
+          - `high`: sends a higher volume of Security events
+
+        The `dd_security_events` option cannot be used with the `path` option.
+      value:
+        type: string
+        display_default: None
+        example: high
+        enum:
+        - high
+        - low
     - name: start
       description: |
         The point at which to start the event subscription.

--- a/win32_event_log/datadog_checks/win32_event_log/check.py
+++ b/win32_event_log/datadog_checks/win32_event_log/check.py
@@ -59,6 +59,8 @@ class Win32EventLogCheck(AgentCheck, ConfigMixin):
         'event_format',
     )
 
+    NEW_PARAMS = ('dd_security_events',)
+
     # https://docs.microsoft.com/en-us/windows/win32/wes/eventmanifestschema-leveltype-complextype#remarks
     #
     # From
@@ -153,6 +155,10 @@ class Win32EventLogCheck(AgentCheck, ConfigMixin):
                 self.log.warning(
                     "%s config option is ignored unless running legacy mode. Please remove it", legacy_param
                 )
+
+        for new_param in self.NEW_PARAMS:
+            if new_param in self.instance:
+                self.warning("%s config option is ignored when running legacy_mode_v2. Please remove it", new_param)
 
     def check(self, _):
         for event in self.consume_events():

--- a/win32_event_log/datadog_checks/win32_event_log/config_models/defaults.py
+++ b/win32_event_log/datadog_checks/win32_event_log/config_models/defaults.py
@@ -40,6 +40,10 @@ def instance_auth_type():
     return 'default'
 
 
+def instance_dd_security_events():
+    return 'None'
+
+
 def instance_disable_generic_tags():
     return False
 

--- a/win32_event_log/datadog_checks/win32_event_log/config_models/defaults.py
+++ b/win32_event_log/datadog_checks/win32_event_log/config_models/defaults.py
@@ -40,10 +40,6 @@ def instance_auth_type():
     return 'default'
 
 
-def instance_dd_security_events():
-    return 'None'
-
-
 def instance_disable_generic_tags():
     return False
 

--- a/win32_event_log/datadog_checks/win32_event_log/config_models/instance.py
+++ b/win32_event_log/datadog_checks/win32_event_log/config_models/instance.py
@@ -49,6 +49,7 @@ class InstanceConfig(BaseModel):
     )
     auth_type: Optional[Literal['default', 'negotiate', 'kerberos', 'ntlm']] = None
     bookmark_frequency: Optional[int] = None
+    dd_security_events: Optional[Literal['high', 'low']] = None
     disable_generic_tags: Optional[bool] = None
     domain: Optional[str] = None
     empty_default_hostname: Optional[bool] = None

--- a/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
+++ b/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
@@ -72,8 +72,22 @@ instances:
     ## channel (you cannot subscribe to Analytic or Debug channels).
     ##
     ## The path is required if `legacy_mode` is set to `false`.
+    ##
+    ## The `path` option cannot be used with the `dd_security_events` option.
     #
     # path: <PATH>
+
+    ## @param dd_security_events - string - optional
+    ## Starting with Agent 7.54, you can automatically send Security Events to Datadog as Logs
+    ## by using the `dd_security_events` option.
+    ##
+    ## Supported values:
+    ##   - `low`: sends only the most important and crtical Security events
+    ##   - `high`: sends a higher volume of Security events
+    ##
+    ## The `dd_security_events` option cannot be used with the `path` option.
+    #
+    # dd_security_events: high
 
     ## @param start - string - optional - default: now
     ## The point at which to start the event subscription.

--- a/win32_event_log/datadog_checks/win32_event_log/legacy/win32_event_log.py
+++ b/win32_event_log/datadog_checks/win32_event_log/legacy/win32_event_log.py
@@ -38,6 +38,7 @@ class Win32EventLogWMI(WinWMICheck):
         'timeout',
         'payload_size',
         'bookmark_frequency',
+        'dd_security_events',
     )
 
     def __init__(self, name, init_config, instances):

--- a/win32_event_log/tests/test_config.py
+++ b/win32_event_log/tests/test_config.py
@@ -25,3 +25,9 @@ def test_legacy_v2_params_notice(dd_run_check, new_check, instance):
     assert (
         'dd_security_events config option is ignored when running legacy_mode_v2. Please remove it'
     ) in check.get_warnings()
+
+
+def test_legacy_v2_params_defaults_dont_notice(dd_run_check, new_check, instance):
+    check = new_check(instance)
+    dd_run_check(check)
+    assert not check.get_warnings()

--- a/win32_event_log/tests/test_config.py
+++ b/win32_event_log/tests/test_config.py
@@ -16,3 +16,12 @@ def test_invalid_message_filter_regular_expression(dd_run_check, new_check, inst
         match='Error compiling pattern for option `{}`: invalid group reference 1 at position 1'.format(option),
     ):
         dd_run_check(check)
+
+
+def test_legacy_v2_params_notice(dd_run_check, new_check, instance):
+    instance['dd_security_events'] = 'high'
+    check = new_check(instance)
+    dd_run_check(check)
+    assert (
+        'dd_security_events config option is ignored when running legacy_mode_v2. Please remove it'
+    ) in check.get_warnings()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add `dd_security_events` to config spec and config example

Add a warning if the option is used in legacy_v2 mode

### Motivation
<!-- What inspired you to submit this pull request? -->
https://datadoghq.atlassian.net/browse/WINA-840

forgot to add in 7.54 when the feature was added, so this is mostly just a docs change

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
