### PR TITLE
Add new `ddtrace` license to known licenses

### DIFF
--- a/datadog_checks_dev/changelog.d/18217.added
+++ b/datadog_checks_dev/changelog.d/18217.added
@@ -1,0 +1,1 @@
+Add new `ddtrace` license to known licenses

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
@@ -90,6 +90,7 @@ KNOWN_LICENSES = {
     'bsd': 'BSD-3-Clause',
     'bsd license': 'BSD-3-Clause',
     '3-clause bsd license': 'BSD-3-Clause',
+    'LICENSE.BSD3': 'BSD-3-Clause',
     'new bsd license': 'BSD-3-Clause',
     'mit license': 'MIT',
     'psf': 'PSF',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add new `ddtrace` license to known licenses

### Motivation
<!-- What inspired you to submit this pull request? -->
https://github.com/DataDog/integrations-core/pull/18215

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
