### PR TITLE
[mongo] fix missing metric attributes for slow operations from logs

### DIFF
--- a/mongo/datadog_checks/mongo/dbm/slow_operations.py
+++ b/mongo/datadog_checks/mongo/dbm/slow_operations.py
@@ -200,9 +200,12 @@ class MongoSlowOperations(DBMAsyncJob):
             "plan_cache_key": slow_operation.get("planCacheKey"),  # only available with profiling
             "query_framework": slow_operation.get("queryFramework"),
             # metrics
+            # mills from profiler, durationMillis from logs
             "mills": slow_operation.get("millis", slow_operation.get("durationMillis", 0)),
-            "num_yields": slow_operation.get("numYield", 0),
-            "response_length": slow_operation.get("responseLength", 0),
+            # numYield from profiler, numYields from logs
+            "num_yields": slow_operation.get("numYield", slow_operation.get("numYields", 0)),
+            # responseLength from profiler, reslen from logs
+            "response_length": slow_operation.get("responseLength", slow_operation.get("reslen", 0)),
             "nreturned": slow_operation.get("nreturned"),
             "nmatched": slow_operation.get("nMatched"),
             "nmodified": slow_operation.get("nModified"),

--- a/mongo/tests/results/slow-operations-mongos.json
+++ b/mongo/tests/results/slow-operations-mongos.json
@@ -22,7 +22,7 @@
                 "query_signature": "a81f9d3c17192d68",
                 "statement": "{\"q\": {\"age\": {\"$gt\": 18}}, \"u\": {\"$set\": {\"subscribed\": false}}, \"multi\": true, \"upsert\": false, \"comment\": \"update customers subscription status by age\"}",
                 "mills": 74,
-                "num_yields": 0,
+                "num_yields": 4,
                 "response_length": 0,
                 "nmatched": 608,
                 "nmodified": 441,
@@ -77,8 +77,8 @@
                 "query_signature": "c5b7bcd45c4d9e9",
                 "statement": "{\"update\": \"customers\", \"ordered\": true, \"comment\": \"update customers subscription status by age\", \"$db\": \"test\"}",
                 "mills": 74,
-                "num_yields": 0,
-                "response_length": 0,
+                "num_yields": 4,
+                "response_length": 60,
                 "cpu_nanos": 74715957,
                 "client": {
                     "hostname": "192.168.65.1:58133"
@@ -130,7 +130,7 @@
                 "query_signature": "ec24a2e9aacce5a0",
                 "statement": "{\"q\": {\"age\": {\"$gt\": 35}}, \"u\": {\"$set\": {\"subscribed\": true}}, \"multi\": true, \"upsert\": false, \"comment\": \"update customers subscription status by age\"}",
                 "mills": 27,
-                "num_yields": 0,
+                "num_yields": 2,
                 "response_length": 0,
                 "nmatched": 495,
                 "nmodified": 495,
@@ -185,8 +185,8 @@
                 "query_signature": "c5b7bcd45c4d9e9",
                 "statement": "{\"update\": \"customers\", \"ordered\": true, \"comment\": \"update customers subscription status by age\", \"$db\": \"test\"}",
                 "mills": 27,
-                "num_yields": 0,
-                "response_length": 0,
+                "num_yields": 2,
+                "response_length": 60,
                 "cpu_nanos": 27721625,
                 "client": {
                     "hostname": "192.168.65.1:58133"
@@ -294,7 +294,7 @@
                 "statement": "{\"update\": \"customers\", \"ordered\": true, \"comment\": \"update customers subscription status by age\", \"$db\": \"test\"}",
                 "mills": 15,
                 "num_yields": 0,
-                "response_length": 0,
+                "response_length": 60,
                 "cpu_nanos": 15198542,
                 "client": {
                     "hostname": "192.168.65.1:58133"
@@ -350,7 +350,7 @@
                 "query_framework": "classic",
                 "mills": 12,
                 "num_yields": 0,
-                "response_length": 0,
+                "response_length": 14089,
                 "nreturned": 101,
                 "keys_examined": 540,
                 "docs_examined": 540,
@@ -389,7 +389,7 @@
                 "query_framework": "classic",
                 "mills": 14,
                 "num_yields": 0,
-                "response_length": 0,
+                "response_length": 110,
                 "nreturned": 0,
                 "keys_examined": 612,
                 "docs_examined": 612,
@@ -420,7 +420,7 @@
                 "query_signature": "a81f9d3c17192d68",
                 "statement": "{\"q\": {\"age\": {\"$gt\": 18}}, \"u\": {\"$set\": {\"subscribed\": false}}, \"multi\": true, \"upsert\": false, \"comment\": \"update customers subscription status by age\"}",
                 "mills": 74,
-                "num_yields": 0,
+                "num_yields": 4,
                 "response_length": 0,
                 "nmatched": 608,
                 "nmodified": 441,
@@ -475,8 +475,8 @@
                 "query_signature": "3583b3bc9478cec2",
                 "statement": "{\"update\": \"customers\", \"ordered\": true, \"comment\": \"update customers subscription status by age\", \"$db\": \"integration\"}",
                 "mills": 74,
-                "num_yields": 0,
-                "response_length": 0,
+                "num_yields": 4,
+                "response_length": 60,
                 "cpu_nanos": 74715957,
                 "client": {
                     "hostname": "192.168.65.1:58133"
@@ -528,7 +528,7 @@
                 "query_signature": "ec24a2e9aacce5a0",
                 "statement": "{\"q\": {\"age\": {\"$gt\": 35}}, \"u\": {\"$set\": {\"subscribed\": true}}, \"multi\": true, \"upsert\": false, \"comment\": \"update customers subscription status by age\"}",
                 "mills": 27,
-                "num_yields": 0,
+                "num_yields": 2,
                 "response_length": 0,
                 "nmatched": 495,
                 "nmodified": 495,
@@ -583,8 +583,8 @@
                 "query_signature": "3583b3bc9478cec2",
                 "statement": "{\"update\": \"customers\", \"ordered\": true, \"comment\": \"update customers subscription status by age\", \"$db\": \"integration\"}",
                 "mills": 27,
-                "num_yields": 0,
-                "response_length": 0,
+                "num_yields": 2,
+                "response_length": 60,
                 "cpu_nanos": 27721625,
                 "client": {
                     "hostname": "192.168.65.1:58133"
@@ -692,7 +692,7 @@
                 "statement": "{\"update\": \"customers\", \"ordered\": true, \"comment\": \"update customers subscription status by age\", \"$db\": \"integration\"}",
                 "mills": 15,
                 "num_yields": 0,
-                "response_length": 0,
+                "response_length": 60,
                 "cpu_nanos": 15198542,
                 "client": {
                     "hostname": "192.168.65.1:58133"
@@ -748,7 +748,7 @@
                 "query_framework": "classic",
                 "mills": 12,
                 "num_yields": 0,
-                "response_length": 0,
+                "response_length": 14089,
                 "nreturned": 101,
                 "keys_examined": 540,
                 "docs_examined": 540,
@@ -787,7 +787,7 @@
                 "query_framework": "classic",
                 "mills": 14,
                 "num_yields": 0,
-                "response_length": 0,
+                "response_length": 110,
                 "nreturned": 0,
                 "keys_examined": 612,
                 "docs_examined": 612,

--- a/mongo/tests/results/slow-operations-standalone.json
+++ b/mongo/tests/results/slow-operations-standalone.json
@@ -213,7 +213,7 @@
                 "query_signature": "a81f9d3c17192d68",
                 "statement": "{\"q\": {\"age\": {\"$gt\": 18}}, \"u\": {\"$set\": {\"subscribed\": false}}, \"multi\": true, \"upsert\": false, \"comment\": \"update customers subscription status by age\"}",
                 "mills": 74,
-                "num_yields": 0,
+                "num_yields": 4,
                 "response_length": 0,
                 "nmatched": 608,
                 "nmodified": 441,
@@ -268,8 +268,8 @@
                 "query_signature": "c5b7bcd45c4d9e9",
                 "statement": "{\"update\": \"customers\", \"ordered\": true, \"comment\": \"update customers subscription status by age\", \"$db\": \"test\"}",
                 "mills": 74,
-                "num_yields": 0,
-                "response_length": 0,
+                "num_yields": 4,
+                "response_length": 60,
                 "cpu_nanos": 74715957,
                 "client": {
                     "hostname": "192.168.65.1:58133"
@@ -321,7 +321,7 @@
                 "query_signature": "ec24a2e9aacce5a0",
                 "statement": "{\"q\": {\"age\": {\"$gt\": 35}}, \"u\": {\"$set\": {\"subscribed\": true}}, \"multi\": true, \"upsert\": false, \"comment\": \"update customers subscription status by age\"}",
                 "mills": 27,
-                "num_yields": 0,
+                "num_yields": 2,
                 "response_length": 0,
                 "nmatched": 495,
                 "nmodified": 495,
@@ -376,8 +376,8 @@
                 "query_signature": "c5b7bcd45c4d9e9",
                 "statement": "{\"update\": \"customers\", \"ordered\": true, \"comment\": \"update customers subscription status by age\", \"$db\": \"test\"}",
                 "mills": 27,
-                "num_yields": 0,
-                "response_length": 0,
+                "num_yields": 2,
+                "response_length": 60,
                 "cpu_nanos": 27721625,
                 "client": {
                     "hostname": "192.168.65.1:58133"
@@ -485,7 +485,7 @@
                 "statement": "{\"update\": \"customers\", \"ordered\": true, \"comment\": \"update customers subscription status by age\", \"$db\": \"test\"}",
                 "mills": 15,
                 "num_yields": 0,
-                "response_length": 0,
+                "response_length": 60,
                 "cpu_nanos": 15198542,
                 "client": {
                     "hostname": "192.168.65.1:58133"
@@ -541,7 +541,7 @@
                 "query_framework": "classic",
                 "mills": 12,
                 "num_yields": 0,
-                "response_length": 0,
+                "response_length": 14089,
                 "nreturned": 101,
                 "keys_examined": 540,
                 "docs_examined": 540,
@@ -580,7 +580,7 @@
                 "query_framework": "classic",
                 "mills": 14,
                 "num_yields": 0,
-                "response_length": 0,
+                "response_length": 110,
                 "nreturned": 0,
                 "keys_examined": 612,
                 "docs_examined": 612,

--- a/mongo/tests/test_dbm_slow_operations.py
+++ b/mongo/tests/test_dbm_slow_operations.py
@@ -30,6 +30,7 @@ def test_mongo_slow_operations_standalone(aggregator, instance_integration_clust
 
     events = aggregator.get_event_platform_events("dbm-activity")
     slow_operation_payload = [event for event in events if event['dbm_type'] == 'slow_query']
+    print(json.dumps(slow_operation_payload))
 
     with open(os.path.join(HERE, "results", "slow-operations-standalone.json"), 'r') as f:
         expected_slow_operation_payload = json.load(f)
@@ -57,6 +58,7 @@ def test_mongo_slow_operations_mongos(aggregator, instance_integration_cluster, 
 
     events = aggregator.get_event_platform_events("dbm-activity")
     slow_operation_payload = [event for event in events if event['dbm_type'] == 'slow_query']
+    print(json.dumps(slow_operation_payload))
 
     with open(os.path.join(HERE, "results", "slow-operations-mongos.json"), 'r') as f:
         expected_slow_operation_payload = json.load(f)


### PR DESCRIPTION
### What does this PR do?
This PR fixes missing metrics `num_yields` and `response_length` for slow operations collected from logs. The bug is caused by different field names between slow operations from profiler or logs.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
