### PR TITLE
[postgres] add role_arn to support cross account iam auth

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -695,12 +695,18 @@ files:
             To enable IAM Authentication, set `aws.managed_authentication.enabled` to `true`.
             If `aws.managed_authentication.enabled` is set, then the `password` fields will be ignored.
             `aws.region` is required to enable IAM Authentication.
+
+            Optionally, you can set `aws.managed_authentication.role_arn` to specify the IAM role ARN.
+            This can be used to perform cross-account authentication.
           value:
             type: object
             properties:
             - name: enabled
               type: boolean
               example: false
+            - name: role_arn
+              type: string
+              example: arn:aws:iam::123456789012:role/MyRole
 
     - name: gcp
       description: |

--- a/postgres/changelog.d/18228.added
+++ b/postgres/changelog.d/18228.added
@@ -1,0 +1,1 @@
+Add new config option `role_arn` to aws managed authentication to support cross account iam auth.

--- a/postgres/datadog_checks/postgres/aws.py
+++ b/postgres/datadog_checks/postgres/aws.py
@@ -4,8 +4,21 @@
 import boto3
 
 
-def generate_rds_iam_token(host, port, username, region):
-    session = boto3.Session(region_name=region)
+def generate_rds_iam_token(host, port, username, region, role_arn=None):
+    if role_arn:
+        # when role_arn is defined, assume the role to generate the token
+        # this can be used for cross-account access
+        sts_client = boto3.client("sts")
+        assumed_role = sts_client.assume_role(RoleArn=role_arn, RoleSessionName="datadog-rds-iam-auth-session")
+        credentials = assumed_role["Credentials"]
+        session = boto3.Session(
+            aws_access_key_id=credentials["AccessKeyId"],
+            aws_secret_access_key=credentials["SecretAccessKey"],
+            aws_session_token=credentials["SessionToken"],
+            region_name=region,
+        )
+    else:
+        session = boto3.Session(region_name=region)
     client = session.client("rds")
     token = client.generate_db_auth_token(DBHostname=host, Port=port, DBUsername=username)
 

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -26,6 +26,7 @@ class ManagedAuthentication(BaseModel):
         frozen=True,
     )
     enabled: Optional[bool] = Field(None, examples=[False])
+    role_arn: Optional[str] = Field(None, examples=['arn:aws:iam::123456789012:role/MyRole'])
 
 
 class Aws(BaseModel):

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -620,6 +620,9 @@ instances:
         ## To enable IAM Authentication, set `aws.managed_authentication.enabled` to `true`.
         ## If `aws.managed_authentication.enabled` is set, then the `password` fields will be ignored.
         ## `aws.region` is required to enable IAM Authentication.
+        ##
+        ## Optionally, you can set `aws.managed_authentication.role_arn` to specify the IAM role ARN.
+        ## This can be used to perform cross-account authentication.
         #
         # managed_authentication: {}
 

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -793,6 +793,7 @@ class PostgreSql(AgentCheck):
                         username=self._config.user,
                         port=self._config.port,
                         region=region,
+                        role_arn=aws_managed_authentication.get('role_arn'),
                     )
             elif 'azure' in self.cloud_metadata:
                 azure_managed_authentication = self.cloud_metadata['azure']['managed_authentication']


### PR DESCRIPTION
### What does this PR do?
This PR adds new optional config option `role_arn` to postgres aws managed authentication.
For example:
```
aws:
    instance_endpoint: xxxxxxxx.us-east-1.rds.amazonaws.com
    region: us-east-1
    managed_authentication:
        enabled: true
        role_arn: arn:aws:iam::xxxxxxxx:role/rds-iam-role
```
The new `role_arn` option can be used to support cross aws account iam authentication. 

TODO: once the change is released, update public doc to include examples for cross account iam authentication.

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-3445

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
