### PR TITLE
Remove dynamic parameter

### DIFF
--- a/flink/README.md
+++ b/flink/README.md
@@ -18,12 +18,12 @@ No additional installation is needed on your server.
 
 1. Configure the [Datadog HTTP Reporter][2] in Flink.
 
-     In your `<FLINK_HOME>/conf/flink-conf.yaml`, add these lines, replacing `<DATADOG_API_KEY>` with your Datadog [API key][5]:
+     In your `<FLINK_HOME>/conf/flink-conf.yaml`, add these lines, replacing `<DATADOG_API_KEY>` with your Datadog [API key][5], and the datacent:
 
     ```yaml
     metrics.reporter.dghttp.factory.class: org.apache.flink.metrics.datadog.DatadogHttpReporterFactory
     metrics.reporter.dghttp.apikey: <DATADOG_API_KEY>
-    metrics.reporter.dghttp.dataCenter: {{< region-param key="dd_datacenter" >}}
+    metrics.reporter.dghttp.dataCenter: US #(optional) The data center (EU/US) to connect to, defaults to US.
     ```
 
 2. Re-map system scopes in your `<FLINK_HOME>/conf/flink-conf.yaml`.

--- a/flink/README.md
+++ b/flink/README.md
@@ -18,7 +18,7 @@ No additional installation is needed on your server.
 
 1. Configure the [Datadog HTTP Reporter][2] in Flink.
 
-     In your `<FLINK_HOME>/conf/flink-conf.yaml`, add these lines, replacing `<DATADOG_API_KEY>` with your Datadog [API key][5], and the datacent:
+     In your `<FLINK_HOME>/conf/flink-conf.yaml`, add these lines, replacing `<DATADOG_API_KEY>` with your Datadog [API key][5]:
 
     ```yaml
     metrics.reporter.dghttp.factory.class: org.apache.flink.metrics.datadog.DatadogHttpReporterFactory


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
- Remove dynamic parameter, Flink uses different datacenter parameters than Datadog.
- There are only two datacenters (EU/US) that are supported. [[source](https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/deployment/metric_reporters/#datadog:~:text=(optional)%20The%20data%20center%20(EU/US)%20to%20connect%20to%2C%20defaults%20to%20US.)]
- [DOCS-8618](https://datadoghq.atlassian.net/browse/DOCS-8618)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[DOCS-8618]: https://datadoghq.atlassian.net/browse/DOCS-8618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ