### PR TITLE
Don't verify certificate when fetching it to get expiration date when tls_verify:false

### DIFF
--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -52,6 +52,11 @@ class HTTPCheck(AgentCheck):
 
     TLS_CONFIG_REMAPPER = {
         "check_hostname": {"name": "tls_validate_hostname"},
+        "disable_ssl_validation": {
+            "name": "tls_verify",
+            "invert": True,
+            "default": True,
+        },
     }
 
     def __init__(self, name, init_config, instances):

--- a/http_check/tests/test_http_integration.py
+++ b/http_check/tests/test_http_integration.py
@@ -98,6 +98,19 @@ def test_check_cert_expiration_bad_hostname(http_check):
 
 
 @pytest.mark.usefixtures("dd_environment")
+def test_check_cert_expiration_bad_hostname_but_verification_disabled(http_check):
+    cert_path = os.path.join(HERE, 'fixtures', 'cacert.pem')
+    instance = {'url': 'https://wronghost.mock/', 'tls_verify': False}
+    http_check.instance = instance
+    status, days_left, seconds_left, msg = http_check.check_cert_expiration(instance, 10, cert_path)
+    # TODO: which status makes sense here?
+    # assert status == AgentCheck.CRITICAL
+    assert days_left == 100
+    assert seconds_left == 100
+    assert 'Hostname mismatch' in msg or "doesn't match" in msg
+
+
+@pytest.mark.usefixtures("dd_environment")
 def test_check_cert_expiration_site_down(http_check):
     cert_path = os.path.join(HERE, 'fixtures', 'cacert.pem')
     instance = {'url': 'https://this.does.not.exist.foo'}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
