### PR TITLE
Move foreign key information to the dependent table

### DIFF
--- a/sqlserver/changelog.d/17933.fixed
+++ b/sqlserver/changelog.d/17933.fixed
@@ -1,0 +1,1 @@
+Move sqlserver schema foreign key information to the dependent table.

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -197,7 +197,7 @@ WHERE
     i.is_unique, i.is_primary_key, i.is_unique_constraint, i.is_disabled;
 """
 
-FOREIGN_KEY_QUERY = """
+FOREIGN_KEY_QUERY2 = """
 SELECT
     FK.referenced_object_id AS id, FK.name AS foreign_key_name,
     OBJECT_NAME(FK.parent_object_id) AS referencing_table,
@@ -209,7 +209,22 @@ FROM
 WHERE
     FK.referenced_object_id IN ({}) GROUP BY FK.name, FK.parent_object_id, FK.referenced_object_id;
 """
-
+FOREIGN_KEY_QUERY = """
+SELECT
+    FK.parent_object_id AS id,
+    FK.name AS foreign_key_name,
+    OBJECT_NAME(FK.parent_object_id) AS referencing_table,
+    STRING_AGG(COL_NAME(FKC.parent_object_id, FKC.parent_column_id), ',') AS referencing_column,
+    OBJECT_NAME(FK.referenced_object_id) AS referenced_table,
+    STRING_AGG(COL_NAME(FKC.referenced_object_id, FKC.referenced_column_id), ',') AS referenced_column
+FROM
+    sys.foreign_keys AS FK
+    JOIN sys.foreign_key_columns AS FKC ON FK.object_id = FKC.constraint_object_id
+WHERE
+    FK.parent_object_id IN ({})
+GROUP BY
+    FK.name, FK.parent_object_id, FK.referenced_object_id;
+"""
 
 def get_query_ao_availability_groups(sqlserver_major_version):
     """

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -197,18 +197,6 @@ WHERE
     i.is_unique, i.is_primary_key, i.is_unique_constraint, i.is_disabled;
 """
 
-FOREIGN_KEY_QUERY2 = """
-SELECT
-    FK.referenced_object_id AS id, FK.name AS foreign_key_name,
-    OBJECT_NAME(FK.parent_object_id) AS referencing_table,
-    STRING_AGG(COL_NAME(FKC.parent_object_id, FKC.parent_column_id),',') AS referencing_column,
-    OBJECT_NAME(FK.referenced_object_id) AS referenced_table,
-    STRING_AGG(COL_NAME(FKC.referenced_object_id, FKC.referenced_column_id),',') AS referenced_column
-FROM
-    sys.foreign_keys AS FK JOIN sys.foreign_key_columns AS FKC ON FK.object_id = FKC.constraint_object_id
-WHERE
-    FK.referenced_object_id IN ({}) GROUP BY FK.name, FK.parent_object_id, FK.referenced_object_id;
-"""
 FOREIGN_KEY_QUERY = """
 SELECT
     FK.parent_object_id AS id,

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -202,9 +202,9 @@ SELECT
     FK.parent_object_id AS id,
     FK.name AS foreign_key_name,
     OBJECT_NAME(FK.parent_object_id) AS referencing_table,
-    STRING_AGG(COL_NAME(FKC.parent_object_id, FKC.parent_column_id), ',') AS referencing_column,
+    STRING_AGG(COL_NAME(FKC.parent_object_id, FKC.parent_column_id),',') AS referencing_column,
     OBJECT_NAME(FK.referenced_object_id) AS referenced_table,
-    STRING_AGG(COL_NAME(FKC.referenced_object_id, FKC.referenced_column_id), ',') AS referenced_column
+    STRING_AGG(COL_NAME(FKC.referenced_object_id, FKC.referenced_column_id),',') AS referenced_column
 FROM
     sys.foreign_keys AS FK
     JOIN sys.foreign_key_columns AS FKC ON FK.object_id = FKC.constraint_object_id

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -226,6 +226,7 @@ GROUP BY
     FK.name, FK.parent_object_id, FK.referenced_object_id;
 """
 
+
 def get_query_ao_availability_groups(sqlserver_major_version):
     """
     Construct the sys.availability_groups QueryExecutor configuration based on the SQL Server major version

--- a/sqlserver/tests/test_metadata.py
+++ b/sqlserver/tests/test_metadata.py
@@ -183,15 +183,6 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                             },
                         ],
                         'partitions': {'partition_count': 12},
-                        'foreign_keys': [
-                            {
-                                'foreign_key_name': 'FK_CityId',
-                                'referencing_table': 'landmarks',
-                                'referencing_column': 'city_id',
-                                'referenced_table': 'cities',
-                                'referenced_column': 'id',
-                            }
-                        ],
                         'indexes': [
                             {
                                 'name': 'PK_Cities',
@@ -242,6 +233,15 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                             },
                         ],
                         'partitions': {'partition_count': 1},
+                        'foreign_keys': [
+                            {
+                                'foreign_key_name': 'FK_CityId',
+                                'referencing_table': 'landmarks',
+                                'referencing_column': 'city_id',
+                                'referenced_table': 'cities',
+                                'referenced_column': 'id',
+                            }
+                        ],
                     },
                     {
                         'id': 'normalized_value',
@@ -270,6 +270,15 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                             },
                         ],
                         'partitions': {'partition_count': 1},
+                        'foreign_keys': [
+                            {
+                                'foreign_key_name': 'FK_RestaurantNameDistrict',
+                                'referencing_table': 'RestaurantReviews',
+                                'referencing_column': 'RestaurantName,District',
+                                'referenced_table': 'Restaurants',
+                                'referenced_column': 'RestaurantName,District',
+                            }
+                        ],
                     },
                     {
                         'id': 'normalized_value',
@@ -298,15 +307,6 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                             },
                         ],
                         'partitions': {'partition_count': 2},
-                        'foreign_keys': [
-                            {
-                                'foreign_key_name': 'FK_RestaurantNameDistrict',
-                                'referencing_table': 'RestaurantReviews',
-                                'referencing_column': 'RestaurantName,District',
-                                'referenced_table': 'Restaurants',
-                                'referenced_column': 'RestaurantName,District',
-                            }
-                        ],
                         'indexes': [
                             {
                                 'name': 'UC_RestaurantNameDistrict',


### PR DESCRIPTION
### What does this PR do?
Moving sqlserver foreign key information to the dependant table

### Motivation
It is better to represent foreign keys like this.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
