### PR TITLE
Updated description for the availability_group option

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -152,10 +152,10 @@ files:
             example: 10000
     - name: availability_group
       description: |
-        You can specify an availability group when `include_ao_metrics`
-        is enabled to monitor a specific availability group.
-        If no availability group is specified, then all availability
-        groups on the current replica will output metrics.
+        When `include_ao_metrics` is enabled, you can provide the resource 
+        group id of a specific availability group that you would like to monitor.
+        If no availability group is specified, then we will collect AlwaysOn metrics 
+        for all availability groups on the current replica.
       value:
         type: string
     - name: only_emit_local

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -147,10 +147,10 @@ instances:
         # history_row_limit: 10000
 
     ## @param availability_group - string - optional
-    ## You can specify an availability group when `include_ao_metrics`
-    ## is enabled to monitor a specific availability group.
-    ## If no availability group is specified, then all availability
-    ## groups on the current replica will output metrics.
+    ## When `include_ao_metrics` is enabled, you can provide the resource 
+    ## group id of a specific availability group that you would like to monitor.
+    ## If no availability group is specified, then we will collect AlwaysOn metrics 
+    ## for all availability groups on the current replica.
     #
     # availability_group: <AVAILABILITY_GROUP>
 


### PR DESCRIPTION
### What does this PR do?
Updated the description for the availability_group option in SQL Server to make the expected value more clear.

### Motivation
The description for `availability_group` was misleading users to put the availability group name instead of the resource group id which is what we actually check against.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
