### PR TITLE
Update Logs Parsing rules for the Teleport Pipeline

### DIFF
--- a/teleport/assets/logs/teleport.yaml
+++ b/teleport/assets/logs/teleport.yaml
@@ -155,7 +155,7 @@ pipeline:
       grok:
         supportRules: >-
           _log_prefix
-          %{date("yyyy-MM-dd'T'HH:mm:ssZZ"):date}\s+%{word:log.level}\s+\[%{notSpace:teleport.component}\]\s+%{notSpace}
+          %{date("yyyy-MM-dd'T'HH:mm:ssZZ"):date}\s+%{word:log.level}\s+(\[%{notSpace:teleport.component}\])?\s+%{notSpace}
 
 
           _log_common_attr %{_log_prefix}\s+(addr.local:%{ipOrHost:network.client.ip}:%{port:network.client.port}\s+)?(addr.remote:%{ipOrHost:network.destination.ip}:%{port:network.destination.port}\s+)?+cluster_name:%{notSpace:teleport.cluster_name}\s+code:%{notSpace:teleport.code}\s+ei:%{notSpace:teleport.eid}

--- a/teleport/assets/logs/teleport_tests.yaml
+++ b/teleport/assets/logs/teleport_tests.yaml
@@ -284,9 +284,35 @@ tests:
         },
         Message_: \"The conditional request failed\"
       } (count=2, closing=false)." inventory/controller.go:510
-    result: null
+    result:
+      custom:
+        date: 1719415513000
+        log:
+          level: "WARN"
+      message: |-
+        2024-06-26T15:25:13Z WARN             "Failed to keep alive ssh server \"b05b3c10-c35a-4f25-b6c4-3b315a1d4ec1\": ConditionalCheckFailedException: The conditional request failed
+        {
+          RespMetadata: {
+            StatusCode: 400,
+            RequestID: \"5LUDO9VEIGQ436RMP6HEDM0D6FVV4KQNSO5AEMVJF66Q9ASUAAJG\"
+          },
+          Message_: \"The conditional request failed\"
+        } (count=2, closing=false)." inventory/controller.go:510
+      status: "warn"
+      tags:
+        - "source:LOGS_SOURCE"
+      timestamp: 1719415513000
   - sample:
       "2024-06-26T15:00:36Z WARN             Restarting watch on error after
       waiting 208.931858ms. Error: watcher closed.
       local/headlessauthn_watcher.go:158"
-    result: null
+    result:
+      custom:
+        date: 1719414036000
+        log:
+          level: "WARN"
+      message: "2024-06-26T15:00:36Z WARN             Restarting watch on error after waiting 208.931858ms. Error: watcher closed. local/headlessauthn_watcher.go:158"
+      status: "warn"
+      tags:
+        - "source:LOGS_SOURCE"
+      timestamp: 1719414036000

--- a/teleport/assets/logs/teleport_tests.yaml
+++ b/teleport/assets/logs/teleport_tests.yaml
@@ -51,7 +51,7 @@ tests:
       message: "2024-06-24T15:36:48Z INFO [AUDIT]     user.login addr.remote:90.118.178.162:19954 cluster_name:teleport-plint code:T1000W ei:0 error:[invalid username, password or second factor] event:user.login method:local success:false time:2024-06-24T15:36:48.688Z uid:f9ec53d9-0263-43a3-a5e6-fc41351e63bb user:teleport-admin user_agent:Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 events/emitter.go:288"
       status: "info"
       tags:
-       - "source:LOGS_SOURCE"
+        - "source:LOGS_SOURCE"
       timestamp: 1719243408000
   - sample: >
       2024-05-28T14:21:41Z WARN [PROXY:1:C] Cache was forced to load session
@@ -272,3 +272,21 @@ tests:
       tags:
         - "source:LOGS_SOURCE"
       timestamp: 1716907052000
+  - sample: >-
+      2024-06-26T15:25:13Z WARN             "Failed to keep alive ssh server
+      \"b05b3c10-c35a-4f25-b6c4-3b315a1d4ec1\": ConditionalCheckFailedException:
+      The conditional request failed
+
+      {
+        RespMetadata: {
+          StatusCode: 400,
+          RequestID: \"5LUDO9VEIGQ436RMP6HEDM0D6FVV4KQNSO5AEMVJF66Q9ASUAAJG\"
+        },
+        Message_: \"The conditional request failed\"
+      } (count=2, closing=false)." inventory/controller.go:510
+    result: null
+  - sample:
+      "2024-06-26T15:00:36Z WARN             Restarting watch on error after
+      waiting 208.931858ms. Error: watcher closed.
+      local/headlessauthn_watcher.go:158"
+    result: null


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Make component name optional in the log prefix helper rule.

### Motivation
<!-- What inspired you to submit this pull request? -->
Parsing `log.level` fails in some rare cases where the component name is missing.
https://datadoghq.atlassian.net/browse/LOI-241

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
