### PR TITLE
[mongo] skip explain get profile level & listCollections command

### DIFF
--- a/mongo/changelog.d/18408.fixed
+++ b/mongo/changelog.d/18408.fixed
@@ -1,1 +1,1 @@
-Skip collect explain plan for get profile level command.
+Skip collect explain plan for get profile level & listCollections command.

--- a/mongo/changelog.d/18408.fixed
+++ b/mongo/changelog.d/18408.fixed
@@ -1,0 +1,1 @@
+Skip collect explain plan for get profile level command.

--- a/mongo/datadog_checks/mongo/dbm/utils.py
+++ b/mongo/datadog_checks/mongo/dbm/utils.py
@@ -47,6 +47,7 @@ UNEXPLAINABLE_COMMANDS = frozenset(
         "delete",
         "explain",
         "profile",  # command to get profile level
+        "listCollections",
     ]
 )
 

--- a/mongo/datadog_checks/mongo/dbm/utils.py
+++ b/mongo/datadog_checks/mongo/dbm/utils.py
@@ -39,6 +39,17 @@ COMMAND_COLLECTION_KEY = frozenset(
     ]
 )
 
+UNEXPLAINABLE_COMMANDS = frozenset(
+    [
+        "getMore",
+        "insert",
+        "update",
+        "delete",
+        "explain",
+        "profile",  # command to get profile level
+    ]
+)
+
 
 def format_key_name(formatter, metric_dict: dict) -> dict:
     # convert camelCase to snake_case
@@ -70,12 +81,8 @@ def should_explain_operation(
         # Skip operations that are not queries
         return False
 
-    if "getMore" in command or "insert" in command or "delete" in command or "update" in command:
-        # Skip operations as they are not queries
-        return False
-
-    if "explain" in command:
-        # Skip operations that are explain commands (cannot explain itself)
+    # if UNEXPLAINABLE_COMMANDS in command, skip
+    if any(command.get(key) for key in UNEXPLAINABLE_COMMANDS):
         return False
 
     db, _ = namespace.split(".", 1)


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug to skip explain get profile level & listCollections command. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
