### PR TITLE
Remove SIT as code owners of checks downloader

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -305,10 +305,10 @@ datadog_checks_base/datadog_checks/base/checks/windows/              @DataDog/wi
 /ping_one/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-backend
 
 # To keep Security up-to-date with changes to the signing tool.
-/datadog_checks_dev/datadog_checks/dev/tooling/signing.py             @DataDog/agent-integrations @trishankatdatadog
+/datadog_checks_dev/datadog_checks/dev/tooling/signing.py             @DataDog/agent-integrations
 # As well as the secure downloader.
-/datadog_checks_downloader/                                           @DataDog/agent-integrations @trishankatdatadog
-docs/developer/process/integration-release.md                         @DataDog/agent-integrations @trishankatdatadog
+/datadog_checks_downloader/                                           @DataDog/agent-integrations
+docs/developer/process/integration-release.md                         @DataDog/agent-integrations
 # As well as the pipelines.
 /.github/workflows/                                                   @DataDog/agent-integrations
 /.github/workflows/build-deps.yml                                     @DataDog/agent-delivery

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -305,15 +305,14 @@ datadog_checks_base/datadog_checks/base/checks/windows/              @DataDog/wi
 /ping_one/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-backend
 
 # To keep Security up-to-date with changes to the signing tool.
-/datadog_checks_dev/datadog_checks/dev/tooling/signing.py             @DataDog/software-integrity-and-trust @DataDog/agent-integrations @trishankatdatadog
+/datadog_checks_dev/datadog_checks/dev/tooling/signing.py             @DataDog/agent-integrations @trishankatdatadog
 # As well as the secure downloader.
-/datadog_checks_downloader/                                           @DataDog/software-integrity-and-trust @DataDog/agent-integrations @trishankatdatadog
-docs/developer/process/integration-release.md                         @DataDog/software-integrity-and-trust @DataDog/agent-integrations @trishankatdatadog
+/datadog_checks_downloader/                                           @DataDog/agent-integrations @trishankatdatadog
+docs/developer/process/integration-release.md                         @DataDog/agent-integrations @trishankatdatadog
 # As well as the pipelines.
 /.github/workflows/                                                   @DataDog/agent-integrations
 /.github/workflows/build-deps.yml                                     @DataDog/agent-delivery
 /.gitlab-ci.yml                                                       @DataDog/agent-integrations
-/.gitlab/software_composition_analysis.yaml                           @DataDog/software-integrity-and-trust
 # Dev container
 /.devcontainer/                                                        @DataDog/agent-integrations @DataDog/container-integrations
 /.devcontainer/dbm                                                     @DataDog/database-monitoring-agent


### PR DESCRIPTION

### What does this PR do?

Remove SIT as code owners of checks downloader


### Motivation

The SIT team is not a core contributor to this software anymore


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
