### PR TITLE
[dbm] Handles mysql flexible server warning bug

### DIFF
--- a/mysql/changelog.d/18450.fixed
+++ b/mysql/changelog.d/18450.fixed
@@ -1,0 +1,1 @@
+Handles mysql azure flexible server warning bug

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -135,7 +135,11 @@ class MySQLActivity(DBMAsyncJob):
             self._log.debug(
                 'Waiting for events_waits_current availability to be determined by the check, skipping run.'
             )
-        if self._check.events_wait_current_enabled is False:
+        # Azure flexible server 
+        azure_deployment_type = ""
+        if self._config.cloud_metadata.get("azure") is not None:
+            azure_deployment_type = self._config.cloud_metadata.get("azure")["deployment_type"]
+        if self._check.events_wait_current_enabled is False and azure_deployment_type != 'flexible_server':
             self._check.record_warning(
                 DatabaseConfigurationError.events_waits_current_not_enabled,
                 warning_with_tags(

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -136,9 +136,7 @@ class MySQLActivity(DBMAsyncJob):
                 'Waiting for events_waits_current availability to be determined by the check, skipping run.'
             )
         # Azure flexible server 
-        azure_deployment_type = ""
-        if self._config.cloud_metadata.get("azure") is not None:
-            azure_deployment_type = self._config.cloud_metadata.get("azure")["deployment_type"]
+        azure_deployment_type = self._config.cloud_metadata.get("azure", {}).get("deployment_type")
         if self._check.events_wait_current_enabled is False and azure_deployment_type != 'flexible_server':
             self._check.record_warning(
                 DatabaseConfigurationError.events_waits_current_not_enabled,

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -135,21 +135,21 @@ class MySQLActivity(DBMAsyncJob):
             self._log.debug(
                 'Waiting for events_waits_current availability to be determined by the check, skipping run.'
             )
-        # Azure flexible server 
-        azure_deployment_type = self._config.cloud_metadata.get("azure", {}).get("deployment_type")
-        if self._check.events_wait_current_enabled is False and azure_deployment_type != 'flexible_server':
-            self._check.record_warning(
-                DatabaseConfigurationError.events_waits_current_not_enabled,
-                warning_with_tags(
-                    'Query activity and wait event collection is disabled on this host. To enable it, the setup '
-                    'consumer `performance-schema-consumer-events-waits-current` must be enabled on the MySQL server. '
-                    'Please refer to the troubleshooting documentation: '
-                    'https://docs.datadoghq.com/database_monitoring/setup_mysql/troubleshooting#%s',
-                    DatabaseConfigurationError.events_waits_current_not_enabled.value,
-                    code=DatabaseConfigurationError.events_waits_current_not_enabled.value,
-                    host=self._check.resolved_hostname,
-                ),
-            )
+        if self._check.events_wait_current_enabled is False:
+            azure_deployment_type = self._config.cloud_metadata.get("azure", {}).get("deployment_type")
+            if azure_deployment_type != "flexible_server":
+                self._check.record_warning(
+                    DatabaseConfigurationError.events_waits_current_not_enabled,
+                    warning_with_tags(
+                        'Query activity and wait event collection is disabled on this host. To enable it, the setup '
+                        'consumer `performance-schema-consumer-events-waits-current` '
+                        'must be enabled on the MySQL server. Please refer to the troubleshooting documentation: '
+                        'https://docs.datadoghq.com/database_monitoring/setup_mysql/troubleshooting#%s',
+                        DatabaseConfigurationError.events_waits_current_not_enabled.value,
+                        code=DatabaseConfigurationError.events_waits_current_not_enabled.value,
+                        host=self._check.resolved_hostname,
+                    ),
+                )
             return
         self._check_version()
         self._collect_activity()

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -476,28 +476,31 @@ def test_events_wait_current_disabled(dbm_instance, dd_run_check, root_conn, agg
     assert check.warnings == []
     assert dbm_activity, "should have collected at least one activity"
 
+
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(
     "cloud_metadata",
     [
-        (
-            {
-                'azure': {
-                    'deployment_type': 'flexible_server',
-                    'name': 'my-instance',
-                },
+        {
+            'azure': {
+                'deployment_type': 'flexible_server',
+                'name': 'my-instance',
             },
-        ),
-    ]
+        },
+    ],
 )
-def test_events_wait_current_disabled_no_warning_azure_flexible_server(dbm_instance, dd_run_check, root_conn, aggregator, cloud_metadata):
+def test_events_wait_current_disabled_no_warning_azure_flexible_server(
+    dbm_instance, dd_run_check, root_conn, aggregator, cloud_metadata
+):
     '''
-    This test verifies that the check will not emit a warning if the events_waits_current is disabled and Azure deployment_type is flexible_server.
+    This test verifies that the check will not emit a warning
+    if the events_waits_current is disabled and Azure deployment_type is flexible_server.
     '''
     if cloud_metadata:
         for k, v in cloud_metadata.items():
             dbm_instance[k] = v
+    dbm_instance['options']['extra_performance_metrics'] = False
     check = MySql(CHECK_NAME, {}, [dbm_instance])
 
     # disable events_waits_current, expect events_wait_current_enabled to be set to False

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -447,7 +447,7 @@ def test_events_wait_current_disabled(dbm_instance, dd_run_check, root_conn, agg
         cursor.execute("UPDATE performance_schema.setup_consumers SET enabled='NO' WHERE name = 'events_waits_current'")
 
     dd_run_check(check)
-    # force query activity to run once, expect it to exist immediately with a warning
+    # force query activity to run once, expect it to exit immediately with a warning
     check._query_activity.run_job()
     dbm_activity = aggregator.get_event_platform_events("dbm-activity")
     assert check.events_wait_current_enabled is False
@@ -475,6 +475,44 @@ def test_events_wait_current_disabled(dbm_instance, dd_run_check, root_conn, agg
     dbm_activity = aggregator.get_event_platform_events("dbm-activity")
     assert check.warnings == []
     assert dbm_activity, "should have collected at least one activity"
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize(
+    "cloud_metadata",
+    [
+        (
+            {
+                'azure': {
+                    'deployment_type': 'flexible_server',
+                    'name': 'my-instance',
+                },
+            },
+        ),
+    ]
+)
+def test_events_wait_current_disabled_no_warning_azure_flexible_server(dbm_instance, dd_run_check, root_conn, aggregator, cloud_metadata):
+    '''
+    This test verifies that the check will not emit a warning if the events_waits_current is disabled and Azure deployment_type is flexible_server.
+    '''
+    if cloud_metadata:
+        for k, v in cloud_metadata.items():
+            dbm_instance[k] = v
+    check = MySql(CHECK_NAME, {}, [dbm_instance])
+
+    # disable events_waits_current, expect events_wait_current_enabled to be set to False
+    with closing(root_conn.cursor()) as cursor:
+        cursor.execute("UPDATE performance_schema.setup_consumers SET enabled='NO' WHERE name = 'events_waits_current'")
+
+    dd_run_check(check)
+
+    # force query activity to run once, expect it to collect nothing
+    check._query_activity.run_job()
+    dbm_activity = aggregator.get_event_platform_events("dbm-activity")
+
+    assert check.events_wait_current_enabled is False
+    assert check.warnings == []
+    assert not dbm_activity, "should not have collected any activity"
 
 
 # the inactive job metrics are emitted from the main integrations


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

A customer was seeing a wrong agent message in DBM UI while using Azure Flexible Server. Query Activity and Wait Event collection [is not supported](https://docs.datadoghq.com/database_monitoring/setup_mysql/troubleshooting/#query-activity-is-missing) for MySQL Azure Flexible Server deployment type, so we should not emit the warning when this is the case. 

<img width="1187" alt="Screenshot 2024-08-28 at 3 42 04 PM" src="https://github.com/user-attachments/assets/c0a1a02b-bece-4b55-b413-ebc4aa7a07d1">

### Motivation
<!-- What inspired you to submit this pull request? -->

Customer support escalation. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
