### PR TITLE
update service check to use current implementation instead of legacy

### DIFF
--- a/vsphere/assets/service_checks.json
+++ b/vsphere/assets/service_checks.json
@@ -2,7 +2,7 @@
     {
         "agent_version": "5.2.0",
         "integration": "vSphere",
-        "check": "vcenter.can_connect",
+        "check": "vsphere.can_connect",
         "statuses": [
             "ok",
             "critical"
@@ -12,6 +12,6 @@
             "vcenter_server"
         ],
         "name": "Can Connect",
-        "description": "Returns status after pinging your vCenter instance. Additional information about response status at the time of collection is included in the check message."
+        "description": "Returns status after trying to connect to your vCenter instance using the API. Additional information about response status at the time of collection is included in the check message."
     }
 ]

--- a/vsphere/assets/service_checks.json
+++ b/vsphere/assets/service_checks.json
@@ -12,6 +12,21 @@
             "vcenter_server"
         ],
         "name": "Can Connect",
-        "description": "Returns status after trying to connect to your vCenter instance using the API. Additional information about response status at the time of collection is included in the check message."
+        "description": "Returns status after trying to connect to your vCenter instance using the API."
+    },
+    {
+        "agent_version": "5.2.0",
+        "integration": "vSphere",
+        "check": "vcenter.can_connect",
+        "statuses": [
+            "ok",
+            "critical"
+        ],
+        "groups": [
+            "host",
+            "vcenter_server"
+        ],
+        "name": "[Legacy] Can Connect",
+        "description": "[Legacy check version] Returns status after pinging your vCenter instance. Additional information about response status at the time of collection is included in the check message."
     }
 ]


### PR DESCRIPTION
### What does this PR do?
* Updates the service check asset : 
    * Use the current namespace `vsphere` instead of the legacy `vcenter` https://github.com/DataDog/integrations-core/blob/b8c883091cbdf86546470f238be58efe2b3ca205/vsphere/datadog_checks/vsphere/vsphere.py#L64-L68
    * Clarifies the description on the API usage, not simply a "ping"

### Motivation
* Customer is confused about having no data for `vcenter.can_connect` which is expected as they are using the non-legacy implementation. Our [documentation](https://docs.datadoghq.com/integrations/vsphere/#service-checks) relies on this asset which is currently the legacy one
<img width="775" alt="image" src="https://github.com/DataDog/integrations-core/assets/97530782/4484d7c7-a728-4dfa-b9ed-6d907e345225">


### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
