### PR TITLE
Send out container uptime metrics for ECS Fargate

### DIFF
--- a/ecs_fargate/changelog.d/17880.added
+++ b/ecs_fargate/changelog.d/17880.added
@@ -1,0 +1,1 @@
+Send out container uptime metrics for ECS Fargate

--- a/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
+++ b/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
@@ -4,6 +4,7 @@
 from __future__ import division
 
 import os
+from datetime import datetime, timezone
 
 import requests
 from dateutil import parser
@@ -176,6 +177,10 @@ class FargateCheck(AgentCheck):
 
             if container.get('Limits', {}).get('CPU', 0) > 0:
                 self.gauge('ecs.fargate.cpu.limit', container['Limits']['CPU'], container_tags[c_id])
+
+            if container.get('StartedAt', '') != '' and container.get('FinishedAt', '') == '':
+                uptime = int((datetime.now(timezone.utc) - parser.isoparse(container['StartedAt'])).total_seconds())
+                self.gauge('ecs.fargate.uptime', uptime, container_tags[c_id])
 
         # Create task tags
         task_tags = get_tags(TASK_TAGGER_ENTITY_ID, True) or []

--- a/ecs_fargate/tests/conftest.py
+++ b/ecs_fargate/tests/conftest.py
@@ -39,6 +39,7 @@ EXPECTED_CONTAINER_METRICS_LINUX = [
     'ecs.fargate.mem.pgmajfault',
     'ecs.fargate.mem.mapped_file',
     'ecs.fargate.mem.max_usage',
+    'ecs.fargate.uptime',
 ]
 
 EXPECTED_CONTAINER_METRICS_WINDOWS = [
@@ -52,6 +53,7 @@ EXPECTED_CONTAINER_METRICS_WINDOWS = [
     'ecs.fargate.io.bytes.write',
     'ecs.fargate.io.ops.read',
     'ecs.fargate.io.bytes.read',
+    'ecs.fargate.uptime',
 ]
 
 EXPECTED_TASK_METRICS = [


### PR DESCRIPTION
### What does this PR do?
Introduce container uptime metrics for ECS Fargate tasks.

### Motivation
We run batch jobs on ECS Fargate and wanted to have metrics (in order to be alerted, but also compare performance, etc.) on how long they take to run.

### Additional Notes
This has been tested and appears to work on our installation.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
