### PR TITLE
clarified cluster agent check docs

### DIFF
--- a/datadog_cluster_agent/README.md
+++ b/datadog_cluster_agent/README.md
@@ -14,7 +14,7 @@ The Datadog Cluster Agent check is included in the [Datadog Agent][2] package.
 No additional installation is needed on your server.
 
 ### Configuration
-The Datadog Cluster Agent check will use [Autodiscovery][3] to automatically configure itself in most scenarios. This check will run in the Datadog Agent pod on the same node as the Cluster Agent pod. It will not run in the Cluster Agent itself.
+The Datadog Cluster Agent check uses [Autodiscovery][3] to automatically configure itself in most scenarios. The check runs in the Datadog Agent pod on the same node as the Cluster Agent pod. It will not run in the Cluster Agent itself.
 
 If you need to further configure the check:
 

--- a/datadog_cluster_agent/README.md
+++ b/datadog_cluster_agent/README.md
@@ -10,24 +10,27 @@ Follow the instructions below to install and configure this check for an Agent r
 
 ### Installation
 
-The Datadog-Cluster-Agent check is included in the [Datadog Agent][2] package.
+The Datadog Cluster Agent check is included in the [Datadog Agent][2] package.
 No additional installation is needed on your server.
 
 ### Configuration
+The Datadog Cluster Agent check will use [Autodiscovery][3] to automatically configure itself in most scenarios. This check will run in the Datadog Agent pod on the same node as the Cluster Agent pod. It will not run in the Cluster Agent itself.
 
-1. Edit the `datadog_cluster_agent.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your datadog_cluster_agent performance data. See the [sample datadog_cluster_agent.d/conf.yaml][3] for all available configuration options.
+If you need to further configure the check:
 
-2. [Restart the Agent][4].
+1. Edit the `datadog_cluster_agent.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your datadog_cluster_agent performance data. See the [sample datadog_cluster_agent.d/conf.yaml][4] for all available configuration options.
+
+2. [Restart the Agent][5].
 
 ### Validation
 
-[Run the Agent's status subcommand][5] and look for `datadog_cluster_agent` under the Checks section.
+[Run the Agent's status subcommand][6] and look for `datadog_cluster_agent` under the Checks section.
 
 ## Data Collected
 
 ### Metrics
 
-See [metadata.csv][6] for a list of metrics provided by this check.
+See [metadata.csv][7] for a list of metrics provided by this check.
 
 ### Events
 
@@ -35,18 +38,19 @@ The Datadog-Cluster-Agent integration does not include any events.
 
 ### Service Checks
 
-See [service_checks.json][7] for a list of service checks provided by this integration.
+See [service_checks.json][8] for a list of service checks provided by this integration.
 
 ## Troubleshooting
 
-Need help? Contact [Datadog support][8].
+Need help? Contact [Datadog support][9].
 
 
 [1]: https://docs.datadoghq.com/agent/cluster_agent/
 [2]: https://docs.datadoghq.com/agent/kubernetes/integrations/
-[3]: https://github.com/DataDog/integrations-core/blob/master/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
-[4]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[5]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[6]: https://github.com/DataDog/integrations-core/blob/master/datadog_cluster_agent/metadata.csv
-[7]: https://github.com/DataDog/integrations-core/blob/master/datadog_cluster_agent/assets/service_checks.json
-[8]: https://docs.datadoghq.com/help/
+[3]: https://docs.datadoghq.com/getting_started/containers/autodiscovery/
+[4]: https://github.com/DataDog/integrations-core/blob/master/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
+[5]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
+[6]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
+[7]: https://github.com/DataDog/integrations-core/blob/master/datadog_cluster_agent/metadata.csv
+[8]: https://github.com/DataDog/integrations-core/blob/master/datadog_cluster_agent/assets/service_checks.json
+[9]: https://docs.datadoghq.com/help/


### PR DESCRIPTION
### What does this PR do?
This PR adds some details about how the Datadog Cluster Agent check runs - namely in a node Agent, not in the Cluster Agent.

### Motivation
The motivation started with a [customer Zendesk ticket](https://datadog.zendesk.com/agent/tickets/1795585). The feedback there was there was confusion about getting the status of the Cluster Agent. The user expected to see the Datadog Cluster Agent integration there.

### Additional Notes
Please merge when ready

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
