### PR TITLE
Add `log` transformer to the QueryManager

### DIFF
--- a/datadog_checks_base/changelog.d/18278.added
+++ b/datadog_checks_base/changelog.d/18278.added
@@ -1,0 +1,1 @@
+Add `log` transformer to the QueryManager

--- a/datadog_checks_base/datadog_checks/base/utils/db/query.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/query.py
@@ -188,8 +188,12 @@ class Query(object):
             if not isinstance(extra, dict):
                 raise ValueError('extra #{} of {} is not a mapping'.format(i, query_name))
 
+            extra_type = extra.get('type')  # type: str
             extra_name = extra.get('name')  # type: str
-            if not extra_name:
+            if extra_type == 'log':
+                # The name is unused
+                extra_name = 'log'
+            elif not extra_name:
                 raise ValueError('field `name` for extra #{} of {} is required'.format(i, query_name))
             elif not isinstance(extra_name, str):
                 raise ValueError('field `name` for extra #{} of {} must be a string'.format(i, query_name))
@@ -202,7 +206,6 @@ class Query(object):
 
             sources[extra_name] = {'type': 'extra', 'index': i}
 
-            extra_type = extra.get('type')  # type: str  # Is the key in a transformers dict
             if not extra_type:
                 if 'expression' in extra:
                     extra_type = 'expression'

--- a/datadog_checks_base/datadog_checks/base/utils/db/transform.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/transform.py
@@ -487,6 +487,58 @@ def get_percent(transformers, name, **modifiers):
     return percent
 
 
+def get_log(transformers, name, **modifiers):
+    # type: (Dict[str, Callable], str, Any) -> Transformer
+    """
+    Send a log.
+
+    The required modifiers are `attributes` and `cursor`.
+
+    For example, if you have this configuration:
+
+    ```yaml
+    columns:
+      - name: msg
+        type: source
+      - name: level
+        type: source
+      - name: time
+        type: source
+      - name: bar
+        type: source
+    extras:
+      - type: log
+        attributes:
+          message: msg
+          status: level
+          date: time
+          foo: bar
+    ```
+
+    then a log will be sent with the following attributes:
+
+    - `message`: value of the `msg` column
+    - `status`: value of the `level` column
+    - `date`: value of the `time` column
+    - `foo`: value of the `bar` column
+    """
+    available_sources = modifiers.pop('sources')
+    attributes = _compile_log_attributes(modifiers, available_sources)
+
+    del available_sources
+    send_log = transformers['__send_log'](transformers, **modifiers)
+    send_log = create_extra_transformer(send_log)
+
+    def log(sources, **kwargs):
+        data = {attribute: sources[source] for attribute, source in attributes.items()}
+        if kwargs['tags']:
+            data['ddtags'] = ','.join(kwargs['tags'])
+
+        send_log(sources, data)
+
+    return log
+
+
 COLUMN_TRANSFORMERS = {
     'temporal_percent': get_temporal_percent,
     'monotonic_gauge': get_monotonic_gauge,
@@ -498,7 +550,36 @@ COLUMN_TRANSFORMERS = {
     'time_elapsed': get_time_elapsed,
 }  # type: Dict[str, Transformer]
 
-EXTRA_TRANSFORMERS = {'expression': get_expression, 'percent': get_percent}  # type: Dict[str, TransformerFactory]
+EXTRA_TRANSFORMERS = {
+    'expression': get_expression,
+    'percent': get_percent,
+    'log': get_log,
+}  # type: Dict[str, TransformerFactory]
+
+
+def _compile_log_attributes(modifiers, available_sources):
+    attributes = modifiers.pop('attributes', None)
+    if attributes is None:
+        raise ValueError('the `attributes` parameter is required')
+    elif not isinstance(attributes, dict):
+        raise ValueError('the `attributes` parameter must be a mapping')
+    elif not attributes:
+        raise ValueError('the `attributes` parameter must not be empty')
+
+    for attribute, source in attributes.items():
+        if not isinstance(source, str):
+            raise ValueError(
+                'source `{}` for attribute `{}` of parameter `attributes` is not a string'.format(source, attribute)
+            )
+
+        if source not in available_sources:
+            raise ValueError(
+                'source `{}` for attribute `{}` of parameter `attributes` is not an available source'.format(
+                    source, attribute
+                )
+            )
+
+    return attributes
 
 
 def _compile_service_check_statuses(modifiers):

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -40,6 +40,7 @@ SUBMISSION_METHODS = {
     # These submission methods require more configuration than just a name
     # and a value and therefore must be defined as a custom transformer.
     'service_check': '__service_check',
+    'send_log': '__send_log',
 }
 
 

--- a/datadog_checks_base/tests/base/utils/db/common.py
+++ b/datadog_checks_base/tests/base/utils/db/common.py
@@ -4,6 +4,8 @@
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.db import QueryManager
 
+CHECK_ID = 'test:instance'
+
 
 def mock_executor(result=()):
     def executor(_):
@@ -18,6 +20,6 @@ def create_query_manager(*args, **kwargs):
         executor = mock_executor()
 
     check = kwargs.pop('check', None) or AgentCheck('test', {}, [{}])
-    check.check_id = 'test:instance'
+    check.check_id = CHECK_ID
 
     return QueryManager(check, executor, args, **kwargs)

--- a/datadog_checks_base/tests/base/utils/db/test_query_manager.py
+++ b/datadog_checks_base/tests/base/utils/db/test_query_manager.py
@@ -871,6 +871,123 @@ class TestTransformerCompilation:
         ):
             query_manager.compile_queries()
 
+    def test_log_no_attributes(self):
+        query_manager = create_query_manager(
+            {
+                'name': 'test query',
+                'query': 'foo',
+                'columns': [{'name': 'test.foo', 'type': 'source'}],
+                'extras': [
+                    {'type': 'log'},
+                ],
+                'tags': ['test:bar'],
+            },
+            executor=mock_executor([[]]),
+            tags=['test:foo'],
+        )
+
+        with pytest.raises(
+            ValueError,
+            match='^error compiling type `log` for extra log of test query: the `attributes` parameter is required$',
+        ):
+            query_manager.compile_queries()
+
+    def test_log_attributes_not_dict(self):
+        query_manager = create_query_manager(
+            {
+                'name': 'test query',
+                'query': 'foo',
+                'columns': [{'name': 'test.foo', 'type': 'source'}],
+                'extras': [
+                    {'type': 'log', 'attributes': 9000},
+                ],
+                'tags': ['test:bar'],
+            },
+            executor=mock_executor([[]]),
+            tags=['test:foo'],
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                '^error compiling type `log` for extra log of test query: '
+                'the `attributes` parameter must be a mapping$'
+            ),
+        ):
+            query_manager.compile_queries()
+
+    def test_log_attributes_empty(self):
+        query_manager = create_query_manager(
+            {
+                'name': 'test query',
+                'query': 'foo',
+                'columns': [{'name': 'test.foo', 'type': 'source'}],
+                'extras': [
+                    {'type': 'log', 'attributes': {}},
+                ],
+                'tags': ['test:bar'],
+            },
+            executor=mock_executor([[]]),
+            tags=['test:foo'],
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                '^error compiling type `log` for extra log of test query: '
+                'the `attributes` parameter must not be empty$'
+            ),
+        ):
+            query_manager.compile_queries()
+
+    def test_log_attributes_status_not_string(self):
+        query_manager = create_query_manager(
+            {
+                'name': 'test query',
+                'query': 'foo',
+                'columns': [{'name': 'test.foo', 'type': 'source'}],
+                'extras': [
+                    {'type': 'log', 'attributes': {'message': 9000}},
+                ],
+                'tags': ['test:bar'],
+            },
+            executor=mock_executor([[]]),
+            tags=['test:foo'],
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                '^error compiling type `log` for extra log of test query: '
+                'source `9000` for attribute `message` of parameter `attributes` is not a string$'
+            ),
+        ):
+            query_manager.compile_queries()
+
+    def test_log_attributes_status_invalid(self):
+        query_manager = create_query_manager(
+            {
+                'name': 'test query',
+                'query': 'foo',
+                'columns': [{'name': 'test.foo', 'type': 'source'}],
+                'extras': [
+                    {'type': 'log', 'attributes': {'message': 'bar'}},
+                ],
+                'tags': ['test:bar'],
+            },
+            executor=mock_executor([[]]),
+            tags=['test:foo'],
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                '^error compiling type `log` for extra log of test query: '
+                'source `bar` for attribute `message` of parameter `attributes` is not an available source$'
+            ),
+        ):
+            query_manager.compile_queries()
+
 
 class TestSubmission:
     @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation

Follow-up to https://github.com/DataDog/integrations-core/pull/18019, allow customers to submit logs from databases

### Additional notes

I haven't yet thought of a way for configuring the cursor plus modifying the query based on the cursor, that will come in another PR