### PR TITLE
Enable local check only after installing it in agent container.

### DIFF
--- a/ddev/changelog.d/18271.fixed
+++ b/ddev/changelog.d/18271.fixed
@@ -1,0 +1,2 @@
+Enable local check only after installing it in agent container.
+This avoids crashing the agent container before we load the local version of the check.

--- a/ddev/changelog.d/18271.fixed
+++ b/ddev/changelog.d/18271.fixed
@@ -1,2 +1,3 @@
-Enable local check only after installing it in agent container.
-This avoids crashing the agent container before we load the local version of the check.
+Enable local check only after installing it in agent docker container.
+This avoids crashing the container with a version of the check that comes bundled with the agent before we load the local version of the check.
+For now limited to docker since that addresses an immediate CI issue. We'll extend it to native agent once we observe it and iron out any kinks.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
#### Before
If the combo of agent and integration found in the pre-built agent image crashes the agent, we can't test a fix with `ddev env test` because we crash before we get to load the local package

#### After
We disable the integration until we've installed the local package.

### Motivation
<!-- What inspired you to submit this pull request? -->

Easier tests, clearer mental model for users.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
