### PR TITLE
Fix centos mirrorlist for kafka consumer tests

### DIFF
--- a/kafka_consumer/tests/docker/kerberos/kdc/Dockerfile
+++ b/kafka_consumer/tests/docker/kerberos/kdc/Dockerfile
@@ -3,6 +3,12 @@ FROM centos:7
 ENV container docker
 
 # 1. Installing Kerberos server, admin and client
+# mirrorlist.contos.org does not exits anymore, the below stack exchange post suggests a workaround
+# https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve
+
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 RUN yum install -y krb5-server krb5-libs krb5-auth-dialog
 RUN yum install -y krb5-workstation krb5-libs
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Same as https://github.com/DataDog/integrations-core/pull/17964 but for kafka consumer integration.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
