### PR TITLE
Add cli option to override org config value at runtime

### DIFF
--- a/ddev/changelog.d/17932.added
+++ b/ddev/changelog.d/17932.added
@@ -1,0 +1,1 @@
+Add cli option to override org config value at runtime

--- a/ddev/src/ddev/cli/__init__.py
+++ b/ddev/src/ddev/cli/__init__.py
@@ -33,6 +33,7 @@ from ddev.utils.fs import Path
 @click.option('--marketplace', '-m', is_flag=True, help='Work on `marketplace`.')
 @click.option('--agent', '-a', is_flag=True, help='Work on `datadog-agent`.')
 @click.option('--here', '-x', is_flag=True, help='Work on the current location.')
+@click.option('--org', '-o', default=None, help='Override org config field for this invocation.')
 @click.option(
     '--color/--no-color',
     default=None,
@@ -69,7 +70,9 @@ from ddev.utils.fs import Path
 )
 @click.version_option(version=__version__, prog_name='ddev')
 @click.pass_context
-def ddev(ctx: click.Context, core, extras, marketplace, agent, here, color, interactive, verbose, quiet, config_file):
+def ddev(
+    ctx: click.Context, core, extras, marketplace, agent, here, org, color, interactive, verbose, quiet, config_file
+):
     """
     \b
          _     _
@@ -105,6 +108,8 @@ def ddev(ctx: click.Context, core, extras, marketplace, agent, here, color, inte
             app.abort(
                 f'Unable to create config file located at `{str(app.config_file.path)}`. Please check your permissions.'
             )
+    if org is not None:
+        app.config.org = org
 
     if not ctx.invoked_subcommand:
         app.display_info(ctx.get_help(), highlight=False)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Useful to quickly switch between configurations of matching DD_SITE and credentials.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
