### PR TITLE
fix gh action that uploads standalone binaries

### DIFF
--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -319,7 +319,7 @@ jobs:
     - name: Upload standalone binaries
       uses: actions/upload-artifact@v4
       with:
-        name: standalone
+        name: standalone-${{ matrix.job.target }}
         path: ddev/archives/*
         if-no-files-found: error
 
@@ -595,6 +595,9 @@ jobs:
         pattern: installers-*
         path: installers
         merge-multiple: true
+
+    - name: Display structure of downloaded files
+      run: ls -R
 
     - name: Push Python artifacts to PyPI
       uses: pypa/gh-action-pypi-publish@v1.8.14

--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -585,8 +585,7 @@ jobs:
     - name: Download binaries
       uses: actions/download-artifact@v4
       with:
-        pattern: standalone-*
-        name: standalone
+        pattern: standalone*
         path: archives
         merge-multiple: true
 


### PR DESCRIPTION
### What does this PR do?
[Relevant Doc](https://github.com/actions/download-artifact/tree/main?tab=readme-ov-file#v4---whats-new:~:text=%23%20A%20glob%20pattern%20to%20the%20artifacts%20that%20should%20be%20downloaded.%0A%20%20%20%20%23%20Ignored%20if%20name%20is%20specified.%0A%20%20%20%20%23%20Optional.%0A%20%20%20%20pattern%3A)

Paper trail:
I was comparing logs of the installers (which were getting uploaded) and binaries which weren't. 

Binaries:
```
Run actions/download-artifact@v4
Downloading single artifact
Preparing to download the following artifacts:
- standalone (ID: 1780011911, Size: 3369639)
```

Installers:
```
Run actions/download-artifact@v4
Found 17 artifact(s)
Filtering artifacts by pattern 'installers-*'
Preparing to download the following artifacts:
- installers-Windows (ID: 1780014765, Size: 46092149)
- installers-macOS (ID: 17800[13](https://github.com/DataDog/integrations-core/actions/runs/10263082736/job/28395022312#step:5:14)758, Size: 3763754)
```

The 17 artifacts that was being logged in the installers made sense because we can see that 17 artifacts were indeed generated, which ruled out an issue with upload. The logs from the binaries also didn't show the `Found 17 artifact(s)` log line which lead me to the issue. 

So what was happening was that it was downloading a specific archive called standalone and then uploading that. The size 3369639 bytes = 3.2 MiB matches the size of the archive.

I purposely used `standalone*` instead of `standalone-*` because inside the standalone archive there's:
`<ddev>-i686-pc-windows-msvc`
`<ddev>-x86_64-pc-windows-msvc`

Which I don't really understand why. I think it could be this [line](https://github.com/DataDog/integrations-core/blob/59bc7c2479ee7f82d4fe2f5544d4b7cffa73af5b/.github/workflows/build-ddev.yml#L322). I guess it makes sense because that's a single job that uploads both binaries.

All in all this PR should allow us to download all the standalone binaries that we end up attaching to the assets in the release (I hope).
