### PR TITLE
Collect blk read/write time from pg_stat_database

### DIFF
--- a/postgres/changelog.d/18169.added
+++ b/postgres/changelog.d/18169.added
@@ -1,0 +1,1 @@
+Collect blk read/write time from pg_stat_database

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -156,6 +156,8 @@ NEWER_92_METRICS = {
     'deadlocks': ('postgresql.deadlocks', AgentCheck.rate),
     'temp_bytes': ('postgresql.temp_bytes', AgentCheck.rate),
     'temp_files': ('postgresql.temp_files', AgentCheck.rate),
+    'blk_read_time': ('postgresql.blk_read_time', AgentCheck.monotonic_count),
+    'blk_write_time': ('postgresql.blk_write_time', AgentCheck.monotonic_count),
 }
 
 CHECKSUM_METRICS = {'checksum_failures': ('postgresql.checksums.checksum_failures', AgentCheck.monotonic_count)}

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -24,6 +24,8 @@ postgresql.bgwriter.checkpoints_timed,count,,,,The number of scheduled checkpoin
 postgresql.bgwriter.maxwritten_clean,count,,,,The number of times the background writer stopped a cleaning scan due to writing too many buffers.,0,postgres,bgw maxwr clean,
 postgresql.bgwriter.sync_time,count,,millisecond,,The total amount of checkpoint processing time spent synchronizing files to disk.,0,postgres,bgw sync time,
 postgresql.bgwriter.write_time,count,,millisecond,,The total amount of checkpoint processing time spent writing files to disk.,0,postgres,bgw wrt time,
+postgresql.blk_read_time,count,,millisecond,,Time spent reading data file blocks by backends in this database if track_io_timing is enabled. This metric is tagged with db.,0,postgres,db blk read,
+postgresql.blk_write_time,count,,millisecond,,Time spent writing data file blocks by backends in this database if track_io_timing is enabled. This metric is tagged with db.,0,postgres,db blk write,
 postgresql.buffer_hit,gauge,,hit,second,"The number of times disk blocks were found in the buffer cache, preventing the need to read from the database. This metric is tagged with db.",1,postgres,buff hit,
 postgresql.buffercache.dirty_buffers,gauge,,buffer,,"Number of dirty shared buffers. pg_buffercache extension needs to be installed. This metric is tagged by db, schema and relation.",0,postgres,buffercache dirty buffers,
 postgresql.buffercache.pinning_backends,gauge,,,,"Number of backends pinning shared buffers. pg_buffercache extension needs to be installed. This metric is tagged by db, schema and relation.",0,postgres,buffercache pinning backends,

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -71,6 +71,8 @@ COMMON_METRICS = [
     'postgresql.deadlocks.count',
     'postgresql.temp_bytes',
     'postgresql.temp_files',
+    'postgresql.blk_read_time',
+    'postgresql.blk_write_time',
 ]
 
 DBM_MIGRATED_METRICS = [


### PR DESCRIPTION
### What does this PR do?
Collect blk time metrics from `pg_stat_database` to create the following metrics:
- `postgresql.blk_read_time`: Time spent reading blocks in ms
- `postgresql.blk_write_time`: Time spent writing blocks in ms

### Motivation
pg_stat_database provides blk_read_time and blk_write_time since PG 9.2. We do have an existing `postgresql.queries.blk_x_time` metric but it is by query and relies on pg_stat_statements. Having the metric on a db level is more reliable and cheaper as it won't be impacted by possible gc of tracked queries in pg_stat_statements.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
