### PR TITLE
pin msodbcsql18 to 18.3.3.1 in ci

### DIFF
--- a/.ddev/ci/scripts/sqlserver/linux/55_install_odbc.sh
+++ b/.ddev/ci/scripts/sqlserver/linux/55_install_odbc.sh
@@ -9,6 +9,6 @@ sudo apt-get install -y --no-install-recommends tdsodbc unixodbc-dev
 curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
 curl https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
 sudo apt-get update
-sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
+sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18=18.3.3.1
 
 set +ex


### PR DESCRIPTION
### What does this PR do?
This PR installs msodbcsql18 version `18.3.3.1` in ci. `18.3.3.1` is the embedded msodbcsql18 version in datadog-agent. Forcing ci to install the exact version avoids test fail when a new msodbcsql18 is released. It also makes sure the test uses the same msodbcsql18 version as datadog-agent.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
