### PR TITLE
Update to python 3.12

### DIFF
--- a/.builders/images/linux-aarch64/Dockerfile
+++ b/.builders/images/linux-aarch64/Dockerfile
@@ -53,11 +53,11 @@ RUN yum install -y perl-IPC-Cmd && \
  ldconfig
 
 # Compile and install Python 3
-ENV PYTHON3_VERSION=3.11.8
+ENV PYTHON3_VERSION=3.12.4
 RUN yum install -y libffi-devel && \
  DOWNLOAD_URL="https://python.org/ftp/python/{{version}}/Python-{{version}}.tgz" \
  VERSION="${PYTHON3_VERSION}" \
- SHA256="d3019a613b9e8761d260d9ebe3bd4df63976de30464e5c0189566e1ae3f61889" \
+ SHA256="01b3c1c082196f3b33168d344a9c85fb07bfe0e7ecfe77fee4443420d1ce2ad9" \
  RELATIVE_PATH="Python-{{version}}" \
  bash install-from-source.sh \
  --prefix=/opt/python/${PYTHON_VERSION} \

--- a/.builders/images/linux-x86_64/Dockerfile
+++ b/.builders/images/linux-x86_64/Dockerfile
@@ -51,11 +51,11 @@ RUN yum install -y perl-IPC-Cmd && \
  ldconfig
 
 # Compile and install Python 3
-ENV PYTHON3_VERSION=3.11.8
+ENV PYTHON3_VERSION=3.12.4
 RUN yum install -y libffi-devel && \
  DOWNLOAD_URL="https://python.org/ftp/python/{{version}}/Python-{{version}}.tgz" \
  VERSION="${PYTHON3_VERSION}" \
- SHA256="d3019a613b9e8761d260d9ebe3bd4df63976de30464e5c0189566e1ae3f61889" \
+ SHA256="01b3c1c082196f3b33168d344a9c85fb07bfe0e7ecfe77fee4443420d1ce2ad9" \
  RELATIVE_PATH="Python-{{version}}" \
  bash install-from-source.sh --prefix=/opt/python/${PYTHON_VERSION} --with-ensurepip=yes --enable-ipv6 --with-dbmliborder=
 ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"

--- a/.builders/images/windows-x86_64/Dockerfile
+++ b/.builders/images/windows-x86_64/Dockerfile
@@ -73,16 +73,16 @@ RUN Get-RemoteFile `
     Approve-File -Path $($Env:USERPROFILE + '\.cargo\bin\rustc.exe') -Hash $Env:RUSTC_HASH
 
 # Install Python 3
-ENV PYTHON_VERSION="3.11.7"
+ENV PYTHON_VERSION="3.12.4"
 RUN Get-RemoteFile `
       -Uri https://www.python.org/ftp/python/$Env:PYTHON_VERSION/python-$Env:PYTHON_VERSION-amd64.exe `
       -Path python-$Env:PYTHON_VERSION-amd64.exe `
-      -Hash 'c117c6444494bbe4cc937e8a5a61899d53f7f5c5bc573c5d130304e457d54024'; `
+      -Hash 'da5809df5cb05200b3a528a186f39b7d6186376ce051b0a393f1ddf67c995258'; `
     Start-Process -Wait python-$Env:PYTHON_VERSION-amd64.exe -ArgumentList '/quiet', 'InstallAllUsers=1'; `
     Remove-Item python-$Env:PYTHON_VERSION-amd64.exe; `
-    & 'C:\Program Files\Python311\python.exe' -m pip install --no-warn-script-location --upgrade pip; `
-    & 'C:\Program Files\Python311\python.exe' -m pip install --no-warn-script-location virtualenv; `
-    & 'C:\Program Files\Python311\python.exe' -m virtualenv 'C:\py3'; `
+    & 'C:\Program Files\Python312\python.exe' -m pip install --no-warn-script-location --upgrade pip; `
+    & 'C:\Program Files\Python312\python.exe' -m pip install --no-warn-script-location virtualenv; `
+    & 'C:\Program Files\Python312\python.exe' -m virtualenv 'C:\py3'; `
     Add-ToPath -Append 'C:\Program Files\Python311'
 
 # Install Python 2

--- a/.builders/images/windows-x86_64/Dockerfile
+++ b/.builders/images/windows-x86_64/Dockerfile
@@ -83,7 +83,7 @@ RUN Get-RemoteFile `
     & 'C:\Program Files\Python312\python.exe' -m pip install --no-warn-script-location --upgrade pip; `
     & 'C:\Program Files\Python312\python.exe' -m pip install --no-warn-script-location virtualenv; `
     & 'C:\Program Files\Python312\python.exe' -m virtualenv 'C:\py3'; `
-    Add-ToPath -Append 'C:\Program Files\Python311'
+    Add-ToPath -Append 'C:\Program Files\Python312'
 
 # Install Python 2
 ENV PYTHON_VERSION="2.7.18"

--- a/.builders/lock.py
+++ b/.builders/lock.py
@@ -36,6 +36,11 @@ def default_python_version() -> str:
     return match.group(1)
 
 
+@cache
+def target_python_for_major(python_major: str):
+    return '2.7' if python_major == '2' else default_python_version()
+
+
 def is_compatible_wheel(
     target_name: str,
     target_python_major: str,
@@ -44,7 +49,7 @@ def is_compatible_wheel(
     platform: str,
 ) -> bool:
     if interpreter.startswith('cp'):
-        target_python = '2.7' if target_python_major == '2' else default_python_version()
+        target_python = target_python_for_major(target_python_major)
         expected_tag = f'cp{target_python_major}' if abi == 'abi3' else f'cp{target_python}'.replace('.', '')
         if expected_tag not in interpreter:
             return False
@@ -134,8 +139,9 @@ def main():
     for target in Path(args.targets_dir).iterdir():
         for python_version in target.iterdir():
             if python_version.name.startswith('py'):
+                python_target = target_python_for_major(python_version.name.strip('py'))
                 generate_lock_file(
-                    python_version / 'frozen.txt', LOCK_FILE_DIR / f'{target.name}_{python_version.name}.txt'
+                    python_version / 'frozen.txt', LOCK_FILE_DIR / f'{target.name}_{python_target}.txt'
                 )
 
         if (image_digest_file := target / 'image_digest').is_file():

--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -24,7 +24,7 @@ defaults:
 
 env:
   APP_NAME: ddev
-  PYTHON_VERSION: "3.11"
+  PYTHON_VERSION: "3.12"
   PYOXIDIZER_VERSION: "0.24.0"
 
 jobs:

--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -28,7 +28,7 @@ defaults:
 
 env:
   PYTHONUNBUFFERED: "1"
-  PYTHON_VERSION: "3.11"
+  PYTHON_VERSION: "3.12"
   DIRECT_DEPENDENCY_FILE: agent_requirements.in
   # https://reproducible-builds.org/specs/source-date-epoch/
   SOURCE_DATE_EPOCH: "1580601600"
@@ -108,7 +108,7 @@ jobs:
       if: matrix.job.image == 'linux-aarch64'
       run: |
         mkdir -p ~/miniconda3
-        wget https://repo.anaconda.com/miniconda/Miniconda3-py311_24.1.2-0-Linux-aarch64.sh -O ~/miniconda3/miniconda.sh
+        wget https://repo.anaconda.com/miniconda/Miniconda3-py312_24.5.0-0-Linux-aarch64.sh -O ~/miniconda3/miniconda.sh
         bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
         rm -rf ~/miniconda3/miniconda.sh
         ~/miniconda3/bin/conda init bash
@@ -204,7 +204,7 @@ jobs:
     env:
       TARGET_NAME: macos-x86_64
       OUT_DIR: output/macos-x86_64
-      DD_PYTHON3: "/Library/Frameworks/Python.framework/Versions/3.11/bin/python"
+      DD_PYTHON3: "/Library/Frameworks/Python.framework/Versions/3.12/bin/python"
       DD_PYTHON2: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
 
     steps:
@@ -218,7 +218,7 @@ jobs:
     - name: Set up Python
       env:
         # Despite the name, this is built for the macOS 11 SDK on arm64 and 10.9+ on intel
-        PYTHON3_DOWNLOAD_URL: "https://www.python.org/ftp/python/3.11.5/python-3.11.5-macos11.pkg"
+        PYTHON3_DOWNLOAD_URL: "https://www.python.org/ftp/python/3.12.4/python-3.12.4-macos11.pkg"
         PYTHON2_DOWNLOAD_URL: "https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg"
       run: |-
         curl "$PYTHON3_DOWNLOAD_URL" -o python3.pkg

--- a/.github/workflows/cache-shared-deps.yml
+++ b/.github/workflows/cache-shared-deps.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-22.04, windows-2022]
 
     env:
-      PYTHON_VERSION: "3.11"
+      PYTHON_VERSION: "3.12"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/compute-matrix.yml
+++ b/.github/workflows/compute-matrix.yml
@@ -15,7 +15,7 @@ defaults:
     shell: bash
 
 env:
-  PYTHON_VERSION: "3.11"
+  PYTHON_VERSION: "3.12"
   MATRIX_SCRIPT: "ddev/src/ddev/utils/scripts/ci_matrix.py"
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
         cache: 'pip'
 
     - name: Upgrade Python packaging tools

--- a/.github/workflows/pr-quick-check.yml
+++ b/.github/workflows/pr-quick-check.yml
@@ -12,7 +12,7 @@ defaults:
     shell: bash
 
 env:
-  PYTHON_VERSION: "3.11"
+  PYTHON_VERSION: "3.12"
   CHECK_SCRIPT: "ddev/src/ddev/utils/scripts/check_pr.py"
 
 jobs:

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Upgrade Python packaging tools
       run: pip install --disable-pip-version-check --upgrade pip setuptools wheel

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Upgrade Python packaging tools
       run: pip install --disable-pip-version-check --upgrade pip setuptools wheel

--- a/.github/workflows/release-hash-check.yml
+++ b/.github/workflows/release-hash-check.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - id: files
       run: |

--- a/.github/workflows/run-validations.yml
+++ b/.github/workflows/run-validations.yml
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     env:
-      PYTHON_VERSION: "3.11"
+      PYTHON_VERSION: "3.12"
       TARGET: ${{ github.event_name == 'pull_request' && 'changed' || '' }}
 
     steps:

--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -94,8 +94,8 @@ jobs:
 
     env:
       FORCE_COLOR: "1"
-      PYTHON_VERSION: "${{ inputs.python-version || '3.11' }}"
-      PYTHON_FILTER: "${{ (inputs.test-py2 && !inputs.test-py3) && '2.7' || (!inputs.test-py2 && inputs.test-py3) && (inputs.python-version || '3.11') || '' }}"
+      PYTHON_VERSION: "${{ inputs.python-version || '3.12' }}"
+      PYTHON_FILTER: "${{ (inputs.test-py2 && !inputs.test-py3) && '2.7' || (!inputs.test-py2 && inputs.test-py3) && (inputs.python-version || '3.12') || '' }}"
       SKIP_ENV_NAME: "${{ (inputs.test-py2 && !inputs.test-py3) && 'py3.*' || (!inputs.test-py2 && inputs.test-py3) && 'py2.*' || '' }}"
       # Windows E2E requires Windows containers
       DDEV_E2E_AGENT: "${{ inputs.platform == 'windows' && (inputs.agent-image-windows || 'datadog/agent-dev:master-py3-win-servercore') || inputs.agent-image }}"

--- a/active_directory/hatch.toml
+++ b/active_directory/hatch.toml
@@ -10,4 +10,4 @@ platforms = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/active_directory/pyproject.toml
+++ b/active_directory/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/active_directory/setup.py
+++ b/active_directory/setup.py
@@ -73,7 +73,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.active_directory'],

--- a/activemq/hatch.toml
+++ b/activemq/hatch.toml
@@ -1,12 +1,12 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["2.15.0"]
 compose-file = ["artemis.yaml"]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["5.15.9"]
 compose-file = ["activemq.yaml"]
 

--- a/activemq/pyproject.toml
+++ b/activemq/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/activemq/setup.py
+++ b/activemq/setup.py
@@ -69,7 +69,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.activemq'],

--- a/activemq_xml/hatch.toml
+++ b/activemq_xml/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["5.11.1"]
 
 [envs.default.overrides]

--- a/activemq_xml/pyproject.toml
+++ b/activemq_xml/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/activemq_xml/setup.py
+++ b/activemq_xml/setup.py
@@ -70,7 +70,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.activemq_xml'],

--- a/aerospike/hatch.toml
+++ b/aerospike/hatch.toml
@@ -9,7 +9,7 @@ mypy-args = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["4", "5.0", "5.3", "5.6"]
 
 [envs.default.overrides]

--- a/aerospike/pyproject.toml
+++ b/aerospike/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/aerospike/setup.py
+++ b/aerospike/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.aerospike'],

--- a/airflow/hatch.toml
+++ b/airflow/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["2.1", "2.6"]
 
 [envs.default.overrides]

--- a/airflow/pyproject.toml
+++ b/airflow/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/amazon_msk/hatch.toml
+++ b/amazon_msk/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/amazon_msk/pyproject.toml
+++ b/amazon_msk/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/amazon_msk/setup.py
+++ b/amazon_msk/setup.py
@@ -69,7 +69,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.amazon_msk'],

--- a/ambari/hatch.toml
+++ b/ambari/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/ambari/pyproject.toml
+++ b/ambari/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/ambari/setup.py
+++ b/ambari/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.ambari'],

--- a/apache/hatch.toml
+++ b/apache/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["2.4.27"]
 
 [envs.default.overrides]

--- a/apache/pyproject.toml
+++ b/apache/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/apache/setup.py
+++ b/apache/setup.py
@@ -78,7 +78,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.apache'],

--- a/arangodb/hatch.toml
+++ b/arangodb/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["3.8"]
 
 [envs.default.overrides]

--- a/arangodb/pyproject.toml
+++ b/arangodb/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/argo_rollouts/hatch.toml
+++ b/argo_rollouts/hatch.toml
@@ -4,7 +4,7 @@
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["1.6.6"]
 
 [envs.default.overrides]

--- a/argo_rollouts/pyproject.toml
+++ b/argo_rollouts/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/argo_workflows/hatch.toml
+++ b/argo_workflows/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]

--- a/argo_workflows/pyproject.toml
+++ b/argo_workflows/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/argocd/hatch.toml
+++ b/argocd/hatch.toml
@@ -4,7 +4,7 @@
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["2.4.7"]
 
 [envs.default.overrides]

--- a/argocd/pyproject.toml
+++ b/argocd/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/aspdotnet/hatch.toml
+++ b/aspdotnet/hatch.toml
@@ -10,4 +10,4 @@ platforms = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/aspdotnet/pyproject.toml
+++ b/aspdotnet/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/aspdotnet/setup.py
+++ b/aspdotnet/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.aspdotnet'],

--- a/avi_vantage/hatch.toml
+++ b/avi_vantage/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]

--- a/avi_vantage/pyproject.toml
+++ b/avi_vantage/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/aws_neuron/hatch.toml
+++ b/aws_neuron/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]

--- a/aws_neuron/pyproject.toml
+++ b/aws_neuron/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/azure_iot_edge/hatch.toml
+++ b/azure_iot_edge/hatch.toml
@@ -12,10 +12,10 @@ mypy-args = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 protocol = ["tls"]
 
 [envs.default.overrides]

--- a/azure_iot_edge/pyproject.toml
+++ b/azure_iot_edge/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/azure_iot_edge/setup.py
+++ b/azure_iot_edge/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.azure_iot_edge'],

--- a/boundary/hatch.toml
+++ b/boundary/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["0.8"]
 
 [envs.default.overrides]

--- a/boundary/pyproject.toml
+++ b/boundary/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/btrfs/hatch.toml
+++ b/btrfs/hatch.toml
@@ -8,4 +8,4 @@ platforms = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/btrfs/pyproject.toml
+++ b/btrfs/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/btrfs/setup.py
+++ b/btrfs/setup.py
@@ -71,7 +71,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.btrfs'],

--- a/cacti/hatch.toml
+++ b/cacti/hatch.toml
@@ -6,4 +6,4 @@ dependencies = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/cacti/pyproject.toml
+++ b/cacti/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/cacti/setup.py
+++ b/cacti/setup.py
@@ -69,7 +69,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.cacti'],

--- a/calico/hatch.toml
+++ b/calico/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]

--- a/calico/pyproject.toml
+++ b/calico/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/calico/setup.py
+++ b/calico/setup.py
@@ -68,7 +68,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.calico'],

--- a/cassandra/hatch.toml
+++ b/cassandra/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]

--- a/cassandra/pyproject.toml
+++ b/cassandra/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/cassandra/setup.py
+++ b/cassandra/setup.py
@@ -69,7 +69,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.cassandra'],

--- a/cassandra_nodetool/hatch.toml
+++ b/cassandra_nodetool/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["2.1", "3.0"]
 
 [envs.default.overrides]

--- a/cassandra_nodetool/pyproject.toml
+++ b/cassandra_nodetool/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/cassandra_nodetool/setup.py
+++ b/cassandra_nodetool/setup.py
@@ -70,7 +70,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.cassandra_nodetool'],

--- a/ceph/hatch.toml
+++ b/ceph/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["4.0", "5.0"]
 
 [envs.default.overrides]

--- a/ceph/pyproject.toml
+++ b/ceph/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/ceph/setup.py
+++ b/ceph/setup.py
@@ -71,7 +71,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.ceph'],

--- a/cert_manager/hatch.toml
+++ b/cert_manager/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/cert_manager/pyproject.toml
+++ b/cert_manager/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/cilium/hatch.toml
+++ b/cilium/hatch.toml
@@ -1,12 +1,12 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 impl = ["legacy"]
 version = ["1.9"]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["1.9", "1.10", "1.11"]
 
 [envs.default.env-vars]

--- a/cilium/pyproject.toml
+++ b/cilium/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/cilium/setup.py
+++ b/cilium/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.cilium'],

--- a/cisco_aci/hatch.toml
+++ b/cisco_aci/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default]
 dependencies = [

--- a/cisco_aci/pyproject.toml
+++ b/cisco_aci/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/cisco_aci/setup.py
+++ b/cisco_aci/setup.py
@@ -65,7 +65,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     packages=['datadog_checks.cisco_aci'],
     # Run-time dependencies

--- a/citrix_hypervisor/hatch.toml
+++ b/citrix_hypervisor/hatch.toml
@@ -9,5 +9,5 @@ mypy-args = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 

--- a/citrix_hypervisor/pyproject.toml
+++ b/citrix_hypervisor/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/citrix_hypervisor/setup.py
+++ b/citrix_hypervisor/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.citrix_hypervisor'],

--- a/clickhouse/hatch.toml
+++ b/clickhouse/hatch.toml
@@ -4,7 +4,7 @@
 CLICKHOUSE_REPOSITORY = "clickhouse/clickhouse-server"
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["18", "19", "20", "21.8", "22.7"]
 
 [envs.default.overrides]

--- a/clickhouse/pyproject.toml
+++ b/clickhouse/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/clickhouse/setup.py
+++ b/clickhouse/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.clickhouse'],

--- a/cloud_foundry_api/hatch.toml
+++ b/cloud_foundry_api/hatch.toml
@@ -15,4 +15,4 @@ mypy-deps = [
 e2e-env = false
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/cloud_foundry_api/pyproject.toml
+++ b/cloud_foundry_api/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/cloud_foundry_api/setup.py
+++ b/cloud_foundry_api/setup.py
@@ -58,7 +58,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.cloud_foundry_api'],

--- a/cloudera/hatch.toml
+++ b/cloudera/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]

--- a/cloudera/pyproject.toml
+++ b/cloudera/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/cockroachdb/hatch.toml
+++ b/cockroachdb/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["2.0", "22.1", "23.2"]
 
 [envs.default.overrides]

--- a/cockroachdb/pyproject.toml
+++ b/cockroachdb/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/cockroachdb/setup.py
+++ b/cockroachdb/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.cockroachdb'],

--- a/confluent_platform/hatch.toml
+++ b/confluent_platform/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["5.4", "6.2"]
 
 [envs.default.overrides]

--- a/confluent_platform/pyproject.toml
+++ b/confluent_platform/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/confluent_platform/setup.py
+++ b/confluent_platform/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.confluent_platform'],

--- a/consul/hatch.toml
+++ b/consul/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["1.6", "1.9"]
 
 [envs.default.overrides]

--- a/consul/pyproject.toml
+++ b/consul/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/consul/setup.py
+++ b/consul/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     packages=['datadog_checks.consul'],
     # Run-time dependencies

--- a/coredns/hatch.toml
+++ b/coredns/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["1.2", "1.8"]
 
 [envs.default.overrides]

--- a/coredns/pyproject.toml
+++ b/coredns/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/coredns/setup.py
+++ b/coredns/setup.py
@@ -67,7 +67,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/couch/hatch.toml
+++ b/couch/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["1.6", "2.3", "3.1"]
 
 [envs.default.overrides]

--- a/couch/pyproject.toml
+++ b/couch/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/couch/setup.py
+++ b/couch/setup.py
@@ -71,7 +71,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.couch'],

--- a/couchbase/hatch.toml
+++ b/couchbase/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 # https://www.couchbase.com/support-policy/enterprise-software
 version = ["6.6", "7.0", "7.1"]
 

--- a/couchbase/pyproject.toml
+++ b/couchbase/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/couchbase/setup.py
+++ b/couchbase/setup.py
@@ -71,7 +71,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.couchbase'],

--- a/crio/hatch.toml
+++ b/crio/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/crio/pyproject.toml
+++ b/crio/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/crio/setup.py
+++ b/crio/setup.py
@@ -68,7 +68,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.crio'],

--- a/datadog_checks_base/hatch.toml
+++ b/datadog_checks_base/hatch.toml
@@ -11,7 +11,7 @@ mypy-args = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default]
 features = ["db", "deps", "http", "json", "kube"]

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dynamic = [

--- a/datadog_checks_base/setup.py
+++ b/datadog_checks_base/setup.py
@@ -71,7 +71,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     packages=['datadog_checks'],
     include_package_data=True,

--- a/datadog_checks_dependency_provider/pyproject.toml
+++ b/datadog_checks_dependency_provider/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "datadog-checks-base>=11.2.0",

--- a/datadog_checks_dependency_provider/setup.py
+++ b/datadog_checks_dependency_provider/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.datadog_checks_dependency_provider'],

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/hatch.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/pyproject.toml
@@ -9,7 +9,7 @@ name = "datadog-{project_name}"
 description = "The {integration_name} check"
 readme = "README.md"
 license = "BSD-3-Clause"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 keywords = [
     "datadog",
     "datadog agent",
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/hatch.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/pyproject.toml
@@ -9,7 +9,7 @@ name = "datadog-{project_name}"
 description = "The {integration_name} check"
 readme = "README.md"
 license = "BSD-3-Clause"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 keywords = [
     "datadog",
     "datadog agent",
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/datadog_checks_dev/hatch.toml
+++ b/datadog_checks_dev/hatch.toml
@@ -7,13 +7,13 @@ e2e-env = false
 DDEV_TESTING_PLUGIN = "true"
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default.overrides]
 matrix.python.features = [
-  { value = "cli", if = ["3.11"] },
+  { value = "cli", if = ["3.12"] },
 ]
 # TODO: remove this when the old CLI is gone
 matrix.python.pre-install-commands = [
-  { value = "python -m pip install --no-deps --disable-pip-version-check {verbosity:flag:-1} -e ../ddev", if = ["3.11"] },
+  { value = "python -m pip install --no-deps --disable-pip-version-check {verbosity:flag:-1} -e ../ddev", if = ["3.12"] },
 ]

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "contextlib2; python_version < '3.0'",

--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -55,7 +55,7 @@ setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],

--- a/datadog_checks_downloader/hatch.toml
+++ b/datadog_checks_downloader/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 
 [envs.default]
 e2e-env = false

--- a/datadog_checks_downloader/pyproject.toml
+++ b/datadog_checks_downloader/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dynamic = [

--- a/datadog_cluster_agent/hatch.toml
+++ b/datadog_cluster_agent/hatch.toml
@@ -1,5 +1,5 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 

--- a/datadog_cluster_agent/pyproject.toml
+++ b/datadog_cluster_agent/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/datadog_cluster_agent/setup.py
+++ b/datadog_cluster_agent/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.datadog_cluster_agent'],

--- a/dcgm/hatch.toml
+++ b/dcgm/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]

--- a/dcgm/pyproject.toml
+++ b/dcgm/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/ddev/hatch.toml
+++ b/ddev/hatch.toml
@@ -5,7 +5,7 @@ mypy-args = [
 ]
 
 [envs.default]
-python = "3.11"
+python = "3.12"
 e2e-env = false
 dependencies = [
   "pyyaml",

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "click~=8.1.6",
@@ -76,12 +76,12 @@ scripts = ["ddev"]
 include = '\.pyi?$'
 line-length = 120
 skip-string-normalization = true
-target-version = ["py311"]
+target-version = ["py312"]
 extend-exclude = "src/ddev/_version.py"
 
 [tool.ruff]
 exclude = []
-target-version = "py311"
+target-version = "py312"
 line-length = 120
 
 [tool.ruff.lint]

--- a/ddev/src/ddev/repo/constants.py
+++ b/ddev/src/ddev/repo/constants.py
@@ -11,4 +11,4 @@ FULL_NAMES = {
 }
 
 # This is automatically maintained
-PYTHON_VERSION = '3.11'
+PYTHON_VERSION = '3.12'

--- a/directory/hatch.toml
+++ b/directory/hatch.toml
@@ -1,6 +1,6 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.bench]

--- a/directory/pyproject.toml
+++ b/directory/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/directory/setup.py
+++ b/directory/setup.py
@@ -71,7 +71,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.directory'],

--- a/disk/hatch.toml
+++ b/disk/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/disk/pyproject.toml
+++ b/disk/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/disk/setup.py
+++ b/disk/setup.py
@@ -69,7 +69,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.disk'],

--- a/dns_check/hatch.toml
+++ b/dns_check/hatch.toml
@@ -7,4 +7,4 @@ mypy-args = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/dns_check/pyproject.toml
+++ b/dns_check/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/dns_check/setup.py
+++ b/dns_check/setup.py
@@ -69,7 +69,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.dns_check'],

--- a/dotnetclr/hatch.toml
+++ b/dotnetclr/hatch.toml
@@ -9,4 +9,4 @@ platforms = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/dotnetclr/pyproject.toml
+++ b/dotnetclr/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/dotnetclr/setup.py
+++ b/dotnetclr/setup.py
@@ -70,7 +70,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.dotnetclr'],

--- a/druid/hatch.toml
+++ b/druid/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/druid/pyproject.toml
+++ b/druid/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/druid/setup.py
+++ b/druid/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.druid'],

--- a/ecs_fargate/hatch.toml
+++ b/ecs_fargate/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/ecs_fargate/pyproject.toml
+++ b/ecs_fargate/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/ecs_fargate/setup.py
+++ b/ecs_fargate/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.ecs_fargate'],

--- a/eks_fargate/hatch.toml
+++ b/eks_fargate/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default]
 e2e-env = false

--- a/eks_fargate/pyproject.toml
+++ b/eks_fargate/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/eks_fargate/setup.py
+++ b/eks_fargate/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.eks_fargate'],

--- a/elastic/hatch.toml
+++ b/elastic/hatch.toml
@@ -2,12 +2,12 @@
 base-package-features = ["deps", "http"]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 flavor = ["elasticsearch"]
 version = ["7.2", "7.7", "7.9", "7.10", "8.8"]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 # Opensearch, compatible with elasticsearch
 flavor = ["opensearch"]
 version = ["1.1"]

--- a/elastic/pyproject.toml
+++ b/elastic/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/elastic/setup.py
+++ b/elastic/setup.py
@@ -70,7 +70,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.elastic'],

--- a/envoy/hatch.toml
+++ b/envoy/hatch.toml
@@ -10,7 +10,7 @@ python = ["2.7"]
 api-version = ["2"]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 api-version = ["2", "3"]
 
 [envs.default.overrides]

--- a/envoy/pyproject.toml
+++ b/envoy/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/envoy/setup.py
+++ b/envoy/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.envoy'],

--- a/esxi/hatch.toml
+++ b/esxi/hatch.toml
@@ -1,11 +1,11 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 setup = ["lab"]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 setup = ["vcsim"]
 version = ["6.5", "7.0"]
 

--- a/esxi/pyproject.toml
+++ b/esxi/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/etcd/hatch.toml
+++ b/etcd/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["v3.4.26" , "v3.5.9"]
 
 [envs.default.overrides]

--- a/etcd/pyproject.toml
+++ b/etcd/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/etcd/setup.py
+++ b/etcd/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.etcd'],

--- a/exchange_server/hatch.toml
+++ b/exchange_server/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default]
 dependencies = [

--- a/exchange_server/pyproject.toml
+++ b/exchange_server/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/exchange_server/setup.py
+++ b/exchange_server/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.exchange_server'],

--- a/external_dns/hatch.toml
+++ b/external_dns/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/external_dns/pyproject.toml
+++ b/external_dns/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/external_dns/setup.py
+++ b/external_dns/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.external_dns'],

--- a/flink/pyproject.toml
+++ b/flink/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/flink/setup.py
+++ b/flink/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.flink'],

--- a/fluentd/hatch.toml
+++ b/fluentd/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["1.17"]
 
 [envs.default.overrides]

--- a/fluentd/pyproject.toml
+++ b/fluentd/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/fluentd/setup.py
+++ b/fluentd/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.fluentd'],

--- a/fluxcd/hatch.toml
+++ b/fluxcd/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]

--- a/fluxcd/pyproject.toml
+++ b/fluxcd/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/fly_io/hatch.toml
+++ b/fly_io/hatch.toml
@@ -1,11 +1,11 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 setup = ["caddy"]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 setup = ["lab"]
 
 [envs.default.overrides]

--- a/fly_io/pyproject.toml
+++ b/fly_io/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/foundationdb/hatch.toml
+++ b/foundationdb/hatch.toml
@@ -7,10 +7,10 @@ dependencies = [
 e2e-env = false
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 protocol = ["tls"]
 
 [envs.default.overrides]

--- a/foundationdb/pyproject.toml
+++ b/foundationdb/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/foundationdb/setup.py
+++ b/foundationdb/setup.py
@@ -68,7 +68,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.foundationdb'],

--- a/gearmand/hatch.toml
+++ b/gearmand/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["1.0", "1.1"]
 
 [envs.default.overrides]

--- a/gearmand/pyproject.toml
+++ b/gearmand/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/gearmand/setup.py
+++ b/gearmand/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.gearmand'],

--- a/gitlab/hatch.toml
+++ b/gitlab/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 # https://about.gitlab.com/support/statement-of-support/#version-support
 version = ["13.12", "14.10", "15.10"]
 

--- a/gitlab/pyproject.toml
+++ b/gitlab/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/gitlab/setup.py
+++ b/gitlab/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.gitlab'],

--- a/gitlab_runner/hatch.toml
+++ b/gitlab_runner/hatch.toml
@@ -5,7 +5,7 @@ DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
 GITLAB_IMAGE = "gitlab/gitlab-ce"
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["10.8.0"]
 
 [envs.default.overrides]

--- a/gitlab_runner/pyproject.toml
+++ b/gitlab_runner/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/gitlab_runner/setup.py
+++ b/gitlab_runner/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.gitlab_runner'],

--- a/glusterfs/hatch.toml
+++ b/glusterfs/hatch.toml
@@ -12,7 +12,7 @@ mypy-deps = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["7.9"]
 
 [envs.default.env-vars]

--- a/glusterfs/pyproject.toml
+++ b/glusterfs/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/glusterfs/setup.py
+++ b/glusterfs/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.glusterfs'],

--- a/go_expvar/hatch.toml
+++ b/go_expvar/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/go_expvar/pyproject.toml
+++ b/go_expvar/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/go_expvar/setup.py
+++ b/go_expvar/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.go_expvar'],

--- a/gunicorn/hatch.toml
+++ b/gunicorn/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["19.9", "20.1"]
 
 [envs.default.overrides]

--- a/gunicorn/pyproject.toml
+++ b/gunicorn/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/gunicorn/setup.py
+++ b/gunicorn/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.gunicorn'],

--- a/haproxy/hatch.toml
+++ b/haproxy/hatch.toml
@@ -1,11 +1,11 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["2.0", "2.2", "2.4", "2.5", "2.6", "2.7"]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["2.0"]
 impl = ["legacy"]
 

--- a/haproxy/pyproject.toml
+++ b/haproxy/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/haproxy/setup.py
+++ b/haproxy/setup.py
@@ -70,7 +70,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.haproxy'],

--- a/harbor/hatch.toml
+++ b/harbor/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["1.10", "2.0", "2.3"]
 
 [envs.default.overrides]

--- a/harbor/pyproject.toml
+++ b/harbor/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/harbor/setup.py
+++ b/harbor/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.harbor'],

--- a/hazelcast/hatch.toml
+++ b/hazelcast/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["4.0"]
 
 [envs.default.overrides]

--- a/hazelcast/pyproject.toml
+++ b/hazelcast/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/hazelcast/setup.py
+++ b/hazelcast/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.hazelcast'],

--- a/hdfs_datanode/hatch.toml
+++ b/hdfs_datanode/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default.env-vars]
 HDFS_RAW_VERSION = "3.1.3"

--- a/hdfs_datanode/pyproject.toml
+++ b/hdfs_datanode/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/hdfs_datanode/setup.py
+++ b/hdfs_datanode/setup.py
@@ -71,7 +71,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.hdfs_datanode'],

--- a/hdfs_namenode/hatch.toml
+++ b/hdfs_namenode/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default.env-vars]
 HDFS_RAW_VERSION = "3.1.3"

--- a/hdfs_namenode/pyproject.toml
+++ b/hdfs_namenode/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/hdfs_namenode/setup.py
+++ b/hdfs_namenode/setup.py
@@ -71,7 +71,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.hdfs_namenode'],

--- a/hive/hatch.toml
+++ b/hive/hatch.toml
@@ -1,5 +1,5 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 

--- a/hive/pyproject.toml
+++ b/hive/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/hivemq/hatch.toml
+++ b/hivemq/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["4.3"]
 
 [envs.default.overrides]

--- a/hivemq/pyproject.toml
+++ b/hivemq/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/http_check/hatch.toml
+++ b/http_check/hatch.toml
@@ -6,4 +6,4 @@ dependencies = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/http_check/pyproject.toml
+++ b/http_check/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/http_check/setup.py
+++ b/http_check/setup.py
@@ -71,7 +71,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.http_check'],

--- a/hudi/hatch.toml
+++ b/hudi/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default.env-vars]
 SPARK_VERSION = "3.2.0"

--- a/hudi/pyproject.toml
+++ b/hudi/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/hudi/setup.py
+++ b/hudi/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.hudi'],

--- a/hyperv/hatch.toml
+++ b/hyperv/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default]
 platforms = [

--- a/hyperv/pyproject.toml
+++ b/hyperv/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/hyperv/setup.py
+++ b/hyperv/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.hyperv'],

--- a/ibm_ace/hatch.toml
+++ b/ibm_ace/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["12"]
 
 [envs.default.overrides]

--- a/ibm_ace/pyproject.toml
+++ b/ibm_ace/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/ibm_db2/hatch.toml
+++ b/ibm_db2/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["11.1"]
 
 [envs.default.env-vars]

--- a/ibm_db2/pyproject.toml
+++ b/ibm_db2/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/ibm_db2/setup.py
+++ b/ibm_db2/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.ibm_db2'],

--- a/ibm_i/hatch.toml
+++ b/ibm_i/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]

--- a/ibm_i/pyproject.toml
+++ b/ibm_i/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/ibm_mq/hatch.toml
+++ b/ibm_mq/hatch.toml
@@ -12,11 +12,11 @@ mypy-deps = [
 ]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["9"]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["9"]
 setup = ["cluster"]
 

--- a/ibm_mq/pyproject.toml
+++ b/ibm_mq/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/ibm_was/hatch.toml
+++ b/ibm_was/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 # We do not test IBM WAS v8. IBM themselves no longer build a docker image for this
 # version and we don't see the need to build and host an image ourselves. For reference:
 # https://github.com/WASdev/ci.docker.websphere-traditional/issues/198

--- a/ibm_was/pyproject.toml
+++ b/ibm_was/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/ibm_was/setup.py
+++ b/ibm_was/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.ibm_was'],

--- a/ignite/hatch.toml
+++ b/ignite/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["2.8", "2.14"]
 
 [envs.default.overrides]

--- a/ignite/pyproject.toml
+++ b/ignite/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/iis/hatch.toml
+++ b/iis/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default]
 dependencies = [

--- a/iis/pyproject.toml
+++ b/iis/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/iis/setup.py
+++ b/iis/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.iis'],

--- a/impala/hatch.toml
+++ b/impala/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["4.0.0"]
 
 [envs.default.overrides]

--- a/impala/pyproject.toml
+++ b/impala/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/istio/hatch.toml
+++ b/istio/hatch.toml
@@ -6,7 +6,7 @@ dependencies = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["1.13"]
 
 [envs.default.overrides]

--- a/istio/pyproject.toml
+++ b/istio/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/istio/setup.py
+++ b/istio/setup.py
@@ -69,7 +69,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.istio'],

--- a/jboss_wildfly/hatch.toml
+++ b/jboss_wildfly/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]

--- a/jboss_wildfly/pyproject.toml
+++ b/jboss_wildfly/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/journald/pyproject.toml
+++ b/journald/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/journald/setup.py
+++ b/journald/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.journald'],

--- a/kafka/hatch.toml
+++ b/kafka/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["2.8", "3.3"]
 
 [envs.default.overrides]

--- a/kafka/pyproject.toml
+++ b/kafka/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/kafka/setup.py
+++ b/kafka/setup.py
@@ -69,7 +69,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.kafka'],

--- a/kafka_consumer/hatch.toml
+++ b/kafka_consumer/hatch.toml
@@ -13,11 +13,11 @@ ZK_VERSION = "3.6.4"
 AUTHENTICATION = "noauth"
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["2.6", "3.3"]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["3.3"]
 auth = ["ssl", "kerberos"]
 

--- a/kafka_consumer/pyproject.toml
+++ b/kafka_consumer/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/karpenter/hatch.toml
+++ b/karpenter/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]

--- a/karpenter/pyproject.toml
+++ b/karpenter/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/kong/hatch.toml
+++ b/kong/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["1.5.0", "3.0.0"]
 
 [envs.default.overrides]

--- a/kong/pyproject.toml
+++ b/kong/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/kong/setup.py
+++ b/kong/setup.py
@@ -69,7 +69,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.kong'],

--- a/kube_apiserver_metrics/hatch.toml
+++ b/kube_apiserver_metrics/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/kube_apiserver_metrics/pyproject.toml
+++ b/kube_apiserver_metrics/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/kube_apiserver_metrics/setup.py
+++ b/kube_apiserver_metrics/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.kube_apiserver_metrics'],

--- a/kube_controller_manager/hatch.toml
+++ b/kube_controller_manager/hatch.toml
@@ -11,7 +11,7 @@ dependencies = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/kube_controller_manager/pyproject.toml
+++ b/kube_controller_manager/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/kube_controller_manager/setup.py
+++ b/kube_controller_manager/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.kube_controller_manager'],

--- a/kube_dns/hatch.toml
+++ b/kube_dns/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/kube_dns/pyproject.toml
+++ b/kube_dns/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/kube_dns/setup.py
+++ b/kube_dns/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.kube_dns'],

--- a/kube_metrics_server/hatch.toml
+++ b/kube_metrics_server/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/kube_metrics_server/pyproject.toml
+++ b/kube_metrics_server/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/kube_metrics_server/setup.py
+++ b/kube_metrics_server/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.kube_metrics_server'],

--- a/kube_proxy/hatch.toml
+++ b/kube_proxy/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default]
 platforms = [

--- a/kube_proxy/pyproject.toml
+++ b/kube_proxy/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/kube_proxy/setup.py
+++ b/kube_proxy/setup.py
@@ -69,7 +69,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.kube_proxy'],

--- a/kube_scheduler/hatch.toml
+++ b/kube_scheduler/hatch.toml
@@ -5,7 +5,7 @@ base-package-features = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default]
 dependencies = [

--- a/kube_scheduler/pyproject.toml
+++ b/kube_scheduler/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/kube_scheduler/setup.py
+++ b/kube_scheduler/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.kube_scheduler'],

--- a/kubelet/hatch.toml
+++ b/kubelet/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default]
 dependencies = [

--- a/kubelet/pyproject.toml
+++ b/kubelet/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/kubelet/setup.py
+++ b/kubelet/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.kubelet'],

--- a/kubernetes_cluster_autoscaler/hatch.toml
+++ b/kubernetes_cluster_autoscaler/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]

--- a/kubernetes_cluster_autoscaler/pyproject.toml
+++ b/kubernetes_cluster_autoscaler/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/kubernetes_state/hatch.toml
+++ b/kubernetes_state/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/kubernetes_state/pyproject.toml
+++ b/kubernetes_state/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/kubernetes_state/setup.py
+++ b/kubernetes_state/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.kubernetes_state'],

--- a/kyototycoon/hatch.toml
+++ b/kyototycoon/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/kyototycoon/pyproject.toml
+++ b/kyototycoon/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/kyototycoon/setup.py
+++ b/kyototycoon/setup.py
@@ -71,7 +71,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.kyototycoon'],

--- a/kyverno/hatch.toml
+++ b/kyverno/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]

--- a/kyverno/pyproject.toml
+++ b/kyverno/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/lighttpd/hatch.toml
+++ b/lighttpd/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 flavor = ["auth", "noauth"]
 
 [envs.default.overrides]

--- a/lighttpd/pyproject.toml
+++ b/lighttpd/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/lighttpd/setup.py
+++ b/lighttpd/setup.py
@@ -65,7 +65,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     packages=['datadog_checks.lighttpd'],
     # Run-time dependencies

--- a/linkerd/hatch.toml
+++ b/linkerd/hatch.toml
@@ -6,7 +6,7 @@ dependencies = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/linkerd/pyproject.toml
+++ b/linkerd/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/linkerd/setup.py
+++ b/linkerd/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.linkerd'],

--- a/linux_proc_extras/hatch.toml
+++ b/linux_proc_extras/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/linux_proc_extras/pyproject.toml
+++ b/linux_proc_extras/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/linux_proc_extras/setup.py
+++ b/linux_proc_extras/setup.py
@@ -69,7 +69,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.linux_proc_extras'],

--- a/mapr/hatch.toml
+++ b/mapr/hatch.toml
@@ -7,4 +7,4 @@ dependencies = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/mapr/pyproject.toml
+++ b/mapr/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/mapr/setup.py
+++ b/mapr/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.mapr'],

--- a/mapreduce/hatch.toml
+++ b/mapreduce/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default]
 dependencies = [

--- a/mapreduce/pyproject.toml
+++ b/mapreduce/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/mapreduce/setup.py
+++ b/mapreduce/setup.py
@@ -71,7 +71,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.mapreduce'],

--- a/marathon/hatch.toml
+++ b/marathon/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/marathon/pyproject.toml
+++ b/marathon/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/marathon/setup.py
+++ b/marathon/setup.py
@@ -70,7 +70,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     packages=['datadog_checks.marathon'],
     install_requires=[CHECKS_BASE_REQ],

--- a/marklogic/hatch.toml
+++ b/marklogic/hatch.toml
@@ -13,7 +13,7 @@ mypy-deps = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["9.0", "10.0", "11.0"]
 
 [envs.default.overrides]

--- a/marklogic/pyproject.toml
+++ b/marklogic/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/marklogic/setup.py
+++ b/marklogic/setup.py
@@ -58,7 +58,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.marklogic'],

--- a/mcache/hatch.toml
+++ b/mcache/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/mcache/pyproject.toml
+++ b/mcache/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/mcache/setup.py
+++ b/mcache/setup.py
@@ -66,7 +66,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     packages=['datadog_checks.mcache'],
     # Run-time dependencies

--- a/mesos_master/hatch.toml
+++ b/mesos_master/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["1.7"]
 
 [envs.default.overrides]

--- a/mesos_master/pyproject.toml
+++ b/mesos_master/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/mesos_master/setup.py
+++ b/mesos_master/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.mesos_master'],

--- a/mesos_slave/hatch.toml
+++ b/mesos_slave/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["1.7"]
 
 [envs.default.overrides]

--- a/mesos_slave/pyproject.toml
+++ b/mesos_slave/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/mesos_slave/setup.py
+++ b/mesos_slave/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.mesos_slave'],

--- a/mongo/hatch.toml
+++ b/mongo/hatch.toml
@@ -7,7 +7,7 @@ dependencies = [
 ]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["4.4", "5.0", "6.0", "7.0"]
 flavor = ["standalone", "shard", "auth", "tls"]
 

--- a/mongo/pyproject.toml
+++ b/mongo/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/mysql/hatch.toml
+++ b/mysql/hatch.toml
@@ -14,19 +14,19 @@ mypy-deps = [
 ]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = [
   "5.7",  # EOL October 21, 2023
   "8.0.36",  # EOL April, 2026
 ]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["8.0"]
 replication = ["group"]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 flavor = ["mariadb"]
 version = [
   "10.2",  # EOL 23 May 2022 (ended)

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/nagios/hatch.toml
+++ b/nagios/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["4.4"]
 
 [envs.default.overrides]

--- a/nagios/pyproject.toml
+++ b/nagios/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/nagios/setup.py
+++ b/nagios/setup.py
@@ -69,7 +69,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.nagios'],

--- a/network/hatch.toml
+++ b/network/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default.overrides]
 platform.windows.e2e-env = { value = false }

--- a/network/pyproject.toml
+++ b/network/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/network/setup.py
+++ b/network/setup.py
@@ -71,7 +71,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.network'],

--- a/nfsstat/hatch.toml
+++ b/nfsstat/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/nfsstat/pyproject.toml
+++ b/nfsstat/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/nfsstat/setup.py
+++ b/nfsstat/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.nfsstat'],

--- a/nginx/hatch.toml
+++ b/nginx/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["1.12", "1.13", "vts"]
 
 [envs.default.env-vars]

--- a/nginx/pyproject.toml
+++ b/nginx/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/nginx/setup.py
+++ b/nginx/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.nginx'],

--- a/nginx_ingress_controller/hatch.toml
+++ b/nginx_ingress_controller/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/nginx_ingress_controller/pyproject.toml
+++ b/nginx_ingress_controller/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/nginx_ingress_controller/setup.py
+++ b/nginx_ingress_controller/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.nginx_ingress_controller'],

--- a/nvidia_triton/hatch.toml
+++ b/nvidia_triton/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]

--- a/nvidia_triton/pyproject.toml
+++ b/nvidia_triton/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/openldap/hatch.toml
+++ b/openldap/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["2.4", "2.6"]
 
 [envs.default.overrides]

--- a/openldap/pyproject.toml
+++ b/openldap/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/openldap/setup.py
+++ b/openldap/setup.py
@@ -66,7 +66,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     packages=['datadog_checks.openldap'],
     # Run-time dependencies

--- a/openmetrics/hatch.toml
+++ b/openmetrics/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/openmetrics/pyproject.toml
+++ b/openmetrics/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/openmetrics/setup.py
+++ b/openmetrics/setup.py
@@ -67,7 +67,7 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.openmetrics'],

--- a/openstack/hatch.toml
+++ b/openstack/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/openstack/pyproject.toml
+++ b/openstack/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/openstack/setup.py
+++ b/openstack/setup.py
@@ -71,7 +71,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.openstack'],

--- a/openstack_controller/hatch.toml
+++ b/openstack_controller/hatch.toml
@@ -1,19 +1,19 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 setup = ["legacy"]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 setup = ["gcp"]
 
 [envs.default.overrides]
-name."^py3.11$".e2e-env = { value = true }
-name."^py3.11-legacy$".e2e-env = { value = true }
+name."^py3.12$".e2e-env = { value = true }
+name."^py3.12-legacy$".e2e-env = { value = true }
 matrix.setup.e2e-env = { value = true, if = ["gcp"], env = ["TF_VAR_credentials_file", "TF_VAR_instance_name", "TF_VAR_desired_status", "TF_VAR_nat_ip", "TF_VAR_network_ip", "TF_VAR_user"] }
 matrix.setup.env-vars = [
   { key = "USE_OPENSTACK_GCP", value = "true", if = ["gcp"] },

--- a/openstack_controller/pyproject.toml
+++ b/openstack_controller/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/oracle/hatch.toml
+++ b/oracle/hatch.toml
@@ -1,12 +1,12 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["12.2"]
 library = ["oracle", "oracle-instant-client", "jdbc"]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["12.2"]
 library = ["oracle", "oracle-instant-client", "jdbc"]
 protocol = ["tcps"]

--- a/oracle/pyproject.toml
+++ b/oracle/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/ossec_security/pyproject.toml
+++ b/ossec_security/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/pan_firewall/pyproject.toml
+++ b/pan_firewall/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/pan_firewall/setup.py
+++ b/pan_firewall/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.pan_firewall'],

--- a/pdh_check/hatch.toml
+++ b/pdh_check/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default]
 dependencies = [

--- a/pdh_check/pyproject.toml
+++ b/pdh_check/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/pdh_check/setup.py
+++ b/pdh_check/setup.py
@@ -70,7 +70,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.pdh_check'],

--- a/pgbouncer/hatch.toml
+++ b/pgbouncer/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["1.7", "1.8", "1.12"]
 
 [envs.default.env-vars]

--- a/pgbouncer/pyproject.toml
+++ b/pgbouncer/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/pgbouncer/setup.py
+++ b/pgbouncer/setup.py
@@ -67,7 +67,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     packages=['datadog_checks.pgbouncer'],
     install_requires=[CHECKS_BASE_REQ],

--- a/php_fpm/hatch.toml
+++ b/php_fpm/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/php_fpm/pyproject.toml
+++ b/php_fpm/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/php_fpm/setup.py
+++ b/php_fpm/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.php_fpm'],

--- a/ping_federate/pyproject.toml
+++ b/ping_federate/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/postfix/hatch.toml
+++ b/postfix/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/postfix/pyproject.toml
+++ b/postfix/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/postfix/setup.py
+++ b/postfix/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.postfix'],

--- a/postgres/hatch.toml
+++ b/postgres/hatch.toml
@@ -15,7 +15,7 @@ mypy-deps = [
 ]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["9.6", "10.0", "11.0", "12.17", "13.0", "14.0", "15.0", "16.0"]
 
 [envs.default.overrides]

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/powerdns_recursor/hatch.toml
+++ b/powerdns_recursor/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["3.7", "4.0"]
 
 [envs.default.overrides]

--- a/powerdns_recursor/pyproject.toml
+++ b/powerdns_recursor/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/powerdns_recursor/setup.py
+++ b/powerdns_recursor/setup.py
@@ -73,7 +73,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.powerdns_recursor'],

--- a/presto/hatch.toml
+++ b/presto/hatch.toml
@@ -6,7 +6,7 @@ dependencies = [
 ]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["346"]
 
 [envs.default.overrides]

--- a/presto/pyproject.toml
+++ b/presto/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/process/hatch.toml
+++ b/process/hatch.toml
@@ -1,6 +1,6 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.bench]

--- a/process/pyproject.toml
+++ b/process/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/process/setup.py
+++ b/process/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.process'],

--- a/prometheus/hatch.toml
+++ b/prometheus/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default]
 platforms = [

--- a/prometheus/pyproject.toml
+++ b/prometheus/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/prometheus/setup.py
+++ b/prometheus/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.prometheus'],

--- a/proxysql/hatch.toml
+++ b/proxysql/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["1.4", "2.0"]
 
 [envs.default.overrides]

--- a/proxysql/pyproject.toml
+++ b/proxysql/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/proxysql/setup.py
+++ b/proxysql/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.proxysql'],

--- a/pulsar/hatch.toml
+++ b/pulsar/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["2.9"]
 
 [envs.default.overrides]

--- a/pulsar/pyproject.toml
+++ b/pulsar/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/rabbitmq/hatch.toml
+++ b/rabbitmq/hatch.toml
@@ -8,17 +8,17 @@ dependencies = [
 
 # Rabbitmq versions <3.8 must be tested on both PY2 and PY3. All these versions use RabbitMQ's management plugin as the source for data.
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["3.7"]
 
 # Rabbitmq versions 3.8+ introduce the Prometheus plugin. This is the preferred way to collect metrics. We drop PY2 support.
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["3.11"]
 
 # We still support metrics from management plugin as a legacy option and continue to support PY2 for them as well.
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["3.11"]
 plugin = ["mgmt"]
 

--- a/rabbitmq/pyproject.toml
+++ b/rabbitmq/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/rabbitmq/setup.py
+++ b/rabbitmq/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.rabbitmq'],

--- a/ray/hatch.toml
+++ b/ray/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["2.8"]
 
 [envs.default.overrides]

--- a/ray/pyproject.toml
+++ b/ray/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/redisdb/hatch.toml
+++ b/redisdb/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["5.0", "6.0", "7.0", "cloud"]
 
 [envs.default.overrides]

--- a/redisdb/pyproject.toml
+++ b/redisdb/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/redisdb/setup.py
+++ b/redisdb/setup.py
@@ -66,7 +66,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     packages=['datadog_checks.redisdb'],
     # Run-time dependencies

--- a/rethinkdb/hatch.toml
+++ b/rethinkdb/hatch.toml
@@ -13,7 +13,7 @@ mypy-deps = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 # Can't support lower 2.3 patch versions due to: https://github.com/rethinkdb/rethinkdb/issues/6108
 version = ["2.3", "2.4"]
 

--- a/rethinkdb/pyproject.toml
+++ b/rethinkdb/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/rethinkdb/setup.py
+++ b/rethinkdb/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.rethinkdb'],

--- a/riak/hatch.toml
+++ b/riak/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/riak/pyproject.toml
+++ b/riak/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/riak/setup.py
+++ b/riak/setup.py
@@ -69,7 +69,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.riak'],

--- a/riakcs/hatch.toml
+++ b/riakcs/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default]
 e2e-env = false

--- a/riakcs/pyproject.toml
+++ b/riakcs/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/riakcs/setup.py
+++ b/riakcs/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.riakcs'],

--- a/sap_hana/hatch.toml
+++ b/sap_hana/hatch.toml
@@ -6,7 +6,7 @@ dependencies = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["2.0"]
 
 [envs.default.overrides]

--- a/sap_hana/pyproject.toml
+++ b/sap_hana/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/sap_hana/setup.py
+++ b/sap_hana/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.sap_hana'],

--- a/scylla/hatch.toml
+++ b/scylla/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7","3.11"]
+python = ["2.7","3.12"]
 version = ["3.1", "3.3", "5.2"]
 
 [envs.default.overrides]

--- a/scylla/pyproject.toml
+++ b/scylla/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/scylla/setup.py
+++ b/scylla/setup.py
@@ -72,7 +72,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.scylla'],

--- a/sidekiq/pyproject.toml
+++ b/sidekiq/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/sidekiq/setup.py
+++ b/sidekiq/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.sidekiq'],

--- a/silk/hatch.toml
+++ b/silk/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default]
 dependencies = [

--- a/silk/pyproject.toml
+++ b/silk/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/silk/setup.py
+++ b/silk/setup.py
@@ -66,7 +66,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.silk'],

--- a/singlestore/hatch.toml
+++ b/singlestore/hatch.toml
@@ -13,4 +13,4 @@ mypy-deps = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/singlestore/pyproject.toml
+++ b/singlestore/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/singlestore/setup.py
+++ b/singlestore/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.singlestore'],

--- a/snmp/hatch.toml
+++ b/snmp/hatch.toml
@@ -14,7 +14,7 @@ python = ["2.7"]
 snmplistener = ["false"]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 snmplistener = ["false", "true"]
 
 [envs.default.overrides]

--- a/snmp/pyproject.toml
+++ b/snmp/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/snmp/setup.py
+++ b/snmp/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.snmp'],

--- a/snowflake/hatch.toml
+++ b/snowflake/hatch.toml
@@ -12,4 +12,4 @@ mypy-deps = [
 ]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]

--- a/snowflake/pyproject.toml
+++ b/snowflake/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/solr/hatch.toml
+++ b/solr/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["8.11", "9.3"]
 
 [envs.default.overrides]

--- a/solr/pyproject.toml
+++ b/solr/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/sonarqube/hatch.toml
+++ b/sonarqube/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["7.9", "8.5", "9.3"]
 
 # You can use M1 env if you want to run on M1 processor machine

--- a/sonarqube/pyproject.toml
+++ b/sonarqube/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/sonarqube/setup.py
+++ b/sonarqube/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.sonarqube'],

--- a/spark/hatch.toml
+++ b/spark/hatch.toml
@@ -6,7 +6,7 @@ dependencies = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["2.4", "3.0"]
 
 [envs.default.overrides]

--- a/spark/pyproject.toml
+++ b/spark/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/spark/setup.py
+++ b/spark/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.spark'],

--- a/sqlserver/hatch.toml
+++ b/sqlserver/hatch.toml
@@ -5,7 +5,7 @@ base-package-features = ["deps", "db", "json"]
 dependencies = ["deepdiff"]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 os = ["linux"]
 version = ["2017", "2019", "2022"]
 setup = ["single", "ha"]
@@ -15,7 +15,7 @@ setup = ["single", "ha"]
 # time out. until we're able to modify and parallelize the work we'll limit the per-driver tests to only a single
 # sqlserver version
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 os = ["windows"]
 driver = ["SQLOLEDB", "SQLNCLI11", "MSOLEDBSQL", "odbc"]
 version = ["2019", "2022"]

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/squid/hatch.toml
+++ b/squid/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["4.13", "5.6"]
 
 [envs.default.overrides]

--- a/squid/pyproject.toml
+++ b/squid/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/squid/setup.py
+++ b/squid/setup.py
@@ -69,7 +69,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.squid'],

--- a/ssh_check/hatch.toml
+++ b/ssh_check/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["8.1", "9.1"]
 
 [envs.default.overrides]

--- a/ssh_check/pyproject.toml
+++ b/ssh_check/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/ssh_check/setup.py
+++ b/ssh_check/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.ssh_check'],

--- a/statsd/hatch.toml
+++ b/statsd/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["0.9"]
 
 [envs.default.overrides]

--- a/statsd/pyproject.toml
+++ b/statsd/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/statsd/setup.py
+++ b/statsd/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.statsd'],

--- a/strimzi/hatch.toml
+++ b/strimzi/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["0.34"]
 
 [envs.default.overrides]

--- a/strimzi/pyproject.toml
+++ b/strimzi/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/supervisord/hatch.toml
+++ b/supervisord/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["3.3"]
 
 [envs.default.overrides]

--- a/supervisord/pyproject.toml
+++ b/supervisord/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/supervisord/setup.py
+++ b/supervisord/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.supervisord'],

--- a/suricata/pyproject.toml
+++ b/suricata/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/system_core/hatch.toml
+++ b/system_core/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/system_core/pyproject.toml
+++ b/system_core/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/system_core/setup.py
+++ b/system_core/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.system_core'],

--- a/system_swap/hatch.toml
+++ b/system_swap/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/system_swap/pyproject.toml
+++ b/system_swap/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/system_swap/setup.py
+++ b/system_swap/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.system_swap'],

--- a/tcp_check/hatch.toml
+++ b/tcp_check/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/tcp_check/pyproject.toml
+++ b/tcp_check/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/tcp_check/setup.py
+++ b/tcp_check/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.tcp_check'],

--- a/teamcity/hatch.toml
+++ b/teamcity/hatch.toml
@@ -5,7 +5,7 @@ python = ["2.7"]
 impl = ["legacy"]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 impl = ["legacy", "openmetrics"]
 
 [envs.default.overrides]

--- a/teamcity/pyproject.toml
+++ b/teamcity/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/teamcity/setup.py
+++ b/teamcity/setup.py
@@ -65,7 +65,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     packages=['datadog_checks.teamcity'],
     # Run-time dependencies

--- a/tekton/hatch.toml
+++ b/tekton/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]

--- a/tekton/pyproject.toml
+++ b/tekton/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/teleport/hatch.toml
+++ b/teleport/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]

--- a/teleport/pyproject.toml
+++ b/teleport/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/temporal/hatch.toml
+++ b/temporal/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["1.19"]
 
 [envs.default.overrides]

--- a/temporal/pyproject.toml
+++ b/temporal/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/tenable/pyproject.toml
+++ b/tenable/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/tenable/setup.py
+++ b/tenable/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.tenable'],

--- a/teradata/hatch.toml
+++ b/teradata/hatch.toml
@@ -1,14 +1,14 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 setup = ["sandbox"]
 
 [envs.default.overrides]
-name."^py3.11$".e2e-env = { value = true }
+name."^py3.12$".e2e-env = { value = true }
 matrix.setup.e2e-env = { value = true, if = ["sandbox"], env = ["TERADATA_SERVER"] }
 matrix.setup.env-vars = [
   { key = "USE_TD_SANDBOX", value = "true", if = ["sandbox"] },

--- a/teradata/pyproject.toml
+++ b/teradata/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/tibco_ems/hatch.toml
+++ b/tibco_ems/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 
 [envs.default]
 e2e-env = false

--- a/tibco_ems/pyproject.toml
+++ b/tibco_ems/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/tls/hatch.toml
+++ b/tls/hatch.toml
@@ -6,4 +6,4 @@ dependencies = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/tls/pyproject.toml
+++ b/tls/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/tls/setup.py
+++ b/tls/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.tls'],

--- a/tomcat/hatch.toml
+++ b/tomcat/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["9.0", "10.0", "10.1"]
 flavor = ["standalone", "embedded"]
 

--- a/tomcat/pyproject.toml
+++ b/tomcat/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/tomcat/setup.py
+++ b/tomcat/setup.py
@@ -69,7 +69,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.tomcat'],

--- a/torchserve/hatch.toml
+++ b/torchserve/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["0.8"]
 
 [envs.default.overrides]

--- a/torchserve/pyproject.toml
+++ b/torchserve/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/traefik_mesh/hatch.toml
+++ b/traefik_mesh/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]

--- a/traefik_mesh/pyproject.toml
+++ b/traefik_mesh/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/traffic_server/hatch.toml
+++ b/traffic_server/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 
 [envs.default.env-vars]
 TRAFFIC_SERVER_VERSION = "9.1.1"

--- a/traffic_server/pyproject.toml
+++ b/traffic_server/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/twemproxy/hatch.toml
+++ b/twemproxy/hatch.toml
@@ -4,7 +4,7 @@
 platforms = ["linux", "macos"]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["0.5.0"]
 
 [envs.default.env-vars]

--- a/twemproxy/pyproject.toml
+++ b/twemproxy/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/twemproxy/setup.py
+++ b/twemproxy/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.twemproxy'],

--- a/twistlock/hatch.toml
+++ b/twistlock/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]

--- a/twistlock/pyproject.toml
+++ b/twistlock/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/twistlock/setup.py
+++ b/twistlock/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.twistlock'],

--- a/varnish/hatch.toml
+++ b/varnish/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["5.2", "6.5"]
 
 [envs.default.overrides]

--- a/varnish/pyproject.toml
+++ b/varnish/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/varnish/setup.py
+++ b/varnish/setup.py
@@ -71,7 +71,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.varnish'],

--- a/vault/hatch.toml
+++ b/vault/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["1.9.0"]
 auth = ["token-auth", "noauth"]
 

--- a/vault/pyproject.toml
+++ b/vault/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/vault/setup.py
+++ b/vault/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.vault'],

--- a/vertica/hatch.toml
+++ b/vertica/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["10.1", "11.1", "12.0", "23.3"]
 
 [envs.default.overrides]

--- a/vertica/pyproject.toml
+++ b/vertica/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/vertica/setup.py
+++ b/vertica/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.vertica'],

--- a/vllm/hatch.toml
+++ b/vllm/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]

--- a/vllm/pyproject.toml
+++ b/vllm/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/voltdb/hatch.toml
+++ b/voltdb/hatch.toml
@@ -15,12 +15,12 @@ mypy-deps = [
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["8.4", "10.0"]
 tls = ["false"]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["8.4"]
 tls = ["true"]
 

--- a/voltdb/pyproject.toml
+++ b/voltdb/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/voltdb/setup.py
+++ b/voltdb/setup.py
@@ -67,9 +67,9 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.voltdb'],

--- a/vsphere/hatch.toml
+++ b/vsphere/hatch.toml
@@ -18,7 +18,7 @@ mypy-args = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["6.7", "7.0"]
 
 [envs.default]

--- a/vsphere/pyproject.toml
+++ b/vsphere/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/vsphere/setup.py
+++ b/vsphere/setup.py
@@ -65,7 +65,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     packages=['datadog_checks.vsphere'],
     # Run-time dependencies

--- a/weaviate/hatch.toml
+++ b/weaviate/hatch.toml
@@ -4,7 +4,7 @@
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["1.20"]
 auth = ["no-auth", "auth"]
 

--- a/weaviate/pyproject.toml
+++ b/weaviate/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/weblogic/hatch.toml
+++ b/weblogic/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["12", "14"]
 
 [envs.default.overrides]

--- a/weblogic/pyproject.toml
+++ b/weblogic/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/weblogic/setup.py
+++ b/weblogic/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.weblogic'],

--- a/win32_event_log/hatch.toml
+++ b/win32_event_log/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default]
 e2e-env = false

--- a/win32_event_log/pyproject.toml
+++ b/win32_event_log/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/win32_event_log/setup.py
+++ b/win32_event_log/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.win32_event_log'],

--- a/windows_performance_counters/hatch.toml
+++ b/windows_performance_counters/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 
 [envs.default]
 platforms = [

--- a/windows_performance_counters/pyproject.toml
+++ b/windows_performance_counters/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/windows_service/hatch.toml
+++ b/windows_service/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default]
 platforms = [

--- a/windows_service/pyproject.toml
+++ b/windows_service/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/windows_service/setup.py
+++ b/windows_service/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.windows_service'],

--- a/wmi_check/hatch.toml
+++ b/wmi_check/hatch.toml
@@ -9,7 +9,7 @@ mypy-args = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default]
 e2e-env = false

--- a/wmi_check/pyproject.toml
+++ b/wmi_check/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/wmi_check/setup.py
+++ b/wmi_check/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.wmi_check'],

--- a/yarn/hatch.toml
+++ b/yarn/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/yarn/pyproject.toml
+++ b/yarn/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/yarn/setup.py
+++ b/yarn/setup.py
@@ -71,7 +71,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.yarn'],

--- a/zk/hatch.toml
+++ b/zk/hatch.toml
@@ -1,12 +1,12 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["3.5.8", "3.6.2"]
 ssl = ["ssl"]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["2.7", "3.12"]
 version = ["3.5.8", "3.6.2"]
 
 [envs.default.overrides]

--- a/zk/pyproject.toml
+++ b/zk/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/zk/setup.py
+++ b/zk/setup.py
@@ -68,7 +68,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     # The package we're going to ship
     packages=['datadog_checks.zk'],


### PR DESCRIPTION
### What does this PR do?

Updates Python minor version to 3.12.

For dependencies, a suffix has been added to the lockfile to allow us to transition on the datadog-agent side without disrupting open PR's.

### Motivation

https://github.com/DataDog/datadog-agent/pull/28492

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
