### PR TITLE
Sy/temporal fix

### DIFF
--- a/temporal/changelog.d/18050.added
+++ b/temporal/changelog.d/18050.added
@@ -1,0 +1,1 @@
+Properly collect `temporal.add_search_attributes.workflow_failure` as a gauge

--- a/temporal/datadog_checks/temporal/metrics.py
+++ b/temporal/datadog_checks/temporal/metrics.py
@@ -43,7 +43,10 @@ METRIC_MAP = {
     'wf_too_many_pending_external_workflow_signals': 'wf_too_many_pending.external_workflow_signals',
     # Frontend
     'add_search_attributes_workflow_success': 'add_search_attributes.workflow_success',
-    'add_search_attributes_workflow_failure': 'add_search_attributes.workflow_failure',
+    'add_search_attributes_workflow_failure': {
+        'name': 'add_search_attributes.workflow_failure',
+        'type': 'native_dynamic',
+    },
     'delete_namespace_workflow_success': 'delete_namespace.workflow_success',
     'delete_namespace_workflow_failure': 'delete_namespace.workflow_failure',
     'version_check_success': 'version_check.success',

--- a/temporal/metadata.csv
+++ b/temporal/metadata.csv
@@ -19,6 +19,7 @@ temporal.server.activity_info.size.count,count,,,,,0,temporal,activity info size
 temporal.server.activity_info.size.sum,count,,byte,,,0,temporal,activity info size sum,
 temporal.server.activity_info.sum,count,,,,,0,temporal,activity info sum,
 temporal.server.add_search_attributes.failures.count,count,,,,,0,temporal,add search attributes failures count,
+temporal.server.add_search_attributes.workflow_failure,gauge,,,,,0,temporal,add search attributes workflow failure count,
 temporal.server.add_search_attributes.workflow_failure.count,count,,,,,0,temporal,add search attributes workflow failure count,
 temporal.server.add_search_attributes.workflow_success.count,count,,,,,0,temporal,add search attributes workflow success count,
 temporal.server.archival.task_invalid_uri.count,count,,,,,0,temporal,archival task invalid uri count,

--- a/temporal/tests/common.py
+++ b/temporal/tests/common.py
@@ -106,6 +106,7 @@ MOCKED_METRICS = [
     "temporal.server.activity_info.size.count",
     "temporal.server.activity_info.size.sum",
     "temporal.server.activity_info.sum",
+    "temporal.server.add_search_attributes.workflow_failure",
     "temporal.server.add_search_attributes.workflow_failure.count",
     "temporal.server.add_search_attributes.workflow_success.count",
     "temporal.server.buffered_events.bucket",


### PR DESCRIPTION
### What does this PR do?
Fix temporal tests and metric matching. Temporal exposes 2 metrics with the same name but as different data types. This change allow both to be collected in their respective types:

```
# HELP ack_level_update add_search_attributes_workflow_failure counter
# TYPE add_search_attributes_workflow_failure counter
add_search_attributes_workflow_failure 10
# HELP ack_level_update add_search_attributes_workflow_failure gauge
# TYPE add_search_attributes_workflow_failure gauge
add_search_attributes_workflow_failure 10
```

to be collected as:
- temporal.server.add_search_attributes.workflow_failure.count
- temporal.server.add_search_attributes.workflow_failure
