### PR TITLE
Update Publish and Submit traces github actions

### DIFF
--- a/.github/workflows/submit-traces.yml
+++ b/.github/workflows/submit-traces.yml
@@ -49,7 +49,7 @@ jobs:
       if: ${{ hashFiles('captured-traces') != '' }}
       run: docker exec $(docker ps --format "{{.ID}}") agent status
 
-    - uses: geekyeggo/delete-artifact@v2
+    - uses: geekyeggo/delete-artifact@v5
       if: steps.download.outcome == 'success'
       with:
         name: "${{ inputs.artifact-name }}"

--- a/.github/workflows/test-results-master.yml
+++ b/.github/workflows/test-results-master.yml
@@ -48,7 +48,7 @@ jobs:
         esac
 
     - name: Create badge
-      uses: emibcn/badge-action@v2.0.2
+      uses: emibcn/badge-action@v2.0.3
       with:
         label: Tests
         status: "${{ fromJSON( steps.test-results.outputs.json ).formatted.stats.tests }} tests, ${{ fromJSON( steps.test-results.outputs.json ).formatted.stats.runs }} runs, ${{ fromJSON( steps.test-results.outputs.json ).formatted.stats.tests_fail }} failed"


### PR DESCRIPTION
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20
- emibcn/badge-action@v2.0.2
- geekyeggo/delete-artifact@v2

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
