### PR TITLE
Rename classes to avoid pytest warnings

### DIFF
--- a/datadog_checks_base/tests/base/utils/test_tracking.py
+++ b/datadog_checks_base/tests/base/utils/test_tracking.py
@@ -31,7 +31,7 @@ class MyException(Exception):
     pass
 
 
-class TestJob:
+class Job:
     def __init__(self, check):
         self.check = check
 
@@ -72,7 +72,7 @@ class TestJob:
 def test_tracked_method(aggregator, debug_stats_kwargs, disable_tracking):
     os.environ['DD_DISABLE_TRACKED_METHOD'] = str(disable_tracking).lower()
     check = HelloCheck(debug_stats_kwargs) if debug_stats_kwargs else AgentCheck(name="hello")
-    job = TestJob(check)
+    job = Job(check)
     result = job.run_job()
     assert result == EXPECTED_RESULT
 


### PR DESCRIPTION
Pytest tries to treat classes that start with 'Test' as tests. Helper class
names shouldn't start with 'Test' to avoid pytest complaining about them.

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
