### PR TITLE
Update README.md

### DIFF
--- a/databricks/README.md
+++ b/databricks/README.md
@@ -469,8 +469,6 @@ Additional helpful documentation, links, and articles:
 
 - [Uploading a Script to Unity Catalog Volume][24]
 
-{{< partial name="whats-next/whats-next.html" >}}
-
 [1]: https://databricks.com/
 [2]: https://docs.datadoghq.com/integrations/spark/?tab=host
 [3]: https://app.datadoghq.com/integrations/spark

--- a/databricks/README.md
+++ b/databricks/README.md
@@ -244,23 +244,28 @@ chmod a+x /tmp/start_datadog.sh
 
 #### With a cluster-scoped init script 
 
-Cluster-scoped init scripts are init scripts defined in a cluster configuration. Cluster-scoped init scripts apply to both clusters you create and those created to run jobs.
+Cluster-scoped init scripts are init scripts defined in a cluster configuration. Cluster-scoped init scripts apply to both clusters you create and those created to run jobs. Databricks currently supports configuration and storage of init scripts via:
+- Workspace Files
+- Unity Catalog Volumes
+- Cloud Object Storage
 
 Use the Databricks UI to edit the cluster to run the init script:
 
 1. Choose one of the following scripts to install the Agent on the driver or on the driver and worker nodes of the cluster.
 2. Modify the script to suit your needs. For example, you can add tags or define a specific configuration for the integration.
-3. Save the script into your workspace with the **Workspace** menu on the left.
+3. Save the script into your workspace with the **Workspace** menu on the left. If using **Unity Catalog Volume**, save the script in your **Volume** with the **Catalog** menu on the left.
 4. On the cluster configuration page, click the **Advanced** options toggle.
 5. In the **Environment variables**, specify the `DD_API_KEY` environment variable and, optionally, the `DD_ENV` and the `DD_SITE` environment variables.
 6. Go to the **Init Scripts** tab.
-7. In the **Destination** dropdown, select the `Workspace` destination type.
-8. Specify a path to the init script.
+7. In the **Destination** dropdown, select the `Workspace` destination type. If using **Unity Catalog Volume**, in the **Destination** dropdown, select the `Volume` destination type.
+8. Specify a path to the init script. 
 9. Click on the **Add** button.
 
 If you stored your `datadog_init_script.sh` directly in the `Shared` workspace, you can access the file at the following path: `/Shared/datadog_init_script.sh`.
 
 If you stored your `datadog_init_script.sh` directly in a user workspace, you can access the file at the following path: `/Users/$EMAIL_ADDRESS/datadog_init_script.sh`.
+
+If you stored your `datadog_init_script.sh` directly in a `Unity Catalog Volume`, you can access the file at the following path: `/Volumes/$VOLUME_PATH/datadog_init_script.sh`.
 
 More information on cluster init scripts can be found in the [Databricks official documentation][16].
 
@@ -460,6 +465,10 @@ Need help? Contact [Datadog support][10].
 
 ## Further Reading
 
+Additional helpful documentation, links, and articles:
+
+- [Uploading a Script to Unity Catalog Volume][24]
+
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://databricks.com/
@@ -483,3 +492,4 @@ Need help? Contact [Datadog support][10].
 [21]: https://raw.githubusercontent.com/DataDog/integrations-core/master/databricks/images/databricks_dashboard.png
 [22]: https://www.datadoghq.com/blog/databricks-monitoring-datadog/
 [23]: https://app.datadoghq.com/integrations/spark
+[24]: https://docs.databricks.com/en/ingestion/add-data/upload-to-volume.html#upload-files-to-a-unity-catalog-volume

--- a/databricks/README.md
+++ b/databricks/README.md
@@ -244,7 +244,7 @@ chmod a+x /tmp/start_datadog.sh
 
 #### With a cluster-scoped init script 
 
-Cluster-scoped init scripts are init scripts defined in a cluster configuration. Cluster-scoped init scripts apply to both clusters you create and those created to run jobs. Databricks currently supports configuration and storage of init scripts via:
+Cluster-scoped init scripts are init scripts defined in a cluster configuration. Cluster-scoped init scripts apply to both clusters you create and those created to run jobs. Databricks supports configuration and storage of init scripts through:
 - Workspace Files
 - Unity Catalog Volumes
 - Cloud Object Storage


### PR DESCRIPTION
Update for support of Unity Catalog Volume

### What does this PR do?
- Request to add another option for installing Agent on Databricks Cluster (Legacy Integration). 
- Databricks looks to have support an option for using `init scripts` in their Unity Catalog Volumes:
 
**This is for only the `Cluster Scoped` option with sub-options:**
  - `All Nodes`
  - `Driver Only`
  - [DD Link](https://docs.datadoghq.com/integrations/databricks/?tab=driveronly#with-a-cluster-scoped-init-script)

  - Customer presented use-case and could not find documentation on DD side to validate. 
  - Was able to validate via Azure Sandbox environment.

**Databricks Reference**:
- [Databricks Unity Catalog](https://docs.databricks.com/en/data-governance/unity-catalog/get-started.html)
- [Upload files (script) to Unity Catalog Volume](https://docs.databricks.com/en/ingestion/add-data/upload-to-volume.html)
### Motivation

- [Zendesk Ticket](https://datadog.zendesk.com/agent/tickets/1768925)

- [Escalation with Verification](https://datadoghq.atlassian.net/browse/AGENT-11970)

- In the hopes to reduce customer inquiries/issues if wanting to use this method of installation (Legacy Integration).

### Additional Notes
- [Where Can `init scripts` be installed?](https://docs.databricks.com/en/init-scripts/index.html#where-can-init-scripts-be-installed)


Shared access mode | Single access mode | No-isolation shared access mode
-- | -- | --
Workspace files | Not supported | All supported Databricks Runtime versions | All supported Databricks Runtime versions
Volumes | 13.3 LTS | 13.3 LTS | Not supported
Cloud storage | 13.3 LTS | All supported Databricks Runtime versions | All supported Databricks Runtime versions




### Review checklist (to be filled by reviewers)

- [X ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ X] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [X ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [X ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
