### PR TITLE
Fix errors resulting from ignore_databases

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -63,7 +63,8 @@ files:
     - name: ignore_databases
       description: |
         A list of database to ignore. No metrics or statement samples will be collected for these databases.
-        Each value can be a plain string or a Postgres pattern.
+        Each value can be a plain string or a Postgres pattern. If you want to ignore the postgres database,
+        set collect_default_database to false in addition to adding it to this array.
         For more information on how patterns work, see https://www.postgresql.org/docs/12/functions-matching.html
       value:
         type: array

--- a/postgres/changelog.d/18287.fixed
+++ b/postgres/changelog.d/18287.fixed
@@ -1,0 +1,2 @@
+Fix errors resulting from certain ignore_databases settings
+Clarified documentation on ignore_databases

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -73,7 +73,8 @@ instances:
 
     ## @param ignore_databases - list of strings - optional
     ## A list of database to ignore. No metrics or statement samples will be collected for these databases.
-    ## Each value can be a plain string or a Postgres pattern.
+    ## Each value can be a plain string or a Postgres pattern. If you want to ignore the postgres database,
+    ## set collect_default_database to false in addition to adding it to this array.
     ## For more information on how patterns work, see https://www.postgresql.org/docs/12/functions-matching.html
     #
     # ignore_databases:

--- a/postgres/datadog_checks/postgres/metrics_cache.py
+++ b/postgres/datadog_checks/postgres/metrics_cache.py
@@ -97,17 +97,18 @@ class PostgresMetricsCache:
             'metrics': metrics,
             'query': "SELECT psd.datname, {metrics_columns} "
             "FROM pg_stat_database psd "
-            "JOIN pg_database pd ON psd.datname = pd.datname",
+            "JOIN pg_database pd ON psd.datname = pd.datname "
+            "WHERE 1=1",
             'relation': False,
             'name': 'instance_metrics',
         }
 
-        res["query"] += " WHERE " + " AND ".join(
-            "psd.datname not ilike '{}'".format(db) for db in self.config.ignore_databases
-        )
-
         if self.config.dbstrict:
             res["query"] += " AND psd.datname in('{}')".format(self.config.dbname)
+        elif len(self.config.ignore_databases) > 0:
+            res["query"] += " AND " + " AND ".join(
+                "psd.datname not ilike '{}'".format(db) for db in self.config.ignore_databases
+            )
 
         return res
 

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -286,7 +286,7 @@ class PostgresStatementSamples(DBMAsyncJob):
     def _get_available_activity_columns(self, all_expected_columns):
         with self._check._get_main_db() as conn:
             with conn.cursor(cursor_factory=CommenterDictCursor) as cursor:
-                try:                    
+                try:
                     cursor.execute(
                         "select * from {pg_stat_activity_view} LIMIT 0".format(
                             pg_stat_activity_view=self._config.pg_stat_activity_view
@@ -296,10 +296,14 @@ class PostgresStatementSamples(DBMAsyncJob):
                     available_columns = [c for c in all_expected_columns if c in all_columns]
                     missing_columns = set(all_expected_columns) - set(available_columns)
                     if missing_columns:
-                        self._log.debug("missing the following expected columns from pg_stat_activity: %s", missing_columns)
+                        self._log.debug(
+                            "missing the following expected columns from pg_stat_activity: %s", missing_columns
+                        )
                     self._log.debug("found available pg_stat_activity columns: %s", available_columns)
                 except psycopg2.errors.InvalidSchemaName as e:
-                    self._log.warning("cannot collect activity due to invalid schema in dbname=%s: %s", self._config.dbname, repr(e))
+                    self._log.warning(
+                        "cannot collect activity due to invalid schema in dbname=%s: %s", self._config.dbname, repr(e)
+                    )
                     return None
                 except psycopg2.DatabaseError as e:
                     # if the schema is valid then it's some problem with the function (missing, or invalid permissions,
@@ -440,11 +444,12 @@ class PostgresStatementSamples(DBMAsyncJob):
             self._check.count(
                 "dd.postgres.statement_samples.error",
                 1,
-                tags=self.tags + ["error:missing-activity-columns"] + self._check._get_debug_tags(),
+                tags=self.tags + ["error:explain-no_plans_possible"] + self._check._get_debug_tags(),
                 hostname=self._check.resolved_hostname,
                 raw=True,
             )
             return
+        print(pg_activity_cols)
         rows = self._get_new_pg_stat_activity(pg_activity_cols)
         rows = self._filter_and_normalize_statement_rows(rows)
         submitted_count = 0

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -286,17 +286,42 @@ class PostgresStatementSamples(DBMAsyncJob):
     def _get_available_activity_columns(self, all_expected_columns):
         with self._check._get_main_db() as conn:
             with conn.cursor(cursor_factory=CommenterDictCursor) as cursor:
-                cursor.execute(
-                    "select * from {pg_stat_activity_view} LIMIT 0".format(
-                        pg_stat_activity_view=self._config.pg_stat_activity_view
+                try:                    
+                    cursor.execute(
+                        "select * from {pg_stat_activity_view} LIMIT 0".format(
+                            pg_stat_activity_view=self._config.pg_stat_activity_view
+                        )
                     )
-                )
-                all_columns = {i[0] for i in cursor.description}
-                available_columns = [c for c in all_expected_columns if c in all_columns]
-                missing_columns = set(all_expected_columns) - set(available_columns)
-                if missing_columns:
-                    self._log.debug("missing the following expected columns from pg_stat_activity: %s", missing_columns)
-                self._log.debug("found available pg_stat_activity columns: %s", available_columns)
+                    all_columns = {i[0] for i in cursor.description}
+                    available_columns = [c for c in all_expected_columns if c in all_columns]
+                    missing_columns = set(all_expected_columns) - set(available_columns)
+                    if missing_columns:
+                        self._log.debug("missing the following expected columns from pg_stat_activity: %s", missing_columns)
+                    self._log.debug("found available pg_stat_activity columns: %s", available_columns)
+                except psycopg2.errors.InvalidSchemaName as e:
+                    self._log.warning("cannot collect activity due to invalid schema in dbname=%s: %s", self._config.dbname, repr(e))
+                    return None
+                except psycopg2.DatabaseError as e:
+                    # if the schema is valid then it's some problem with the function (missing, or invalid permissions,
+                    # incorrect definition)
+                    self._check.record_warning(
+                        DatabaseConfigurationError.undefined_explain_function,
+                        warning_with_tags(
+                            "Unable to collect activity columns in dbname=%s. Check that the function "
+                            "%s exists in the database. See "
+                            "https://docs.datadoghq.com/database_monitoring/setup_postgres/troubleshooting#%s "
+                            "for more details: %s",
+                            self._config.dbname,
+                            self._config.pg_stat_activity_view,
+                            DatabaseConfigurationError.undefined_activity_view.value,
+                            str(e),
+                            host=self._check.resolved_hostname,
+                            dbname=self._config.dbname,
+                            code=DatabaseConfigurationError.undefined_activity_view.value,
+                        ),
+                    )
+                    return None
+
         return available_columns
 
     def _filter_and_normalize_statement_rows(self, rows):
@@ -409,6 +434,17 @@ class PostgresStatementSamples(DBMAsyncJob):
     def _collect_statement_samples(self):
         start_time = time.time()
         pg_activity_cols = self._get_pg_stat_activity_cols_cached(PG_STAT_ACTIVITY_COLS)
+        # If we couldn't get activity columns it's likely we're missing schema access
+        # Or critical functions are missing
+        if pg_activity_cols is None:
+            self._check.count(
+                "dd.postgres.statement_samples.error",
+                1,
+                tags=self.tags + ["error:missing-activity-columns"] + self._check._get_debug_tags(),
+                hostname=self._check.resolved_hostname,
+                raw=True,
+            )
+            return
         rows = self._get_new_pg_stat_activity(pg_activity_cols)
         rows = self._filter_and_normalize_statement_rows(rows)
         submitted_count = 0

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -313,11 +313,10 @@ class PostgresStatementSamples(DBMAsyncJob):
                         warning_with_tags(
                             "Unable to collect activity columns in dbname=%s. Check that the function "
                             "%s exists in the database. See "
-                            "https://docs.datadoghq.com/database_monitoring/setup_postgres/troubleshooting#%s "
+                            "https://docs.datadoghq.com/database_monitoring/setup_postgres/troubleshooting "
                             "for more details: %s",
                             self._config.dbname,
                             self._config.pg_stat_activity_view,
-                            DatabaseConfigurationError.undefined_activity_view.value,
                             str(e),
                             host=self._check.resolved_hostname,
                             dbname=self._config.dbname,

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -267,7 +267,7 @@ class PostgresStatementSamples(DBMAsyncJob):
 
         with self._check._get_main_db() as conn:
             with conn.cursor(cursor_factory=CommenterDictCursor) as cursor:
-                self._log.debug("Running query [%s] %s", query, params)
+                self._log.warning("Running query [%s] %s", query, params)
                 cursor.execute(query, params)
                 rows = cursor.fetchall()
 
@@ -373,7 +373,7 @@ class PostgresStatementSamples(DBMAsyncJob):
         if self._config.dbstrict:
             extra_filters = " AND datname = %s"
             params = params + (self._config.dbname,)
-        else:
+        elif len(self._config.ignore_databases) > 0:
             extra_filters = " AND " + " AND ".join("datname NOT ILIKE %s" for _ in self._config.ignore_databases)
             params = params + tuple(self._config.ignore_databases)
         if filter_stale_idle_conn and self._activity_last_query_start:

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -267,7 +267,7 @@ class PostgresStatementSamples(DBMAsyncJob):
 
         with self._check._get_main_db() as conn:
             with conn.cursor(cursor_factory=CommenterDictCursor) as cursor:
-                self._log.warning("Running query [%s] %s", query, params)
+                self._log.debug("Running query [%s] %s", query, params)
                 cursor.execute(query, params)
                 rows = cursor.fetchall()
 
@@ -449,7 +449,6 @@ class PostgresStatementSamples(DBMAsyncJob):
                 raw=True,
             )
             return
-        print(pg_activity_cols)
         rows = self._get_new_pg_stat_activity(pg_activity_cols)
         rows = self._filter_and_normalize_statement_rows(rows)
         submitted_count = 0

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -31,7 +31,6 @@ class DatabaseConfigurationError(Enum):
     pg_stat_statements_not_created = 'pg-stat-statements-not-created'
     pg_stat_statements_not_loaded = 'pg-stat-statements-not-loaded'
     undefined_explain_function = 'undefined-explain-function'
-    undefined_activity_view = 'undefined-pg-stat-activity-view'
     high_pg_stat_statements_max = 'high-pg-stat-statements-max-configuration'
     autodiscovered_databases_exceeds_limit = 'autodiscovered-databases-exceeds-limit'
     autodiscovered_metrics_exceeds_collection_interval = "autodiscovered-metrics-exceeds-collection-interval"

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -31,6 +31,7 @@ class DatabaseConfigurationError(Enum):
     pg_stat_statements_not_created = 'pg-stat-statements-not-created'
     pg_stat_statements_not_loaded = 'pg-stat-statements-not-loaded'
     undefined_explain_function = 'undefined-explain-function'
+    undefined_activity_view = 'undefined-pg-stat-activity-view'
     high_pg_stat_statements_max = 'high-pg-stat-statements-max-configuration'
     autodiscovered_databases_exceeds_limit = 'autodiscovered-databases-exceeds-limit'
     autodiscovered_metrics_exceeds_collection_interval = "autodiscovered-metrics-exceeds-collection-interval"

--- a/postgres/tests/test_connections.py
+++ b/postgres/tests/test_connections.py
@@ -184,9 +184,9 @@ def test_conn_pool_no_leaks_on_prune(pg_instance):
         deadline = conn_info.deadline
         approximate_deadline = datetime.datetime.now() + datetime.timedelta(milliseconds=ttl_long)
         assert (
-            approximate_deadline - datetime.timedelta(seconds=1)
+            approximate_deadline - datetime.timedelta(seconds=2)
             < deadline
-            < approximate_deadline + datetime.timedelta(seconds=1)
+            < approximate_deadline + datetime.timedelta(seconds=2)
         )
         assert not db.closed
         assert db.status == psycopg2.extensions.STATUS_READY

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -705,7 +705,7 @@ def test_failed_explain_handling(
             "dogs_noschema",
             "SELECT * FROM kennel WHERE id = %s",
             123,
-            "error:missing-activity-columns",
+            "error:explain-no_plans_possible",
             [{'code': 'invalid_schema', 'message': "<class 'psycopg2.errors.InvalidSchemaName'>"}],
             StatementTruncationState.not_truncated.value,
             [],
@@ -756,8 +756,7 @@ def test_failed_explain_handling(
         ),
     ],
 )
-@pytest.mark.parametrize("dbstrict,ignore_databases", [(True, []), (False, ['dogs']), (False, [])])
-
+@pytest.mark.parametrize("dbstrict,ignore_databases", [(True, [])])
 def test_statement_samples_collect(
     aggregator,
     integration_check,
@@ -774,7 +773,7 @@ def test_statement_samples_collect(
     datadog_agent,
     expected_warnings,
     dbstrict,
-    ignore_databases
+    ignore_databases,
 ):
     dbm_instance['pg_stat_activity_view'] = pg_stat_activity_view
     dbm_instance['query_metrics']['enabled'] = False
@@ -783,6 +782,8 @@ def test_statement_samples_collect(
     dbm_instance['ignore_databases'] = ignore_databases
     check = integration_check(dbm_instance)
     check._connect()
+
+    print("EXECUTING: {dbm_instance}".format(dbm_instance=dbm_instance))
 
     conn = psycopg2.connect(host=HOST, dbname=dbname, user=user, password=password)
     # we are able to see the full query (including the raw parameters) in pg_stat_activity because psycopg2 uses

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -785,8 +785,6 @@ def test_statement_samples_collect(
     check = integration_check(dbm_instance)
     check._connect()
 
-    print("EXECUTING: {dbm_instance}".format(dbm_instance=dbm_instance))
-
     conn = psycopg2.connect(host=HOST, dbname=dbname, user=user, password=password)
     # we are able to see the full query (including the raw parameters) in pg_stat_activity because psycopg2 uses
     # the simple query protocol, sending the whole query as a plain string to postgres.

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -24,7 +24,7 @@ from datadog_checks.postgres.statement_samples import (
     StatementTruncationState,
 )
 from datadog_checks.postgres.statements import PG_STAT_STATEMENTS_METRICS_COLUMNS, PG_STAT_STATEMENTS_TIMING_COLUMNS
-from datadog_checks.postgres.util import DatabaseConfigurationError, payload_pg_version
+from datadog_checks.postgres.util import payload_pg_version
 from datadog_checks.postgres.version_utils import V12
 
 from .common import (

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -756,7 +756,9 @@ def test_failed_explain_handling(
         ),
     ],
 )
-@pytest.mark.parametrize("dbstrict,ignore_databases", [(True, [])])
+@pytest.mark.parametrize(
+    "dbstrict,ignore_databases", [(True, []), (False, []), (False, ['foo']), (False, ['postgres'])]
+)
 def test_statement_samples_collect(
     aggregator,
     integration_check,

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -756,6 +756,8 @@ def test_failed_explain_handling(
         ),
     ],
 )
+@pytest.mark.parametrize("dbstrict,ignore_databases", [(True, []), (False, ['dogs']), (False, [])])
+
 def test_statement_samples_collect(
     aggregator,
     integration_check,
@@ -771,9 +773,13 @@ def test_statement_samples_collect(
     expected_statement_truncated,
     datadog_agent,
     expected_warnings,
+    dbstrict,
+    ignore_databases
 ):
     dbm_instance['pg_stat_activity_view'] = pg_stat_activity_view
     dbm_instance['query_metrics']['enabled'] = False
+    dbm_instance['dbstrict'] = dbstrict
+    dbm_instance['ignore_databases'] = ignore_databases
     check = integration_check(dbm_instance)
     check._connect()
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
* Fixes various edge case errors that could result from `ignore_databases` being set in combination with other options
* Clarifies the documentation on how `ignore_databases` interacts with `collect_default_database`

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
