### PR TITLE
Separate parsing crashes before and while we loop over metric items

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/libs/prometheus.py
+++ b/datadog_checks_base/datadog_checks/base/checks/libs/prometheus.py
@@ -11,11 +11,14 @@ from six.moves import zip
 
 def text_fd_to_metric_families(fd):
     raw_lines, input_lines = tee(fd, 2)
-    try:
-        for raw_line, metric_family in zip(raw_lines, _parse_payload(input_lines)):  # noqa: B007
+    # It's important to start parsing outside of the for-loop.
+    # This way we treat crashes before we yield the first parsed line differently than crashes while yielding.
+    parsed_lines = _parse_payload(input_lines)
+    for raw_line, metric_family in zip(raw_lines, parsed_lines):
+        try:
             yield metric_family
-    except Exception as e:
-        raise ValueError("Failed to parse the metric response '{}': {}".format(raw_line, e))
+        except Exception as e:
+            raise ValueError("Failed to parse the metric response '{}': {}".format(raw_line, e))
 
 
 # This copies most of the code from upstream at that version:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Tweak to a recently merged (and not released yet) [PR](https://github.com/DataDog/integrations-core/pull/17514). It started out as a way to satisfy the linter, but then became a logic change.

cc @Nevon 
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
