### PR TITLE
Add the siem team to review logs integrations files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -284,4 +284,4 @@ docs/developer/process/integration-release.md                         @DataDog/a
 
 # LEAVE THE FOLLOWING LOG OWNERSHIP LAST IN THE FILE
 # Make sure logs team is the full owner for all logs related files
-**/assets/logs/                          @DataDog/logs-backend
+**/assets/logs/                          @DataDog/logs-backend @DataDog/siem-logs-reviewers


### PR DESCRIPTION
For Q3 2024, some engineer from the SIEM team will help the logs teams to review some integrations. This PR is to set ownership to this new team including SIEM engineers.
