### PR TITLE
[FRAGENT-807] Adding more events/resource to be filtered in vSphere with event_resource_filters

### DIFF
--- a/vsphere/assets/configuration/spec.yaml
+++ b/vsphere/assets/configuration/spec.yaml
@@ -277,7 +277,14 @@ files:
                 type: string
       - name: event_resource_filters
         description: |
-          Which resource types to collect AlarmStatusChangedEvent events for.
+          For events that can be filtered by resources, specify which resources to collect these events for.
+
+          The events that can be filtered by resource are as follows: AlarmAcknowledgedEvent,
+          AlarmActionTriggeredEvent, AlarmClearedEvent, AlarmCreatedEvent, AlarmEmailCompletedEvent,
+          AlarmEmailFailedEvent, AlarmReconfiguredEvent, AlarmRemovedEvent, AlarmScriptCompleteEvent,
+          AlarmScriptFailedEvent, AlarmSnmpCompletedEvent, AlarmSnmpFailedEvent, AlarmStatusChangedEvent,
+          CustomFieldValueChangedEvent, GeneralUserEvent, PermissionEvent, ScheduledTaskEvent
+
           Available resource types are vm, host, datastore, datacenter, and cluster.
 
           By default, the integration will only collect these events for VMs and Hosts.

--- a/vsphere/assets/configuration/spec.yaml
+++ b/vsphere/assets/configuration/spec.yaml
@@ -288,6 +288,8 @@ files:
             - 'datastore'
             - 'datacenter'
             - 'cluster'
+            - 'storage_pod'
+            - 'vcenter_object_manager'
           type: array
           display_default: ['vm', 'host']
           items:

--- a/vsphere/changelog.d/17917.added
+++ b/vsphere/changelog.d/17917.added
@@ -1,0 +1,1 @@
+Added more events/resource to be filtered in vSphere with event_resource_filters

--- a/vsphere/datadog_checks/vsphere/constants.py
+++ b/vsphere/datadog_checks/vsphere/constants.py
@@ -29,6 +29,8 @@ MOR_TYPE_AS_STRING = {
     vim.Datacenter: 'datacenter',
     vim.Datastore: 'datastore',
     vim.ClusterComputeResource: 'cluster',
+    vim.StoragePod: 'storage_pod',
+    vim.vslm.vcenter.VStorageObjectManager: 'vstorage_object_manager',
 }
 
 ALL_RESOURCES = [
@@ -195,3 +197,23 @@ EXCLUDE_FILTERS = {
     'VmReconfiguredEvent': [],
     'VmSuspendedEvent': [],
 }
+
+EVENTS_FILTERABLE_BY_RESOURCE = [
+    'AlarmAcknowledgedEvent',
+    'AlarmActionTriggeredEvent',
+    'AlarmClearedEvent',
+    'AlarmCreatedEvent',
+    'AlarmEmailCompletedEvent',
+    'AlarmEmailFailedEvent',
+    'AlarmReconfiguredEvent',
+    'AlarmRemovedEvent',
+    'AlarmScriptCompleteEvent',
+    'AlarmScriptFailedEvent',
+    'AlarmSnmpCompletedEvent',
+    'AlarmSnmpFailedEvent',
+    'AlarmStatusChangedEvent',
+    'CustomFieldValueChangedEvent',
+    'GeneralUserEvent',
+    'PermissionEvent',
+    'ScheduledTaskEvent',
+]

--- a/vsphere/datadog_checks/vsphere/constants.py
+++ b/vsphere/datadog_checks/vsphere/constants.py
@@ -198,7 +198,7 @@ EXCLUDE_FILTERS = {
     'VmSuspendedEvent': [],
 }
 
-EVENTS_FILTERABLE_BY_RESOURCE = [
+PER_RESOURCE_EVENTS = [
     'AlarmAcknowledgedEvent',
     'AlarmActionTriggeredEvent',
     'AlarmClearedEvent',

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -247,7 +247,14 @@ instances:
     #   - <CLUSTER_REGEX>
 
     ## @param event_resource_filters - list of strings - optional - default: ['vm', 'host']
-    ## Which resource types to collect AlarmStatusChangedEvent events for.
+    ## For events that can be filtered by resources, specify which resources to collect these events for.
+    ##
+    ## The events that can be filtered by resource are as follows: AlarmAcknowledgedEvent,
+    ## AlarmActionTriggeredEvent, AlarmClearedEvent, AlarmCreatedEvent, AlarmEmailCompletedEvent,
+    ## AlarmEmailFailedEvent, AlarmReconfiguredEvent, AlarmRemovedEvent, AlarmScriptCompleteEvent,
+    ## AlarmScriptFailedEvent, AlarmSnmpCompletedEvent, AlarmSnmpFailedEvent, AlarmStatusChangedEvent,
+    ## CustomFieldValueChangedEvent, GeneralUserEvent, PermissionEvent, ScheduledTaskEvent
+    ##
     ## Available resource types are vm, host, datastore, datacenter, and cluster.
     ##
     ## By default, the integration will only collect these events for VMs and Hosts.

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -258,6 +258,8 @@ instances:
     #   - datastore
     #   - datacenter
     #   - cluster
+    #   - storage_pod
+    #   - vcenter_object_manager
 
     ## @param include_events - list of mappings - optional
     ## The events that should be collected by the vSphere integration.

--- a/vsphere/datadog_checks/vsphere/event.py
+++ b/vsphere/datadog_checks/vsphere/event.py
@@ -13,9 +13,9 @@ from datadog_checks.base import ensure_unicode
 
 from .constants import (
     DEFAULT_EVENT_RESOURCES,
-    EVENTS_FILTERABLE_BY_RESOURCE,
     EXCLUDE_FILTERS,
     MOR_TYPE_AS_STRING,
+    PER_RESOURCE_EVENTS,
     SOURCE_TYPE,
 )
 
@@ -46,7 +46,7 @@ class VSphereEvent(object):
 
     def _is_filtered(self):
         # Filter the unwanted types
-        if self.event_type in EVENTS_FILTERABLE_BY_RESOURCE:
+        if self.event_type in PER_RESOURCE_EVENTS:
             # Get the entity type/name
             self.entity_type = self.raw_event.entity.entity.__class__
 

--- a/vsphere/datadog_checks/vsphere/event.py
+++ b/vsphere/datadog_checks/vsphere/event.py
@@ -11,7 +11,13 @@ from pyVmomi import vim
 
 from datadog_checks.base import ensure_unicode
 
-from .constants import DEFAULT_EVENT_RESOURCES, EXCLUDE_FILTERS, MOR_TYPE_AS_STRING, SOURCE_TYPE
+from .constants import (
+    DEFAULT_EVENT_RESOURCES,
+    EVENTS_FILTERABLE_BY_RESOURCE,
+    EXCLUDE_FILTERS,
+    MOR_TYPE_AS_STRING,
+    SOURCE_TYPE,
+)
 
 
 class VSphereEvent(object):
@@ -40,7 +46,7 @@ class VSphereEvent(object):
 
     def _is_filtered(self):
         # Filter the unwanted types
-        if self.event_type == 'AlarmStatusChangedEvent':
+        if self.event_type in EVENTS_FILTERABLE_BY_RESOURCE:
             # Get the entity type/name
             self.entity_type = self.raw_event.entity.entity.__class__
 

--- a/vsphere/tests/conftest.py
+++ b/vsphere/tests/conftest.py
@@ -112,8 +112,9 @@ def mock_threadpool():
 
 @pytest.fixture
 def mock_api():
-    with patch('datadog_checks.vsphere.vsphere.VSphereAPI', MockedAPI):
-        yield
+    with patch('datadog_checks.vsphere.vsphere.VSphereAPI') as mocked_api:
+        mocked_api.side_effect = MockedAPI
+        yield mocked_api
 
 
 @pytest.fixture

--- a/vsphere/tests/test_event.py
+++ b/vsphere/tests/test_event.py
@@ -28,9 +28,9 @@ def test_allowed_event_list():
 
 
 @pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
-def test_events_collection(aggregator, realtime_instance):
+def test_events_collection(aggregator, realtime_instance, dd_run_check):
     check = VSphereCheck('vsphere', {}, [realtime_instance])
-    check.initiate_api_connection()
+    dd_run_check(check)
     time_initial = check.latest_event_query
 
     time1 = dt.datetime.now()
@@ -123,7 +123,7 @@ def test_events_collection(aggregator, realtime_instance):
     aggregator.reset()
     realtime_instance['event_resource_filters'] = ['vm', 'host', 'DATAcenter', 'Cluster', 'datastore']
     check = VSphereCheck('vsphere', {}, [realtime_instance])
-    check.initiate_api_connection()
+    dd_run_check(check)
 
     check.api.mock_events = [event2, event3, event3, event4]
     check.check(None)
@@ -143,7 +143,7 @@ def test_events_collection(aggregator, realtime_instance):
     aggregator.reset()
     realtime_instance['event_resource_filters'] = ['host', 'datacenter', 'cluster', 'datastore']
     check = VSphereCheck('vsphere', {}, [realtime_instance])
-    check.initiate_api_connection()
+    dd_run_check(check)
 
     check.api.mock_events = [event2, event3, event3, event4]
     check.check(None)
@@ -162,7 +162,7 @@ def test_events_collection(aggregator, realtime_instance):
     aggregator.reset()
     realtime_instance['event_resource_filters'] = []
     check = VSphereCheck('vsphere', {}, [realtime_instance])
-    check.initiate_api_connection()
+    dd_run_check(check)
 
     check.api.mock_events = [event2, event3, event3, event4]
     check.check(None)
@@ -175,7 +175,7 @@ def test_events_collection(aggregator, realtime_instance):
 
 
 @pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
-def test_include_events_ok(aggregator, realtime_instance):
+def test_include_events_ok(aggregator, realtime_instance, dd_run_check):
     realtime_instance['include_events'] = [
         {"event": "AlarmStatusChangedEvent", "excluded_messages": ["Gray to Green", "Green to Gray"]}
     ]
@@ -184,7 +184,7 @@ def test_include_events_ok(aggregator, realtime_instance):
         {},
         [realtime_instance],
     )
-    check.initiate_api_connection()
+    dd_run_check(check)
 
     event1 = vim.event.AlarmStatusChangedEvent()
     event1.createdTime = dt.datetime.now()
@@ -206,7 +206,7 @@ def test_include_events_ok(aggregator, realtime_instance):
 
 
 @pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
-def test_include_events_filtered(aggregator, realtime_instance):
+def test_include_events_filtered(aggregator, realtime_instance, dd_run_check):
     realtime_instance['include_events'] = [
         {"event": "AlarmStatusChangedEvent", "excluded_messages": ["Gray to Green", "Green to Gray"]}
     ]
@@ -215,7 +215,7 @@ def test_include_events_filtered(aggregator, realtime_instance):
         {},
         [realtime_instance],
     )
-    check.initiate_api_connection()
+    dd_run_check(check)
 
     event1 = vim.event.AlarmStatusChangedEvent()
     event1.createdTime = dt.datetime.now()
@@ -236,7 +236,7 @@ def test_include_events_filtered(aggregator, realtime_instance):
 
 
 @pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
-def test_include_events_incorrectly_formatted_event(aggregator, realtime_instance):
+def test_include_events_incorrectly_formatted_event(aggregator, realtime_instance, dd_run_check):
     realtime_instance['include_events'] = [
         {"event": "IncorrectlyFormattedEvent", "excluded_messages": ["Gray to Green", "Green to Gray"]}
     ]
@@ -245,7 +245,7 @@ def test_include_events_incorrectly_formatted_event(aggregator, realtime_instanc
         {},
         [realtime_instance],
     )
-    check.initiate_api_connection()
+    dd_run_check(check)
 
     event1 = vim.event.AlarmStatusChangedEvent()
     event1.createdTime = dt.datetime.now()
@@ -266,14 +266,14 @@ def test_include_events_incorrectly_formatted_event(aggregator, realtime_instanc
 
 
 @pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
-def test_include_events_ok_new_event_type(aggregator, realtime_instance):
+def test_include_events_ok_new_event_type(aggregator, realtime_instance, dd_run_check):
     realtime_instance['include_events'] = [{"event": "AlarmAcknowledgedEvent", "excluded_messages": ["Remove Alarm"]}]
     check = VSphereCheck(
         'vsphere',
         {},
         [realtime_instance],
     )
-    check.initiate_api_connection()
+    dd_run_check(check)
 
     event1 = vim.event.AlarmAcknowledgedEvent()
     event1.createdTime = dt.datetime.now()
@@ -294,7 +294,7 @@ def test_include_events_ok_new_event_type(aggregator, realtime_instance):
 
 
 @pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
-def test_include_events_ok_new_resource(aggregator, realtime_instance):
+def test_include_events_ok_new_resource(aggregator, realtime_instance, dd_run_check):
     realtime_instance['include_events'] = [{"event": "AlarmAcknowledgedEvent", "excluded_messages": ["Remove Alarm"]}]
     realtime_instance['event_resource_filters'] = ['storage_pod']
     check = VSphereCheck(
@@ -302,7 +302,7 @@ def test_include_events_ok_new_resource(aggregator, realtime_instance):
         {},
         [realtime_instance],
     )
-    check.initiate_api_connection()
+    dd_run_check(check)
 
     event1 = vim.event.AlarmAcknowledgedEvent()
     event1.createdTime = dt.datetime.now()
@@ -323,7 +323,7 @@ def test_include_events_ok_new_resource(aggregator, realtime_instance):
 
 
 @pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
-def test_include_events_excluded_message_new_resource(aggregator, realtime_instance):
+def test_include_events_excluded_message_new_resource(aggregator, realtime_instance, dd_run_check):
     realtime_instance['include_events'] = [
         {"event": "AlarmAcknowledgedEvent", "excluded_messages": ["The Alarm was acknowledged"]}
     ]
@@ -333,7 +333,7 @@ def test_include_events_excluded_message_new_resource(aggregator, realtime_insta
         {},
         [realtime_instance],
     )
-    check.initiate_api_connection()
+    dd_run_check(check)
 
     event1 = vim.event.AlarmAcknowledgedEvent()
     event1.createdTime = dt.datetime.now()
@@ -352,7 +352,7 @@ def test_include_events_excluded_message_new_resource(aggregator, realtime_insta
 
 
 @pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
-def test_include_events_empty_event_resource_filters(aggregator, realtime_instance):
+def test_include_events_empty_event_resource_filters(aggregator, realtime_instance, dd_run_check):
     realtime_instance['include_events'] = [{"event": "AlarmAcknowledgedEvent", "excluded_messages": ["Remove Alarm"]}]
     realtime_instance['event_resource_filters'] = []
     check = VSphereCheck(
@@ -360,7 +360,7 @@ def test_include_events_empty_event_resource_filters(aggregator, realtime_instan
         {},
         [realtime_instance],
     )
-    check.initiate_api_connection()
+    dd_run_check(check)
 
     event1 = vim.event.AlarmAcknowledgedEvent()
     event1.createdTime = dt.datetime.now()

--- a/vsphere/tests/test_event.py
+++ b/vsphere/tests/test_event.py
@@ -20,7 +20,7 @@ def mock_api_with_events(events):
 
     def get_perf_counter_by_level(_):
         return {}
-    
+
     def get_new_events(start_time):
         return events
 

--- a/vsphere/tests/test_event.py
+++ b/vsphere/tests/test_event.py
@@ -291,3 +291,61 @@ def test_include_events_ok_new_event_type(aggregator, realtime_instance):
     assert len(aggregator.events) == 1
     assert "The Alarm was acknowledged" in aggregator.events[0]['msg_text']
     assert aggregator.events[0]['msg_title'] == "AlarmAcknowledgedEvent"
+
+
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
+def test_include_events_ok_new_resource(aggregator, realtime_instance):
+    realtime_instance['include_events'] = [{"event": "AlarmAcknowledgedEvent", "excluded_messages": ["Remove Alarm"]}]
+    realtime_instance['event_resource_filters'] = ['storage_pod']
+    check = VSphereCheck(
+        'vsphere',
+        {},
+        [realtime_instance],
+    )
+    check.initiate_api_connection()
+
+    event1 = vim.event.AlarmAcknowledgedEvent()
+    event1.createdTime = dt.datetime.now()
+    event1.entity = vim.event.ManagedEntityEventArgument()
+    event1.entity.entity = vim.StoragePod(moId="pod1")
+    event1.entity.name = "pod1"
+    event1.alarm = vim.event.AlarmEventArgument()
+    event1.alarm.name = "alarm1"
+    event1.datacenter = vim.event.DatacenterEventArgument()
+    event1.datacenter.name = "dc1"
+    event1.fullFormattedMessage = "The Alarm was acknowledged"
+    aggregator.reset()
+    check.api.mock_events = [event1]
+    check.check(None)
+    assert len(aggregator.events) == 1
+    assert "The Alarm was acknowledged" in aggregator.events[0]['msg_text']
+    assert aggregator.events[0]['msg_title'] == "AlarmAcknowledgedEvent"
+
+
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
+def test_include_events_excluded_message_new_resource(aggregator, realtime_instance):
+    realtime_instance['include_events'] = [
+        {"event": "AlarmAcknowledgedEvent", "excluded_messages": ["The Alarm was acknowledged"]}
+    ]
+    realtime_instance['event_resource_filters'] = ['storage_pod']
+    check = VSphereCheck(
+        'vsphere',
+        {},
+        [realtime_instance],
+    )
+    check.initiate_api_connection()
+
+    event1 = vim.event.AlarmAcknowledgedEvent()
+    event1.createdTime = dt.datetime.now()
+    event1.entity = vim.event.ManagedEntityEventArgument()
+    event1.entity.entity = vim.StoragePod(moId="pod1")
+    event1.entity.name = "pod1"
+    event1.alarm = vim.event.AlarmEventArgument()
+    event1.alarm.name = "alarm1"
+    event1.datacenter = vim.event.DatacenterEventArgument()
+    event1.datacenter.name = "dc1"
+    event1.fullFormattedMessage = "The Alarm was acknowledged"
+    aggregator.reset()
+    check.api.mock_events = [event1]
+    check.check(None)
+    assert len(aggregator.events) == 0

--- a/vsphere/tests/test_event.py
+++ b/vsphere/tests/test_event.py
@@ -349,3 +349,30 @@ def test_include_events_excluded_message_new_resource(aggregator, realtime_insta
     check.api.mock_events = [event1]
     check.check(None)
     assert len(aggregator.events) == 0
+
+
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
+def test_include_events_empty_event_resource_filters(aggregator, realtime_instance):
+    realtime_instance['include_events'] = [{"event": "AlarmAcknowledgedEvent", "excluded_messages": ["Remove Alarm"]}]
+    realtime_instance['event_resource_filters'] = []
+    check = VSphereCheck(
+        'vsphere',
+        {},
+        [realtime_instance],
+    )
+    check.initiate_api_connection()
+
+    event1 = vim.event.AlarmAcknowledgedEvent()
+    event1.createdTime = dt.datetime.now()
+    event1.entity = vim.event.ManagedEntityEventArgument()
+    event1.entity.entity = vim.VirtualMachine(moId="vm1")
+    event1.entity.name = "vm1"
+    event1.alarm = vim.event.AlarmEventArgument()
+    event1.alarm.name = "alarm1"
+    event1.datacenter = vim.event.DatacenterEventArgument()
+    event1.datacenter.name = "dc1"
+    event1.fullFormattedMessage = "The Alarm was acknowledged"
+    aggregator.reset()
+    check.api.mock_events = [event1]
+    check.check(None)
+    assert len(aggregator.events) == 0

--- a/vsphere/tests/test_event.py
+++ b/vsphere/tests/test_event.py
@@ -4,11 +4,34 @@
 
 import datetime as dt
 
+import mock
 import pytest
 from pyVmomi import vim
 
 from datadog_checks.vsphere import VSphereCheck
 from datadog_checks.vsphere.constants import EXCLUDE_FILTERS
+
+from .mocked_api import MockedAPI
+
+
+def mock_api_with_events(events):
+    def get_infrastructure():
+        return {}
+
+    def get_perf_counter_by_level(_):
+        return {}
+    
+    def get_new_events(start_time):
+        return events
+
+    def create_mocked_api(config, log):
+        mocked_api = MockedAPI(config, log)
+        mocked_api.get_new_events = mock.MagicMock(side_effect=get_new_events)
+        mocked_api.get_infrastructure = mock.MagicMock(side_effect=get_infrastructure)
+        mocked_api.get_perf_counter_by_level = mock.MagicMock(side_effect=get_perf_counter_by_level)
+        return mocked_api
+
+    return mock.MagicMock(side_effect=create_mocked_api)
 
 
 def test_allowed_event_list():
@@ -27,16 +50,23 @@ def test_allowed_event_list():
     assert sorted(str(e) for e in expected_events) == sorted(str(e) for e in allowed_events)
 
 
-@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
-def test_events_collection(aggregator, realtime_instance, dd_run_check):
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_rest_api')
+def test_events_collection_no_events(aggregator, realtime_instance, dd_run_check, mock_api):
     check = VSphereCheck('vsphere', {}, [realtime_instance])
-    dd_run_check(check)
     time_initial = check.latest_event_query
+    mock_api.side_effect = mock_api_with_events([])
+    dd_run_check(check)
 
+    dd_run_check(check)
+
+    assert len(aggregator.events) == 0
+    assert check.latest_event_query > time_initial  # check time not changed if there is no event
+
+
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_rest_api')
+def test_events_collection_one_event(aggregator, realtime_instance, dd_run_check, mock_api):
+    check = VSphereCheck('vsphere', {}, [realtime_instance])
     time1 = dt.datetime.now()
-    time2 = time1 + dt.timedelta(seconds=3)
-    time3 = time1 + dt.timedelta(seconds=5)
-
     event1 = vim.event.AlarmStatusChangedEvent()
     event1.createdTime = time1
     event1.entity = vim.event.ManagedEntityEventArgument()
@@ -49,7 +79,26 @@ def test_events_collection(aggregator, realtime_instance, dd_run_check):
     event1.datacenter = vim.event.DatacenterEventArgument()
     event1.datacenter.name = "dc1"
     event1.fullFormattedMessage = "Green to Red"
+    mock_api.side_effect = mock_api_with_events([event1])
 
+    dd_run_check(check)
+
+    aggregator.assert_event(
+        "vCenter monitor status changed on this alarm, it was green and it's now red.",
+        count=1,
+        tags=['vcenter_server:FAKE'],
+    )
+    assert len(aggregator.events) == 1
+    assert aggregator.events[0]['msg_title'] == "[Triggered] alarm1 on VM vm1 is now red"
+    assert check.latest_event_query == time1 + dt.timedelta(seconds=1)
+
+
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_rest_api')
+def test_events_collection_three_events(aggregator, realtime_instance, dd_run_check, mock_api):
+    check = VSphereCheck('vsphere', {}, [realtime_instance])
+    time1 = dt.datetime.now()
+    time2 = time1 + dt.timedelta(seconds=3)
+    time3 = time1 + dt.timedelta(seconds=5)
     event2 = vim.event.AlarmStatusChangedEvent()
     event2.createdTime = time2
     event2.entity = vim.event.ManagedEntityEventArgument()
@@ -62,7 +111,6 @@ def test_events_collection(aggregator, realtime_instance, dd_run_check):
     event2.datacenter = vim.event.DatacenterEventArgument()
     event2.datacenter.name = "dc1"
     event2.fullFormattedMessage = "Yellow to Red"
-
     event3 = vim.event.AlarmStatusChangedEvent()
     event3.createdTime = time3
     event3.entity = vim.event.ManagedEntityEventArgument()
@@ -75,7 +123,6 @@ def test_events_collection(aggregator, realtime_instance, dd_run_check):
     event3.datacenter = vim.event.DatacenterEventArgument()
     event3.datacenter.name = "dc1"
     event3.fullFormattedMessage = "Red to Red"
-
     event4 = vim.event.AlarmStatusChangedEvent()
     event4.createdTime = time3
     event4.entity = vim.event.ManagedEntityEventArgument()
@@ -88,29 +135,10 @@ def test_events_collection(aggregator, realtime_instance, dd_run_check):
     event4.datacenter = vim.event.DatacenterEventArgument()
     event4.datacenter.name = "dc1"
     event4.fullFormattedMessage = "Red to Green"
+    mock_api.side_effect = mock_api_with_events([event2, event3, event3, event4])
 
-    # No events
-    check.check(None)
-    assert len(aggregator.events) == 0
-    assert check.latest_event_query > time_initial  # check time not changed if there is no event
+    dd_run_check(check)
 
-    # 1 events
-    aggregator.reset()
-    check.api.mock_events = [event1]
-    check.check(None)
-    aggregator.assert_event(
-        "vCenter monitor status changed on this alarm, it was green and it's now red.",
-        count=1,
-        tags=['vcenter_server:FAKE'],
-    )
-    assert len(aggregator.events) == 1
-    assert aggregator.events[0]['msg_title'] == "[Triggered] alarm1 on VM vm1 is now red"
-    assert check.latest_event_query == time1 + dt.timedelta(seconds=1)
-
-    # 3 events
-    aggregator.reset()
-    check.api.mock_events = [event2, event3, event3, event4]
-    check.check(None)
     for from_status, to_status, count in [('yellow', 'red', 1), ('red', 'red', 2)]:
         aggregator.assert_event(
             "vCenter monitor status changed on this alarm, it was {} and it's now {}.".format(from_status, to_status),
@@ -120,13 +148,56 @@ def test_events_collection(aggregator, realtime_instance, dd_run_check):
     assert len(aggregator.events) == 3
     assert check.latest_event_query == time3 + dt.timedelta(seconds=1)
 
-    aggregator.reset()
+
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_rest_api')
+def test_events_collection_three_events_with_event_resource_filters_all(
+    aggregator, realtime_instance, dd_run_check, mock_api
+):
     realtime_instance['event_resource_filters'] = ['vm', 'host', 'DATAcenter', 'Cluster', 'datastore']
     check = VSphereCheck('vsphere', {}, [realtime_instance])
+    time1 = dt.datetime.now()
+    time2 = time1 + dt.timedelta(seconds=3)
+    time3 = time1 + dt.timedelta(seconds=5)
+    event2 = vim.event.AlarmStatusChangedEvent()
+    event2.createdTime = time2
+    event2.entity = vim.event.ManagedEntityEventArgument()
+    event2.entity.entity = vim.VirtualMachine(moId="vm1")
+    event2.entity.name = "vm1"
+    event2.alarm = vim.event.AlarmEventArgument()
+    event2.alarm.name = "alarm1"
+    setattr(event2, 'from', 'yellow')
+    event2.to = 'red'
+    event2.datacenter = vim.event.DatacenterEventArgument()
+    event2.datacenter.name = "dc1"
+    event2.fullFormattedMessage = "Yellow to Red"
+    event3 = vim.event.AlarmStatusChangedEvent()
+    event3.createdTime = time3
+    event3.entity = vim.event.ManagedEntityEventArgument()
+    event3.entity.entity = vim.VirtualMachine(moId="vm1")
+    event3.entity.name = "vm1"
+    event3.alarm = vim.event.AlarmEventArgument()
+    event3.alarm.name = "alarm1"
+    setattr(event3, 'from', 'red')
+    event3.to = 'red'
+    event3.datacenter = vim.event.DatacenterEventArgument()
+    event3.datacenter.name = "dc1"
+    event3.fullFormattedMessage = "Red to Red"
+    event4 = vim.event.AlarmStatusChangedEvent()
+    event4.createdTime = time3
+    event4.entity = vim.event.ManagedEntityEventArgument()
+    event4.entity.entity = vim.ClusterComputeResource(moId="c1")
+    event4.entity.name = "c1"
+    event4.alarm = vim.event.AlarmEventArgument()
+    event4.alarm.name = "alarm1"
+    setattr(event4, 'from', 'red')
+    event4.to = 'green'
+    event4.datacenter = vim.event.DatacenterEventArgument()
+    event4.datacenter.name = "dc1"
+    event4.fullFormattedMessage = "Red to Green"
+    mock_api.side_effect = mock_api_with_events([event2, event3, event3, event4])
+
     dd_run_check(check)
 
-    check.api.mock_events = [event2, event3, event3, event4]
-    check.check(None)
     for from_status, to_status, count, additional_tags in [
         ('yellow', 'red', 1, []),
         ('red', 'red', 2, []),
@@ -140,13 +211,56 @@ def test_events_collection(aggregator, realtime_instance, dd_run_check):
     assert len(aggregator.events) == 4
     assert check.latest_event_query == time3 + dt.timedelta(seconds=1)
 
-    aggregator.reset()
+
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_rest_api')
+def test_events_collection_three_events_with_event_resource_filters_no_vm(
+    aggregator, realtime_instance, dd_run_check, mock_api
+):
     realtime_instance['event_resource_filters'] = ['host', 'datacenter', 'cluster', 'datastore']
     check = VSphereCheck('vsphere', {}, [realtime_instance])
+    time1 = dt.datetime.now()
+    time2 = time1 + dt.timedelta(seconds=3)
+    time3 = time1 + dt.timedelta(seconds=5)
+    event2 = vim.event.AlarmStatusChangedEvent()
+    event2.createdTime = time2
+    event2.entity = vim.event.ManagedEntityEventArgument()
+    event2.entity.entity = vim.VirtualMachine(moId="vm1")
+    event2.entity.name = "vm1"
+    event2.alarm = vim.event.AlarmEventArgument()
+    event2.alarm.name = "alarm1"
+    setattr(event2, 'from', 'yellow')
+    event2.to = 'red'
+    event2.datacenter = vim.event.DatacenterEventArgument()
+    event2.datacenter.name = "dc1"
+    event2.fullFormattedMessage = "Yellow to Red"
+    event3 = vim.event.AlarmStatusChangedEvent()
+    event3.createdTime = time3
+    event3.entity = vim.event.ManagedEntityEventArgument()
+    event3.entity.entity = vim.VirtualMachine(moId="vm1")
+    event3.entity.name = "vm1"
+    event3.alarm = vim.event.AlarmEventArgument()
+    event3.alarm.name = "alarm1"
+    setattr(event3, 'from', 'red')
+    event3.to = 'red'
+    event3.datacenter = vim.event.DatacenterEventArgument()
+    event3.datacenter.name = "dc1"
+    event3.fullFormattedMessage = "Red to Red"
+    event4 = vim.event.AlarmStatusChangedEvent()
+    event4.createdTime = time3
+    event4.entity = vim.event.ManagedEntityEventArgument()
+    event4.entity.entity = vim.ClusterComputeResource(moId="c1")
+    event4.entity.name = "c1"
+    event4.alarm = vim.event.AlarmEventArgument()
+    event4.alarm.name = "alarm1"
+    setattr(event4, 'from', 'red')
+    event4.to = 'green'
+    event4.datacenter = vim.event.DatacenterEventArgument()
+    event4.datacenter.name = "dc1"
+    event4.fullFormattedMessage = "Red to Green"
+    mock_api.side_effect = mock_api_with_events([event2, event3, event3, event4])
+
     dd_run_check(check)
 
-    check.api.mock_events = [event2, event3, event3, event4]
-    check.check(None)
     for from_status, to_status, count, additional_tags in [
         ('red', 'green', 1, ['vsphere_type:cluster', 'vsphere_resource:c1'])
     ]:
@@ -159,33 +273,73 @@ def test_events_collection(aggregator, realtime_instance, dd_run_check):
     assert aggregator.events[0]['msg_title'] == "[Recovered] alarm1 on cluster c1 is now green"
     assert check.latest_event_query == time3 + dt.timedelta(seconds=1)
 
-    aggregator.reset()
+
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_rest_api')
+def test_events_collection_three_events_with_event_resource_filters_empty(
+    aggregator, realtime_instance, dd_run_check, mock_api
+):
     realtime_instance['event_resource_filters'] = []
     check = VSphereCheck('vsphere', {}, [realtime_instance])
+    time1 = dt.datetime.now()
+    time2 = time1 + dt.timedelta(seconds=3)
+    time3 = time1 + dt.timedelta(seconds=5)
+    event2 = vim.event.AlarmStatusChangedEvent()
+    event2.createdTime = time2
+    event2.entity = vim.event.ManagedEntityEventArgument()
+    event2.entity.entity = vim.VirtualMachine(moId="vm1")
+    event2.entity.name = "vm1"
+    event2.alarm = vim.event.AlarmEventArgument()
+    event2.alarm.name = "alarm1"
+    setattr(event2, 'from', 'yellow')
+    event2.to = 'red'
+    event2.datacenter = vim.event.DatacenterEventArgument()
+    event2.datacenter.name = "dc1"
+    event2.fullFormattedMessage = "Yellow to Red"
+    event3 = vim.event.AlarmStatusChangedEvent()
+    event3.createdTime = time3
+    event3.entity = vim.event.ManagedEntityEventArgument()
+    event3.entity.entity = vim.VirtualMachine(moId="vm1")
+    event3.entity.name = "vm1"
+    event3.alarm = vim.event.AlarmEventArgument()
+    event3.alarm.name = "alarm1"
+    setattr(event3, 'from', 'red')
+    event3.to = 'red'
+    event3.datacenter = vim.event.DatacenterEventArgument()
+    event3.datacenter.name = "dc1"
+    event3.fullFormattedMessage = "Red to Red"
+    event4 = vim.event.AlarmStatusChangedEvent()
+    event4.createdTime = time3
+    event4.entity = vim.event.ManagedEntityEventArgument()
+    event4.entity.entity = vim.ClusterComputeResource(moId="c1")
+    event4.entity.name = "c1"
+    event4.alarm = vim.event.AlarmEventArgument()
+    event4.alarm.name = "alarm1"
+    setattr(event4, 'from', 'red')
+    event4.to = 'green'
+    event4.datacenter = vim.event.DatacenterEventArgument()
+    event4.datacenter.name = "dc1"
+    event4.fullFormattedMessage = "Red to Green"
+    mock_api.side_effect = mock_api_with_events([event2, event3, event3, event4])
+
     dd_run_check(check)
 
-    check.api.mock_events = [event2, event3, event3, event4]
-    check.check(None)
     assert len(aggregator.events) == 0
     assert check.latest_event_query == time3 + dt.timedelta(seconds=1)
 
+
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_rest_api')
+def test_events_collection_exception_if_invalid_resource(realtime_instance):
     with pytest.raises(Exception, match=r"Invalid resource type specified in `event_resource_filters`: hey."):
         realtime_instance['event_resource_filters'] = ['hey']
-        check = VSphereCheck('vsphere', {}, [realtime_instance])
+        _ = VSphereCheck('vsphere', {}, [realtime_instance])
 
 
-@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
-def test_include_events_ok(aggregator, realtime_instance, dd_run_check):
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_rest_api')
+def test_include_events_ok(aggregator, realtime_instance, dd_run_check, mock_api):
     realtime_instance['include_events'] = [
         {"event": "AlarmStatusChangedEvent", "excluded_messages": ["Gray to Green", "Green to Gray"]}
     ]
-    check = VSphereCheck(
-        'vsphere',
-        {},
-        [realtime_instance],
-    )
-    dd_run_check(check)
-
+    check = VSphereCheck('vsphere', {}, [realtime_instance])
     event1 = vim.event.AlarmStatusChangedEvent()
     event1.createdTime = dt.datetime.now()
     event1.entity = vim.event.ManagedEntityEventArgument()
@@ -198,25 +352,20 @@ def test_include_events_ok(aggregator, realtime_instance, dd_run_check):
     event1.datacenter = vim.event.DatacenterEventArgument()
     event1.datacenter.name = "dc1"
     event1.fullFormattedMessage = "Green to Red"
-    aggregator.reset()
-    check.api.mock_events = [event1]
-    check.check(None)
+    mock_api.side_effect = mock_api_with_events([event1])
+
+    dd_run_check(check)
+
     assert len(aggregator.events) == 1
     assert aggregator.events[0]['msg_title'] == "[Triggered] alarm1 on VM vm1 is now red"
 
 
-@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
-def test_include_events_filtered(aggregator, realtime_instance, dd_run_check):
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_rest_api')
+def test_include_events_filtered(aggregator, realtime_instance, dd_run_check, mock_api):
     realtime_instance['include_events'] = [
         {"event": "AlarmStatusChangedEvent", "excluded_messages": ["Gray to Green", "Green to Gray"]}
     ]
-    check = VSphereCheck(
-        'vsphere',
-        {},
-        [realtime_instance],
-    )
-    dd_run_check(check)
-
+    check = VSphereCheck('vsphere', {}, [realtime_instance])
     event1 = vim.event.AlarmStatusChangedEvent()
     event1.createdTime = dt.datetime.now()
     event1.entity = vim.event.ManagedEntityEventArgument()
@@ -229,24 +378,19 @@ def test_include_events_filtered(aggregator, realtime_instance, dd_run_check):
     event1.datacenter = vim.event.DatacenterEventArgument()
     event1.datacenter.name = "dc1"
     event1.fullFormattedMessage = "Green to Gray"
-    aggregator.reset()
-    check.api.mock_events = [event1]
-    check.check(None)
+    mock_api.side_effect = mock_api_with_events([event1])
+
+    dd_run_check(check)
+
     assert len(aggregator.events) == 0
 
 
-@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
-def test_include_events_incorrectly_formatted_event(aggregator, realtime_instance, dd_run_check):
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_rest_api')
+def test_include_events_incorrectly_formatted_event(aggregator, realtime_instance, dd_run_check, mock_api):
     realtime_instance['include_events'] = [
         {"event": "IncorrectlyFormattedEvent", "excluded_messages": ["Gray to Green", "Green to Gray"]}
     ]
-    check = VSphereCheck(
-        'vsphere',
-        {},
-        [realtime_instance],
-    )
-    dd_run_check(check)
-
+    check = VSphereCheck('vsphere', {}, [realtime_instance])
     event1 = vim.event.AlarmStatusChangedEvent()
     event1.createdTime = dt.datetime.now()
     event1.entity = vim.event.ManagedEntityEventArgument()
@@ -259,22 +403,17 @@ def test_include_events_incorrectly_formatted_event(aggregator, realtime_instanc
     event1.datacenter = vim.event.DatacenterEventArgument()
     event1.datacenter.name = "dc1"
     event1.fullFormattedMessage = "Green to Red"
-    aggregator.reset()
-    check.api.mock_events = [event1]
-    check.check(None)
+    mock_api.side_effect = mock_api_with_events([event1])
+
+    dd_run_check(check)
+
     assert len(aggregator.events) == 0
 
 
-@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
-def test_include_events_ok_new_event_type(aggregator, realtime_instance, dd_run_check):
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_rest_api')
+def test_include_events_ok_new_event_type(aggregator, realtime_instance, dd_run_check, mock_api):
     realtime_instance['include_events'] = [{"event": "AlarmAcknowledgedEvent", "excluded_messages": ["Remove Alarm"]}]
-    check = VSphereCheck(
-        'vsphere',
-        {},
-        [realtime_instance],
-    )
-    dd_run_check(check)
-
+    check = VSphereCheck('vsphere', {}, [realtime_instance])
     event1 = vim.event.AlarmAcknowledgedEvent()
     event1.createdTime = dt.datetime.now()
     event1.entity = vim.event.ManagedEntityEventArgument()
@@ -285,25 +424,20 @@ def test_include_events_ok_new_event_type(aggregator, realtime_instance, dd_run_
     event1.datacenter = vim.event.DatacenterEventArgument()
     event1.datacenter.name = "dc1"
     event1.fullFormattedMessage = "The Alarm was acknowledged"
-    aggregator.reset()
-    check.api.mock_events = [event1]
-    check.check(None)
+    mock_api.side_effect = mock_api_with_events([event1])
+
+    dd_run_check(check)
+
     assert len(aggregator.events) == 1
     assert "The Alarm was acknowledged" in aggregator.events[0]['msg_text']
     assert aggregator.events[0]['msg_title'] == "AlarmAcknowledgedEvent"
 
 
-@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
-def test_include_events_ok_new_resource(aggregator, realtime_instance, dd_run_check):
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_rest_api')
+def test_include_events_ok_new_resource(aggregator, realtime_instance, dd_run_check, mock_api):
     realtime_instance['include_events'] = [{"event": "AlarmAcknowledgedEvent", "excluded_messages": ["Remove Alarm"]}]
     realtime_instance['event_resource_filters'] = ['storage_pod']
-    check = VSphereCheck(
-        'vsphere',
-        {},
-        [realtime_instance],
-    )
-    dd_run_check(check)
-
+    check = VSphereCheck('vsphere', {}, [realtime_instance])
     event1 = vim.event.AlarmAcknowledgedEvent()
     event1.createdTime = dt.datetime.now()
     event1.entity = vim.event.ManagedEntityEventArgument()
@@ -314,27 +448,22 @@ def test_include_events_ok_new_resource(aggregator, realtime_instance, dd_run_ch
     event1.datacenter = vim.event.DatacenterEventArgument()
     event1.datacenter.name = "dc1"
     event1.fullFormattedMessage = "The Alarm was acknowledged"
-    aggregator.reset()
-    check.api.mock_events = [event1]
-    check.check(None)
+    mock_api.side_effect = mock_api_with_events([event1])
+
+    dd_run_check(check)
+
     assert len(aggregator.events) == 1
     assert "The Alarm was acknowledged" in aggregator.events[0]['msg_text']
     assert aggregator.events[0]['msg_title'] == "AlarmAcknowledgedEvent"
 
 
-@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
-def test_include_events_excluded_message_new_resource(aggregator, realtime_instance, dd_run_check):
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_rest_api')
+def test_include_events_excluded_message_new_resource(aggregator, realtime_instance, dd_run_check, mock_api):
     realtime_instance['include_events'] = [
         {"event": "AlarmAcknowledgedEvent", "excluded_messages": ["The Alarm was acknowledged"]}
     ]
     realtime_instance['event_resource_filters'] = ['storage_pod']
-    check = VSphereCheck(
-        'vsphere',
-        {},
-        [realtime_instance],
-    )
-    dd_run_check(check)
-
+    check = VSphereCheck('vsphere', {}, [realtime_instance])
     event1 = vim.event.AlarmAcknowledgedEvent()
     event1.createdTime = dt.datetime.now()
     event1.entity = vim.event.ManagedEntityEventArgument()
@@ -345,23 +474,18 @@ def test_include_events_excluded_message_new_resource(aggregator, realtime_insta
     event1.datacenter = vim.event.DatacenterEventArgument()
     event1.datacenter.name = "dc1"
     event1.fullFormattedMessage = "The Alarm was acknowledged"
-    aggregator.reset()
-    check.api.mock_events = [event1]
-    check.check(None)
+    mock_api.side_effect = mock_api_with_events([event1])
+
+    dd_run_check(check)
+
     assert len(aggregator.events) == 0
 
 
-@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
-def test_include_events_empty_event_resource_filters(aggregator, realtime_instance, dd_run_check):
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_rest_api')
+def test_include_events_empty_event_resource_filters(aggregator, realtime_instance, dd_run_check, mock_api):
     realtime_instance['include_events'] = [{"event": "AlarmAcknowledgedEvent", "excluded_messages": ["Remove Alarm"]}]
     realtime_instance['event_resource_filters'] = []
-    check = VSphereCheck(
-        'vsphere',
-        {},
-        [realtime_instance],
-    )
-    dd_run_check(check)
-
+    check = VSphereCheck('vsphere', {}, [realtime_instance])
     event1 = vim.event.AlarmAcknowledgedEvent()
     event1.createdTime = dt.datetime.now()
     event1.entity = vim.event.ManagedEntityEventArgument()
@@ -372,7 +496,8 @@ def test_include_events_empty_event_resource_filters(aggregator, realtime_instan
     event1.datacenter = vim.event.DatacenterEventArgument()
     event1.datacenter.name = "dc1"
     event1.fullFormattedMessage = "The Alarm was acknowledged"
-    aggregator.reset()
-    check.api.mock_events = [event1]
-    check.check(None)
+    mock_api.side_effect = mock_api_with_events([event1])
+
+    dd_run_check(check)
+
     assert len(aggregator.events) == 0


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
