### PR TITLE
Send metrics for Postgres table statistics.

### DIFF
--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -110,6 +110,15 @@ def get_schema_field(descriptors):
     raise CheckException("The descriptors are missing a schema field")
 
 
+def get_relation_field(descriptors):
+    # type: (List[Tuple[Any, str]]) -> str
+    """Return column containing the relation name for that query."""
+    for column, name in descriptors:
+        if name == 'table':
+            return column
+    raise CheckException("The descriptors are missing a table field")
+
+
 def payload_pg_version(version):
     if not version:
         return ""

--- a/postgres/tests/test_relations_integration.py
+++ b/postgres/tests/test_relations_integration.py
@@ -1,0 +1,32 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+import pytest
+from .utils import requires_over_12
+from datadog_checks.postgres.relationsmanager import QUERY_TABLE_STATISTICS
+from .common import _get_expected_tags
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+@requires_over_12
+def test_autodiscovery_collect_table_statistic_metrics(aggregator, integration_check, pg_instance):
+    """
+    Check that metrics get collected for each database discovered.
+    """
+    pg_instance['relations'] = ['public.breed']
+
+    check = integration_check(pg_instance)
+    check.check(pg_instance)
+
+    expected_metrics = [q for q in QUERY_TABLE_STATISTICS['metrics'].keys()]
+
+    for metric in expected_metrics:
+        aggregator.assert_metric(
+            metric,
+            tags=_get_expected_tags(check, pg_instance, db='dogs_nofunc', schema='public', function='dummy_function'),
+        )
+
+    aggregator.assert_metric(
+        'dd.postgres._collect_relations_autodiscovery.time',
+    )


### PR DESCRIPTION
### What does this PR do?

Sends metrics for table statistic information stored in `pg_stats`. This **excludes** any information that includes any concrete table values, e.g. `most_common_vals` is excluded. That data may be sensitive and has to be treated with greater care, but the aggregate data is safe to send.

### Motivation

Table statistics are very useful in determining why the query planner is choosing certain plans.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
