### PR TITLE
Sy/add zabbix exception

### DIFF
--- a/datadog_checks_dev/changelog.d/18197.added
+++ b/datadog_checks_dev/changelog.d/18197.added
@@ -1,0 +1,1 @@
+Add an exception for Zabbix (Community Edition) to pass validations

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
@@ -33,6 +33,8 @@ IGNORE_DEFAULT_INSTANCE = {'ceph', 'dotnetclr', 'gunicorn', 'marathon', 'pgbounc
 
 TEMPLATES = ['default', 'openmetrics_legacy', 'openmetrics', 'jmx']
 
+EXCEPTION_MAPPINGS = {'Zabbix (Community Version)': 'Zabbix'}
+
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Validate default configuration files')
 @click.argument('check', shell_complete=complete_valid_checks, required=False)
@@ -100,6 +102,7 @@ def config(ctx, check, sync, verbose):
             version = None
         else:
             display_name = manifest.get_display_name()
+            display_name = EXCEPTION_MAPPINGS.get(display_name, display_name)
             source = check
             version = get_version_string(check)
 


### PR DESCRIPTION
### What does this PR do?
Zabbix was changed to zabbix (community edition). This change in the manifest causes validations to fail. If we rename the files following the manifest name, then we have to also rename the metric namespace. I think the easier approach would be to just add an exception that maps zabbix community edition to zabbix so that all the files and namespace doesn't need to be changed. 

Related PR:
https://github.com/DataDog/integrations-extras/pull/2454

PR that changed the name of zabbix:
https://github.com/DataDog/integrations-extras/pull/2268