### PR TITLE
[mongo] skip emit samples on unexplainable operations

### DIFF
--- a/mongo/changelog.d/17785.fixed
+++ b/mongo/changelog.d/17785.fixed
@@ -1,0 +1,1 @@
+Skip emitting mongodb samples on unexplainable operations

--- a/mongo/datadog_checks/mongo/dbm/operation_samples.py
+++ b/mongo/datadog_checks/mongo/dbm/operation_samples.py
@@ -125,6 +125,7 @@ class MongoOperationSamples(DBMAsyncJob):
                     explain_plan_cache_key=(operation_metadata["dbname"], query_signature),
                 ):
                     yield activity, None
+                    continue
 
                 explain_plan = self._get_explain_plan(
                     op=operation.get("op"), command=command, dbname=operation_metadata["dbname"]


### PR DESCRIPTION
### What does this PR do?
This PR skips emitting mongodb operation samples (DBM only) on unexplainable operations such as getmore. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
