### PR TITLE
[mongo] Add tag clustername to mongo metrics

### DIFF
--- a/mongo/changelog.d/17876.added
+++ b/mongo/changelog.d/17876.added
@@ -1,0 +1,1 @@
+Add tag `clustername` to mongo metrics. This tag is set only when `cluster_name` is provided in the integration configuration.

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -97,8 +97,6 @@ class MongoConfig(object):
         self.custom_queries = instance.get("custom_queries", [])
 
         self._base_tags = list(set(instance.get('tags', [])))
-        self.service_check_tags = self._compute_service_check_tags()
-        self.metric_tags = self._compute_metric_tags()
 
         # DBM config options
         self.dbm_enabled = is_affirmative(instance.get('dbm', False))
@@ -111,6 +109,10 @@ class MongoConfig(object):
 
         # MongoDB instance hostname override
         self.reported_database_hostname = instance.get('reported_database_hostname', None)
+
+        # Generate tags for service checks and metrics
+        self.service_check_tags = self._compute_service_check_tags()
+        self.metric_tags = self._compute_metric_tags()
 
     def _get_clean_server_name(self):
         try:
@@ -143,7 +145,10 @@ class MongoConfig(object):
         return service_check_tags
 
     def _compute_metric_tags(self):
-        return self._base_tags + ['server:%s' % self.clean_server_name]
+        tags = self._base_tags + ['server:%s' % self.clean_server_name]
+        if self.cluster_name:
+            tags.append('clustername:%s' % self.cluster_name)
+        return tags
 
     @property
     def operation_samples(self):

--- a/mongo/tests/results/opeartion-activities-mongos.json
+++ b/mongo/tests/results/opeartion-activities-mongos.json
@@ -7,6 +7,7 @@
         "collection_interval": 10,
         "ddtags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
+            "clustername:my_cluster",
             "sharding_cluster_role:mongos"
         ],
         "timestamp": 1715911398111.2722,

--- a/mongo/tests/results/opeartion-activities-standalone.json
+++ b/mongo/tests/results/opeartion-activities-standalone.json
@@ -5,7 +5,7 @@
         "ddsource": "mongodb",
         "dbm_type": "activity",
         "collection_interval": 10,
-        "ddtags": ["server:mongodb://testUser2:*****@localhost:27017/test"],
+        "ddtags": ["server:mongodb://testUser2:*****@localhost:27017/test", "clustername:my_cluster"],
         "timestamp": 1715911398111.2722,
         "mongodb_activity": [
             {

--- a/mongo/tests/results/operation-samples-mongos.json
+++ b/mongo/tests/results/operation-samples-mongos.json
@@ -4,7 +4,7 @@
         "dbm_type": "plan",
         "ddagentversion": "0.0.0",
         "ddsource": "mongodb",
-        "ddtags": "server:mongodb://testUser2:*****@localhost:27017/test,sharding_cluster_role:mongos",
+        "ddtags": "server:mongodb://testUser2:*****@localhost:27017/test,clustername:my_cluster,sharding_cluster_role:mongos",
         "timestamp": 1715911398111.2722,
         "network": {
             "client": {

--- a/mongo/tests/results/operation-samples-standalone.json
+++ b/mongo/tests/results/operation-samples-standalone.json
@@ -4,7 +4,7 @@
         "dbm_type": "plan",
         "ddagentversion": "0.0.0",
         "ddsource": "mongodb",
-        "ddtags": "server:mongodb://testUser2:*****@localhost:27017/test",
+        "ddtags": "server:mongodb://testUser2:*****@localhost:27017/test,clustername:my_cluster",
         "timestamp": 1715911398111.2722,
         "network": {
             "client": {

--- a/mongo/tests/test_dbm_operation_samples.py
+++ b/mongo/tests/test_dbm_operation_samples.py
@@ -68,7 +68,6 @@ def test_mongo_operation_samples_mongos(aggregator, instance_integration_cluster
         expected_samples = json.load(f)
         assert len(dbm_samples) == len(expected_samples)
         for i, sample in enumerate(dbm_samples):
-            print(json.dumps(sample))
             assert sample == expected_samples[i]
 
     # assert activities
@@ -76,7 +75,6 @@ def test_mongo_operation_samples_mongos(aggregator, instance_integration_cluster
         expected_activities = json.load(f)
         assert len(dbm_activities) == len(expected_activities)
         for i, activity in enumerate(dbm_activities):
-            print(json.dumps(activity))
             assert activity == expected_activities[i]
 
 

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -100,7 +100,7 @@ def test_integration_mongos(instance_integration_cluster, aggregator, check, dd_
             'jumbo',
             'sessions',
         ],
-        ['sharding_cluster_role:mongos'],
+        ['sharding_cluster_role:mongos', 'clustername:my_cluster'],
     )
 
     aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?
This PR adds tag `clustername` to mongo metrics when `cluster_name` is provided in the configuration. Tag name `clustername` also matches the default tag for metrics pushed by MongoDB Atlas. 

<img width="1406" alt="image" src="https://github.com/DataDog/integrations-core/assets/4964070/81d7945f-4dd7-4843-af30-6e4d13a4c055">

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
