### PR TITLE
Filter out PREPARE dd_ statements in query metrics

### DIFF
--- a/postgres/changelog.d/17902.fixed
+++ b/postgres/changelog.d/17902.fixed
@@ -1,0 +1,1 @@
+Filter out `PREPARE dd_` statements in query metrics. This query is used by postgres integration internally to collect explain plan for queries using extended protocol. 

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -43,6 +43,7 @@ SELECT {cols}
          ON pg_stat_statements.dbid = pg_database.oid
   WHERE query != '<insufficient privilege>'
   AND query NOT LIKE 'EXPLAIN %%'
+  AND query NOT LIKE '%%PREPARE dd_%%'
   {queryid_filter}
   {filters}
   {extra_clauses}


### PR DESCRIPTION
### What does this PR do?
This PR filters out `PREPARE dd_` statements in postgres query metrics as these queries are internal agent queries to explain queries using extended protocols.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
