### PR TITLE
Add cluster_name as tag to PG metrics

### DIFF
--- a/postgres/changelog.d/18402.added
+++ b/postgres/changelog.d/18402.added
@@ -1,0 +1,1 @@
+Add cluster_name as tag to PG metrics

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -136,6 +136,7 @@ class PostgreSql(AgentCheck):
         self.check_initializations.append(self.set_resolved_hostname_metadata)
         self.check_initializations.append(self._connect)
         self.check_initializations.append(self.load_version)
+        self.check_initializations.append(self.load_system_identifier)
         self.check_initializations.append(self.initialize_is_aurora)
         self.check_initializations.append(self._query_manager.compile_queries)
         self.tags_without_db = [t for t in copy.copy(self.tags) if not t.startswith("db:")]
@@ -940,9 +941,10 @@ class PostgreSql(AgentCheck):
             tags_to_add.append(f'postgresql_version:{self.raw_version}')
 
             # Add system identifier as a tag
-            self.load_system_identifier()
-            tags.append(f'system_identifier:{self.system_identifier}')
-            tags_to_add.append(f'system_identifier:{self.system_identifier}')
+            if self.system_identifier:
+                tags.append(f'system_identifier:{self.system_identifier}')
+                tags_to_add.append(f'system_identifier:{self.system_identifier}')
+
             if self._config.tag_replication_role:
                 replication_role_tag = "replication_role:{}".format(self._get_replication_role())
                 tags.append(replication_role_tag)

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -141,7 +141,15 @@ def _get_expected_replication_tags(check, pg_instance, with_host=True, with_db=F
 
 
 def _get_expected_tags(
-    check, pg_instance, with_host=True, with_db=False, with_version=True, with_sys_id=True, role='master', **kwargs
+    check,
+    pg_instance,
+    with_host=True,
+    with_db=False,
+    with_version=True,
+    with_sys_id=True,
+    with_cluster_name=True,
+    role='master',
+    **kwargs,
 ):
     base_tags = pg_instance['tags'] + [f'port:{pg_instance["port"]}']
     if role:
@@ -150,6 +158,8 @@ def _get_expected_tags(
         base_tags.append(f'db:{pg_instance["dbname"]}')
     if with_host:
         base_tags.append(f'dd.internal.resource:database_instance:{check.resolved_hostname}')
+    if with_cluster_name and check.cluster_name:
+        base_tags.append(f'postgresql_cluster_name:{check.cluster_name}')
     if with_sys_id and check.system_identifier:
         base_tags.append(f'system_identifier:{check.system_identifier}')
     if with_version and check.raw_version:

--- a/postgres/tests/compose/etc/postgresql/postgresql.conf
+++ b/postgres/tests/compose/etc/postgresql/postgresql.conf
@@ -5,6 +5,7 @@ pg_stat_statements.track=all
 track_io_timing=on
 track_functions=pl
 statement_timeout = 10000
+cluster_name = 'primary'
 
 wal_level = logical
 max_wal_senders = 10

--- a/postgres/tests/compose/etc/postgresql_replica2/postgresql.conf
+++ b/postgres/tests/compose/etc/postgresql_replica2/postgresql.conf
@@ -6,6 +6,7 @@ pg_stat_statements.track=all
 track_io_timing=on
 track_functions=pl
 statement_timeout = 10000
+cluster_name = 'replica2'
 
 hot_standby = on
 hot_standby_feedback = off

--- a/postgres/tests/test_discovery.py
+++ b/postgres/tests/test_discovery.py
@@ -162,7 +162,7 @@ def test_autodiscovery_refresh(integration_check, pg_instance):
     del pg_instance['dbname']
     pg_instance["database_autodiscovery"]['refresh'] = 1
     check = integration_check(pg_instance)
-    run_one_check(check, pg_instance)
+    run_one_check(check)
 
     assert check.autodiscovery is not None
     databases = check.autodiscovery.get_items()

--- a/postgres/tests/test_e2e.py
+++ b/postgres/tests/test_e2e.py
@@ -20,6 +20,9 @@ def test_e2e(check, dd_agent_check, pg_instance):
         cur.execute("SELECT system_identifier FROM pg_control_system();")
         check.system_identifier = cur.fetchone()[0]
 
+        cur.execute("SHOW cluster_name;")
+        check.cluster_name = cur.fetchone()[0]
+
     expected_tags = _get_expected_tags(check, pg_instance, with_host=False)
     check_bgw_metrics(aggregator, expected_tags)
     check_common_metrics(aggregator, expected_tags=expected_tags, count=None)

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -1115,7 +1115,7 @@ def test_collect_wal_metrics_metrics(aggregator, integration_check, pg_instance,
     check.is_aurora = False
     check.check(pg_instance)
 
-    expected_tags = _get_expected_tags(check, pg_instance)
+    expected_tags = _get_expected_tags(check, pg_instance, with_sys_id=False)
     # if collect_wal_metrics is not set, wal metrics are collected on pg >= 10 by default
     expected_count = 0 if collect_wal_metrics is False else 1
     check_file_wal_metrics(aggregator, expected_tags=expected_tags, count=expected_count)

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -69,7 +69,9 @@ pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')
 def test_common_metrics(aggregator, integration_check, pg_instance, is_aurora):
     check = integration_check(pg_instance)
     check.is_aurora = is_aurora
-    check.check(pg_instance)
+
+    # Use check.run() to go through initilization queries
+    check.run()
 
     expected_tags = _get_expected_tags(check, pg_instance)
     check_common_metrics(aggregator, expected_tags=expected_tags)
@@ -104,6 +106,14 @@ def _increase_txid(cur):
     cur.execute(query)
 
 
+def test_initialization_tags(integration_check, pg_instance):
+    check = integration_check(pg_instance)
+    check.run()
+    # After run, initialization queries should have set system identifier and cluster_name tags
+    assert check.cluster_name == 'primary'
+    assert check.system_identifier is not None
+
+
 def test_snapshot_xmin(aggregator, integration_check, pg_instance):
     with psycopg2.connect(host=HOST, dbname=DB_NAME, user="postgres", password="datad0g") as conn:
         conn.set_session(autocommit=True)
@@ -115,7 +125,7 @@ def test_snapshot_xmin(aggregator, integration_check, pg_instance):
             cur.execute(query)
             xmin = float(cur.fetchall()[0][0])
     check = integration_check(pg_instance)
-    check.check(pg_instance)
+    check.run()
 
     expected_tags = _get_expected_tags(check, pg_instance)
     aggregator.assert_metric('postgresql.snapshot.xmin', count=1, tags=expected_tags)
@@ -131,7 +141,7 @@ def test_snapshot_xmin(aggregator, integration_check, pg_instance):
 
     aggregator.reset()
     check = integration_check(pg_instance)
-    check.check(pg_instance)
+    check.run()
     aggregator.assert_metric('postgresql.snapshot.xmin', count=1, tags=expected_tags)
     assert aggregator.metrics('postgresql.snapshot.xmin')[0].value > xmin
     aggregator.assert_metric('postgresql.snapshot.xmax', count=1, tags=expected_tags)
@@ -155,7 +165,7 @@ def test_snapshot_xip(aggregator, integration_check, pg_instance):
             _increase_txid(cur2)
 
     check = integration_check(pg_instance)
-    check.check(pg_instance)
+    check.run()
 
     # Cleanup
     cur.close()
@@ -168,7 +178,7 @@ def test_snapshot_xip(aggregator, integration_check, pg_instance):
 def test_common_metrics_without_size(aggregator, integration_check, pg_instance):
     pg_instance['collect_database_size_metrics'] = False
     check = integration_check(pg_instance)
-    check.check(pg_instance)
+    check.run()
     assert 'postgresql.database_size' not in aggregator.metric_names
 
 
@@ -178,7 +188,7 @@ def test_uptime(aggregator, integration_check, pg_instance):
             cur.execute("SELECT FLOOR(EXTRACT(EPOCH FROM current_timestamp - pg_postmaster_start_time()))")
             uptime = cur.fetchall()[0][0]
     check = integration_check(pg_instance)
-    check.check(pg_instance)
+    check.run()
     expected_tags = _get_expected_tags(check, pg_instance)
     assert_metric_at_least(
         aggregator, 'postgresql.uptime', count=1, lower_bound=uptime, higher_bound=uptime + 1, tags=expected_tags
@@ -188,7 +198,7 @@ def test_uptime(aggregator, integration_check, pg_instance):
 @requires_over_14
 def test_session_number(aggregator, integration_check, pg_instance):
     check = integration_check(pg_instance)
-    check.check(pg_instance)
+    check.run()
     expected_tags = _get_expected_tags(check, pg_instance, db='postgres')
     with _get_conn(pg_instance) as conn:
         with conn.cursor() as cur:
@@ -204,7 +214,7 @@ def test_session_number(aggregator, integration_check, pg_instance):
     time.sleep(0.5)
 
     aggregator.reset()
-    check.check(pg_instance)
+    check.run()
 
     aggregator.assert_metric('postgresql.sessions.count', value=session_number + 1, count=1, tags=expected_tags)
 
@@ -220,7 +230,7 @@ def test_session_idle_and_killed(aggregator, integration_check, pg_instance):
     time.sleep(0.5)
 
     check = integration_check(pg_instance)
-    check.check(pg_instance)
+    check.run()
     expected_tags = _get_expected_tags(check, pg_instance, db=DB_NAME)
 
     aggregator.assert_metric('postgresql.sessions.idle_in_transaction_time', value=0, count=1, tags=expected_tags)
@@ -248,7 +258,7 @@ def test_session_idle_and_killed(aggregator, integration_check, pg_instance):
     sock.shutdown(socket.SHUT_RDWR)
 
     aggregator.reset()
-    check.check(pg_instance)
+    check.run()
 
     assert_metric_at_least(
         aggregator, 'postgresql.sessions.idle_in_transaction_time', count=1, lower_bound=0.5, tags=expected_tags
@@ -273,7 +283,7 @@ def test_unsupported_replication(aggregator, integration_check, pg_instance):
     # This simulate an error in the fmt function, as it's a bit hard to mock psycopg
     with mock.patch.object(fmt, 'format', passthrough=True) as mock_fmt:
         mock_fmt.side_effect = format_with_error
-        check.check(pg_instance)
+        check.run()
 
     # Verify our mocking was called
     assert called == [True]
@@ -288,7 +298,7 @@ def test_can_connect_service_check(aggregator, integration_check, pg_instance):
     # First: check run with a valid postgres instance
     check = integration_check(pg_instance)
 
-    check.check(pg_instance)
+    check.run()
     expected_tags = _get_expected_tags(check, pg_instance, with_db=True)
     aggregator.assert_service_check('postgres.can_connect', count=1, status=PostgreSql.OK, tags=expected_tags)
     aggregator.reset()
@@ -302,7 +312,7 @@ def test_can_connect_service_check(aggregator, integration_check, pg_instance):
         check.check(pg_instance)
     # Since we can't connect to the host, we can't gather the replication role
     tags_without_role = _get_expected_tags(
-        check, pg_instance, with_db=True, with_version=False, with_sys_id=False, role=None
+        check, pg_instance, with_db=True, with_version=False, with_sys_id=False, with_cluster_name=False, role=None
     )
     aggregator.assert_service_check('postgres.can_connect', count=1, status=PostgreSql.CRITICAL, tags=tags_without_role)
     aggregator.reset()
@@ -329,7 +339,7 @@ def test_can_connect_service_check(aggregator, integration_check, pg_instance):
 
 def test_connections_metrics(aggregator, integration_check, pg_instance):
     check = integration_check(pg_instance)
-    check.check(pg_instance)
+    check.run()
 
     expected_tags = _get_expected_tags(check, pg_instance)
     for name in CONNECTION_METRICS:
@@ -345,10 +355,12 @@ def test_buffercache_metrics(aggregator, integration_check, pg_instance):
 
     with _get_superconn(pg_instance) as conn:
         with conn.cursor() as cur:
+            # Flush possible dirty buffers
+            cur.execute('CHECKPOINT;')
             # Generate some usage on persons relation
             cur.execute('select * FROM persons;')
 
-    check.check(pg_instance)
+    check.run()
     base_tags = _get_expected_tags(check, pg_instance)
 
     # Check specific persons relation
@@ -374,7 +386,7 @@ def test_locks_metrics_no_relations(aggregator, integration_check, pg_instance):
     with psycopg2.connect(host=HOST, dbname=DB_NAME, user="postgres", password="datad0g") as conn:
         with conn.cursor() as cur:
             cur.execute('LOCK persons')
-            check.check(pg_instance)
+            check.run()
 
     aggregator.assert_metric('postgresql.locks', count=0)
 
@@ -382,7 +394,7 @@ def test_locks_metrics_no_relations(aggregator, integration_check, pg_instance):
 def test_activity_metrics(aggregator, integration_check, pg_instance):
     pg_instance['collect_activity_metrics'] = True
     check = integration_check(pg_instance)
-    check.check(pg_instance)
+    check.run()
 
     expected_tags = _get_expected_tags(check, pg_instance, db=DB_NAME, app='datadog-agent', user='datadog')
     check_activity_metrics(aggregator, expected_tags)
@@ -392,7 +404,7 @@ def test_activity_metrics_no_application_aggregation(aggregator, integration_che
     pg_instance['collect_activity_metrics'] = True
     pg_instance['activity_metrics_excluded_aggregations'] = ['application_name']
     check = integration_check(pg_instance)
-    check.check(pg_instance)
+    check.run()
 
     expected_tags = _get_expected_tags(check, pg_instance, db=DB_NAME, user='datadog')
     check_activity_metrics(aggregator, expected_tags)
@@ -404,7 +416,7 @@ def test_activity_metrics_no_aggregations(aggregator, integration_check, pg_inst
     # Setting it should issue a warning, be ignored and still produce an aggregation by db
     pg_instance['activity_metrics_excluded_aggregations'] = ['datname', 'application_name', 'usename']
     check = integration_check(pg_instance)
-    check.check(pg_instance)
+    check.run()
 
     expected_tags = _get_expected_tags(check, pg_instance, db=DB_NAME)
     check_activity_metrics(aggregator, expected_tags)
@@ -435,7 +447,7 @@ def test_activity_vacuum_excluded(aggregator, integration_check, pg_instance):
     _increase_txid(cur)
 
     # Gather metrics
-    check.check(pg_instance)
+    check.run()
 
     expected_tags = _get_expected_tags(check, pg_instance, db=DB_NAME, app='test', user=USER_ADMIN)
     aggregator.assert_metric('postgresql.waiting_queries', value=1, count=1, tags=expected_tags)
@@ -456,7 +468,7 @@ def test_backend_transaction_age(aggregator, integration_check, pg_instance):
     pg_instance['collect_activity_metrics'] = True
     check = integration_check(pg_instance)
 
-    check.check(pg_instance)
+    check.run()
 
     dd_agent_tags = _get_expected_tags(check, pg_instance, db=DB_NAME, app='datadog-agent', user='datadog')
     test_tags = _get_expected_tags(check, pg_instance, db=DB_NAME, app='test', user='datadog')
@@ -479,7 +491,7 @@ def test_backend_transaction_age(aggregator, integration_check, pg_instance):
     start_transaction_time = time.time()
 
     aggregator.reset()
-    check.check(pg_instance)
+    check.run()
 
     if float(POSTGRES_VERSION) >= 9.6:
         aggregator.assert_metric('postgresql.activity.backend_xid_age', value=1, count=1, tags=test_tags)
@@ -503,7 +515,7 @@ def test_backend_transaction_age(aggregator, integration_check, pg_instance):
 
     aggregator.reset()
     transaction_age_lower_bound = time.time() - start_transaction_time
-    check.check(pg_instance)
+    check.run()
 
     if float(POSTGRES_VERSION) >= 9.6:
         # Check that the xmin and xid is 2 tx old
@@ -534,12 +546,12 @@ def test_wrong_version(integration_check, pg_instance):
     # Enforce the wrong version
     check._version_utils.get_raw_version = mock.MagicMock(return_value="9.6.0")
 
-    check.check(pg_instance)
+    check.run()
     assert_state_clean(check)
     # Reset the mock to a good version
     check._version_utils.get_raw_version = mock.MagicMock(return_value="13.0.0")
 
-    check.check(pg_instance)
+    check.run()
     assert_state_set(check)
 
 
@@ -607,7 +619,7 @@ def test_wal_stats(aggregator, integration_check, pg_instance, is_aurora):
     check.is_aurora = is_aurora
     if is_aurora is True:
         return
-    check.check(pg_instance)
+    check.run()
 
     expected_tags = _get_expected_tags(check, pg_instance)
     aggregator.assert_metric('postgresql.wal.records', count=1, tags=expected_tags)
@@ -653,7 +665,7 @@ def test_wal_metrics(aggregator, integration_check, pg_instance, is_aurora):
         cur.execute("select count(*) from pg_ls_waldir();")
         expected_num_wals = cur.fetchall()[0][0]
 
-    check.check(pg_instance)
+    check.run()
 
     expected_wal_size = expected_num_wals * wal_size
     dd_agent_tags = _get_expected_tags(check, pg_instance)
@@ -663,7 +675,7 @@ def test_wal_metrics(aggregator, integration_check, pg_instance, is_aurora):
 
 def test_pg_control(aggregator, integration_check, pg_instance):
     check = integration_check(pg_instance)
-    check.check(pg_instance)
+    check.run()
 
     dd_agent_tags = _get_expected_tags(check, pg_instance)
     aggregator.assert_metric('postgresql.control.timeline_id', count=1, value=1, tags=dd_agent_tags)
@@ -673,7 +685,7 @@ def test_pg_control(aggregator, integration_check, pg_instance):
         cur.execute("CHECKPOINT;")
 
     aggregator.reset()
-    check.check(pg_instance)
+    check.run()
     # checkpoint should be less than 2s old
     assert_metric_at_least(
         aggregator, 'postgresql.control.checkpoint_delay', count=1, higher_bound=2.0, tags=dd_agent_tags
@@ -689,7 +701,7 @@ def test_config_tags_is_unchanged_between_checks(integration_check, pg_instance)
         _get_expected_tags(check, pg_instance, db=DB_NAME, with_version=False, with_sys_id=False, role=None)
     )
     for _ in range(3):
-        check.check(pg_instance)
+        check.run()
         assert set(check._config.tags) == expected_tags
 
 
@@ -718,7 +730,7 @@ def test_correct_hostname(dbm_enabled, reported_hostname, expected_hostname, agg
         'datadog_checks.postgres.PostgreSql.resolve_db_host', return_value=expected_hostname
     ) as resolve_db_host:
         check = PostgreSql('test_instance', {}, [pg_instance])
-        check.check(pg_instance)
+        check.run()
         if reported_hostname:
             assert resolve_db_host.called is False, 'Expected resolve_db_host.called to be False'
         else:
@@ -765,7 +777,7 @@ def test_database_instance_metadata(aggregator, pg_instance, dbm_enabled, report
     expected_host = reported_hostname if reported_hostname else 'stubbed.hostname'
     expected_tags = pg_instance['tags'] + ['port:{}'.format(pg_instance['port'])]
     check = PostgreSql('test_instance', {}, [pg_instance])
-    run_one_check(check, pg_instance)
+    run_one_check(check)
 
     dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
     event = next((e for e in dbm_metadata if e['kind'] == 'database_instance'), None)
@@ -782,7 +794,7 @@ def test_database_instance_metadata(aggregator, pg_instance, dbm_enabled, report
 
     # Run a second time and expect the metadata to not be emitted again because of the cache TTL
     aggregator.reset()
-    run_one_check(check, pg_instance)
+    run_one_check(check)
 
     dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
     event = next((e for e in dbm_metadata if e['kind'] == 'database_instance'), None)
@@ -1085,7 +1097,7 @@ def test_replication_tag(aggregator, integration_check, pg_instance):
     check = integration_check(pg_instance)
 
     # no replication
-    check.check(pg_instance)
+    check.run()
     aggregator.assert_metric(test_metric, tags=_get_expected_tags(check, pg_instance, role=None))
     aggregator.reset()
 
@@ -1093,14 +1105,14 @@ def test_replication_tag(aggregator, integration_check, pg_instance):
     pg_instance['tag_replication_role'] = True
     check = integration_check(pg_instance)
 
-    check.check(pg_instance)
+    check.run()
     aggregator.assert_metric(test_metric, tags=_get_expected_tags(check, pg_instance, role='master'))
     aggregator.reset()
 
     # switchover: master -> standby
     standby_role = 'standby'
     check._get_replication_role = mock.MagicMock(return_value=standby_role)
-    check.check(pg_instance)
+    check.run()
     aggregator.assert_metric(test_metric, tags=_get_expected_tags(check, pg_instance, role=standby_role))
 
 
@@ -1115,7 +1127,7 @@ def test_collect_wal_metrics_metrics(aggregator, integration_check, pg_instance,
     check.is_aurora = False
     check.check(pg_instance)
 
-    expected_tags = _get_expected_tags(check, pg_instance, with_sys_id=False)
+    expected_tags = _get_expected_tags(check, pg_instance, with_cluster_name=False, with_sys_id=False)
     # if collect_wal_metrics is not set, wal metrics are collected on pg >= 10 by default
     expected_count = 0 if collect_wal_metrics is False else 1
     check_file_wal_metrics(aggregator, expected_tags=expected_tags, count=expected_count)
@@ -1156,7 +1168,7 @@ def test_propagate_agent_tags(
         assert check._config._should_propagate_agent_tags(pg_instance, init_config) == should_propagate_agent_tags
         if should_propagate_agent_tags:
             assert all(tag in check.tags for tag in agent_tags)
-            check.check(pg_instance)
+            check.run()
             expected_tags = _get_expected_tags(check, pg_instance, with_db=True)
             aggregator.assert_service_check(
                 'postgres.can_connect', count=1, status=PostgreSql.OK, tags=expected_tags + agent_tags
@@ -1175,7 +1187,7 @@ def test_pg_stat_io_metrics(aggregator, integration_check, pg_instance, dbm_enab
     pg_instance['collect_resources'] = {'collection_interval': 0.1}
 
     check = integration_check(pg_instance)
-    run_one_check(check, pg_instance)
+    run_one_check(check)
 
     expected_tags = _get_expected_tags(check, pg_instance)
     expected_count = 0 if dbm_enabled is False else 1

--- a/postgres/tests/test_pg_replication.py
+++ b/postgres/tests/test_pg_replication.py
@@ -33,8 +33,9 @@ pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')
 def test_common_replica_metrics(aggregator, integration_check, metrics_cache_replica, pg_replica_instance):
     check = integration_check(pg_replica_instance)
     check._connect()
-    check.initialize_is_aurora()
-    check.check(pg_replica_instance)
+
+    # Use check.run() to go through initilization queries
+    check.run()
 
     expected_tags = _get_expected_replication_tags(check, pg_replica_instance)
     check_common_metrics(aggregator, expected_tags=expected_tags)
@@ -54,6 +55,20 @@ def test_common_replica_metrics(aggregator, integration_check, metrics_cache_rep
     check_performance_metrics(aggregator, expected_tags=check.debug_stats_kwargs()['tags'])
 
     aggregator.assert_all_metrics_covered()
+
+
+@requires_over_10
+def test_replica_initialization_tags(integration_check, pg_replica_instance, pg_replica_instance2):
+    check = integration_check(pg_replica_instance)
+    check.run()
+    assert check.cluster_name == ''
+    assert check.system_identifier is not None
+
+    check2 = integration_check(pg_replica_instance2)
+    check2.run()
+    # After run, initialization queries should have set system identifier and cluster_name tags
+    assert check2.cluster_name == 'replica2'
+    assert check2.system_identifier is not None
 
 
 @requires_over_10

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -137,16 +137,16 @@ def test_statement_metrics_multiple_pgss_rows_single_query_signature(
             _run_query(1)
 
         _run_query(0)
-        run_one_check(check, dbm_instance, cancel=False)
+        run_one_check(check, cancel=False)
 
         # Call one query
         _run_query(0)
-        run_one_check(check, dbm_instance, cancel=False)
+        run_one_check(check, cancel=False)
         aggregator.reset()
 
         # Call other query that maps to same query signature
         _run_query(1)
-        run_one_check(check, dbm_instance, cancel=False)
+        run_one_check(check, cancel=False)
 
         obfuscated_param = '?'
         query0 = queries[0] % (obfuscated_param,)
@@ -236,16 +236,16 @@ def test_statement_metrics(
 
     check = integration_check(dbm_instance)
     check._connect()
-    run_one_check(check, dbm_instance, cancel=False)
+    run_one_check(check, cancel=False)
 
     # We can't change track_io_timing at runtime, but we can change what the integration thinks the runtime value is
     # This must be done after the first check since postgres settings are loaded from the database then
     check.pg_settings["track_io_timing"] = "on" if track_io_timing_enabled else "off"
 
     _run_queries()
-    run_one_check(check, dbm_instance, cancel=False)
+    run_one_check(check, cancel=False)
     _run_queries()
-    run_one_check(check, dbm_instance, cancel=False)
+    run_one_check(check, cancel=False)
 
     def _should_catch_query(dbname):
         # we can always catch it if the query originals in the same DB
@@ -416,9 +416,9 @@ def test_statement_metrics_cloud_metadata(
     check._connect()
 
     _run_queries()
-    run_one_check(check, dbm_instance)
+    run_one_check(check)
     _run_queries()
-    run_one_check(check, dbm_instance)
+    run_one_check(check)
 
     events = aggregator.get_event_platform_events("dbm-metrics")
     assert len(events) == 1, "should capture exactly one metrics payload"
@@ -456,9 +456,9 @@ def test_wal_metrics(aggregator, integration_check, dbm_instance):
     check._connect()
 
     _run_queries()
-    run_one_check(check, dbm_instance)
+    run_one_check(check)
     _run_queries()
-    run_one_check(check, dbm_instance)
+    run_one_check(check)
 
     events = aggregator.get_event_platform_events("dbm-metrics")
     assert len(events) == 1, "should capture exactly one metrics payload"
@@ -505,7 +505,7 @@ def test_statement_metrics_with_duplicates(aggregator, integration_check, dbm_in
 
                 cursor.execute(query, (['app1', 'app2'],))
                 cursor.execute(query, (['app1', 'app2', 'app3'],))
-                run_one_check(check, dbm_instance)
+                run_one_check(check)
 
     events = aggregator.get_event_platform_events("dbm-metrics")
     assert len(events) == 1
@@ -641,7 +641,7 @@ def test_failed_explain_handling(
         pytest.skip("not relevant for postgres {version}".format(version=POSTGRES_VERSION))
 
     # run check so all internal state is correctly initialized
-    run_one_check(check, dbm_instance)
+    run_one_check(check)
 
     # clear out contents of aggregator so we measure only the metrics generated during this specific part of the test
     aggregator.reset()
@@ -793,7 +793,7 @@ def test_statement_samples_collect(
     # pg_stat_activity
     try:
         conn.cursor().execute(query, (arg,))
-        run_one_check(check, dbm_instance)
+        run_one_check(check)
         tags = _get_expected_tags(check, dbm_instance, with_host=False, db=dbname)
 
         dbm_samples = aggregator.get_event_platform_events("dbm-samples")
@@ -902,11 +902,11 @@ def test_statement_metadata(
         cursor.execute(
             query,
         )
-        run_one_check(check, dbm_instance)
+        run_one_check(check)
         cursor.execute(
             query,
         )
-        run_one_check(check, dbm_instance)
+        run_one_check(check)
 
     # Test samples metadata, metadata in samples is an object under `db`.
     samples = aggregator.get_event_platform_events("dbm-samples")
@@ -965,8 +965,8 @@ def test_statement_reported_hostname(
 
     check = integration_check(dbm_instance)
 
-    run_one_check(check, dbm_instance)
-    run_one_check(check, dbm_instance)
+    run_one_check(check)
+    run_one_check(check)
 
     samples = aggregator.get_event_platform_events("dbm-samples")
     assert samples, "should have collected at least one sample"
@@ -1111,7 +1111,7 @@ def test_activity_snapshot_collection(
         # ... now execute the test query
         wait(conn)
         conn.cursor().execute(query, (arg,))
-        run_one_check(check, dbm_instance)
+        run_one_check(check)
         dbm_activity_event = aggregator.get_event_platform_events("dbm-activity")
 
         if POSTGRES_VERSION.split('.')[0] == "9" and pg_stat_activity_view == "pg_stat_activity":
@@ -1203,7 +1203,7 @@ def test_activity_snapshot_collection(
         blocking_conn.close()
         # Wait collection interval to make sure dbm events are reported
         time.sleep(dbm_instance['query_activity']['collection_interval'])
-        run_one_check(check, dbm_instance)
+        run_one_check(check)
         dbm_activity_event = aggregator.get_event_platform_events("dbm-activity")
         event = dbm_activity_event[1]
         assert len(event['postgres_activity']) > 0
@@ -1248,8 +1248,8 @@ def test_activity_reported_hostname(
     check = integration_check(dbm_instance)
     check._connect()
 
-    run_one_check(check, dbm_instance)
-    run_one_check(check, dbm_instance)
+    run_one_check(check)
+    run_one_check(check)
 
     dbm_activity = aggregator.get_event_platform_events("dbm-activity")
     assert dbm_activity, "should have at least one activity sample"
@@ -1399,9 +1399,9 @@ def test_statement_run_explain_errors(
     check = integration_check(dbm_instance)
     check._connect()
 
-    run_one_check(check, dbm_instance)
+    run_one_check(check)
     _, explain_err_code, err = check.statement_samples._run_and_track_explain("datadog_test", query, query, query)
-    run_one_check(check, dbm_instance)
+    run_one_check(check)
 
     assert explain_err_code == expected_explain_err_code
     assert err == expected_err
@@ -1453,9 +1453,9 @@ def test_statement_run_explain_parameterized_queries(
     if check.version < V12:
         return
 
-    run_one_check(check, dbm_instance)
+    run_one_check(check)
     _, explain_err_code, err = check.statement_samples._run_and_track_explain("datadog_test", query, query, query)
-    run_one_check(check, dbm_instance)
+    run_one_check(check)
 
     assert explain_err_code == expected_explain_err_code
     assert err == expected_err
@@ -1475,7 +1475,7 @@ def test_statement_samples_dbstrict(aggregator, integration_check, dbm_instance,
         conn.cursor().execute(query, (arg,))
         connections.append(conn)
 
-    run_one_check(check, dbm_instance)
+    run_one_check(check)
     dbm_samples = aggregator.get_event_platform_events("dbm-samples")
 
     for _, _, dbname, query, arg in SAMPLE_QUERIES:
@@ -1505,7 +1505,7 @@ def test_async_job_enabled(
     dbm_instance['query_metrics'] = {'enabled': statement_metrics_enabled, 'run_sync': False}
     check = integration_check(dbm_instance)
     check._connect()
-    run_one_check(check, dbm_instance)
+    run_one_check(check)
     if statement_samples_enabled or statement_activity_enabled:
         assert check.statement_samples._job_loop_future is not None
     else:
@@ -1633,7 +1633,7 @@ def test_statement_samples_unique_plans_rate_limits(aggregator, integration_chec
         # repeat the same set of queries multiple times to ensure we're testing the per-query TTL rate limit
         for q in queries:
             cursor.execute(q)
-            run_one_check(check, dbm_instance)
+            run_one_check(check)
     cursor.close()
 
     def _sample_key(e):
@@ -1694,7 +1694,7 @@ def test_disabled_activity_or_explain_plans(
     try:
         conn.autocommit = True
         conn.cursor().execute(query, (arg,))
-        run_one_check(check, dbm_instance)
+        run_one_check(check)
         dbm_activity = aggregator.get_event_platform_events("dbm-activity")
         dbm_samples = aggregator.get_event_platform_events("dbm-samples")
 
@@ -1736,7 +1736,7 @@ def test_async_job_cancel_cancel(aggregator, integration_check, dbm_instance):
     dbm_instance['query_metrics']['run_sync'] = False
     check = integration_check(dbm_instance)
     check._connect()
-    run_one_check(check, dbm_instance)
+    run_one_check(check)
     assert not check.statement_samples._job_loop_future.running(), "samples thread should be stopped"
     assert not check.statement_metrics._job_loop_future.running(), "metrics thread should be stopped"
     # if the thread doesn't start until after the cancel signal is set then the db connection will never
@@ -1893,7 +1893,7 @@ def test_statement_metrics_database_errors(
         return_value=metric_columns,
         side_effect=error,
     ):
-        run_one_check(check, dbm_instance)
+        run_one_check(check)
 
     expected_tags = _get_expected_tags(
         check, dbm_instance, with_host=False, with_db=True, agent_hostname='stubbed.hostname'
@@ -1935,7 +1935,7 @@ def test_pg_stat_statements_max_warning(
     dbm_instance['query_metrics']['pg_stat_statements_max_warning_threshold'] = pg_stat_statements_max_threshold
     check = integration_check(dbm_instance)
     check._connect()
-    run_one_check(check, dbm_instance)
+    run_one_check(check)
 
     assert check.warnings == expected_warnings
 
@@ -1950,7 +1950,7 @@ def test_pg_stat_statements_dealloc(aggregator, integration_check, dbm_instance_
             cur.execute("select pg_stat_statements_reset();")
 
     check = integration_check(dbm_instance_replica2)
-    run_one_check(check, dbm_instance_replica2)
+    run_one_check(check)
 
     conn = _get_conn(dbm_instance_replica2)
     count_statements = 0
@@ -1974,7 +1974,8 @@ def test_pg_stat_statements_dealloc(aggregator, integration_check, dbm_instance_
             cur.execute("select {};".format(parameters))
 
     aggregator.reset()
-    run_one_check(check, dbm_instance_replica2)
+    check = integration_check(dbm_instance_replica2)
+    run_one_check(check)
     aggregator.assert_metric("postgresql.pg_stat_statements.max", value=100, tags=expected_tags)
     if float(POSTGRES_VERSION) >= 14.0:
         aggregator.assert_metric("postgresql.pg_stat_statements.dealloc", value=1, tags=expected_tags)
@@ -2002,9 +2003,9 @@ def test_plan_time_metrics(aggregator, integration_check, dbm_instance):
     check._connect()
 
     _run_queries()
-    run_one_check(check, dbm_instance)
+    run_one_check(check)
     _run_queries()
-    run_one_check(check, dbm_instance)
+    run_one_check(check)
 
     events = aggregator.get_event_platform_events("dbm-metrics")
     assert len(events) == 1, "should capture exactly one metrics payload"

--- a/postgres/tests/utils.py
+++ b/postgres/tests/utils.py
@@ -121,12 +121,12 @@ def run_vacuum_thread(pg_instance, vacuum_query, application_name='test'):
     return run_query_thread(pg_instance, vacuum_query, application_name, init_stmts)
 
 
-def run_one_check(check, db_instance, cancel=True):
+def run_one_check(check, cancel=True):
     """
     Run check and immediately cancel.
     Waits for all threads to close before continuing.
     """
-    check.check(db_instance)
+    check.run()
     if cancel:
         check.cancel()
     if check.statement_samples._job_loop_future is not None:


### PR DESCRIPTION
### What does this PR do?
Set `cluster_name` as a `postgresql_cluster_name` metric tag if it's configured in postgresql.conf. 

### Motivation
PostgreSQL instances can set a cluster_name parameter that will be used in the process' title. There's currently no standard way to name a cluster so custom_tags are used as a replacement but this usually leads to having different tag names. Relying on the defined cluster_name from postgresql.conf allows to have a standard tag.

### Additional Notes
The fetch of the system identifier was moved from being executed at every check to the initialiser's checks. This required some changes in the test to use `check.run()` instead of `check.check(...)` in order to go through the initialisation queries to correctly set the expected tags. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
