### PR TITLE
ping 8.0.36 version for mysql

### DIFF
--- a/mysql/hatch.toml
+++ b/mysql/hatch.toml
@@ -17,12 +17,12 @@ mypy-deps = [
 python = ["3.11"]
 version = [
   "5.7",  # EOL October 21, 2023
-  "8.0",  # EOL April, 2026
+  "8.0.36",  # EOL April, 2026
 ]
 
 [[envs.default.matrix]]
 python = ["3.11"]
-version = ["8.0"]
+version = ["8.0.36"]
 replication = ["group"]
 
 [[envs.default.matrix]]
@@ -39,9 +39,9 @@ version = [
 
 [envs.default.overrides]
 matrix.version.env-vars = [
-  { key = "COMPOSE_FILE", value = "mysql8.yaml", if = ["8.0"] },
+  { key = "COMPOSE_FILE", value = "mysql8.yaml", if = ["8.0.36"] },
 ]
-name."8.0-group".env-vars = [
+name."8.0.36-group".env-vars = [
   { key = "COMPOSE_FILE", value = "mysql8-group.yaml" },
 ]
 

--- a/mysql/hatch.toml
+++ b/mysql/hatch.toml
@@ -22,7 +22,7 @@ version = [
 
 [[envs.default.matrix]]
 python = ["3.11"]
-version = ["8.0.36"]
+version = ["8.0"]
 replication = ["group"]
 
 [[envs.default.matrix]]
@@ -41,7 +41,7 @@ version = [
 matrix.version.env-vars = [
   { key = "COMPOSE_FILE", value = "mysql8.yaml", if = ["8.0.36"] },
 ]
-name."8.0.36-group".env-vars = [
+name."8.0-group".env-vars = [
   { key = "COMPOSE_FILE", value = "mysql8-group.yaml" },
 ]
 

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -513,7 +513,7 @@ def _mysql_docker_repo():
         # https://github.com/DataDog/integrations-core/pull/4669)
         if MYSQL_VERSION in ('5.6', '5.7'):
             return 'bergerx/mysql-replication'
-        elif MYSQL_VERSION == '8.0' or MYSQL_VERSION == 'latest':
+        elif MYSQL_VERSION.startswith('8') or MYSQL_VERSION == 'latest':
             return 'bitnami/mysql'
     elif MYSQL_FLAVOR == 'mariadb':
         return 'bitnami/mariadb'


### PR DESCRIPTION
### What does this PR do?
This PR pings mysql version `8.0.36` in the test to fix nightly test failure due to container fail to start.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
