### PR TITLE
update mirror endpoint for kerberos tests

### DIFF
--- a/datadog_checks_base/tests/compose/kerberos/kerberos-kdc/Dockerfile
+++ b/datadog_checks_base/tests/compose/kerberos/kerberos-kdc/Dockerfile
@@ -3,9 +3,13 @@ FROM centos:centos7
 # https://github.com/edseymour/kinit-sidecar/blob/master/example-server/Dockerfile
 
 # install kdc and kadmin
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
 RUN yum install -y krb5-server krb5-workstation && yum clean all
 RUN mkdir -p /var/kerberos/krb5kdc.d && \
-    mkdir -p /etc/krb5.conf.d 
+    mkdir -p /etc/krb5.conf.d
 
 ADD init.sh /
 ADD kdc.conf /var/kerberos/krb5kdc/
@@ -22,3 +26,4 @@ VOLUME ["/var/kerberos/krb5kdc","/var/kerberos/krb5kdc.d", "/etc/krb5.conf.d" , 
 EXPOSE 8888 8464 8749
 
 ENTRYPOINT ["/init.sh"]
+

--- a/datadog_checks_base/tests/compose/kerberos/kerberos-kdc/Dockerfile
+++ b/datadog_checks_base/tests/compose/kerberos/kerberos-kdc/Dockerfile
@@ -3,6 +3,10 @@ FROM centos:centos7
 # https://github.com/edseymour/kinit-sidecar/blob/master/example-server/Dockerfile
 
 # install kdc and kadmin
+
+# mirrorlist.contos.org does not exits anymore, the below stack exchange post suggests a workaround
+# https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve
+
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds a step updating all `.repo` files in the setup of Kerberos tests in order to fix the unresolved CentOS mirror url.

### Motivation
<!-- What inspired you to submit this pull request? -->
[This](https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve) stack exchange post explains that since the mirror url "mirrorlist.centos.org" no longer exists, some changes need to be made if we want to keep supporting CentOS 7.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
