### PR TITLE
[Backport 7.57.x] skip explain get profile level & listCollections command

### DIFF
--- a/mongo/changelog.d/18408.fixed
+++ b/mongo/changelog.d/18408.fixed
@@ -1,0 +1,1 @@
+Skip collect explain plan for get profile level & listCollections command.

--- a/mongo/datadog_checks/mongo/dbm/operation_samples.py
+++ b/mongo/datadog_checks/mongo/dbm/operation_samples.py
@@ -9,7 +9,7 @@ from typing import List, Optional, Tuple
 
 from bson import json_util
 
-from datadog_checks.mongo.dbm.utils import format_key_name
+from datadog_checks.mongo.dbm.utils import UNEXPLAINABLE_COMMANDS, format_key_name
 
 try:
     import datadog_agent
@@ -213,7 +213,7 @@ class MongoOperationSamples(DBMAsyncJob):
             self._check.log.debug("Skipping explain operation type %s: %s", op, command)
             return False
 
-        if "getMore" in command or "insert" in command or "delete" in command or "update" in command:
+        if any(command.get(key) for key in UNEXPLAINABLE_COMMANDS):
             # Skip operations as they are not queries
             self._check.log.debug("Skipping operations that are not queries: %s", op, command)
             return False

--- a/mongo/datadog_checks/mongo/dbm/utils.py
+++ b/mongo/datadog_checks/mongo/dbm/utils.py
@@ -6,6 +6,18 @@
 from datadog_checks.base.utils.common import to_native_string
 
 
+UNEXPLAINABLE_COMMANDS = frozenset(
+    [
+        "getMore",
+        "insert",
+        "update",
+        "delete",
+        "explain",
+        "profile",  # command to get profile level
+        "listCollections",
+    ]
+)
+
 def format_key_name(formatter, metric_dict: dict) -> dict:
     # convert camelCase to snake_case
     formatted = {}


### PR DESCRIPTION
### What does this PR do?
Backport #18408 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
