### PR TITLE
Add another metric to check

### DIFF
--- a/fly_io/manifest.json
+++ b/fly_io/manifest.json
@@ -37,7 +37,10 @@
       },
       "metrics": {
         "prefix": "fly_io.",
-        "check": "fly_io.instance.up",
+        "check": [
+          "fly_io.instance.up",
+          "fly_io.machine.cpus.count"
+        ],
         "metadata_path": "metadata.csv"
       },
       "service_checks": {


### PR DESCRIPTION
### What does this PR do?
Adds a metric to check for fly from the rest API
### Motivation
still register integration if openmetrics endpoint is down

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
