### PR TITLE
[PLINT-449] Add more robust error handling

### DIFF
--- a/fly_io/changelog.d/18337.fixed
+++ b/fly_io/changelog.d/18337.fixed
@@ -1,0 +1,1 @@
+Add more robust error handling.

--- a/fly_io/datadog_checks/fly_io/check.py
+++ b/fly_io/datadog_checks/fly_io/check.py
@@ -53,18 +53,15 @@ class FlyIoCheck(OpenMetricsBaseCheckV2, ConfigMixin):
             'hostname_label': 'instance',
         }
 
+    @handle_error
     def _get_app_status(self, app_name):
         self.log.debug("Getting app status for %s", app_name)
         app_details_endpoint = f"{self.machines_api_endpoint}/v1/apps/{app_name}"
         response = self.http.get(app_details_endpoint)
-        try:
-            response.raise_for_status()
-            app = response.json()
-            app_status = app.get("status")
-            return app_status
-        except Exception:
-            self.log.info("Failed to collect app status for app %s", app_name)
-            return None
+        response.raise_for_status()
+        app = response.json()
+        app_status = app.get("status")
+        return app_status
 
     @handle_error
     def _submit_machine_guest_metrics(self, guest, tags, machine_id):

--- a/fly_io/datadog_checks/fly_io/check.py
+++ b/fly_io/datadog_checks/fly_io/check.py
@@ -25,6 +25,7 @@ from .constants import (
     VOLUME_ENCRYPTED_METRIC,
     VOLUME_SIZE_METRIC,
 )
+from .errors import handle_error
 from .metrics import METRICS, RENAME_LABELS_MAP
 
 
@@ -65,6 +66,7 @@ class FlyIoCheck(OpenMetricsBaseCheckV2, ConfigMixin):
             self.log.info("Failed to collect app status for app %s", app_name)
             return None
 
+    @handle_error
     def _submit_machine_guest_metrics(self, guest, tags, machine_id):
         self.log.debug("Getting machine guest metrics for %s", machine_id)
         num_cpus = guest.get("cpus")
@@ -83,12 +85,14 @@ class FlyIoCheck(OpenMetricsBaseCheckV2, ConfigMixin):
         if memory is not None:
             self.gauge(MACHINE_MEM_METRIC, value=memory, tags=tags, hostname=machine_id)
 
+    @handle_error
     def _submit_machine_init_metrics(self, machine_init, tags, machine_id):
         self.log.debug("Getting machine init metrics for %s", machine_id)
         swap_size_mb = machine_init.get("swap_size_mb")
         if swap_size_mb is not None:
             self.gauge(MACHINE_SWAP_SIZE_METRIC, value=swap_size_mb, tags=tags, hostname=machine_id)
 
+    @handle_error
     def _collect_volumes_for_app(self, app_name, app_tags):
         self.log.debug("Getting volumes for app %s in org %s", app_name, self.org_slug)
         volumes_endpoint = f"{self.machines_api_endpoint}/v1/apps/{app_name}/volumes"
@@ -143,6 +147,7 @@ class FlyIoCheck(OpenMetricsBaseCheckV2, ConfigMixin):
             if blocks_avail is not None:
                 self.gauge(VOLUME_BLOCKS_AVAIL_METRIC, value=blocks_avail, tags=all_tags)
 
+    @handle_error
     def _collect_machines_for_app(self, app_name, app_tags):
         self.log.debug("Getting machines for app %s in org %s", app_name, self.org_slug)
         machines_endpoint = f"{self.machines_api_endpoint}/v1/apps/{app_name}/machines"
@@ -184,6 +189,7 @@ class FlyIoCheck(OpenMetricsBaseCheckV2, ConfigMixin):
         if len(external_host_tags) > 0:
             self.set_external_tags(external_host_tags)
 
+    @handle_error
     def _collect_app_metrics(self):
         self.log.debug("Getting apps for org %s", self.org_slug)
         apps_endpoint = f"{self.machines_api_endpoint}/v1/apps"

--- a/fly_io/datadog_checks/fly_io/errors.py
+++ b/fly_io/datadog_checks/fly_io/errors.py
@@ -1,0 +1,31 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from functools import wraps
+
+import requests
+
+
+def handle_error(f):
+    @wraps(f)
+    def wrapper(check, *args, **kwargs):
+        try:
+            result = f(check, *args, **kwargs)
+            return result
+        except requests.exceptions.RequestException as e:
+            check.log.debug(
+                "Encountered a RequestException in '%s' [%s]: %s",
+                f.__name__,
+                type(e),
+                e,
+            )
+        except Exception as e:
+            check.log.error(
+                "Encountered an Exception in '%s' [%s]: %s",
+                f.__name__,
+                type(e),
+                e,
+            )
+        return None
+
+    return wrapper

--- a/fly_io/tests/test_unit.py
+++ b/fly_io/tests/test_unit.py
@@ -94,7 +94,6 @@ def test_rest_api_app_metrics(dd_run_check, aggregator, instance, caplog):
 )
 @pytest.mark.usefixtures('mock_http_get')
 def test_rest_api_exception(dd_run_check, instance, aggregator):
-
     check = FlyIoCheck('fly_io', {}, [instance])
     with pytest.raises(Exception, match=r'requests.exceptions.HTTPError'):
         dd_run_check(check)
@@ -105,6 +104,70 @@ def test_rest_api_exception(dd_run_check, instance, aggregator):
         aggregator.assert_metric(metric, at_least=1, hostname="708725eaa12297")
         aggregator.assert_metric(metric, at_least=1, hostname="20976671ha2292")
         aggregator.assert_metric(metric, at_least=1, hostname="119dc024cbf534")
+
+
+@pytest.mark.parametrize(
+    ('mock_http_get'),
+    [
+        pytest.param(
+            {
+                'http_error': {
+                    '/v1/apps/example-app-1/machines': MockResponse(json_data=[{'state': 'started', 'config': None}])
+                }
+            },
+            id='malformed response',
+        ),
+    ],
+    indirect=['mock_http_get'],
+)
+@pytest.mark.usefixtures('mock_http_get')
+def test_bad_response_exception(dd_run_check, instance, aggregator, caplog):
+    caplog.set_level(logging.ERROR)
+    check = FlyIoCheck('fly_io', {}, [instance])
+    dd_run_check(check)
+
+    assert (
+        "Encountered an Exception in '_collect_machines_for_app' [<class 'AttributeError'>]: "
+        "'NoneType' object has no attribute 'get'" in caplog.text
+    )
+
+    for metric in MOCKED_PROMETHEUS_METRICS:
+        aggregator.assert_metric(metric, at_least=1, hostname="708725eaa12297")
+        aggregator.assert_metric(metric, at_least=1, hostname="20976671ha2292")
+        aggregator.assert_metric(metric, at_least=1, hostname="119dc024cbf534")
+
+    for metric in VOLUME_METRICS:
+        aggregator.assert_metric(metric['name'], metric['value'], count=metric['count'], tags=metric['tags'])
+
+
+@pytest.mark.parametrize(
+    ('mock_http_get'),
+    [
+        pytest.param(
+            {'http_error': {'/v1/apps/example-app-1/volumes': MockResponse(status_code=404)}},
+            id='http error',
+        ),
+    ],
+    indirect=['mock_http_get'],
+)
+@pytest.mark.usefixtures('mock_http_get')
+def test_http_error_exception(dd_run_check, instance, aggregator, caplog):
+    caplog.set_level(logging.DEBUG)
+    check = FlyIoCheck('fly_io', {}, [instance])
+    dd_run_check(check)
+
+    assert (
+        "Encountered a RequestException in '_collect_volumes_for_app' [<class 'requests.exceptions.HTTPError'>]: "
+        "404 Client Error: None for url: None" in caplog.text
+    )
+
+    for metric in MOCKED_PROMETHEUS_METRICS:
+        aggregator.assert_metric(metric, at_least=1, hostname="708725eaa12297")
+        aggregator.assert_metric(metric, at_least=1, hostname="20976671ha2292")
+        aggregator.assert_metric(metric, at_least=1, hostname="119dc024cbf534")
+
+    for metric in MACHINE_INIT_METRICS:
+        aggregator.assert_metric(metric['name'], metric['value'], count=metric['count'], tags=metric['tags'])
 
 
 @pytest.mark.usefixtures("mock_http_get")

--- a/fly_io/tests/test_unit.py
+++ b/fly_io/tests/test_unit.py
@@ -207,19 +207,19 @@ def test_external_host_tags(instance, datadog_agent, dd_run_check):
     [
         pytest.param(
             {'http_error': {'/v1/apps/example-app-2': MockResponse(status_code=404)}},
-            ['Failed to collect app status for app example-app-2'],
+            ['RequestException in \'_get_app_status\' [<class \'requests.exceptions.HTTPError\'>]: 404'],
             id='one app',
         ),
         pytest.param(
             {
                 'http_error': {
                     '/v1/apps/example-app-1': MockResponse(status_code=404),
-                    '/v1/apps/example-app-2': MockResponse(status_code=404),
+                    '/v1/apps/example-app-2': MockResponse(status_code=500),
                 }
             },
             [
-                'Failed to collect app status for app example-app-2',
-                'Failed to collect app status for app example-app-1',
+                'RequestException in \'_get_app_status\' [<class \'requests.exceptions.HTTPError\'>]: 404',
+                'RequestException in \'_get_app_status\' [<class \'requests.exceptions.HTTPError\'>]: 500',
             ],
             id='two apps',
         ),


### PR DESCRIPTION
### What does this PR do?
Adds error handle decorator to catch http and misc errors to preserve metric collection
### Motivation
catch errors for all api methods while not repeating code
### Additional Notes
inspired by [openstack_controller](https://github.com/DataDog/integrations-core/blob/master/openstack_controller/datadog_checks/openstack_controller/components/component.py#L67) and [vsphere](https://github.com/DataDog/integrations-core/blob/master/vsphere/datadog_checks/vsphere/api.py#L28)  
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
