### PR TITLE
Fix tests that expect DBMAsync to put thread to sleep in sync mode

### DIFF
--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -32,6 +32,7 @@ DEFAULT_FQ_SUCCESS_QUERY = "SELECT * FROM information_schema.TABLES"
 
 CLOSE_TO_ZERO_INTERVAL = 0.0000001
 
+
 @pytest.fixture
 def dbm_instance(instance_complex):
     instance_complex['dbm'] = True
@@ -41,7 +42,11 @@ def dbm_instance(instance_complex):
     # Set collection_interval close to 0 if the test runs the check multiple times.
     # This ensures that DBMAsync does not skip job executions, as a job should not be executed
     # more frequently than its collection period.
-    instance_complex['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': CLOSE_TO_ZERO_INTERVAL}
+    instance_complex['query_metrics'] = {
+        'enabled': True,
+        'run_sync': True,
+        'collection_interval': CLOSE_TO_ZERO_INTERVAL,
+    }
     # don't need query activity for these tests
     instance_complex['query_activity'] = {'enabled': False}
     instance_complex['collect_settings'] = {'enabled': False}

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -302,7 +302,7 @@ def test_statement_metrics_cloud_metadata(
     if input_cloud_metadata:
         for k, v in input_cloud_metadata.items():
             dbm_instance[k] = v
-    dbm_instance['collect_settings']['collection_interval'] = 0.0000001
+    dbm_instance['query_metrics']['collection_interval'] = 0.0000001
     mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
 
     def run_query(q):

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -32,14 +32,15 @@ DEFAULT_FQ_SUCCESS_QUERY = "SELECT * FROM information_schema.TABLES"
 
 CLOSE_TO_ZERO_INTERVAL = 0.0000001
 
+
 @pytest.fixture
 def dbm_instance(instance_complex):
     instance_complex['dbm'] = True
     instance_complex['disable_generic_tags'] = False
     # set the default for tests to run sychronously to ensure we don't have orphaned threads running around
     instance_complex['query_samples'] = {'enabled': True, 'run_sync': True, 'collection_interval': 1}
-    # Set collection_interval close to 0. This is needed if the test runs the check multiple times. 
-    # This prevents DBMAsync from skipping job executions, as it is designed 
+    # Set collection_interval close to 0. This is needed if the test runs the check multiple times.
+    # This prevents DBMAsync from skipping job executions, as it is designed
     # to not execute jobs more frequently than their collection period.
     instance_complex['query_metrics'] = {
         'enabled': True,

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -99,6 +99,7 @@ def test_statement_samples_enabled_config(dbm_instance, statement_samples_key, s
 def test_statement_metrics(
     aggregator, dd_run_check, dbm_instance, query, default_schema, datadog_agent, aurora_replication_role
 ):
+    dbm_instance['query_metrics']['collection_interval'] = 0.0000001
     mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
 
     def run_query(q):
@@ -301,6 +302,7 @@ def test_statement_metrics_cloud_metadata(
     if input_cloud_metadata:
         for k, v in input_cloud_metadata.items():
             dbm_instance[k] = v
+    dbm_instance['query_metrics']['collection_interval'] = 0.0000001
     mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
 
     def run_query(q):
@@ -400,6 +402,7 @@ def test_statement_samples_collect(
     caplog.set_level(logging.INFO, logger="datadog_checks.mysql.collection_utils")
     caplog.set_level(logging.DEBUG, logger="datadog_checks")
     caplog.set_level(logging.DEBUG, logger="tests.test_mysql")
+    dbm_instance['query_samples']['collection_interval'] = 0.0000001
 
     mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
     if explain_strategy:

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -38,7 +38,7 @@ def dbm_instance(instance_complex):
     # set the default for tests to run sychronously to ensure we don't have orphaned threads running around
     instance_complex['query_samples'] = {'enabled': True, 'run_sync': True, 'collection_interval': 1}
     # collection_interval close to 0 is needed if test runs the check several times
-    # Otherwise, DBMAsync would skip a job execution. 
+    # Otherwise, DBMAsync would skip a job execution.
     instance_complex['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.0000001}
     # don't need query activity for these tests
     instance_complex['query_activity'] = {'enabled': False}

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -32,16 +32,15 @@ DEFAULT_FQ_SUCCESS_QUERY = "SELECT * FROM information_schema.TABLES"
 
 CLOSE_TO_ZERO_INTERVAL = 0.0000001
 
-
 @pytest.fixture
 def dbm_instance(instance_complex):
     instance_complex['dbm'] = True
     instance_complex['disable_generic_tags'] = False
     # set the default for tests to run sychronously to ensure we don't have orphaned threads running around
     instance_complex['query_samples'] = {'enabled': True, 'run_sync': True, 'collection_interval': 1}
-    # Set collection_interval close to 0 if the test runs the check multiple times.
-    # This ensures that DBMAsync does not skip job executions, as a job should not be executed
-    # more frequently than its collection period.
+    # Set collection_interval close to 0. This is needed if the test runs the check multiple times. 
+    # This prevents DBMAsync from skipping job executions, as it is designed 
+    # to not execute jobs more frequently than their collection period.
     instance_complex['query_metrics'] = {
         'enabled': True,
         'run_sync': True,

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -37,8 +37,9 @@ def dbm_instance(instance_complex):
     instance_complex['disable_generic_tags'] = False
     # set the default for tests to run sychronously to ensure we don't have orphaned threads running around
     instance_complex['query_samples'] = {'enabled': True, 'run_sync': True, 'collection_interval': 1}
-    # set a very small collection interval so the tests go fast
-    instance_complex['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
+    # collection_interval close to 0 is needed if test runs the check several times
+    # Otherwise, DBMAsync would skip a job execution. 
+    instance_complex['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.0000001}
     # don't need query activity for these tests
     instance_complex['query_activity'] = {'enabled': False}
     instance_complex['collect_settings'] = {'enabled': False}
@@ -99,7 +100,6 @@ def test_statement_samples_enabled_config(dbm_instance, statement_samples_key, s
 def test_statement_metrics(
     aggregator, dd_run_check, dbm_instance, query, default_schema, datadog_agent, aurora_replication_role
 ):
-    dbm_instance['query_metrics']['collection_interval'] = 0.0000001
     mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
 
     def run_query(q):
@@ -302,7 +302,6 @@ def test_statement_metrics_cloud_metadata(
     if input_cloud_metadata:
         for k, v in input_cloud_metadata.items():
             dbm_instance[k] = v
-    dbm_instance['query_metrics']['collection_interval'] = 0.0000001
     mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
 
     def run_query(q):
@@ -666,7 +665,6 @@ def test_statement_reported_hostname(
 ):
     dbm_instance['reported_hostname'] = reported_hostname
     dbm_instance['query_samples']['collection_interval'] = 0.0000001
-    dbm_instance['query_metrics']['collection_interval'] = 0.0000001
     mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
 
     dd_run_check(mysql_check)

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -302,7 +302,7 @@ def test_statement_metrics_cloud_metadata(
     if input_cloud_metadata:
         for k, v in input_cloud_metadata.items():
             dbm_instance[k] = v
-    dbm_instance['query_metrics']['collection_interval'] = 0.0000001
+    dbm_instance['collect_settings']['collection_interval'] = 0.0000001
     mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
 
     def run_query(q):
@@ -665,6 +665,8 @@ def test_statement_reported_hostname(
     aggregator, dd_run_check, dbm_instance, datadog_agent, reported_hostname, expected_hostname
 ):
     dbm_instance['reported_hostname'] = reported_hostname
+    dbm_instance['query_samples']['collection_interval'] = 0.0000001
+    dbm_instance['query_metrics']['collection_interval'] = 0.0000001
     mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
 
     dd_run_check(mysql_check)

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -531,8 +531,8 @@ def dbm_instance(pg_instance):
     pg_instance['pg_stat_activity_view'] = "datadog.pg_stat_activity()"
     pg_instance['query_samples'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.2}
     pg_instance['query_activity'] = {'enabled': True, 'collection_interval': 0.2}
-    # Set collection_interval close to 0. This is needed if the test runs the check multiple times. 
-    # This prevents DBMAsync from skipping job executions, as it is designed 
+    # Set collection_interval close to 0. This is needed if the test runs the check multiple times.
+    # This prevents DBMAsync from skipping job executions, as it is designed
     # to not execute jobs more frequently than their collection period.
     pg_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': CLOSE_TO_ZERO_INTERVAL}
     pg_instance['collect_resources'] = {'enabled': False}

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -66,11 +66,10 @@ def stop_orphaned_threads():
     DBMAsyncJob.executor.shutdown(wait=True)
     DBMAsyncJob.executor = ThreadPoolExecutor()
 
-import pdb
+
 @pytest.mark.parametrize("dbm_enabled_key", dbm_enabled_keys)
 @pytest.mark.parametrize("dbm_enabled", [True, False])
 def test_dbm_enabled_config(integration_check, dbm_instance, dbm_enabled_key, dbm_enabled):
-    #pdb.set_trace()
     # test to make sure we continue to support the old key
     for k in dbm_enabled_keys:
         dbm_instance.pop(k, None)

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -531,9 +531,9 @@ def dbm_instance(pg_instance):
     pg_instance['pg_stat_activity_view'] = "datadog.pg_stat_activity()"
     pg_instance['query_samples'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.2}
     pg_instance['query_activity'] = {'enabled': True, 'collection_interval': 0.2}
-    # Set collection_interval close to 0 if the test runs the check multiple times.
-    # This ensures that DBMAsync does not skip job executions, as a job should not be executed
-    # more frequently than its collection period.
+    # Set collection_interval close to 0. This is needed if the test runs the check multiple times. 
+    # This prevents DBMAsync from skipping job executions, as it is designed 
+    # to not execute jobs more frequently than their collection period.
     pg_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': CLOSE_TO_ZERO_INTERVAL}
     pg_instance['collect_resources'] = {'enabled': False}
     return pg_instance

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -87,7 +87,7 @@ def test_statement_metrics_multiple_pgss_rows_single_query_signature(
     # don't need samples for this test
     dbm_instance['query_samples'] = {'enabled': False}
     dbm_instance['query_activity'] = {'enabled': False}
-    dbm_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'incremental_query_metrics': True}
+    dbm_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'incremental_query_metrics': True, 'collection_interval':0.0000001}
     connections = {}
 
     def normalize_query(q):
@@ -226,7 +226,7 @@ def test_statement_metrics(
     dbm_instance['query_samples'] = {'enabled': False}
     dbm_instance['query_activity'] = {'enabled': False}
     # very low collection interval for test purposes
-    dbm_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
+    dbm_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.0000001}
     connections = {}
 
     def _run_queries():
@@ -860,6 +860,8 @@ def test_statement_metadata(
     dbm_instance['pg_stat_statements_view'] = pg_stat_statements_view
     dbm_instance['query_samples']['run_sync'] = True
     dbm_instance['query_metrics']['run_sync'] = True
+    dbm_instance['query_metrics']['collection_interval'] = 0.0000001
+    dbm_instance['query_samples']['collection_interval'] = 0.0000001
 
     # If query or normalized_query changes, the query_signatures for both will need to be updated as well.
     query = '''
@@ -944,6 +946,8 @@ def test_statement_reported_hostname(
 ):
     dbm_instance['query_samples']['run_sync'] = True
     dbm_instance['query_metrics']['run_sync'] = True
+    dbm_instance['query_metrics']['collection_interval'] = 0.0000001
+    dbm_instance['query_samples']['collection_interval'] = 0.0000001
     dbm_instance['reported_hostname'] = reported_hostname
 
     check = integration_check(dbm_instance)
@@ -1064,6 +1068,8 @@ def test_activity_snapshot_collection(
     # No need for query metrics here
     dbm_instance['query_metrics']['enabled'] = False
     dbm_instance['collect_resources']['enabled'] = False
+    dbm_instance['query_metrics']['collection_interval'] = 0.0000001
+    dbm_instance['collect_resources']['collection_interval'] = 0.0000001
     check = integration_check(dbm_instance)
     check._connect()
 

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -87,7 +87,12 @@ def test_statement_metrics_multiple_pgss_rows_single_query_signature(
     # don't need samples for this test
     dbm_instance['query_samples'] = {'enabled': False}
     dbm_instance['query_activity'] = {'enabled': False}
-    dbm_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'incremental_query_metrics': True, 'collection_interval':0.0000001}
+    dbm_instance['query_metrics'] = {
+        'enabled': True,
+        'run_sync': True,
+        'incremental_query_metrics': True,
+        'collection_interval': 0.0000001,
+    }
     connections = {}
 
     def normalize_query(q):

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -88,7 +88,7 @@ def test_statement_metrics_multiple_pgss_rows_single_query_signature(
     # don't need samples for this test
     dbm_instance['query_samples'] = {'enabled': False}
     dbm_instance['query_activity'] = {'enabled': False}
-    dbm_instance['incremental_query_metrics'] = True
+    dbm_instance['query_metrics']['incremental_query_metrics'] = True
     connections = {}
 
     def normalize_query(q):

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -45,7 +45,6 @@ SELF_HOSTED_ENGINE_EDITIONS = {
     ENGINE_EDITION_ENTERPRISE,
     ENGINE_EDITION_EXPRESS,
 }
-import pdb
 
 @pytest.fixture(autouse=True)
 def stop_orphaned_threads():

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -62,8 +62,8 @@ def dbm_instance(instance_docker):
     instance_docker['procedure_metrics'] = {'enabled': False}
     instance_docker['collect_settings'] = {'enabled': False}
     instance_docker['query_activity'] = {'enabled': False}
-    # Set collection_interval close to 0. This is needed if the test runs the check multiple times. 
-    # This prevents DBMAsync from skipping job executions, as it is designed 
+    # Set collection_interval close to 0. This is needed if the test runs the check multiple times.
+    # This prevents DBMAsync from skipping job executions, as it is designed
     # to not execute jobs more frequently than their collection period.
     instance_docker['query_metrics'] = {
         'enabled': True,

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -681,7 +681,6 @@ def test_statement_cloud_metadata(
 def test_statement_reported_hostname(
     aggregator, dd_run_check, dbm_instance, bob_conn, datadog_agent, reported_hostname, expected_hostname
 ):
-
     dbm_instance['reported_hostname'] = reported_hostname
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
 

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -62,9 +62,9 @@ def dbm_instance(instance_docker):
     instance_docker['procedure_metrics'] = {'enabled': False}
     instance_docker['collect_settings'] = {'enabled': False}
     instance_docker['query_activity'] = {'enabled': False}
-    # Set collection_interval close to 0 if the test runs the check multiple times.
-    # This prevents DBMAsync from skipping job executions, as a job should not be executed
-    # more frequently than its collection period.
+    # Set collection_interval close to 0. This is needed if the test runs the check multiple times. 
+    # This prevents DBMAsync from skipping job executions, as it is designed 
+    # to not execute jobs more frequently than their collection period.
     instance_docker['query_metrics'] = {
         'enabled': True,
         'run_sync': True,

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -33,7 +33,6 @@ from datadog_checks.sqlserver.const import (
 from datadog_checks.sqlserver.statements import SQL_SERVER_QUERY_METRICS_COLUMNS, obfuscate_xml_plan
 
 from .common import CHECK_NAME, OPERATION_TIME_METRIC_NAME
-
 from .utils import CLOSE_TO_ZERO_INTERVAL
 
 try:

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -314,12 +314,10 @@ def test_statement_metrics_and_plans(
     # 2) load the test queries into the StatementMetrics state
     # 3) emit the query metrics based on the diff of current and last state
     dd_run_check(check)
-    time.sleep(2)
     for _ in range(0, exe_count):
         for params in param_groups:
             bob_conn.execute_with_retries(query, params, database=database)
     dd_run_check(check)
-    time.sleep(2)
     aggregator.reset()
     for _ in range(0, exe_count):
         for params in param_groups:

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -303,7 +303,6 @@ def test_statement_metrics_and_plans(
     if disable_secondary_tags:
         dbm_instance['query_metrics']['disable_secondary_tags'] = True
     dbm_instance['query_activity'] = {'enabled': True, 'collection_interval': 2}
-
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
 
     # the check must be run three times:
@@ -323,7 +322,6 @@ def test_statement_metrics_and_plans(
         for params in param_groups:
             bob_conn.execute_with_retries(query, params, database=database)
     dd_run_check(check)
-
 
     _conn_key_prefix = "dbm-"
     with check.connection.open_managed_default_connection(key_prefix=_conn_key_prefix):

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -974,7 +974,6 @@ def test_statement_with_embedded_characters(aggregator, datadog_agent, dd_run_ch
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
     query = "EXEC nullCharTest;"
 
-
     def _obfuscate_sql(sql_query, options=None):
         return json.dumps({'query': sql_query, 'metadata': {}})
 

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -46,6 +46,7 @@ SELF_HOSTED_ENGINE_EDITIONS = {
     ENGINE_EDITION_EXPRESS,
 }
 
+
 @pytest.fixture(autouse=True)
 def stop_orphaned_threads():
     # make sure we shut down any orphaned threads and create a new Executor for each test
@@ -278,6 +279,7 @@ test_statement_metrics_and_plans_parameterized = (
     ],
 )
 
+
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(*test_statement_metrics_and_plans_parameterized)
@@ -300,7 +302,6 @@ def test_statement_metrics_and_plans(
     caplog.set_level(logging.INFO)
     if disable_secondary_tags:
         dbm_instance['query_metrics']['disable_secondary_tags'] = True
-        dbm_instance['query_metrics']['collection_interval']
     dbm_instance['query_activity'] = {'enabled': True, 'collection_interval': 2}
 
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])

--- a/sqlserver/tests/test_stored_procedures.py
+++ b/sqlserver/tests/test_stored_procedures.py
@@ -56,8 +56,8 @@ def dbm_instance(instance_docker):
     instance_docker['query_metrics'] = {'enabled': False}
     instance_docker['query_activity'] = {'enabled': False}
     instance_docker['collect_settings'] = {'enabled': False}
-    # Set collection_interval close to 0. This is needed if the test runs the check multiple times. 
-    # This prevents DBMAsync from skipping job executions, as it is designed 
+    # Set collection_interval close to 0. This is needed if the test runs the check multiple times.
+    # This prevents DBMAsync from skipping job executions, as it is designed
     # to not execute jobs more frequently than their collection period.
     instance_docker['procedure_metrics'] = {
         'enabled': True,

--- a/sqlserver/tests/test_stored_procedures.py
+++ b/sqlserver/tests/test_stored_procedures.py
@@ -221,6 +221,7 @@ def test_procedure_metrics(
     datadog_agent,
 ):
     caplog.set_level(logging.INFO)
+    dbm_instance['procedure_metrics']['collection_interval'] = 0.0000001
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
 
     # the check must be run three times:
@@ -289,6 +290,7 @@ def test_procedure_metrics(
 @pytest.mark.usefixtures('dd_environment')
 def test_procedure_metrics_limit(aggregator, dd_run_check, dbm_instance, bob_conn):
     dbm_instance['procedure_metrics']['max_procedures'] = 2
+    dbm_instance['procedure_metrics']['collection_interval'] = 0.0000001
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
 
     # the check must be run three times:

--- a/sqlserver/tests/test_stored_procedures.py
+++ b/sqlserver/tests/test_stored_procedures.py
@@ -21,7 +21,6 @@ from datadog_checks.sqlserver.const import (
 from datadog_checks.sqlserver.stored_procedures import SQL_SERVER_PROCEDURE_METRICS_COLUMNS
 
 from .common import CHECK_NAME, OPERATION_TIME_METRIC_NAME
-
 from .utils import CLOSE_TO_ZERO_INTERVAL
 
 try:

--- a/sqlserver/tests/test_stored_procedures.py
+++ b/sqlserver/tests/test_stored_procedures.py
@@ -56,9 +56,9 @@ def dbm_instance(instance_docker):
     instance_docker['query_metrics'] = {'enabled': False}
     instance_docker['query_activity'] = {'enabled': False}
     instance_docker['collect_settings'] = {'enabled': False}
-    # Set collection_interval close to 0 if the test runs the check multiple times.
-    # This ensures that DBMAsync does not skip job executions, as a job should not be executed
-    # more frequently than its collection period.
+    # Set collection_interval close to 0. This is needed if the test runs the check multiple times. 
+    # This prevents DBMAsync from skipping job executions, as it is designed 
+    # to not execute jobs more frequently than their collection period.
     instance_docker['procedure_metrics'] = {
         'enabled': True,
         'run_sync': True,

--- a/sqlserver/tests/utils.py
+++ b/sqlserver/tests/utils.py
@@ -12,6 +12,8 @@ import pytest
 
 from datadog_checks.dev.utils import running_on_windows_ci
 
+# Used in tests as 0 is converted to the default collectio interval.
+CLOSE_TO_ZERO_INTERVAL = 0.0000001
 
 def is_always_on():
     return os.environ["COMPOSE_FOLDER"] == 'compose-ha'

--- a/sqlserver/tests/utils.py
+++ b/sqlserver/tests/utils.py
@@ -15,7 +15,6 @@ from datadog_checks.dev.utils import running_on_windows_ci
 # Used in tests as 0 is converted to the default collectio interval.
 CLOSE_TO_ZERO_INTERVAL = 0.0000001
 
-
 def is_always_on():
     return os.environ["COMPOSE_FOLDER"] == 'compose-ha'
 

--- a/sqlserver/tests/utils.py
+++ b/sqlserver/tests/utils.py
@@ -15,6 +15,7 @@ from datadog_checks.dev.utils import running_on_windows_ci
 # Used in tests as 0 is converted to the default collectio interval.
 CLOSE_TO_ZERO_INTERVAL = 0.0000001
 
+
 def is_always_on():
     return os.environ["COMPOSE_FOLDER"] == 'compose-ha'
 


### PR DESCRIPTION
### What does this PR do?
Fixes tests that relied on main thread being put to sleep by DBMAsync.
Tests started to fail after this PR - https://github.com/DataDog/integrations-core/pull/17716 got submitted.



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
