### PR TITLE
[dbm] fix flapping sqlserver_version

### DIFF
--- a/sqlserver/changelog.d/17750.fixed
+++ b/sqlserver/changelog.d/17750.fixed
@@ -1,0 +1,1 @@
+[sqlserver] fix missing sqlserver_version

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -135,7 +135,7 @@ class SQLServer(AgentCheck):
         self.static_info_cache = TTLCache(
             maxsize=100,
             # cache these for a full day
-            ttl=60 * 5,
+            ttl=60 * 60 * 24,
         )
         # _database_instance_emitted: limit the collection and transmission of the database instance metadata
         self._database_instance_emitted = TTLCache(
@@ -234,7 +234,6 @@ class SQLServer(AgentCheck):
         )
 
     def set_resolved_hostname(self):
-        # load static information cache
         self.load_static_information()
         if self._resolved_hostname is None:
             if self._config.reported_hostname:
@@ -735,6 +734,7 @@ class SQLServer(AgentCheck):
 
     def check(self, _):
         if self.do_check:
+            self.load_static_information()
             # configure custom queries for the check
             if self._query_manager is None:
                 # use QueryManager to process custom queries

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -135,7 +135,7 @@ class SQLServer(AgentCheck):
         self.static_info_cache = TTLCache(
             maxsize=100,
             # cache these for a full day
-            ttl=60 * 60 * 24,
+            ttl=60 * 5,
         )
         # _database_instance_emitted: limit the collection and transmission of the database instance metadata
         self._database_instance_emitted = TTLCache(
@@ -747,14 +747,13 @@ class SQLServer(AgentCheck):
                     [QUERY_SERVER_STATIC_INFO], executor=self.execute_query_raw
                 )
                 self.server_state_queries.compile_queries()
-
-            self._send_database_instance_metadata()
             if self._config.proc:
                 self.do_stored_procedure_check()
             else:
                 self.collect_metrics()
             if self._config.autodiscovery and self._config.autodiscovery_db_service_check:
                 self._check_database_conns()
+            self._send_database_instance_metadata()
             if self._config.dbm_enabled:
                 self.statement_metrics.run_job_loop(self.tags)
                 self.procedure_metrics.run_job_loop(self.tags)

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -747,13 +747,14 @@ class SQLServer(AgentCheck):
                     [QUERY_SERVER_STATIC_INFO], executor=self.execute_query_raw
                 )
                 self.server_state_queries.compile_queries()
+
+            self._send_database_instance_metadata()
             if self._config.proc:
                 self.do_stored_procedure_check()
             else:
                 self.collect_metrics()
             if self._config.autodiscovery and self._config.autodiscovery_db_service_check:
                 self._check_database_conns()
-            self._send_database_instance_metadata()
             if self._config.dbm_enabled:
                 self.statement_metrics.run_job_loop(self.tags)
                 self.procedure_metrics.run_job_loop(self.tags)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We received customer reports about missing `sqlserver_version`. The problem is that we store the version in a cache that has a 1 day TTL, and we never refresh the cache. The fix is to refresh the cache during each check run.

You can see the problem here where I changed the TTL to 5 minutes:

<img width="1177" alt="image" src="https://github.com/DataDog/integrations-core/assets/2474082/eea565b0-41a0-4415-af78-25c5a23dc846">


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
