### PR TITLE
postgres: add log to specify Agent uses password or token to connect to db

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -802,7 +802,7 @@ class PostgreSql(AgentCheck):
                     identity_scope = azure_managed_authentication.get('identity_scope', None)
                     password = azure.generate_managed_identity_token(client_id=client_id, identity_scope=identity_scope)
 
-            self.log.info(
+            self.log.debug(
                 "Try to connect to %s with %s",
                 self._config.host,
                 "password" if password == self._config.password else "token",

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -802,6 +802,12 @@ class PostgreSql(AgentCheck):
                     identity_scope = azure_managed_authentication.get('identity_scope', None)
                     password = azure.generate_managed_identity_token(client_id=client_id, identity_scope=identity_scope)
 
+            self.log.info(
+                "Try to connect to %s with %s",
+                self._config.host,
+                "password" if password == self._config.password else "token",
+            )
+
             args = {
                 'host': self._config.host,
                 'user': self._config.user,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add log to report Agent uses password or token for connection.

### Motivation
<!-- What inspired you to submit this pull request? -->

- For easy troubleshooting.
- Agent replaces a given password with token implicitly when `aws` / `azure` section is configured.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

```
2024-08-13 05:14:17 UTC | CORE | DEBUG | (pkg/collector/python/datadog_agent.go:131 in LogMessage) | postgres:8343993ddd1c5f02 | (postgres.py:796) | Try to connect to 172.25.0.3 with password
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
