### PR TITLE
[sqlserver] fix connection string password obfuscation in OLE DB driver error message

### DIFF
--- a/sqlserver/changelog.d/18203.fixed
+++ b/sqlserver/changelog.d/18203.fixed
@@ -1,0 +1,1 @@
+Fix password obfuscation in OLE DB driver error message when one or more backslash exist in the password. 

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -23,7 +23,13 @@ except ImportError:
     pyodbc = None
 
 from .azure import generate_managed_identity_token
-from .connection_errors import ConnectionErrorCode, SQLConnectionError, error_with_tags, format_connection_exception
+from .connection_errors import (
+    ConnectionErrorCode,
+    SQLConnectionError,
+    error_with_tags,
+    format_connection_exception,
+    obfuscate_error_msg,
+)
 
 logger = logging.getLogger(__file__)
 
@@ -288,9 +294,7 @@ class Connection(object):
             if tcp_connection_status != "OK" and conn_warn_msg is ConnectionErrorCode.unknown:
                 conn_warn_msg = ConnectionErrorCode.tcp_connection_failed
 
-            password = self.instance.get('password')
-            if password is not None:
-                exception_msg = exception_msg.replace(password, "*" * 6)
+            exception_msg = obfuscate_error_msg(exception_msg, self.instance.get('password'))
 
             check_err_message = error_with_tags(
                 "Unable to connect to SQL Server, see %s#%s for more details on how to debug this issue. "

--- a/sqlserver/datadog_checks/sqlserver/connection_errors.py
+++ b/sqlserver/datadog_checks/sqlserver/connection_errors.py
@@ -143,3 +143,17 @@ def _lookup_conn_error_and_msg(hresult, msg):
         if res and len(res) == 2:
             return res[0], res[1]
     return None, ConnectionErrorCode.unknown
+
+
+def obfuscate_error_msg(msg, password):
+    """
+    Obfuscates the password in the error message.
+    """
+    # obfuscate the password in the error message
+    # regex to match the `Password=<password>;` in the connection string
+    # and replace it with `Password=***;` (case insensitive)
+    obfuscated_error_msg = re.sub(r"(?i)(Password=)([^;]+)", r"\1******", msg)
+    if password:
+        # this is a fallback in case the password is not in the connection string
+        obfuscated_error_msg = obfuscated_error_msg.replace(password, "*" * 6)
+    return obfuscated_error_msg

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -17,7 +17,11 @@ from datadog_checks.sqlserver.connection import (
     SQLConnectionError,
     parse_connection_string_properties,
 )
-from datadog_checks.sqlserver.connection_errors import ConnectionErrorCode, format_connection_exception
+from datadog_checks.sqlserver.connection_errors import (
+    ConnectionErrorCode,
+    format_connection_exception,
+    obfuscate_error_msg,
+)
 
 from .common import CHECK_NAME, SQLSERVER_MAJOR_VERSION
 
@@ -566,3 +570,78 @@ def test_restore_current_database_context(instance_docker):
                 cursor.execute("USE tempdb")
                 assert check.connection._get_current_database_context() == "tempdb"
         assert check.connection._get_current_database_context() == current_db
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "error_message,password,expected_error_message",
+    [
+        pytest.param(
+            "TCP-connection(ERROR: The requested address is not valid in its context), Exception: "
+            "OperationalError(com_error(-2147352567, 'Exception occurred.', (0, 'Microsoft OLE DB Driver for SQL "
+            "Server', \"Login failed for user 'datadog'.\", None, 0, 2147217843), None), 'Error opening connection to "
+            "\"ConnectRetryCount=2;Provider=MSOLEDBSQL;Data Source=localhost;User ID=datadog;Password=PWD123!;\"')",
+            "PWD123!",
+            "TCP-connection(ERROR: The requested address is not valid in its context), Exception: "
+            "OperationalError(com_error(-2147352567, 'Exception occurred.', (0, 'Microsoft OLE DB Driver for SQL "
+            "Server', \"Login failed for user 'datadog'.\", None, 0, 2147217843), None), 'Error opening connection to "
+            "\"ConnectRetryCount=2;Provider=MSOLEDBSQL;Data Source=localhost;User ID=datadog;Password=******;\"')",
+            id="regular_password",
+        ),
+        pytest.param(
+            "TCP-connection(ERROR: The requested address is not valid in its context), Exception: "
+            "OperationalError(com_error(-2147352567, 'Exception occurred.', (0, 'Microsoft OLE DB Driver for SQL "
+            "Server', \"Login failed for user 'datadog'.\", None, 0, 2147217843), None), 'Error opening connection to "
+            "\"ConnectRetryCount=2;Provider=MSOLEDBSQL;Data Source=localhost;User ID=datadog;Password=Pass\\\\Wrd;\"')",
+            "Pass\\Wrd",
+            "TCP-connection(ERROR: The requested address is not valid in its context), Exception: "
+            "OperationalError(com_error(-2147352567, 'Exception occurred.', (0, 'Microsoft OLE DB Driver for SQL "
+            "Server', \"Login failed for user 'datadog'.\", None, 0, 2147217843), None), 'Error opening connection to "
+            "\"ConnectRetryCount=2;Provider=MSOLEDBSQL;Data Source=localhost;User ID=datadog;Password=******;\"')",
+            id="password_with_backslash",
+        ),
+        pytest.param(
+            "TCP-connection(ERROR: The requested address is not valid in its context), Exception: "
+            "OperationalError(com_error(-2147352567, 'Exception occurred.', (0, 'Microsoft OLE DB Driver for SQL "
+            "Server', \"Login failed for user 'datadog'.\", None, 0, 2147217843), None), 'Error opening connection to "
+            "\"ConnectRetryCount=2;Provider=MSOLEDBSQL;Data Source=localhost;User ID=datadog;Password=;\"')",
+            "",
+            "TCP-connection(ERROR: The requested address is not valid in its context), Exception: "
+            "OperationalError(com_error(-2147352567, 'Exception occurred.', (0, 'Microsoft OLE DB Driver for SQL "
+            "Server', \"Login failed for user 'datadog'.\", None, 0, 2147217843), None), 'Error opening connection to "
+            "\"ConnectRetryCount=2;Provider=MSOLEDBSQL;Data Source=localhost;User ID=datadog;Password=;\"')",
+            id="empty_password",
+        ),
+        pytest.param(
+            "TCP-connection(ERROR: The requested address is not valid in its context), Exception: "
+            "OperationalError(com_error(-2147352567, 'Exception occurred.', (0, 'Microsoft OLE DB Driver for SQL "
+            "Server', \"Login failed for user 'datadog'.\", None, 0, 2147217843), None), 'Error opening connection to "
+            "\"ConnectRetryCount=2;Provider=MSOLEDBSQL;Data Source=localhost;User ID=datadog;Password=;\"')",
+            None,
+            "TCP-connection(ERROR: The requested address is not valid in its context), Exception: "
+            "OperationalError(com_error(-2147352567, 'Exception occurred.', (0, 'Microsoft OLE DB Driver for SQL "
+            "Server', \"Login failed for user 'datadog'.\", None, 0, 2147217843), None), 'Error opening connection to "
+            "\"ConnectRetryCount=2;Provider=MSOLEDBSQL;Data Source=localhost;User ID=datadog;Password=;\"')",
+            id="no_password",
+        ),
+        pytest.param(
+            "TCP-connection(ERROR: The requested address is not valid in its context), Exception: "
+            "OperationalError(com_error(-2147352567, 'Exception occurred.', (0, 'Microsoft OLE DB Driver for SQL "
+            "Server', \"Login failed for user 'datadog'.\", None, 0, 2147217843), None), 'Error opening connection to "
+            "\"ConnectRetryCount=2;Provider=MSOLEDBSQL;Data Source=localhost;User ID=datadog;Password=\"12345\";\"')",
+            "\"12345!D!T\"",
+            "TCP-connection(ERROR: The requested address is not valid in its context), Exception: "
+            "OperationalError(com_error(-2147352567, 'Exception occurred.', (0, 'Microsoft OLE DB Driver for SQL "
+            "Server', \"Login failed for user 'datadog'.\", None, 0, 2147217843), None), 'Error opening connection to "
+            "\"ConnectRetryCount=2;Provider=MSOLEDBSQL;Data Source=localhost;User ID=datadog;Password=******;\"')",
+            id="password_with_quotes",
+        ),
+    ],
+)
+def test_obfuscate_error_msg(
+    error_message,
+    password,
+    expected_error_message,
+):
+    obfuscated_error_message = obfuscate_error_msg(error_message, password)
+    assert obfuscated_error_message == expected_error_message


### PR DESCRIPTION
### What does this PR do?
This PR fixes connection string password obfuscation in OLE DB driver error message when one or more backslash exist in the password. 

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4349

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
