### PR TITLE
GlusterFS uses stdlib subprocess

### DIFF
--- a/glusterfs/changelog.d/18276.fixed
+++ b/glusterfs/changelog.d/18276.fixed
@@ -1,0 +1,1 @@
+GlusterFS uses stdlib subprocess

--- a/glusterfs/datadog_checks/glusterfs/check.py
+++ b/glusterfs/datadog_checks/glusterfs/check.py
@@ -10,13 +10,13 @@ except ImportError:
 
 import os
 import shlex
+import subprocess
 from typing import Dict, List  # noqa: F401
 
 from six import iteritems
 
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.config import is_affirmative
-from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
 from .metrics import BRICK_STATS, CLUSTER_STATS, PARSE_METRICS, VOL_SUBVOL_STATS, VOLUME_STATS
 
@@ -24,6 +24,17 @@ GLUSTER_VERSION = 'glfs_version'
 CLUSTER_STATUS = 'cluster_status'
 
 GSTATUS_PATH = '/opt/datadog-agent/embedded/sbin/gstatus'
+
+
+def get_subprocess_output(cmd, log, raise_on_empty_output=True):
+    log.debug('Running get_subprocess_output with cmd: %s', cmd)
+    res = subprocess.run(cmd, capture_output=True)
+    if not res.stdout and raise_on_empty_output:
+        msg = "expected subprocess output but had none."
+        if res.stderr:
+            msg += " Error: {}".format(str(res.stderr))
+        raise Exception(msg)
+    return res.stdout, res.stderr, res.returncode
 
 
 class GlusterfsCheck(AgentCheck):

--- a/glusterfs/hatch.toml
+++ b/glusterfs/hatch.toml
@@ -12,7 +12,7 @@ mypy-deps = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["7.9"]
 
 [envs.default.env-vars]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
