### PR TITLE
[dbm] Handles group replication metrics for MySQL version < 8.0.2

### DIFF
--- a/mysql/changelog.d/18024.fixed
+++ b/mysql/changelog.d/18024.fixed
@@ -1,0 +1,1 @@
+Fixed group replication metrics for MySQL version < 8.0.2

--- a/mysql/datadog_checks/mysql/const.py
+++ b/mysql/datadog_checks/mysql/const.py
@@ -290,6 +290,9 @@ GROUP_REPLICATION_VARS = {
     'Transactions_check': ('mysql.replication.group.transactions_check', GAUGE),
     'Conflict_detected': ('mysql.replication.group.conflicts_detected', GAUGE),
     'Transactions_row_validating': ('mysql.replication.group.transactions_validating', GAUGE),
+}
+
+EXTRA_GROUP_REPLICATION_VARS = {
     'Transactions_remote_applier_queue': ('mysql.replication.group.transactions_in_applier_queue', GAUGE),
     'Transactions_remote_applied': ('mysql.replication.group.transactions_applied', GAUGE),
     'Transactions_local_proposed': ('mysql.replication.group.transactions_proposed', GAUGE),

--- a/mysql/datadog_checks/mysql/const.py
+++ b/mysql/datadog_checks/mysql/const.py
@@ -292,7 +292,8 @@ GROUP_REPLICATION_VARS = {
     'Transactions_row_validating': ('mysql.replication.group.transactions_validating', GAUGE),
 }
 
-EXTRA_GROUP_REPLICATION_VARS = {
+# Metrics added to MySQL in 8.0.2
+GROUP_REPLICATION_VARS_8_0_2 = {
     'Transactions_remote_applier_queue': ('mysql.replication.group.transactions_in_applier_queue', GAUGE),
     'Transactions_remote_applied': ('mysql.replication.group.transactions_applied', GAUGE),
     'Transactions_local_proposed': ('mysql.replication.group.transactions_proposed', GAUGE),

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -39,6 +39,7 @@ from .const import (
     GALERA_VARS,
     GAUGE,
     GROUP_REPLICATION_VARS,
+    EXTRA_GROUP_REPLICATION_VARS,
     INNODB_VARS,
     MONOTONIC,
     OPTIONAL_STATUS_VARS,
@@ -62,7 +63,9 @@ from .queries import (
     SQL_95TH_PERCENTILE,
     SQL_AVG_QUERY_RUN_TIME,
     SQL_GROUP_REPLICATION_MEMBER,
+    SQL_GROUP_REPLICATION_MEMBER_EXTENDED,
     SQL_GROUP_REPLICATION_METRICS,
+    SQL_GROUP_REPLICATION_METRICS_EXTENDED,
     SQL_GROUP_REPLICATION_PLUGIN_STATUS,
     SQL_INNODB_ENGINES,
     SQL_PROCESS_LIST,
@@ -653,11 +656,18 @@ class MySql(AgentCheck):
     def _collect_group_replica_metrics(self, db, results):
         try:
             with closing(db.cursor(CommenterCursor)) as cursor:
-                cursor.execute(SQL_GROUP_REPLICATION_MEMBER)
+                # Version 8.0.2 introduced new columns to replication_group_members and replication_group_member_stats
+                extended_group_replication_metrics = self.version.version_compatible((8, 0, 2))
+
+                query_to_execute = SQL_GROUP_REPLICATION_MEMBER
+                if extended_group_replication_metrics:
+                    query_to_execute = SQL_GROUP_REPLICATION_MEMBER_EXTENDED
+                
+                cursor.execute(query_to_execute)
                 replica_results = cursor.fetchone()
                 status = self.OK
                 additional_tags = []
-                if replica_results is None or len(replica_results) < 3:
+                if replica_results is None or len(replica_results) < 2:
                     self.log.warning(
                         'Unable to get group replica status, setting mysql.replication.group.status as CRITICAL'
                     )
@@ -667,8 +677,10 @@ class MySql(AgentCheck):
                     additional_tags = [
                         'channel_name:{}'.format(replica_results[0]),
                         'member_state:{}'.format(replica_results[1]),
-                        'member_role:{}'.format(replica_results[2]),
                     ]
+                    if extended_group_replication_metrics and len(replica_results) > 2:
+                        additional_tags.append('member_role:{}'.format(replica_results[2]))
+
                     self.gauge('mysql.replication.group.member_status', 1, tags=additional_tags + self.tags)
 
                 self.service_check(
@@ -677,7 +689,11 @@ class MySql(AgentCheck):
                     tags=self._service_check_tags() + additional_tags,
                 )
 
-                cursor.execute(SQL_GROUP_REPLICATION_METRICS)
+                metrics_to_fetch = SQL_GROUP_REPLICATION_METRICS
+                if extended_group_replication_metrics:
+                    metrics_to_fetch = SQL_GROUP_REPLICATION_METRICS_EXTENDED
+
+                cursor.execute(metrics_to_fetch)
                 r = cursor.fetchone()
 
                 if r is None:
@@ -689,15 +705,19 @@ class MySql(AgentCheck):
                     'Transactions_check': r[2],
                     'Conflict_detected': r[3],
                     'Transactions_row_validating': r[4],
-                    'Transactions_remote_applier_queue': r[5],
-                    'Transactions_remote_applied': r[6],
-                    'Transactions_local_proposed': r[7],
-                    'Transactions_local_rollback': r[8],
                 }
-                # Submit metrics now, so it's possible to attach `channel_name` tag
-                self._submit_metrics(GROUP_REPLICATION_VARS, results, self.tags + ['channel_name:{}'.format(r[0])])
+                vars_to_submit = GROUP_REPLICATION_VARS
+                if extended_group_replication_metrics:
+                    results['Transactions_remote_applier_queue'] = r[5]
+                    results['Transactions_remote_applied'] = r[6]
+                    results['Transactions_local_proposed'] = r[7]
+                    results['Transactions_local_rollback'] = r[8]
+                    vars_to_submit.update(EXTRA_GROUP_REPLICATION_VARS)
 
-                return GROUP_REPLICATION_VARS
+                # Submit metrics now, so it's possible to attach `channel_name` tag
+                self._submit_metrics(vars_to_submit, results, self.tags + ['channel_name:{}'.format(r[0])])
+
+                return vars_to_submit
         except Exception as e:
             self.warning("Internal error happened during the group replication check: %s", e)
             return {}

--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -59,11 +59,22 @@ FROM information_schema.replica_host_status
 WHERE server_id = @@aurora_server_id"""
 
 SQL_GROUP_REPLICATION_MEMBER = """\
+SELECT channel_name, member_state
+FROM performance_schema.replication_group_members
+WHERE member_id = @@server_uuid"""
+
+SQL_GROUP_REPLICATION_MEMBER_EXTENDED = """\
 SELECT channel_name, member_state, member_role
 FROM performance_schema.replication_group_members
 WHERE member_id = @@server_uuid"""
 
 SQL_GROUP_REPLICATION_METRICS = """\
+SELECT channel_name,count_transactions_in_queue,count_transactions_checked,count_conflicts_detected,
+count_transactions_rows_validating
+FROM performance_schema.replication_group_member_stats
+WHERE channel_name IN ('group_replication_applier', 'group_replication_recovery') AND member_id = @@server_uuid"""
+
+SQL_GROUP_REPLICATION_METRICS_EXTENDED = """\
 SELECT channel_name,count_transactions_in_queue,count_transactions_checked,count_conflicts_detected,
 count_transactions_rows_validating,count_transactions_remote_in_applier_queue,count_transactions_remote_applied,
 count_transactions_local_proposed,count_transactions_local_rollback

--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -63,7 +63,7 @@ SELECT channel_name, member_state
 FROM performance_schema.replication_group_members
 WHERE member_id = @@server_uuid"""
 
-SQL_GROUP_REPLICATION_MEMBER_EXTENDED = """\
+SQL_GROUP_REPLICATION_MEMBER_8_0_2 = """\
 SELECT channel_name, member_state, member_role
 FROM performance_schema.replication_group_members
 WHERE member_id = @@server_uuid"""
@@ -74,7 +74,7 @@ count_transactions_rows_validating
 FROM performance_schema.replication_group_member_stats
 WHERE channel_name IN ('group_replication_applier', 'group_replication_recovery') AND member_id = @@server_uuid"""
 
-SQL_GROUP_REPLICATION_METRICS_EXTENDED = """\
+SQL_GROUP_REPLICATION_METRICS_8_0_2 = """\
 SELECT channel_name,count_transactions_in_queue,count_transactions_checked,count_conflicts_detected,
 count_transactions_rows_validating,count_transactions_remote_in_applier_queue,count_transactions_remote_applied,
 count_transactions_local_proposed,count_transactions_local_rollback

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -17,6 +17,7 @@ from datadog_checks.mysql.const import (
     BINLOG_VARS,
     GALERA_VARS,
     GROUP_REPLICATION_VARS,
+    GROUP_REPLICATION_VARS_8_0_2,
     INNODB_VARS,
     OPTIONAL_STATUS_VARS,
     OPTIONAL_STATUS_VARS_5_6_6,
@@ -167,16 +168,11 @@ def _assert_complex_config(aggregator, service_check_tags, metric_tags, hostname
 
     if MYSQL_REPLICATION == 'group':
 
-        extended_group_replication_metrics = MYSQL_VERSION_PARSED >= parse_version('8.0.2')
-
         testable_metrics.extend(variables.GROUP_REPLICATION_VARS)
-        if extended_group_replication_metrics:
-            testable_metrics.extend(variables.EXTRA_GROUP_REPLICATION_VARS)
-
         additional_tags = ['channel_name:group_replication_applier', 'member_state:ONLINE']
-        if extended_group_replication_metrics:
+        if MYSQL_VERSION_PARSED >= parse_version('8.0'):
+            testable_metrics.extend(variables.GROUP_REPLICATION_VARS_8_0_2)
             additional_tags.append('member_role:PRIMARY')
-
         aggregator.assert_service_check(
             'mysql.replication.group.status',
             status=MySql.OK,
@@ -542,7 +538,7 @@ def test_only_custom_queries(aggregator, dd_run_check, instance_custom_queries):
     ]
 
     if MYSQL_VERSION_PARSED >= parse_version('8.0.2'):
-        standard_metric_sets.append(variables.EXTRA_GROUP_REPLICATION_VARS)  
+        standard_metric_sets.append(GROUP_REPLICATION_VARS_8_0_2)
 
     for metric_set in standard_metric_sets:
         for metric_def in metric_set.values():

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -166,12 +166,21 @@ def _assert_complex_config(aggregator, service_check_tags, metric_tags, hostname
     operation_time_metrics = variables.SIMPLE_OPERATION_TIME_METRICS + variables.COMPLEX_OPERATION_TIME_METRICS
 
     if MYSQL_REPLICATION == 'group':
+
+        extended_group_replication_metrics = MYSQL_VERSION_PARSED >= parse_version('8.0.2')
+
         testable_metrics.extend(variables.GROUP_REPLICATION_VARS)
+        if extended_group_replication_metrics:
+            testable_metrics.extend(variables.EXTRA_GROUP_REPLICATION_VARS)
+
+        additional_tags = ['channel_name:group_replication_applier', 'member_state:ONLINE']
+        if extended_group_replication_metrics:
+            additional_tags.append('member_role:PRIMARY')
+
         aggregator.assert_service_check(
             'mysql.replication.group.status',
             status=MySql.OK,
-            tags=service_check_tags
-            + ['channel_name:group_replication_applier', 'member_role:PRIMARY', 'member_state:ONLINE'],
+            tags=service_check_tags + additional_tags,
             count=1,
         )
         operation_time_metrics.extend(variables.GROUP_REPLICATION_OPERATION_TIME_METRICS)
@@ -531,6 +540,10 @@ def test_only_custom_queries(aggregator, dd_run_check, instance_custom_queries):
         GROUP_REPLICATION_VARS,
         variables.QUERY_EXECUTOR_METRIC_SETS,
     ]
+
+    if MYSQL_VERSION_PARSED >= parse_version('8.0.2'):
+        standard_metric_sets.append(variables.EXTRA_GROUP_REPLICATION_VARS)  
+
     for metric_set in standard_metric_sets:
         for metric_def in metric_set.values():
             metric = metric_def[0]

--- a/mysql/tests/variables.py
+++ b/mysql/tests/variables.py
@@ -267,12 +267,15 @@ GROUP_REPLICATION_VARS = [
     'mysql.replication.group.member_status',
     'mysql.replication.group.conflicts_detected',
     'mysql.replication.group.transactions',
-    'mysql.replication.group.transactions_applied',
-    'mysql.replication.group.transactions_in_applier_queue',
     'mysql.replication.group.transactions_check',
+    'mysql.replication.group.transactions_validating',
+]
+
+EXTRA_GROUP_REPLICATION_VARS= [
+    'mysql.replication.group.transactions_in_applier_queue',
+    'mysql.replication.group.transactions_applied',
     'mysql.replication.group.transactions_proposed',
     'mysql.replication.group.transactions_rollback',
-    'mysql.replication.group.transactions_validating',
 ]
 
 SIMPLE_OPERATION_TIME_METRICS = [

--- a/mysql/tests/variables.py
+++ b/mysql/tests/variables.py
@@ -271,7 +271,7 @@ GROUP_REPLICATION_VARS = [
     'mysql.replication.group.transactions_validating',
 ]
 
-EXTRA_GROUP_REPLICATION_VARS= [
+GROUP_REPLICATION_VARS_8_0_2 = [
     'mysql.replication.group.transactions_in_applier_queue',
     'mysql.replication.group.transactions_applied',
     'mysql.replication.group.transactions_proposed',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Previously, we where assuming the following columns existed in every MySQL version:

- `COUNT_TRANSACTIONS_REMOTE_IN_APPLIER_QUEUE`
- `COUNT_TRANSACTIONS_REMOTE_APPLIED`
- `COUNT_TRANSACTION_LOCAL_PROPOSED`
- `COUNT_TRANSACTION_LOCAL_ROLLEDBACK`
- `member_role`

This only exist in version [8.0.2+](https://dev.mysql.com/blog-archive/group-replication-extending-group-replication-performance_schema-tables/), so we need to handle this case for lower versions. 

### Motivation
<!-- What inspired you to submit this pull request? -->

https://datadoghq.atlassian.net/browse/DBMON-2842

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
