### PR TITLE
[mongo] add modules to mongodb instance metadata

### DIFF
--- a/mongo/changelog.d/18473.added
+++ b/mongo/changelog.d/18473.added
@@ -1,0 +1,1 @@
+Add modules to mongodb instance metadata. `modules` are a list of add-on modules that mongod was built with. Possible values currently include "enterprise" and "rocksdb".

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -292,7 +292,7 @@ class MongoDb(AgentCheck):
             self.set_metadata('version', self._mongo_version)
             self.log.debug('version: %s', self._mongo_version)
             self._mongo_modules = server_info.get('modules', [])
-            self.set_metadata('modules', self._mongo_modules.join(','))
+            self.set_metadata('modules', ','.join(self._mongo_modules))
             self.log.debug('modules: %s', self._mongo_modules)
         if self._resolved_hostname is None:
             self._resolved_hostname = self._config.reported_database_hostname or self.api_client.hostname

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -292,7 +292,7 @@ class MongoDb(AgentCheck):
             self.set_metadata('version', self._mongo_version)
             self.log.debug('version: %s', self._mongo_version)
             self._mongo_modules = server_info.get('modules', [])
-            self.set_metadata('modules', self._mongo_modules)
+            self.set_metadata('modules', self._mongo_modules.join(','))
             self.log.debug('modules: %s', self._mongo_modules)
         if self._resolved_hostname is None:
             self._resolved_hostname = self._config.reported_database_hostname or self.api_client.hostname

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -298,6 +298,8 @@ class MongoDb(AgentCheck):
             self._resolved_hostname = self._config.reported_database_hostname or self.api_client.hostname
             self.set_metadata('resolved_hostname', self._resolved_hostname)
             self.log.debug('resolved_hostname: %s', self._resolved_hostname)
+        if self._config.cluster_name:
+            self.set_metadata('cluster_name', self._config.cluster_name)
 
     def _unset_metadata(self):
         self.log.debug('Due to connection failure we will need to reset the metadata.')

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -102,6 +102,7 @@ class MongoDb(AgentCheck):
 
         self.deployment_type = None
         self._mongo_version = None
+        self._mongo_modules = None
         self._resolved_hostname = None
 
         # _database_instance_emitted: limit the collection and transmission of the database instance metadata
@@ -283,12 +284,16 @@ class MongoDb(AgentCheck):
             self.service_check(SERVICE_CHECK_NAME, AgentCheck.OK, tags=self._config.service_check_tags)
 
     def _refresh_metadata(self):
-        if self._mongo_version is None:
-            self.log.debug('No mongo_version metadata present, refreshing it.')
-            self._mongo_version = self.api_client.server_info().get('version', '0.0')
+        if self._mongo_version is None or self._mongo_modules is None:
+            self.log.debug('No mongo_version or mongo_module metadata present, refreshing it.')
+            server_info = self.api_client.server_info()
+            self._mongo_version = server_info.get('version', '0.0')
             self._mongo_version_parsed = Version(self._mongo_version.split("-")[0])
             self.set_metadata('version', self._mongo_version)
             self.log.debug('version: %s', self._mongo_version)
+            self._mongo_modules = server_info.get('modules', [])
+            self.set_metadata('modules', self._mongo_modules)
+            self.log.debug('modules: %s', self._mongo_modules)
         if self._resolved_hostname is None:
             self._resolved_hostname = self._config.reported_database_hostname or self.api_client.hostname
             self.set_metadata('resolved_hostname', self._resolved_hostname)
@@ -360,7 +365,10 @@ class MongoDb(AgentCheck):
         if self._resolved_hostname not in self._database_instance_emitted:
             # DO NOT emit with internal resource tags, as the metadata event is used to CREATE the databse instance
             tags = self._get_tags()
-            mongodb_instance_metadata = {"cluster_name": self._config.cluster_name} | deployment.instance_metadata
+            mongodb_instance_metadata = {
+                "cluster_name": self._config.cluster_name,
+                "modules": self._mongo_modules,
+            } | deployment.instance_metadata
             database_instance = {
                 "host": self._resolved_hostname,
                 "agent_version": datadog_agent.get_version(),

--- a/mongo/tests/fixtures/server_info
+++ b/mongo/tests/fixtures/server_info
@@ -1,7 +1,7 @@
 {
     "version": "4.1.13",
     "gitVersion": "441714bc4c70699950f3ac51a5cac41dcd413eaa",
-    "modules": [],
+    "modules": ["enterprise"],
     "allocator": "tcmalloc",
     "javascriptEngine": "mozjs",
     "sysInfo": "deprecated",

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -34,6 +34,7 @@ def _assert_mongodb_instance_event(
     shards,
     cluster_type,
     cluster_name,
+    modules,
 ):
     mongodb_instance_event = _get_mongodb_instance_event(aggregator)
     if not dbm:
@@ -54,6 +55,7 @@ def _assert_mongodb_instance_event(
         "shards": shards,
         "cluster_type": cluster_type,
         "cluster_name": cluster_name,
+        "modules": modules,
     }
     assert mongodb_instance_event['metadata'] == {
         'dbm': dbm,
@@ -136,6 +138,7 @@ def test_integration_mongos(instance_integration_cluster, aggregator, check, dd_
         ],
         cluster_type='sharded_cluster',
         cluster_name='my_cluster',
+        modules=['enterprise'],
     )
 
 
@@ -237,6 +240,7 @@ def test_integration_replicaset_primary_in_shard(instance_integration, aggregato
         shards=None,
         cluster_type='sharded_cluster',
         cluster_name=None,
+        modules=['enterprise'],
     )
 
 
@@ -298,6 +302,7 @@ def test_integration_replicaset_secondary_in_shard(instance_integration, aggrega
         shards=None,
         cluster_type='sharded_cluster',
         cluster_name=None,
+        modules=['enterprise'],
     )
 
 
@@ -353,6 +358,7 @@ def test_integration_replicaset_arbiter_in_shard(instance_integration, aggregato
         shards=None,
         cluster_type='sharded_cluster',
         cluster_name=None,
+        modules=['enterprise'],
     )
 
 
@@ -452,6 +458,7 @@ def test_integration_configsvr_primary(instance_integration, aggregator, check, 
         shards=None,
         cluster_type='sharded_cluster',
         cluster_name=None,
+        modules=['enterprise'],
     )
 
 
@@ -512,6 +519,7 @@ def test_integration_configsvr_secondary(instance_integration, aggregator, check
         shards=None,
         cluster_type='sharded_cluster',
         cluster_name=None,
+        modules=['enterprise'],
     )
 
 
@@ -615,6 +623,7 @@ def test_integration_replicaset_primary(instance_integration, aggregator, check,
         shards=None,
         cluster_type='replica_set',
         cluster_name=None,
+        modules=['enterprise'],
     )
 
 
@@ -722,6 +731,7 @@ def test_integration_replicaset_primary_config(instance_integration, aggregator,
         shards=None,
         cluster_type='replica_set',
         cluster_name=None,
+        modules=['enterprise'],
     )
 
 
@@ -790,6 +800,7 @@ def test_integration_replicaset_secondary(
         shards=None,
         cluster_type='replica_set',
         cluster_name=None,
+        modules=['enterprise'],
     )
 
 
@@ -844,6 +855,7 @@ def test_integration_replicaset_arbiter(instance_integration, aggregator, check,
         shards=None,
         cluster_type='replica_set',
         cluster_name=None,
+        modules=['enterprise'],
     )
 
 
@@ -894,6 +906,7 @@ def test_standalone(instance_integration, aggregator, check, dd_run_check):
         shards=None,
         cluster_type=None,
         cluster_name=None,
+        modules=['enterprise'],
     )
 
 
@@ -1084,6 +1097,7 @@ def test_integration_reemit_mongodb_instance_on_deployment_change(
         shards=None,
         cluster_type='sharded_cluster',
         cluster_name='my_cluster',
+        modules=['enterprise'],
     )
     aggregator.reset()
 

--- a/mongo/tests/test_integration_standalone.py
+++ b/mongo/tests/test_integration_standalone.py
@@ -235,4 +235,4 @@ def test_metadata(check, instance, datadog_agent, reported_database_hostname):
         assert check._resolved_hostname == reported_database_hostname
     datadog_agent.assert_metadata('test:123', version_metadata)
     datadog_agent.assert_metadata('test:123', {'resolved_hostname': check._resolved_hostname})
-    datadog_agent.assert_metadata_count(len(version_metadata) + 3)
+    datadog_agent.assert_metadata_count(len(version_metadata) + 4)


### PR DESCRIPTION
### What does this PR do?
This PR adds `modules` to mongodb instance metadata. `modules` are a list of add-on modules that [mongod](https://www.mongodb.com/docs/manual/reference/program/mongod/#mongodb-binary-bin.mongod) was built with. Possible values currently include "enterprise" and "rocksdb". This can be used to determine if the mongodb instance is built with community or enterprise edition.

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4487

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
