### PR TITLE
[mongo] limit max number of collections to be monitored per database

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -149,6 +149,14 @@ files:
               - "admin$"
               - "config$"
               - "local$"
+        - name: max_collection_per_database
+          description: |
+            The maximum number of collections to collect metrics from per database.
+            Defaults to 20.
+          value:
+            type: integer
+            example: 20
+            display_default: 20
         - name: refresh_interval
           description: Frequency in seconds of scans for new databases. Defaults to 10 minutes.
           value:

--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -152,11 +152,11 @@ files:
         - name: max_collection_per_database
           description: |
             The maximum number of collections to collect metrics from per database.
-            Defaults to 20.
+            Defaults to 100.
           value:
             type: integer
-            example: 20
-            display_default: 20
+            example: 100
+            display_default: 100
         - name: refresh_interval
           description: Frequency in seconds of scans for new databases. Defaults to 10 minutes.
           value:

--- a/mongo/changelog.d/18416.added
+++ b/mongo/changelog.d/18416.added
@@ -1,0 +1,1 @@
+Add config option `database_autodiscovery.max_collections_per_database` to limit max number of collections to be monitored per autodiscoverd database. This option is applied to collection stats metrics and collection indexes stats metrics.

--- a/mongo/datadog_checks/mongo/api.py
+++ b/mongo/datadog_checks/mongo/api.py
@@ -156,12 +156,19 @@ class MongoApi(object):
     def server_status(self):
         return self['admin'].command('serverStatus')
 
-    def list_authorized_collections(self, db_name):
+    def list_authorized_collections(
+        self,
+        db_name,
+        limit=None,
+    ):
         try:
-            return self[db_name].list_collection_names(
+            coll_names = self[db_name].list_collection_names(
                 filter={"type": "collection"},  # Only return collections, not views
                 authorizedCollections=True,
             )
+            if limit:
+                return coll_names[:limit]
+            return coll_names
         except OperationFailure:
             # The user is not authorized to run listCollections on this database.
             # This is NOT a critical error, so we log it as a warning.

--- a/mongo/datadog_checks/mongo/collectors/coll_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/coll_stats.py
@@ -19,6 +19,7 @@ class CollStatsCollector(MongoCollector):
         super(CollStatsCollector, self).__init__(check, tags)
         self.coll_names = coll_names
         self.db_name = db_name
+        self.max_collections_per_database = check._config.database_autodiscovery_config['max_collections_per_database']
 
     def compatible_with(self, deployment):
         # Can only be run once per cluster.
@@ -27,7 +28,7 @@ class CollStatsCollector(MongoCollector):
     def _get_collections(self, api):
         if self.coll_names:
             return self.coll_names
-        return api.list_authorized_collections(self.db_name)
+        return api.list_authorized_collections(self.db_name, limit=self.max_collections_per_database)
 
     def __calculate_oplatency_avg(self, latency_stats):
         """Calculate the average operation latency."""

--- a/mongo/datadog_checks/mongo/collectors/index_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/index_stats.py
@@ -15,6 +15,7 @@ class IndexStatsCollector(MongoCollector):
         super(IndexStatsCollector, self).__init__(check, tags)
         self.coll_names = coll_names
         self.db_name = db_name
+        self.max_collections_per_database = check._config.database_autodiscovery_config['max_collections_per_database']
 
     def compatible_with(self, deployment):
         # Can only be run once per cluster.
@@ -23,7 +24,7 @@ class IndexStatsCollector(MongoCollector):
     def _get_collections(self, api):
         if self.coll_names:
             return self.coll_names
-        return api.list_authorized_collections(self.db_name)
+        return api.list_authorized_collections(self.db_name, limit=self.max_collections_per_database)
 
     def collect(self, api):
         coll_names = self._get_collections(api)

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -223,6 +223,6 @@ class MongoConfig(object):
                 database_autodiscovery_config['include'] = include_list
         # Limit the maximum number of collections per database to monitor
         database_autodiscovery_config["max_collections_per_database"] = int(
-            database_autodiscovery_config.get("max_collections_per_database", 20)
+            database_autodiscovery_config.get("max_collections_per_database", 100)
         )
         return database_autodiscovery_config

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -221,4 +221,8 @@ class MongoConfig(object):
             if not database_autodiscovery_config.get('include'):
                 # if database_autodiscovery is enabled but include list is not set, set the include list
                 database_autodiscovery_config['include'] = include_list
+        # Limit the maximum number of collections per database to monitor
+        database_autodiscovery_config["max_collections_per_database"] = int(
+            database_autodiscovery_config.get("max_collections_per_database", 20)
+        )
         return database_autodiscovery_config

--- a/mongo/datadog_checks/mongo/config_models/instance.py
+++ b/mongo/datadog_checks/mongo/config_models/instance.py
@@ -50,6 +50,7 @@ class DatabaseAutodiscovery(BaseModel):
     enabled: Optional[bool] = None
     exclude: Optional[tuple[str, ...]] = None
     include: Optional[tuple[str, ...]] = None
+    max_collection_per_database: Optional[int] = None
     max_databases: Optional[int] = None
     refresh_interval: Optional[int] = None
 

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -132,11 +132,11 @@ instances:
         #   - config$
         #   - local$
 
-        ## @param max_collection_per_database - integer - optional - default: 20
+        ## @param max_collection_per_database - integer - optional - default: 100
         ## The maximum number of collections to collect metrics from per database.
-        ## Defaults to 20.
+        ## Defaults to 100.
         #
-        # max_collection_per_database: 20
+        # max_collection_per_database: 100
 
         ## @param refresh_interval - integer - optional - default: 600
         ## Frequency in seconds of scans for new databases. Defaults to 10 minutes.

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -132,6 +132,12 @@ instances:
         #   - config$
         #   - local$
 
+        ## @param max_collection_per_database - integer - optional - default: 20
+        ## The maximum number of collections to collect metrics from per database.
+        ## Defaults to 20.
+        #
+        # max_collection_per_database: 20
+
         ## @param refresh_interval - integer - optional - default: 600
         ## Frequency in seconds of scans for new databases. Defaults to 10 minutes.
         #

--- a/mongo/datadog_checks/mongo/dbm/operation_samples.py
+++ b/mongo/datadog_checks/mongo/dbm/operation_samples.py
@@ -90,9 +90,7 @@ class MongoOperationSamples(DBMAsyncJob):
 
         activities = []
 
-        for activity, sample in self._get_operation_samples(
-            now, databases_monitored=self._check._database_autodiscovery.databases
-        ):
+        for activity, sample in self._get_operation_samples(now, databases_monitored=self._check.databases_monitored):
             if sample:
                 self._check.log.debug("Sending operation sample: %s", sample)
                 self._check.database_monitoring_query_sample(json_util.dumps(sample))

--- a/mongo/datadog_checks/mongo/dbm/slow_operations.py
+++ b/mongo/datadog_checks/mongo/dbm/slow_operations.py
@@ -77,7 +77,7 @@ class MongoSlowOperations(DBMAsyncJob):
 
         slow_operation_events = []
 
-        for db_name in self._check._database_autodiscovery.databases:
+        for db_name in self._check.databases_monitored:
             if not is_mongos and self._is_profiling_enabled(db_name):
                 for slow_operation in self._collect_slow_operations_from_profiler(
                     db_name, last_ts=last_collection_timestamp

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -157,10 +157,9 @@ class MongoDb(AgentCheck):
             # regardless of the auto-discovery settings.
             potential_collectors.append(DbStatCollector(self, db_name, dbstats_tag_dbname, tags))
 
-        monitored_dbs = all_dbs if self._database_autodiscovery.autodiscovery_enabled else [self._config.db_name]
         # When autodiscovery is enabled, we collect collstats and indexstats for all auto-discovered databases
         # Otherwise, we collect collstats and indexstats for the database specified in the configuration
-        for db_name in monitored_dbs:
+        for db_name in self.databases_monitored:
             # For backward compatibility, coll_names is ONLY applied when autodiscovery is not enabled
             # Otherwise, we collect collstats & indexstats for all auto-discovered databases and authorized collections
             coll_names = None if self._database_autodiscovery.autodiscovery_enabled else self._config.coll_names
@@ -319,6 +318,12 @@ class MongoDb(AgentCheck):
         if database_count:
             self.gauge('mongodb.dbs', database_count, tags=tags)
         return dbnames
+
+    @property
+    def databases_monitored(self):
+        if self._database_autodiscovery.autodiscovery_enabled:
+            return self._database_autodiscovery.databases
+        return [self._config.db_name]
 
     def _diagnose_tls(self):
         # Check TLS config. Specifically, we might want to check that if `tls` is

--- a/mongo/tests/conftest.py
+++ b/mongo/tests/conftest.py
@@ -154,6 +154,7 @@ def instance_integration_cluster_autodiscovery(instance_integration_cluster):
     instance = copy.deepcopy(instance_integration_cluster)
     instance["database_autodiscovery"] = {
         "enabled": True,
+        "max_collections_per_database": 5,
     }
     return instance
 

--- a/mongo/tests/fixtures/profile-admin
+++ b/mongo/tests/fixtures/profile-admin
@@ -1,0 +1,6 @@
+{
+    "was": 0,
+    "slowms": 100,
+    "sampleRate": 1,
+    "ok": 1
+}

--- a/mongo/tests/test_dbm_operation_samples.py
+++ b/mongo/tests/test_dbm_operation_samples.py
@@ -17,12 +17,14 @@ pytestmark = [pytest.mark.usefixtures('dd_environment'), pytest.mark.integration
 
 @mock_now(1715911398.1112723)
 @common.standalone
-def test_mongo_operation_samples_standalone(aggregator, instance_integration_cluster, check, dd_run_check):
-    instance_integration_cluster['dbm'] = True
-    instance_integration_cluster['operation_samples'] = {'enabled': True, 'run_sync': True}
-    instance_integration_cluster['slow_operations'] = {'enabled': False}
+def test_mongo_operation_samples_standalone(
+    aggregator, instance_integration_cluster_autodiscovery, check, dd_run_check
+):
+    instance_integration_cluster_autodiscovery['dbm'] = True
+    instance_integration_cluster_autodiscovery['operation_samples'] = {'enabled': True, 'run_sync': True}
+    instance_integration_cluster_autodiscovery['slow_operations'] = {'enabled': False}
 
-    mongo_check = check(instance_integration_cluster)
+    mongo_check = check(instance_integration_cluster_autodiscovery)
     with mock_pymongo("standalone"):
         aggregator.reset()
         run_check_once(mongo_check, dd_run_check)
@@ -53,12 +55,12 @@ def test_mongo_operation_samples_standalone(aggregator, instance_integration_clu
 
 @mock_now(1715911398.11127223)
 @common.shard
-def test_mongo_operation_samples_mongos(aggregator, instance_integration_cluster, check, dd_run_check):
-    instance_integration_cluster['dbm'] = True
-    instance_integration_cluster['operation_samples'] = {'enabled': True, 'run_sync': True}
-    instance_integration_cluster['slow_operations'] = {'enabled': False}
+def test_mongo_operation_samples_mongos(aggregator, instance_integration_cluster_autodiscovery, check, dd_run_check):
+    instance_integration_cluster_autodiscovery['dbm'] = True
+    instance_integration_cluster_autodiscovery['operation_samples'] = {'enabled': True, 'run_sync': True}
+    instance_integration_cluster_autodiscovery['slow_operations'] = {'enabled': False}
 
-    mongo_check = check(instance_integration_cluster)
+    mongo_check = check(instance_integration_cluster_autodiscovery)
     aggregator.reset()
     with mock_pymongo("mongos"):
         run_check_once(mongo_check, dd_run_check)

--- a/mongo/tests/test_dbm_slow_operations.py
+++ b/mongo/tests/test_dbm_slow_operations.py
@@ -17,14 +17,17 @@ pytestmark = [pytest.mark.usefixtures('dd_environment'), pytest.mark.integration
 
 @mock_now(1715911398.1112723)
 @common.standalone
-def test_mongo_slow_operations_standalone(aggregator, instance_integration_cluster, check, dd_run_check):
-    instance_integration_cluster['reported_database_hostname'] = "mongohost"
-    instance_integration_cluster['dbm'] = True
-    instance_integration_cluster['slow_operations'] = {'enabled': True, 'run_sync': True}
-    instance_integration_cluster['database_autodiscovery'] = {'enabled': True, 'include': ['integration$', 'test$']}
-    instance_integration_cluster['operation_samples'] = {'enabled': False}
+def test_mongo_slow_operations_standalone(aggregator, instance_integration_cluster_autodiscovery, check, dd_run_check):
+    instance_integration_cluster_autodiscovery['reported_database_hostname'] = "mongohost"
+    instance_integration_cluster_autodiscovery['dbm'] = True
+    instance_integration_cluster_autodiscovery['slow_operations'] = {'enabled': True, 'run_sync': True}
+    instance_integration_cluster_autodiscovery['database_autodiscovery'] = {
+        'enabled': True,
+        'include': ['integration$', 'test$'],
+    }
+    instance_integration_cluster_autodiscovery['operation_samples'] = {'enabled': False}
 
-    mongo_check = check(instance_integration_cluster)
+    mongo_check = check(instance_integration_cluster_autodiscovery)
     aggregator.reset()
     with mock_pymongo("standalone"):
         run_check_once(mongo_check, dd_run_check)
@@ -52,14 +55,17 @@ def test_mongo_slow_operations_standalone(aggregator, instance_integration_clust
 
 @mock_now(1715911398.1112723)
 @common.shard
-def test_mongo_slow_operations_mongos(aggregator, instance_integration_cluster, check, dd_run_check):
-    instance_integration_cluster['reported_database_hostname'] = "mongohost"
-    instance_integration_cluster['dbm'] = True
-    instance_integration_cluster['slow_operations'] = {'enabled': True, 'run_sync': True}
-    instance_integration_cluster['database_autodiscovery'] = {'enabled': True, 'include': ['integration$', 'test$']}
-    instance_integration_cluster['operation_samples'] = {'enabled': False}
+def test_mongo_slow_operations_mongos(aggregator, instance_integration_cluster_autodiscovery, check, dd_run_check):
+    instance_integration_cluster_autodiscovery['reported_database_hostname'] = "mongohost"
+    instance_integration_cluster_autodiscovery['dbm'] = True
+    instance_integration_cluster_autodiscovery['slow_operations'] = {'enabled': True, 'run_sync': True}
+    instance_integration_cluster_autodiscovery['database_autodiscovery'] = {
+        'enabled': True,
+        'include': ['integration$', 'test$'],
+    }
+    instance_integration_cluster_autodiscovery['operation_samples'] = {'enabled': False}
 
-    mongo_check = check(instance_integration_cluster)
+    mongo_check = check(instance_integration_cluster_autodiscovery)
     aggregator.reset()
     with mock_pymongo("mongos"):
         run_check_once(mongo_check, dd_run_check)


### PR DESCRIPTION
### What does this PR do?
This PR adds a config option `database_autodiscovery.max_collections_per_database` (default to 100) to `database_autodiscovery` configuration block. This option is applied to limit the maximum number of collections per database to collect collection stats and indexes stats. 

### Motivation
`$collStats` and `$indexStats` aggregation can have negative performance impact on the monitored database when number of collections is high.
https://datadoghq.atlassian.net/browse/DBMON-4461

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
