### PR TITLE
Update etcd0 to latest to be compatible with gh runner docker v26

### DIFF
--- a/twemproxy/tests/compose/docker-compose.yaml
+++ b/twemproxy/tests/compose/docker-compose.yaml
@@ -11,22 +11,31 @@ services:
       - "6102:6379"
 
   etcd0:
-    image: quay.io/coreos/etcd:v2.2.0
+    image: quay.io/coreos/etcd:v3.5.14
     volumes:
       - /usr/share/ca-certificates/:/etc/ssl/certs
     ports:
       - 4001:4001
       - 2380:2380
       - 2379:2379
-    command: |
-      -name etcd0
-      -advertise-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001,http://etcd0:2379,http://etcd0:4001
-      -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001
-      -initial-advertise-peer-urls http://0.0.0.0:2380
-      -listen-peer-urls http://0.0.0.0:2380
-      -initial-cluster-token etcd-cluster-1
-      -initial-cluster etcd0=http://0.0.0.0:2380
-      -initial-cluster-state new
+    command:
+      - etcd
+      - -name
+      - etcd0
+      - -advertise-client-urls
+      - http://0.0.0.0:2379,http://0.0.0.0:4001,http://etcd0:2379,http://etcd0:4001
+      - -listen-client-urls
+      - http://0.0.0.0:2379,http://0.0.0.0:4001
+      - -initial-advertise-peer-urls
+      - http://0.0.0.0:2380
+      - -listen-peer-urls
+      - http://0.0.0.0:2380
+      - -initial-cluster-token
+      - etcd-cluster-1
+      - -initial-cluster
+      - etcd0=http://0.0.0.0:2380
+      - -initial-cluster-state
+      - new
     depends_on:
       - redis1
       - redis2


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
