### PR TITLE
postgres: fall back to password authentication after token authentication failed

### DIFF
--- a/postgres/changelog.d/18313.added
+++ b/postgres/changelog.d/18313.added
@@ -1,0 +1,1 @@
+Fall back to password authentication after token authentication failed


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fall back to password authentication after token authentication failed

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/integrations-core/pull/18312 was for the similar motivation.

When a user follows [Manual setup](https://github.com/DataDog/documentation/blob/f91d6431a0b069ee71627d09ac2f4d7ef2a84188/content/en/database_monitoring/setup_postgres/aurora.md?plain=1#L195-L217) for Aurora managed Postgres, it implicitly means Agent uses IAM authentication.

This behavior is undocumented and a user expects Agent uses password authentication.

- https://github.com/DataDog/integrations-core/blob/69760ff1a198b0835ddcc896b7cf0f6d539d381a/postgres/datadog_checks/postgres/config.py#L246-L252
- https://github.com/DataDog/integrations-core/blob/69760ff1a198b0835ddcc896b7cf0f6d539d381a/postgres/datadog_checks/postgres/postgres.py#L785-L797

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
