### PR TITLE
Retry envoy docker setup more times

### DIFF
--- a/envoy/tests/conftest.py
+++ b/envoy/tests/conftest.py
@@ -31,7 +31,7 @@ def dd_environment():
         build=True,
         endpoints="{}/stats".format(URL),
         log_patterns=['front-envoy(.*?)all dependencies initialized. starting workers'],
-        attempts=2,
+        attempts=5,
     ):
         # Exercising envoy a bit will trigger extra metrics
         requests.get('http://{}:8000/service/1'.format(HOST))


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
CI occasionally fails with retry errors when we fail to set up the docker containers for envoy.

This adds some more retries to get us to pass more often.

### Motivation
<!-- What inspired you to submit this pull request? -->


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
