### PR TITLE
Add telemetry scraping for Autoscaling

### DIFF
--- a/datadog_cluster_agent/changelog.d/18265.added
+++ b/datadog_cluster_agent/changelog.d/18265.added
@@ -1,0 +1,1 @@
+Add telemetry scraping for Autoscaling

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
@@ -20,6 +20,20 @@ DEFAULT_METRICS = {
     'admission_webhooks_reconcile_success': 'admission_webhooks.reconcile_success',
     'admission_webhooks_response_duration': 'admission_webhooks.response_duration',
     'admission_webhooks_webhooks_received': 'admission_webhooks.webhooks_received',
+    'autoscaling_workload_autoscaler_conditions': 'autoscaling.workload.autoscaler_conditions',
+    'autoscaling_workload_horizontal_scaling_actions': 'autoscaling.workload.horizontal_scaling_actions',
+    'autoscaling_workload_horizontal_scaling_applied_replicas': 'autoscaling.workload.horizontal_scaling_applied_replicas',  # noqa: E501
+    'autoscaling_workload_horizontal_scaling_received_replicas': 'autoscaling.workload.horizontal_scaling_received_replicas',  # noqa: E501
+    'autoscaling_workload_queue_adds': 'autoscaling.workload.queue_adds',
+    'autoscaling_workload_queue_depth': 'autoscaling.workload.queue_depth',
+    'autoscaling_workload_queue_latency': 'autoscaling.workload.queue_latency',
+    'autoscaling_workload_queue_longest_running_processor': 'autoscaling.workload.queue_longest_running_processor',
+    'autoscaling_workload_queue_retries': 'autoscaling.workload.queue_retries',
+    'autoscaling_workload_queue_unfinished_work': 'autoscaling.workload.queue_unfinished_work',
+    'autoscaling_workload_queue_work_duration': 'autoscaling.workload.queue_work_duration',
+    'autoscaling_workload_vertical_rollout_triggered': 'autoscaling.workload.vertical_rollout_triggered',
+    'autoscaling_workload_vertical_scaling_received_limits': 'autoscaling.workload.vertical_scaling_received_limits',
+    'autoscaling_workload_vertical_scaling_received_requests': 'autoscaling.workload.vertical_scaling_received_requests',  # noqa: E501
     'aggregator__flush': 'aggregator.flush',
     'aggregator__processed': 'aggregator.processed',
     'api_requests': 'api_requests',


### PR DESCRIPTION
### What does this PR do?

Add scraping of Autoscaling metrics in DCA check

### Motivation
Autoscaling Private Beta

### Additional Notes
Currently not documented and no payloads added on purpose. Things are likely to change and will really be available when we hit public beta, for which we will come back and add documentation and test paylods.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [x] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
