### PR TITLE
[AGENT-11701] Fix TeamCity Integration

### DIFF
--- a/teamcity/changelog.d/18041.fixed
+++ b/teamcity/changelog.d/18041.fixed
@@ -1,0 +1,1 @@
+[AGENT-11701] Fix handling of projects with no builds

--- a/teamcity/changelog.d/18041.fixed
+++ b/teamcity/changelog.d/18041.fixed
@@ -1,1 +1,1 @@
-[AGENT-11701] Fix handling of projects with no builds
+Fix handling of projects with no builds. We used to refresh all the projects whenever we encountered a build config that didn't have any builds associated with it. Now we refresh only the specific build config that's lacking builds.

--- a/teamcity/datadog_checks/teamcity/teamcity_rest.py
+++ b/teamcity/datadog_checks/teamcity/teamcity_rest.py
@@ -240,7 +240,11 @@ class TeamCityRest(AgentCheck):
     def _collect_new_builds(self, project_id):
         last_build_id = self.bc_store.get_last_build_id(project_id, self.current_build_config)
         if not last_build_id:
-            self._initialize()
+            self.log.debug('Checking for initial builds...')
+            initial_builds = get_response(
+                self, 'last_build', build_conf=self.current_build_config, project_id=project_id
+            )
+            return initial_builds
         else:
             self.log.debug('Checking for new builds...')
             new_builds = get_response(

--- a/teamcity/datadog_checks/teamcity/teamcity_rest.py
+++ b/teamcity/datadog_checks/teamcity/teamcity_rest.py
@@ -240,13 +240,16 @@ class TeamCityRest(AgentCheck):
     def _collect_new_builds(self, project_id):
         last_build_id = self.bc_store.get_last_build_id(project_id, self.current_build_config)
         if not last_build_id:
-            self.log.debug('No builds for project {} and build config {}, checking again'.format(project_id, self.current_build_config))
+            # We want to handle the case of an unbuilt build config by checking for any last builds
+            self.log.debug(
+                'No builds for project %d and build config %d checking again', project_id, self.current_build_config
+            )
             ressource = "last_build"
-            options = {"project_id":project_id}
+            options = {"project_id": project_id}
         else:
             self.log.debug('Checking for new builds...')
             ressource = "new_builds"
-            options = {"since_build":project_id}
+            options = {"since_build": project_id}
         return get_response(self, ressource, build_conf=self.current_build_config, **options)
 
     def _get_build_config_type(self, build_config):

--- a/teamcity/datadog_checks/teamcity/teamcity_rest.py
+++ b/teamcity/datadog_checks/teamcity/teamcity_rest.py
@@ -242,14 +242,14 @@ class TeamCityRest(AgentCheck):
         if not last_build_id:
             # We want to handle the case of an unbuilt build config by checking for any last builds
             self.log.debug(
-                'No builds for project %d and build config %d checking again', project_id, self.current_build_config
+                'No builds for project %d and build config %d, checking again', project_id, self.current_build_config
             )
             ressource = "last_build"
             options = {"project_id": project_id}
         else:
             self.log.debug('Checking for new builds...')
             ressource = "new_builds"
-            options = {"since_build": project_id}
+            options = {"since_build": last_build_id}
         return get_response(self, ressource, build_conf=self.current_build_config, **options)
 
     def _get_build_config_type(self, build_config):

--- a/teamcity/datadog_checks/teamcity/teamcity_rest.py
+++ b/teamcity/datadog_checks/teamcity/teamcity_rest.py
@@ -240,17 +240,14 @@ class TeamCityRest(AgentCheck):
     def _collect_new_builds(self, project_id):
         last_build_id = self.bc_store.get_last_build_id(project_id, self.current_build_config)
         if not last_build_id:
-            self.log.debug('Checking for initial builds...')
-            initial_builds = get_response(
-                self, 'last_build', build_conf=self.current_build_config, project_id=project_id
-            )
-            return initial_builds
+            self.log.debug('No builds for project {} and build config {}, checking again'.format(project_id, self.current_build_config))
+            ressource = "last_build"
+            options = {"project_id":project_id}
         else:
             self.log.debug('Checking for new builds...')
-            new_builds = get_response(
-                self, 'new_builds', build_conf=self.current_build_config, since_build=last_build_id
-            )
-            return new_builds
+            ressource = "new_builds"
+            options = {"since_build":project_id}
+        return get_response(self, ressource, build_conf=self.current_build_config, **options)
 
     def _get_build_config_type(self, build_config):
         if self.is_deployment:


### PR DESCRIPTION
### What does this PR do?
Handles TeamCity projects that have yet to be built.
<!-- A brief description of the change being made with this pull request. -->

### Motivation
The logic before this PR was such that if a `build config` had no builds, a re-initialization of all projects and `build configs` would be triggered. 
This is not what we want.
Now we only trigger a request to check if said `build config` has had its first build(s).
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
