### PR TITLE
[mongo] add index usage per second metric

### DIFF
--- a/mongo/changelog.d/18405.added
+++ b/mongo/changelog.d/18405.added
@@ -1,0 +1,1 @@
+Add metric `mongodb.collection.indexes.accesses.opsps` to measure number of times the index was used per second.

--- a/mongo/datadog_checks/mongo/collectors/base.py
+++ b/mongo/datadog_checks/mongo/collectors/base.py
@@ -124,6 +124,6 @@ class MongoCollector(object):
 
             metric_name_alias = self._normalize(metric_name_alias, submit_method, prefix)
             submit_method(self.check, metric_name_alias, value, tags=tags)
-            if metric_name_alias.endswith("countps"):
-                # Keep old incorrect metric name (only 'top' metrics are affected)
+            if metric_name_alias.endswith("countps") or metric_name_alias.endswith("accesses.opsps"):
+                # Keep old incorrect metric name (only 'top' and 'index' metrics are affected)
                 self.gauge(metric_name_alias[:-2], value, tags=tags)

--- a/mongo/datadog_checks/mongo/metrics.py
+++ b/mongo/datadog_checks/mongo/metrics.py
@@ -357,6 +357,10 @@ COLLECTION_METRICS = {
     'collection.collectionScans.nonTailable': GAUGE,
 }
 
+INDEX_METRICS = {
+    'indexes.accesses.ops': RATE,
+}
+
 """
 Mapping for case-sensitive metric name suffixes.
 

--- a/mongo/metadata.csv
+++ b/mongo/metadata.csv
@@ -19,6 +19,7 @@ mongodb.collection.commands.latency.avg,gauge,,microsecond,,Average latency for 
 mongodb.collection.commands.opsps,gauge,,operation,second,Number of command operations per second on the collection.,0,mongodb,command operations per second,,
 mongodb.collection.count,gauge,,item,,Total number of objects in the collection.,0,mongodb,number of objects in the collection,,
 mongodb.collection.indexes.accesses.ops,gauge,,event,,Number of time the index was used.,0,mongodb,index usage,,
+mongodb.collection.indexes.accesses.opsps,gauge,,event,,Number of time the index was used per second.,0,mongodb,index usage per second,,
 mongodb.collection.indexsizes,gauge,,byte,,Size of index in bytes.,0,mongodb,index size,,
 mongodb.collection.max,gauge,,document,,Maximum number of documents in a capped collection.,0,mongodb,max documents in capped collection,,
 mongodb.collection.maxsize,gauge,,byte,,Maximum size of a capped collection in bytes.,0,mongodb,max size of capped collection,,

--- a/mongo/tests/results/metrics-indexes-stats-autodiscover.json
+++ b/mongo/tests/results/metrics-indexes-stats-autodiscover.json
@@ -86,5 +86,93 @@
             "collection:bar",
             "db:integration"
         ]
+    },
+    {
+        "name": "mongodb.collection.indexes.accesses.opsps",
+        "type": 1,
+        "value": 1243.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "name:_id_",
+            "collection:foo",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.collection.indexes.accesses.opsps",
+        "type": 1,
+        "value": 12.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "name:_id_",
+            "collection:bar",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.collection.indexes.accesses.opsps",
+        "type": 1,
+        "value": 1243.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "name:_id_",
+            "collection:foo",
+            "db:admin"
+        ]
+    },
+    {
+        "name": "mongodb.collection.indexes.accesses.opsps",
+        "type": 1,
+        "value": 12.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "name:_id_",
+            "collection:bar",
+            "db:admin"
+        ]
+    },
+    {
+        "name": "mongodb.collection.indexes.accesses.opsps",
+        "type": 1,
+        "value": 1243.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "name:_id_",
+            "collection:foo",
+            "db:config"
+        ]
+    },
+    {
+        "name": "mongodb.collection.indexes.accesses.opsps",
+        "type": 1,
+        "value": 12.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "name:_id_",
+            "collection:bar",
+            "db:config"
+        ]
+    },
+    {
+        "name": "mongodb.collection.indexes.accesses.opsps",
+        "type": 1,
+        "value": 1243.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "name:_id_",
+            "collection:foo",
+            "db:integration"
+        ]
+    },
+    {
+        "name": "mongodb.collection.indexes.accesses.opsps",
+        "type": 1,
+        "value": 12.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "name:_id_",
+            "collection:bar",
+            "db:integration"
+        ]
     }
 ]

--- a/mongo/tests/results/metrics-indexes-stats.json
+++ b/mongo/tests/results/metrics-indexes-stats.json
@@ -20,5 +20,27 @@
             "collection:bar",
             "db:test"
         ]
+    },
+    {
+        "name": "mongodb.collection.indexes.accesses.opsps",
+        "type": 1,
+        "value": 1243.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "name:_id_",
+            "collection:foo",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.collection.indexes.accesses.opsps",
+        "type": 1,
+        "value": 12.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "name:_id_",
+            "collection:bar",
+            "db:test"
+        ]
     }
 ]


### PR DESCRIPTION
### What does this PR do?
This PR adds new metric `mongodb.collection.indexes.accesses.opsps` to measure number of times the index was used per second. The existing `mongodb.collection.indexes.accesses.ops` metric is an ever increasing value. The new metric provides better insights into index usage changes. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
