### PR TITLE
Remove use of python from integration process signatures

### DIFF
--- a/ray/manifest.json
+++ b/ray/manifest.json
@@ -39,7 +39,7 @@
         "metadata_path": "assets/service_checks.json"
       },
       "process_signatures": [
-        "python -m ray.util.client.server",
+        "ray.util.client.server",
         "gcs_server",
         "raylet"
       ],

--- a/supervisord/manifest.json
+++ b/supervisord/manifest.json
@@ -43,7 +43,6 @@
         "metadata_path": "assets/service_checks.json"
       },
       "process_signatures": [
-        "python supervisord",
         "supervisord"
       ],
       "source_type_id": 116,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Remove the use of `python` as part of any process signatures used for auto detection.

### Motivation
<!-- What inspired you to submit this pull request? -->
`python` itself is not necessary to detect any integration and conflicts with other ways to launch python integrations such as `python3`. This results in missed matches. Removing it will remove the ambiguity and allow proper matching. This was verified by regenerating the catalog in dd-go and verifying existing tests pass.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
