### PR TITLE
[FRAGENT-807] Adding an include_events config option to vSphere

### DIFF
--- a/vsphere/README.md
+++ b/vsphere/README.md
@@ -59,7 +59,7 @@ collect_per_instance_filters:
 
 ### Events
 
-This check watches vCenter's Event Manager for events and emits them to Datadog. It emits the following event types:
+This check watches vCenter's Event Manager for events and emits them to Datadog. The check defaults to emit the following event types:
 
 - AlarmStatusChangedEvent
 - VmBeingHotMigratedEvent
@@ -70,6 +70,8 @@ This check watches vCenter's Event Manager for events and emits them to Datadog.
 - VmMessageEvent
 - VmSuspendedEvent
 - VmPoweredOffEvent
+
+However, events can be added or removed using the `vsphere.d/conf.yaml` file. See the `include_events` parameter section in the [sample vsphere.d/conf.yaml][4].
 
 ### Service Checks
 

--- a/vsphere/assets/configuration/spec.yaml
+++ b/vsphere/assets/configuration/spec.yaml
@@ -300,11 +300,14 @@ files:
           However, while the keys should be events to include, the value should be an
           array of message regexes to exclude/filter out. For example, if the key
           is 'AlarmStatusChangedEvent' and the values for this key are 'Gray to Green' and 'Green to Gray',
-          then all events name 'AlarmStatusChangedEvent' that don't have the option of 'Gray to Green'
+          then all events named 'AlarmStatusChangedEvent' that don't have the message 'Gray to Green'
           and 'Green to Gray' will be included.
           
           Currently, events can only be collected from the following resources:
           VMs, hosts, datacenters, datastores, and clusters.
+
+          The default events reported are listed here:
+          https://github.com/DataDog/integrations-core/tree/master/vsphere#events
 
         value:
           example:

--- a/vsphere/assets/configuration/spec.yaml
+++ b/vsphere/assets/configuration/spec.yaml
@@ -313,15 +313,15 @@ files:
                 - <EVENT_OPTION_REGEX_CORRESPONDING_TO_EVENT_NAME_TO_EXCLUDE_1>
                 - <EVENT_OPTION_REGEX_CORRESPONDING_TO_EVENT_NAME_TO_EXCLUDE_2>
           type: array
-          display_default: [['AlarmStatusChangedEvent', [r'Gray to Green', r'Green to Gray']],
+          display_default: [['AlarmStatusChangedEvent', ['Gray to Green', 'Green to Gray']],
               ['TaskEvent', [
-                r'Initialize powering On',
-                r'Power Off virtual machine',
-                r'Power On virtual machine',
-                r'Reconfigure virtual machine',
-                r'Relocate virtual machine',
-                r'Suspend virtual machine',
-                r'Migrate virtual machine',
+                'Initialize powering On',
+                'Power Off virtual machine',
+                'Power On virtual machine',
+                'Reconfigure virtual machine',
+                'Relocate virtual machine',
+                'Suspend virtual machine',
+                'Migrate virtual machine',
               ]],
               ['VmBeingHotMigratedEvent', []],
               ['VmMessageEvent', []],

--- a/vsphere/assets/configuration/spec.yaml
+++ b/vsphere/assets/configuration/spec.yaml
@@ -292,6 +292,54 @@ files:
           display_default: ['vm', 'host']
           items:
             type: string
+      - name: include_events
+        description: |
+          The events that should be collected by the vSphere integration.
+
+          Each event is an object represented with the event name itself as a key.
+          However, while the keys should be events to include, the value should be an
+          array of event option regexes to exclude/filter out. For example, if the key
+          is 'AlarmStatusChangedEvent' and the values for this key are 'Gray to Green' and 'Green to Gray',
+          then all events name 'AlarmStatusChangedEvent' that don't have the option of 'Gray to Green'
+          and 'Green to Gray' will be included.
+          
+          Currently, events can only be collected from the following resources:
+          VMs, hosts, datacenters, datastores, and clusters.
+
+        value:
+          example:
+            - event: <EVENT_NAME_TO_INCLUDE>
+            - messages:
+                - <EVENT_OPTION_REGEX_CORRESPONDING_TO_EVENT_NAME_TO_EXCLUDE_1>
+                - <EVENT_OPTION_REGEX_CORRESPONDING_TO_EVENT_NAME_TO_EXCLUDE_2>
+          type: array
+          display_default: [['AlarmStatusChangedEvent', [r'Gray to Green', r'Green to Gray']],
+              ['TaskEvent', [
+                r'Initialize powering On',
+                r'Power Off virtual machine',
+                r'Power On virtual machine',
+                r'Reconfigure virtual machine',
+                r'Relocate virtual machine',
+                r'Suspend virtual machine',
+                r'Migrate virtual machine',
+              ]],
+              ['VmBeingHotMigratedEvent', []],
+              ['VmMessageEvent', []],
+              ['VmMigratedEvent', []],
+              ['VmPoweredOnEvent', []],
+              ['VmPoweredOffEvent', []],
+              ['VmReconfiguredEvent', []],
+              ['VmSuspendedEvent', []],
+          ]
+          items:
+            type: object
+            properties:
+              - name: event
+                type: string
+              - name: messages
+                type: array
+                items:
+                  type: string
       - name: collect_tags
         description: |
           If true, the vSphere Tags will be collected.

--- a/vsphere/assets/configuration/spec.yaml
+++ b/vsphere/assets/configuration/spec.yaml
@@ -296,7 +296,7 @@ files:
         description: |
           The events that should be collected by the vSphere integration.
 
-          Each event is an object represented with the event name itself as a key.
+          Each event is an object represented with the "event" itself as a key.
           However, while the keys should be events to include, the value should be an
           array of message regexes to exclude/filter out. For example, if the key
           is 'AlarmStatusChangedEvent' and the values for this key are 'Gray to Green' and 'Green to Gray',

--- a/vsphere/assets/configuration/spec.yaml
+++ b/vsphere/assets/configuration/spec.yaml
@@ -296,9 +296,8 @@ files:
         description: |
           The events that should be collected by the vSphere integration.
 
-          Each event is an object represented with the "event" itself as a key.
-          However, while the keys should be events to include, the value should be an
-          array of message regexes to exclude/filter out. For example, if the key
+          The "event" specifies the event type you want to include, and the "excluded_messages" is a list of
+          messages of that event type you do not want to collect. For example, if the key
           is 'AlarmStatusChangedEvent' and the values for this key are 'Gray to Green' and 'Green to Gray',
           then all events named 'AlarmStatusChangedEvent' that don't have the message 'Gray to Green'
           and 'Green to Gray' will be included.

--- a/vsphere/assets/configuration/spec.yaml
+++ b/vsphere/assets/configuration/spec.yaml
@@ -298,7 +298,7 @@ files:
 
           Each event is an object represented with the event name itself as a key.
           However, while the keys should be events to include, the value should be an
-          array of event option regexes to exclude/filter out. For example, if the key
+          array of message regexes to exclude/filter out. For example, if the key
           is 'AlarmStatusChangedEvent' and the values for this key are 'Gray to Green' and 'Green to Gray',
           then all events name 'AlarmStatusChangedEvent' that don't have the option of 'Gray to Green'
           and 'Green to Gray' will be included.
@@ -309,9 +309,9 @@ files:
         value:
           example:
             - event: <EVENT_NAME_TO_INCLUDE>
-            - messages:
-                - <EVENT_OPTION_REGEX_CORRESPONDING_TO_EVENT_NAME_TO_EXCLUDE_1>
-                - <EVENT_OPTION_REGEX_CORRESPONDING_TO_EVENT_NAME_TO_EXCLUDE_2>
+              excluded_messages:
+                - <EVENT_MESSAGE_REGEX_CORRESPONDING_TO_EVENT_NAME_TO_EXCLUDE_1>
+                - <EVENT_MESSAGE_REGEX_CORRESPONDING_TO_EVENT_NAME_TO_EXCLUDE_2>
           type: array
           display_default: [['AlarmStatusChangedEvent', ['Gray to Green', 'Green to Gray']],
               ['TaskEvent', [
@@ -336,7 +336,7 @@ files:
             properties:
               - name: event
                 type: string
-              - name: messages
+                name: excluded_messages
                 type: array
                 items:
                   type: string

--- a/vsphere/assets/configuration/spec.yaml
+++ b/vsphere/assets/configuration/spec.yaml
@@ -313,24 +313,6 @@ files:
                 - <EVENT_MESSAGE_REGEX_CORRESPONDING_TO_EVENT_NAME_TO_EXCLUDE_1>
                 - <EVENT_MESSAGE_REGEX_CORRESPONDING_TO_EVENT_NAME_TO_EXCLUDE_2>
           type: array
-          display_default: [['AlarmStatusChangedEvent', ['Gray to Green', 'Green to Gray']],
-              ['TaskEvent', [
-                'Initialize powering On',
-                'Power Off virtual machine',
-                'Power On virtual machine',
-                'Reconfigure virtual machine',
-                'Relocate virtual machine',
-                'Suspend virtual machine',
-                'Migrate virtual machine',
-              ]],
-              ['VmBeingHotMigratedEvent', []],
-              ['VmMessageEvent', []],
-              ['VmMigratedEvent', []],
-              ['VmPoweredOnEvent', []],
-              ['VmPoweredOffEvent', []],
-              ['VmReconfiguredEvent', []],
-              ['VmSuspendedEvent', []],
-          ]
           items:
             type: object
             properties:

--- a/vsphere/changelog.d/17855.added
+++ b/vsphere/changelog.d/17855.added
@@ -1,0 +1,1 @@
+Adding an include_events config option to vSphere

--- a/vsphere/datadog_checks/vsphere/api.py
+++ b/vsphere/datadog_checks/vsphere/api.py
@@ -349,7 +349,7 @@ class VSphereAPI(object):
             exclude_filters = {}
             for item in self.config.include_events:
                 event_name = item["event"]
-                excluded_messages = [rf"{msg}" for msg in item["excluded_messages"]]
+                excluded_messages = [r'{}'.format(msg) for msg in item["excluded_messages"]]
                 exclude_filters[event_name] = excluded_messages
         return [getattr(vim.event, event_type) for event_type in exclude_filters.keys()]
 

--- a/vsphere/datadog_checks/vsphere/api.py
+++ b/vsphere/datadog_checks/vsphere/api.py
@@ -325,7 +325,7 @@ class VSphereAPI(object):
 
     @smart_retry
     def get_allowed_events(self):
-        if not isinstance(self.config, VSphereConfig) or not self.config.include_events:
+        if not isinstance(self.config, VSphereConfig) or self.config.include_events is None:
             exclude_filters = {
                 'AlarmStatusChangedEvent': [r'Gray to Green', r'Green to Gray'],
                 'TaskEvent': [

--- a/vsphere/datadog_checks/vsphere/api.py
+++ b/vsphere/datadog_checks/vsphere/api.py
@@ -325,12 +325,7 @@ class VSphereAPI(object):
 
     @smart_retry
     def get_allowed_events(self):
-        if (
-            not isinstance(self.config, VSphereConfig)
-            or not self.config.include_events
-            or 'event' not in self.config.include_events
-            or 'options' not in self.config.include_events
-        ):
+        if not isinstance(self.config, VSphereConfig) or not self.config.include_events:
             exclude_filters = {
                 'AlarmStatusChangedEvent': [r'Gray to Green', r'Green to Gray'],
                 'TaskEvent': [
@@ -352,8 +347,7 @@ class VSphereAPI(object):
             }
         else:
             exclude_filters = {
-                event_object['event']: [r'{}'.format(elt) for elt in event_object['options']]
-                for event_object in self.config.include_events
+                event[0]: [r'{}'.format(elt) for elt in event[1]] for event in self.config.include_events
             }
         return [getattr(vim.event, event_type) for event_type in exclude_filters.keys()]
 

--- a/vsphere/datadog_checks/vsphere/api.py
+++ b/vsphere/datadog_checks/vsphere/api.py
@@ -346,9 +346,11 @@ class VSphereAPI(object):
                 'VmSuspendedEvent': [],
             }
         else:
-            exclude_filters = {
-                event[0]: [r'{}'.format(elt) for elt in event[1]] for event in self.config.include_events
-            }
+            exclude_filters = {}
+            for item in self.config.include_events:
+                event_name = item["event"]
+                excluded_messages = [rf"{msg}" for msg in item["excluded_messages"]]
+                exclude_filters[event_name] = excluded_messages
         return [getattr(vim.event, event_type) for event_type in exclude_filters.keys()]
 
     @smart_retry

--- a/vsphere/datadog_checks/vsphere/config.py
+++ b/vsphere/datadog_checks/vsphere/config.py
@@ -26,6 +26,7 @@ from datadog_checks.vsphere.constants import (
     DEFAULT_THREAD_COUNT,
     DEFAULT_VSPHERE_ATTR_PREFIX,
     DEFAULT_VSPHERE_TAG_PREFIX,
+    EXCLUDE_FILTERS,
     EXTRA_FILTER_PROPERTIES_FOR_VMS,
     HISTORICAL,
     MOR_TYPE_AS_STRING,
@@ -127,25 +128,7 @@ class VSphereConfig(object):
         )
         self.include_events = instance.get("include_events", None)
         if self.include_events is None:
-            self.exclude_filters = {
-                'AlarmStatusChangedEvent': [r'Gray to Green', r'Green to Gray'],
-                'TaskEvent': [
-                    r'Initialize powering On',
-                    r'Power Off virtual machine',
-                    r'Power On virtual machine',
-                    r'Reconfigure virtual machine',
-                    r'Relocate virtual machine',
-                    r'Suspend virtual machine',
-                    r'Migrate virtual machine',
-                ],
-                'VmBeingHotMigratedEvent': [],
-                'VmMessageEvent': [],
-                'VmMigratedEvent': [],
-                'VmPoweredOnEvent': [],
-                'VmPoweredOffEvent': [],
-                'VmReconfiguredEvent': [],
-                'VmSuspendedEvent': [],
-            }
+            self.exclude_filters = EXCLUDE_FILTERS
         else:
             self.exclude_filters = {}
             for item in self.include_events:

--- a/vsphere/datadog_checks/vsphere/config.py
+++ b/vsphere/datadog_checks/vsphere/config.py
@@ -125,6 +125,7 @@ class VSphereConfig(object):
         self.event_resource_filters = self._normalize_event_resource_filters(
             instance.get("event_resource_filters", DEFAULT_EVENT_RESOURCES)
         )
+        self.include_events = instance.get("include_events", {})
 
         # Since `collect_per_instance_filters` have the same structure as `metric_filters` we use the same parser
         self.collect_per_instance_filters = self._parse_metric_regex_filters(

--- a/vsphere/datadog_checks/vsphere/config.py
+++ b/vsphere/datadog_checks/vsphere/config.py
@@ -126,6 +126,32 @@ class VSphereConfig(object):
             instance.get("event_resource_filters", DEFAULT_EVENT_RESOURCES)
         )
         self.include_events = instance.get("include_events", None)
+        if self.include_events is None:
+            self.exclude_filters = {
+                'AlarmStatusChangedEvent': [r'Gray to Green', r'Green to Gray'],
+                'TaskEvent': [
+                    r'Initialize powering On',
+                    r'Power Off virtual machine',
+                    r'Power On virtual machine',
+                    r'Reconfigure virtual machine',
+                    r'Relocate virtual machine',
+                    r'Suspend virtual machine',
+                    r'Migrate virtual machine',
+                ],
+                'VmBeingHotMigratedEvent': [],
+                'VmMessageEvent': [],
+                'VmMigratedEvent': [],
+                'VmPoweredOnEvent': [],
+                'VmPoweredOffEvent': [],
+                'VmReconfiguredEvent': [],
+                'VmSuspendedEvent': [],
+            }
+        else:
+            self.exclude_filters = {}
+            for item in self.include_events:
+                event_name = item["event"]
+                excluded_messages = [r'{}'.format(msg) for msg in item["excluded_messages"]]
+                self.exclude_filters[event_name] = excluded_messages
 
         # Since `collect_per_instance_filters` have the same structure as `metric_filters` we use the same parser
         self.collect_per_instance_filters = self._parse_metric_regex_filters(

--- a/vsphere/datadog_checks/vsphere/config.py
+++ b/vsphere/datadog_checks/vsphere/config.py
@@ -125,7 +125,7 @@ class VSphereConfig(object):
         self.event_resource_filters = self._normalize_event_resource_filters(
             instance.get("event_resource_filters", DEFAULT_EVENT_RESOURCES)
         )
-        self.include_events = instance.get("include_events", {})
+        self.include_events = instance.get("include_events", None)
 
         # Since `collect_per_instance_filters` have the same structure as `metric_filters` we use the same parser
         self.collect_per_instance_filters = self._parse_metric_regex_filters(

--- a/vsphere/datadog_checks/vsphere/config_models/instance.py
+++ b/vsphere/datadog_checks/vsphere/config_models/instance.py
@@ -31,6 +31,14 @@ class CollectPerInstanceFilters(BaseModel):
     vm: Optional[tuple[str, ...]] = None
 
 
+class IncludeEvent(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    excluded_messages: Optional[tuple[str, ...]] = None
+
+
 class MetricFilters(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -147,6 +155,7 @@ class InstanceConfig(BaseModel):
     excluded_host_tags: Optional[tuple[str, ...]] = None
     host: str
     include_datastore_cluster_folder_tag: Optional[bool] = None
+    include_events: Optional[tuple[IncludeEvent, ...]] = None
     max_historical_metrics: Optional[int] = None
     metric_filters: Optional[MetricFilters] = None
     metric_patterns: Optional[MetricPatterns] = None

--- a/vsphere/datadog_checks/vsphere/constants.py
+++ b/vsphere/datadog_checks/vsphere/constants.py
@@ -175,3 +175,23 @@ PROPERTY_METRICS_BY_RESOURCE_TYPE = {
     'cluster': CLUSTER_SIMPLE_PROPERTIES,
     'datastore': DATASTORE_SIMPLE_PROPERTIES,
 }
+
+EXCLUDE_FILTERS = {
+    'AlarmStatusChangedEvent': [r'Gray to Green', r'Green to Gray'],
+    'TaskEvent': [
+        r'Initialize powering On',
+        r'Power Off virtual machine',
+        r'Power On virtual machine',
+        r'Reconfigure virtual machine',
+        r'Relocate virtual machine',
+        r'Suspend virtual machine',
+        r'Migrate virtual machine',
+    ],
+    'VmBeingHotMigratedEvent': [],
+    'VmMessageEvent': [],
+    'VmMigratedEvent': [],
+    'VmPoweredOnEvent': [],
+    'VmPoweredOffEvent': [],
+    'VmReconfiguredEvent': [],
+    'VmSuspendedEvent': [],
+}

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -259,6 +259,25 @@ instances:
     #   - datacenter
     #   - cluster
 
+    ## @param include_events - list of mappings - optional - default: [['AlarmStatusChangedEvent', ["r'Gray to Green'", "r'Green to Gray'"]], ['TaskEvent', ["r'Initialize powering On'", "r'Power Off virtual machine'", "r'Power On virtual machine'", "r'Reconfigure virtual machine'", "r'Relocate virtual machine'", "r'Suspend virtual machine'", "r'Migrate virtual machine'"]], ['VmBeingHotMigratedEvent', []], ['VmMessageEvent', []], ['VmMigratedEvent', []], ['VmPoweredOnEvent', []], ['VmPoweredOffEvent', []], ['VmReconfiguredEvent', []], ['VmSuspendedEvent', []]]
+    ## The events that should be collected by the vSphere integration.
+    ##
+    ## Each event is an object represented with the event name itself as a key.
+    ## However, while the keys should be events to include, the value should be an
+    ## array of event option regexes to exclude/filter out. For example, if the key
+    ## is 'AlarmStatusChangedEvent' and the values for this key are 'Gray to Green' and 'Green to Gray',
+    ## then all events name 'AlarmStatusChangedEvent' that don't have the option of 'Gray to Green'
+    ## and 'Green to Gray' will be included.
+    ##
+    ## Currently, events can only be collected from the following resources:
+    ## VMs, hosts, datacenters, datastores, and clusters.
+    #
+    # include_events:
+    #   - event: <EVENT_NAME_TO_INCLUDE>
+    #   - messages:
+    #     - <EVENT_OPTION_REGEX_CORRESPONDING_TO_EVENT_NAME_TO_EXCLUDE_1>
+    #     - <EVENT_OPTION_REGEX_CORRESPONDING_TO_EVENT_NAME_TO_EXCLUDE_2>
+
     ## @param collect_tags - boolean - optional - default: false
     ## If true, the vSphere Tags will be collected.
     ## The final tag sent to Datadog is composed of the vSphere tags prefix + vSphere tag category as key and

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -266,11 +266,14 @@ instances:
     ## However, while the keys should be events to include, the value should be an
     ## array of message regexes to exclude/filter out. For example, if the key
     ## is 'AlarmStatusChangedEvent' and the values for this key are 'Gray to Green' and 'Green to Gray',
-    ## then all events name 'AlarmStatusChangedEvent' that don't have the option of 'Gray to Green'
+    ## then all events named 'AlarmStatusChangedEvent' that don't have the message 'Gray to Green'
     ## and 'Green to Gray' will be included.
     ##
     ## Currently, events can only be collected from the following resources:
     ## VMs, hosts, datacenters, datastores, and clusters.
+    ##
+    ## The default events reported are listed here:
+    ## https://github.com/DataDog/integrations-core/tree/master/vsphere#events
     #
     # include_events:
     #   - event: <EVENT_NAME_TO_INCLUDE>

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -259,7 +259,7 @@ instances:
     #   - datacenter
     #   - cluster
 
-    ## @param include_events - list of mappings - optional - default: [['AlarmStatusChangedEvent', ['Gray to Green', 'Green to Gray']], ['TaskEvent', ['Initialize powering On', 'Power Off virtual machine', 'Power On virtual machine', 'Reconfigure virtual machine', 'Relocate virtual machine', 'Suspend virtual machine', 'Migrate virtual machine']], ['VmBeingHotMigratedEvent', []], ['VmMessageEvent', []], ['VmMigratedEvent', []], ['VmPoweredOnEvent', []], ['VmPoweredOffEvent', []], ['VmReconfiguredEvent', []], ['VmSuspendedEvent', []]]
+    ## @param include_events - list of mappings - optional
     ## The events that should be collected by the vSphere integration.
     ##
     ## Each event is an object represented with the event name itself as a key.

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -262,9 +262,8 @@ instances:
     ## @param include_events - list of mappings - optional
     ## The events that should be collected by the vSphere integration.
     ##
-    ## Each event is an object represented with the "event" itself as a key.
-    ## However, while the keys should be events to include, the value should be an
-    ## array of message regexes to exclude/filter out. For example, if the key
+    ## The "event" specifies the event type you want to include, and the "excluded_messages" is a list of
+    ## messages of that event type you do not want to collect. For example, if the key
     ## is 'AlarmStatusChangedEvent' and the values for this key are 'Gray to Green' and 'Green to Gray',
     ## then all events named 'AlarmStatusChangedEvent' that don't have the message 'Gray to Green'
     ## and 'Green to Gray' will be included.

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -259,12 +259,12 @@ instances:
     #   - datacenter
     #   - cluster
 
-    ## @param include_events - list of mappings - optional - default: [['AlarmStatusChangedEvent', ["r'Gray to Green'", "r'Green to Gray'"]], ['TaskEvent', ["r'Initialize powering On'", "r'Power Off virtual machine'", "r'Power On virtual machine'", "r'Reconfigure virtual machine'", "r'Relocate virtual machine'", "r'Suspend virtual machine'", "r'Migrate virtual machine'"]], ['VmBeingHotMigratedEvent', []], ['VmMessageEvent', []], ['VmMigratedEvent', []], ['VmPoweredOnEvent', []], ['VmPoweredOffEvent', []], ['VmReconfiguredEvent', []], ['VmSuspendedEvent', []]]
+    ## @param include_events - list of mappings - optional - default: [['AlarmStatusChangedEvent', ['Gray to Green', 'Green to Gray']], ['TaskEvent', ['Initialize powering On', 'Power Off virtual machine', 'Power On virtual machine', 'Reconfigure virtual machine', 'Relocate virtual machine', 'Suspend virtual machine', 'Migrate virtual machine']], ['VmBeingHotMigratedEvent', []], ['VmMessageEvent', []], ['VmMigratedEvent', []], ['VmPoweredOnEvent', []], ['VmPoweredOffEvent', []], ['VmReconfiguredEvent', []], ['VmSuspendedEvent', []]]
     ## The events that should be collected by the vSphere integration.
     ##
     ## Each event is an object represented with the event name itself as a key.
     ## However, while the keys should be events to include, the value should be an
-    ## array of event option regexes to exclude/filter out. For example, if the key
+    ## array of message regexes to exclude/filter out. For example, if the key
     ## is 'AlarmStatusChangedEvent' and the values for this key are 'Gray to Green' and 'Green to Gray',
     ## then all events name 'AlarmStatusChangedEvent' that don't have the option of 'Gray to Green'
     ## and 'Green to Gray' will be included.
@@ -274,9 +274,9 @@ instances:
     #
     # include_events:
     #   - event: <EVENT_NAME_TO_INCLUDE>
-    #   - messages:
-    #     - <EVENT_OPTION_REGEX_CORRESPONDING_TO_EVENT_NAME_TO_EXCLUDE_1>
-    #     - <EVENT_OPTION_REGEX_CORRESPONDING_TO_EVENT_NAME_TO_EXCLUDE_2>
+    #     excluded_messages:
+    #     - <EVENT_MESSAGE_REGEX_CORRESPONDING_TO_EVENT_NAME_TO_EXCLUDE_1>
+    #     - <EVENT_MESSAGE_REGEX_CORRESPONDING_TO_EVENT_NAME_TO_EXCLUDE_2>
 
     ## @param collect_tags - boolean - optional - default: false
     ## If true, the vSphere Tags will be collected.

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -262,7 +262,7 @@ instances:
     ## @param include_events - list of mappings - optional
     ## The events that should be collected by the vSphere integration.
     ##
-    ## Each event is an object represented with the event name itself as a key.
+    ## Each event is an object represented with the "event" itself as a key.
     ## However, while the keys should be events to include, the value should be an
     ## array of message regexes to exclude/filter out. For example, if the key
     ## is 'AlarmStatusChangedEvent' and the values for this key are 'Gray to Green' and 'Green to Gray',

--- a/vsphere/datadog_checks/vsphere/event.py
+++ b/vsphere/datadog_checks/vsphere/event.py
@@ -37,7 +37,7 @@ EXCLUDE_FILTERS = {
 class VSphereEvent(object):
     UNKNOWN = 'unknown'
 
-    def __init__(self, raw_event, event_config, tags, event_resource_filters, include_events=None):
+    def __init__(self, raw_event, event_config, tags, event_resource_filters, exclude_filters=EXCLUDE_FILTERS):
         self.raw_event = raw_event
         if self.raw_event and self.raw_event.__class__.__name__.startswith('vim.event'):
             self.event_type = self.raw_event.__class__.__name__[10:]
@@ -55,15 +55,8 @@ class VSphereEvent(object):
             self.event_config = {}
         else:
             self.event_config = event_config
-        if include_events is None:
-            self.exclude_filters = EXCLUDE_FILTERS
-        else:
-            self.exclude_filters = {}
-            for item in include_events:
-                event_name = item["event"]
-                excluded_messages = [r'{}'.format(msg) for msg in item["excluded_messages"]]
-                self.exclude_filters[event_name] = excluded_messages
-        self.allowed_events = [getattr(vim.event, event_type) for event_type in self.exclude_filters.keys()]
+        self.exclude_filters = exclude_filters
+        self.allowed_events = [getattr(vim.event, event_type) for event_type in exclude_filters.keys()]
         self.event_resource_filters = event_resource_filters
 
     def _is_filtered(self):

--- a/vsphere/datadog_checks/vsphere/event.py
+++ b/vsphere/datadog_checks/vsphere/event.py
@@ -55,7 +55,7 @@ class VSphereEvent(object):
             self.event_config = {}
         else:
             self.event_config = event_config
-        if not include_events:
+        if include_events is None:
             self.exclude_filters = EXCLUDE_FILTERS
         else:
             self.exclude_filters = {}

--- a/vsphere/datadog_checks/vsphere/event.py
+++ b/vsphere/datadog_checks/vsphere/event.py
@@ -37,7 +37,7 @@ EXCLUDE_FILTERS = {
 class VSphereEvent(object):
     UNKNOWN = 'unknown'
 
-    def __init__(self, raw_event, event_config, tags, event_resource_filters):
+    def __init__(self, raw_event, event_config, tags, event_resource_filters, include_events=None):
         self.raw_event = raw_event
         if self.raw_event and self.raw_event.__class__.__name__.startswith('vim.event'):
             self.event_type = self.raw_event.__class__.__name__[10:]
@@ -55,18 +55,10 @@ class VSphereEvent(object):
             self.event_config = {}
         else:
             self.event_config = event_config
-        if (
-            'include_events' not in self.event_config
-            or not self.event_config.include_events
-            or 'event' not in self.event_config.include_events
-            or 'options' not in self.event_config.include_events
-        ):
+        if not include_events:
             self.exclude_filters = EXCLUDE_FILTERS
         else:
-            self.exclude_filters = {
-                event_object['event']: [r'{}'.format(elt) for elt in event_object['options']]
-                for event_object in self.event_config.include_events
-            }
+            self.exclude_filters = {event[0]: [r'{}'.format(elt) for elt in event[1]] for event in include_events}
         self.allowed_events = [getattr(vim.event, event_type) for event_type in self.exclude_filters.keys()]
         self.event_resource_filters = event_resource_filters
 

--- a/vsphere/datadog_checks/vsphere/event.py
+++ b/vsphere/datadog_checks/vsphere/event.py
@@ -61,7 +61,7 @@ class VSphereEvent(object):
             self.exclude_filters = {}
             for item in include_events:
                 event_name = item["event"]
-                excluded_messages = [rf"{msg}" for msg in item["excluded_messages"]]
+                excluded_messages = [r'{}'.format(msg) for msg in item["excluded_messages"]]
                 self.exclude_filters[event_name] = excluded_messages
         self.allowed_events = [getattr(vim.event, event_type) for event_type in self.exclude_filters.keys()]
         self.event_resource_filters = event_resource_filters

--- a/vsphere/datadog_checks/vsphere/event.py
+++ b/vsphere/datadog_checks/vsphere/event.py
@@ -11,27 +11,7 @@ from pyVmomi import vim
 
 from datadog_checks.base import ensure_unicode
 
-from .constants import DEFAULT_EVENT_RESOURCES, MOR_TYPE_AS_STRING, SOURCE_TYPE
-
-EXCLUDE_FILTERS = {
-    'AlarmStatusChangedEvent': [r'Gray to Green', r'Green to Gray'],
-    'TaskEvent': [
-        r'Initialize powering On',
-        r'Power Off virtual machine',
-        r'Power On virtual machine',
-        r'Reconfigure virtual machine',
-        r'Relocate virtual machine',
-        r'Suspend virtual machine',
-        r'Migrate virtual machine',
-    ],
-    'VmBeingHotMigratedEvent': [],
-    'VmMessageEvent': [],
-    'VmMigratedEvent': [],
-    'VmPoweredOnEvent': [],
-    'VmPoweredOffEvent': [],
-    'VmReconfiguredEvent': [],
-    'VmSuspendedEvent': [],
-}
+from .constants import DEFAULT_EVENT_RESOURCES, EXCLUDE_FILTERS, MOR_TYPE_AS_STRING, SOURCE_TYPE
 
 
 class VSphereEvent(object):
@@ -56,7 +36,6 @@ class VSphereEvent(object):
         else:
             self.event_config = event_config
         self.exclude_filters = exclude_filters
-        self.allowed_events = [getattr(vim.event, event_type) for event_type in exclude_filters.keys()]
         self.event_resource_filters = event_resource_filters
 
     def _is_filtered(self):

--- a/vsphere/datadog_checks/vsphere/event.py
+++ b/vsphere/datadog_checks/vsphere/event.py
@@ -58,7 +58,11 @@ class VSphereEvent(object):
         if not include_events:
             self.exclude_filters = EXCLUDE_FILTERS
         else:
-            self.exclude_filters = {event[0]: [r'{}'.format(elt) for elt in event[1]] for event in include_events}
+            self.exclude_filters = {}
+            for item in include_events:
+                event_name = item["event"]
+                excluded_messages = [rf"{msg}" for msg in item["excluded_messages"]]
+                self.exclude_filters[event_name] = excluded_messages
         self.allowed_events = [getattr(vim.event, event_type) for event_type in self.exclude_filters.keys()]
         self.event_resource_filters = event_resource_filters
 

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -644,7 +644,7 @@ class VSphereCheck(AgentCheck):
                     event_config,
                     self._config.base_tags,
                     self._config.event_resource_filters,
-                    self._config.include_events,
+                    self._config.exclude_filters,
                 )
                 # Can return None if the event if filtered out
                 event_payload = normalized_event.get_datadog_payload()

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -640,7 +640,11 @@ class VSphereCheck(AgentCheck):
                     "Processing event with id:%s, type:%s: msg:%s", event.key, type(event), event.fullFormattedMessage
                 )
                 normalized_event = VSphereEvent(
-                    event, event_config, self._config.base_tags, self._config.event_resource_filters
+                    event,
+                    event_config,
+                    self._config.base_tags,
+                    self._config.event_resource_filters,
+                    self._config.include_events,
                 )
                 # Can return None if the event if filtered out
                 event_payload = normalized_event.get_datadog_payload()

--- a/vsphere/tests/test_event.py
+++ b/vsphere/tests/test_event.py
@@ -190,3 +190,87 @@ def test_events_collection(aggregator, realtime_instance):
     with pytest.raises(Exception, match=r"Invalid resource type specified in `event_resource_filters`: hey."):
         realtime_instance['event_resource_filters'] = ['hey']
         check = VSphereCheck('vsphere', {}, [realtime_instance])
+
+
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
+def test_include_events_ok(aggregator, realtime_instance):
+    realtime_instance['include_events'] = [['AlarmStatusChangedEvent', [r'Gray to Green', r'Green to Gray']]]
+    check = VSphereCheck(
+        'vsphere',
+        {},
+        [realtime_instance],
+    )
+    check.initiate_api_connection()
+
+    event1 = vim.event.AlarmStatusChangedEvent()
+    event1.createdTime = dt.datetime.now()
+    event1.entity = vim.event.ManagedEntityEventArgument()
+    event1.entity.entity = vim.VirtualMachine(moId="vm1")
+    event1.entity.name = "vm1"
+    event1.alarm = vim.event.AlarmEventArgument()
+    event1.alarm.name = "alarm1"
+    setattr(event1, 'from', 'green')
+    event1.to = 'red'
+    event1.datacenter = vim.event.DatacenterEventArgument()
+    event1.datacenter.name = "dc1"
+    event1.fullFormattedMessage = "Green to Red"
+    aggregator.reset()
+    check.api.mock_events = [event1]
+    check.check(None)
+    assert len(aggregator.events) == 1
+
+
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
+def test_include_events_filtered(aggregator, realtime_instance):
+    realtime_instance['include_events'] = [['AlarmStatusChangedEvent', [r'Gray to Green', r'Green to Gray']]]
+    check = VSphereCheck(
+        'vsphere',
+        {},
+        [realtime_instance],
+    )
+    check.initiate_api_connection()
+
+    event1 = vim.event.AlarmStatusChangedEvent()
+    event1.createdTime = dt.datetime.now()
+    event1.entity = vim.event.ManagedEntityEventArgument()
+    event1.entity.entity = vim.VirtualMachine(moId="vm1")
+    event1.entity.name = "vm1"
+    event1.alarm = vim.event.AlarmEventArgument()
+    event1.alarm.name = "alarm1"
+    setattr(event1, 'from', 'green')
+    event1.to = 'gray'
+    event1.datacenter = vim.event.DatacenterEventArgument()
+    event1.datacenter.name = "dc1"
+    event1.fullFormattedMessage = "Green to Gray"
+    aggregator.reset()
+    check.api.mock_events = [event1]
+    check.check(None)
+    assert len(aggregator.events) == 0
+
+
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
+def test_include_events_incorrectly_formatted_filter(aggregator, realtime_instance):
+    realtime_instance['include_events'] = [['Incorrect_Filter_Name', [r'Gray to Green', r'Green to Gray']]]
+    check = VSphereCheck(
+        'vsphere',
+        {},
+        [realtime_instance],
+    )
+    check.initiate_api_connection()
+
+    event1 = vim.event.AlarmStatusChangedEvent()
+    event1.createdTime = dt.datetime.now()
+    event1.entity = vim.event.ManagedEntityEventArgument()
+    event1.entity.entity = vim.VirtualMachine(moId="vm1")
+    event1.entity.name = "vm1"
+    event1.alarm = vim.event.AlarmEventArgument()
+    event1.alarm.name = "alarm1"
+    setattr(event1, 'from', 'green')
+    event1.to = 'red'
+    event1.datacenter = vim.event.DatacenterEventArgument()
+    event1.datacenter.name = "dc1"
+    event1.fullFormattedMessage = "Green to Red"
+    aggregator.reset()
+    check.api.mock_events = [event1]
+    check.check(None)
+    assert len(aggregator.events) == 0

--- a/vsphere/tests/test_event.py
+++ b/vsphere/tests/test_event.py
@@ -8,7 +8,6 @@ import pytest
 from pyVmomi import vim
 
 from datadog_checks.vsphere import VSphereCheck
-from datadog_checks.vsphere.event import ALLOWED_EVENTS
 
 
 def test_allowed_event_list():
@@ -23,7 +22,27 @@ def test_allowed_event_list():
         vim.event.VmReconfiguredEvent,
         vim.event.VmSuspendedEvent,
     ]
-    assert sorted(str(e) for e in expected_events) == sorted(str(e) for e in ALLOWED_EVENTS)
+    EXCLUDE_FILTERS = {
+        'AlarmStatusChangedEvent': [r'Gray to Green', r'Green to Gray'],
+        'TaskEvent': [
+            r'Initialize powering On',
+            r'Power Off virtual machine',
+            r'Power On virtual machine',
+            r'Reconfigure virtual machine',
+            r'Relocate virtual machine',
+            r'Suspend virtual machine',
+            r'Migrate virtual machine',
+        ],
+        'VmBeingHotMigratedEvent': [],
+        'VmMessageEvent': [],
+        'VmMigratedEvent': [],
+        'VmPoweredOnEvent': [],
+        'VmPoweredOffEvent': [],
+        'VmReconfiguredEvent': [],
+        'VmSuspendedEvent': [],
+    }
+    allowed_events = [getattr(vim.event, event_type) for event_type in EXCLUDE_FILTERS.keys()]
+    assert sorted(str(e) for e in expected_events) == sorted(str(e) for e in allowed_events)
 
 
 @pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')

--- a/vsphere/tests/test_event.py
+++ b/vsphere/tests/test_event.py
@@ -194,7 +194,9 @@ def test_events_collection(aggregator, realtime_instance):
 
 @pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
 def test_include_events_ok(aggregator, realtime_instance):
-    realtime_instance['include_events'] = [['AlarmStatusChangedEvent', [r'Gray to Green', r'Green to Gray']]]
+    realtime_instance['include_events'] = [
+        {"event": "AlarmStatusChangedEvent", "excluded_messages": ["Gray to Green", "Green to Gray"]}
+    ]
     check = VSphereCheck(
         'vsphere',
         {},
@@ -218,11 +220,14 @@ def test_include_events_ok(aggregator, realtime_instance):
     check.api.mock_events = [event1]
     check.check(None)
     assert len(aggregator.events) == 1
+    assert aggregator.events[0]['msg_title'] == "[Triggered] alarm1 on VM vm1 is now red"
 
 
 @pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
 def test_include_events_filtered(aggregator, realtime_instance):
-    realtime_instance['include_events'] = [['AlarmStatusChangedEvent', [r'Gray to Green', r'Green to Gray']]]
+    realtime_instance['include_events'] = [
+        {"event": "AlarmStatusChangedEvent", "excluded_messages": ["Gray to Green", "Green to Gray"]}
+    ]
     check = VSphereCheck(
         'vsphere',
         {},
@@ -249,8 +254,10 @@ def test_include_events_filtered(aggregator, realtime_instance):
 
 
 @pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
-def test_include_events_incorrectly_formatted_filter(aggregator, realtime_instance):
-    realtime_instance['include_events'] = [['Incorrect_Filter_Name', [r'Gray to Green', r'Green to Gray']]]
+def test_include_events_incorrectly_formatted_event(aggregator, realtime_instance):
+    realtime_instance['include_events'] = [
+        {"event": "IncorrectlyFormattedEvent", "excluded_messages": ["Gray to Green", "Green to Gray"]}
+    ]
     check = VSphereCheck(
         'vsphere',
         {},

--- a/vsphere/tests/test_event.py
+++ b/vsphere/tests/test_event.py
@@ -8,7 +8,7 @@ import pytest
 from pyVmomi import vim
 
 from datadog_checks.vsphere import VSphereCheck
-from datadog_checks.vsphere.event import EXCLUDE_FILTERS
+from datadog_checks.vsphere.constants import EXCLUDE_FILTERS
 
 
 def test_allowed_event_list():


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The vSphere integration currently only reports events from a hardcoded list. We want to allow customers to determine which events they want to receive, as well as which messages from said events they don't want to receive.
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
