### PR TITLE
Limit the cases in which an agent build pipeline is triggered

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,10 +49,11 @@ validate-log-integrations:
 trigger-agent-build:
   stage: trigger
   image: $VALIDATE_AGENT_BUILD
-  # Exclude release branches without dependency change
   rules:
+    # Never trigger for tag pipelines
     - if: $CI_COMMIT_TAG
       when: never
+    # Trigger on non-release branches
     - if: ($CI_COMMIT_BRANCH !~ /^7.[0-9]{2}.x/)
       when: always
   cache:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,10 +51,8 @@ trigger-agent-build:
   image: $VALIDATE_AGENT_BUILD
   # Exclude release branches without dependency change
   rules:
-    - if: ($CI_COMMIT_BRANCH =~ /^7.[0-9]{2}.x/)
-      changes:
-        - .deps/*
-      when: always
+    - if: $CI_COMMIT_TAG
+      when: never
     - if: ($CI_COMMIT_BRANCH !~ /^7.[0-9]{2}.x/)
       when: always
   cache:


### PR DESCRIPTION
### What does this PR do?

Avoid triggering Agent build pipelines on:
- tag pipelines
- release branches (this should no longer be needed at this point)

### Motivation

The current logic has flaws that causes unnecessary triggers on release branches; in the case of tags, a massive number of references might be created which spawns the same number of pipelines (#incident-28175).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
