### PR TITLE
None check

### DIFF
--- a/postgres/tests/test_replication_slot.py
+++ b/postgres/tests/test_replication_slot.py
@@ -22,8 +22,8 @@ def test_physical_replication_slots(aggregator, integration_check, pg_instance):
             cur.execute("select pg_wal_lsn_diff(pg_current_wal_lsn(), redo_lsn) from pg_control_checkpoint();")
             redo_lsn_age = int(cur.fetchall()[0][0])
             cur.execute('select age(xmin) FROM pg_replication_slots;')
-            rows = cur.fetchall()
-            xmin_age_higher_bound += int(rows[0][0]) if rows is not None else 0
+            bound = cur.fetchall()[0][0]
+            xmin_age_higher_bound += int(bound) if bound is not None else 0
 
             cur.execute("select * from pg_create_physical_replication_slot('phys_1');")
             cur.execute("select * from pg_create_physical_replication_slot('phys_2', true);")

--- a/postgres/tests/test_replication_slot.py
+++ b/postgres/tests/test_replication_slot.py
@@ -17,6 +17,8 @@ pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')
 @requires_over_10
 def test_physical_replication_slots(aggregator, integration_check, pg_instance):
     check = integration_check(pg_instance)
+    # It seemingly can take a small amount of time for the pg_replication_slots to be saturated
+    # TODO: Poll for its existence as a ready check
     time.sleep(1)
     redo_lsn_age = 0
     xmin_age_higher_bound = 1

--- a/postgres/tests/test_replication_slot.py
+++ b/postgres/tests/test_replication_slot.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import time
 import psycopg2
 import pytest
 
@@ -15,6 +16,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')
 @requires_over_10
 def test_physical_replication_slots(aggregator, integration_check, pg_instance):
     check = integration_check(pg_instance)
+    time.sleep(1)
     redo_lsn_age = 0
     xmin_age_higher_bound = 1
     with psycopg2.connect(host=HOST, dbname=DB_NAME, user="postgres", password="datad0g") as conn:

--- a/postgres/tests/test_replication_slot.py
+++ b/postgres/tests/test_replication_slot.py
@@ -22,7 +22,8 @@ def test_physical_replication_slots(aggregator, integration_check, pg_instance):
             cur.execute("select pg_wal_lsn_diff(pg_current_wal_lsn(), redo_lsn) from pg_control_checkpoint();")
             redo_lsn_age = int(cur.fetchall()[0][0])
             cur.execute('select age(xmin) FROM pg_replication_slots;')
-            xmin_age_higher_bound += int(cur.fetchall()[0][0])
+            rows = cur.fetchall()
+            xmin_age_higher_bound += int(rows[0][0]) if rows is not None else 0
 
             cur.execute("select * from pg_create_physical_replication_slot('phys_1');")
             cur.execute("select * from pg_create_physical_replication_slot('phys_2', true);")

--- a/postgres/tests/test_replication_slot.py
+++ b/postgres/tests/test_replication_slot.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import time
+
 import psycopg2
 import pytest
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds a sleep to make sure the `pg_replication_slots` table is saturated. Not an ideal solution but it will un-flake this test until we can implement better polling across our tests.

![SLEEP](https://i.imgflip.com/8uh8d0.jpg)

### Motivation
<!-- What inspired you to submit this pull request? -->
There appears to be a small delay before this table is ready.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
