### PR TITLE
[sqlserver] Bump embedded odbc driver to 18.3.3.1

### DIFF
--- a/sqlserver/changelog.d/17765.added
+++ b/sqlserver/changelog.d/17765.added
@@ -1,0 +1,1 @@
+Update embedded odbc driver config odbcinist.ini to use msodbcsql 18.3.3.1

--- a/sqlserver/datadog_checks/sqlserver/data/driver_config/odbcinst.ini
+++ b/sqlserver/datadog_checks/sqlserver/data/driver_config/odbcinst.ini
@@ -6,5 +6,5 @@ Driver=/opt/datadog-agent/embedded/lib/libtdsodbc.so
 
 [ODBC Driver 18 for SQL Server]
 Description=Microsoft ODBC Driver 18 for SQL Server
-Driver=/opt/datadog-agent/embedded/msodbcsql/lib64/libmsodbcsql-18.3.so.2.1
+Driver=/opt/datadog-agent/embedded/msodbcsql/lib64/libmsodbcsql-18.3.so.3.1
 UsageCount=1


### PR DESCRIPTION
### What does this PR do?
This PR updates the embedded odbc driver config to use msodbcsql 18.3.3.1.

Tested with new driver
<img width="1531" alt="image" src="https://github.com/DataDog/integrations-core/assets/4964070/43e0f12f-f14c-432a-8385-073cd9beba48">


### Motivation
<!-- What inspired you to submit this pull request? -->
https://datadoghq.atlassian.net/browse/DBMON-4155

### Additional Notes
depends on https://github.com/DataDog/datadog-agent/pull/26195

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
