### PR TITLE
Using constant values instead of reassigning variables in each check run

### DIFF
--- a/windows_service/changelog.d/17749.fixed
+++ b/windows_service/changelog.d/17749.fixed
@@ -1,0 +1,1 @@
+Using constant values instead of reassigning variables in each check run

--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -115,6 +115,7 @@ class ServiceView(object):
     }
     STARTUP_TYPE_DELAYED_AUTO = "automatic_delayed_start"
     STARTUP_TYPE_UNKNOWN = "unknown"
+    DISPLAY_NAME_UNKNOWN = "Not_Found"
 
     def __init__(self, scm_handle, name):
         self.scm_handle = scm_handle
@@ -308,18 +309,16 @@ class WindowsService(AgentCheck):
             for service in services_unseen:
                 # if a name doesn't match anything (wrong name or no permission to access the service), report UNKNOWN
                 status = self.UNKNOWN
-                startup_type_string = ServiceView.STARTUP_TYPE_UNKNOWN
-                display_name = "Not_Found"
 
                 tags = ['windows_service:{}'.format(service)]
 
                 tags.extend(custom_tags)
 
                 if instance.get('windows_service_startup_type_tag', False):
-                    tags.append('windows_service_startup_type:{}'.format(startup_type_string))
+                    tags.append('windows_service_startup_type:{}'.format(ServiceView.STARTUP_TYPE_UNKNOWN))
 
                 if instance.get('collect_display_name_as_tag', False):
-                    tags.append('display_name:{}'.format(display_name))
+                    tags.append('display_name:{}'.format(ServiceView.DISPLAY_NAME_UNKNOWN))
 
                 if not instance.get('disable_legacy_service_tag', False):
                     self._log_deprecation('service_tag', 'windows_service')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Moving some variables to be constants in the `ServiceView` class rather than being reassigned in each check loop.

### Motivation
<!-- What inspired you to submit this pull request? -->
https://github.com/DataDog/integrations-core/pull/17657#discussion_r1622862493
https://datadoghq.atlassian.net/browse/WINA-795

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
