### PR TITLE
Fix typo when saving broker timestamp

### DIFF
--- a/kafka_consumer/changelog.d/18307.fixed
+++ b/kafka_consumer/changelog.d/18307.fixed
@@ -1,0 +1,1 @@
+Fix a typo when writing to persistent cache to calculate the estimated consumer lag.

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -97,15 +97,12 @@ class KafkaCheck(AgentCheck):
     def _load_broker_timestamps(self):
         """Loads broker timestamps from persistent cache."""
         broker_timestamps = defaultdict(dict)
-        cached_value = json.loads(self.read_persistent_cache("broker_timestamps_")).strip()
-        self.log.info("cached_value: %s ", cached_value)
-        if cached_value:
-          try:
-              for topic_partition, content in json.loads(self.read_persistent_cache("broker_timestamps_")).items():
-                  for offset, timestamp in content.items():
-                      broker_timestamps[topic_partition][int(offset)] = timestamp
-          except Exception as e:
-              self.log.warning('Could not read broker timestamps from cache: %s', str(e))
+        try:
+            for topic_partition, content in json.loads(self.read_persistent_cache("broker_timestamps_")).items():
+                for offset, timestamp in content.items():
+                    broker_timestamps[topic_partition][int(offset)] = timestamp
+        except Exception as e:
+            self.log.warning('Could not read broker timestamps from cache: %s', str(e))
         return broker_timestamps
 
     def _add_broker_timestamps(self, broker_timestamps, highwater_offsets):

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -97,12 +97,15 @@ class KafkaCheck(AgentCheck):
     def _load_broker_timestamps(self):
         """Loads broker timestamps from persistent cache."""
         broker_timestamps = defaultdict(dict)
-        try:
-            for topic_partition, content in json.loads(self.read_persistent_cache("broker_timestamps_")).items():
-                for offset, timestamp in content.items():
-                    broker_timestamps[topic_partition][int(offset)] = timestamp
-        except Exception as e:
-            self.log.warning('Could not read broker timestamps from cache: %s', str(e))
+        cached_value = json.loads(self.read_persistent_cache("broker_timestamps_")).strip()
+        self.log.info("cached_value: %s ", cached_value)
+        if cached_value:
+          try:
+              for topic_partition, content in json.loads(self.read_persistent_cache("broker_timestamps_")).items():
+                  for offset, timestamp in content.items():
+                      broker_timestamps[topic_partition][int(offset)] = timestamp
+          except Exception as e:
+              self.log.warning('Could not read broker timestamps from cache: %s', str(e))
         return broker_timestamps
 
     def _add_broker_timestamps(self, broker_timestamps, highwater_offsets):

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -97,6 +97,8 @@ class KafkaCheck(AgentCheck):
     def _load_broker_timestamps(self):
         """Loads broker timestamps from persistent cache."""
         broker_timestamps = defaultdict(dict)
+        cached_value = json.loads(self.read_persistent_cache("broker_timestamps_")).strip()
+        self.log.info("cached_value: %s ", cached_value)
         try:
             for topic_partition, content in json.loads(self.read_persistent_cache("broker_timestamps_")).items():
                 for offset, timestamp in content.items():

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -49,15 +49,16 @@ class KafkaCheck(AgentCheck):
         highwater_offsets = {}
         broker_timestamps = defaultdict(dict)
         cluster_id = ""
+        persistent_cache_key = "broker_timestamps_"
         try:
             if len(consumer_offsets) < self._context_limit:
                 # Fetch highwater offsets
                 # Expected format: ({(topic, partition): offset}, cluster_id)
                 highwater_offsets, cluster_id = self.client.get_highwater_offsets(consumer_offsets)
                 if self._data_streams_enabled:
-                    broker_timestamps = self._load_broker_timestamps()
+                    broker_timestamps = self._load_broker_timestamps(persistent_cache_key)
                     self._add_broker_timestamps(broker_timestamps, highwater_offsets)
-                    self._save_broker_timestamps(broker_timestamps)
+                    self._save_broker_timestamps(broker_timestamps, persistent_cache_key)
             else:
                 self.warning("Context limit reached. Skipping highwater offset collection.")
         except Exception:
@@ -94,13 +95,11 @@ class KafkaCheck(AgentCheck):
         if self.config._close_admin_client:
             self.client.close_admin_client()
 
-    def _load_broker_timestamps(self):
+    def _load_broker_timestamps(self, persistent_cache_key):
         """Loads broker timestamps from persistent cache."""
         broker_timestamps = defaultdict(dict)
-        cached_value = json.loads(self.read_persistent_cache("broker_timestamps_")).strip()
-        self.log.info("cached_value: %s ", cached_value)
         try:
-            for topic_partition, content in json.loads(self.read_persistent_cache("broker_timestamps_")).items():
+            for topic_partition, content in json.loads(self.read_persistent_cache(persistent_cache_key)).items():
                 for offset, timestamp in content.items():
                     broker_timestamps[topic_partition][int(offset)] = timestamp
         except Exception as e:
@@ -115,9 +114,9 @@ class KafkaCheck(AgentCheck):
             if len(timestamps) > self._max_timestamps:
                 del timestamps[min(timestamps)]
 
-    def _save_broker_timestamps(self, broker_timestamps):
+    def _save_broker_timestamps(self, broker_timestamps, persistent_cache_key):
         """Saves broker timestamps to persistent cache."""
-        self.write_persistent_cache("broker_timestamps_", json.dumps(broker_timestamps))
+        self.write_persistent_cache(persistent_cache_key, json.dumps(broker_timestamps))
 
     def report_highwater_offsets(self, highwater_offsets, contexts_limit, cluster_id):
         """Report the broker highwater offsets."""

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -115,7 +115,7 @@ class KafkaCheck(AgentCheck):
 
     def _save_broker_timestamps(self, broker_timestamps):
         """Saves broker timestamps to persistent cache."""
-        self.write_persistent_cache("broker_timestamps", json.dumps(broker_timestamps))
+        self.write_persistent_cache("broker_timestamps_", json.dumps(broker_timestamps))
 
     def report_highwater_offsets(self, highwater_offsets, contexts_limit, cluster_id):
         """Report the broker highwater offsets."""


### PR DESCRIPTION
### What does this PR do?
Make the write and the read from persistent cache use the same key (fix typo).

### Motivation
https://datadoghq.atlassian.net/browse/AGENT-11612

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
