### PR TITLE
catch 404 error when returned for missing build

### DIFF
--- a/teamcity/datadog_checks/teamcity/common.py
+++ b/teamcity/datadog_checks/teamcity/common.py
@@ -135,6 +135,9 @@ def get_response(check, resource, **kwargs):
             check.log.error("Access denied. Enable guest authentication or check user permissions.")
         check.log.exception("Couldn't fetch resource %s, got code %s", resource_name, resp.status_code)
         raise
+    except requests.exceptions.HTTPError: 
+        if resp.status_code == 404: 
+            check.log.exception("Resource %s not found, got code %s", resource_name, resp.status_code)
     except Exception as e:
         check.log.exception("Couldn't fetch resource %s, unhandled exception %s", resource_name, str(e))
         raise


### PR DESCRIPTION
### What does this PR do?
Catches a 404 error returned from Teamcity when it is unable to find a build requested by the integration 

### Motivation
Customer request 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
