### PR TITLE
Revert "(DOCS-8102) Hide Snowflake agent integration doc"

### DIFF
--- a/snowflake/manifest.json
+++ b/snowflake/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "23e9084d-5801-4a71-88fe-f62b7c1bb289",
   "app_id": "snowflake",
-  "display_on_public_website": false,
+  "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
Reverts DataDog/integrations-core#17731 -- doc-merging logic not yet implemented