### PR TITLE
ik/ceph with robust ddev env test

### DIFF
--- a/ceph/changelog.d/18251.fixed
+++ b/ceph/changelog.d/18251.fixed
@@ -1,0 +1,1 @@
+Switch ceph to use built-in subprocess

--- a/ceph/datadog_checks/ceph/ceph.py
+++ b/ceph/datadog_checks/ceph/ceph.py
@@ -5,6 +5,7 @@ from __future__ import division
 
 import os
 import re
+import subprocess
 
 import simplejson as json
 from six import iteritems
@@ -12,7 +13,6 @@ from six import iteritems
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.config import _is_affirmative
 from datadog_checks.base.errors import CheckException
-from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
 
 class Ceph(AgentCheck):
@@ -62,7 +62,7 @@ class Ceph(AgentCheck):
         for cmd in ('mon_status', 'status', 'df detail', 'osd pool stats', 'osd perf', 'health detail', 'osd metadata'):
             try:
                 args = '{} {} -fjson'.format(ceph_args, cmd)
-                output, _, _ = get_subprocess_output(args.split(), self.log)
+                output = subprocess.run(args.split(), capture_output=True).stdout
                 res = json.loads(output)
             except Exception as e:
                 self.log.warning('Unable to parse data from cmd=%s: %s', cmd, e)

--- a/ceph/hatch.toml
+++ b/ceph/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["4.0", "5.0"]
 
 [envs.default.overrides]

--- a/ddev/changelog.d/18271.fixed
+++ b/ddev/changelog.d/18271.fixed
@@ -1,0 +1,2 @@
+Enable local check only after installing it in agent container.
+This avoids crashing the agent container before we load the local version of the check.


### PR DESCRIPTION
- **Enable local check only after installing it in agent container.**
- **add changelog**
- **Switch ceph to use built-in subprocess**
- **add changelog**

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
