### PR TITLE
Avoid trying to deconstruct None object

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -299,6 +299,7 @@ class DBMAsyncJob(object):
         self._job_tags = self._tags + ["job:{}".format(self._job_name)]
         self._job_tags_str = ','.join(self._job_tags)
         self._last_check_run = time.time()
+        self._is_check_running = False
         if self._run_sync or is_affirmative(os.environ.get('DBM_THREADED_JOB_RUN_SYNC', "false")):
             self._log.debug("Running threaded job synchronously. job=%s", self._job_name)
             self._run_sync_job_rate_limited()
@@ -321,6 +322,12 @@ class DBMAsyncJob(object):
                         "dd.{}.async_job.inactive_stop".format(self._dbms), 1, tags=self._job_tags, raw=True
                     )
                     break
+                if self._is_check_running:
+                    self._log.warn("[%s] Job loop attempted double run", self._job_tags_str)
+                    self._check.increment("dd.{}.double_async_job".format(self._dbms), tags=self._job_tags)
+                    continue
+                
+                self._is_check_running = True
                 if self._check.should_profile_memory():
                     self._check.profile_memory(
                         self._run_job_rate_limited,
@@ -329,6 +336,7 @@ class DBMAsyncJob(object):
                     )
                 else:
                     self._run_job_rate_limited()
+                self._is_check_running = False
         except Exception as e:
             if self._cancel_event.isSet():
                 # canceling can cause exceptions if the connection is closed the middle of the check run

--- a/mysql/changelog.d/17872.fixed
+++ b/mysql/changelog.d/17872.fixed
@@ -1,0 +1,1 @@
+Avoid simultaneous check runs with MySQL integration

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -541,7 +541,7 @@ class MySql(AgentCheck):
             # report size of tables in MiB to Datadog
             self.log.debug("Collecting Table Row Stats Metrics.")
             with tracked_query(self, operation="table_rows_stats_metrics"):
-                (rows_read_total, rows_changed_total) = self._query_rows_stats_per_table(db)
+                (rows_read_total, rows_changed_total) = self._query_rows_stats_per_table(db) or (None, None)
             results['information_table_rows_read_total'] = rows_read_total
             results['information_table_rows_changed_total'] = rows_changed_total
             metrics.update(TABLE_ROWS_STATS_VARS)
@@ -549,7 +549,7 @@ class MySql(AgentCheck):
         if is_affirmative(self._config.options.get('table_size_metrics', False)):
             # report size of tables in MiB to Datadog
             with tracked_query(self, operation="table_size_metrics"):
-                (table_index_size, table_data_size) = self._query_size_per_table(db)
+                (table_index_size, table_data_size) = self._query_size_per_table(db) or (None, None)
             results['information_table_index_size'] = table_index_size
             results['information_table_data_size'] = table_data_size
             metrics.update(TABLE_VARS)
@@ -557,7 +557,7 @@ class MySql(AgentCheck):
         if is_affirmative(self._config.options.get('system_table_size_metrics', False)):
             # report size of tables in MiB to Datadog
             with tracked_query(self, operation="system_table_size_metrics"):
-                (table_index_size, table_data_size) = self._query_size_per_table(db, system_tables=True)
+                (table_index_size, table_data_size) = self._query_size_per_table(db, system_tables=True) or (None, None)
             if results.get('information_table_index_size'):
                 results['information_table_index_size'].update(table_index_size)
             else:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes a bug where the MySQL integration tries to destructure a tuple returned by a function that can return None.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
