### PR TITLE
[NDM] [Cisco ACI] Add config flag for enabling sending metadata to NDM

### DIFF
--- a/cisco_aci/assets/configuration/spec.yaml
+++ b/cisco_aci/assets/configuration/spec.yaml
@@ -99,9 +99,9 @@ files:
       value:
         type: string
         example: default
-    - name: enable_ndm
+    - name: send_ndm_metadata
       description: |
-        Set to `true` to enable Network Device Monitoring.
+        Set to `true` to enable Network Device Monitoring metadata (for devices and interfaces) to be sent.
       value:
         type: boolean
         example: False

--- a/cisco_aci/assets/configuration/spec.yaml
+++ b/cisco_aci/assets/configuration/spec.yaml
@@ -99,6 +99,13 @@ files:
       value:
         type: string
         example: default
+    - name: enable_ndm
+      description: |
+        Set to `true` to enable Network Device Monitoring.
+      value:
+        type: boolean
+        example: False
+        display_default: False
     - template: instances/http
       overrides:
         username.display_priority: 9

--- a/cisco_aci/changelog.d/18099.added
+++ b/cisco_aci/changelog.d/18099.added
@@ -1,0 +1,1 @@
+[NDM] [Cisco ACI] Add config flag for enabling sending metadata to NDM

--- a/cisco_aci/datadog_checks/cisco_aci/config_models/defaults.py
+++ b/cisco_aci/datadog_checks/cisco_aci/config_models/defaults.py
@@ -40,10 +40,6 @@ def instance_empty_default_hostname():
     return False
 
 
-def instance_enable_ndm():
-    return False
-
-
 def instance_kerberos_auth():
     return 'disabled'
 
@@ -74,6 +70,10 @@ def instance_persist_connections():
 
 def instance_request_size():
     return 16
+
+
+def instance_send_ndm_metadata():
+    return False
 
 
 def instance_skip_proxy():

--- a/cisco_aci/datadog_checks/cisco_aci/config_models/defaults.py
+++ b/cisco_aci/datadog_checks/cisco_aci/config_models/defaults.py
@@ -40,6 +40,10 @@ def instance_empty_default_hostname():
     return False
 
 
+def instance_enable_ndm():
+    return False
+
+
 def instance_kerberos_auth():
     return 'disabled'
 

--- a/cisco_aci/datadog_checks/cisco_aci/config_models/instance.py
+++ b/cisco_aci/datadog_checks/cisco_aci/config_models/instance.py
@@ -70,7 +70,6 @@ class InstanceConfig(BaseModel):
     connect_timeout: Optional[float] = None
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
-    enable_ndm: Optional[bool] = None
     extra_headers: Optional[MappingProxyType[str, Any]] = None
     headers: Optional[MappingProxyType[str, Any]] = None
     kerberos_auth: Optional[str] = None
@@ -91,6 +90,7 @@ class InstanceConfig(BaseModel):
     pwd: Optional[str] = None
     read_timeout: Optional[float] = None
     request_size: Optional[float] = None
+    send_ndm_metadata: Optional[bool] = None
     service: Optional[str] = None
     skip_proxy: Optional[bool] = None
     tags: Optional[tuple[str, ...]] = None

--- a/cisco_aci/datadog_checks/cisco_aci/config_models/instance.py
+++ b/cisco_aci/datadog_checks/cisco_aci/config_models/instance.py
@@ -70,6 +70,7 @@ class InstanceConfig(BaseModel):
     connect_timeout: Optional[float] = None
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
+    enable_ndm: Optional[bool] = None
     extra_headers: Optional[MappingProxyType[str, Any]] = None
     headers: Optional[MappingProxyType[str, Any]] = None
     kerberos_auth: Optional[str] = None

--- a/cisco_aci/datadog_checks/cisco_aci/data/conf.yaml.example
+++ b/cisco_aci/datadog_checks/cisco_aci/data/conf.yaml.example
@@ -130,6 +130,11 @@ instances:
     #
     # namespace: default
 
+    ## @param enable_ndm - boolean - optional - default: false
+    ## Set to `true` to enable Network Device Monitoring.
+    #
+    # enable_ndm: false
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/cisco_aci/datadog_checks/cisco_aci/data/conf.yaml.example
+++ b/cisco_aci/datadog_checks/cisco_aci/data/conf.yaml.example
@@ -130,10 +130,10 @@ instances:
     #
     # namespace: default
 
-    ## @param enable_ndm - boolean - optional - default: false
-    ## Set to `true` to enable Network Device Monitoring.
+    ## @param send_ndm_metadata - boolean - optional - default: false
+    ## Set to `true` to enable Network Device Monitoring metadata (for devices and interfaces) to be sent.
     #
-    # enable_ndm: false
+    # send_ndm_metadata: false
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/cisco_aci/datadog_checks/cisco_aci/fabric.py
+++ b/cisco_aci/datadog_checks/cisco_aci/fabric.py
@@ -35,8 +35,8 @@ class Fabric:
         self.check_tags = check.check_tags
         self.namespace = namespace
 
-        # Config for submitting to NDM
-        self.enable_ndm = self.instance.get('enable_ndm', False)
+        # Config for submitting device/interface metadata to NDM
+        self.send_ndm_metadata = self.instance.get('send_ndm_metadata', False)
 
         # grab some functions from the check
         self.gauge = check.gauge
@@ -47,13 +47,16 @@ class Fabric:
         self.external_host_tags = self.check.external_host_tags
         self.event_platform_event = check.event_platform_event
 
+    def ndm_enabled(self):
+        return PY3 and self.send_ndm_metadata
+
     def collect(self):
         fabric_pods = self.api.get_fabric_pods()
         fabric_nodes = self.api.get_fabric_nodes()
         self.log.info("%s pods and %s nodes computed", len(fabric_nodes), len(fabric_pods))
         pods = self.submit_pod_health(fabric_pods)
         devices, interfaces = self.submit_nodes_health_and_metadata(fabric_nodes, pods)
-        if PY3 and self.enable_ndm:
+        if self.ndm_enabled():
             collect_timestamp = int(time.time())
             batches = self.batch_payloads(devices, interfaces, collect_timestamp)
             for batch in batches:
@@ -99,7 +102,7 @@ class Fabric:
                 continue
             self.log.info("processing node %s on pod %s", node_id, pod_id)
             try:
-                if PY3 and self.enable_ndm:
+                if self.ndm_enabled():
                     device_metadata.append(self.submit_node_metadata(node_attrs, tags))
                 self.submit_process_metric(n, tags + self.check_tags + user_tags, hostname=hostname)
             except (exceptions.APIConnectionException, exceptions.APIParsingException):
@@ -109,7 +112,7 @@ class Fabric:
                     stats = self.api.get_node_stats(pod_id, node_id)
                     self.submit_fabric_metric(stats, tags, 'fabricNode', hostname=hostname)
                     eth_metadata = self.process_eth(node_attrs)
-                    if PY3 and self.enable_ndm:
+                    if self.ndm_enabled():
                         interface_metadata.extend(eth_metadata)
                 except (exceptions.APIConnectionException, exceptions.APIParsingException):
                     pass
@@ -131,7 +134,7 @@ class Fabric:
             eth_id = eth_attrs['id']
             tags = self.tagger.get_fabric_tags(e, 'l1PhysIf')
             tags.extend(common_tags)
-            if PY3 and self.enable_ndm:
+            if self.ndm_enabled():
                 interfaces.append(self.create_interface_metadata(e, node.get('address', ''), tags, hostname))
             try:
                 stats = self.api.get_eth_stats(pod_id, node['id'], eth_id)

--- a/cisco_aci/tests/common.py
+++ b/cisco_aci/tests/common.py
@@ -32,7 +32,7 @@ CONFIG_WITH_TAGS = {
     'pwd': PASSWORD,
     'tenant': ['DataDog'],
     "tags": ["project:cisco_aci"],
-    "enable_ndm": True,
+    "send_ndm_metadata": True,
 }
 
 # list of fixture names

--- a/cisco_aci/tests/common.py
+++ b/cisco_aci/tests/common.py
@@ -32,6 +32,7 @@ CONFIG_WITH_TAGS = {
     'pwd': PASSWORD,
     'tenant': ['DataDog'],
     "tags": ["project:cisco_aci"],
+    "enable_ndm": True,
 }
 
 # list of fixture names


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Part of the proposal to deal with new and existing customers that will be using Cisco ACI integration to explicitly enable sending metadata to NDM.

**Changes**
* Add config flag `enable_ndm` that defaults to False
* Send device/interface metadata if this flag is enabled

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
