### PR TITLE
[NDM] Pin pysmi version for breaking generate traps DB tests

### DIFF
--- a/datadog_checks_dev/changelog.d/18066.fixed
+++ b/datadog_checks_dev/changelog.d/18066.fixed
@@ -1,0 +1,1 @@
+[NDM] Pin pysmi version for breaking generate traps DB tests

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -80,7 +80,7 @@ cli = [
     "pathspec>=0.10.0",
     "platformdirs>=2.0.0a3",
     "pydantic>=2.0.2",
-    "pysmi>=0.3.4",
+    "pysmi==0.3.4",
     "securesystemslib[crypto]==0.28.0",
     "semver>=2.13.0",
     "tabulate>=0.8.9",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Slack thread for context:
https://dd.slack.com/archives/C01C4E552HJ/p1721246310606769

Breaking tests in `datadog_checks_dev` due to pysmi update from July 16, 2024 ([version 1.4.4](https://pypi.org/project/pysmi/) was being picked up)

Pinning the version that was being utilized before for now

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
