### PR TITLE
Remove baremetal allocations microversion check

### DIFF
--- a/openstack_controller/changelog.d/17791.fixed
+++ b/openstack_controller/changelog.d/17791.fixed
@@ -1,0 +1,1 @@
+Remove baremetal allocations microversion check

--- a/openstack_controller/changelog.d/17791.removed
+++ b/openstack_controller/changelog.d/17791.removed
@@ -1,1 +1,0 @@
-Remove baremetal allocations microversion check

--- a/openstack_controller/changelog.d/17791.removed
+++ b/openstack_controller/changelog.d/17791.removed
@@ -1,0 +1,1 @@
+Remove baremetal allocations microversion check

--- a/openstack_controller/datadog_checks/openstack_controller/api/api_rest.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api/api_rest.py
@@ -473,12 +473,6 @@ class ApiRest(Api):
         return response.json().get('drivers', [])
 
     def get_baremetal_allocations(self):
-        if float(self.config.ironic_microversion) < 1.52:
-            self.log.info(
-                "Ironic microversion is below 1.52 and set to %s, cannot collect allocations",
-                self.config.ironic_microversion,
-            )
-            return []
         return self.make_paginated_request(
             '{}/v1/allocations'.format(self._catalog.get_endpoint_by_type(Component.Types.BAREMETAL.value)),
             'allocations',

--- a/openstack_controller/datadog_checks/openstack_controller/api/api_sdk.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api/api_sdk.py
@@ -298,12 +298,6 @@ class ApiSdk(Api):
         return [driver.to_dict(original_names=True) for driver in self.connection.baremetal.drivers()]
 
     def get_baremetal_allocations(self):
-        if float(self.config.ironic_microversion) < 1.52:
-            self.log.info(
-                "Ironic microversion is below 1.52 and set to %s, cannot collect allocations",
-                self.config.ironic_microversion,
-            )
-            return []
         return [
             allocation.to_dict(original_names=True)
             for allocation in self.call_paginated_api(

--- a/openstack_controller/tests/configs.py
+++ b/openstack_controller/tests/configs.py
@@ -237,14 +237,6 @@ REST_IRONIC_MICROVERSION_1_80 = {
     'use_legacy_check_version': False,
 }
 
-REST_IRONIC_MICROVERSION_1_10 = {
-    'keystone_server_url': 'http://127.0.0.1:8080/identity',
-    'username': 'admin',
-    'password': 'password',
-    'ironic_microversion': '1.10',
-    'use_legacy_check_version': False,
-}
-
 REST_MICROVERSION_3_70 = {
     'keystone_server_url': 'http://127.0.0.1:8080/identity',
     'username': 'admin',

--- a/openstack_controller/tests/configs.py
+++ b/openstack_controller/tests/configs.py
@@ -460,13 +460,6 @@ SDK_IRONIC_MICROVERSION_1_80 = {
     'use_legacy_check_version': False,
 }
 
-SDK_IRONIC_MICROVERSION_1_10 = {
-    'openstack_cloud_name': 'test_cloud',
-    'openstack_config_file_path': TEST_OPENSTACK_CONFIG_UNIT_TESTS_PATH,
-    'ironic_microversion': '1.10',
-    'use_legacy_check_version': False,
-}
-
 SDK_MICROVERSION_3_70 = {
     'openstack_cloud_name': 'test_cloud',
     'openstack_config_file_path': TEST_OPENSTACK_CONFIG_UNIT_TESTS_PATH,

--- a/openstack_controller/tests/test_unit_ironic.py
+++ b/openstack_controller/tests/test_unit_ironic.py
@@ -508,30 +508,6 @@ def test_allocations_metrics(aggregator, check, dd_run_check, metrics):
 
 
 @pytest.mark.parametrize(
-    ('instance'),
-    [
-        pytest.param(
-            configs.REST_IRONIC_MICROVERSION_1_10,
-            id='api rest microversion default',
-        ),
-        pytest.param(
-            configs.SDK_IRONIC_MICROVERSION_1_10,
-            id='api sdk microversion default',
-        ),
-    ],
-)
-@pytest.mark.usefixtures('mock_http_get', 'mock_http_post', 'openstack_connection')
-def test_allocations_low_microversion(aggregator, check, dd_run_check, caplog):
-    caplog.set_level(logging.INFO)
-    dd_run_check(check)
-    assert 'Ironic microversion is below 1.52 and set to 1.10, cannot collect allocations' in caplog.text
-    aggregator.assert_metric(
-        'openstack.ironic.allocation.count',
-        count=0,
-    )
-
-
-@pytest.mark.parametrize(
     ('connection_baremetal', 'instance', 'paginated_limit', 'api_type', 'expected_api_calls'),
     [
         pytest.param(


### PR DESCRIPTION
### What does this PR do?
Remove baremetal allocations microversion check

### Motivation
We no longer need microversion checking of baremetal allocations as we handle it the common way like a 400/500 error if it fails.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
