### PR TITLE
Stop testing integrations against Python 2.

### DIFF
--- a/active_directory/hatch.toml
+++ b/active_directory/hatch.toml
@@ -10,4 +10,4 @@ platforms = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/activemq_xml/hatch.toml
+++ b/activemq_xml/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["5.11.1"]
 
 [envs.default.overrides]

--- a/aerospike/hatch.toml
+++ b/aerospike/hatch.toml
@@ -9,7 +9,7 @@ mypy-args = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["4", "5.0", "5.3", "5.6"]
 
 [envs.default.overrides]

--- a/amazon_msk/hatch.toml
+++ b/amazon_msk/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/ambari/hatch.toml
+++ b/ambari/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/apache/hatch.toml
+++ b/apache/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["2.4.27"]
 
 [envs.default.overrides]

--- a/aspdotnet/hatch.toml
+++ b/aspdotnet/hatch.toml
@@ -10,4 +10,4 @@ platforms = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/azure_iot_edge/hatch.toml
+++ b/azure_iot_edge/hatch.toml
@@ -12,10 +12,7 @@ mypy-args = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
-
-[[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 protocol = ["tls"]
 
 [envs.default.overrides]

--- a/btrfs/hatch.toml
+++ b/btrfs/hatch.toml
@@ -8,4 +8,4 @@ platforms = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/cacti/hatch.toml
+++ b/cacti/hatch.toml
@@ -6,4 +6,4 @@ dependencies = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/cassandra_nodetool/hatch.toml
+++ b/cassandra_nodetool/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["2.1", "3.0"]
 
 [envs.default.overrides]

--- a/ceph/hatch.toml
+++ b/ceph/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["4.0", "5.0"]
 
 [envs.default.overrides]

--- a/cilium/hatch.toml
+++ b/cilium/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 impl = ["legacy"]
 version = ["1.9"]
 

--- a/cisco_aci/hatch.toml
+++ b/cisco_aci/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default]
 dependencies = [

--- a/citrix_hypervisor/hatch.toml
+++ b/citrix_hypervisor/hatch.toml
@@ -9,5 +9,5 @@ mypy-args = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 

--- a/clickhouse/hatch.toml
+++ b/clickhouse/hatch.toml
@@ -4,7 +4,7 @@
 CLICKHOUSE_REPOSITORY = "clickhouse/clickhouse-server"
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["18", "19", "20", "21.8", "22.7"]
 
 [envs.default.overrides]

--- a/cloud_foundry_api/hatch.toml
+++ b/cloud_foundry_api/hatch.toml
@@ -15,4 +15,4 @@ mypy-deps = [
 e2e-env = false
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/cockroachdb/hatch.toml
+++ b/cockroachdb/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["2.0", "22.1", "23.2"]
 
 [envs.default.overrides]

--- a/confluent_platform/hatch.toml
+++ b/confluent_platform/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["5.4", "6.2"]
 
 [envs.default.overrides]

--- a/consul/hatch.toml
+++ b/consul/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["1.6", "1.9"]
 
 [envs.default.overrides]

--- a/coredns/hatch.toml
+++ b/coredns/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["1.2", "1.8"]
 
 [envs.default.overrides]

--- a/couch/hatch.toml
+++ b/couch/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["1.6", "2.3", "3.1"]
 
 [envs.default.overrides]

--- a/couchbase/hatch.toml
+++ b/couchbase/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 # https://www.couchbase.com/support-policy/enterprise-software
 version = ["6.6", "7.0", "7.1"]
 

--- a/crio/hatch.toml
+++ b/crio/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/datadog_checks_base/hatch.toml
+++ b/datadog_checks_base/hatch.toml
@@ -11,7 +11,7 @@ mypy-args = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default]
 features = ["db", "deps", "http", "json", "kube"]

--- a/datadog_checks_dev/hatch.toml
+++ b/datadog_checks_dev/hatch.toml
@@ -7,7 +7,7 @@ e2e-env = false
 DDEV_TESTING_PLUGIN = "true"
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default.overrides]
 matrix.python.features = [

--- a/datadog_cluster_agent/hatch.toml
+++ b/datadog_cluster_agent/hatch.toml
@@ -1,5 +1,5 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 

--- a/directory/hatch.toml
+++ b/directory/hatch.toml
@@ -1,6 +1,6 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.bench]

--- a/disk/hatch.toml
+++ b/disk/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/dns_check/hatch.toml
+++ b/dns_check/hatch.toml
@@ -7,4 +7,4 @@ mypy-args = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/dotnetclr/hatch.toml
+++ b/dotnetclr/hatch.toml
@@ -9,4 +9,4 @@ platforms = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/druid/hatch.toml
+++ b/druid/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/ecs_fargate/hatch.toml
+++ b/ecs_fargate/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/eks_fargate/hatch.toml
+++ b/eks_fargate/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default]
 e2e-env = false

--- a/elastic/hatch.toml
+++ b/elastic/hatch.toml
@@ -2,12 +2,12 @@
 base-package-features = ["deps", "http"]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 flavor = ["elasticsearch"]
 version = ["7.2", "7.7", "7.9", "7.10", "8.8"]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 # Opensearch, compatible with elasticsearch
 flavor = ["opensearch"]
 version = ["1.1"]

--- a/envoy/hatch.toml
+++ b/envoy/hatch.toml
@@ -6,10 +6,6 @@ dependencies = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7"]
-api-version = ["2"]
-
-[[envs.default.matrix]]
 python = ["3.11"]
 api-version = ["2", "3"]
 

--- a/etcd/hatch.toml
+++ b/etcd/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["v3.4.26" , "v3.5.9"]
 
 [envs.default.overrides]

--- a/exchange_server/hatch.toml
+++ b/exchange_server/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default]
 dependencies = [

--- a/external_dns/hatch.toml
+++ b/external_dns/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/fluentd/hatch.toml
+++ b/fluentd/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["1.17"]
 
 [envs.default.overrides]

--- a/gearmand/hatch.toml
+++ b/gearmand/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["1.0", "1.1"]
 
 [envs.default.overrides]

--- a/gitlab/hatch.toml
+++ b/gitlab/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 # https://about.gitlab.com/support/statement-of-support/#version-support
 version = ["13.12", "14.10", "15.10"]
 

--- a/gitlab_runner/hatch.toml
+++ b/gitlab_runner/hatch.toml
@@ -5,7 +5,7 @@ DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
 GITLAB_IMAGE = "gitlab/gitlab-ce"
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["10.8.0"]
 
 [envs.default.overrides]

--- a/glusterfs/hatch.toml
+++ b/glusterfs/hatch.toml
@@ -12,7 +12,7 @@ mypy-deps = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["7.9"]
 
 [envs.default.env-vars]

--- a/go_expvar/hatch.toml
+++ b/go_expvar/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/haproxy/hatch.toml
+++ b/haproxy/hatch.toml
@@ -1,11 +1,11 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["2.0", "2.2", "2.4", "2.5", "2.6", "2.7"]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["2.0"]
 impl = ["legacy"]
 

--- a/harbor/hatch.toml
+++ b/harbor/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["1.10", "2.0", "2.3"]
 
 [envs.default.overrides]

--- a/hdfs_datanode/hatch.toml
+++ b/hdfs_datanode/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default.env-vars]
 HDFS_RAW_VERSION = "3.1.3"

--- a/hdfs_namenode/hatch.toml
+++ b/hdfs_namenode/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default.env-vars]
 HDFS_RAW_VERSION = "3.1.3"

--- a/http_check/hatch.toml
+++ b/http_check/hatch.toml
@@ -6,4 +6,4 @@ dependencies = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/hudi/hatch.toml
+++ b/hudi/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default.env-vars]
 SPARK_VERSION = "3.2.0"

--- a/hyperv/hatch.toml
+++ b/hyperv/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default]
 platforms = [

--- a/ibm_db2/hatch.toml
+++ b/ibm_db2/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["11.1"]
 
 [envs.default.env-vars]

--- a/ibm_was/hatch.toml
+++ b/ibm_was/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 # We do not test IBM WAS v8. IBM themselves no longer build a docker image for this
 # version and we don't see the need to build and host an image ourselves. For reference:
 # https://github.com/WASdev/ci.docker.websphere-traditional/issues/198

--- a/iis/hatch.toml
+++ b/iis/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default]
 dependencies = [

--- a/istio/hatch.toml
+++ b/istio/hatch.toml
@@ -6,7 +6,7 @@ dependencies = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["1.13"]
 
 [envs.default.overrides]

--- a/kong/hatch.toml
+++ b/kong/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["1.5.0", "3.0.0"]
 
 [envs.default.overrides]

--- a/kube_apiserver_metrics/hatch.toml
+++ b/kube_apiserver_metrics/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/kube_controller_manager/hatch.toml
+++ b/kube_controller_manager/hatch.toml
@@ -11,7 +11,7 @@ dependencies = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/kube_dns/hatch.toml
+++ b/kube_dns/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/kube_metrics_server/hatch.toml
+++ b/kube_metrics_server/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/kube_proxy/hatch.toml
+++ b/kube_proxy/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default]
 platforms = [

--- a/kube_scheduler/hatch.toml
+++ b/kube_scheduler/hatch.toml
@@ -5,7 +5,7 @@ base-package-features = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default]
 dependencies = [

--- a/kubelet/hatch.toml
+++ b/kubelet/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default]
 dependencies = [

--- a/kubernetes_state/hatch.toml
+++ b/kubernetes_state/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/kyototycoon/hatch.toml
+++ b/kyototycoon/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/lighttpd/hatch.toml
+++ b/lighttpd/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 flavor = ["auth", "noauth"]
 
 [envs.default.overrides]

--- a/linkerd/hatch.toml
+++ b/linkerd/hatch.toml
@@ -6,7 +6,7 @@ dependencies = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/linux_proc_extras/hatch.toml
+++ b/linux_proc_extras/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/mapr/hatch.toml
+++ b/mapr/hatch.toml
@@ -7,4 +7,4 @@ dependencies = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/mapreduce/hatch.toml
+++ b/mapreduce/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default]
 dependencies = [

--- a/marathon/hatch.toml
+++ b/marathon/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/marklogic/hatch.toml
+++ b/marklogic/hatch.toml
@@ -13,7 +13,7 @@ mypy-deps = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["9.0", "10.0", "11.0"]
 
 [envs.default.overrides]

--- a/mcache/hatch.toml
+++ b/mcache/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/mesos_master/hatch.toml
+++ b/mesos_master/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["1.7"]
 
 [envs.default.overrides]

--- a/mesos_slave/hatch.toml
+++ b/mesos_slave/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["1.7"]
 
 [envs.default.overrides]

--- a/nagios/hatch.toml
+++ b/nagios/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["4.4"]
 
 [envs.default.overrides]

--- a/network/hatch.toml
+++ b/network/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default.overrides]
 platform.windows.e2e-env = { value = false }

--- a/nfsstat/hatch.toml
+++ b/nfsstat/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/nginx/hatch.toml
+++ b/nginx/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["1.12", "1.13", "vts"]
 
 [envs.default.env-vars]

--- a/nginx_ingress_controller/hatch.toml
+++ b/nginx_ingress_controller/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/openldap/hatch.toml
+++ b/openldap/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["2.4", "2.6"]
 
 [envs.default.overrides]

--- a/openmetrics/hatch.toml
+++ b/openmetrics/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/openstack/hatch.toml
+++ b/openstack/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/pdh_check/hatch.toml
+++ b/pdh_check/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default]
 dependencies = [

--- a/php_fpm/hatch.toml
+++ b/php_fpm/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/postfix/hatch.toml
+++ b/postfix/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/powerdns_recursor/hatch.toml
+++ b/powerdns_recursor/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["3.7", "4.0"]
 
 [envs.default.overrides]

--- a/process/hatch.toml
+++ b/process/hatch.toml
@@ -1,6 +1,6 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.bench]

--- a/prometheus/hatch.toml
+++ b/prometheus/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default]
 platforms = [

--- a/proxysql/hatch.toml
+++ b/proxysql/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["1.4", "2.0"]
 
 [envs.default.overrides]

--- a/rabbitmq/hatch.toml
+++ b/rabbitmq/hatch.toml
@@ -6,22 +6,12 @@ dependencies = [
   "pika==1.3.2; python_version > '3.0'",
 ]
 
-# Rabbitmq versions <3.8 must be tested on both PY2 and PY3. All these versions use RabbitMQ's management plugin as the source for data.
-[[envs.default.matrix]]
-python = ["2.7", "3.11"]
-version = ["3.7"]
-
-# Rabbitmq versions 3.8+ introduce the Prometheus plugin. This is the preferred way to collect metrics. We drop PY2 support.
+# Rabbitmq versions 3.8+ introduce the Prometheus plugin. This is the preferred way to collect metrics.
+# We still support metrics from management plugin as a legacy option.
 [[envs.default.matrix]]
 python = ["3.11"]
-version = ["3.11"]
-
-# We still support metrics from management plugin as a legacy option and continue to support PY2 for them as well.
-[[envs.default.matrix]]
-python = ["2.7", "3.11"]
-version = ["3.11"]
-plugin = ["mgmt"]
-
+version = ["3.7", "3.11"]
+flavor = ["mgmt", "openmetrics"]
 
 [envs.default.overrides]
 matrix.version.env-vars = "RABBITMQ_VERSION"

--- a/redisdb/hatch.toml
+++ b/redisdb/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["5.0", "6.0", "7.0", "cloud"]
 
 [envs.default.overrides]

--- a/rethinkdb/hatch.toml
+++ b/rethinkdb/hatch.toml
@@ -13,7 +13,7 @@ mypy-deps = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 # Can't support lower 2.3 patch versions due to: https://github.com/rethinkdb/rethinkdb/issues/6108
 version = ["2.3", "2.4"]
 

--- a/riak/hatch.toml
+++ b/riak/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/riakcs/hatch.toml
+++ b/riakcs/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default]
 e2e-env = false

--- a/sap_hana/hatch.toml
+++ b/sap_hana/hatch.toml
@@ -6,7 +6,7 @@ dependencies = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["2.0"]
 
 [envs.default.overrides]

--- a/scylla/hatch.toml
+++ b/scylla/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7","3.11"]
+python = ["3.11"]
 version = ["3.1", "3.3", "5.2"]
 
 [envs.default.overrides]

--- a/silk/hatch.toml
+++ b/silk/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default]
 dependencies = [

--- a/singlestore/hatch.toml
+++ b/singlestore/hatch.toml
@@ -13,4 +13,4 @@ mypy-deps = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/snmp/hatch.toml
+++ b/snmp/hatch.toml
@@ -1,17 +1,5 @@
 [env.collectors.datadog-checks]
 check-types = false
-mypy-args = [
-    "--py2",
-    "--disallow-untyped-defs",
-    "--follow-imports silent",
-    "--install-types",
-    "--non-interactive",
-    "datadog_checks/snmp",
-]
-
-[[envs.default.matrix]]
-python = ["2.7"]
-snmplistener = ["false"]
 
 [[envs.default.matrix]]
 python = ["3.11"]

--- a/sonarqube/hatch.toml
+++ b/sonarqube/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["7.9", "8.5", "9.3"]
 
 # You can use M1 env if you want to run on M1 processor machine

--- a/spark/hatch.toml
+++ b/spark/hatch.toml
@@ -6,7 +6,7 @@ dependencies = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["2.4", "3.0"]
 
 [envs.default.overrides]

--- a/squid/hatch.toml
+++ b/squid/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["4.13", "5.6"]
 
 [envs.default.overrides]

--- a/ssh_check/hatch.toml
+++ b/ssh_check/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["8.1", "9.1"]
 
 [envs.default.overrides]

--- a/statsd/hatch.toml
+++ b/statsd/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["0.9"]
 
 [envs.default.overrides]

--- a/supervisord/hatch.toml
+++ b/supervisord/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["3.3"]
 
 [envs.default.overrides]

--- a/system_core/hatch.toml
+++ b/system_core/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/system_swap/hatch.toml
+++ b/system_swap/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/tcp_check/hatch.toml
+++ b/tcp_check/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/teamcity/hatch.toml
+++ b/teamcity/hatch.toml
@@ -1,10 +1,6 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7"]
-impl = ["legacy"]
-
-[[envs.default.matrix]]
 python = ["3.11"]
 impl = ["legacy", "openmetrics"]
 

--- a/tls/hatch.toml
+++ b/tls/hatch.toml
@@ -6,4 +6,4 @@ dependencies = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/twemproxy/hatch.toml
+++ b/twemproxy/hatch.toml
@@ -4,7 +4,7 @@
 platforms = ["linux", "macos"]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["0.5.0"]
 
 [envs.default.env-vars]

--- a/twistlock/hatch.toml
+++ b/twistlock/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]

--- a/varnish/hatch.toml
+++ b/varnish/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["5.2", "6.5"]
 
 [envs.default.overrides]

--- a/vault/hatch.toml
+++ b/vault/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["1.9.0"]
 auth = ["token-auth", "noauth"]
 

--- a/vertica/hatch.toml
+++ b/vertica/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["10.1", "11.1", "12.0", "23.3"]
 
 [envs.default.overrides]

--- a/voltdb/hatch.toml
+++ b/voltdb/hatch.toml
@@ -15,14 +15,9 @@ mypy-deps = [
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["8.4", "10.0"]
-tls = ["false"]
-
-[[envs.default.matrix]]
-python = ["2.7", "3.11"]
-version = ["8.4"]
-tls = ["true"]
+tls = ["false", "true"]
 
 [envs.default.overrides]
 matrix.version.env-vars = [

--- a/vsphere/hatch.toml
+++ b/vsphere/hatch.toml
@@ -18,7 +18,7 @@ mypy-args = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["6.7", "7.0"]
 
 [envs.default]

--- a/weblogic/hatch.toml
+++ b/weblogic/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["12", "14"]
 
 [envs.default.overrides]

--- a/win32_event_log/hatch.toml
+++ b/win32_event_log/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default]
 e2e-env = false

--- a/windows_service/hatch.toml
+++ b/windows_service/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default]
 platforms = [

--- a/wmi_check/hatch.toml
+++ b/wmi_check/hatch.toml
@@ -9,7 +9,7 @@ mypy-args = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default]
 e2e-env = false

--- a/yarn/hatch.toml
+++ b/yarn/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/zk/hatch.toml
+++ b/zk/hatch.toml
@@ -1,19 +1,13 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.11"]
+python = ["3.11"]
 version = ["3.5.8", "3.6.2"]
-ssl = ["ssl"]
-
-[[envs.default.matrix]]
-python = ["2.7", "3.11"]
-version = ["3.5.8", "3.6.2"]
+ssl = ["true", "false"]
 
 [envs.default.overrides]
 matrix.version.env-vars = "ZK_VERSION"
-matrix.ssl.env-vars = [
-    { key = "SSL", value = "true", if = ["ssl"] },
-]
+matrix.ssl.env-vars = "SSL"
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Remove python 2.7 from the `hatch.toml` for integrations.

### Motivation
<!-- What inspired you to submit this pull request? -->
We officially dropped support for Python 2.7 with Agent 7.54+.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
