### PR TITLE
Enforce format of timestamp logs attribute

### DIFF
--- a/datadog_checks_base/changelog.d/18218.added
+++ b/datadog_checks_base/changelog.d/18218.added
@@ -1,0 +1,1 @@
+Enforce format of timestamp logs attribute

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -1000,7 +1000,10 @@ class AgentCheck(object):
         Parameters:
 
             data (dict[str, str]):
-                The log data to send.
+                The log data to send. The following keys are treated specially, if present:
+
+                - timestamp: should be an integer or float representing the number of seconds since the Unix epoch
+                - ddtags: if not defined, it will automatically be set based on the instance's `tags` option
             cursor (dict[str, Any] or None):
                 Metadata associated with the log which will be saved to disk. The most recent value may be
                 retrieved with the `get_log_cursor` method.
@@ -1011,6 +1014,11 @@ class AgentCheck(object):
         attributes = data.copy()
         if 'ddtags' not in attributes and self.formatted_tags:
             attributes['ddtags'] = self.formatted_tags
+
+        timestamp = attributes.get('timestamp')
+        if timestamp is not None:
+            # convert seconds to milliseconds
+            attributes['timestamp'] = int(timestamp * 1000)
 
         datadog_agent.send_log(to_json(attributes), self.check_id)
         if cursor is not None:

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -614,6 +614,24 @@ class TestLogSubmission:
         assert check.get_log_cursor(stream='stream1') == {'data': '1'}
         assert check.get_log_cursor(stream='stream2') == {'data': '2'}
 
+    def test_timestamp(self, datadog_agent):
+        check = AgentCheck('check_name', {}, [{}])
+        check.check_id = 'test'
+
+        check.send_log({'message': 'foo', 'timestamp': 1722958617.2842212})
+        check.send_log({'message': 'bar', 'timestamp': 1722958619.2358432})
+        check.send_log({'message': 'baz', 'timestamp': 1722958620.5963688})
+
+        datadog_agent.assert_logs(
+            check.check_id,
+            [
+                {'message': 'foo', 'timestamp': 1722958617284},
+                {'message': 'bar', 'timestamp': 1722958619235},
+                {'message': 'baz', 'timestamp': 1722958620596},
+            ],
+        )
+        assert check.get_log_cursor() is None
+
 
 class TestLogsEnabledDetection:
     def test_default(self, datadog_agent):


### PR DESCRIPTION
### Motivation

Backend expects milliseconds but Python's timestamps are usually seconds