### PR TITLE
Drop testing on rabbitmq versions incompatible with gh runner docker v26

### DIFF
--- a/rabbitmq/hatch.toml
+++ b/rabbitmq/hatch.toml
@@ -9,17 +9,17 @@ dependencies = [
 # Rabbitmq versions <3.8 must be tested on both PY2 and PY3. All these versions use RabbitMQ's management plugin as the source for data.
 [[envs.default.matrix]]
 python = ["2.7", "3.11"]
-version = ["3.5", "3.6", "3.7"]
+version = ["3.7"]
 
 # Rabbitmq versions 3.8+ introduce the Prometheus plugin. This is the preferred way to collect metrics. We drop PY2 support.
 [[envs.default.matrix]]
 python = ["3.11"]
-version = ["3.8", "3.9", "3.10", "3.11"]
+version = ["3.11"]
 
 # We still support metrics from management plugin as a legacy option and continue to support PY2 for them as well.
 [[envs.default.matrix]]
 python = ["2.7", "3.11"]
-version = ["3.8", "3.9", "3.10", "3.11"]
+version = ["3.11"]
 plugin = ["mgmt"]
 
 


### PR DESCRIPTION
py2: remove 3.5, 3.6
py3: rmeove 3.8, 3.9, 3.10

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
