### PR TITLE
Update pydantic to v2.7.3

### DIFF
--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -61,7 +61,7 @@ psutil==5.9.0
 psycopg2-binary==2.9.9; python_version > '3.0'
 pyasn1==0.4.6
 pycryptodomex==3.20.0
-pydantic==2.0.2; python_version > '3.0'
+pydantic==2.7.3; python_version > '3.0'
 pyjwt==1.7.1; python_version < '3.0'
 pyjwt==2.8.0; python_version > '3.0'
 pymongo[srv]==4.7.1; python_version >= '3.9'

--- a/datadog_checks_base/changelog.d/17781.changed
+++ b/datadog_checks_base/changelog.d/17781.changed
@@ -1,0 +1,1 @@
+Update pydantic to v2.7.3

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -55,7 +55,7 @@ deps = [
     "prometheus-client==0.20.0; python_version > '3.0'",
     "protobuf==3.17.3; python_version < '3.0'",
     "protobuf==5.26.1; python_version > '3.0'",
-    "pydantic==2.0.2; python_version > '3.0'",
+    "pydantic==2.7.3; python_version > '3.0'",
     "python-dateutil==2.9.0.post0",
     "pywin32==228; sys_platform == 'win32' and python_version < '3.0'",
     "pywin32==306; sys_platform == 'win32' and python_version > '3.0'",

--- a/datadog_checks_dev/changelog.d/17781.fixed
+++ b/datadog_checks_dev/changelog.d/17781.fixed
@@ -1,0 +1,1 @@
+Update pydantic to v2.7.3

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -79,7 +79,7 @@ cli = [
     "pip-tools",
     "pathspec>=0.10.0",
     "platformdirs>=2.0.0a3",
-    "pydantic>=2.0.2, <2.4.0",
+    "pydantic>=2.0.2",
     "pysmi>=0.3.4",
     "securesystemslib[crypto]==0.28.0",
     "semver>=2.13.0",

--- a/ddev/changelog.d/17781.fixed
+++ b/ddev/changelog.d/17781.fixed
@@ -1,0 +1,1 @@
+Update pydantic to v2.7.3

--- a/ddev/src/ddev/plugin/external/hatch/environment_collector.py
+++ b/ddev/src/ddev/plugin/external/hatch/environment_collector.py
@@ -147,7 +147,7 @@ class DatadogChecksEnvironmentCollector(EnvironmentCollectorInterface):
                 'black==24.2.0',
                 'ruff==0.3.3',
                 # Keep in sync with: /datadog_checks_base/pyproject.toml
-                'pydantic==2.0.2',
+                'pydantic==2.7.3',
             ],
         }
         config = {'lint': lint_env}

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -17,7 +17,7 @@ $ ddev test postgres -l
 ┃ Name   ┃ Type    ┃ Features ┃ Dependencies    ┃ Environment variables   ┃ Scripts   ┃
 ┡━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
 │ lint   │ virtual │          │ black==22.12.0  │                         │ all       │
-│        │         │          │ pydantic==2.0.2 │                         │ fmt       │
+│        │         │          │ pydantic==2.7.3 │                         │ fmt       │
 │        │         │          │ ruff==0.0.257   │                         │ style     │
 ├────────┼─────────┼──────────┼─────────────────┼─────────────────────────┼───────────┤
 │ latest │ virtual │ deps     │                 │ POSTGRES_VERSION=latest │ benchmark │


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
Pydantic v2.7.3 update is a breaking change for datadog_checks_base. This requires datamodel-code-generator to be updated which results in the auto generated model names to be updated for multiple of integrations, it basically pluralizes the model names, for example `Counter` becomes `Counters`. So the `ddev validate models` will fail for this PR for all the affected integrations.

The corrective path for that is to use the to be released datadog_checks_base version (mostly v37.0.0) and then run ddev validate models to fix the integrations. Apply those changes and release all the affected integrations.

This is a case of circular dependency, we are going to solve this by allowing the master pipeline to be in an unstable state (i.e., failing pipelines) for few hours till this is resolved.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
