### PR TITLE
Bump the `pysnmp` version for py3.12

### DIFF
--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -73,7 +73,7 @@ pyopenssl==24.2.1; python_version > '3.0'
 pysmi==0.3.4; python_version < '3.0'
 pysmi==1.4.4; python_version > '3.0'
 pysnmp-mibs==0.1.6
-pysnmp==4.4.9
+pysnmp==4.4.10
 pysocks==1.7.1
 python-binary-memcached==0.26.1; sys_platform != 'win32' and python_version < '3.0'
 python-binary-memcached==0.31.2; sys_platform != 'win32' and python_version > '3.0'

--- a/snmp/changelog.d/18245.changed
+++ b/snmp/changelog.d/18245.changed
@@ -1,0 +1,1 @@
+bump pysnmp version to 4.9.10

--- a/snmp/changelog.d/18245.changed
+++ b/snmp/changelog.d/18245.changed
@@ -1,1 +1,0 @@
-bump pysnmp version to 4.9.10

--- a/snmp/changelog.d/18245.fixed
+++ b/snmp/changelog.d/18245.fixed
@@ -1,0 +1,1 @@
+Bump pysnmp version to 4.9.10

--- a/snmp/datadog_checks/snmp/commands.py
+++ b/snmp/datadog_checks/snmp/commands.py
@@ -9,6 +9,7 @@ from pysnmp.entity.rfc3413 import cmdgen
 from pysnmp.hlapi.asyncore.cmdgen import vbProcessor
 from pysnmp.proto import errind
 from pysnmp.proto.rfc1905 import endOfMibView
+from pysnmp.smi.rfc1902 import ObjectIdentity, ObjectType
 
 from datadog_checks.base.errors import CheckException
 
@@ -33,13 +34,17 @@ def snmp_get(config, oids, lookup_mib):
     def callback(  # type: ignore
         snmpEngine, sendRequestHandle, errorIndication, errorStatus, errorIndex, varBinds, cbCtx
     ):
-        var_binds = vbProcessor.unmakeVarBinds(snmpEngine, varBinds, lookup_mib)
+        if lookup_mib:
+            mibViewController = vbProcessor.getMibViewController(snmpEngine)
+            varBinds = [
+                ObjectType(ObjectIdentity(x[0]), x[1]).resolveWithMib(mibViewController, ignoreErrors=False)
+                for x in varBinds
+            ]
 
         cbCtx['error'] = errorIndication
-        cbCtx['var_binds'] = var_binds
+        cbCtx['var_binds'] = varBinds
 
     ctx = {}  # type: Dict[str, Any]
-
     var_binds = vbProcessor.makeVarBinds(config._snmp_engine, oids)
 
     cmdgen.GetCommandGenerator().sendVarBinds(

--- a/snmp/pyproject.toml
+++ b/snmp/pyproject.toml
@@ -47,7 +47,7 @@ deps = [
     "pysmi==0.3.4; python_version < '3.0'",
     "pysmi==1.4.4; python_version > '3.0'",
     "pysnmp-mibs==0.1.6",
-    "pysnmp==4.4.9",
+    "pysnmp==4.4.10",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR bumps `pysnmp` to fix integration tests for py3.12

### Motivation
<!-- What inspired you to submit this pull request? -->
[4.4.10](https://github.com/pysnmp/pysnmp/blob/main/CHANGES.txt) rebased MIB importing code onto `importlib` because `imp` is long deprecated. Python 3.12 removes `imp`.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
