### PR TITLE
Pass explicit paths for dependencies for building lxml

### DIFF
--- a/.builders/images/macos-x86_64/extra_build.sh
+++ b/.builders/images/macos-x86_64/extra_build.sh
@@ -26,6 +26,13 @@ fi
 # Make sure IBM MQ libraries are found under /opt/mqm even when we're using the builder cache
 sudo cp -Rf "${DD_PREFIX_PATH}/mqm" /opt
 
+# lxml has some custom logic for finding the libxml and libxslt libraries that it depends on,
+# which ignores existing CFLAGS / LDFLAGS,
+# based on the xml2-config and xslt-config binaries provided by those libraries.
+# We need to override those to avoid the build from picking up the system ones.
+echo "WITH_XML2_CONFIG=${DD_PREFIX_PATH}/bin/xml2-config" >> $DD_ENV_FILE
+echo "WITH_XSLT_CONFIG=${DD_PREFIX_PATH}/bin/xslt-config" >> $DD_ENV_FILE
+
 # Empty arrays are flagged as unset when using the `-u` flag. This is the safest way to work around that
 # (see https://stackoverflow.com/a/61551944)
 pip_no_binary=${always_build[@]+"${always_build[@]}"}

--- a/.builders/scripts/build_wheels.py
+++ b/.builders/scripts/build_wheels.py
@@ -109,7 +109,7 @@ def main():
 
         # Fetch or build wheels
         command_args = [
-            str(python_path), '-m', 'pip', '-v', 'wheel',
+            str(python_path), '-m', 'pip', 'wheel',
             '-r', str(MOUNT_DIR / 'requirements.in'),
             '--wheel-dir', str(staged_wheel_dir),
             '--extra-index-url', CUSTOM_EXTERNAL_INDEX,

--- a/.builders/scripts/build_wheels.py
+++ b/.builders/scripts/build_wheels.py
@@ -109,7 +109,7 @@ def main():
 
         # Fetch or build wheels
         command_args = [
-            str(python_path), '-m', 'pip', 'wheel',
+            str(python_path), '-m', 'pip', '-v', 'wheel',
             '-r', str(MOUNT_DIR / 'requirements.in'),
             '--wheel-dir', str(staged_wheel_dir),
             '--extra-index-url', CUSTOM_EXTERNAL_INDEX,


### PR DESCRIPTION
### What does this PR do?

Passes additional environment variables to ensure we use the correct libxml2 and lxslt versions.

### Motivation

A build flaked (https://github.com/DataDog/integrations-core/actions/runs/10380933633/job/28741538776#step:7:1069) and it included this message:

```
Building against libxml2 2.9.4 and libxslt 1.1.29
```

That means the dependencies we built explicitly for this python package are not being picked up given that the versions don't match:
https://github.com/DataDog/integrations-core/blob/138b5e104dc6be1f2103713391e82cfc43c0120f/.builders/images/macos-x86_64/builder_setup.sh#L47-L49

### Additional Notes

- This is not too well documented in lxml's building docs, and the setup script has quite a bit of complex logic. The piece of code that led me to find these env variables is:
https://github.com/lxml/lxml/blob/c17c1ca0496fbde3827c01cecd6a37d848142772/setupinfo.py#L407-L415
- I did a run with the verbose flag on pip to ensure the versions are what we expect: https://github.com/DataDog/integrations-core/actions/runs/10419363332/job/28857253137?pr=18353 (the log is huge, but searching for lxml in the raw logs it's easy to find).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
