### PR TITLE
Bump `ibm_db` version

### DIFF
--- a/ibm_db2/hatch.toml
+++ b/ibm_db2/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.11"]
+python = ["3.12"]
 version = ["11.1"]
 
 [envs.default.env-vars]

--- a/ibm_db2/hatch.toml
+++ b/ibm_db2/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.12"]
+python = ["3.11"]
 version = ["11.1"]
 
 [envs.default.env-vars]

--- a/ibm_db2/hatch.toml
+++ b/ibm_db2/hatch.toml
@@ -11,7 +11,7 @@ IBM_DB_INSTALLER_URL = "https://ddintegrations.blob.core.windows.net/ibm-db2/"
 [envs.default]
 dependencies = [
   "ibm_db==3.0.1; python_version < '3.0'",
-  "ibm_db==3.2.2; python_version > '3.0'",
+  "ibm_db==3.2.3; python_version > '3.0'",
 ]
 
 [envs.bench]

--- a/ibm_db2/tests/docker/requirements.txt
+++ b/ibm_db2/tests/docker/requirements.txt
@@ -1,2 +1,2 @@
 ibm_db==3.0.1; python_version < "3.0" 
-ibm_db==3.2.2; python_version > "3.0"
+ibm_db==3.2.3; python_version > "3.0"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Bumped version of IBM DB due to failing CI in python 3.12 bump

### Motivation
<!-- What inspired you to submit this pull request? -->
https://github.com/ibmdb/python-ibmdb/pull/920

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
