### PR TITLE
[mongo] collect search indexes for mongodb atlas instance

### DIFF
--- a/mongo/changelog.d/18476.added
+++ b/mongo/changelog.d/18476.added
@@ -1,0 +1,1 @@
+Collect MongoDB Atlas search indexes in schema collection (DBM only). 

--- a/mongo/datadog_checks/mongo/api.py
+++ b/mongo/datadog_checks/mongo/api.py
@@ -118,6 +118,9 @@ class MongoApi(object):
     def index_information(self, db_name, coll_name, session=None):
         return self[db_name][coll_name].index_information(session=session)
 
+    def list_search_indexes(self, db_name, coll_name, session=None):
+        return self[db_name][coll_name].list_search_indexes(session=session)
+
     def sharded_data_distribution_stats(self, session=None):
         return self["admin"].aggregate([{"$shardedDataDistribution": {}}], session=session)
 

--- a/mongo/datadog_checks/mongo/common.py
+++ b/mongo/datadog_checks/mongo/common.py
@@ -36,6 +36,14 @@ ALLOWED_CUSTOM_METRICS_TYPES = ['gauge', 'rate', 'count', 'monotonic_count']
 ALLOWED_CUSTOM_QUERIES_COMMANDS = ['aggregate', 'count', 'find']
 
 
+class HostingType:
+    ATLAS = "mongodb-atlas"
+    ALIBABA_APSARADB = "alibaba-apsaradb"
+    DOCUMENTDB = "amazon-documentdb"
+    SELF_HOSTED = "self-hosted"
+    UNKNOWN = "unknown"
+
+
 def get_state_name(state):
     """Maps a mongod node state id to a human readable string."""
     if state in REPLSET_MEMBER_STATES:

--- a/mongo/datadog_checks/mongo/dbm/schemas.py
+++ b/mongo/datadog_checks/mongo/dbm/schemas.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 
 from bson import json_util
 
+from datadog_checks.mongo.common import HostingType
 from datadog_checks.mongo.dbm.utils import MONGODB_SYSTEM_DATABASES
 
 try:
@@ -100,6 +101,7 @@ class MongoSchemas(DBMAsyncJob):
     def _discover_collection(self, dbname, collname):
         schema = self._discover_collection_schema(dbname, collname)
         indexes = self._discover_collection_indexes(dbname, collname)
+        search_indexes = self._discover_collection_search_indexes(dbname, collname)
         is_sharded = self._check.api_client.is_collection_sharded(dbname, collname)
         return {
             "name": collname,
@@ -107,6 +109,7 @@ class MongoSchemas(DBMAsyncJob):
             "sharded": is_sharded,
             "docs": schema,
             "indexes": indexes,
+            "search_indexes": search_indexes,
         }
 
     def _discover_collection_schema(self, dbname, collname):
@@ -204,6 +207,40 @@ class MongoSchemas(DBMAsyncJob):
             if value == "2d":
                 return "geospatial"
         return "regular"
+
+    def _discover_collection_search_indexes(self, dbname, collname):
+        if not self._check.deployment_type.hosting_type == HostingType.ATLAS:
+            self._check.log.debug("Search indexes are only supported for Atlas deployments")
+            return []
+
+        try:
+            search_indexes = self._check.api_client.list_search_indexes(dbname, collname)
+            return [self._create_search_index_payload(search_index) for search_index in search_indexes]
+        except Exception as e:
+            self._check.log.error("Error collecting search indexes for %s.%s: %s", dbname, collname, e)
+            return []
+
+    def _create_search_index_payload(self, search_index):
+        definition_mappings = search_index.get("latestDefinition", {}).get("mappings", {})
+        definition_mappings_fields = definition_mappings.get("fields", {})
+        payload = {
+            "name": search_index["name"],
+            "type": search_index["type"],
+            "status": search_index["status"],
+            "queryable": search_index["queryable"],
+            "version": search_index.get("latestDefinitionVersion", {}).get("version"),
+            "mappings": {
+                "dynamic": definition_mappings.get("dynamic"),
+                "fields": [
+                    {
+                        "field": field_name,
+                        "type": field_details["type"],
+                    }
+                    for field_name, field_details in definition_mappings_fields.items()
+                ],
+            },
+        }
+        return payload
 
     def _submit_schema_payload(self, base_payload, dbname, collections):
         payload = {

--- a/mongo/datadog_checks/mongo/dbm/schemas.py
+++ b/mongo/datadog_checks/mongo/dbm/schemas.py
@@ -228,7 +228,7 @@ class MongoSchemas(DBMAsyncJob):
             "type": search_index["type"],
             "status": search_index["status"],
             "queryable": search_index["queryable"],
-            "version": search_index.get("latestDefinitionVersion", {}).get("version"),
+            "version": str(search_index.get("latestDefinitionVersion", {}).get("version", "")),
             "mappings": {
                 "dynamic": definition_mappings.get("dynamic"),
                 "fields": [

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -32,6 +32,7 @@ from datadog_checks.mongo.collectors.jumbo_stats import JumboStatsCollector
 from datadog_checks.mongo.collectors.session_stats import SessionStatsCollector
 from datadog_checks.mongo.common import (
     SERVICE_CHECK_NAME,
+    HostingType,
     MongosDeployment,
     ReplicaSetDeployment,
     StandaloneDeployment,
@@ -50,14 +51,6 @@ except ImportError:
     from ..stubs import datadog_agent
 
 long = int
-
-
-class HostingType:
-    ATLAS = "mongodb-atlas"
-    ALIBABA_APSARADB = "alibaba-apsaradb"
-    DOCUMENTDB = "amazon-documentdb"
-    SELF_HOSTED = "self-hosted"
-    UNKNOWN = "unknown"
 
 
 class MongoDb(AgentCheck):

--- a/mongo/tests/fixtures/list_search_indexes
+++ b/mongo/tests/fixtures/list_search_indexes
@@ -1,0 +1,111 @@
+[
+    {
+        "id": "66d224013287e81dc36ee3a0",
+        "name": "cast_fullplot_genres_title",
+        "type": "search",
+        "status": "READY",
+        "queryable": true,
+        "latestDefinitionVersion": {
+            "version": 1,
+            "createdAt": {
+                "$date": "2024-08-30T20:04:15.147Z"
+            }
+        },
+        "latestDefinition": {
+            "mappings": {
+                "dynamic": true,
+                "fields": {
+                    "highlight": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "statusDetail": [
+            {
+                "hostname": "atlas-dj4qz5-shard-00-00",
+                "status": "READY",
+                "queryable": true,
+                "mainIndex": {
+                    "status": "READY",
+                    "queryable": true,
+                    "definitionVersion": {
+                        "version": 1,
+                        "createdAt": {
+                            "$date": "2024-08-30T20:04:15Z"
+                        }
+                    },
+                    "definition": {
+                        "mappings": {
+                            "dynamic": true,
+                            "fields": {
+                                "highlight": {
+                                    "type": "string",
+                                    "indexOptions": "offsets",
+                                    "store": true,
+                                    "norms": "include"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "hostname": "atlas-dj4qz5-shard-00-01",
+                "status": "READY",
+                "queryable": true,
+                "mainIndex": {
+                    "status": "READY",
+                    "queryable": true,
+                    "definitionVersion": {
+                        "version": 1,
+                        "createdAt": {
+                            "$date": "2024-08-30T20:04:15Z"
+                        }
+                    },
+                    "definition": {
+                        "mappings": {
+                            "dynamic": true,
+                            "fields": {
+                                "highlight": {
+                                    "type": "string",
+                                    "indexOptions": "offsets",
+                                    "store": true,
+                                    "norms": "include"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "hostname": "atlas-dj4qz5-shard-00-02",
+                "status": "READY",
+                "queryable": true,
+                "mainIndex": {
+                    "status": "READY",
+                    "queryable": true,
+                    "definitionVersion": {
+                        "version": 1,
+                        "createdAt": {
+                            "$date": "2024-08-30T20:04:15Z"
+                        }
+                    },
+                    "definition": {
+                        "mappings": {
+                            "dynamic": true,
+                            "fields": {
+                                "highlight": {
+                                    "type": "string",
+                                    "indexOptions": "offsets",
+                                    "store": true,
+                                    "norms": "include"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    }
+]

--- a/mongo/tests/mocked_api.py
+++ b/mongo/tests/mocked_api.py
@@ -52,6 +52,10 @@ class MockedCollection(object):
         with open(os.path.join(HERE, "fixtures", "index_information"), 'r') as f:
             return json.load(f, object_hook=json_util.object_hook)
 
+    def list_search_indexes(self, session=None, **kwargs):
+        with open(os.path.join(HERE, "fixtures", "list_search_indexes"), 'r') as f:
+            return json.load(f, object_hook=json_util.object_hook)
+
     def aggregate(self, pipeline, session=None, **kwargs):
         if '$indexStats' in pipeline[0]:
             with open(os.path.join(HERE, "fixtures", f"$indexStats-{self._coll_name}"), 'r') as f:

--- a/mongo/tests/results/schemas-standalone-atlas.json
+++ b/mongo/tests/results/schemas-standalone-atlas.json
@@ -9,8 +9,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "clustername:my_cluster",
-            "hosting_type:self-hosted",
-            "sharding_cluster_role:mongos"
+            "hosting_type:mongodb-atlas"
         ],
         "timestamp": 1715911398111.2722,
         "metadata": [
@@ -20,7 +19,7 @@
                     {
                         "name": "foo",
                         "namespace": "integration.foo",
-                        "sharded": true,
+                        "sharded": false,
                         "docs": [
                             {
                                 "name": "_id",
@@ -314,12 +313,29 @@
                                 "case_insensitive": true
                             }
                         ],
-                        "search_indexes": []
+                        "search_indexes": [
+                            {
+                                "mappings": {
+                                    "dynamic": true,
+                                    "fields": [
+                                        {
+                                            "field": "highlight",
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "name": "cast_fullplot_genres_title",
+                                "queryable": true,
+                                "status": "READY",
+                                "type": "search",
+                                "version": 1
+                            }
+                        ]
                     },
                     {
                         "name": "bar",
                         "namespace": "integration.bar",
-                        "sharded": true,
+                        "sharded": false,
                         "docs": [
                             {
                                 "name": "_id",
@@ -583,7 +599,24 @@
                                 "case_insensitive": true
                             }
                         ],
-                        "search_indexes": []
+                        "search_indexes": [
+                            {
+                                "mappings": {
+                                    "dynamic": true,
+                                    "fields": [
+                                        {
+                                            "field": "highlight",
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "name": "cast_fullplot_genres_title",
+                                "queryable": true,
+                                "status": "READY",
+                                "type": "search",
+                                "version": 1
+                            }
+                        ]
                     }
                 ]
             }
@@ -599,8 +632,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "clustername:my_cluster",
-            "hosting_type:self-hosted",
-            "sharding_cluster_role:mongos"
+            "hosting_type:mongodb-atlas"
         ],
         "timestamp": 1715911398111.2722,
         "metadata": [
@@ -610,7 +642,7 @@
                     {
                         "name": "foo",
                         "namespace": "test.foo",
-                        "sharded": true,
+                        "sharded": false,
                         "docs": [
                             {
                                 "name": "_id",
@@ -904,12 +936,29 @@
                                 "case_insensitive": true
                             }
                         ],
-                        "search_indexes": []
+                        "search_indexes": [
+                            {
+                                "mappings": {
+                                    "dynamic": true,
+                                    "fields": [
+                                        {
+                                            "field": "highlight",
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "name": "cast_fullplot_genres_title",
+                                "queryable": true,
+                                "status": "READY",
+                                "type": "search",
+                                "version": 1
+                            }
+                        ]
                     },
                     {
                         "name": "bar",
                         "namespace": "test.bar",
-                        "sharded": true,
+                        "sharded": false,
                         "docs": [
                             {
                                 "name": "_id",
@@ -1173,7 +1222,24 @@
                                 "case_insensitive": true
                             }
                         ],
-                        "search_indexes": []
+                        "search_indexes": [
+                            {
+                                "mappings": {
+                                    "dynamic": true,
+                                    "fields": [
+                                        {
+                                            "field": "highlight",
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "name": "cast_fullplot_genres_title",
+                                "queryable": true,
+                                "status": "READY",
+                                "type": "search",
+                                "version": 1
+                            }
+                        ]
                     }
                 ]
             }

--- a/mongo/tests/results/schemas-standalone-atlas.json
+++ b/mongo/tests/results/schemas-standalone-atlas.json
@@ -328,7 +328,7 @@
                                 "queryable": true,
                                 "status": "READY",
                                 "type": "search",
-                                "version": 1
+                                "version": "1"
                             }
                         ]
                     },
@@ -614,7 +614,7 @@
                                 "queryable": true,
                                 "status": "READY",
                                 "type": "search",
-                                "version": 1
+                                "version": "1"
                             }
                         ]
                     }
@@ -951,7 +951,7 @@
                                 "queryable": true,
                                 "status": "READY",
                                 "type": "search",
-                                "version": 1
+                                "version": "1"
                             }
                         ]
                     },
@@ -1237,7 +1237,7 @@
                                 "queryable": true,
                                 "status": "READY",
                                 "type": "search",
-                                "version": 1
+                                "version": "1"
                             }
                         ]
                     }

--- a/mongo/tests/results/schemas-standalone.json
+++ b/mongo/tests/results/schemas-standalone.json
@@ -312,7 +312,8 @@
                                 "type": "regular",
                                 "case_insensitive": true
                             }
-                        ]
+                        ],
+                        "search_indexes": []
                     },
                     {
                         "name": "bar",
@@ -580,7 +581,8 @@
                                 "type": "regular",
                                 "case_insensitive": true
                             }
-                        ]
+                        ],
+                        "search_indexes": []
                     }
                 ]
             }
@@ -899,7 +901,8 @@
                                 "type": "regular",
                                 "case_insensitive": true
                             }
-                        ]
+                        ],
+                        "search_indexes": []
                     },
                     {
                         "name": "bar",
@@ -1167,7 +1170,8 @@
                                 "type": "regular",
                                 "case_insensitive": true
                             }
-                        ]
+                        ],
+                        "search_indexes": []
                     }
                 ]
             }

--- a/mongo/tests/test_dbm_schemas.py
+++ b/mongo/tests/test_dbm_schemas.py
@@ -5,6 +5,7 @@
 import json
 import os
 
+import mock
 import pytest
 
 from . import common
@@ -82,3 +83,30 @@ def test_mongo_schemas_arbiter(aggregator, instance_arbiter, check, dd_run_check
     mongodb_databases = next((e for e in dbm_metadata if e['kind'] == 'mongodb_databases'), None)
 
     assert mongodb_databases is None
+
+
+@mock_now(1715911398.1112723)
+@common.standalone
+def test_mongo_schemas_standalone_atlas(aggregator, instance_integration_cluster_autodiscovery, check, dd_run_check):
+    instance_integration_cluster_autodiscovery['reported_database_hostname'] = "mongohost"
+    instance_integration_cluster_autodiscovery['dbm'] = True
+    instance_integration_cluster_autodiscovery['schemas'] = {'enabled': True, 'run_sync': True}
+    instance_integration_cluster_autodiscovery['database_autodiscovery']['include'] = ['integration$', 'test$']
+    instance_integration_cluster_autodiscovery['operation_samples'] = {'enabled': False}
+    instance_integration_cluster_autodiscovery['slow_operations'] = {'enabled': False}
+
+    mongo_check = check(instance_integration_cluster_autodiscovery)
+    aggregator.reset()
+    with mock_pymongo("standalone"):
+        with mock.patch('datadog_checks.mongo.api.MongoApi.hostname', new_callable=mock.PropertyMock) as mock_hostname:
+            mock_hostname.return_value = 'atlas-hostname.mongodb.net'
+            run_check_once(mongo_check, dd_run_check)
+
+    dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
+    mongodb_databases = [e for e in dbm_metadata if e['kind'] == 'mongodb_databases']
+
+    with open(os.path.join(HERE, "results", "schemas-standalone-atlas.json"), 'r') as f:
+        expected_mongodb_databases = json.load(f)
+        assert len(mongodb_databases) == len(expected_mongodb_databases)
+        for i, db in enumerate(mongodb_databases):
+            assert db == expected_mongodb_databases[i]


### PR DESCRIPTION
### What does this PR do?
This PR adds search indexes to mongo schema collection for mongodb atlas instance.

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4488

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
