### PR TITLE
Fix rate limiter in sync mode of DBMAsync job.

### DIFF
--- a/datadog_checks_base/changelog.d/17893.fixed
+++ b/datadog_checks_base/changelog.d/17893.fixed
@@ -1,0 +1,1 @@
+take into account job execution time in rate limiter

--- a/datadog_checks_base/changelog.d/17893.fixed
+++ b/datadog_checks_base/changelog.d/17893.fixed
@@ -1,1 +1,1 @@
-take into account job execution time in rate limiter
+Fix rate limiter in sync mode of DBMAsync job. Prior to this change, the DBMAsync job would not take into account the time of the job execution when throttling by the collection interval.

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -368,12 +368,8 @@ class DBMAsyncJob(object):
 
     def _run_sync_job_rate_limited(self):
         if self._rate_limiter.shall_execute():
-            try:
-                self._run_job_traced()
-            except:
-                raise
-            finally:
-                self._rate_limiter.update_last_time()
+            self._rate_limiter.update_last_time()
+            self._run_job_traced()
 
     def _run_job_rate_limited(self):
         try:

--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -292,10 +292,11 @@ def test_dbm_sync_job_rate_limit(aggregator):
 
 
 def test_dbm_sync_long_job_rate_limit(aggregator):
-    rate_limit = 2
-    job = TestJob(AgentCheck(), run_sync=True, rate_limit=rate_limit, job_execution_time=1)
+    collection_interval = 0.5
+    rate_limit = 1 / collection_interval
+    job = TestJob(AgentCheck(), run_sync=True, rate_limit=rate_limit, job_execution_time=2 * collection_interval)
     job.run_job_loop([])
-    # despite jobs being executed one after another rate limiter shouldnt block
+    # despite jobs being executed one after another rate limiter shouldn't block execution
     # as jobs are slower than the collection interval
     job.run_job_loop([])
     assert job.count_executed == 2

--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -206,7 +206,7 @@ def test_obfuscate_sql_with_metadata_replace_null_character(input_query, expecte
 
 
 class TestJob(DBMAsyncJob):
-    def __init__(self, check, run_sync=False, enabled=True, rate_limit=10, min_collection_interval=15):
+    def __init__(self, check, run_sync=False, enabled=True, rate_limit=10, min_collection_interval=15, job_execution_time=0):
         super(TestJob, self).__init__(
             check,
             run_sync=run_sync,
@@ -219,12 +219,16 @@ class TestJob(DBMAsyncJob):
             job_name="test-job",
             shutdown_callback=self.test_shutdown,
         )
+        self._job_execution_time = job_execution_time
+        self.count_executed = 0
 
     def test_shutdown(self):
         self._check.count("dbm.async_job_test.shutdown", 1)
 
     def run_job(self):
         self._check.count("dbm.async_job_test.run_job", 1)
+        self.count_executed += 1
+        time.sleep(self._job_execution_time)
 
 
 def test_dbm_async_job():
@@ -272,6 +276,25 @@ def test_dbm_async_job_run_sync(aggregator):
     assert job._job_loop_future is None
     aggregator.assert_metric("dbm.async_job_test.run_job")
 
+def test_dbm_sync_job_rate_limit(aggregator):
+    rate_limit = 1
+    job = TestJob(AgentCheck(), run_sync=True, rate_limit=rate_limit)
+    for i in range(0,2):
+        # 2 runs out of 3 should be skipped
+        job.run_job_loop([])
+    time.sleep(1/rate_limit)
+    # this run should be allowed
+    job.run_job_loop([])
+    assert job.count_executed == 2
+
+def test_dbm_sync_long_job_rate_limit(aggregator):
+    rate_limit = 2
+    job = TestJob(AgentCheck(), run_sync=True, rate_limit=rate_limit, job_execution_time = 1)
+    job.run_job_loop([])
+    # despite jobs being executed one after another rate limiter shouldnt block 
+    # as jobs are slower than the collection interval
+    job.run_job_loop([])
+    assert job.count_executed == 2
 
 def test_dbm_async_job_rate_limit(aggregator):
     # test the main collection loop rate limit

--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -206,7 +206,9 @@ def test_obfuscate_sql_with_metadata_replace_null_character(input_query, expecte
 
 
 class TestJob(DBMAsyncJob):
-    def __init__(self, check, run_sync=False, enabled=True, rate_limit=10, min_collection_interval=15, job_execution_time=0):
+    def __init__(
+        self, check, run_sync=False, enabled=True, rate_limit=10, min_collection_interval=15, job_execution_time=0
+    ):
         super(TestJob, self).__init__(
             check,
             run_sync=run_sync,
@@ -276,25 +278,28 @@ def test_dbm_async_job_run_sync(aggregator):
     assert job._job_loop_future is None
     aggregator.assert_metric("dbm.async_job_test.run_job")
 
+
 def test_dbm_sync_job_rate_limit(aggregator):
     rate_limit = 1
     job = TestJob(AgentCheck(), run_sync=True, rate_limit=rate_limit)
-    for i in range(0,2):
+    for _ in range(0, 2):
         # 2 runs out of 3 should be skipped
         job.run_job_loop([])
-    time.sleep(1/rate_limit)
+    time.sleep(1 / rate_limit)
     # this run should be allowed
     job.run_job_loop([])
     assert job.count_executed == 2
 
+
 def test_dbm_sync_long_job_rate_limit(aggregator):
     rate_limit = 2
-    job = TestJob(AgentCheck(), run_sync=True, rate_limit=rate_limit, job_execution_time = 1)
+    job = TestJob(AgentCheck(), run_sync=True, rate_limit=rate_limit, job_execution_time=1)
     job.run_job_loop([])
-    # despite jobs being executed one after another rate limiter shouldnt block 
+    # despite jobs being executed one after another rate limiter shouldnt block
     # as jobs are slower than the collection interval
     job.run_job_loop([])
     assert job.count_executed == 2
+
 
 def test_dbm_async_job_rate_limit(aggregator):
     # test the main collection loop rate limit


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug in DBMAsync job that is ran in sync mode.

### Motivation
Prior to this change, the DBMAsync job would not take into account the time of the job execution when throttling by the collection interval.
Before:
<--job runs--><--collection interval--><--job runs-->
After
<--collection interval--> <--collection interval-->
<--job runs--> ..............                <--job runs-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
