### PR TITLE
Enable manual triggering of dependency build & resolution

### DIFF
--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -267,7 +267,8 @@ jobs:
 
   publish:
     name: Publish artifacts
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (github.ref == 'master' || startsWith(github.ref, '7.')))
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (github.ref == 
+    github.event.repository.default_branch || startsWith(github.ref, '7.')))
     needs:
     - build
     - build-macos

--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -1,6 +1,7 @@
 name: Build dependencies
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
     - master
@@ -266,7 +267,7 @@ jobs:
 
   publish:
     name: Publish artifacts
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (github.ref == 'master' || startsWith(github.ref, '7.')))
     needs:
     - build
     - build-macos


### PR DESCRIPTION
### What does this PR do?

Makes it possible to manually trigger a dependency resolution (via the GitHub Actions UI). The result of that workflow is getting up to date dependencies uploaded to our index, and triggering an automated PR to update the lockfile.

### Motivation

Being able to get updated versions of transitive dependencies without having to update any direct dependency; also enabling a escape hatch to trigger the workflow for situations where some part of the process may fail unexpectedly.

### Additional Notes

- It's not clear from the documentation, but only members with write access should be able to trigger this manually (i.e. the same people that can already merge PR's).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
