### PR TITLE
[NDM] [Cisco ACI] Refactor batched payloads to fix incorrect status

### DIFF
--- a/cisco_aci/datadog_checks/cisco_aci/models.py
+++ b/cisco_aci/datadog_checks/cisco_aci/models.py
@@ -10,6 +10,10 @@ if six.PY3:
 
     from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
 
+    """
+    Cisco ACI Response Models
+    """
+
     class NodeAttributes(BaseModel):
         address: Optional[str] = None
         fabric_st: Optional[str] = Field(default=None, alias="fabricSt")
@@ -56,6 +60,10 @@ if six.PY3:
                 if 'ethpmPhysIf' in child:
                     return EthpmPhysIf(**child['ethpmPhysIf'])
             return None
+
+    """
+    NDM Models
+    """
 
     class DeviceMetadata(BaseModel):
         id: Optional[str] = Field(default=None)
@@ -158,3 +166,13 @@ if six.PY3:
         devices: Optional[list[DeviceMetadata]] = Field(default_factory=list)
         interfaces: Optional[list[InterfaceMetadata]] = Field(default_factory=list)
         collect_timestamp: Optional[int] = None
+        size: Optional[int] = Field(default=0, exclude=True)
+
+        model_config = ConfigDict(validate_assignment=True, use_enum_values=True)
+
+        def append_metadata(self, metadata: DeviceMetadata | InterfaceMetadata):
+            if isinstance(metadata, DeviceMetadata):
+                self.devices.append(metadata)
+            if isinstance(metadata, InterfaceMetadata):
+                self.interfaces.append(metadata)
+            self.size += 1

--- a/cisco_aci/datadog_checks/cisco_aci/ndm.py
+++ b/cisco_aci/datadog_checks/cisco_aci/ndm.py
@@ -1,0 +1,123 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+
+from six import PY3
+
+if PY3:
+    from datadog_checks.cisco_aci.models import (
+        DeviceMetadata,
+        InterfaceMetadata,
+        NetworkDevicesMetadata,
+        Node,
+        PhysIf,
+    )
+
+from . import helpers
+
+VENDOR_CISCO = 'cisco'
+PAYLOAD_METADATA_BATCH_SIZE = 100
+
+
+def create_node_metadata(node_attrs, tags, namespace):
+    """
+    Create a DeviceMetadata object from a node's attributes
+    """
+    node = Node(attributes=node_attrs)
+    hostname = helpers.get_hostname_from_dn(node.attributes.dn)
+    id_tags = common_tags(node.attributes.address, hostname, namespace)
+    device_tags = [
+        'device_vendor:{}'.format(VENDOR_CISCO),
+        "source:cisco-aci",
+    ]
+    device = DeviceMetadata(
+        id='{}:{}'.format(namespace, node.attributes.address),
+        id_tags=id_tags,
+        tags=device_tags + tags,
+        name=hostname,
+        ip_address=node.attributes.address,
+        model=node.attributes.model,
+        fabric_st=node.attributes.fabric_st,
+        vendor=VENDOR_CISCO,
+        version=node.attributes.version,
+        serial_number=node.attributes.serial,
+        device_type=node.attributes.device_type,
+    )
+    return device
+
+
+def create_interface_metadata(phys_if, address, namespace):
+    """
+    Create an InterfaceMetadata object from a physical interface
+    """
+    eth = PhysIf(**phys_if.get('l1PhysIf', {}))
+    interface = InterfaceMetadata(
+        device_id='{}:{}'.format(namespace, address),
+        id_tags=['interface:{}'.format(eth.attributes.name)],
+        index=eth.attributes.id,
+        name=eth.attributes.name,
+        description=eth.attributes.desc,
+        mac_address=eth.attributes.router_mac,
+        admin_status=eth.attributes.admin_st,
+    )
+    if eth.ethpm_phys_if:
+        interface.oper_status = eth.ethpm_phys_if.attributes.oper_st
+
+    return interface
+
+
+def get_device_info(device):
+    """
+    Get device ID and node ID from a device object
+    """
+    for tag in device.tags:
+        if tag.startswith('node_id'):
+            node_id = tag.split(':')[1]
+            break
+    return device.id, node_id
+
+
+def batch_payloads(namespace, devices, interfaces, collect_ts):
+    """
+    Batch payloads into NetworkDevicesMetadata objects
+    """
+    network_devices_metadata = NetworkDevicesMetadata(namespace=namespace, collect_timestamp=collect_ts)
+    for device in devices:
+        current_payload, new_payload = append_to_payload(device, network_devices_metadata, namespace, collect_ts)
+        if new_payload:
+            yield current_payload
+            network_devices_metadata = new_payload
+
+    for interface in interfaces:
+        current_payload, new_payload = append_to_payload(interface, network_devices_metadata, namespace, collect_ts)
+        if new_payload:
+            yield current_payload
+            network_devices_metadata = new_payload
+
+    yield network_devices_metadata
+
+
+def append_to_payload(item, current_payload, namespace, collect_ts):
+    """
+    Append metadata to a NetworkDevicesMetadata payload, creating a new payload if batch size is reached
+    """
+    if current_payload.size < PAYLOAD_METADATA_BATCH_SIZE:
+        current_payload.append_metadata(item)
+        return current_payload, None
+    else:
+        new_payload = NetworkDevicesMetadata(namespace=namespace, collect_timestamp=collect_ts)
+        new_payload.append_metadata(item)
+        return current_payload, new_payload
+
+
+def common_tags(address, hostname, namespace):
+    """
+    Return a list of common tags (following NDM standards) for a device
+    """
+    return [
+        'device_ip:{}'.format(address),
+        'device_namespace:{}'.format(namespace),
+        'device_hostname:{}'.format(hostname),
+        'device_id:{}:{}'.format(namespace, address),
+    ]

--- a/cisco_aci/tests/fixtures/metadata.py
+++ b/cisco_aci/tests/fixtures/metadata.py
@@ -6,9 +6,6 @@ import six
 
 if six.PY3:
     from datadog_checks.cisco_aci.models import DeviceMetadataList, InterfaceMetadata, NetworkDevicesMetadata
-else:
-    DeviceMetadataList = None
-    NetworkDevicesMetadata = None
 
 DEVICE_METADATA = [
     {
@@ -36,6 +33,7 @@ DEVICE_METADATA = [
         ],
         'ip_address': '10.0.200.0',
         'model': 'N9K-C93180YC-FX',
+        'fabric_st': 'active',
         'name': 'pod-1-node-101',
         'serial_number': 'FDO20440TS1',
         'status': 1,
@@ -67,6 +65,7 @@ DEVICE_METADATA = [
         ],
         'ip_address': '10.0.200.1',
         'model': 'N9K-C93180YC-FX',
+        'fabric_st': 'active',
         'name': 'pod-1-node-102',
         'serial_number': 'FDO20510HCA',
         'status': 1,
@@ -98,6 +97,7 @@ DEVICE_METADATA = [
         ],
         'ip_address': '10.0.200.2',
         'model': 'N9K-C9336PQ',
+        'fabric_st': 'active',
         'name': 'pod-1-node-202',
         'serial_number': 'SAL2014N5T7',
         'status': 1,
@@ -128,9 +128,10 @@ DEVICE_METADATA = [
         ],
         'ip_address': '10.0.200.3',
         'model': 'APIC-SERVER-M1',
+        'fabric_st': 'unknown',
         'name': 'pod-1-node-3',
         'serial_number': 'FCH1927V11T',
-        'status': 4,
+        'status': 2,
         'vendor': 'cisco',
         'version': 'A',
     },
@@ -158,9 +159,10 @@ DEVICE_METADATA = [
         ],
         'ip_address': '10.0.200.4',
         'model': 'APIC-SERVER-M1',
+        'fabric_st': 'unknown',
         'name': 'pod-1-node-1',
         'serial_number': 'FCH1928V0SL',
-        'status': 4,
+        'status': 2,
         'vendor': 'cisco',
         'version': 'A',
     },
@@ -189,6 +191,7 @@ DEVICE_METADATA = [
         ],
         'ip_address': '10.0.200.5',
         'model': 'N9K-C9336PQ',
+        'fabric_st': 'active',
         'name': 'pod-1-node-201',
         'serial_number': 'SAL2014N5U4',
         'status': 1,
@@ -219,9 +222,10 @@ DEVICE_METADATA = [
         ],
         'ip_address': '10.0.200.6',
         'model': 'APIC-SERVER-M1',
+        'fabric_st': 'unknown',
         'name': 'pod-1-node-2',
         'serial_number': 'FCH1928V06Q',
-        'status': 4,
+        'status': 2,
         'vendor': 'cisco',
         'version': 'A',
     },
@@ -2741,18 +2745,19 @@ MOCK_TIME_EPOCH = 1326511294
 
 EXPECTED_INTERFACE_METADATA = [InterfaceMetadata(**im) for im in INTERFACE_METADATA]
 
-EXPECTED_DEVICE_METADATA_EVENTS = [
-    NetworkDevicesMetadata(namespace='default', devices=[ndm_meta], collect_timestamp=MOCK_TIME_EPOCH)
-    for ndm_meta in DEVICE_METADATA
-]
-EXPECTED_INTERFACE_METADATA_EVENTS = [
+EXPECTED_METADATA_EVENTS = [
     NetworkDevicesMetadata(
-        namespace='default', interfaces=INTERFACE_METADATA[0:100], collect_timestamp=MOCK_TIME_EPOCH
+        namespace='default',
+        devices=DEVICE_METADATA,
+        interfaces=INTERFACE_METADATA[0:93],
+        collect_timestamp=MOCK_TIME_EPOCH,
     ),
     NetworkDevicesMetadata(
-        namespace='default', interfaces=INTERFACE_METADATA[100:200], collect_timestamp=MOCK_TIME_EPOCH
+        namespace='default', interfaces=INTERFACE_METADATA[93:193], collect_timestamp=MOCK_TIME_EPOCH
     ),
     NetworkDevicesMetadata(
-        namespace='default', interfaces=INTERFACE_METADATA[200::], collect_timestamp=MOCK_TIME_EPOCH
+        namespace='default',
+        interfaces=INTERFACE_METADATA[193::],
+        collect_timestamp=MOCK_TIME_EPOCH,
     ),
 ]

--- a/cisco_aci/tests/test_fabric.py
+++ b/cisco_aci/tests/test_fabric.py
@@ -10,13 +10,9 @@ from datadog_checks.cisco_aci.api import Api
 
 if six.PY3:
     from .fixtures.metadata import (
-        EXPECTED_DEVICE_METADATA_EVENTS,
         EXPECTED_INTERFACE_METADATA,
-        EXPECTED_INTERFACE_METADATA_EVENTS,
+        EXPECTED_METADATA_EVENTS,
     )
-else:
-    EXPECTED_DEVICE_METADATA_RESULT = None
-    EXPECTED_INTERFACE_METADATA_RESULT = None
 
 from freezegun import freeze_time
 
@@ -84,14 +80,8 @@ def test_fabric_mocked(aggregator):
 
         if six.PY3:
             ndm_metadata = aggregator.get_event_platform_events("network-devices-metadata")
-            device_metadata = [dm for dm in ndm_metadata if 'devices' in dm and len(dm['devices']) > 0]
-            interface_metadata = [im for im in ndm_metadata if 'interfaces' in im and len(im['interfaces']) > 0]
-
-            expected_devices = [event.model_dump() for event in EXPECTED_DEVICE_METADATA_EVENTS]
-            expected_interfaces = [event.model_dump(exclude_none=True) for event in EXPECTED_INTERFACE_METADATA_EVENTS]
-
-            assert device_metadata == expected_devices
-            assert interface_metadata == expected_interfaces
+            expected_metadata = [event.model_dump(mode="json", exclude_none=True) for event in EXPECTED_METADATA_EVENTS]
+            assert ndm_metadata == expected_metadata
 
             interface_tag_mapping = {
                 'default:10.0.200.0': hn101,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
During QA - Device metadata was returning a status of `2` which means that the device is down / unreachable even though on the contrary, it seems to be active from the logic in the code

There is an issue with the Pydantic model with enums that some wires got crossed - this refactor makes the batching better for devices and cleans up the NDM related code into a separate file as well

Tests are updated accordingly to test the fabric state matches the status from the response

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
