### PR TITLE
Request /v1/apps as a health check instead of the base URL

### DIFF
--- a/fly_io/datadog_checks/fly_io/check.py
+++ b/fly_io/datadog_checks/fly_io/check.py
@@ -204,14 +204,9 @@ class FlyIoCheck(OpenMetricsBaseCheckV2, ConfigMixin):
             self.set_external_tags(external_host_tags)
 
     @handle_error
-    def _collect_app_metrics(self):
+    def _collect_app_metrics(self, apps_data):
         self.log.debug("Getting apps for org %s", self.org_slug)
-        apps_endpoint = f"{self.machines_api_endpoint}/v1/apps"
-        params = {'org_slug': self.org_slug}
-
-        response = self.http.get(apps_endpoint, params=params)
-        response.raise_for_status()
-        apps = response.json().get("apps", [])
+        apps = apps_data.get("apps", [])
 
         for app in apps:
             app_name = app.get("name")
@@ -234,16 +229,20 @@ class FlyIoCheck(OpenMetricsBaseCheckV2, ConfigMixin):
 
     def _collect_machines_api_metrics(self):
         self.log.debug("Collecting metrics from machines api %s", self.machines_api_endpoint)
-        response = self.http.get(f"{self.machines_api_endpoint}/")
+        params = {'org_slug': self.org_slug}
+        response = self.http.get(f"{self.machines_api_endpoint}/v1/apps", params=params)
+        apps_data = None
         try:
             response.raise_for_status()
+            apps_data = response.json()
         except Exception as e:
             self.gauge(MACHINES_API_UP_METRIC, 0, tags=self.tags)
             self.log.error("Encountered an error hitting machines REST API %s: %s", self.machines_api_endpoint, str(e))
             raise
+
         self.log.debug("Connected to the machines API %s", self.machines_api_endpoint)
         self.gauge(MACHINES_API_UP_METRIC, 1, tags=self.tags)
-        self._collect_app_metrics()
+        self._collect_app_metrics(apps_data)
 
     def check(self, instance):
         super().check(instance)

--- a/fly_io/tests/test_unit.py
+++ b/fly_io/tests/test_unit.py
@@ -95,11 +95,11 @@ def test_rest_api_app_metrics(dd_run_check, aggregator, instance, caplog):
     ('mock_http_get'),
     [
         pytest.param(
-            {'http_error': {'/': MockResponse(status_code=500)}},
+            {'http_error': {'/v1/apps': MockResponse(status_code=500)}},
             id='500',
         ),
         pytest.param(
-            {'http_error': {'/': MockResponse(status_code=404)}},
+            {'http_error': {'/v1/apps': MockResponse(status_code=404)}},
             id='404',
         ),
     ],


### PR DESCRIPTION
### What does this PR do?
There are two base [machines API](https://fly.io/docs/machines/api/working-with-machines-api/#connecting-to-the-api
) URLs: `http://_api.internal:4280` and `https://api.machines.dev`. When requesting the internal endpoint `http://_api.internal:4280/` directly, it is [expected](https://community.fly.io/t/404-page-not-found/5492) to receive a 404. This PR ensures we don't request that base URL as a health check

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
An alternative approach is to still request the base API. If the URL is the internal endpoint, only pass the health check if it's a 404 error. otherwise raise an exception
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
