### PR TITLE
Use blocking to make sure dbm synchronous collection waits till collection interval is passed before next collection

### DIFF
--- a/mysql/tests/common.py
+++ b/mysql/tests/common.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
+import time
 from sys import maxsize
 
 import pytest
@@ -39,3 +40,9 @@ requires_static_version = pytest.mark.skipif(
 requires_classic_replication = pytest.mark.skipif(
     MYSQL_REPLICATION != 'classic', reason='Classic replication not active, skipping'
 )
+
+
+def run_one_check(dd_run_check, check, blocking=False):
+    dd_run_check(check)
+    if blocking:
+        time.sleep(check.instance.get('min_collection_interval', 0))

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -88,6 +88,7 @@ def instance_basic():
 @pytest.fixture
 def instance_complex():
     return {
+        'min_collection_interval': 0.2,
         'host': common.HOST,
         'username': common.USER,
         'password': common.PASS,

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -372,6 +372,7 @@ def test_activity_collection_rate_limit(aggregator, dd_run_check, dbm_instance):
     # test the activity collection loop rate limit
     aggregator.reset()
     collection_interval = 0.1
+    dbm_instance['min_collection_interval'] = 15
     dbm_instance['query_activity']['collection_interval'] = collection_interval
     dbm_instance['query_activity']['run_sync'] = False
     check = MySql(CHECK_NAME, {}, [dbm_instance])

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -87,7 +87,6 @@ def test_statement_metrics_multiple_pgss_rows_single_query_signature(
     # don't need samples for this test
     dbm_instance['query_samples'] = {'enabled': False}
     dbm_instance['query_activity'] = {'enabled': False}
-    dbm_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'incremental_query_metrics': True}
     connections = {}
 
     def normalize_query(q):

--- a/postgres/tests/utils.py
+++ b/postgres/tests/utils.py
@@ -121,10 +121,11 @@ def run_vacuum_thread(pg_instance, vacuum_query, application_name='test'):
     return run_query_thread(pg_instance, vacuum_query, application_name, init_stmts)
 
 
-def run_one_check(check, db_instance, cancel=True):
+def run_one_check(check, db_instance, cancel=True, blocking=False):
     """
     Run check and immediately cancel.
     Waits for all threads to close before continuing.
+    Blocking is used to wait for the min_collection_interval to pass.
     """
     check.check(db_instance)
     if cancel:
@@ -135,3 +136,5 @@ def run_one_check(check, db_instance, cancel=True):
         check.statement_metrics._job_loop_future.result()
     if check.metadata_samples._job_loop_future is not None:
         check.metadata_samples._job_loop_future.result()
+    if blocking:
+        time.sleep(db_instance.get('min_collection_interval', 0))

--- a/sqlserver/tests/utils.py
+++ b/sqlserver/tests/utils.py
@@ -4,6 +4,7 @@
 import os
 import string
 import threading
+import time
 from copy import copy
 from random import choice, randint, shuffle
 
@@ -220,3 +221,9 @@ class HighCardinalityQueries:
     @staticmethod
     def _create_rand_string(length=5):
         return ''.join(choice(string.ascii_lowercase + string.digits) for _ in range(length))
+
+
+def run_one_check(dd_run_check, check, blocking=False):
+    dd_run_check(check)
+    if blocking:
+        time.sleep(check.instance.get('min_collection_interval', 0))


### PR DESCRIPTION
### What does this PR do?
This PR fixes master CI failure due to the way DBM synchronous collection behavior was changed in #17716 .
Prior to the #17716 , synchronous collection will sleep till collection interval is passed before next collection starts. Now synchronous collection will not sleep the thread but instead check if the time between now and last collection exceeds the collection interval or not. 
This change breaks master CI pipeline because now consecutive collections might not be executed due to the time between now and last collection not exceed the collection interval. 
This PR attempts to "restore" the old behavior in tests by explicitly sleep between collections. Follow up changes required to run DBM collection in async mode to match the default integration behavior.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
