### PR TITLE
[mongo] collection stats metrics should be optional

### DIFF
--- a/mongo/changelog.d/18342.fixed
+++ b/mongo/changelog.d/18342.fixed
@@ -1,0 +1,2 @@
+Fixed a bug where optional MongoDB collection stats metrics were always collected, regardless of configuration.
+

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -161,7 +161,8 @@ class MongoDb(AgentCheck):
             # For backward compatibility, coll_names is ONLY applied when autodiscovery is not enabled
             # Otherwise, we collect collstats & indexstats for all auto-discovered databases and authorized collections
             coll_names = None if self._database_autodiscovery.autodiscovery_enabled else self._config.coll_names
-            potential_collectors.append(CollStatsCollector(self, db_name, tags, coll_names=coll_names))
+            if 'collection' in self._config.additional_metrics:
+                potential_collectors.append(CollStatsCollector(self, db_name, tags, coll_names=coll_names))
             if self._config.collections_indexes_stats:
                 if self._mongo_version_parsed >= Version("3.2"):
                     potential_collectors.append(IndexStatsCollector(self, db_name, tags, coll_names=coll_names))


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug where the optional collections stats metrics are always collected regardless it's enabled or not.

### Motivation
MongoDB collection stats metrics are optional and can be enabled by adding `collection` to `additional_metrics` config. Running `$collStats` on every collection (especially when database autodiscovery is enabled) can be a costly operation when a database has large number of collections. As per our document, collection stats metrics is opted in. 
However the integration always collects collection stats metrics but only skips submitting the collection stats metrics. This behavior is undesired and put unwanted load on the monitored database.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
