### PR TITLE
Ensures that 'should_bypass_proxy' correctly considers unix:/// URLs

### DIFF
--- a/datadog_checks_base/changelog.d/18119.fixed
+++ b/datadog_checks_base/changelog.d/18119.fixed
@@ -1,0 +1,1 @@
+Ensures that 'should_bypass_proxy' correctly considers unix:/// URLs

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -591,11 +591,16 @@ def handle_kerberos_cache(cache_file_path):
 def should_bypass_proxy(url, no_proxy_uris):
     # Accepts a URL and a list of no_proxy URIs
     # Returns True if URL should bypass the proxy.
-    parsed_uri = urlparse(url).hostname
+    parsed_uri_parts = urlparse(url)
+    parsed_uri = parsed_uri_parts.hostname
 
     if '*' in no_proxy_uris:
         # A single * character is supported, which matches all hosts, and effectively disables the proxy.
         # See: https://curl.haxx.se/libcurl/c/CURLOPT_NOPROXY.html
+        return True
+
+    if parsed_uri_parts.scheme == "unix":
+        # Unix domain sockets semantically do not make sense to proxy
         return True
 
     for no_proxy_uri in no_proxy_uris:


### PR DESCRIPTION
### What does this PR do?
Fixes a bug when making HTTP requests to Unix sockets

### Motivation
I encountered the following bug in production when trying to specify a unix socket path for an openmetrics endpoint.

```
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.11/site-packages/datadog_checks/base/utils/http.py", line 609, in should_bypass_proxy
          ipaddress = ip_address(ensure_unicode(parsed_uri))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/opt/datadog-agent/embedded/lib/python3.11/ipaddress.py", line 54, in ip_address
          raise ValueError(f'{address!r} does not appear to be an IPv4 or IPv6 address')
      ValueError: None does not appear to be an IPv4 or IPv6 address

      During handling of the above exception, another exception occurred:

      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.11/site-packages/datadog_checks/base/checks/base.py", line 1224, in run
          self.check(instance)
        File "/opt/datadog-agent/embedded/lib/python3.11/site-packages/datadog_checks/base/checks/openmetrics/v2/base.py", line 75, in check
          scraper.scrape()
        File "/opt/datadog-agent/embedded/lib/python3.11/site-packages/datadog_checks/base/checks/openmetrics/v2/scraper.py", line 244, in scrape
          for metric in self.consume_metrics(runtime_data):
        File "/opt/datadog-agent/embedded/lib/python3.11/site-packages/datadog_checks/base/checks/openmetrics/v2/scraper.py", line 264, in consume_metrics
          for metric in metric_parser:
        File "/opt/datadog-agent/embedded/lib/python3.11/site-packages/datadog_checks/base/checks/openmetrics/v2/scraper.py", line 286, in parse_metrics
          line_streamer = chain([next(line_streamer)], line_streamer)
                                 ^^^^^^^^^^^^^^^^^^^
        File "/opt/datadog-agent/embedded/lib/python3.11/site-packages/datadog_checks/base/checks/openmetrics/v2/scraper.py", line 366, in stream_connection_lines
          with self.get_connection() as connection:
               ^^^^^^^^^^^^^^^^^^^^^
        File "/opt/datadog-agent/embedded/lib/python3.11/site-packages/datadog_checks/base/checks/openmetrics/v2/scraper.py", line 394, in get_connection
          response = self.send_request()
                     ^^^^^^^^^^^^^^^^^^^
        File "/opt/datadog-agent/embedded/lib/python3.11/site-packages/datadog_checks/base/checks/openmetrics/v2/scraper.py", line 422, in send_request
          return self.http.get(self.endpoint, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/opt/datadog-agent/embedded/lib/python3.11/site-packages/datadog_checks/base/utils/http.py", line 355, in get
          return self._request('get', url, options)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/opt/datadog-agent/embedded/lib/python3.11/site-packages/datadog_checks/base/utils/http.py", line 379, in _request
          if self.no_proxy_uris and should_bypass_proxy(url, self.no_proxy_uris):
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/opt/datadog-agent/embedded/lib/python3.11/site-packages/datadog_checks/base/utils/http.py", line 625, in should_bypass_proxy
          if no_proxy_uri == parsed_uri or parsed_uri.endswith(dot_no_proxy_uri):
                                           ^^^^^^^^^^^^^^^^^^^
      AttributeError: 'NoneType' object has no attribute 'endswith'
```

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
