### PR TITLE
Fixed the heat endpoint for the Openstack Controller

### DIFF
--- a/openstack_controller/changelog.d/17996.fixed
+++ b/openstack_controller/changelog.d/17996.fixed
@@ -1,0 +1,1 @@
+Fixed the heat endpoint for the Openstack Controller

--- a/openstack_controller/datadog_checks/openstack_controller/api/api_rest.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api/api_rest.py
@@ -32,7 +32,7 @@ class ApiRest(Api):
 
     def get_response_time(self, endpoint_types, remove_project_id=True, is_heat=False):
         endpoint = (
-            self._catalog.get_endpoint_by_type(endpoint_types).replace(f"/v1/{self._current_project_id}", "")  
+            self._catalog.get_endpoint_by_type(endpoint_types).replace(f"/v1/{self._current_project_id}", "")
             if is_heat
             else (
                 self._catalog.get_endpoint_by_type(endpoint_types).replace(self._current_project_id, "")

--- a/openstack_controller/datadog_checks/openstack_controller/api/api_rest.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api/api_rest.py
@@ -43,6 +43,7 @@ class ApiRest(Api):
         self.log.debug("getting response time for `%s`", endpoint)
         response = self.http.get(endpoint)
         response.raise_for_status()
+        self.log.debug(response.json())
         return response.elapsed.total_seconds() * 1000
 
     def get_auth_projects(self):

--- a/openstack_controller/datadog_checks/openstack_controller/api/api_rest.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api/api_rest.py
@@ -30,11 +30,15 @@ class ApiRest(Api):
     def component_in_catalog(self, component_types):
         return self._catalog.has_component(component_types)
 
-    def get_response_time(self, endpoint_types, remove_project_id=True):
+    def get_response_time(self, endpoint_types, remove_project_id=True, is_heat=False):
         endpoint = (
-            self._catalog.get_endpoint_by_type(endpoint_types).replace(self._current_project_id, "")
-            if self._current_project_id and remove_project_id
-            else self._catalog.get_endpoint_by_type(endpoint_types)
+            self._catalog.get_endpoint_by_type(endpoint_types).replace("/v1/" + self._current_project_id, "")
+            if is_heat
+            else (
+                self._catalog.get_endpoint_by_type(endpoint_types).replace(self._current_project_id, "")
+                if self._current_project_id and remove_project_id
+                else self._catalog.get_endpoint_by_type(endpoint_types)
+            )
         )
         self.log.debug("getting response time for `%s`", endpoint)
         response = self.http.get(endpoint)
@@ -604,7 +608,7 @@ class ApiRest(Api):
 
     def get_heat_stacks(self, project_id):
         return self.make_paginated_request(
-            '{}/v1/{}/stacks'.format(self._catalog.get_endpoint_by_type(Component.Types.HEAT.value), project_id),
+            '{}/stacks'.format(self._catalog.get_endpoint_by_type(Component.Types.HEAT.value)),
             'stacks',
             'id',
             next_signifier='links',

--- a/openstack_controller/datadog_checks/openstack_controller/api/api_rest.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api/api_rest.py
@@ -32,7 +32,7 @@ class ApiRest(Api):
 
     def get_response_time(self, endpoint_types, remove_project_id=True, is_heat=False):
         endpoint = (
-            self._catalog.get_endpoint_by_type(endpoint_types).replace("/v1/" + self._current_project_id, "")
+            self._catalog.get_endpoint_by_type(endpoint_types).replace(f"/v1/{self._current_project_id}", "")  
             if is_heat
             else (
                 self._catalog.get_endpoint_by_type(endpoint_types).replace(self._current_project_id, "")
@@ -43,7 +43,6 @@ class ApiRest(Api):
         self.log.debug("getting response time for `%s`", endpoint)
         response = self.http.get(endpoint)
         response.raise_for_status()
-        self.log.debug(response.json())
         return response.elapsed.total_seconds() * 1000
 
     def get_auth_projects(self):

--- a/openstack_controller/datadog_checks/openstack_controller/api/api_sdk.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api/api_sdk.py
@@ -118,7 +118,7 @@ class ApiSdk(Api):
     def get_response_time(self, endpoint_types, remove_project_id=True, is_heat=False):
         endpoint = self._catalog.get_endpoint_by_type(endpoint_types)
         endpoint = (
-            self._catalog.get_endpoint_by_type(endpoint_types).replace("/v1/" + self._access.project_id, "")
+            self._catalog.get_endpoint_by_type(endpoint_types).replace(f"/v1/{self._access.project_id}", "")
             if is_heat
             else (
                 endpoint.replace(self._access.project_id, "")

--- a/openstack_controller/datadog_checks/openstack_controller/api/api_sdk.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api/api_sdk.py
@@ -115,10 +115,16 @@ class ApiSdk(Api):
         self.connection.authorize()
         self.http.options['headers']['X-Auth-Token'] = self.connection.session.auth.get_token(self.connection.session)
 
-    def get_response_time(self, endpoint_types, remove_project_id=True):
+    def get_response_time(self, endpoint_types, remove_project_id=True, is_heat=False):
         endpoint = self._catalog.get_endpoint_by_type(endpoint_types)
         endpoint = (
-            endpoint.replace(self._access.project_id, "") if self._access.project_id and remove_project_id else endpoint
+            self._catalog.get_endpoint_by_type(endpoint_types).replace("/v1/" + self._access.project_id, "")
+            if is_heat
+            else (
+                endpoint.replace(self._access.project_id, "")
+                if self._access.project_id and remove_project_id
+                else endpoint
+            )
         )
         response = self.http.get(endpoint)
         response.raise_for_status()

--- a/openstack_controller/datadog_checks/openstack_controller/components/heat.py
+++ b/openstack_controller/datadog_checks/openstack_controller/components/heat.py
@@ -26,7 +26,7 @@ class Heat(Component):
     @Component.http_error(report_service_check=True)
     def _report_response_time(self, global_components_config, tags):
         self.check.log.debug("reporting `%s` response time", Heat.ID.value)
-        response_time = self.check.api.get_response_time(Heat.TYPES.value)
+        response_time = self.check.api.get_response_time(Heat.TYPES.value, is_heat=True)
         self.check.log.debug("`%s` response time: %s", Heat.ID.value, response_time)
         self.check.gauge(HEAT_RESPONSE_TIME, response_time, tags=tags)
 

--- a/openstack_controller/tests/fixtures/POST/identity/v3/auth/tokens/1e6e233e637d4d55a50a62b63398ad15.json
+++ b/openstack_controller/tests/fixtures/POST/identity/v3/auth/tokens/1e6e233e637d4d55a50a62b63398ad15.json
@@ -187,7 +187,7 @@
             "id": "168f02a638de42f6b66b60b01f905830",
             "interface": "public",
             "region_id": "RegionOne",
-            "url": "http://127.0.0.1:8004/heat-api",
+            "url": "http://127.0.0.1:8004/heat-api/v1/1e6e233e637d4d55a50a62b63398ad15",
             "region": "RegionOne"
           }
         ],

--- a/openstack_controller/tests/fixtures/POST/identity/v3/auth/tokens/6e39099cccde4f809b003d9e0dd09304.json
+++ b/openstack_controller/tests/fixtures/POST/identity/v3/auth/tokens/6e39099cccde4f809b003d9e0dd09304.json
@@ -195,7 +195,7 @@
             "id": "168f02a638de42f6b66b60b01f905830",
             "interface": "public",
             "region_id": "RegionOne",
-            "url": "http://127.0.0.1:8004/heat-api",
+            "url": "http://127.0.0.1:8004/heat-api/v1/6e39099cccde4f809b003d9e0dd09304",
             "region": "RegionOne"
           }
         ],

--- a/openstack_controller/tests/fixtures/POST/identity/v3/auth/tokens/system.json
+++ b/openstack_controller/tests/fixtures/POST/identity/v3/auth/tokens/system.json
@@ -106,6 +106,20 @@
         {
           "endpoints": [
             {
+              "id": "168f02a638de42f6b66b60b01f905830",
+              "interface": "public",
+              "region_id": "RegionOne",
+              "url": "http://127.0.0.1:8004/heat-api",
+              "region": "RegionOne"
+            }
+          ],
+          "id": "36f45c02edba4500adc2bc5974d22bf0",
+          "type": "orchestration",
+          "name": "heat"
+        },
+        {
+          "endpoints": [
+            {
               "id": "7e6cdeb2744345b7953d7b356245afec",
               "interface": "admin",
               "region_id": "RegionOne",

--- a/openstack_controller/tests/test_unit_heat.py
+++ b/openstack_controller/tests/test_unit_heat.py
@@ -101,25 +101,23 @@ def test_not_in_catalog(aggregator, check, dd_run_check, caplog, mock_http_post,
 
 
 @pytest.mark.parametrize(
-    ('mock_http_get', 'instance', 'expected_api_calls'),
+    ('mock_http_get', 'instance'),
     [
         pytest.param(
             {'http_error': {'/heat-api': MockResponse(status_code=500)}},
             configs.REST,
-            2,
             id='api rest',
         ),
         pytest.param(
             {'http_error': {'/heat-api': MockResponse(status_code=500)}},
             configs.SDK,
-            3,
             id='api sdk',
         ),
     ],
     indirect=['mock_http_get'],
 )
 @pytest.mark.usefixtures('mock_http_get', 'mock_http_post', 'openstack_connection')
-def test_response_time_exception(aggregator, check, dd_run_check, mock_http_get, expected_api_calls):
+def test_response_time_exception(aggregator, check, dd_run_check, mock_http_get):
     dd_run_check(check)
     aggregator.assert_metric(
         'openstack.heat.response_time',
@@ -134,7 +132,7 @@ def test_response_time_exception(aggregator, check, dd_run_check, mock_http_get,
     for call in mock_http_get.call_args_list:
         args, kwargs = call
         args_list += list(args)
-    assert args_list.count('http://127.0.0.1:8004/heat-api') == expected_api_calls
+    assert args_list.count('http://127.0.0.1:8004/heat-api') == 3
 
 
 @pytest.mark.parametrize(

--- a/openstack_controller/tests/test_unit_heat.py
+++ b/openstack_controller/tests/test_unit_heat.py
@@ -101,23 +101,25 @@ def test_not_in_catalog(aggregator, check, dd_run_check, caplog, mock_http_post,
 
 
 @pytest.mark.parametrize(
-    ('mock_http_get', 'instance'),
+    ('mock_http_get', 'instance', 'expected_api_calls'),
     [
         pytest.param(
             {'http_error': {'/heat-api': MockResponse(status_code=500)}},
             configs.REST,
+            2,
             id='api rest',
         ),
         pytest.param(
             {'http_error': {'/heat-api': MockResponse(status_code=500)}},
             configs.SDK,
+            3,
             id='api sdk',
         ),
     ],
     indirect=['mock_http_get'],
 )
 @pytest.mark.usefixtures('mock_http_get', 'mock_http_post', 'openstack_connection')
-def test_response_time_exception(aggregator, check, dd_run_check, mock_http_get):
+def test_response_time_exception(aggregator, check, dd_run_check, mock_http_get, expected_api_calls):
     dd_run_check(check)
     aggregator.assert_metric(
         'openstack.heat.response_time',
@@ -132,7 +134,7 @@ def test_response_time_exception(aggregator, check, dd_run_check, mock_http_get)
     for call in mock_http_get.call_args_list:
         args, kwargs = call
         args_list += list(args)
-    assert args_list.count('http://127.0.0.1:8004/heat-api') == 2
+    assert args_list.count('http://127.0.0.1:8004/heat-api') == expected_api_calls
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We noticed that the heat stacks weren't being discovered in the Openstack Controller integration:
`2024-07-03 15:55:34 UTC | CORE | DEBUG | (pkg/collector/python/datadog_agent.go:133 in LogMessage) | - | (connectionpool.py:474) | [http://10.164.0.33:80](http://10.164.0.33/) "GET /heat-api/v1/***************************87d1e/v1/***************************87d1e/stacks HTTP/1.1" 404 154
2024-07-03 15:55:34 UTC | CORE | ERROR | (pkg/collector/python/datadog_agent.go:127 in LogMessage) | openstack_controller:92e51db26f99a1e5 | (component.py:79) | HTTPError: <Response [404]>`

When reading the API documentation for heat (https://docs.openstack.org/api-ref/orchestration/v1/), there is no endpoint for /v1 or /v1/{tenant_id}. 

So looking at how we get the endpoint in https://github.com/DataDog/integrations-core/blob/master/openstack_controller/datadog_checks/openstack_controller/api/api_rest.py#L34, either the project_id can be removed (causing /v1 to be made the endpoint) or the project_id can be kept (causing /v1/{tenant_id} to be the endpoint).

As such, a specific edge case needed to be added for generating the endpoint for the heat component.
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
