### PR TITLE
adding `use_oneshot` parameter to speed up check runs with `psutil.Process().oneshot()`

### DIFF
--- a/process/assets/configuration/spec.yaml
+++ b/process/assets/configuration/spec.yaml
@@ -140,4 +140,11 @@ files:
         value:
           type: integer
           example: 120
+      - name: use_oneshot
+        description: |
+          If set to `true`, the check uses `psutil.Process().oneshot()` to collect and cache process metrics. 
+          This can help speed up the check completion.
+        value:
+          type: boolean
+          example: false
       - template: instances/default

--- a/process/assets/configuration/spec.yaml
+++ b/process/assets/configuration/spec.yaml
@@ -146,5 +146,5 @@ files:
           This can help speed up the check completion.
         value:
           type: boolean
-          example: false
+          example: true
       - template: instances/default

--- a/process/changelog.d/17817.added
+++ b/process/changelog.d/17817.added
@@ -1,1 +1,1 @@
-adding `use_oneshot` parameter to speed up check runs with `psutil.Process().oneshot()`
+Add `use_oneshot` parameter to speed up check runs with `psutil.Process().oneshot()`

--- a/process/changelog.d/17817.added
+++ b/process/changelog.d/17817.added
@@ -1,0 +1,1 @@
+adding `use_oneshot` parameter to speed up check runs with `psutil.Process().oneshot()`

--- a/process/datadog_checks/process/config_models/defaults.py
+++ b/process/datadog_checks/process/config_models/defaults.py
@@ -50,3 +50,7 @@ def instance_pid_cache_duration():
 
 def instance_try_sudo():
     return False
+
+
+def instance_use_oneshot():
+    return False

--- a/process/datadog_checks/process/config_models/defaults.py
+++ b/process/datadog_checks/process/config_models/defaults.py
@@ -53,4 +53,4 @@ def instance_try_sudo():
 
 
 def instance_use_oneshot():
-    return False
+    return True

--- a/process/datadog_checks/process/config_models/instance.py
+++ b/process/datadog_checks/process/config_models/instance.py
@@ -51,6 +51,7 @@ class InstanceConfig(BaseModel):
     tags: Optional[tuple[str, ...]] = None
     thresholds: Optional[MappingProxyType[str, Any]] = None
     try_sudo: Optional[bool] = None
+    use_oneshot: Optional[bool] = None
     user: Optional[str] = None
 
     @model_validator(mode='before')

--- a/process/datadog_checks/process/data/conf.yaml.example
+++ b/process/datadog_checks/process/data/conf.yaml.example
@@ -136,6 +136,12 @@ instances:
     #
     # pid_cache_duration: 120
 
+    ## @param use_oneshot - boolean - optional - default: false
+    ## If set to `true`, the check uses `psutil.Process().oneshot()` to collect and cache process metrics. 
+    ## This can help speed up the check completion.
+    #
+    # use_oneshot: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/process/datadog_checks/process/data/conf.yaml.example
+++ b/process/datadog_checks/process/data/conf.yaml.example
@@ -136,11 +136,11 @@ instances:
     #
     # pid_cache_duration: 120
 
-    ## @param use_oneshot - boolean - optional - default: false
+    ## @param use_oneshot - boolean - optional - default: true
     ## If set to `true`, the check uses `psutil.Process().oneshot()` to collect and cache process metrics. 
     ## This can help speed up the check completion.
     #
-    # use_oneshot: false
+    # use_oneshot: true
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -295,6 +295,7 @@ class ProcessCheck(AgentCheck):
             p = self.process_cache[name][pid]
 
             if self.use_oneshot:
+                self.log.debug("Using psutil Process.oneshot()")
                 with p.oneshot():
                     st = self.run_psutil_methods(pid, p, st, new_process)
             else:

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -77,7 +77,7 @@ class ProcessCheck(AgentCheck):
         self.collect_children = is_affirmative(self.instance.get('collect_children', False))
         self.user = self.instance.get('user', False)
         self.try_sudo = self.instance.get('try_sudo', False)
-        self.use_oneshot = self.instance.get('use_oneshot', False)
+        self.use_oneshot = is_affirmative(self.instance.get('use_oneshot', True))
 
         # ad stands for access denied
         # We cache the PIDs getting this error and don't iterate on them more often than `access_denied_cache_duration``

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -77,6 +77,7 @@ class ProcessCheck(AgentCheck):
         self.collect_children = is_affirmative(self.instance.get('collect_children', False))
         self.user = self.instance.get('user', False)
         self.try_sudo = self.instance.get('try_sudo', False)
+        self.use_oneshot = self.instance.get('use_oneshot', False)
 
         # ad stands for access denied
         # We cache the PIDs getting this error and don't iterate on them more often than `access_denied_cache_duration``
@@ -293,65 +294,74 @@ class ProcessCheck(AgentCheck):
 
             p = self.process_cache[name][pid]
 
-            meminfo = self.psutil_wrapper(p, 'memory_info', ['rss', 'vms'])
-            st['rss'].append(meminfo.get('rss'))
-            st['vms'].append(meminfo.get('vms'))
-
-            mem_percent = self.psutil_wrapper(p, 'memory_percent')
-            st['mem_pct'].append(mem_percent)
-
-            # will fail on win32 and solaris
-            shared_mem = self.psutil_wrapper(p, 'memory_info', ['shared']).get('shared')
-            if shared_mem is not None and meminfo.get('rss') is not None:
-                st['real'].append(meminfo['rss'] - shared_mem)
+            if self.use_oneshot:
+                with p.oneshot():
+                    st = self.run_psutil_methods(pid, p, st, new_process)
             else:
-                st['real'].append(None)
+                st = self.run_psutil_methods(pid, p, st, new_process)
 
-            ctxinfo = self.psutil_wrapper(p, 'num_ctx_switches', ['voluntary', 'involuntary'])
-            st['ctx_swtch_vol'].append(ctxinfo.get('voluntary'))
-            st['ctx_swtch_invol'].append(ctxinfo.get('involuntary'))
+        return st
 
-            st['thr'].append(self.psutil_wrapper(p, 'num_threads'))
+    def run_psutil_methods(self, pid, p, st, new_process):
+        meminfo = self.psutil_wrapper(p, 'memory_info', ['rss', 'vms'])
+        st['rss'].append(meminfo.get('rss'))
+        st['vms'].append(meminfo.get('vms'))
 
-            cpu_percent = self.psutil_wrapper(p, 'cpu_percent')
-            cpu_count = psutil.cpu_count()
-            if not new_process:
-                # psutil returns `0.` for `cpu_percent` the
-                # first time it's sampled on a process,
-                # so save the value only on non-new processes
-                st['cpu'].append(cpu_percent)
-                if cpu_count > 0 and cpu_percent is not None:
-                    st['cpu_norm'].append(cpu_percent / cpu_count)
-                else:
-                    self.log.debug('could not calculate the normalized cpu pct, cpu_count: %s', cpu_count)
-            st['open_fd'].append(self.psutil_wrapper(p, 'num_fds'))
-            st['open_handle'].append(self.psutil_wrapper(p, 'num_handles'))
+        mem_percent = self.psutil_wrapper(p, 'memory_percent')
+        st['mem_pct'].append(mem_percent)
 
-            ioinfo = self.psutil_wrapper(p, 'io_counters', ['read_count', 'write_count', 'read_bytes', 'write_bytes'])
-            st['r_count'].append(ioinfo.get('read_count'))
-            st['w_count'].append(ioinfo.get('write_count'))
-            st['r_bytes'].append(ioinfo.get('read_bytes'))
-            st['w_bytes'].append(ioinfo.get('write_bytes'))
+        # will fail on win32 and solaris
+        shared_mem = self.psutil_wrapper(p, 'memory_info', ['shared']).get('shared')
+        if shared_mem is not None and meminfo.get('rss') is not None:
+            st['real'].append(meminfo['rss'] - shared_mem)
+        else:
+            st['real'].append(None)
 
-            pagefault_stats = self.get_pagefault_stats(pid)
-            if pagefault_stats is not None:
-                (minflt, cminflt, majflt, cmajflt) = pagefault_stats
-                st['minflt'].append(minflt)
-                st['cminflt'].append(cminflt)
-                st['majflt'].append(majflt)
-                st['cmajflt'].append(cmajflt)
+        ctxinfo = self.psutil_wrapper(p, 'num_ctx_switches', ['voluntary', 'involuntary'])
+        st['ctx_swtch_vol'].append(ctxinfo.get('voluntary'))
+        st['ctx_swtch_invol'].append(ctxinfo.get('involuntary'))
+
+        st['thr'].append(self.psutil_wrapper(p, 'num_threads'))
+
+        cpu_percent = self.psutil_wrapper(p, 'cpu_percent')
+        cpu_count = psutil.cpu_count()
+        if not new_process:
+            # psutil returns `0.` for `cpu_percent` the
+            # first time it's sampled on a process,
+            # so save the value only on non-new processes
+            st['cpu'].append(cpu_percent)
+            if cpu_count > 0 and cpu_percent is not None:
+                st['cpu_norm'].append(cpu_percent / cpu_count)
             else:
-                st['minflt'].append(None)
-                st['cminflt'].append(None)
-                st['majflt'].append(None)
-                st['cmajflt'].append(None)
+                self.log.debug('could not calculate the normalized cpu pct, cpu_count: %s', cpu_count)
+        st['open_fd'].append(self.psutil_wrapper(p, 'num_fds'))
+        st['open_handle'].append(self.psutil_wrapper(p, 'num_handles'))
 
-            # calculate process run time
-            create_time = self.psutil_wrapper(p, 'create_time')
-            if create_time is not None:
-                now = time.time()
-                run_time = now - create_time
-                st['run_time'].append(run_time)
+        ioinfo = self.psutil_wrapper(p, 'io_counters', ['read_count', 'write_count', 'read_bytes', 'write_bytes'])
+        st['r_count'].append(ioinfo.get('read_count'))
+        st['w_count'].append(ioinfo.get('write_count'))
+        st['r_bytes'].append(ioinfo.get('read_bytes'))
+        st['w_bytes'].append(ioinfo.get('write_bytes'))
+
+        pagefault_stats = self.get_pagefault_stats(pid)
+        if pagefault_stats is not None:
+            (minflt, cminflt, majflt, cmajflt) = pagefault_stats
+            st['minflt'].append(minflt)
+            st['cminflt'].append(cminflt)
+            st['majflt'].append(majflt)
+            st['cmajflt'].append(cmajflt)
+        else:
+            st['minflt'].append(None)
+            st['cminflt'].append(None)
+            st['majflt'].append(None)
+            st['cmajflt'].append(None)
+
+        # calculate process run time
+        create_time = self.psutil_wrapper(p, 'create_time')
+        if create_time is not None:
+            now = time.time()
+            run_time = now - create_time
+            st['run_time'].append(run_time)
 
         return st
 

--- a/process/hatch.toml
+++ b/process/hatch.toml
@@ -2,3 +2,5 @@
 
 [[envs.default.matrix]]
 python = ["2.7", "3.11"]
+
+[envs.bench]

--- a/process/tests/test_bench.py
+++ b/process/tests/test_bench.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2018-present
+# (C) Datadog, Inc. 2024-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from datadog_checks.process import ProcessCheck

--- a/process/tests/test_bench.py
+++ b/process/tests/test_bench.py
@@ -1,0 +1,36 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from datadog_checks.process import ProcessCheck
+
+from . import common
+
+
+def test_run(benchmark, dd_run_check):
+    instance = {
+        'name': 'py',
+        'search_string': ['python'],
+        'exact_match': False,
+        'ignored_denied_access': True,
+        'thresholds': {'warning': [1, 10], 'critical': [1, 100]},
+    }
+    process = ProcessCheck(common.CHECK_NAME, {}, [instance])
+    dd_run_check(process)
+
+    benchmark(dd_run_check, process)
+
+
+def test_run_oneshot(benchmark, dd_run_check):
+    instance = {
+        'name': 'py',
+        'search_string': ['python'],
+        'exact_match': False,
+        'ignored_denied_access': True,
+        'use_oneshot': True,
+        'thresholds': {'warning': [1, 10], 'critical': [1, 100]},
+    }
+    process = ProcessCheck(common.CHECK_NAME, {}, [instance])
+    dd_run_check(process)
+
+    benchmark(dd_run_check, process)

--- a/process/tests/test_bench.py
+++ b/process/tests/test_bench.py
@@ -13,6 +13,7 @@ def test_run(benchmark, dd_run_check):
         'search_string': ['python'],
         'exact_match': False,
         'ignored_denied_access': True,
+        'use_oneshot': False,
         'thresholds': {'warning': [1, 10], 'critical': [1, 100]},
     }
     process = ProcessCheck(common.CHECK_NAME, {}, [instance])

--- a/process/tests/test_bench.py
+++ b/process/tests/test_bench.py
@@ -1,7 +1,6 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
 from datadog_checks.process import ProcessCheck
 
 from . import common

--- a/process/tests/test_process.py
+++ b/process/tests/test_process.py
@@ -237,7 +237,8 @@ def test_check_missing_process(aggregator, dd_run_check, caplog):
     aggregator.assert_service_check('process.up', count=1, status=process.CRITICAL)
     assert "Unable to find process named ['fooprocess', '/usr/bin/foo'] among processes" in caplog.text
 
-@pytest.mark.parametrize("oneshot",[True,False])
+
+@pytest.mark.parametrize("oneshot", [True, False])
 def test_check_real_process(aggregator, dd_run_check, oneshot):
     "Check that we detect python running (at least this process)"
     from datadog_checks.base.utils.platform import Platform

--- a/process/tests/test_process.py
+++ b/process/tests/test_process.py
@@ -222,14 +222,6 @@ def test_check_filter_user(mock_process, reset_process_list_cache, aggregator, d
     aggregator.assert_metric('system.processes.number', value=2, tags=generate_expected_tags(instance))
 
 
-@patch('psutil.Process', return_value=MockProcess())
-def test_use_oneshot(mock_process, reset_process_list_cache, aggregator, dd_run_check):
-    instance = {'name': 'foo', 'pid': 1, 'use_oneshot': True}
-    process = ProcessCheck(common.CHECK_NAME, {}, [instance])
-    dd_run_check(process)
-    aggregator.assert_metric('system.processes.number', value=1, tags=generate_expected_tags(instance))
-
-
 def test_check_missing_pid(aggregator, dd_run_check):
     instance = {'name': 'foo', 'pid_file': '/foo/bar/baz'}
     process = ProcessCheck(common.CHECK_NAME, {}, [instance])
@@ -245,8 +237,8 @@ def test_check_missing_process(aggregator, dd_run_check, caplog):
     aggregator.assert_service_check('process.up', count=1, status=process.CRITICAL)
     assert "Unable to find process named ['fooprocess', '/usr/bin/foo'] among processes" in caplog.text
 
-
-def test_check_real_process(aggregator, dd_run_check):
+@pytest.mark.parametrize("oneshot",[True,False])
+def test_check_real_process(aggregator, dd_run_check, oneshot):
     "Check that we detect python running (at least this process)"
     from datadog_checks.base.utils.platform import Platform
 
@@ -256,48 +248,7 @@ def test_check_real_process(aggregator, dd_run_check):
         'exact_match': False,
         'ignored_denied_access': True,
         'thresholds': {'warning': [1, 10], 'critical': [1, 100]},
-        'use_oneshot': False,
-    }
-    process = ProcessCheck(common.CHECK_NAME, {}, [instance])
-    expected_tags = generate_expected_tags(instance)
-    dd_run_check(process)
-    for mname in common.PROCESS_METRIC:
-        # cases where we don't actually expect some metrics here:
-        #  - if io_counters() is not available
-        #  - if memory_info_ex() is not available
-        #  - first run so no `cpu.pct`
-        if (
-            (not _PSUTIL_IO_COUNTERS and '.io' in mname)
-            or (not _PSUTIL_MEM_SHARED and 'mem.real' in mname)
-            or mname == 'system.processes.cpu.pct'
-        ):
-            continue
-
-        if Platform.is_windows():
-            metric = common.UNIX_TO_WINDOWS_MAP.get(mname, mname)
-        else:
-            metric = mname
-        aggregator.assert_metric(metric, at_least=1, tags=expected_tags)
-
-    aggregator.assert_service_check('process.up', count=1, tags=expected_tags + ['process:py'])
-
-    # this requires another run
-    dd_run_check(process)
-    aggregator.assert_metric('system.processes.cpu.pct', count=1, tags=expected_tags)
-    aggregator.assert_metric('system.processes.cpu.normalized_pct', count=1, tags=expected_tags)
-
-
-def test_check_real_process_oneshot(aggregator, dd_run_check):
-    "Check that we detect python running (at least this process)"
-    from datadog_checks.base.utils.platform import Platform
-
-    instance = {
-        'name': 'py',
-        'search_string': ['python'],
-        'exact_match': False,
-        'ignored_denied_access': True,
-        'thresholds': {'warning': [1, 10], 'critical': [1, 100]},
-        'use_oneshot': True,
+        'use_oneshot': oneshot,
     }
     process = ProcessCheck(common.CHECK_NAME, {}, [instance])
     expected_tags = generate_expected_tags(instance)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This check adds a bool parameter `use_oneshot` that can be set to true so that the check uses `psutil.Process().oneshot()` (https://psutil.readthedocs.io/en/latest/#psutil.Process.oneshot) to cache metrics and have a ~2x speed up of the check run.

This defaults to `true` so that users are using the quicker/more efficient version of the check.

### Motivation
<!-- What inspired you to submit this pull request? -->
https://datadoghq.atlassian.net/browse/WINA-805

### Additional Notes
<!-- Anything else we should know when reviewing? -->
From psutil docs: https://psutil.readthedocs.io/en/latest/#psutil.Process.oneshot

> The advice is to use this every time you retrieve more than one information about the process.

With this in mind we have set `use_oneshot` to be true by default since the check runs the `psutil.Process` methods often. So far this was tested through ddev on a Windows Laptop and a Linux container.

Benchmark results:
![image](https://github.com/DataDog/integrations-core/assets/36865458/eaec4a20-d104-40ca-b91c-eda1cd70b2b3)


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
