### PR TITLE
Update Databricks integration

### DIFF
--- a/databricks/README.md
+++ b/databricks/README.md
@@ -47,7 +47,7 @@ partial -->
 A global init script runs on every cluster created in your workspace. Global init scripts are useful when you want to enforce organization-wide library configurations or security screens. 
 
 <div class="alert alert-info">Only workspace admins can manage global init scripts.</div>
-<div class="alert alert-info">Global init scripts only run on clusters configured with single user or legacy no-isolation shared access mode, so Databricks recommends configuring all init scripts as cluster-scoped init scripts and managing them across your workspace using cluster policies.</div>
+<div class="alert alert-info">Global init scripts only run on clusters configured with single user or legacy no-isolation shared access mode. Therefore, Databricks recommends configuring all init scripts as cluster-scoped and managing them across your workspace using cluster policies.</div>
 
 Use the Databricks UI to edit the global init scripts:
 

--- a/databricks/README.md
+++ b/databricks/README.md
@@ -47,6 +47,7 @@ partial -->
 A global init script runs on every cluster created in your workspace. Global init scripts are useful when you want to enforce organization-wide library configurations or security screens. 
 
 <div class="alert alert-info">Only workspace admins can manage global init scripts.</div>
+<div class="alert alert-info">Global init scripts only run on clusters configured with single user or legacy no-isolation shared access mode, so Databricks recommends configuring all init scripts as cluster-scoped init scripts and managing them across your workspace using cluster policies.</div>
 
 Use the Databricks UI to edit the global init scripts:
 


### PR DESCRIPTION
Adding note from databricks documentation regarding global init scripts

### What does this PR do?
Customer reached about some confusion in our databricks documentation, where global init scripts only run on clusters configured with single user or legacy no-isolation shared access mode. There is a link to the databricks documentation, but worth noting in our documents.

### Motivation
https://datadog.zendesk.com/agent/tickets/1808056

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
