### PR TITLE
[mongo] include replica set tags in metrics

### DIFF
--- a/mongo/changelog.d/18463.added
+++ b/mongo/changelog.d/18463.added
@@ -1,0 +1,1 @@
+Include replica set tags in metrics.

--- a/mongo/datadog_checks/mongo/common.py
+++ b/mongo/datadog_checks/mongo/common.py
@@ -141,7 +141,9 @@ class MongosDeployment(Deployment):
 
 
 class ReplicaSetDeployment(Deployment):
-    def __init__(self, hosting_type, replset_name, replset_state, hosts, replset_me, cluster_role=None):
+    def __init__(
+        self, hosting_type, replset_name, replset_state, hosts, replset_me, cluster_role=None, replset_tags=None
+    ):
         super(ReplicaSetDeployment, self).__init__(hosting_type)
         self.replset_name = replset_name
         self.replset_state = replset_state
@@ -153,6 +155,7 @@ class ReplicaSetDeployment(Deployment):
         self.is_secondary = replset_state == SECONDARY_STATE_ID
         self.is_arbiter = replset_state == ARBITER_STATE_ID
         self.hosts = hosts
+        self._replset_tags = replset_tags
 
     def is_principal(self):
         # There is only ever one primary node in a replica set.
@@ -175,6 +178,12 @@ class ReplicaSetDeployment(Deployment):
         if self.use_shards:
             tags.append('sharding_cluster_role:{}'.format(self.cluster_role))
         return tags
+
+    @property
+    def replset_tags(self):
+        if not self._replset_tags:
+            return []
+        return ["replset_{}:{}".format(k.lower(), v) for k, v in self._replset_tags.items()]
 
     @property
     def instance_metadata(self):

--- a/mongo/datadog_checks/mongo/dbm/operation_samples.py
+++ b/mongo/datadog_checks/mongo/dbm/operation_samples.py
@@ -303,7 +303,7 @@ class MongoOperationSamples(DBMAsyncJob):
             "dbm_type": "plan",
             "ddagentversion": datadog_agent.get_version(),
             "ddsource": "mongo",
-            "ddtags": ",".join(self._check._get_tags(include_deployment_tags=True)),
+            "ddtags": ",".join(self._check._get_tags()),
             "timestamp": now * 1000,
             "network": {
                 "client": operation_metadata["client"],
@@ -358,7 +358,7 @@ class MongoOperationSamples(DBMAsyncJob):
             "ddsource": "mongo",
             "dbm_type": "activity",
             "collection_interval": self._collection_interval,
-            "ddtags": self._check._get_tags(include_deployment_tags=True),
+            "ddtags": self._check._get_tags(),
             "timestamp": now * 1000,
             "mongodb_activity": activities,
         }

--- a/mongo/datadog_checks/mongo/dbm/schemas.py
+++ b/mongo/datadog_checks/mongo/dbm/schemas.py
@@ -61,7 +61,7 @@ class MongoSchemas(DBMAsyncJob):
             "kind": "mongodb_databases",
             "collection_interval": self._collection_interval,
             "dbms_version": self._check._mongo_version,
-            "tags": self._check._get_tags(include_deployment_tags=True),
+            "tags": self._check._get_tags(),
         }
 
         collected_collections = 0

--- a/mongo/datadog_checks/mongo/dbm/slow_operations.py
+++ b/mongo/datadog_checks/mongo/dbm/slow_operations.py
@@ -123,7 +123,7 @@ class MongoSlowOperations(DBMAsyncJob):
             profiling_level = self._check.api_client.get_profiling_level(db_name)
             level = profiling_level.get("was", 0)  # profiling by default is disabled
             slowms = profiling_level.get("slowms", 100)  # slowms threshold is 100ms by default
-            tags = self._check._get_tags(include_deployment_tags=True, include_internal_resource_tags=True)
+            tags = self._check._get_tags(include_internal_resource_tags=True)
             tags.append("db:%s" % db_name)
             # Emit the profiling level and slowms as raw metrics
             # raw ensures that level = 0 is also emitted
@@ -291,7 +291,7 @@ class MongoSlowOperations(DBMAsyncJob):
             "dbm_type": "plan",
             "ddagentversion": datadog_agent.get_version(),
             "ddsource": "mongo",
-            "ddtags": ",".join(self._check._get_tags(include_deployment_tags=True)),
+            "ddtags": ",".join(self._check._get_tags()),
             "timestamp": slow_operation["ts"] * 1000,
             "network": {
                 "client": self._get_slow_operation_client(slow_operation),
@@ -371,7 +371,7 @@ class MongoSlowOperations(DBMAsyncJob):
             "ddsource": "mongo",
             "dbm_type": "slow_query",
             "collection_interval": self._collection_interval,
-            "ddtags": self._check._get_tags(include_deployment_tags=True),
+            "ddtags": self._check._get_tags(),
             "timestamp": time.time() * 1000,
             "mongodb_slow_queries": slow_operation_events,
         }

--- a/mongo/tests/fixtures/isMaster-replica-primary
+++ b/mongo/tests/fixtures/isMaster-replica-primary
@@ -3,7 +3,9 @@
         "replset-data-0.mongo.default.svc.cluster.local:27017",
         "replset-data-1.mongo.default.svc.cluster.local:27017"
     ],
-    "arbiters": ["replset-arbiter-0.mongo.default.svc.cluster.local:27017"],
+    "arbiters": [
+        "replset-arbiter-0.mongo.default.svc.cluster.local:27017"
+    ],
     "setName": "replset",
     "setVersion": 1,
     "ismaster": true,
@@ -99,5 +101,9 @@
             "t": 1600348939,
             "i": 85
         }
+    },
+    "tags": {
+        "nodeType": "ELECTABLE",
+        "workloadType": "OPERATIONAL"
     }
 }

--- a/mongo/tests/results/metrics-replset-lag-from-primary.json
+++ b/mongo/tests/results/metrics-replset-lag-from-primary.json
@@ -9,7 +9,9 @@
             "replset_name:replset",
             "replset_state:primary",
             "replset_me:replset-data-0.mongo.default.svc.cluster.local:27017",
-            "hosting_type:self-hosted"
+            "hosting_type:self-hosted",
+            "replset_nodetype:ELECTABLE",
+            "replset_workloadtype:OPERATIONAL"
         ]
     },
     {
@@ -22,7 +24,9 @@
             "replset_name:replset",
             "replset_state:secondary",
             "replset_me:replset-data-0.mongo.default.svc.cluster.local:27017",
-            "hosting_type:self-hosted"
+            "hosting_type:self-hosted",
+            "replset_nodetype:ELECTABLE",
+            "replset_workloadtype:OPERATIONAL"
         ]
     },
     {
@@ -35,7 +39,9 @@
             "replset_name:replset",
             "replset_state:secondary",
             "replset_me:replset-data-0.mongo.default.svc.cluster.local:27017",
-            "hosting_type:self-hosted"
+            "hosting_type:self-hosted",
+            "replset_nodetype:ELECTABLE",
+            "replset_workloadtype:OPERATIONAL"
         ]
     }
 ]

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -527,6 +527,8 @@ def test_integration_replicaset_primary(instance_integration, aggregator, check,
         'replset_state:primary',
         'replset_me:replset-data-0.mongo.default.svc.cluster.local:27017',
         'hosting_type:self-hosted',
+        'replset_nodetype:ELECTABLE',
+        'replset_workloadtype:OPERATIONAL',
     ]
     metrics_categories = [
         'count-dbs',
@@ -629,6 +631,8 @@ def test_integration_replicaset_primary_config(instance_integration, aggregator,
         'replset_state:primary',
         'replset_me:replset-data-0.mongo.default.svc.cluster.local:27017',
         'hosting_type:self-hosted',
+        'replset_nodetype:ELECTABLE',
+        'replset_workloadtype:OPERATIONAL',
     ]
     metrics_categories = [
         'count-dbs',
@@ -1105,6 +1109,8 @@ def test_integration_database_autodiscovery(instance_integration_autodiscovery, 
         'replset_state:primary',
         'replset_me:replset-data-0.mongo.default.svc.cluster.local:27017',
         'hosting_type:self-hosted',
+        'replset_nodetype:ELECTABLE',
+        'replset_workloadtype:OPERATIONAL',
     ]
     metrics_categories = [
         'count-dbs',


### PR DESCRIPTION
### What does this PR do?
This PR includes replica set tags in metrics. Replica set tags are optional tags set in replica set configuration. 
NOTE: The replica set tags are different from MongoDB Atlas cluster tags. MongoDB Atlas cluster tags cannot be retrieved with mongodb driver api at the moment. 

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4485

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
