### PR TITLE
Switch away from deprecated ssl API

### DIFF
--- a/spark/tests/test_spark.py
+++ b/spark/tests/test_spark.py
@@ -1306,9 +1306,11 @@ class StandaloneAppsResponseHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 
 def run_ssl_server():
     cert_file = os.path.join(CERTIFICATE_DIR, 'server.pem')
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(cert_file)
 
     httpd = BaseHTTPServer.HTTPServer((SSL_SERVER_ADDRESS, SSL_SERVER_PORT), StandaloneAppsResponseHandler)
-    httpd.socket = ssl.wrap_socket(httpd.socket, certfile=cert_file, server_side=False)
+    httpd.socket = context.wrap_socket(httpd.socket, server_side=False)
     httpd.timeout = 5
 
     threading.Thread(target=httpd.handle_request).start()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Preparation for https://github.com/DataDog/integrations-core/pull/18212

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
