### PR TITLE
Combine streams to single pipe

### DIFF
--- a/datadog_checks_base/changelog.d/18273.added
+++ b/datadog_checks_base/changelog.d/18273.added
@@ -1,0 +1,1 @@
+Combine streams to single pipe

--- a/datadog_checks_base/datadog_checks/base/utils/replay/execute.py
+++ b/datadog_checks_base/datadog_checks/base/utils/replay/execute.py
@@ -43,7 +43,7 @@ def run_with_isolation(check, aggregator, datadog_agent):
         ],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
         env=env_vars,
     )
     with process:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Combines `stderr` with `stdout` (using `stderr=subprocess.STDOUT`) so only one pipe carries both regular messages and error messages. 

### Motivation
<!-- What inspired you to submit this pull request? -->
`master` pipeline hangs when running `test_replay_all` in `datadog_checks_base`

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
