### PR TITLE
[CONTINT-4331] Update Container Waiting Graphs in Kubernetes OOTB Dashboards

### DIFF
--- a/datadog_operator/assets/dashboards/operator_overview.json
+++ b/datadog_operator/assets/dashboards/operator_overview.json
@@ -708,7 +708,7 @@
                                     "response_format": "scalar",
                                     "queries": [
                                         {
-                                            "query": "sum:kubernetes.containers.state.waiting{$scope,$cluster,kube_app_name:datadog-operator,reason:crashloopbackoff} by {kube_cluster_name,image_tag}",
+                                            "query": "sum:kubernetes_state.container.status_report.count.waiting{$scope,$cluster,kube_app_name:datadog-operator,reason:crashloopbackoff} by {kube_cluster_name,image_tag}",
                                             "data_source": "metrics",
                                             "name": "query1",
                                             "aggregator": "last"

--- a/kubernetes/assets/dashboards/kubernetes_clusters.json
+++ b/kubernetes/assets/dashboards/kubernetes_clusters.json
@@ -3173,7 +3173,7 @@
                             "requests": [
                                 {
                                     "display_type": "bars",
-                                    "q": "sum:kubernetes_state.container.waiting{$cluster,reason:crashloopbackoff,*,$scope} by {pod_name}",
+                                    "q": "sum:kubernetes_state.container.status_report.count.waiting{$cluster,reason:crashloopbackoff,*,$scope} by {pod_name}",
                                     "style": {
                                         "line_type": "solid",
                                         "line_width": "normal",
@@ -3551,10 +3551,10 @@
                                         },
                                         {
                                             "alias_name": "waiting",
-                                            "expression": "sum:kubernetes_state.container.waiting{$cluster,$scope}"
+                                            "expression": "sum:kubernetes_state.container.status_report.count.waiting{$cluster,$scope}"
                                         }
                                     ],
-                                    "q": "sum:kubernetes_state.container.ready{$cluster,$scope}, sum:kubernetes_state.container.running{$cluster,$scope}, sum:kubernetes_state.container.terminated{$cluster,$scope}, sum:kubernetes_state.container.waiting{$cluster,$scope}",
+                                    "q": "sum:kubernetes_state.container.ready{$cluster,$scope}, sum:kubernetes_state.container.running{$cluster,$scope}, sum:kubernetes_state.container.terminated{$cluster,$scope}, sum:kubernetes_state.container.status_report.count.waiting{$cluster,$scope}",
                                     "style": {
                                         "line_type": "solid",
                                         "line_width": "normal",
@@ -3650,7 +3650,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes.containers.state.waiting{$cluster,reason:crashloopbackoff,$scope} by {pod_name}"
+                                            "query": "sum:kubernetes_state.container.status_report.count.waiting{$cluster,reason:crashloopbackoff,$scope} by {pod_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",

--- a/kubernetes/assets/dashboards/kubernetes_dashboard.json
+++ b/kubernetes/assets/dashboards/kubernetes_dashboard.json
@@ -731,7 +731,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes_state.container.waiting{$cluster,$namespace,$deployment,$statefulset,$replicaset,$daemonset,reason:crashloopbackoff,$scope,$daemonset,$label,$node,$service} by {pod_name}"
+                                            "query": "sum:kubernetes_state.container.status_report.count.waiting{$cluster,$namespace,$deployment,$statefulset,$replicaset,$daemonset,reason:crashloopbackoff,$scope,$daemonset,$label,$node,$service} by {pod_name}"
                                         }
                                     ],
                                     "style": {
@@ -1462,7 +1462,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes_state.container.waiting{$scope,$deployment,$statefulset,$replicaset,$daemonset,$service,$namespace,$label,$cluster,$node}"
+                                            "query": "sum:kubernetes_state.container.status_report.count.waiting{$scope,$deployment,$statefulset,$replicaset,$daemonset,$service,$namespace,$label,$cluster,$node}"
                                         }
                                     ],
                                     "response_format": "timeseries",

--- a/kubernetes/assets/dashboards/kubernetes_pods.json
+++ b/kubernetes/assets/dashboards/kubernetes_pods.json
@@ -542,7 +542,7 @@
                         "name": "query3"
                       },
                       {
-                        "query": "sum:kubernetes_state.container.waiting{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job}",
+                        "query": "sum:kubernetes_state.container.status_report.count.waiting{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job}",
                         "data_source": "metrics",
                         "name": "query4"
                       }
@@ -625,7 +625,7 @@
                     "on_right_yaxis": false,
                     "queries": [
                       {
-                        "query": "sum:kubernetes.containers.state.waiting{$cluster,$namespace,$deployment,reason:crashloopbackoff,$scope,$statefulset,$daemonset,$job} by {pod_name}",
+                        "query": "sum:kubernetes_state.container.status_report.count.waiting{$cluster,$namespace,$deployment,reason:crashloopbackoff,$scope,$statefulset,$daemonset,$job} by {pod_name}",
                         "data_source": "metrics",
                         "name": "query1"
                       }

--- a/vsphere/assets/dashboards/vmware_vsphere_tkg_-_overview.json
+++ b/vsphere/assets/dashboards/vmware_vsphere_tkg_-_overview.json
@@ -1014,7 +1014,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query4",
-                                            "query": "sum:kubernetes_state.container.waiting{$namespace,$scope,$vsphere_cluster,$vsphere_host,$vsphere_vcenter,$pod_name,$kube_container_name}"
+                                            "query": "sum:kubernetes_state.container.status_report.count.waiting{$namespace,$scope,$vsphere_cluster,$vsphere_host,$vsphere_vcenter,$pod_name,$kube_container_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -1123,7 +1123,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes.containers.state.waiting{$namespace,$deployment,reason:crashloopbackoff,$scope,$statefulset,$daemonset,$job,$vsphere_cluster,$vsphere_host,$vsphere_vcenter,$pod_name,$kube_container_name} by {pod_name}"
+                                            "query": "sum:kubernetes_state.container.status_report.count.waiting{$namespace,$deployment,reason:crashloopbackoff,$scope,$statefulset,$daemonset,$job,$vsphere_cluster,$vsphere_host,$vsphere_vcenter,$pod_name,$kube_container_name} by {pod_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
https://datadoghq.atlassian.net/browse/CONTINT-4331

Updated Kubernetes OOTB Dashboards to use the most recent container status waiting metric from `kube-state-metrics`. Allows users to use the `reason` tag. Also synchronizes the data between the `Container States` widget and `Containers in CrashloopBackOff (by Pod)` widget. 

Previously a mix of `kubernetes_state.container.waiting` and `kubernetes.containers.state.waiting` were used. Now all cases use `kubernetes_state.container.status_report.count.waiting`.

### Motivation
<!-- What inspired you to submit this pull request? -->

Users could not access a `reason` tag for some `container.status.waiting` metrics on the Dashboards. Different metrics were being used in different places on the dashboards as well. Updated all instances to the most recent metric from `kube-state-metrics` to synchronize them and ensure all have a `reason` tag.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
