### PR TITLE
Retry gitlab runner test if we get transient 502 response

### DIFF
--- a/gitlab_runner/tests/test_e2e.py
+++ b/gitlab_runner/tests/test_e2e.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import time
 
 from flaky import flaky
 
@@ -16,7 +17,10 @@ def _rerun_on_502_response(err, name, test, plugin):
     In this case we just want to retry the request without waiting.
     """
 
-    return 'Http status code 502 on url' in str(err)
+    we_retry = 'Http status code 502 on url' in str(err)
+    if we_retry:
+        time.sleep(5)
+    return we_retry
 
 
 @flaky(max_runs=5, rerun_filter=_rerun_on_502_response)

--- a/gitlab_runner/tests/test_e2e.py
+++ b/gitlab_runner/tests/test_e2e.py
@@ -2,12 +2,31 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+from flaky import flaky
+
 from datadog_checks.gitlab_runner import GitlabRunnerCheck
 
 from .common import CONFIG, CUSTOM_TAGS, GITLAB_RUNNER_TAGS
 
 
+def _rerun_on_502_response(err, name, test, plugin):
+    """
+    Gitlab randomly returns 502 sometimes even if it's up and running fine.
+
+    In this case we just want to retry the request without waiting.
+    """
+
+    return 'Http status code 502 on url' in str(err)
+
+
+@flaky(max_runs=5, rerun_filter=_rerun_on_502_response)
 def test_e2e(dd_agent_check):
+    """
+    Because this test's flakiness is very specific we still run it in master CI.
+
+    We retry it to get past the transient 502 response.
+    """
+
     aggregator = dd_agent_check(CONFIG)
     aggregator.assert_service_check(
         GitlabRunnerCheck.MASTER_SERVICE_CHECK_NAME, status=GitlabRunnerCheck.OK, tags=GITLAB_RUNNER_TAGS + CUSTOM_TAGS


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Reliable CI tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
