### PR TITLE
[eci][oci] update Oracle tile name to Oracle Database

### DIFF
--- a/oracle/README.md
+++ b/oracle/README.md
@@ -1,4 +1,4 @@
-# Oracle Integration
+# Oracle Database Integration
 
 ![Oracle Dashboard][1]
 

--- a/oracle/manifest.json
+++ b/oracle/manifest.json
@@ -9,7 +9,7 @@
     "support": "README.md#Support",
     "changelog": "CHANGELOG.md",
     "description": "Oracle relational database system designed for enterprise grid computing",
-    "title": "Oracle",
+    "title": "Oracle Database",
     "media": [],
     "classifier_tags": [
       "Category::Data Stores",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
- Updates the oracle tile name to `Oracle Database`

### Motivation
<!-- What inspired you to submit this pull request? -->
- An `Oracle Cloud Infrastructure` integration is being built. Since the existing `Oracle` integration is for Oracle Databases, it will be nice to make this more specific to not cause confusion with the OCI integration 

### Additional Notes
<!-- Anything else we should know when reviewing? -->
- @romandatadog discussed and got approval from `Jonathan Morin`, `Casey Culligan`, and `Justin Iso`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
