### PR TITLE
Propagate agent host tags for postgres

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -6,8 +6,8 @@ files:
     options:
     - name: propagate_agent_tags
       description: |
-        Set to `true` to propagate the tags from `datadog.yaml` to the check.
-        When set to `true`, the tags from `datadog.yaml` are added to the check's tags for all instances.
+        Set to `true` to propagate the tags from `datadog.yaml` and the agent host tags to the check.
+        When set to `true`, the tags from the agent host are added to the check's tags for all instances.
       value:
         example: false
         type: boolean
@@ -977,8 +977,8 @@ files:
         display_default: false
     - name: propagate_agent_tags
       description: |
-        Set to `true` to propagate the tags from `datadog.yaml` to the check.
-        When set to `true`, the tags from `datadog.yaml` are added to the check's tags.
+        Set to `true` to propagate the tags from `datadog.yaml` and the agent host tags to the check.
+        When set to `true`, the tags from the agent host are added to the check's tags for all instances.
         This option takes precedence over the `propagate_agent_tags` option in `init_config`.
       value:
         example: false

--- a/postgres/changelog.d/18358.added
+++ b/postgres/changelog.d/18358.added
@@ -1,1 +1,1 @@
-Propagate agent host tags for postgres integration
+Update the propagate_agent_tags setting. When set to `true`, the tags from the agent host (including the ones in `datadog.yaml`) are added to the check's tags for all instances.

--- a/postgres/changelog.d/18358.added
+++ b/postgres/changelog.d/18358.added
@@ -1,1 +1,1 @@
-Update the propagate_agent_tags setting. When set to `true`, the tags from the agent host (including the ones in `datadog.yaml`) are added to the check's tags for all instances.
+Update the propagate_agent_tags setting. When set to `true`, the tags from the agent host are now added to the check's tags for all instances.

--- a/postgres/changelog.d/18358.added
+++ b/postgres/changelog.d/18358.added
@@ -1,0 +1,1 @@
+Propagate agent host tags for postgres integration

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -6,11 +6,6 @@ from typing import Optional
 
 from six import PY2, PY3, iteritems
 
-try:
-    import datadog_agent
-except ImportError:
-    from ..stubs import datadog_agent
-
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from datadog_checks.base.utils.aws import rds_parse_tags_from_endpoint
 from datadog_checks.base.utils.db.utils import get_agent_host_tags

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -168,7 +168,7 @@ class PostgresConfig:
         )
         self.baseline_metrics_expiry = self.statement_metrics_config.get('baseline_metrics_expiry', 300)
 
-    def _build_tags(self, custom_tags, propagate_agent_tags=True):
+    def _build_tags(self, custom_tags, propagate_agent_tags):
         # Clean up tags in case there was a None entry in the instance
         # e.g. if the yaml contains tags: but no actual tags
         if custom_tags is None:

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -168,7 +168,7 @@ class PostgresConfig:
         )
         self.baseline_metrics_expiry = self.statement_metrics_config.get('baseline_metrics_expiry', 300)
 
-    def _build_tags(self, custom_tags, propagate_agent_tags=False):
+    def _build_tags(self, custom_tags, propagate_agent_tags=True):
         # Clean up tags in case there was a None entry in the instance
         # e.g. if the yaml contains tags: but no actual tags
         if custom_tags is None:

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -13,6 +13,7 @@ except ImportError:
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from datadog_checks.base.utils.aws import rds_parse_tags_from_endpoint
+from datadog_checks.base.utils.db.utils import get_agent_host_tags
 
 SSL_MODES = {'disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full'}
 TABLE_COUNT_LIMIT = 200
@@ -68,7 +69,7 @@ class PostgresConfig:
         self.max_connections = instance.get('max_connections', 30)
         self.tags = self._build_tags(
             custom_tags=instance.get('tags', []),
-            agent_tags=datadog_agent.get_config('tags') or [],
+            agent_tags=get_agent_host_tags(),
             propagate_agent_tags=self._should_propagate_agent_tags(instance, init_config),
         )
 

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -201,7 +201,9 @@ class PostgresConfig:
                 agent_tags = get_agent_host_tags()
                 tags.extend(agent_tags)
             except Exception as e:
-                raise ConfigurationError('propagate_agent_tags enabled but there was an error fetching agent tags {}'.format(e))
+                raise ConfigurationError(
+                    'propagate_agent_tags enabled but there was an error fetching agent tags {}'.format(e)
+                )
         return tags
 
     @staticmethod

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -4,7 +4,7 @@ init_config:
 
     ## @param propagate_agent_tags - boolean - optional - default: false
     ## Set to `true` to propagate the tags from `datadog.yaml` to the check.
-    ## When set to `true`, the tags from `datadog.yaml` are added to the check's tags for all instances.
+    ## When set to `true`, the tags from the agent host (including the ones in `datadog.yaml`) are added to the check's tags for all instances.
     #
     # propagate_agent_tags: false
 
@@ -824,7 +824,7 @@ instances:
 
     ## @param propagate_agent_tags - boolean - optional - default: false
     ## Set to `true` to propagate the tags from `datadog.yaml` to the check.
-    ## When set to `true`, the tags from `datadog.yaml` are added to the check's tags.
+    ## When set to `true`, the tags from the agent host (including the ones in `datadog.yaml`) are added to the check's tags for all instances.
     ## This option takes precedence over the `propagate_agent_tags` option in `init_config`.
     #
     # propagate_agent_tags: false

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -4,7 +4,7 @@ init_config:
 
     ## @param propagate_agent_tags - boolean - optional - default: false
     ## Set to `true` to propagate the tags from `datadog.yaml` to the check.
-    ## When set to `true`, the tags from the agent host (including the ones in `datadog.yaml`) are added to the check's tags for all instances.
+    ## When set to `true`, the tags from the agent host (including the tags in `datadog.yaml`) are added to the check's tags for all instances.
     #
     # propagate_agent_tags: false
 
@@ -824,7 +824,7 @@ instances:
 
     ## @param propagate_agent_tags - boolean - optional - default: false
     ## Set to `true` to propagate the tags from `datadog.yaml` to the check.
-    ## When set to `true`, the tags from the agent host (including the ones in `datadog.yaml`) are added to the check's tags for all instances.
+    ## When set to `true`, the tags from the agent host (including the tags in `datadog.yaml`) are added to the check's tags for all instances.
     ## This option takes precedence over the `propagate_agent_tags` option in `init_config`.
     #
     # propagate_agent_tags: false

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -3,8 +3,8 @@
 init_config:
 
     ## @param propagate_agent_tags - boolean - optional - default: false
-    ## Set to `true` to propagate the tags from `datadog.yaml` to the check.
-    ## When set to `true`, the tags from the agent host (including the tags in `datadog.yaml`) are added to the check's tags for all instances.
+    ## Set to `true` to propagate the tags from `datadog.yaml` and the agent host tags to the check.
+    ## When set to `true`, the tags from the agent host are added to the check's tags for all instances.
     #
     # propagate_agent_tags: false
 
@@ -823,8 +823,8 @@ instances:
         # keep_identifier_quotation: false
 
     ## @param propagate_agent_tags - boolean - optional - default: false
-    ## Set to `true` to propagate the tags from `datadog.yaml` to the check.
-    ## When set to `true`, the tags from the agent host (including the tags in `datadog.yaml`) are added to the check's tags for all instances.
+    ## Set to `true` to propagate the tags from `datadog.yaml` and the agent host tags to the check.
+    ## When set to `true`, the tags from the agent host are added to the check's tags for all instances.
     ## This option takes precedence over the `propagate_agent_tags` option in `init_config`.
     #
     # propagate_agent_tags: false

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=36.5.0",
+    "datadog-checks-base>=36.5.1",
 ]
 dynamic = [
     "version",

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=36.5.1",
+    "datadog-checks-base>=36.14.0",
 ]
 dynamic = [
     "version",

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -10,7 +10,6 @@ import psycopg2
 import pytest
 
 from datadog_checks.base.errors import ConfigurationError
-from datadog_checks.base.stubs import datadog_agent
 from datadog_checks.postgres import PostgreSql
 from datadog_checks.postgres.__about__ import __version__
 from datadog_checks.postgres.util import BUFFERCACHE_METRICS, DatabaseHealthCheckError, PartialFormatter, fmt
@@ -1152,8 +1151,7 @@ def test_propagate_agent_tags(
 
     agent_tags = ["my-env:test-env", "random:tag", "bar:foo"]
 
-    with mock.patch.object(datadog_agent, 'get_config', passthrough=True) as mock_agent:
-        mock_agent.side_effect = lambda option: agent_tags
+    with mock.patch('datadog_checks.postgres.config.get_agent_host_tags', return_value=agent_tags):
         check = integration_check(pg_instance, init_config)
         assert check._config._should_propagate_agent_tags(pg_instance, init_config) == should_propagate_agent_tags
         if should_propagate_agent_tags:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

In https://github.com/DataDog/integrations-core/pull/18269 and https://github.com/DataDog/datadog-agent/pull/28027, I added functions to get the host tags of the agent host. This PR updates the agent host tags that we use in the postgres integration. This change only affects customers with the `propagate_agent_tags` flag set to true. By calling `get_agent_host_tags`, we not only use the tags in the conf.yaml file but also other tags on the agent host. 

### Motivation
<!-- What inspired you to submit this pull request? -->
Metrics emitted by DBM integrations (postgres, sql server, and mysql) are tagged with the tags from the database instance host. We would like to update the `propagate_agent_tags` option (default false) that allows us to also consider the tags of the agent host. If this setting is enabled, we will propagate all agent host tags. This allows user to opt-in to having their postgres metrics tagged with the agent host tags.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
