### PR TITLE
Convert an integration test to unit test.

### DIFF
--- a/datadog_checks_base/changelog.d/18438.added
+++ b/datadog_checks_base/changelog.d/18438.added
@@ -1,0 +1,1 @@
+`utils.http.RequestsWrapper` accepts a session at initialization, useful for testing and controlling sessions in general.

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -156,7 +156,7 @@ class RequestsWrapper(object):
         'tls_protocols_allowed',
     )
 
-    def __init__(self, instance, init_config, remapper=None, logger=None):
+    def __init__(self, instance, init_config, remapper=None, logger=None, session=None):
         self.logger = logger or LOGGER
         default_fields = dict(STANDARD_FIELDS)
 
@@ -329,7 +329,7 @@ class RequestsWrapper(object):
         # https://requests.readthedocs.io/en/latest/user/advanced/#session-objects
         # https://requests.readthedocs.io/en/latest/user/advanced/#keep-alive
         self.persist_connections = self.tls_use_host_header or is_affirmative(config['persist_connections'])
-        self._session = None
+        self._session = session
 
         # Whether or not to log request information like method and url
         self.log_requests = is_affirmative(config['log_requests'])


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Along the way also add optional kwarg to override the `session` attribute of `RequestsWrapper`.

### Motivation
<!-- What inspired you to submit this pull request? -->
This test's flakiness wasn't worth the value it was delivering, i.e. testing
that the requests lib respects the timeout.

We've refocused the test on checking that we provide the timeout correctly to
requests and that we let the timeout error bubble up.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
