### PR TITLE
PG: Make query collection interval configurable

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -290,6 +290,26 @@ files:
       value:
         type: boolean
         example: false
+    - name: collection_intervals
+      description: |
+        Per query configuration of collection interval (in seconds) of datadog agent's queries.
+        query_name is the name used in the query descriptor found in util.py and relationsmanager.py and should
+        match the source of the metric. For example, pg_class_size, pg_class, pg_stat_database...
+        This is only available for queries using QueryExecutor.
+      value:
+        type: array
+        items:
+          type: object
+          properties:
+            - name: query_name
+              type: string
+            - name: collection_interval
+              type: integer
+        example:
+          - query_name: pg_class
+            collection_interval: 30
+          - query_name: pg_class_size
+            collection_interval: 360
     - name: data_directory
       description: |
         The data directory of your postgres installation

--- a/postgres/changelog.d/18136.added
+++ b/postgres/changelog.d/18136.added
@@ -1,0 +1,1 @@
+Make query collection interval configurable

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -89,6 +89,7 @@ class PostgresConfig:
         self.collect_database_size_metrics = is_affirmative(instance.get('collect_database_size_metrics', True))
         self.collect_wal_metrics = self._should_collect_wal_metrics(instance.get('collect_wal_metrics'))
         self.collect_bloat_metrics = is_affirmative(instance.get('collect_bloat_metrics', False))
+        self.collection_intervals = instance.get('collection_intervals', {}) or {}
         self.data_directory = instance.get('data_directory', None)
         self.ignore_databases = instance.get('ignore_databases', DEFAULT_IGNORE_DATABASES)
         if is_affirmative(instance.get('collect_default_database', True)):

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -86,6 +86,15 @@ class CollectSettings(BaseModel):
     ignored_settings_patterns: Optional[tuple[str, ...]] = None
 
 
+class CollectionInterval(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    collection_interval: Optional[int] = None
+    query_name: Optional[str] = None
+
+
 class CustomQuery(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -229,6 +238,7 @@ class InstanceConfig(BaseModel):
     collect_schemas: Optional[CollectSchemas] = None
     collect_settings: Optional[CollectSettings] = None
     collect_wal_metrics: Optional[bool] = None
+    collection_intervals: Optional[tuple[CollectionInterval, ...]] = None
     custom_queries: Optional[tuple[CustomQuery, ...]] = None
     data_directory: Optional[str] = None
     database_autodiscovery: Optional[DatabaseAutodiscovery] = None

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -239,6 +239,18 @@ instances:
     #
     # collect_wal_metrics: false
 
+    ## @param collection_intervals - list of mappings - optional
+    ## Per query configuration of collection interval (in seconds) of datadog agent's queries.
+    ## query_name is the name used in the query descriptor found in util.py and relationsmanager.py and should
+    ## match the source of the metric. For example, pg_class_size, pg_class, pg_stat_database...
+    ## This is only available for queries using QueryExecutor.
+    #
+    # collection_intervals:
+    #   - query_name: pg_class
+    #     collection_interval: 30
+    #   - query_name: pg_class_size
+    #     collection_interval: 360
+
     ## @param data_directory - string - optional - default: /usr/local/pgsql/data
     ## The data directory of your postgres installation
     ## Required when collecting WAL metrics.

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -351,6 +351,20 @@ class PostgreSql(AgentCheck):
             self._collect_dynamic_queries_autodiscovery(per_database_queries)
         else:
             queries.extend(per_database_queries)
+
+        # Build query_name to collection interval mapping
+        query_to_intervals = {}
+        for el in self._config.collection_intervals:
+            query_name = el['query_name']
+            collection_interval = el['collection_interval']
+            query_to_intervals[query_name] = collection_interval
+
+        # Adjust query collection_interval time
+        for query in queries:
+            collection_interval = query_to_intervals.get(query['name'])
+            if collection_interval:
+                query['collection_interval'] = collection_interval
+
         self._dynamic_queries.append(self._new_query_executor(queries, db=self.db))
         for dynamic_query in self._dynamic_queries:
             dynamic_query.compile_queries()

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -15,6 +15,7 @@ from datadog_checks.postgres.util import (
     QUERY_PG_CONTROL_CHECKPOINT,
     QUERY_PG_REPLICATION_SLOTS,
     QUERY_PG_REPLICATION_SLOTS_STATS,
+    QUERY_PG_STAT_DATABASE_CONFLICTS,
     QUERY_PG_STAT_WAL_RECEIVER,
     QUERY_PG_UPTIME,
     REPLICATION_STATS_METRICS,
@@ -77,14 +78,6 @@ COMMON_METRICS = [
 
 DBM_MIGRATED_METRICS = [
     'postgresql.connections',
-]
-
-CONFLICT_METRICS = [
-    'postgresql.conflicts.tablespace',
-    'postgresql.conflicts.lock',
-    'postgresql.conflicts.snapshot',
-    'postgresql.conflicts.bufferpin',
-    'postgresql.conflicts.deadlock',
 ]
 
 COMMON_BGW_METRICS = [
@@ -352,8 +345,8 @@ def check_conflict_metrics(aggregator, expected_tags, count=1):
         return
     for db in COMMON_DBS:
         db_tags = expected_tags + ['db:{}'.format(db)]
-        for name in CONFLICT_METRICS:
-            aggregator.assert_metric(name, count=count, tags=db_tags)
+        for metric_name in _iterate_metric_name(QUERY_PG_STAT_DATABASE_CONFLICTS):
+            aggregator.assert_metric(metric_name, count=count, tags=db_tags)
 
 
 def check_bgw_metrics(aggregator, expected_tags, count=1):

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -101,12 +101,12 @@ COMMON_DBS = ['dogs', 'postgres', 'dogs_nofunc', 'dogs_noschema', DB_NAME]
 CHECK_PERFORMANCE_METRICS = [
     'archiver_metrics',
     'bgw_metrics',
-    'connections_metrics',
+    'pg_stat_database_connections',
     'count_metrics',
     'instance_metrics',
     'replication_metrics',
     'replication_stats_metrics',
-    'slru_metrics',
+    'pg_stat_slru',
 ]
 
 requires_static_version = pytest.mark.skipif(USING_LATEST, reason='Version `latest` is ever-changing, skipping')
@@ -398,7 +398,7 @@ def check_performance_metrics(aggregator, expected_tags, count=1, is_aurora=Fals
     if is_aurora:
         expected_metrics = expected_metrics - {'replication_metrics'}
     if float(POSTGRES_VERSION) < 13.0:
-        expected_metrics = expected_metrics - {'slru_metrics'}
+        expected_metrics = expected_metrics - {'pg_stat_slru'}
     if float(POSTGRES_VERSION) < 10.0:
         expected_metrics = expected_metrics - {'replication_stats_metrics'}
     for name in expected_metrics:


### PR DESCRIPTION
### What does this PR do?
Make collection interval configurable on a per query basis

### Motivation
Some queries executed by the agent can be expensive to run, like getting tables' sizes on db with a lot of relations. This could lead to situation where running the check takes longer than the collection interval. Currently, the only solution is to disable the offending which is not great.

This patch adds a way to make collection_interval configurable for queries that are using the QueryExecutor. This will allow the user to run some queries at a higher collection interval, generating the related metrics while limiting impact of expensive queries on both the db and the agent.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
