### PR TITLE
feat(openai): Query logs by log tag

### DIFF
--- a/openai/assets/dashboards/overview_dashboard.json
+++ b/openai/assets/dashboards/overview_dashboard.json
@@ -1526,7 +1526,7 @@
                   "response_format": "event_list",
                   "query": {
                     "data_source": "logs_stream",
-                    "query_string": "openai.request.endpoint:\"/v1/completions\" ",
+                    "query_string": "openai.request.endpoint:\"/v1/completions\" OR @openai.request.endpoint:\"/v1/completions\" ",
                     "indexes": [],
                     "storage": "hot",
                     "sort": {
@@ -1586,7 +1586,7 @@
                   "response_format": "event_list",
                   "query": {
                     "data_source": "logs_stream",
-                    "query_string": "openai.request.endpoint:\"/v1/chat/completions\" ",
+                    "query_string": "openai.request.endpoint:\"/v1/chat/completions\" OR @openai.request.endpoint:\"/v1/chat/completions\" ",
                     "indexes": [],
                     "storage": "hot",
                     "sort": {
@@ -1706,7 +1706,7 @@
                   "response_format": "event_list",
                   "query": {
                     "data_source": "logs_stream",
-                    "query_string": "openai.request.endpoint:/v1/images/* ",
+                    "query_string": "openai.request.endpoint:/v1/images/* OR @openai.request.endpoint:/v1/images/* ",
                     "indexes": [],
                     "storage": "hot",
                     "sort": {
@@ -1774,7 +1774,7 @@
                   "response_format": "event_list",
                   "query": {
                     "data_source": "logs_stream",
-                    "query_string": "openai.request.endpoint:/v1/audio/* ",
+                    "query_string": "openai.request.endpoint:/v1/audio/* OR @openai.request.endpoint:/v1/audio/* ",
                     "indexes": [],
                     "storage": "hot",
                     "sort": {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR allows for the Log Widgets of the OpenAI OOTB dashboard to query logs using `@`.

### Motivation
<!-- What inspired you to submit this pull request? -->

The implementation of the OpenAI Integration was just merged in the PHP Tracing Library: https://github.com/DataDog/dd-trace-php/pull/2685

OOTB, logs generated from the PHP Integration, despite having the `openai.request.endpoint` tag, weren't picked up by the logs widget as shown in the screenshot below

![image](https://github.com/user-attachments/assets/cd6bf0de-038e-483b-bbc7-e6a821cb426e)

![image](https://github.com/user-attachments/assets/eba1480a-b087-48da-87d7-33729dcc7fe9)


However, when using `@`, they were:
![image](https://github.com/user-attachments/assets/700f140e-13d0-4b6f-be28-f1981132c29b)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
