### PR TITLE
Improve log error for invalid ssl option in postgres config

### DIFF
--- a/postgres/changelog.d/18047.added
+++ b/postgres/changelog.d/18047.added
@@ -1,0 +1,1 @@
+Added warning when ssl option for Postgres check is invalid

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -31,7 +31,7 @@ class PostgresConfig:
     GAUGE = AgentCheck.gauge
     MONOTONIC = AgentCheck.monotonic_count
 
-    def __init__(self, instance, init_config, check):
+    def __init__(self, instance, init_config, check={'warning': print}):
         self.host = instance.get('host', '')
         if not self.host:
             raise ConfigurationError('Specify a Postgres host to connect to.')

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -31,7 +31,7 @@ class PostgresConfig:
     GAUGE = AgentCheck.gauge
     MONOTONIC = AgentCheck.monotonic_count
 
-    def __init__(self, instance, init_config, check={'warning': print}):
+    def __init__(self, instance, init_config, check):
         self.host = instance.get('host', '')
         if not self.host:
             raise ConfigurationError('Specify a Postgres host to connect to.')

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -31,7 +31,7 @@ class PostgresConfig:
     GAUGE = AgentCheck.gauge
     MONOTONIC = AgentCheck.monotonic_count
 
-    def __init__(self, instance, init_config):
+    def __init__(self, instance, init_config, check):
         self.host = instance.get('host', '')
         if not self.host:
             raise ConfigurationError('Specify a Postgres host to connect to.')
@@ -75,7 +75,11 @@ class PostgresConfig:
         ssl = instance.get('ssl', "allow")
         if ssl in SSL_MODES:
             self.ssl_mode = ssl
+        else:
+            check.warning(f"Invalid ssl option '{ssl}', should be one of {SSL_MODES}. Defaulting to 'allow'.")
+            self.ssl_mode = "allow"
 
+        
         self.ssl_cert = instance.get('ssl_cert', None)
         self.ssl_root_cert = instance.get('ssl_root_cert', None)
         self.ssl_key = instance.get('ssl_key', None)

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -79,7 +79,6 @@ class PostgresConfig:
             check.warning(f"Invalid ssl option '{ssl}', should be one of {SSL_MODES}. Defaulting to 'allow'.")
             self.ssl_mode = "allow"
 
-        
         self.ssl_cert = instance.get('ssl_cert', None)
         self.ssl_root_cert = instance.get('ssl_root_cert', None)
         self.ssl_key = instance.get('ssl_key', None)

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -112,7 +112,7 @@ class PostgreSql(AgentCheck):
                 "DEPRECATION NOTICE: The managed_identity option is deprecated and will be removed in a future version."
                 " Please use the new azure.managed_authentication option instead."
             )
-        self._config = PostgresConfig(self.instance, self.init_config)
+        self._config = PostgresConfig(self.instance, self.init_config, self)
         self.cloud_metadata = self._config.cloud_metadata
         self.tags = self._config.tags
         # Keep a copy of the tags without the internal resource tags so they can be used for paths that don't

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -106,13 +106,13 @@ def pg_replica_logical():
 
 @pytest.fixture
 def metrics_cache(pg_instance):
-    config = PostgresConfig(instance=pg_instance, init_config={})
+    config = PostgresConfig(instance=pg_instance, init_config={}, check={'warning': print})
     return PostgresMetricsCache(config)
 
 
 @pytest.fixture
 def metrics_cache_replica(pg_replica_instance):
-    config = PostgresConfig(instance=pg_replica_instance, init_config={})
+    config = PostgresConfig(instance=pg_replica_instance, init_config={}, check={'warning': print})
     return PostgresMetricsCache(config)
 
 

--- a/postgres/tests/test_metrics_cache.py
+++ b/postgres/tests/test_metrics_cache.py
@@ -28,7 +28,7 @@ COMMON_AND_MAIN_CHECK_METRICS = dict(COMMON_METRICS, **DBM_MIGRATED_METRICS)
     ],
 )
 def test_aurora_replication_metrics(pg_instance, version, is_aurora, expected_metrics):
-    config = PostgresConfig(instance=pg_instance, init_config={})
+    config = PostgresConfig(instance=pg_instance, init_config={}, check={'warning': print})
     cache = PostgresMetricsCache(config)
     replication_metrics = cache.get_replication_metrics(version, is_aurora)
     assert replication_metrics == expected_metrics
@@ -50,7 +50,7 @@ def test_dbm_enabled_conn_metric(pg_instance, version, is_dbm_enabled, expected_
     pg_instance['dbm'] = is_dbm_enabled
     pg_instance['collect_resources'] = {'enabled': False}
     pg_instance['collect_database_size_metrics'] = False
-    config = PostgresConfig(instance=pg_instance, init_config={})
+    config = PostgresConfig(instance=pg_instance, init_config={}, check={'warning': print})
     cache = PostgresMetricsCache(config)
     instance_metrics = cache.get_instance_metrics(version)
     assert instance_metrics['metrics'] == expected_metrics


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds a warning when `ssl` is set to an invalid value, and defaults to `allow` in those cases

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Resolves #16764

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
