### PR TITLE
Drop testing on mesos-slave versions incompatible with gh runner docker v26

### DIFF
--- a/mesos_slave/hatch.toml
+++ b/mesos_slave/hatch.toml
@@ -2,11 +2,9 @@
 
 [[envs.default.matrix]]
 python = ["2.7", "3.11"]
-version = ["1.0", "1.1", "1.7"]
+version = ["1.7"]
 
 [envs.default.overrides]
 matrix.version.env-vars = [
-  { key = "MESOS_SLAVE_VERSION", value = "1.0.1-2.0.93.ubuntu1404", if = ["1.0"] },
-  { key = "MESOS_SLAVE_VERSION", value = "1.1.0-2.0.107.ubuntu1404", if = ["1.1"] },
   { key = "MESOS_SLAVE_VERSION", value = "1.7.1", if = ["1.7"] },
 ]

--- a/mesos_slave/tests/common.py
+++ b/mesos_slave/tests/common.py
@@ -15,8 +15,7 @@ FIXTURE_DIR = os.path.join(HERE, 'fixtures')
 CHECK_NAME = 'mesos_slave'
 URL = 'http://{}:5051'.format(get_docker_hostname())
 
-# TODO: tests uses mock data which hard codes version '0.22.0'
-MESOS_SLAVE_VERSION = '0.22.0'
+MESOS_SLAVE_VERSION = '1.7.1'
 
 INSTANCE = {'url': URL, 'tasks': ['hello'], 'tags': ['instance:mytag1']}
 

--- a/mesos_slave/tests/fixtures/state.json
+++ b/mesos_slave/tests/fixtures/state.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.22.0",
+  "version": "1.7.1",
   "started_tasks": 0,
   "start_time": 1428673344.06054,
   "staged_tasks": 1,
@@ -113,8 +113,8 @@
       "role": "*"
     }
   ],
-  "git_sha": "e890e2414903bb69cab730d5204f10b10d2e91bb",
-  "git_tag": "0.22.0",
+  "git_sha": "d5678c3c5500cec72e22e775d9d048c55c128954",
+  "git_tag": "1.7.1",
   "hostname": "localhost",
   "id": "20150410-134224-16777343-5050-1778-S0",
   "killed_tasks": 0,


### PR DESCRIPTION
Before: 1.0, 1.1, 1.7
After: 1.7

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
https://datadoghq.atlassian.net/browse/AI-3951

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
