### PR TITLE
Port 7.55 integration releases to master

### DIFF
--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 36.7.1 / 2024-06-11
+
+***Fixed***:
+
+* Bump the `requests` version to 2.32.3 on Python 3 ([#17702](https://github.com/DataDog/integrations-core/pull/17702))
+
 ## 36.7.0 / 2024-05-31
 
 ***Added***:

--- a/datadog_checks_base/changelog.d/17702.fixed
+++ b/datadog_checks_base/changelog.d/17702.fixed
@@ -1,1 +1,0 @@
-Bump the `requests` version to 2.32.3 on Python 3

--- a/datadog_checks_base/datadog_checks/base/__about__.py
+++ b/datadog_checks_base/datadog_checks/base/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = "36.7.0"
+__version__ = "36.7.1"

--- a/kafka_consumer/CHANGELOG.md
+++ b/kafka_consumer/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 4.4.0 / 2024-06-11
+
+***Added***:
+
+* Update confluent_kafka and librdkafka ([#17726](https://github.com/DataDog/integrations-core/pull/17726))
+
 ## 4.3.0 / 2024-03-22 / Agent 7.53.0
 
 ***Added***:

--- a/kafka_consumer/changelog.d/17726.added
+++ b/kafka_consumer/changelog.d/17726.added
@@ -1,1 +1,0 @@
-Update confluent_kafka and librdkafka

--- a/kafka_consumer/datadog_checks/kafka_consumer/__about__.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "4.3.0"
+__version__ = "4.4.0"

--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 12.5.1 / 2024-06-11
+
+***Fixed***:
+
+* Bump the `pymysql` version to 1.1.1 on Python 3 ([#17696](https://github.com/DataDog/integrations-core/pull/17696))
+
 ## 12.5.0 / 2024-05-31
 
 ***Added***:

--- a/mysql/datadog_checks/mysql/__about__.py
+++ b/mysql/datadog_checks/mysql/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "12.5.0"
+__version__ = "12.5.1"

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -25,7 +25,7 @@ datadog-cassandra==1.18.0
 datadog-ceph==2.10.0; sys_platform != 'win32'
 datadog-cert-manager==4.1.1
 datadog-checkpoint-quantum-firewall==1.0.0
-datadog-checks-base==36.7.0
+datadog-checks-base==36.7.1
 datadog-checks-dependency-provider==1.4.0
 datadog-checks-downloader==4.6.0
 datadog-cilium==3.5.0
@@ -88,7 +88,7 @@ datadog-impala==2.2.1
 datadog-istio==6.1.1
 datadog-jboss-wildfly==2.2.0
 datadog-journald==1.2.0
-datadog-kafka-consumer==4.3.0
+datadog-kafka-consumer==4.4.0
 datadog-kafka==2.16.0
 datadog-karpenter==1.4.0
 datadog-kong==3.2.1
@@ -113,7 +113,7 @@ datadog-mcache==4.1.0; sys_platform != 'win32'
 datadog-mesos-master==3.3.1; sys_platform != 'win32'
 datadog-mesos-slave==3.3.1; sys_platform != 'win32'
 datadog-mongo==6.5.0
-datadog-mysql==12.5.0
+datadog-mysql==12.5.1
 datadog-nagios==1.13.0
 datadog-network==3.3.0
 datadog-nfsstat==1.13.0; sys_platform == 'linux2'


### PR DESCRIPTION
- **Fix Fluentd tests (#17822)**
- **variables clearly differentiate between collections and counts (#17827)**
- **Drop testing on mesos-slave versions incompatible with gh runner docker v26 (#17823)**
- **Update mesos-master and mesos-slave versions for tests (#17825)**
- **Update test docker images of mesos-master (#17824)**
- **Drop testing on rabbitmq versions incompatible with gh runner docker v26 (#17826)**
- **Update etcd0 to latest to be compatible with gh runner docker v26 (#17828)**
- **Fix metrics names in kubernetes cluster autoscaler dashboard (#17803)**
- **Port 7.55 integration releases (#17792) to master**

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
