### PR TITLE
Add pip cache to CI test jobs

### DIFF
--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -141,6 +141,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "${{ env.PYTHON_VERSION }}"
+        cache: 'pip'
 
     - name: Restore cache
       if: inputs.repo == 'core'
@@ -397,9 +398,9 @@ jobs:
 
     - name: Upload coverage data
       if: >
-        inputs.standard && 
-        !github.event.repository.private && 
-        always() && 
+        inputs.standard &&
+        !github.event.repository.private &&
+        always() &&
         inputs.pytest-args != '-m flaky'
       # Flaky tests will have low coverage, don't upload it to avoid pipeline failure
       uses: codecov/codecov-action@v4


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds a pip cache to our CI test jobs.

### Motivation
<!-- What inspired you to submit this pull request? -->
We install quite a few dependencies for in order to execute our tests in CI.
We've already introduced the pip cache to the job that builds our docs, it shaved 2 minutes off the job's runtime.
There have been no issues with it in several months, so it's time we try it for the test jobs too.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
