### PR TITLE
Remove schema collection dependency on relations configuration

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -600,7 +600,7 @@ files:
       options:
         - name: enabled
           description: |
-            Enable collection of database schemas. Requires `dbm: true` and relation metrics must be enabled.
+            Enable collection of database schemas. Requires `dbm: true`.
           value:
             type: boolean
             example: false

--- a/postgres/changelog.d/18144.fixed
+++ b/postgres/changelog.d/18144.fixed
@@ -1,0 +1,1 @@
+Remove schema collection dependency on relation metrics. Instead a warning is issued when the missing metrics will impact which tables are collected.

--- a/postgres/changelog.d/18144.fixed
+++ b/postgres/changelog.d/18144.fixed
@@ -1,1 +1,2 @@
-Remove schema collection and dependency on relation metrics. Instead a warning is issued when the missing metrics will impact which tables are collected. Also removed autodiscovery dependency on relation metrics.
+Remove schema collection and dependency on relation metrics. Instead a warning is issued when the missing metrics will impact which tables are collected.
+Removed the autodiscovery dependency on relation metrics; autodiscovery should now work even if relation metrics are not configured.

--- a/postgres/changelog.d/18144.fixed
+++ b/postgres/changelog.d/18144.fixed
@@ -1,1 +1,1 @@
-Remove schema collection dependency on relation metrics. Instead a warning is issued when the missing metrics will impact which tables are collected.
+Remove schema collection and dependency on relation metrics. Instead a warning is issued when the missing metrics will impact which tables are collected. Also removed autodiscovery dependency on relation metrics.

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -466,7 +466,7 @@ instances:
     # collect_schemas:
 
         ## @param enabled - boolean - optional - default: false
-        ## Enable collection of database schemas. Requires `dbm: true` and relation metrics must be enabled.
+        ## Enable collection of database schemas. Requires `dbm: true`.
         #
         # enabled: false
 

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -394,12 +394,12 @@ class PostgresMetadata(DBMAsyncJob):
             cursor.execute(PG_TABLES_QUERY_V10_PLUS.format(schema_oid=schema_id))
         rows = cursor.fetchall()
         table_info = [dict(row) for row in rows]
-        
+
         limit = self._config.schemas_metadata_config.get("max_tables", 300)
 
         if len(table_info) <= limit:
             return table_info
-        
+
         if not self._config.relations:
             self._check.log.warning(
                 "Number of tables exceeds limit of %d set by max_tables but "
@@ -412,7 +412,7 @@ class PostgresMetadata(DBMAsyncJob):
                 dbname,
             )
             return table_info[:limit]
-        
+
         return self._sort_and_limit_table_info(cursor, dbname, table_info, limit)
 
     def _sort_and_limit_table_info(

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -404,7 +404,7 @@ class PostgresMetadata(DBMAsyncJob):
             self._check.log.warning(
                 "Number of tables exceeds limit of %d set by max_tables but "
                 "relation metrics are not configured for %s."
-                "Please configure relations to collect metrics for all tables."
+                "Please configure relation metrics for all tables to sort by most active."
                 "See https://docs.datadoghq.com/database_monitoring/setup_postgres/"
                 "selfhosted/?tab=postgres15#monitoring-relation-metrics-for-multiple-databases "
                 "for details on how to enable relation metrics.",

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -388,26 +388,30 @@ class PostgresMetadata(DBMAsyncJob):
 
         If any tables are partitioned, only the master paritition table name will be returned, and none of its children.
         """
-        limit = self._config.schemas_metadata_config.get("max_tables", 300)
-        if len(table_info) > limit:
-            if not self._config.relations:
-                self._check.log.warning("Number of tables exceeds limit of {limit} set by max_tables but relation metrics are not configured for {dbname}."
-                                        "Please configure relations to collect metrics for all tables."
-                                        "See https://docs.datadoghq.com/database_monitoring/setup_postgres/selfhosted/?tab=postgres15#monitoring-relation-metrics-for-multiple-databases "
-                                        "for details on how to enable relation metrics.".format(limit=limit, dbname=dbname)
-                                        )
-                return table_info
-            if VersionUtils.transform_version(str(self._check.version))["version.major"] == "9":
-                cursor.execute(PG_TABLES_QUERY_V9.format(schema_oid=schema_id))
-            else:
-                cursor.execute(PG_TABLES_QUERY_V10_PLUS.format(schema_oid=schema_id))
-            rows = cursor.fetchall()
-            table_info = [dict(row) for row in rows]
-            return self._sort_and_limit_table_info(cursor, dbname, table_info, limit)
+        if VersionUtils.transform_version(str(self._check.version))["version.major"] == "9":
+            cursor.execute(PG_TABLES_QUERY_V9.format(schema_oid=schema_id))
         else:
-            return table_info
-            
+            cursor.execute(PG_TABLES_QUERY_V10_PLUS.format(schema_oid=schema_id))
+        rows = cursor.fetchall()
+        table_info = [dict(row) for row in rows]
 
+        limit = self._config.schemas_metadata_config.get("max_tables", 300)
+
+        if len(table_info) <= limit:
+            return table_info
+        if not self._config.relations:
+            self._check.log.warning(
+                "Number of tables exceeds limit of {limit} set by max_tables but "
+                "relation metrics are not configured for {dbname}."
+                "Please configure relations to collect metrics for all tables."
+                "See https://docs.datadoghq.com/database_monitoring/setup_postgres/"
+                "selfhosted/?tab=postgres15#monitoring-relation-metrics-for-multiple-databases "
+                "for details on how to enable relation metrics.",
+                limit=limit,
+                dbname=dbname,
+            )
+            return table_info
+        return self._sort_and_limit_table_info(cursor, dbname, table_info, limit)
 
     def _sort_and_limit_table_info(
         self, cursor, dbname, table_info: List[Dict[str, Union[str, bool]]], limit: int
@@ -432,10 +436,6 @@ class PostgresMetadata(DBMAsyncJob):
                 cursor.execute(PARTITION_ACTIVITY_QUERY.format(parent_oid=info["id"]))
                 row = cursor.fetchone()
                 return row.get("total_activity", 0) if row is not None else 0
-
-        # We only sort to filter by top so no need to waste resources if we're going to return everything
-        if len(table_info) <= limit:
-            return table_info
 
         # if relation metrics are enabled, sorted based on last activity information
         table_info = sorted(table_info, key=sort_tables, reverse=True)

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -151,7 +151,6 @@ class PostgreSql(AgentCheck):
                 "Database autodiscovery is enabled, but relation-level metrics are not being collected."
                 "All metrics will be gathered from global view, and autodiscovery will not run."
             )
-            return None
 
         discovery = PostgresAutodiscovery(
             self,

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -149,7 +149,7 @@ class PostgreSql(AgentCheck):
         if not self._config.relations:
             self.log.warning(
                 "Database autodiscovery is enabled, but relation-level metrics are not being collected."
-                "All metrics will be gathered from global view, and autodiscovery will not run."
+                "All metrics will be gathered from global view."
             )
 
         discovery = PostgresAutodiscovery(

--- a/postgres/tests/test_discovery.py
+++ b/postgres/tests/test_discovery.py
@@ -169,7 +169,7 @@ def test_autodiscovery_refresh(integration_check, pg_instance):
 @pytest.mark.usefixtures('dd_environment')
 def test_autodiscovery_relations_disabled(integration_check, pg_instance):
     """
-    If no relation metrics are being collected, autodiscovery should not run.
+    If no relation metrics are being collected, autodiscovery should still run.
     """
     pg_instance["database_autodiscovery"] = DISCOVERY_CONFIG
     pg_instance['relations'] = []
@@ -177,7 +177,7 @@ def test_autodiscovery_relations_disabled(integration_check, pg_instance):
     check = integration_check(pg_instance)
     run_one_check(check, pg_instance)
 
-    assert check.autodiscovery is None
+    assert check.autodiscovery is not None
 
 
 @pytest.mark.integration

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -89,8 +89,6 @@ def test_collect_schemas(integration_check, dbm_instance, aggregator):
     tables_got = []
 
     for schema_event in (e for e in dbm_metadata if e['kind'] == 'pg_databases'):
-        print(schema_event)
-
         assert schema_event.get("timestamp") is not None
         # there should only be one database, datadog_test
         database_metadata = schema_event['metadata']

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -61,7 +61,7 @@ def test_collect_schemas(integration_check, dbm_instance, aggregator):
     check = integration_check(dbm_instance)
     run_one_check(check, dbm_instance)
     dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
-    
+
     # check that all expected tables are present
     tables_set = {
         'persons',
@@ -138,6 +138,7 @@ def test_collect_schemas(integration_check, dbm_instance, aggregator):
     assert_fields(tables_got, tables_set)
     assert_not_fields(tables_got, tables_not_reported_set)
 
+
 def test_collect_schemas_max_tables(integration_check, dbm_instance, aggregator):
     dbm_instance["collect_schemas"] = {'enabled': True, 'collection_interval': 0.5, 'max_tables': 1}
     dbm_instance['relations'] = []
@@ -150,7 +151,6 @@ def test_collect_schemas_max_tables(integration_check, dbm_instance, aggregator)
     for schema_event in (e for e in dbm_metadata if e['kind'] == 'pg_databases'):
         database_metadata = schema_event['metadata']
         assert len(database_metadata[0]['schemas'][0]['tables']) == 1
-    
 
 
 def assert_fields(keys: List[str], fields: List[str]):

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -150,6 +150,16 @@ def test_collect_schemas_max_tables(integration_check, dbm_instance, aggregator)
         database_metadata = schema_event['metadata']
         assert len(database_metadata[0]['schemas'][0]['tables']) == 1
 
+    # Rerun check with relations enabled
+    dbm_instance['relations'] = [{'relation_regex': '.*'}]
+    check = integration_check(dbm_instance)
+    run_one_check(check, dbm_instance)
+    dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
+
+    for schema_event in (e for e in dbm_metadata if e['kind'] == 'pg_databases'):
+        database_metadata = schema_event['metadata']
+        assert len(database_metadata[0]['schemas'][0]['tables']) == 1
+
 
 def assert_fields(keys: List[str], fields: List[str]):
     for field in fields:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Removes the restriction on postgres schema collection that relation metrics must be enabled. Replaces it with a warning if there are too many tables to return all of them and relation metrics are disabled.

### Motivation
<!-- What inspired you to submit this pull request? -->
This requirement is confusing to users and usually unnecessary. In the cases where the warning triggers, a sampling of tables will be returned and users can troubleshoot one of the two solutions for the missing tables.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
