### PR TITLE
Add tests for openmetrics counters

### DIFF
--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_counter.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_counter.py
@@ -34,6 +34,87 @@ def test_basic(aggregator, dd_run_check, mock_http_response):
     aggregator.assert_all_metrics_covered()
 
 
+def test_basic_incorrect_suffix(aggregator, dd_run_check, mock_http_response):
+    """
+    We won't collect counter metrics unless they end in '_total'.
+
+    We commonly see metrics that end in '_count' or ones that have no meaningful suffix at all.
+    Here we make sure that by default these won't be collected.
+    """
+
+    mock_http_response(
+        """
+        # HELP go_memstats_alloc_bytes_count Total number of bytes allocated, even if freed.
+        # TYPE go_memstats_alloc_bytes_count counter
+        go_memstats_alloc_bytes_total 9.339544592e+09
+        # HELP go_memstats_frees Total number of frees.
+        # TYPE go_memstats_frees counter
+        go_memstats_frees_total 1.28219257e+08
+        """
+    )
+    check = get_check({'metrics': ['.+']})
+    dd_run_check(check)
+
+    assert not aggregator.metrics('test.go_memstats_alloc_bytes.count')
+    assert not aggregator.metrics('test.go_memstats_frees.count')
+    aggregator.assert_all_metrics_covered()
+
+
+def test_untyped_correct_suffix(aggregator, dd_run_check, mock_http_response):
+    """
+    We can force a metric that is 'untyped' in the raw payload to a counter as long as it ends in '_total'.
+    """
+
+    mock_http_response(
+        """
+        # HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+        # TYPE go_memstats_alloc_bytes_total untyped
+        go_memstats_alloc_bytes_total 9.339544592e+09
+        """
+    )
+    check = get_check(
+        {'metrics': [{'go_memstats_alloc_bytes_total': {'name': 'go_memstats_alloc_bytes', 'type': 'counter'}}]}
+    )
+    dd_run_check(check)
+
+    aggregator.assert_metric(
+        'test.go_memstats_alloc_bytes.count', 9339544592, metric_type=aggregator.MONOTONIC_COUNT, tags=['endpoint:test']
+    )
+    aggregator.assert_all_metrics_covered()
+
+
+def test_untyped_incorrect_suffix(aggregator, dd_run_check, mock_http_response):
+    """
+    Forcing an untyped metric as a counter won't work without it ending in '_total'.
+    """
+
+    mock_http_response(
+        """
+        # HELP go_memstats_alloc_bytes_count Total number of bytes allocated, even if freed.
+        # TYPE go_memstats_alloc_bytes_count counter
+        go_memstats_alloc_bytes_total 9.339544592e+09
+        # HELP go_memstats_frees Total number of frees.
+        # TYPE go_memstats_frees counter
+        go_memstats_frees_total 1.28219257e+08
+        """
+    )
+    check = get_check(
+        {
+            'metrics': [
+                {
+                    'go_memstats_alloc_bytes': {'name': 'go_memstats_alloc_bytes', 'type': 'counter'},
+                    'go_memstats_frees': {'name': 'go_memstats_frees', 'type': 'counter'},
+                }
+            ]
+        }
+    )
+    dd_run_check(check)
+
+    assert not aggregator.metrics('test.go_memstats_alloc_bytes.count')
+    assert not aggregator.metrics('test.go_memstats_frees.count')
+    aggregator.assert_all_metrics_covered()
+
+
 def test_tags(aggregator, dd_run_check, mock_http_response):
     mock_http_response(
         """


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add some more tests for openmetrics counters

### Motivation
<!-- What inspired you to submit this pull request? -->
The point about `_total` suffixes comes up from time to time, it would be good to formalize it with a test.

Also I could not find where we test the logic to force untyped metrics to be counters.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
