### PR TITLE
[mongo] Properly handle the null value of waiting_for_latch in operation sampling

### DIFF
--- a/mongo/changelog.d/17997.fixed
+++ b/mongo/changelog.d/17997.fixed
@@ -1,0 +1,1 @@
+Fix the default null value for waiting_for_latch in operation sampling. When an operation is not waiting for latch, waiting_for_latch should be an empty dict instead of boolean False.

--- a/mongo/datadog_checks/mongo/dbm/operation_samples.py
+++ b/mongo/datadog_checks/mongo/dbm/operation_samples.py
@@ -368,7 +368,7 @@ class MongoOperationSamples(DBMAsyncJob):
             "waiting_for_flow_control": operation.get("waitingForFlowControl", False),  # bool
             "flow_control_stats": self._format_key_name(operation.get("flowControlStats", {})),  # dict
             # Latches
-            "waiting_for_latch": operation.get("waitingForLatch", {}),  # dict
+            "waiting_for_latch": self._format_key_name(operation.get("waitingForLatch", {})),  # dict
             # cursor
             "cursor": self._get_operation_cursor(operation),  # dict
         }

--- a/mongo/datadog_checks/mongo/dbm/operation_samples.py
+++ b/mongo/datadog_checks/mongo/dbm/operation_samples.py
@@ -368,7 +368,7 @@ class MongoOperationSamples(DBMAsyncJob):
             "waiting_for_flow_control": operation.get("waitingForFlowControl", False),  # bool
             "flow_control_stats": self._format_key_name(operation.get("flowControlStats", {})),  # dict
             # Latches
-            "waiting_for_latch": operation.get("waitingForLatch", False),  # bool
+            "waiting_for_latch": operation.get("waitingForLatch", {}),  # dict
             # cursor
             "cursor": self._get_operation_cursor(operation),  # dict
         }

--- a/mongo/datadog_checks/mongo/dbm/types.py
+++ b/mongo/datadog_checks/mongo/dbm/types.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from typing import List, Optional, TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 
 class OperationSampleClientDriver(TypedDict, total=False):
@@ -106,9 +106,9 @@ class OperationSampleOperationStatsFlowControlStats(TypedDict, total=False):
 
 
 class OperationSampleOperationStatsWaitingForLatch(TypedDict, total=False):
-    timestamp: str
-    captureName: str
-    backtrace: List[str]
+    timestamp: Optional[Dict[str, str]]
+    capture_name: Optional[str]
+    backtrace: Optional[List[str]]
 
 
 class OperationSampleOperationStatsCursor(TypedDict, total=False):

--- a/mongo/tests/fixtures/$currentOp-standalone
+++ b/mongo/tests/fixtures/$currentOp-standalone
@@ -118,6 +118,12 @@
             }
         },
         "waitingForFlowControl": false,
-        "flowControlStats": {}
+        "flowControlStats": {},
+        "waitingForLatch": {
+            "timestamp": {
+                "$date": "2024-05-16T18:06:38.419Z"
+            },
+            "captureName": "FutureResolution"
+        }
     }
 ]

--- a/mongo/tests/results/opeartion-activities-mongos.json
+++ b/mongo/tests/results/opeartion-activities-mongos.json
@@ -54,7 +54,7 @@
                 },
                 "waiting_for_flow_control": false,
                 "flow_control_stats": {},
-                "waiting_for_latch": false,
+                "waiting_for_latch": {},
                 "type": "op",
                 "op": "query",
                 "shard": "shard04",
@@ -119,7 +119,7 @@
                 },
                 "waiting_for_flow_control": false,
                 "flow_control_stats": {},
-                "waiting_for_latch": false,
+                "waiting_for_latch": {},
                 "cursor": {
                     "cursor_id": 7153547462305880513,
                     "created_date": "2024-06-13T20:50:10.806000",

--- a/mongo/tests/results/opeartion-activities-standalone.json
+++ b/mongo/tests/results/opeartion-activities-standalone.json
@@ -47,7 +47,7 @@
                 },
                 "waiting_for_flow_control": false,
                 "flow_control_stats": {},
-                "waiting_for_latch": false,
+                "waiting_for_latch": {},
                 "type": "op",
                 "op": "query",
                 "shard": null,

--- a/mongo/tests/results/opeartion-activities-standalone.json
+++ b/mongo/tests/results/opeartion-activities-standalone.json
@@ -47,7 +47,12 @@
                 },
                 "waiting_for_flow_control": false,
                 "flow_control_stats": {},
-                "waiting_for_latch": {},
+                "waiting_for_latch": {
+                    "timestamp": {
+                        "$date": "2024-05-16T18:06:38.419Z"
+                    },
+                    "capture_name": "FutureResolution"
+                },
                 "type": "op",
                 "op": "query",
                 "shard": null,

--- a/mongo/tests/results/operation-samples-mongos.json
+++ b/mongo/tests/results/operation-samples-mongos.json
@@ -750,7 +750,7 @@
             },
             "waiting_for_flow_control": false,
             "flow_control_stats": {},
-            "waiting_for_latch": false,
+            "waiting_for_latch": {},
             "type": "op",
             "op": "query",
             "shard": "shard04",

--- a/mongo/tests/results/operation-samples-standalone.json
+++ b/mongo/tests/results/operation-samples-standalone.json
@@ -168,7 +168,12 @@
             },
             "waiting_for_flow_control": false,
             "flow_control_stats": {},
-            "waiting_for_latch": {},
+            "waiting_for_latch": {
+                "timestamp": {
+                    "$date": "2024-05-16T18:06:38.419Z"
+                },
+                "capture_name": "FutureResolution"
+            },
             "type": "op",
             "op": "query",
             "shard": null,

--- a/mongo/tests/results/operation-samples-standalone.json
+++ b/mongo/tests/results/operation-samples-standalone.json
@@ -168,7 +168,7 @@
             },
             "waiting_for_flow_control": false,
             "flow_control_stats": {},
-            "waiting_for_latch": false,
+            "waiting_for_latch": {},
             "type": "op",
             "op": "query",
             "shard": null,


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug where the null value of `waiting_for_latch` in operation sampling is wrongly set to bool `False`. The correct waiting_for_latch null value should be an empty dict when an operation is not waiting for latch.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
