### PR TITLE
[tcp_checks] If dns-resolve failed don't report metrics.

### DIFF
--- a/tcp_check/changelog.d/17912.added
+++ b/tcp_check/changelog.d/17912.added
@@ -1,0 +1,1 @@
+[tcp_checks] If dns-resolve failed don't report metrics.

--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -116,8 +116,13 @@ class TCPCheck(AgentCheck):
         start = get_precise_time()  # Avoid initialisation warning
 
         if self.should_resolve_ips():
-            self.resolve_ips()
-            self.ip_cache_last_ts = start
+            try:
+                self.resolve_ips()
+                self.ip_cache_last_ts = start
+            except CheckException as e:
+                self.log.error("DNS resolution failed: %s", str(e))
+                self.report_as_service_check(AgentCheck.CRITICAL, "DNS resolution failed", str(e))
+                return  # The dns-resolve failed
 
         self.log.debug("Connecting to %s on port %d", self.host, self.port)
 


### PR DESCRIPTION
### What does this PR do?
TCP CHECKS data is reported even when `DNS RESOLVE fails`, causing confusion in monitoring.
If `DNS RESOLVE` failed don't report metrics.

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
