### PR TITLE
Add github actions workflow permissions advisor

### DIFF
--- a/.github/workflows/permissions-advisor.yml
+++ b/.github/workflows/permissions-advisor.yml
@@ -1,0 +1,26 @@
+name: Permissions Advisor
+
+permissions:
+  actions: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'The name of the workflow file to analyze'
+        required: true
+        type: string
+      count:
+        description: 'How many last runs to analyze'
+        required: false
+        type: number
+        default: 10
+
+jobs:
+  advisor:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: GitHubSecurityLab/actions-permissions/advisor@v1
+      with:
+        name: ${{ inputs.name }}
+        count: ${{ inputs.count }}


### PR DESCRIPTION
### What does this PR do?
Adds a workflow that helps to understand the permissions required for a given workflow

### Motivation
https://datadoghq.atlassian.net/browse/SINT-2063

### Additional Notes
https://github.blog/2023-06-26-new-tool-to-secure-your-github-actions/

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
