### PR TITLE
[datadog_cluster_agent] Add tagger and workloadmeta metrics

### DIFF
--- a/datadog_cluster_agent/changelog.d/18030.added
+++ b/datadog_cluster_agent/changelog.d/18030.added
@@ -1,0 +1,1 @@
+Add tagger and workloadmeta metrics

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
@@ -57,6 +57,12 @@ DEFAULT_METRICS = {
     'rate_limit_queries_remaining_min': 'datadog.rate_limit_queries.remaining_min',
     'rate_limit_queries_reset': 'datadog.rate_limit_queries.reset',
     'secret_backend__elapsed_ms': 'secret_backend.elapsed',
+    'tagger_stored_entities': 'tagger.stored_entities',
+    'tagger_updated_entities': 'tagger.updated_entities',
+    'workloadmeta_events_received': 'workloadmeta.events_received',
+    'workloadmeta_notifications_sent': 'workloadmeta.notifications_sent',
+    'workloadmeta_stored_entities': 'workloadmeta.stored_entities',
+    'workloadmeta_subscribers': 'workloadmeta.subscribers',
 }
 
 

--- a/datadog_cluster_agent/metadata.csv
+++ b/datadog_cluster_agent/metadata.csv
@@ -56,5 +56,10 @@ datadog.cluster_agent.kubernetes_apiserver.emitted_events,count,,,,"Datadog even
 datadog.cluster_agent.kubernetes_apiserver.kube_events,count,,,,"Kubernetes events processed by the kubernetes_apiserver check",0,datadog_cluster_agent,apiserver events,
 datadog.cluster_agent.language_detection_dca_handler.processed_requests,count,,,,"The number of process language detection requests processed by the handler",0,datadog_cluster_agent,language detection processed requests,
 datadog.cluster_agent.language_detection_patcher.patches,count,,,,"The number of patch requests sent by the patcher to the kube api server",0,datadog_cluster_agent,language detection patches,
-
 datadog.cluster_agent.secret_backend.elapsed,gauge,,millisecond,,The elapsed time of secret backend invocation,0,datadog_cluster_agent,secret backend elapsed time duration,
+datadog.cluster_agent.tagger.stored_entities,gauge,,,,Number of entities stored in the tagger,0,datadog_cluster_agent,tagger stored entities,
+datadog.cluster_agent.tagger.updated_entities,count,,,,Number of updates made to entities in the tagger,0,datadog_cluster_agent,tagger updated entities,
+datadog.cluster_agent.workloadmeta.events_received,count,,,,Number of events received by workloadmeta,0,datadog_cluster_agent,workloadmeta events received,
+datadog.cluster_agent.workloadmeta.notifications_sent,count,,,,Number of notifications sent by workloadmeta to its subscribers,0,datadog_cluster_agent,workloadmeta notifications sent,
+datadog.cluster_agent.workloadmeta.stored_entities,gauge,,,,Number of entities stored in workloadmeta,0,datadog_cluster_agent,workloadmeta stored entities,
+datadog.cluster_agent.workloadmeta.subscribers,gauge,,,,Number of workloadmeta subscribers,0,datadog_cluster_agent,workloadmeta subscribers,

--- a/datadog_cluster_agent/tests/fixtures/metrics.txt
+++ b/datadog_cluster_agent/tests/fixtures/metrics.txt
@@ -477,3 +477,22 @@ language_detection_dca_handler_processed_requests{status="success"} 3
 language_detection_patcher_patches{namespace="default",owner_kind="Deployment",owner_name="dummy-dsd-app-java",status="error"} 1
 language_detection_patcher_patches{namespace="default",owner_kind="Deployment",owner_name="dummy-dsd-app-java",status="retry"} 1
 language_detection_patcher_patches{namespace="default",owner_kind="Deployment",owner_name="dummy-python-app",status="success"} 1
+# HELP tagger_stored_entities Number of entities in the store.
+# TYPE tagger_stored_entities gauge
+tagger_stored_entities{prefix="internal",source="workloadmeta-static"} 1
+# HELP tagger_updated_entities Number of updates made to entities.
+# TYPE tagger_updated_entities counter
+tagger_updated_entities 2
+# HELP workloadmeta_events_received Number of events received by the workloadmeta store.
+# TYPE workloadmeta_events_received counter
+workloadmeta_events_received{kind="kubernetes_node",source="kubeapiserver"} 1
+# HELP workloadmeta_notifications_sent Number of notifications sent by workloadmeta to its subscribers
+# TYPE workloadmeta_notifications_sent counter
+workloadmeta_notifications_sent{status="success",subscriber_name="tagger-workloadmeta"} 1
+# HELP workloadmeta_pull_duration The time it takes to pull from the collectors (in seconds)
+# HELP workloadmeta_stored_entities Number of entities in the store.
+# TYPE workloadmeta_stored_entities gauge
+workloadmeta_stored_entities{kind="kubernetes_node",source="kubeapiserver"} 1
+# HELP workloadmeta_subscribers Number of subscribers.
+# TYPE workloadmeta_subscribers gauge
+workloadmeta_subscribers 2

--- a/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
+++ b/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
@@ -70,6 +70,12 @@ METRICS = [
     'language_detection_dca_handler.processed_requests',
     'language_detection_patcher.patches',
     'secret_backend.elapsed',
+    'tagger.stored_entities',
+    'tagger.updated_entities',
+    'workloadmeta.events_received',
+    'workloadmeta.notifications_sent',
+    'workloadmeta.stored_entities',
+    'workloadmeta.subscribers',
 ]
 
 


### PR DESCRIPTION
### What does this PR do?

Adds some tagger and workloadmeta metrics to the `datadog_cluster_agent` integration:
- tagger.stored_entities
- tagger.updated_entities
- workloadmeta.events_received
- workloadmeta.notifications_sent
- workloadmeta.stored_entities
- workloadmeta.subscribers


### Motivation

The tagger and workloadmeta are used in some features offered by the Datadog Cluster Agent and these metrics are useful to debug potential issues.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
