### PR TITLE
Change flaky test marker to work with pytest marker selection

### DIFF
--- a/datadog_checks_base/tests/base/utils/http/test_http.py
+++ b/datadog_checks_base/tests/base/utils/http/test_http.py
@@ -7,7 +7,6 @@ import mock
 import pytest
 import requests
 import requests_unixsocket
-from flaky import flaky
 from six import PY2, iteritems
 
 from datadog_checks.base import AgentCheck
@@ -82,7 +81,7 @@ class TestUnixDomainSocket:
         assert adapter is not None
         assert isinstance(adapter, requests_unixsocket.UnixAdapter)
 
-    @flaky(max_runs=3, rerun_filter=lambda err, name, test, plugin: PY2)
+    @pytest.mark.flaky(max_runs=3, rerun_filter=lambda err, name, test, plugin: PY2)
     @pytest.mark.skipif(ON_WINDOWS, reason='AF_UNIX not supported by Python on Windows yet')
     def test_uds_request(self, uds_path):
         # type: (str) -> None

--- a/datadog_checks_downloader/tests/test_downloader.py
+++ b/datadog_checks_downloader/tests/test_downloader.py
@@ -20,7 +20,6 @@ from urllib.parse import urljoin
 
 import pytest
 import requests
-from flaky import flaky
 from freezegun import freeze_time
 from packaging.version import parse as parse_version
 from tenacity import retry, stop_after_attempt, wait_exponential
@@ -87,7 +86,7 @@ def _do_run_downloader(argv):
 
 
 @pytest.mark.online
-@flaky(max_runs=3, rerun_filter=delay_rerun)
+@pytest.mark.flaky(max_runs=3, rerun_filter=delay_rerun)
 def test_download(capfd, distribution_name, distribution_version, temporary_local_repo, disable_verification, mocker):
     """Test datadog-checks-downloader successfully downloads and validates a wheel file."""
     argv = [distribution_name, "--version", distribution_version]

--- a/gitlab/tests/test_e2e.py
+++ b/gitlab/tests/test_e2e.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import pytest
-from flaky import flaky
 
 from datadog_checks.dev.utils import get_metadata_metrics
 
@@ -19,7 +18,7 @@ def test_e2e_legacy(dd_agent_check, legacy_config):
 
 
 @pytest.mark.parametrize('use_openmetrics', [True, False], indirect=True)
-@flaky(max_runs=5)
+@pytest.mark.flaky(max_runs=5)
 # GitLab can start returning 502s even if all the conditions were met in the e2e env.
 # Example:
 # tests/test_e2e.py::test_e2e[True] PASSED                                 [ 66%]

--- a/postgres/tests/test_deadlock.py
+++ b/postgres/tests/test_deadlock.py
@@ -8,7 +8,6 @@ import time
 
 import psycopg2
 import pytest
-from flaky import flaky
 
 from .common import DB_NAME, HOST, POSTGRES_VERSION, _get_expected_tags
 
@@ -33,7 +32,7 @@ def wait_on_result(cursor=None, sql=None, binds=None, expected_value=None):
     POSTGRES_VERSION is None or float(POSTGRES_VERSION) < 9.2,
     reason='Deadlock test requires version 9.2 or higher (make sure POSTGRES_VERSION is set)',
 )
-@flaky(max_runs=5)
+@pytest.mark.flaky(max_runs=5)
 def test_deadlock(aggregator, dd_run_check, integration_check, pg_instance):
     '''
     This test creates a deadlock by having two connections update the same two rows in opposite order.

--- a/postgres/tests/test_logical_replication.py
+++ b/postgres/tests/test_logical_replication.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
-from flaky import flaky
 
 from datadog_checks.postgres.util import STAT_SUBSCRIPTION_METRICS
 
@@ -33,7 +32,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')
 
 
 @requires_over_11
-@flaky(max_runs=5)
+@pytest.mark.flaky(max_runs=5)
 def test_common_logical_replica_metrics(aggregator, integration_check, pg_replica_logical):
     check = integration_check(pg_replica_logical)
     check._connect()

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -8,7 +8,6 @@ import time
 import mock
 import psycopg2
 import pytest
-from flaky import flaky
 
 from datadog_checks.base.errors import ConfigurationError
 from datadog_checks.base.stubs import datadog_agent
@@ -453,7 +452,7 @@ def test_activity_vacuum_excluded(aggregator, integration_check, pg_instance):
     thread.join()
 
 
-@flaky(max_runs=5)
+@pytest.mark.flaky(max_runs=5)
 def test_backend_transaction_age(aggregator, integration_check, pg_instance):
     pg_instance['collect_activity_metrics'] = True
     check = integration_check(pg_instance)
@@ -588,7 +587,7 @@ def test_state_clears_on_connection_error(integration_check, pg_instance):
     'is_aurora',
     [True, False],
 )
-@flaky(max_runs=5)
+@pytest.mark.flaky(max_runs=5)
 def test_wal_stats(aggregator, integration_check, pg_instance, is_aurora):
     conn = _get_superconn(pg_instance)
     with conn.cursor() as cur:

--- a/postgres/tests/test_pg_replication.py
+++ b/postgres/tests/test_pg_replication.py
@@ -4,7 +4,6 @@
 import time
 
 import pytest
-from flaky import flaky
 
 from .common import (
     DB_NAME,
@@ -131,7 +130,7 @@ def test_conflicts_lock(aggregator, integration_check, pg_instance, pg_replica_i
 
 
 @requires_over_10
-@flaky(max_runs=5)
+@pytest.mark.flaky(max_runs=5)
 def test_conflicts_snapshot(aggregator, integration_check, pg_instance, pg_replica_instance2):
     check = integration_check(pg_replica_instance2)
 

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -4,7 +4,6 @@
 
 import psycopg2
 import pytest
-from flaky import flaky
 
 from datadog_checks.base import ConfigurationError
 from datadog_checks.postgres.relationsmanager import (
@@ -250,7 +249,7 @@ def test_index_metrics(aggregator, integration_check, pg_instance):
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-@flaky(max_runs=5)
+@pytest.mark.flaky(max_runs=5)
 def test_vacuum_age(aggregator, integration_check, pg_instance):
     pg_instance['relations'] = ['persons']
     pg_instance['dbname'] = 'datadog_test'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Replaces `@flaky` with `@pytest.mark.flaky`

### Motivation
<!-- What inspired you to submit this pull request? -->
`@pytest.mark.flaky` has the same features **plus it lets you (de)select tests using pytest**.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
