### PR TITLE
[postgres] fix flaky test caused by int cast with NoneType

### DIFF
--- a/postgres/tests/test_replication_slot.py
+++ b/postgres/tests/test_replication_slot.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import psycopg2
 import pytest
-from flaky import flaky
 
 from datadog_checks.postgres.util import QUERY_PG_REPLICATION_SLOTS_STATS
 
@@ -13,7 +12,6 @@ from .utils import requires_over_10, requires_over_14
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]
 
 
-@flaky(max_runs=5)
 @requires_over_10
 def test_physical_replication_slots(aggregator, integration_check, pg_instance):
     check = integration_check(pg_instance)


### PR DESCRIPTION
### What does this PR do?
This PR fixes flaky postgres `test_physical_replication_slots`  test caused by int cast with NoneType.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
