### PR TITLE
[dbm] remove alpha label for settings collection

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -270,7 +270,7 @@ files:
                   Note that this runs a heavy query against your database to compute the relevant metrics
                   for all your existing schemas. Due to the nature of these calls, if you have a
                   high number of tables and schemas, this may have a negative impact on your database performance.
-                  Only tables and schemas for which the user has been granted SELECT privileges are collected. 
+                  Only tables and schemas for which the user has been granted SELECT privileges are collected.
 
                   See also the MySQL metrics listing: https://docs.datadoghq.com/integrations/mysql/#metrics
                 value:
@@ -346,7 +346,7 @@ files:
               example: false
               display_default: false
           - name: collect_settings
-            description: Configure collection of performance_schema.global_variables. This is an alpha feature.
+            description: Configure collection of performance_schema.global_variables.
             options:
               - name: enabled
                 description: |
@@ -490,20 +490,20 @@ files:
                   example: 10
           - name: aws
             description: |
-              This block defines the configuration for AWS RDS and Aurora instances. 
-              
-              Complete this section if you have installed the Datadog AWS Integration 
-              (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances 
+              This block defines the configuration for AWS RDS and Aurora instances.
+
+              Complete this section if you have installed the Datadog AWS Integration
+              (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances
               with MySQL integration telemetry.
-              
+
               These values are only applied when `dbm: true` option is set.
             options:
               - name: instance_endpoint
                 description: |
-                  Equal to the Endpoint.Address of the instance the agent is connecting to. 
+                  Equal to the Endpoint.Address of the instance the agent is connecting to.
                   This value is optional if the value of `host` is already configured to the instance endpoint.
-                  
-                  For more information on instance endpoints, 
+
+                  For more information on instance endpoints,
                   see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
                 value:
                   type: string
@@ -512,17 +512,17 @@ files:
           - name: gcp
             description: |
               This block defines the configuration for Google Cloud SQL instances.
-              
-              Complete this section if you have installed the Datadog GCP Integration 
-              (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances 
+
+              Complete this section if you have installed the Datadog GCP Integration
+              (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances
               with MySQL integration telemetry.
-              
+
               These values are only applied when `dbm: true` option is set.
             options:
               - name: project_id
                 description: |
                   Equal to the GCP resource's project ID.
-                  
+
                   For more information on project IDs,
                   See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
                 value:
@@ -531,7 +531,7 @@ files:
               - name: instance_id
                 description: |
                   Equal to the GCP resource's instance ID.
-                  
+
                   For more information on instance IDs,
                   See the GCP docs https://cloud.google.com/sql/docs/mysql/instance-settings#instance-id-2ndgen
                 value:
@@ -541,23 +541,23 @@ files:
           - name: azure
             description: |
               This block defines the configuration for Azure Database for MySQL.
-              
-              Complete this section if you have installed the Datadog Azure Integration 
-              (https://docs.datadoghq.com/integrations/azure) to enrich instances 
+
+              Complete this section if you have installed the Datadog Azure Integration
+              (https://docs.datadoghq.com/integrations/azure) to enrich instances
               with MySQL integration telemetry.
-              
+
               These values are only applied when `dbm: true` option is set.
             options:
               - name: deployment_type
                 description: |
-                  Equal to the deployment type for the managed database. 
-                  
+                  Equal to the deployment type for the managed database.
+
                   Acceptable values are:
-                    - `flexible_server` 
+                    - `flexible_server`
                     - `single_server`
                     - `virtual_machine`
-                  
-                  For more information on deployment types, 
+
+                  For more information on deployment types,
                   see the Azure docs https://docs.microsoft.com/en-us/azure/mysql/select-right-deployment-type
                 value:
                   type: string
@@ -565,7 +565,7 @@ files:
               - name: fully_qualified_domain_name
                 description: |
                   Equal to the full qualified domain name of the Azure MySQL database.
-                  
+
                   This value is optional if the value of `host` is already configured to the fully qualified domain name.
                 value:
                   type: string
@@ -698,7 +698,7 @@ files:
             hidden: true
             description: |
               Set the database instance collection interval (in seconds). The database instance collection sends
-              basic information about the database instance along with a signal that it still exists. 
+              basic information about the database instance along with a signal that it still exists.
               This collection does not involve any additional queries to the database.
             value:
               type: number

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -287,7 +287,7 @@ instances:
         ## Note that this runs a heavy query against your database to compute the relevant metrics
         ## for all your existing schemas. Due to the nature of these calls, if you have a
         ## high number of tables and schemas, this may have a negative impact on your database performance.
-        ## Only tables and schemas for which the user has been granted SELECT privileges are collected. 
+        ## Only tables and schemas for which the user has been granted SELECT privileges are collected.
         ##
         ## See also the MySQL metrics listing: https://docs.datadoghq.com/integrations/mysql/#metrics
         #
@@ -350,7 +350,7 @@ instances:
     #
     # dbm: false
 
-    ## Configure collection of performance_schema.global_variables. This is an alpha feature.
+    ## Configure collection of performance_schema.global_variables.
     #
     # collect_settings:
 
@@ -478,10 +478,10 @@ instances:
         #
         # collection_interval: 10
 
-    ## This block defines the configuration for AWS RDS and Aurora instances. 
+    ## This block defines the configuration for AWS RDS and Aurora instances.
     ##
-    ## Complete this section if you have installed the Datadog AWS Integration 
-    ## (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances 
+    ## Complete this section if you have installed the Datadog AWS Integration
+    ## (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances
     ## with MySQL integration telemetry.
     ##
     ## These values are only applied when `dbm: true` option is set.
@@ -489,18 +489,18 @@ instances:
     # aws:
 
         ## @param instance_endpoint - string - optional - default: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
-        ## Equal to the Endpoint.Address of the instance the agent is connecting to. 
+        ## Equal to the Endpoint.Address of the instance the agent is connecting to.
         ## This value is optional if the value of `host` is already configured to the instance endpoint.
         ##
-        ## For more information on instance endpoints, 
+        ## For more information on instance endpoints,
         ## see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
         #
         # instance_endpoint: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
 
     ## This block defines the configuration for Google Cloud SQL instances.
     ##
-    ## Complete this section if you have installed the Datadog GCP Integration 
-    ## (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances 
+    ## Complete this section if you have installed the Datadog GCP Integration
+    ## (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances
     ## with MySQL integration telemetry.
     ##
     ## These values are only applied when `dbm: true` option is set.
@@ -525,8 +525,8 @@ instances:
 
     ## This block defines the configuration for Azure Database for MySQL.
     ##
-    ## Complete this section if you have installed the Datadog Azure Integration 
-    ## (https://docs.datadoghq.com/integrations/azure) to enrich instances 
+    ## Complete this section if you have installed the Datadog Azure Integration
+    ## (https://docs.datadoghq.com/integrations/azure) to enrich instances
     ## with MySQL integration telemetry.
     ##
     ## These values are only applied when `dbm: true` option is set.
@@ -534,14 +534,14 @@ instances:
     # azure:
 
         ## @param deployment_type - string - optional - default: flexible_server
-        ## Equal to the deployment type for the managed database. 
+        ## Equal to the deployment type for the managed database.
         ##
         ## Acceptable values are:
-        ##   - `flexible_server` 
+        ##   - `flexible_server`
         ##   - `single_server`
         ##   - `virtual_machine`
         ##
-        ## For more information on deployment types, 
+        ## For more information on deployment types,
         ## see the Azure docs https://docs.microsoft.com/en-us/azure/mysql/select-right-deployment-type
         #
         # deployment_type: flexible_server

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -7,7 +7,7 @@ files:
     - name: propagate_agent_tags
       description: |
         Set to `true` to propagate the tags from `datadog.yaml` to the check.
-        When set to `true`, the tags from `datadog.yaml` are added to the check's tags for all instances.        
+        When set to `true`, the tags from `datadog.yaml` are added to the check's tags for all instances.
       value:
         example: false
         type: boolean
@@ -275,7 +275,7 @@ files:
     - name: collect_wal_metrics
       description: |
         Collect metrics about WAL file age.
-        NOTE: 
+        NOTE:
         For Postgres 9.6 and below, you must run the check local to your database if you want to enable this option.
         Starting Postgres 10, WAL file metrics are enabled by default using `pg_ls_waldir` and don't need local access.
       value:
@@ -527,7 +527,7 @@ files:
             type: number
             example: 3500
     - name: collect_settings
-      description: Configure collection of pg_settings. This is an alpha feature.
+      description: Configure collection of pg_settings.
       options:
         - name: enabled
           description: |
@@ -544,7 +544,7 @@ files:
             example: 600
         - name: ignored_settings_patterns
           description: |
-            A list of setting patterns to ignore. Any setting key matching one of the value in this list will 
+            A list of setting patterns to ignore. Any setting key matching one of the value in this list will
             not be collected. This uses the traditional LIKE pattern-matching approach.
           value:
               type: array

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -4,7 +4,7 @@ init_config:
 
     ## @param propagate_agent_tags - boolean - optional - default: false
     ## Set to `true` to propagate the tags from `datadog.yaml` to the check.
-    ## When set to `true`, the tags from `datadog.yaml` are added to the check's tags for all instances.        
+    ## When set to `true`, the tags from `datadog.yaml` are added to the check's tags for all instances.
     #
     # propagate_agent_tags: false
 
@@ -214,7 +214,7 @@ instances:
 
     ## @param collect_wal_metrics - boolean - optional - default: false
     ## Collect metrics about WAL file age.
-    ## NOTE: 
+    ## NOTE:
     ## For Postgres 9.6 and below, you must run the check local to your database if you want to enable this option.
     ## Starting Postgres 10, WAL file metrics are enabled by default using `pg_ls_waldir` and don't need local access.
     #
@@ -405,7 +405,7 @@ instances:
         #
         # payload_row_limit: 3500
 
-    ## Configure collection of pg_settings. This is an alpha feature.
+    ## Configure collection of pg_settings.
     #
     # collect_settings:
 
@@ -421,7 +421,7 @@ instances:
         # collection_interval: 600
 
         ## @param ignored_settings_patterns - list of strings - optional
-        ## A list of setting patterns to ignore. Any setting key matching one of the value in this list will 
+        ## A list of setting patterns to ignore. Any setting key matching one of the value in this list will
         ## not be collected. This uses the traditional LIKE pattern-matching approach.
         #
         # ignored_settings_patterns:

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -230,10 +230,10 @@ files:
         example: false
     - name: index_usage_metrics_interval
       description: |
-        Configure the interval (in seconds) for the collection of index usage statistics from the 
-        `sys.dm_db_index_usage_stats` DMV. 
+        Configure the interval (in seconds) for the collection of index usage statistics from the
+        `sys.dm_db_index_usage_stats` DMV.
         Defaults to 300 seconds (5 minutes). If you intend on updating this value, it is strongly recommended
-        to use a consistent value throughout all SQL Server agent deployments. 
+        to use a consistent value throughout all SQL Server agent deployments.
       value:
         type: integer
         example: 300
@@ -302,7 +302,7 @@ files:
         example: false
         display_default: false
     - name: collect_settings
-      description: Configure collection of sys.configurations. This is an alpha feature.
+      description: Configure collection of sys.configurations.
       options:
         - name: enabled
           description: |
@@ -713,9 +713,9 @@ files:
         type: number
         example: 1800
         display_default: false
-    - name: schemas_collection 
+    - name: schemas_collection
       description: |
-        Configure collection of schemas. If `database_autodiscovery` is not enabled, data is collected 
+        Configure collection of schemas. If `database_autodiscovery` is not enabled, data is collected
         only for the database configured with `database` parameter.
       options:
         - name: enabled
@@ -732,7 +732,7 @@ files:
             example: 600
         - name: max_execution_time
           description: |
-            Set the maximum time for schema collection (in seconds). Defaults to 10 seconds. 
+            Set the maximum time for schema collection (in seconds). Defaults to 10 seconds.
             Capped by `schemas_collection.collection_interval`
           value:
             type: number

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -217,10 +217,10 @@ instances:
     # include_index_usage_metrics_tempdb: false
 
     ## @param index_usage_metrics_interval - integer - optional - default: 300
-    ## Configure the interval (in seconds) for the collection of index usage statistics from the 
-    ## `sys.dm_db_index_usage_stats` DMV. 
+    ## Configure the interval (in seconds) for the collection of index usage statistics from the
+    ## `sys.dm_db_index_usage_stats` DMV.
     ## Defaults to 300 seconds (5 minutes). If you intend on updating this value, it is strongly recommended
-    ## to use a consistent value throughout all SQL Server agent deployments. 
+    ## to use a consistent value throughout all SQL Server agent deployments.
     #
     # index_usage_metrics_interval: 300
 
@@ -280,7 +280,7 @@ instances:
     #
     # dbm: false
 
-    ## Configure collection of sys.configurations. This is an alpha feature.
+    ## Configure collection of sys.configurations.
     #
     # collect_settings:
 
@@ -659,7 +659,7 @@ instances:
     #
     # ignore_missing_database: false
 
-    ## Configure collection of schemas. If `database_autodiscovery` is not enabled, data is collected 
+    ## Configure collection of schemas. If `database_autodiscovery` is not enabled, data is collected
     ## only for the database configured with `database` parameter.
     #
     # schemas_collection:
@@ -675,7 +675,7 @@ instances:
         # collection_interval: 600
 
         ## @param max_execution_time - number - optional - default: 10
-        ## Set the maximum time for schema collection (in seconds). Defaults to 10 seconds. 
+        ## Set the maximum time for schema collection (in seconds). Defaults to 10 seconds.
         ## Capped by `schemas_collection.collection_interval`
         #
         # max_execution_time: 10


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

The collection of settings is generally available, so we can remove the alpha label.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
