### PR TITLE
[mongo] rename dbms from mongodb to mongo

### DIFF
--- a/mongo/changelog.d/18067.fixed
+++ b/mongo/changelog.d/18067.fixed
@@ -1,0 +1,1 @@
+Rename dbms from `mongodb` to `mongo` so that dbms is consistent with integration name. 

--- a/mongo/datadog_checks/mongo/dbm/operation_samples.py
+++ b/mongo/datadog_checks/mongo/dbm/operation_samples.py
@@ -77,7 +77,7 @@ class MongoOperationSamples(DBMAsyncJob):
             rate_limit=1 / self._collection_interval,
             run_sync=self._operation_samples_config.get("run_sync", False),  # Default to running sync
             enabled=self._operation_samples_config["enabled"],
-            dbms="mongodb",
+            dbms="mongo",
             min_collection_interval=check._config.min_collection_interval,
             job_name="operation-samples",
         )
@@ -389,7 +389,7 @@ class MongoOperationSamples(DBMAsyncJob):
             "host": self._check._resolved_hostname,
             "dbm_type": "plan",
             "ddagentversion": datadog_agent.get_version(),
-            "ddsource": "mongodb",
+            "ddsource": "mongo",
             "ddtags": ",".join(self._check._get_tags(include_deployment_tags=True)),
             "timestamp": now * 1000,
             "network": {
@@ -441,7 +441,7 @@ class MongoOperationSamples(DBMAsyncJob):
         return {
             "host": self._check._resolved_hostname,
             "ddagentversion": datadog_agent.get_version(),
-            "ddsource": "mongodb",
+            "ddsource": "mongo",
             "dbm_type": "activity",
             "collection_interval": self._collection_interval,
             "ddtags": self._check._get_tags(include_deployment_tags=True),

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -329,7 +329,7 @@ class MongoDb(AgentCheck):
             database_instance = {
                 "host": self._resolved_hostname,
                 "agent_version": datadog_agent.get_version(),
-                "dbms": "mongodb",
+                "dbms": "mongo",
                 "kind": "mongodb_instance",
                 "collection_interval": self._config.database_instance_collection_interval,
                 'dbms_version': self._mongo_version,

--- a/mongo/tests/results/opeartion-activities-mongos.json
+++ b/mongo/tests/results/opeartion-activities-mongos.json
@@ -2,7 +2,7 @@
     {
         "host": "d4c6071697ea:27017",
         "ddagentversion": "0.0.0",
-        "ddsource": "mongodb",
+        "ddsource": "mongo",
         "dbm_type": "activity",
         "collection_interval": 10,
         "ddtags": [

--- a/mongo/tests/results/opeartion-activities-standalone.json
+++ b/mongo/tests/results/opeartion-activities-standalone.json
@@ -2,7 +2,7 @@
     {
         "host": "d4c6071697ea:27017",
         "ddagentversion": "0.0.0",
-        "ddsource": "mongodb",
+        "ddsource": "mongo",
         "dbm_type": "activity",
         "collection_interval": 10,
         "ddtags": ["server:mongodb://testUser2:*****@localhost:27017/test", "clustername:my_cluster"],

--- a/mongo/tests/results/operation-samples-mongos.json
+++ b/mongo/tests/results/operation-samples-mongos.json
@@ -3,7 +3,7 @@
         "host": "d4c6071697ea:27017",
         "dbm_type": "plan",
         "ddagentversion": "0.0.0",
-        "ddsource": "mongodb",
+        "ddsource": "mongo",
         "ddtags": "server:mongodb://testUser2:*****@localhost:27017/test,clustername:my_cluster,sharding_cluster_role:mongos",
         "timestamp": 1715911398111.2722,
         "network": {

--- a/mongo/tests/results/operation-samples-standalone.json
+++ b/mongo/tests/results/operation-samples-standalone.json
@@ -3,7 +3,7 @@
         "host": "d4c6071697ea:27017",
         "dbm_type": "plan",
         "ddagentversion": "0.0.0",
-        "ddsource": "mongodb",
+        "ddsource": "mongo",
         "ddtags": "server:mongodb://testUser2:*****@localhost:27017/test,clustername:my_cluster",
         "timestamp": 1715911398111.2722,
         "network": {

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -57,7 +57,7 @@ def _assert_mongodb_instance_event(
     assert mongodb_instance_event is not None
     assert mongodb_instance_event['host'] == check._resolved_hostname
     assert mongodb_instance_event['host'] == check._resolved_hostname
-    assert mongodb_instance_event['dbms'] == "mongodb"
+    assert mongodb_instance_event['dbms'] == "mongo"
     assert mongodb_instance_event['tags'].sort() == expected_tags.sort()
 
     expected_instance_metadata = {


### PR DESCRIPTION
### What does this PR do?
Rename dbms from mongodb to mongo so that dbms is consistent with integration name. This is to prevent double tagging on dbms with two different values `mongo` and `mongodb`. 

### Motivation
Prevent tag `dbms` double tagging with two different values `mongo` and `mongodb`. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
