### PR TITLE
Kubernetes cluster autoscaler enable public display

### DIFF
--- a/kubernetes_cluster_autoscaler/manifest.json
+++ b/kubernetes_cluster_autoscaler/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "3a3fc186-af02-48e5-8b68-ee9ef37ea566",
   "app_id": "kubernetes-cluster-autoscaler",
-  "display_on_public_website": false,
+  "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?
Display public docs for the integration and enables the tile

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
