### PR TITLE
Added default port

### DIFF
--- a/postgres/changelog.d/18386.fixed
+++ b/postgres/changelog.d/18386.fixed
@@ -1,1 +1,3 @@
 Added default port
+
+This PR will set the default port to 5432 when user don't provide one, this corrects issue when the generated IAM authentication token is invalid when a port isn't provided.

--- a/postgres/changelog.d/18386.fixed
+++ b/postgres/changelog.d/18386.fixed
@@ -1,0 +1,1 @@
+Added default port

--- a/postgres/changelog.d/18386.fixed
+++ b/postgres/changelog.d/18386.fixed
@@ -1,3 +1,1 @@
-Added default port
-
-This PR will set the default port to 5432 when user don't provide one, this corrects issue when the generated IAM authentication token is invalid when a port isn't provided.
+Set the default port to 5432 when user don't provide one, this corrects the issue where the generated IAM authentication token is invalid when a port isn't provided.

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -35,7 +35,7 @@ class PostgresConfig:
         self.host = instance.get('host', '')
         if not self.host:
             raise ConfigurationError('Specify a Postgres host to connect to.')
-        self.port = instance.get('port', '')
+        self.port = instance.get('port', '5432')
         if self.port != '':
             self.port = int(self.port)
         self.user = instance.get('username', '')


### PR DESCRIPTION
Added the expected default port to the PostgresConfig

### What does this PR do?
This PR will actually set the default port to 5432 when user don't provide a port in the conf.yaml.

### Motivation
When the `port` is empty in the `postgres.d/conf.yaml`, we currently would leave the `port` as an empty string and then if the user was trying to use IAM Authentication, the generate token would be invalid for authenticating because no port is provided.

When using standard authentication this isn't an issue because `psycopg2` will use `5432` as the port if none if provided to it. 

### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
