### PR TITLE
Switch back to the intial database while collecting schemas

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/schemas.py
+++ b/sqlserver/datadog_checks/sqlserver/schemas.py
@@ -204,7 +204,7 @@ class Schemas(DBMAsyncJob):
                                 db_name, e
                             )
                         )
-                        return
+                        break
                     except Exception as e:
                         self._log.error(
                             "While executing fetch schemas for databse {}, the following exception occured {}".format(

--- a/sqlserver/datadog_checks/sqlserver/schemas.py
+++ b/sqlserver/datadog_checks/sqlserver/schemas.py
@@ -201,14 +201,16 @@ class Schemas(DBMAsyncJob):
                             self._fetch_schema_data(cursor, start_time, db_name)
                         except StopIteration as e:
                             self._log.error(
-                                "While executing fetch schemas for databse {}, the following exception occured {}".format(
+                                """While executing fetch schemas for databse {},
+                                   the following exception occured {}""".format(
                                     db_name, e
                                 )
                             )
                             break
                         except Exception as e:
                             self._log.error(
-                                "While executing fetch schemas for databse {}, the following exception occured {}".format(
+                                """While executing fetch schemas for databse {},
+                                   the following exception occured {}""".format(
                                     db_name, e
                                 )
                             )


### PR DESCRIPTION
### What does this PR do?
Fixes the early return that wouldve prevented switching back to the original DB during the schema collection

### Motivation
we need to switch back to the original DB when the collection of schemas is stoped on one of them

### Additional Notes
fix for unreleased feature, hence no changelog

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
