### PR TITLE
Network Path integration is currently not supported on windows

### DIFF
--- a/network_path/manifest.json
+++ b/network_path/manifest.json
@@ -13,7 +13,6 @@
     "media": [],
     "classifier_tags": [
       "Supported OS::Linux",
-      "Supported OS::Windows",
       "Category::Network",
       "Offering::Integration"
     ]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Network Path integration is currently not supported on windows

### Motivation
<!-- What inspired you to submit this pull request? -->

Network Path integration is currently not supported on windows

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
