### PR TITLE
Force rebuild of dependencies from scratch 7.54.x

### DIFF
--- a/.builders/.force-rebuild
+++ b/.builders/.force-rebuild
@@ -1,0 +1,1 @@
+A change to forces a rebuild of the docker images


### PR DESCRIPTION
Due to some lack of prevision, https://github.com/DataDog/integrations-core/pull/17709 failed to trigger the dependency resolution that would've made the changes to the Dockerfiles (that affect the buiild) go into effect.

When we managed to trigger the resolution afterwards, the previously defined Docker image continued to be pulled because we rely on changes to the builders file to decide whether to rebuild or not: https://github.com/DataDog/integrations-core/blob/ac4c0569e5b6104b3807b2d921130aa00739be5d/.github/workflows/build-deps.yml#L92-L93

This edge case triggered the actual fix to not be built and uploaded, and thus not propagated to the Agent.

This PR forces a rebuild from scratch to make sure we're using the latest for everything.