### PR TITLE
[mongo] collect metric number of views in the database

### DIFF
--- a/mongo/changelog.d/18334.added
+++ b/mongo/changelog.d/18334.added
@@ -1,0 +1,1 @@
+Add metric `mongodb.stats.views` to report number of views in the database.

--- a/mongo/datadog_checks/mongo/metrics.py
+++ b/mongo/datadog_checks/mongo/metrics.py
@@ -142,6 +142,7 @@ BASE_METRICS = {
     "stats.totalFreeStorageSize": GAUGE,
     "stats.fsUsedSize": GAUGE,
     "stats.fsTotalSize": GAUGE,
+    "stats.views": GAUGE,
     "sessions.count": GAUGE,
     "uptime": GAUGE,
     "system.memSizeMB": (GAUGE, "system.mem.total"),  # total amount of system memory

--- a/mongo/metadata.csv
+++ b/mongo/metadata.csv
@@ -226,6 +226,7 @@ mongodb.stats.objects,gauge,,object,,Number of objects (documents) in the databa
 mongodb.stats.storagesize,gauge,,byte,,Total amount of space allocated to collections in this database for document storage.,0,mongodb,stats storagesize,,
 mongodb.stats.totalfreestoragesize,gauge,,byte,,Total amount of free storage space allocated for both documents and indexes in all collections in the database.,0,mongodb,stats total free storage size,,
 mongodb.stats.totalsize,gauge,,byte,,Total amount of disk space allocated for both documents and indexes in all collections in the database. Includes used and free storage space.,0,mongodb,stats totalsize,,
+mongodb.stats.views,gauge,,,,Contains a count of the number of views in the database.,0,mongodb,stats views,,
 mongodb.system.cpu.cores,gauge,,core,,The total number of available logical processor cores.,0,mongodb,system cpu cores,,
 mongodb.system.mem.limit,gauge,,megabyte,,The system memory (RAM) usage limit. For example running in a container may impose memory limits that are lower than the total system memory.,0,mongodb,system mem limit,,
 mongodb.system.mem.total,gauge,,megabyte,,The total amount of system memory (RAM).,0,mongodb,system mem total,,

--- a/mongo/tests/fixtures/dbstats-local
+++ b/mongo/tests/fixtures/dbstats-local
@@ -1,7 +1,7 @@
 {
     "db": "local",
     "collections": 7,
-    "views": 0,
+    "views": 1,
     "objects": 6938,
     "avgObjSize": 214.15696166042088,
     "dataSize": 1485821.0,

--- a/mongo/tests/results/metrics-dbstats-local.json
+++ b/mongo/tests/results/metrics-dbstats-local.json
@@ -138,5 +138,15 @@
             "cluster:db:local",
             "db:local"
         ]
+    },
+    {
+        "name": "mongodb.stats.views",
+        "type": 0,
+        "value": 1.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:local",
+            "db:local"
+        ]
     }
 ]


### PR DESCRIPTION
### What does this PR do?
This PR adds a new metric `mongodb.stats.views` for number of views in the database.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
