### PR TITLE
[mongo] fix mongodb.collection.indexes.accesses.opsps metric unit

### DIFF
--- a/mongo/metadata.csv
+++ b/mongo/metadata.csv
@@ -19,7 +19,7 @@ mongodb.collection.commands.latency.avg,gauge,,microsecond,,Average latency for 
 mongodb.collection.commands.opsps,gauge,,operation,second,Number of command operations per second on the collection.,0,mongodb,command operations per second,,
 mongodb.collection.count,gauge,,item,,Total number of objects in the collection.,0,mongodb,number of objects in the collection,,
 mongodb.collection.indexes.accesses.ops,gauge,,event,,Number of time the index was used.,0,mongodb,index usage,,
-mongodb.collection.indexes.accesses.opsps,gauge,,event,,Number of time the index was used per second.,0,mongodb,index usage per second,,
+mongodb.collection.indexes.accesses.opsps,gauge,,event,second,Number of time the index was used per second.,0,mongodb,index usage per second,,
 mongodb.collection.indexsizes,gauge,,byte,,Size of index in bytes.,0,mongodb,index size,,
 mongodb.collection.max,gauge,,document,,Maximum number of documents in a capped collection.,0,mongodb,max documents in capped collection,,
 mongodb.collection.maxsize,gauge,,byte,,Maximum size of a capped collection in bytes.,0,mongodb,max size of capped collection,,


### PR DESCRIPTION
### What does this PR do?
`mongodb.collection.indexes.accesses.opsps` should be events/second.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
