### PR TITLE
[mongo] Continue coll/index stats collection if user is not authorized to perform aggregation

### DIFF
--- a/mongo/changelog.d/18044.fixed
+++ b/mongo/changelog.d/18044.fixed
@@ -1,1 +1,1 @@
-Fix coll stats metrics failure when the agent user is not authorized to perform $collStats aggregation on a collection. This fix prevents check to fail when an OperationFailure is raised to run $collStats on system collections such as system.replset on local database.
+Fix coll or index stats metrics failure when the agent user is not authorized to perform $collStats or $indexStats aggregation on a collection. This fix prevents check to fail when an OperationFailure is raised to run $collStats or $indexStats on system collections such as system.replset on local database.

--- a/mongo/changelog.d/18044.fixed
+++ b/mongo/changelog.d/18044.fixed
@@ -1,0 +1,1 @@
+Fix coll stats metrics failure when the agent user is not authorized to perform $collStats aggregation on a collection. This fix prevents check to fail when an OperationFailure is raised to run $collStats on system collections such as system.replset on local database.

--- a/mongo/datadog_checks/mongo/collectors/coll_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/coll_stats.py
@@ -34,13 +34,13 @@ class CollStatsCollector(MongoCollector):
         for coll_name in coll_names:
             # Grab the stats from the collection
             try:
-                coll_stats = api.coll_stats(self.db_name, coll_name)
+                collection_stats = api.coll_stats(self.db_name, coll_name)
             except OperationFailure as e:
                 # Atlas restricts $collStats on system collections
                 self.log.warning("Could not collect stats for collection %s: %s", coll_name, e)
                 continue
 
-            for coll_stats in coll_stats:
+            for coll_stats in collection_stats:
                 # Submit the metrics
                 storage_stats = coll_stats.get('storageStats', {})
                 latency_stats = coll_stats.get('latencyStats', {})

--- a/mongo/datadog_checks/mongo/collectors/index_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/index_stats.py
@@ -2,6 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+from pymongo.errors import OperationFailure
+
 from datadog_checks.mongo.collectors.base import MongoCollector
 
 
@@ -34,6 +36,9 @@ class IndexStatsCollector(MongoCollector):
                     ]
                     val = int(stats.get('accesses', {}).get('ops', 0))
                     self.gauge('mongodb.collection.indexes.accesses.ops', val, idx_tags)
+            except OperationFailure as e:
+                # Atlas restricts $indexStats on system collections
+                self.log.warning("Could not collect index stats for collection %s: %s", coll_name, e)
             except Exception as e:
                 self.log.error("Could not fetch indexes stats for collection %s: %s", coll_name, e)
                 raise e


### PR DESCRIPTION
### What does this PR do?
This PR fixes `OperationFailure` error on collection stats metrics when the datadog user is not authorized to run `$collStats` or `$indexStats` aggregation on system collections (e.g. system.replset on local database) on MongoDB Atlas. 
When `OperationFailure` happens in collection stats metrics, we will continue with the remain collections and log a warning message. 

### Motivation
`read` permission on `local` database grants access to datadog user to run `$collStats` or `$indexStats` aggregation for self-hosted mongodb. However `$collStats` or `$indexStats` fails for system collections on local database for MongoDB Atlas with error `not authorized on local to execute command`. 
The fix prevents the check to fail when `$collStats` or `$indexStats` fails for one collection. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
