### PR TITLE
Brush up docs for send_log method

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -1000,12 +1000,13 @@ class AgentCheck(object):
         Parameters:
 
             data (dict[str, str]):
-                the log data to send.
+                The log data to send.
             cursor (dict[str, Any] or None):
-                metadata associated with the log which will be saved to disk. the most recent value may be
+                Metadata associated with the log which will be saved to disk. The most recent value may be
                 retrieved with the `get_log_cursor` method.
             stream (str):
-                the stream associated with this log, used for accurate cursor persistence.
+                The stream associated with this log, used for accurate cursor persistence.
+                Has no effect if `cursor` argument is `None`.
         """
         attributes = data.copy()
         if 'ddtags' not in attributes and self.formatted_tags:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Minor fixes to the docstring of the unreleased `send_log` method.

Since it hasn't been released yet, there's no need for a changelog

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
