### PR TITLE
Remove min collection interval from recommended config 

### DIFF
--- a/fly_io/README.md
+++ b/fly_io/README.md
@@ -28,7 +28,6 @@ The Fly.io check is included in the [Datadog Agent][2] package. We recommend run
     ```
     instances:
     - empty_default_hostname: true
-      min_collection_interval: 10
       headers:
           Authorization: Bearer <YOUR_FLY_TOKEN>
       machines_api_endpoint: http://_api.internal:4280


### PR DESCRIPTION
### What does this PR do?
Remove min collection interval from recommended config 
### Motivation
we should use the default collection interval for now
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
