### PR TITLE
Revert "[oracle] add oracle integration deprecation notice to readme …

### DIFF
--- a/oracle/README.md
+++ b/oracle/README.md
@@ -2,12 +2,6 @@
 
 ![Oracle Dashboard][1]
 
-## Deprecation notice
-
-The Oracle integration is deprecated and will be removed in a future release. For customers using Datadog Agent version 7.52.0 or earlier, the existing Oracle integration will continue to function. Starting from Datadog Agent version 7.53.0, the Oracle integration has been automatically migrated to the new implementation written in Go, available in [`datadog-agent`][16].
-
-We strongly recommend upgrading to the latest Datadog Agent to take full advantage of the new Oracle integration, along with the [Database Monitoring (DBM)][2] feature, for enhanced insights into query performance and database health. DBM offers a comprehensive set of features, including query-level metrics, live and historical query snapshots, wait event analysis, database load, query explain plans, and blocking query insights.
-
 ## Overview
 
 The Oracle integration provides health and performance metrics for your Oracle database in near real-time. Visualize these metrics with the provided dashboard and create monitors to alert your team on Oracle database states.
@@ -446,4 +440,3 @@ Need help? Contact [Datadog support][14].
 [13]: https://www.oracle.com/database/technologies/instant-client/winx64-64-downloads.html
 [14]: https://docs.datadoghq.com/help/
 [15]: https://docs.oracle.com/en/database/oracle/oracle-database/19/mxcli/installing-and-removing-oracle-database-client.html
-[16]: https://github.com/DataDog/datadog-agent/tree/main/pkg/collector/corechecks/oracle


### PR DESCRIPTION
…(#18434)"

This reverts commit 59ae38e5d4cc659ef7e64f7069331e561a67df08.

### What does this PR do?
The oracle integration readme has been used to document configuration for the new oracle check implemented in Go. Adding the deprecation notice in the readme causes confusions to customers. Revert the previous PR. 
For customers on old datadog-agent versions, they can refer to this existing [configuration document](https://docs.datadoghq.com/integrations/guide/deprecated-oracle-integration/?tab=linux)

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
