### PR TITLE
[mongo] cache database profiling level to avoid repeated queries

### DIFF
--- a/mongo/changelog.d/18461.fixed
+++ b/mongo/changelog.d/18461.fixed
@@ -1,0 +1,1 @@
+Cache database profiling level to avoid repeated queries in slow operations sampling.

--- a/mongo/datadog_checks/mongo/dbm/slow_operations.py
+++ b/mongo/datadog_checks/mongo/dbm/slow_operations.py
@@ -7,6 +7,7 @@ import time
 from datetime import datetime
 
 from bson import json_util
+from cachetools import TTLCache
 from pymongo.errors import OperationFailure
 
 from datadog_checks.mongo.dbm.utils import (
@@ -44,6 +45,11 @@ class MongoSlowOperations(DBMAsyncJob):
         self._explained_operations_ratelimiter = RateLimitingTTLCache(
             maxsize=self._slow_operations_config['explained_operations_cache_maxsize'],
             ttl=45 * 60 / self._slow_operations_config['explained_operations_per_hour_per_query'],
+        )
+        # _database_profiling_levels: cache the profiling levels for each database
+        self._database_profiling_levels = TTLCache(
+            maxsize=check._database_autodiscovery._max_databases,
+            ttl=60 * 60,  # 1 hour
         )
 
         super(MongoSlowOperations, self).__init__(
@@ -120,6 +126,9 @@ class MongoSlowOperations(DBMAsyncJob):
 
     def _is_profiling_enabled(self, db_name):
         try:
+            if db_name in self._database_profiling_levels:
+                return self._database_profiling_levels[db_name] > 0
+
             profiling_level = self._check.api_client.get_profiling_level(db_name)
             level = profiling_level.get("was", 0)  # profiling by default is disabled
             slowms = profiling_level.get("slowms", 100)  # slowms threshold is 100ms by default
@@ -129,9 +138,12 @@ class MongoSlowOperations(DBMAsyncJob):
             # raw ensures that level = 0 is also emitted
             self._check.gauge('mongodb.profiling.level', level, tags=tags, raw=True)
             self._check.gauge('mongodb.profiling.slowms', slowms, tags=tags, raw=True)
+            # Cache the profiling level
+            self._database_profiling_levels[db_name] = level
             return level > 0
         except OperationFailure:
             # If the command fails, we assume profiling is not enabled
+            self._database_profiling_levels[db_name] = 0
             return False
 
     def _collect_slow_operations_from_profiler(self, db_name, last_ts):

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -112,13 +112,14 @@ class MongoDb(AgentCheck):
 
         self.diagnosis.register(self._diagnose_tls)
 
+        # Database autodiscovery
+        self._database_autodiscovery = MongoDBDatabaseAutodiscovery(check=self)
+
         # DBM
         self._operation_samples = MongoOperationSamples(check=self)
         self._slow_operations = MongoSlowOperations(check=self)
         self._schemas = MongoSchemas(check=self)
 
-        # Database autodiscovery
-        self._database_autodiscovery = MongoDBDatabaseAutodiscovery(check=self)
         self._api = None
 
     @property

--- a/mongo/pyproject.toml
+++ b/mongo/pyproject.toml
@@ -39,6 +39,7 @@ license = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "pymongo[srv]==4.8.0; python_version >= '3.9'",
+    "cachetools==5.4.0; python_version > '3.0'",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?
This PR adds a TTL cache (ttl 60 mins) to avoid repeated query for database profiling level in slow operations collections.

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4484

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
