### PR TITLE
Provide CODECOV_TOKEN as env var to Upload coverage data job

### DIFF
--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -272,3 +272,5 @@ jobs:
       with:
         files: "${{ inputs.target }}/coverage.xml"
         flags: "${{ inputs.target }}"
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### What does this PR do?
Add env var CODECOV_TOKEN to `Upload coverage data` job

### Motivation
Master pipelines have `Error: Codecov token not found. Please provide Codecov token with -t flag.` while running Upload code coverage job. Code coverage data can be beneficial for developers and also used for analytics.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
