### PR TITLE
[mongo] Update mongo config yaml to unhide DBM config options

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -90,7 +90,6 @@ files:
         example:
           [ one_database, other_database ]
     - name: dbm
-      hidden: true
       description: |
         Set to `true` enable Database Monitoring.
         
@@ -102,7 +101,6 @@ files:
         example: false
         display_default: false
     - name: cluster_name
-      hidden: true
       description: |
         The name of the cluster to which the monitored MongoDB instance belongs.
         Used to group MongoDB instances in a MongoDB cluster.
@@ -128,6 +126,22 @@ files:
         type: number
         example: 1800
         display_default: false
+    - name: operation_samples
+      description: Configure collection of MongoDB operation samples and explain plans.
+      options:
+        - name: enabled
+          description: |
+            Enable collection of operation samples. Requires `dbm: true`.
+          value:
+            type: boolean
+            example: true
+        - name: collection_interval
+          description: |
+            Set the operation samples collection interval in seconds. Each collection involves capturing
+            current operations with $currentOp aggregation pipeline and explain plans for each operation.
+          value:
+            type: number
+            example: 10
     - name: replica_check
       description: |
         Whether or not to read from available replicas.

--- a/mongo/changelog.d/17940.added
+++ b/mongo/changelog.d/17940.added
@@ -1,0 +1,1 @@
+Update mongo conf.yaml.example to include DBM for MongoDB config options. The new config options includes `dbm`, `cluster_name`, `operation_samples.enabled` & `operation_samples.collection_interval`.

--- a/mongo/datadog_checks/mongo/config_models/instance.py
+++ b/mongo/datadog_checks/mongo/config_models/instance.py
@@ -51,6 +51,15 @@ class MetricPatterns(BaseModel):
     include: Optional[tuple[str, ...]] = None
 
 
+class OperationSamples(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    collection_interval: Optional[float] = None
+    enabled: Optional[bool] = None
+
+
 class InstanceConfig(BaseModel):
     model_config = ConfigDict(
         validate_default=True,
@@ -74,6 +83,7 @@ class InstanceConfig(BaseModel):
     hosts: Optional[Union[str, tuple[str, ...]]] = None
     metric_patterns: Optional[MetricPatterns] = None
     min_collection_interval: Optional[float] = None
+    operation_samples: Optional[OperationSamples] = None
     options: Optional[MappingProxyType[str, Any]] = None
     password: Optional[str] = None
     replica_check: Optional[bool] = None

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -84,12 +84,44 @@ instances:
     #   - one_database
     #   - other_database
 
+    ## @param dbm - boolean - optional - default: false
+    ## Set to `true` enable Database Monitoring.
+    ##
+    ## NOTE: Database Monitoring for MongoDB is currently in private beta.
+    ## If you are interested in participating, please reach out to your Datadog Customer Success Manager.
+    #
+    # dbm: false
+
+    ## @param cluster_name - string - optional
+    ## The name of the cluster to which the monitored MongoDB instance belongs.
+    ## Used to group MongoDB instances in a MongoDB cluster.
+    ## Please note that the cluster name must be unique for each MongoDB cluster.
+    ##
+    ## Required when `dbm` is enabled.
+    #
+    # cluster_name: <CLUSTER_NAME>
+
     ## @param reported_database_hostname - string - optional
     ## Set the reported database hostname for the connected mongodb instance. This value overrides the mongodb hostname 
     ## detected by the Agent from mongodb admin command serverStatus. It can be useful to set a custom hostname
     ## when connecting to a remote database through a proxy.
     #
     # reported_database_hostname: <REPORTED_DATABASE_HOSTNAME>
+
+    ## Configure collection of MongoDB operation samples and explain plans.
+    #
+    # operation_samples:
+
+        ## @param enabled - boolean - optional - default: true
+        ## Enable collection of operation samples. Requires `dbm: true`.
+        #
+        # enabled: true
+
+        ## @param collection_interval - number - optional - default: 10
+        ## Set the operation samples collection interval in seconds. Each collection involves capturing
+        ## current operations with $currentOp aggregation pipeline and explain plans for each operation.
+        #
+        # collection_interval: 10
 
     ## @param replica_check - boolean - optional - default: true
     ## Whether or not to read from available replicas.


### PR DESCRIPTION
### What does this PR do?
This PR unhides the DBM config options in mongo configuration spec since DBM for MongoDB is now in private beta.

### Motivation
Get Mongo integration config ready for DBM for MongoDB [private beta](https://docs.datadoghq.com/database_monitoring/setup_mongodb/)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
