### PR TITLE
CODEOWNERS: rename agent-build-and-releases to agent-delivery

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,10 +16,10 @@ manifest.json         @DataDog/documentation @DataDog/agent-integrations
 **/assets/logs        @DataDog/logs-backend @DataDog/documentation @DataDog/agent-integrations
 
 # Dependencies
-/.deps/                            @DataDog/agent-integrations @DataDog/agent-build-and-releases
-/.builders/                        @DataDog/agent-build-and-releases
-/.builders/images/                 @DataDog/agent-integrations @DataDog/agent-build-and-releases
-/.builders/patches/                @DataDog/agent-integrations @DataDog/agent-build-and-releases
+/.deps/                            @DataDog/agent-integrations @DataDog/agent-delivery
+/.builders/                        @DataDog/agent-delivery
+/.builders/images/                 @DataDog/agent-integrations @DataDog/agent-delivery
+/.builders/patches/                @DataDog/agent-integrations @DataDog/agent-delivery
 
 # Checks base
 /datadog_checks_base/                                          @DataDog/agent-integrations
@@ -306,7 +306,7 @@ datadog_checks_base/datadog_checks/base/checks/windows/              @DataDog/wi
 docs/developer/process/integration-release.md                         @DataDog/software-integrity-and-trust @DataDog/agent-integrations @trishankatdatadog
 # As well as the pipelines.
 /.github/workflows/                                                   @DataDog/agent-integrations
-/.github/workflows/build-deps.yml                                     @DataDog/agent-build-and-releases
+/.github/workflows/build-deps.yml                                     @DataDog/agent-delivery
 /.gitlab-ci.yml                                                       @DataDog/agent-integrations
 /.gitlab/software_composition_analysis.yaml                           @DataDog/software-integrity-and-trust
 # Dev container


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Rename team agent-build-and-release to agent-delivery following recent reorg
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
