### PR TITLE
Drop explain plan failures to debug level

### DIFF
--- a/postgres/changelog.d/17974.changed
+++ b/postgres/changelog.d/17974.changed
@@ -1,0 +1,3 @@
+Drop explain plan errors to debug level.
+
+Explain plan collection can fail for any number of legitimate reasons, so avoid polluting the logs by logging them at the debug level.

--- a/postgres/datadog_checks/postgres/explain_parameterized_queries.py
+++ b/postgres/datadog_checks/postgres/explain_parameterized_queries.py
@@ -124,7 +124,7 @@ class ExplainParameterizedQueries:
             logged_statement = obfuscated_statement
             if self._config.log_unobfuscated_plans:
                 logged_statement = statement
-            logger.warning(
+            logger.debug(
                 'Failed to create prepared statement when explaining statement(%s)=[%s] | err=[%s]',
                 query_signature,
                 logged_statement,
@@ -159,7 +159,7 @@ class ExplainParameterizedQueries:
             logged_statement = obfuscated_statement
             if self._config.log_unobfuscated_plans:
                 logged_statement = statement
-            logger.warning(
+            logger.debug(
                 'Failed to explain parameterized statement(%s)=[%s] | err=[%s]',
                 query_signature,
                 logged_statement,
@@ -173,7 +173,7 @@ class ExplainParameterizedQueries:
                 dbname, "DEALLOCATE PREPARE dd_{query_signature}".format(query_signature=query_signature)
             )
         except Exception as e:
-            logger.warning(
+            logger.debug(
                 'Failed to deallocate prepared statement query_signature=[%s] | err=[%s]',
                 query_signature,
                 e,


### PR DESCRIPTION
### What does this PR do?

Explain plan collection can fail for any number of legitimate reasons, so avoid polluting the logs by logging them at the debug level.

### Motivation

We heard feedback that these logs were noisy in the cases where explain plan collection was expected to fail.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
