### PR TITLE
Revert "[dbm] fix flapping sqlserver_version"

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -242,6 +242,7 @@ class SQLServer(AgentCheck):
         )
 
     def set_resolved_hostname(self):
+        # load static information cache
         self.load_static_information()
         if self._resolved_hostname is None:
             if self._config.reported_hostname:
@@ -758,7 +759,6 @@ class SQLServer(AgentCheck):
 
     def check(self, _):
         if self.do_check:
-            self.load_static_information()
             # configure custom queries for the check
             if self._query_manager is None:
                 # use QueryManager to process custom queries


### PR DESCRIPTION
Reverts DataDog/integrations-core#17750

Reverting this PR as it contains a *very* bad bug where the host field on metrics and events will fall back to `None` when the static information cache reaches its TTL of 1 day. When this happens, we see gaps in data for sqlserver instances because our backend drops these as bad payloads. We can see an example of this happening in our integration environment:

![Screenshot 2024-08-07 at 1 11 00 PM](https://github.com/user-attachments/assets/0a19b0b1-157b-4791-aa48-3304888eb7dd)

... meanwhile, if we log the payloads we see the `host` value is set to `null`:

```
{"host":null,"ddagentversion":"7.56.0","ddsource":"sqlserver",...
```

A follow up PR will be merged to fix the version tag issue in a subsequent release https://github.com/DataDog/integrations-core/pull/18237