### PR TITLE
Prevent hostname evaluating to None in sqlserver check

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -275,6 +275,10 @@ class SQLServer(AgentCheck):
 
     @property
     def resolved_hostname(self):
+        # ensure _resolved_hostname is never None when referenced by other parts
+        # of this check. If it falls back to None, this will result in gaps in data
+        if self._resolved_hostname is None:
+            return self.set_resolved_hostname()
         return self._resolved_hostname
 
     def load_static_information(self):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This change prevents a *very* bad bug where the host field on metrics and events will fall back to `None` when the static information cache reaches its TTL of 1 day. When this happens, we see gaps in data for sqlserver instances because our backend drops these as bad payloads. We can see an example of this happening in our integration environment:

![Screenshot 2024-08-07 at 1 11 00 PM](https://github.com/user-attachments/assets/0a19b0b1-157b-4791-aa48-3304888eb7dd)

... meanwhile, if we log the payloads we see the `host` value is set to `null`:

```{"host":null,"ddagentversion":"7.56.0","ddsource":"sqlserver",...
```

### Motivation
<!-- What inspired you to submit this pull request? -->

In this previous change https://github.com/DataDog/integrations-core/pull/17750 we updated the check to call

```python
    def check(self, _):
        if self.do_check:
            self.load_static_information()
```

on each check run. This function does a few things:

1. Checks to see we are missing key/value pairs in our static information cache
2. re-loads the cache if this is the case
3. if keys are missing, **it also resets the `self._resolved_hostname` value to `None`**, but it _never_ initializes the value

This makes the `load_static_information` not safe to call outside of the context of the `set_resolved_hostname` function. In order to prevent the resolved_hostname property from ever returning `None` we add a null check && re-initialize the value if necessary:

```python
        if self._resolved_hostname is None:
            return self.set_resolved_hostname()
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
