### PR TITLE
[mysql] revert default read_timeout

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -86,10 +86,11 @@ files:
           - name: read_timeout
             description: |
               The timeout for reading from the connection in seconds.
-              The default read timeout is 10 seconds.
+              By default, no read timeout is set.
             value:
               type: number
               example: 10
+              display_default: null
 
           - name: ssl
             description: |

--- a/mysql/changelog.d/18097.fixed
+++ b/mysql/changelog.d/18097.fixed
@@ -1,0 +1,1 @@
+Revert the default 10s mysql connection read_timeout

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -28,7 +28,7 @@ class MySQLConfig(object):
         self.additional_status = instance.get('additional_status', [])
         self.additional_variable = instance.get('additional_variable', [])
         self.connect_timeout = instance.get('connect_timeout', 10)
-        self.read_timeout = instance.get('read_timeout', 10)
+        self.read_timeout = instance.get('read_timeout', None)
         self.max_custom_queries = instance.get('max_custom_queries', DEFAULT_MAX_CUSTOM_QUERIES)
         self.charset = instance.get('charset')
         self.dbm_enabled = is_affirmative(instance.get('dbm', instance.get('deep_database_monitoring', False)))

--- a/mysql/datadog_checks/mysql/config_models/defaults.py
+++ b/mysql/datadog_checks/mysql/config_models/defaults.py
@@ -52,9 +52,5 @@ def instance_port():
     return 3306
 
 
-def instance_read_timeout():
-    return 10
-
-
 def instance_use_global_custom_queries():
     return 'true'

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -75,9 +75,9 @@ instances:
     #
     # connect_timeout: 10
 
-    ## @param read_timeout - number - optional - default: 10
+    ## @param read_timeout - number - optional
     ## The timeout for reading from the connection in seconds.
-    ## The default read timeout is 10 seconds.
+    ## By default, no read timeout is set.
     #
     # read_timeout: 10
 

--- a/mysql/tests/test_connection.py
+++ b/mysql/tests/test_connection.py
@@ -25,7 +25,7 @@ def test_connection_with_defaults_file():
         'autocommit': True,
         'ssl': None,
         'connect_timeout': 10,
-        'read_timeout': 10,
+        'read_timeout': None,
         'read_default_file': '/foo/bar',
     }
     assert 'host' not in connection_args
@@ -45,7 +45,7 @@ def test_connection_with_sock():
         'autocommit': True,
         'ssl': None,
         'connect_timeout': 10,
-        'read_timeout': 10,
+        'read_timeout': None,
         'unix_socket': '/foo/bar',
         'user': 'ddog',
         'passwd': 'pwd',
@@ -65,7 +65,7 @@ def test_connection_with_host():
         'autocommit': True,
         'ssl': None,
         'connect_timeout': 10,
-        'read_timeout': 10,
+        'read_timeout': None,
         'user': 'ddog',
         'passwd': 'pwd',
         'host': 'localhost',
@@ -80,7 +80,7 @@ def test_connection_with_host_and_port():
         'autocommit': True,
         'ssl': None,
         'connect_timeout': 10,
-        'read_timeout': 10,
+        'read_timeout': None,
         'user': 'ddog',
         'passwd': 'pwd',
         'host': 'localhost',
@@ -102,6 +102,6 @@ def test_connection_with_charset(instance_basic):
         'port': common.PORT,
         'ssl': None,
         'connect_timeout': 10,
-        'read_timeout': 10,
+        'read_timeout': None,
         'charset': 'utf8mb4',
     }


### PR DESCRIPTION
### What does this PR do?
This PR reverts the default 10s read_timeout for MySQL integration as we see connection leaks in rare cases.

### Motivation
Due to the default 10s read_timeout, mysql queries can sometimes timeout and result in uncaught exception. The uncaught exceptions that happen in DBM async threads will cause those threads to shutdown. A new thread will be started with a new database connection. In rare cases, the database connection from prior thread is closed on the client side but remains open on the database server side. This has resulted in more new connections being opened with datadog user and caused connection surge on the database. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
