### PR TITLE
Support log submission from checks

### DIFF
--- a/datadog_checks_base/changelog.d/18019.added
+++ b/datadog_checks_base/changelog.d/18019.added
@@ -1,0 +1,1 @@
+Support log submission from checks

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -5,7 +5,6 @@ import copy
 import functools
 import importlib
 import inspect
-import json
 import logging
 import re
 import traceback
@@ -51,6 +50,7 @@ from ..utils.http import RequestsWrapper
 from ..utils.limiter import Limiter
 from ..utils.metadata import MetadataManager
 from ..utils.secrets import SecretsSanitizer
+from ..utils.serialization import from_json, to_json
 from ..utils.tagging import GENERIC_TAGS
 from ..utils.tls import TlsContextWrapper
 from ..utils.tracing import traced_class
@@ -309,6 +309,9 @@ class AgentCheck(object):
         if not PY2:
             self.check_initializations.append(self.load_configuration_models)
 
+        self.__formatted_tags = None
+        self.__logs_enabled = None
+
     def _create_metrics_pattern(self, metric_patterns, option_name):
         all_patterns = metric_patterns.get(option_name, [])
 
@@ -397,6 +400,36 @@ class AgentCheck(object):
             self._http = RequestsWrapper(self.instance or {}, self.init_config, self.HTTP_CONFIG_REMAPPER, self.log)
 
         return self._http
+
+    @property
+    def logs_enabled(self):
+        # type: () -> bool
+        """
+        Returns True if logs are enabled, False otherwise.
+        """
+        if self.__logs_enabled is None:
+            self.__logs_enabled = bool(datadog_agent.get_config('logs_enabled'))
+
+        return self.__logs_enabled
+
+    @property
+    def formatted_tags(self):
+        # type: () -> str
+        if self.__formatted_tags is None:
+            normalized_tags = set()
+            for tag in self.instance.get('tags', []):
+                key, _, value = tag.partition(':')
+                if not value:
+                    continue
+
+                if self.disable_generic_tags and key in GENERIC_TAGS:
+                    key = '{}_{}'.format(self.name, key)
+
+                normalized_tags.add('{}:{}'.format(key, value))
+
+            self.__formatted_tags = ','.join(sorted(normalized_tags))
+
+        return self.__formatted_tags
 
     @property
     def diagnosis(self):
@@ -945,6 +978,34 @@ class AgentCheck(object):
             self, self.check_id, self._format_namespace(name, raw), status, tags, hostname, message
         )
 
+    def send_log(self, data, cursor=None, stream='default'):
+        # type: (dict[str, str], dict[str, Any] | None, str) -> None
+        """Send a log for submission.
+
+        Parameters:
+
+            data (dict[str, str]):
+                the log data to send.
+            cursor (dict[str, Any] or None):
+                metadata associated with the log which will be saved to disk. the most recent value may be
+                retrieved with the `get_log_cursor` method.
+            stream (str):
+                the stream associated with this log, used for accurate cursor persistence.
+        """
+        attributes = data.copy()
+        if 'ddtags' not in attributes and self.formatted_tags:
+            attributes['ddtags'] = self.formatted_tags
+
+        datadog_agent.send_log(to_json(attributes), self.check_id)
+        if cursor is not None:
+            self.write_persistent_cache('log_cursor_{}'.format(stream), to_json(cursor))
+
+    def get_log_cursor(self, stream='default'):
+        # type: (str) -> dict[str, Any] | None
+        """Returns the most recent log cursor from disk."""
+        data = self.read_persistent_cache('log_cursor_{}'.format(stream))
+        return from_json(data) if data else None
+
     def _log_deprecation(self, deprecation_key, *args):
         # type: (str, *str) -> None
         """
@@ -1118,7 +1179,7 @@ class AgentCheck(object):
         The agent calls this method to retrieve diagnostics from integrations. This method
         runs explicit diagnostics if available.
         """
-        return json.dumps([d._asdict() for d in (self.diagnosis.diagnoses + self.diagnosis.run_explicit())])
+        return to_json([d._asdict() for d in (self.diagnosis.diagnoses + self.diagnosis.run_explicit())])
 
     def _get_requests_proxy(self):
         # type: () -> ProxySettings
@@ -1231,7 +1292,7 @@ class AgentCheck(object):
         except Exception as e:
             message = self.sanitize(str(e))
             tb = self.sanitize(traceback.format_exc())
-            error_report = json.dumps([{'message': message, 'traceback': tb}])
+            error_report = to_json([{'message': message, 'traceback': tb}])
         finally:
             if self.metric_limiter:
                 if is_affirmative(self.debug_metrics.get('metric_contexts', False)):

--- a/datadog_checks_base/datadog_checks/base/checks/logs/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/logs/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/datadog_checks_base/datadog_checks/base/checks/logs/crawler/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/logs/crawler/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/datadog_checks_base/datadog_checks/base/checks/logs/crawler/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/logs/crawler/base.py
@@ -1,0 +1,34 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Iterable
+
+from datadog_checks.base import AgentCheck
+
+if TYPE_CHECKING:
+    from datadog_checks.base.checks.logs.crawler.stream import LogStream
+
+
+class LogCrawlerCheck(AgentCheck, ABC):
+    @abstractmethod
+    def get_log_streams(self) -> Iterable[LogStream]:
+        """
+        Yields the log streams associated with this check.
+        """
+
+    def process_streams(self) -> None:
+        """
+        Process the log streams and send the collected logs.
+
+        Crawler checks that need more functionality can implement the `check` method and call this directly.
+        """
+        for stream in self.get_log_streams():
+            last_cursor = self.get_log_cursor(stream.name)
+            for record in stream.records(cursor=last_cursor):
+                self.send_log(record.data, cursor=record.cursor, stream=stream.name)
+
+    def check(self, _) -> None:
+        self.process_streams()

--- a/datadog_checks_base/datadog_checks/base/checks/logs/crawler/stream.py
+++ b/datadog_checks_base/datadog_checks/base/checks/logs/crawler/stream.py
@@ -25,13 +25,23 @@ class LogStream(ABC):
 
     @property
     def check(self) -> AgentCheck:
+        """
+        The AgentCheck instance associated with this LogStream.
+        """
         return self.__check
 
     @property
     def name(self) -> str:
+        """
+        The name of this LogStream.
+        """
         return self.__name
 
     def construct_tags(self, tags: list[str]) -> list[str]:
+        """
+        Returns a formatted string of tags which may be used directly as the `ddtags` field of logs.
+        This will include the `tags` from the integration instance config.
+        """
         formatted_tags = ','.join(tags)
         return f'{self.check.formatted_tags},{formatted_tags}' if self.check.formatted_tags else formatted_tags
 

--- a/datadog_checks_base/datadog_checks/base/checks/logs/crawler/stream.py
+++ b/datadog_checks_base/datadog_checks/base/checks/logs/crawler/stream.py
@@ -1,0 +1,42 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Iterable
+
+if TYPE_CHECKING:
+    from datadog_checks.base import AgentCheck
+
+
+class LogRecord:
+    __slots__ = ('cursor', 'data')
+
+    def __init__(self, data: dict[str, str], *, cursor: dict[str, Any] | None):
+        self.data = data
+        self.cursor = cursor
+
+
+class LogStream(ABC):
+    def __init__(self, *, check: AgentCheck, name: str):
+        self.__check = check
+        self.__name = name
+
+    @property
+    def check(self) -> AgentCheck:
+        return self.__check
+
+    @property
+    def name(self) -> str:
+        return self.__name
+
+    def construct_tags(self, tags: list[str]) -> list[str]:
+        formatted_tags = ','.join(tags)
+        return f'{self.check.formatted_tags},{formatted_tags}' if self.check.formatted_tags else formatted_tags
+
+    @abstractmethod
+    def records(self, *, cursor: dict[str, Any] | None = None) -> Iterable[LogRecord]:
+        """
+        Yields log records as they are received.
+        """

--- a/datadog_checks_base/datadog_checks/base/utils/serialization.py
+++ b/datadog_checks_base/datadog_checks/base/utils/serialization.py
@@ -8,13 +8,27 @@ try:
 
     impl = 'orjson'
     sort_keys_kwargs = {'option': json.OPT_SORT_KEYS}
+
+    def from_json(s, **kwargs):
+        return json.loads(s, **kwargs)
+
+    def to_json(d, **kwargs):
+        return json.dumps(d, **kwargs).decode()
+
 except ImportError:
     import json
 
     impl = 'stdlib'
     sort_keys_kwargs = {'sort_keys': True}
 
+    def from_json(s, **kwargs):
+        return json.loads(s, **kwargs)
+
+    def to_json(d, **kwargs):
+        return json.dumps(d, **kwargs)
+
+
 logger = logging.getLogger(__name__)
 logger.debug('Using JSON implementation from %s', impl)
 
-__all__ = ['json']
+__all__ = ['from_json', 'json', 'sort_keys_kwargs', 'to_json']

--- a/datadog_checks_base/tests/base/checks/logs/__init__.py
+++ b/datadog_checks_base/tests/base/checks/logs/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/datadog_checks_base/tests/base/checks/logs/crawler/__init__.py
+++ b/datadog_checks_base/tests/base/checks/logs/crawler/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/datadog_checks_base/tests/base/checks/logs/crawler/test_base.py
+++ b/datadog_checks_base/tests/base/checks/logs/crawler/test_base.py
@@ -1,0 +1,58 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from datadog_checks.dev.testing import requires_py3
+
+pytestmark = [requires_py3]
+
+
+# TODO: Remove lazy imports and `.format` calls when we drop support for Python 2
+def test_submission(dd_run_check, datadog_agent):
+    from datadog_checks.base.checks.logs.crawler.base import LogCrawlerCheck
+    from datadog_checks.base.checks.logs.crawler.stream import LogRecord, LogStream
+
+    class TestLogStream(LogStream):
+        def __init__(self, start, **kwargs):
+            super().__init__(**kwargs)
+
+            self.cursor_counter = start
+
+        def records(self, cursor=None):
+            start = cursor['counter'] + 1 if cursor is not None else self.cursor_counter
+            for i in range(start, start + 2):
+                message = '{} {}'.format(self.name, i)
+                data = (
+                    {'message': message}
+                    if i % 2 == 0
+                    else {'message': message, 'ddtags': self.construct_tags(['{}:tag{}'.format(self.name, i)])}
+                )
+                yield LogRecord(data, cursor={'counter': i})
+
+    class TestLogCrawlerCheck(LogCrawlerCheck):
+        def get_log_streams(self):
+            return iter(
+                [
+                    TestLogStream(start=2, check=self, name='stream1'),
+                    TestLogStream(start=6, check=self, name='stream2'),
+                ]
+            )
+
+    check = TestLogCrawlerCheck('test', {}, [{'tags': ['foo:bar', 'baz:qux']}])
+    check.check_id = 'test'
+
+    for _ in range(2):
+        dd_run_check(check)
+
+    datadog_agent.assert_logs(
+        check.check_id,
+        [
+            {'message': 'stream1 2', 'ddtags': 'baz:qux,foo:bar'},
+            {'message': 'stream1 3', 'ddtags': 'baz:qux,foo:bar,stream1:tag3'},
+            {'message': 'stream2 6', 'ddtags': 'baz:qux,foo:bar'},
+            {'message': 'stream2 7', 'ddtags': 'baz:qux,foo:bar,stream2:tag7'},
+            {'message': 'stream1 4', 'ddtags': 'baz:qux,foo:bar'},
+            {'message': 'stream1 5', 'ddtags': 'baz:qux,foo:bar,stream1:tag5'},
+            {'message': 'stream2 8', 'ddtags': 'baz:qux,foo:bar'},
+            {'message': 'stream2 9', 'ddtags': 'baz:qux,foo:bar,stream2:tag9'},
+        ],
+    )

--- a/datadog_checks_base/tests/base/checks/logs/crawler/test_base.py
+++ b/datadog_checks_base/tests/base/checks/logs/crawler/test_base.py
@@ -15,10 +15,10 @@ def test_submission(dd_run_check, datadog_agent):
         def __init__(self, start, **kwargs):
             super().__init__(**kwargs)
 
-            self.cursor_counter = start
+            self.start = start
 
         def records(self, cursor=None):
-            start = cursor['counter'] + 1 if cursor is not None else self.cursor_counter
+            start = cursor['counter'] + 1 if cursor is not None else self.start
             for i in range(start, start + 2):
                 message = '{} {}'.format(self.name, i)
                 data = (

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -541,6 +541,93 @@ class TestServiceChecks:
         aggregator.assert_service_check('service_check', status=AgentCheck.OK)
 
 
+class TestLogSubmission:
+    def test_cursor(self, datadog_agent):
+        check = AgentCheck('check_name', {}, [{}])
+        check.check_id = 'test'
+
+        check.send_log({'message': 'foo'}, cursor={'data': '1'})
+        check.send_log({'message': 'bar'}, cursor={'data': '2'})
+        check.send_log({'message': 'baz'})
+
+        datadog_agent.assert_logs(
+            check.check_id,
+            [
+                {'message': 'foo'},
+                {'message': 'bar'},
+                {'message': 'baz'},
+            ],
+        )
+        assert check.get_log_cursor() == {'data': '2'}
+
+    def test_no_cursor(self, datadog_agent):
+        check = AgentCheck('check_name', {}, [{}])
+        check.check_id = 'test'
+
+        check.send_log({'message': 'foo'})
+        check.send_log({'message': 'bar'})
+        check.send_log({'message': 'baz'})
+
+        datadog_agent.assert_logs(
+            check.check_id,
+            [
+                {'message': 'foo'},
+                {'message': 'bar'},
+                {'message': 'baz'},
+            ],
+        )
+        assert check.get_log_cursor() is None
+
+    def test_tags(self, datadog_agent):
+        check = AgentCheck('check_name', {}, [{'tags': ['foo:bar', 'baz:qux']}])
+        check.check_id = 'test'
+
+        check.send_log({'message': 'foo'})
+        check.send_log({'message': 'bar', 'ddtags': 'bar:baz'})
+        check.send_log({'message': 'baz'})
+
+        datadog_agent.assert_logs(
+            check.check_id,
+            [
+                {'message': 'foo', 'ddtags': 'baz:qux,foo:bar'},
+                {'message': 'bar', 'ddtags': 'bar:baz'},
+                {'message': 'baz', 'ddtags': 'baz:qux,foo:bar'},
+            ],
+        )
+
+    def test_stream(self, datadog_agent):
+        check = AgentCheck('check_name', {}, [{}])
+        check.check_id = 'test'
+
+        check.send_log({'message': 'foo'}, cursor={'data': '1'}, stream='stream1')
+        check.send_log({'message': 'bar'}, cursor={'data': '2'}, stream='stream2')
+        check.send_log({'message': 'baz'})
+
+        datadog_agent.assert_logs(
+            check.check_id,
+            [
+                {'message': 'foo'},
+                {'message': 'bar'},
+                {'message': 'baz'},
+            ],
+        )
+        assert check.get_log_cursor(stream='stream1') == {'data': '1'}
+        assert check.get_log_cursor(stream='stream2') == {'data': '2'}
+
+
+class TestLogsEnabledDetection:
+    def test_default(self, datadog_agent):
+        check = AgentCheck('check_name', {}, [{}])
+
+        assert check.logs_enabled is False
+
+    def test_enabled(self, datadog_agent):
+        check = AgentCheck('check_name', {}, [{}])
+        datadog_agent._config['logs_enabled'] = True
+
+        assert check.logs_enabled is True
+
+
 class TestTags:
     def test_default_string(self):
         check = AgentCheck()


### PR DESCRIPTION
### What does this PR do?

This adds a `send_log` method to the base class which sends a log to the Agent for eventual submission. There is also a `cursor` keyword argument which may be used to persist metadata across Agent restarts in order to resume from the point of shutdown.

### Additional Notes

Blocked on https://github.com/DataDog/datadog-agent/pull/26978