### PR TITLE
add default monitor for wincrashdetect

### DIFF
--- a/wincrashdetect/assets/monitors/windows_crash.json
+++ b/wincrashdetect/assets/monitors/windows_crash.json
@@ -1,5 +1,5 @@
 {
-    "version": 1,
+    "version": 2,
     "created_at": "2024-07-09",
     "title": "Windows Crash Detection",
     "tags": [
@@ -20,7 +20,6 @@
             },
             "enable_logs_sample": false,
             "notify_audit": false,
-            "on_missing_data": "default",
             "include_tags": true,
             "new_group_delay": 60,
             "groupby_simple_monitor": false,

--- a/wincrashdetect/assets/monitors/windows_crash.json
+++ b/wincrashdetect/assets/monitors/windows_crash.json
@@ -6,7 +6,7 @@
     "tags": [
         "integration:wincrashdetect"
     ],
-    "description": "The Windows Crash Detection check will send an event if, on Agent startup, a new crash dump file is detected.  This monitor alerts when a crash is detected.",
+    "description": "The Windows Crash Detection check sends an event if a new crash dump file is detected on Agent startup.  This monitor alerts when a crash is detected.",
     "definition": {
         "name": "A Windows system crash has been detected",
         "type": "event-v2 alert",

--- a/wincrashdetect/assets/monitors/windows_crash.json
+++ b/wincrashdetect/assets/monitors/windows_crash.json
@@ -1,6 +1,7 @@
 {
     "version": 2,
     "created_at": "2024-07-09",
+    "last_updated_at": "2024-07-09",
     "title": "Windows Crash Detection",
     "tags": [
         "integration:wincrashdetect"

--- a/wincrashdetect/assets/monitors/windows_crash.json
+++ b/wincrashdetect/assets/monitors/windows_crash.json
@@ -1,0 +1,35 @@
+{
+    "version": 1,
+    "created_at": "2024-07-09",
+    "title": "Windows Crash Detection",
+    "tags": [
+        "integration:wincrashdetect"
+    ],
+    "description": "The Windows Crash Detection check will send an event if, on Agent startup, a new crash dump file is detected.  This monitor alerts when a crash is detected.",
+    "definition": {
+        "name": "A Windows system crash has been detected",
+        "type": "event-v2 alert",
+        "query": "events(\"source:windows_crash_detection\").rollup(\"count\").by(\"host\").last(\"10m\") > 0",
+        "message": "{{#is_alert}}\n\nThe Windows Crash Detection integration is reporting that a system crash occurred on Windows host {{host.name}}\n\n{{/is_alert}}",
+        "tags": [
+            "integration:wincrashdetect"
+        ],
+        "options": {
+            "thresholds": {
+                "critical": 0
+            },
+            "enable_logs_sample": false,
+            "notify_audit": false,
+            "on_missing_data": "default",
+            "include_tags": true,
+            "new_group_delay": 60,
+            "groupby_simple_monitor": false,
+            "silenced": {},
+            "avalanche_window": 20
+        },
+        "priority": 2,
+        "restriction_policy": {
+            "bindings": []
+        }
+    }
+}

--- a/wincrashdetect/manifest.json
+++ b/wincrashdetect/manifest.json
@@ -34,6 +34,9 @@
       },
       "source_type_id": 10389,
       "auto_install": true
+    },
+    "monitors": {
+      "windows_crash":  "assets/monitors/windows_crash.json"
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
adds a default monitor to the existing wincrashdetect check

### Motivation
feature request

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
