### PR TITLE
MySQL - Remove cryptography from pyproject.toml

### DIFF
--- a/mysql/changelog.d/18280.fixed
+++ b/mysql/changelog.d/18280.fixed
@@ -1,0 +1,1 @@
+Removed cryptography from optional dependencies

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -39,8 +39,6 @@ license = "BSD-3-Clause"
 deps = [
     "cachetools==3.1.1; python_version < '3.0'",
     "cachetools==5.4.0; python_version > '3.0'",
-    "cryptography==3.3.2; python_version < '3.0'",
-    "cryptography==42.0.8; python_version > '3.0'",
     "pymysql==0.10.1; python_version < '3.0'",
     "pymysql==1.1.1; python_version > '3.0'",
 ]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
The `cryptography` module is not used in any of the python files
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
