### PR TITLE
[Postgres] Ignore explain plan collection queries in query metrics

### DIFF
--- a/postgres/changelog.d/17903.fixed
+++ b/postgres/changelog.d/17903.fixed
@@ -1,0 +1,1 @@
+Ignore DBM explain plan collection queries in query metrics.

--- a/postgres/datadog_checks/postgres/cursor.py
+++ b/postgres/datadog_checks/postgres/cursor.py
@@ -17,8 +17,14 @@ class BaseCommenterCursor:
         self.__attributes = DD_QUERY_ATTRIBUTES
         super().__init__(*args, **kwargs)
 
-    def execute(self, query, vars=None):
+    def execute(self, query, vars=None, ignore_query_metric=False):
+        '''
+        When ignore is True, a /* DDIGNORE */ comment will be added to the query.
+        This comment indicates that the query should be ignored in query metrics.
+        '''
         query = add_sql_comment(query, prepand=True, **self.__attributes)
+        if ignore_query_metric:
+            query = '{} {}'.format('/* DDIGNORE */', query)
         return super().execute(query, vars)
 
 

--- a/postgres/datadog_checks/postgres/explain_parameterized_queries.py
+++ b/postgres/datadog_checks/postgres/explain_parameterized_queries.py
@@ -185,12 +185,12 @@ class ExplainParameterizedQueries:
         with self._check.db_pool.get_connection(dbname, self._check._config.idle_connection_timeout) as conn:
             with conn.cursor(cursor_factory=CommenterDictCursor) as cursor:
                 logger.debug('Executing query=[%s]', query)
-                cursor.execute(query)
+                cursor.execute(query, ignore_query_metric=True)
 
     def _execute_query_and_fetch_rows(self, dbname, query):
         with self._check.db_pool.get_connection(dbname, self._check._config.idle_connection_timeout) as conn:
             with conn.cursor(cursor_factory=CommenterDictCursor) as cursor:
-                cursor.execute(query)
+                cursor.execute(query, ignore_query_metric=True)
                 return cursor.fetchall()
 
     def _is_parameterized_query(self, statement: str) -> bool:

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -556,7 +556,8 @@ class PostgresStatementSamples(DBMAsyncJob):
                 cursor.execute(
                     """SELECT {explain_function}($stmt${statement}$stmt$)""".format(
                         explain_function=self._explain_function, statement=statement
-                    )
+                    ),
+                    ignore_query_metric=True,
                 )
                 result = cursor.fetchone()
                 self._check.histogram(

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -42,7 +42,7 @@ SELECT {cols}
   LEFT JOIN pg_database
          ON pg_stat_statements.dbid = pg_database.oid
   WHERE query != '<insufficient privilege>'
-  AND query NOT LIKE 'EXPLAIN %%'
+  AND query NOT LIKE '/* DDIGNORE */%%'
   {queryid_filter}
   {filters}
   {extra_clauses}

--- a/postgres/tests/test_cursor.py
+++ b/postgres/tests/test_cursor.py
@@ -10,27 +10,30 @@ from .utils import _get_superconn
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_integration_connection_with_commenter_cursor(integration_check, pg_instance):
+@pytest.mark.parametrize('ignore', [True, False])
+def test_integration_connection_with_commenter_cursor(integration_check, pg_instance, ignore):
     check = integration_check(pg_instance)
 
     with check.db() as conn:
         # verify CommenterCursor and CommenterDictCursor prepend the query with /* service='datadog-agent' */
         with conn.cursor(cursor_factory=CommenterCursor) as cursor:
-            cursor.execute('SELECT name, setting FROM pg_settings where name = %s', ('pg_stat_statements.max',))
+            cursor.execute(
+                'SELECT name, setting FROM pg_settings where name = %s', ('pg_stat_statements.max',), ignore=ignore
+            )
             result = cursor.fetchone()
             assert result[0] == 'pg_stat_statements.max'
-        __check_prepand_sql_comment(pg_instance)
+        __check_prepand_sql_comment(pg_instance, ignore)
 
         with conn.cursor(cursor_factory=CommenterDictCursor) as cursor:
-            cursor.execute('SELECT name, setting FROM pg_settings where name = %s', ('max_connections',))
+            cursor.execute('SELECT name, setting FROM pg_settings where name = %s', ('max_connections',), ignore=ignore)
             result = cursor.fetchone()
             assert result['name'] == 'max_connections'
-        __check_prepand_sql_comment(pg_instance)
+        __check_prepand_sql_comment(pg_instance, ignore)
 
     check.cancel()
 
 
-def __check_prepand_sql_comment(pg_instance):
+def __check_prepand_sql_comment(pg_instance, ignore):
     # collect query_text from pg_stat_activity
     # assert /* service='datadog-agent' */ is present in the query
     super_conn = _get_superconn(pg_instance)
@@ -38,5 +41,8 @@ def __check_prepand_sql_comment(pg_instance):
         cursor.execute("SELECT query FROM pg_stat_activity where query like '%pg_settings%'")
         result = cursor.fetchall()
         assert len(result) > 0
-        assert result[0][0].startswith('/* service=\'datadog-agent\' */')
+        comment = '/* service=\'datadog-agent\' */'
+        if ignore:
+            comment = '{} {}'.format('/* DDIGNORE */', comment)
+        assert result[0][0].startswith(comment)
     super_conn.close()

--- a/postgres/tests/test_cursor.py
+++ b/postgres/tests/test_cursor.py
@@ -18,14 +18,20 @@ def test_integration_connection_with_commenter_cursor(integration_check, pg_inst
         # verify CommenterCursor and CommenterDictCursor prepend the query with /* service='datadog-agent' */
         with conn.cursor(cursor_factory=CommenterCursor) as cursor:
             cursor.execute(
-                'SELECT name, setting FROM pg_settings where name = %s', ('pg_stat_statements.max',), ignore=ignore
+                'SELECT name, setting FROM pg_settings where name = %s',
+                ('pg_stat_statements.max',),
+                ignore_query_metric=ignore,
             )
             result = cursor.fetchone()
             assert result[0] == 'pg_stat_statements.max'
         __check_prepand_sql_comment(pg_instance, ignore)
 
         with conn.cursor(cursor_factory=CommenterDictCursor) as cursor:
-            cursor.execute('SELECT name, setting FROM pg_settings where name = %s', ('max_connections',), ignore=ignore)
+            cursor.execute(
+                'SELECT name, setting FROM pg_settings where name = %s',
+                ('max_connections',),
+                ignore_query_metric=ignore,
+            )
             result = cursor.fetchone()
             assert result['name'] == 'max_connections'
         __check_prepand_sql_comment(pg_instance, ignore)

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -724,10 +724,10 @@ def test_failed_explain_handling(
                 "datadog.explain_statement exists in the database. See "
                 "https://docs.datadoghq.com/database_monitoring/setup_postgres/troubleshooting#undefined-explain-function"
                 " for more details: function datadog.explain_statement(unknown) does not exist\nLINE 1: "
-                "/* service='datadog-agent' */ SELECT datadog.explain_stateme...\n"
-                "                                             ^\nHINT:  No function matches the given name"
-                " and argument types. You might need to add explicit type casts.\n\ncode=undefined-explain-function "
-                "dbname=dogs_nofunc host=stubbed.hostname",
+                "... DDIGNORE */ /* service='datadog-agent' */ SELECT datadog.ex...\n"
+                "                                                             ^\nHINT:  No function matches the given "
+                "name and argument types. You might need to add explicit type casts.\n\ncode=undefined-explain-function"
+                " dbname=dogs_nofunc host=stubbed.hostname",
             ],
         ),
         (


### PR DESCRIPTION
### What does this PR do?
This PR prepends a new comment `/* DDIGNORE */` to the DBM explain plan collection queries. The comment `/* DDIGNORE */` is used to ignore these queries in query metrics.
With this change, below agent queries are ignored in query metrics
- `SELECT datadog.explain_statement ( ? )` - pre-configured function to explain non-parametrized queries
- `PREPARE dd_{query_signature} AS {statement}` - creates prepared statement to explain queries with extended protocol
- `DEALLOCATE PREPARE dd_{query_signature}` - deallocate the prepared statement used for explain

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
