### PR TITLE
[mongo] obfuscated parsedQuery filters and indexBounds in explain plan

### DIFF
--- a/mongo/datadog_checks/mongo/dbm/utils.py
+++ b/mongo/datadog_checks/mongo/dbm/utils.py
@@ -5,7 +5,7 @@
 
 from typing import Optional, Tuple
 
-from bson import json_util
+from bson import json_util, regex
 
 from datadog_checks.base.utils.common import to_native_string
 from datadog_checks.base.utils.db.sql import compute_exec_plan_signature
@@ -54,6 +54,22 @@ UNEXPLAINABLE_COMMANDS = frozenset(
         "explain",
         "profile",  # command to get profile level
         "listCollections",
+    ]
+)
+
+COMMAND_KEYS_TO_REMOVE = frozenset(["comment", "lsid", "$clusterTime"])
+
+EXPLAIN_PLAN_KEYS_TO_REMOVE = frozenset(
+    [
+        "serverInfo",
+        "serverParameters",
+        "command",
+        "ok",
+        "$clusterTime",
+        "operationTime",
+        "$configServerState",
+        "lastCommittedOpTime",
+        "$gleStats",
     ]
 )
 
@@ -125,15 +141,13 @@ def format_explain_plan(explain_plan: dict) -> dict:
     if not explain_plan:
         return None
 
-    plan = {
-        key: value
-        for key, value in explain_plan.items()
-        if key not in ("serverInfo", "serverParameters", "command", "ok", "$clusterTime", "operationTime")
-    }
+    plan = {key: value for key, value in explain_plan.items() if key not in EXPLAIN_PLAN_KEYS_TO_REMOVE}
+
+    obfuscated_plan = obfuscate_explain_plan(plan)
 
     return {
-        "definition": plan,
-        "signature": compute_exec_plan_signature(json_util.dumps(plan)),
+        "definition": obfuscated_plan,
+        "signature": compute_exec_plan_signature(json_util.dumps(obfuscated_plan)),
     }
 
 
@@ -165,6 +179,34 @@ def obfuscate_command(command: dict):
     # - lsid: The lsid field is a unique identifier for the session
     # - $clusterTime: The $clusterTime field is a logical time used for ordering of operations
     obfuscated_command = command.copy()
-    for key in ("comment", "lsid", "$clusterTime"):
+    for key in COMMAND_KEYS_TO_REMOVE:
         obfuscated_command.pop(key, None)
     return datadog_agent.obfuscate_mongodb_string(json_util.dumps(obfuscated_command))
+
+
+def obfuscate_explain_plan(plan):
+    if isinstance(plan, dict):
+        obfuscated_plan = {}
+        for key, value in plan.items():
+            if key in ["filter", "parsedQuery", "indexBounds"]:
+                obfuscated_plan[key] = obfuscate_literals(value)
+            else:
+                obfuscated_plan[key] = obfuscate_explain_plan(value)
+        return obfuscated_plan
+    elif isinstance(plan, list):
+        return [obfuscate_explain_plan(item) for item in plan]
+    else:
+        return plan
+
+
+def obfuscate_literals(value):
+    if isinstance(value, dict):
+        return {k: obfuscate_literals(v) for k, v in value.items()}
+    elif isinstance(value, list):
+        return [obfuscate_literals(v) for v in value]
+    elif isinstance(value, (str, int, float, bool)):
+        return "?"
+    elif isinstance(value, regex.Regex):
+        return regex.Regex("?", value.flags)
+    else:
+        return value

--- a/mongo/tests/results/operation-samples-mongos.json
+++ b/mongo/tests/results/operation-samples-mongos.json
@@ -79,7 +79,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         }
                                                     }
@@ -136,7 +136,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         }
                                                     }
@@ -193,7 +193,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         }
                                                     }
@@ -250,7 +250,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         }
                                                     }
@@ -361,7 +361,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         },
                                                         "keysExamined": 16,
@@ -460,7 +460,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         },
                                                         "keysExamined": 12,
@@ -559,7 +559,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         },
                                                         "keysExamined": 9,
@@ -658,7 +658,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         },
                                                         "keysExamined": 14,
@@ -694,7 +694,7 @@
                         ]
                     }
                 },
-                "signature": "5991253f621eccd0"
+                "signature": "9f964b7dcbe792eb"
             },
             "query_signature": "50114961ffa245f7",
             "application": null,

--- a/mongo/tests/results/operation-samples-standalone.json
+++ b/mongo/tests/results/operation-samples-standalone.json
@@ -34,13 +34,13 @@
                             "$and": [
                                 {
                                     "data": {
-                                        "$gt": 0.6283678507530881
+                                        "$gt": "?"
                                     }
                                 },
                                 {
                                     "message": {
                                         "$regularExpression": {
-                                            "pattern": "log",
+                                            "pattern": "?",
                                             "options": ""
                                         }
                                     }
@@ -58,13 +58,13 @@
                                 "$and": [
                                     {
                                         "data": {
-                                            "$gt": 0.6283678507530881
+                                            "$gt": "?"
                                         }
                                     },
                                     {
                                         "message": {
                                             "$regularExpression": {
-                                                "pattern": "log",
+                                                "pattern": "?",
                                                 "options": ""
                                             }
                                         }
@@ -87,13 +87,13 @@
                                 "$and": [
                                     {
                                         "data": {
-                                            "$gt": 0.6283678507530881
+                                            "$gt": "?"
                                         }
                                     },
                                     {
                                         "message": {
                                             "$regularExpression": {
-                                                "pattern": "log",
+                                                "pattern": "?",
                                                 "options": ""
                                             }
                                         }
@@ -115,7 +115,7 @@
                         "allPlansExecution": []
                     }
                 },
-                "signature": "466d69277a94ff1f"
+                "signature": "6f93ef1b4ea189ab"
             },
             "query_signature": "a5c9a4483fa9bcdf",
             "application": null,

--- a/mongo/tests/results/slow-operations-explain-plans-mongos.json
+++ b/mongo/tests/results/slow-operations-explain-plans-mongos.json
@@ -68,7 +68,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         }
                                                     }
@@ -125,7 +125,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         }
                                                     }
@@ -182,7 +182,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         }
                                                     }
@@ -239,7 +239,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         }
                                                     }
@@ -350,7 +350,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         },
                                                         "keysExamined": 16,
@@ -449,7 +449,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         },
                                                         "keysExamined": 12,
@@ -548,7 +548,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         },
                                                         "keysExamined": 9,
@@ -647,7 +647,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         },
                                                         "keysExamined": 14,
@@ -683,7 +683,7 @@
                         ]
                     }
                 },
-                "signature": "5991253f621eccd0"
+                "signature": "9f964b7dcbe792eb"
             },
             "query_signature": "2e0dfc1416f51975",
             "application": null,
@@ -792,7 +792,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         }
                                                     }
@@ -849,7 +849,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         }
                                                     }
@@ -906,7 +906,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         }
                                                     }
@@ -963,7 +963,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         }
                                                     }
@@ -1074,7 +1074,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         },
                                                         "keysExamined": 16,
@@ -1173,7 +1173,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         },
                                                         "keysExamined": 12,
@@ -1272,7 +1272,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         },
                                                         "keysExamined": 9,
@@ -1371,7 +1371,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         },
                                                         "keysExamined": 14,
@@ -1407,7 +1407,7 @@
                         ]
                     }
                 },
-                "signature": "5991253f621eccd0"
+                "signature": "9f964b7dcbe792eb"
             },
             "query_signature": "6f544fbdad56d0dc",
             "application": null,
@@ -1511,7 +1511,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         }
                                                     }
@@ -1568,7 +1568,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         }
                                                     }
@@ -1625,7 +1625,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         }
                                                     }
@@ -1682,7 +1682,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         }
                                                     }
@@ -1793,7 +1793,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         },
                                                         "keysExamined": 16,
@@ -1892,7 +1892,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         },
                                                         "keysExamined": 12,
@@ -1991,7 +1991,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         },
                                                         "keysExamined": 9,
@@ -2090,7 +2090,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         },
                                                         "keysExamined": 14,
@@ -2126,7 +2126,7 @@
                         ]
                     }
                 },
-                "signature": "5991253f621eccd0"
+                "signature": "9f964b7dcbe792eb"
             },
             "query_signature": "cde36dfcce436712",
             "application": null,
@@ -2235,7 +2235,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         }
                                                     }
@@ -2292,7 +2292,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         }
                                                     }
@@ -2349,7 +2349,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         }
                                                     }
@@ -2406,7 +2406,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         }
                                                     }
@@ -2517,7 +2517,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         },
                                                         "keysExamined": 16,
@@ -2616,7 +2616,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         },
                                                         "keysExamined": 12,
@@ -2715,7 +2715,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         },
                                                         "keysExamined": 9,
@@ -2814,7 +2814,7 @@
                                                         "direction": "forward",
                                                         "indexBounds": {
                                                             "user_id": [
-                                                                "[MinKey, MaxKey]"
+                                                                "?"
                                                             ]
                                                         },
                                                         "keysExamined": 14,
@@ -2850,7 +2850,7 @@
                         ]
                     }
                 },
-                "signature": "5991253f621eccd0"
+                "signature": "9f964b7dcbe792eb"
             },
             "query_signature": "d6bf9ce5ca12a12c",
             "application": null,

--- a/mongo/tests/results/slow-operations-explain-plans-standalone.json
+++ b/mongo/tests/results/slow-operations-explain-plans-standalone.json
@@ -42,7 +42,7 @@
                                 "stage": "FETCH",
                                 "filter": {
                                     "age": {
-                                        "$gt": 63
+                                        "$gt": "?"
                                     }
                                 },
                                 "nReturned": 0,
@@ -82,7 +82,7 @@
                                     "direction": "forward",
                                     "indexBounds": {
                                         "name": [
-                                            "[MinKey, MaxKey]"
+                                            "?"
                                         ]
                                     },
                                     "keysExamined": 417,
@@ -94,7 +94,7 @@
                         }
                     }
                 },
-                "signature": "c158c55ee53541f9"
+                "signature": "a0e139ab93266440"
             },
             "query_signature": "7e73a3e6720168b8",
             "application": null,
@@ -153,13 +153,13 @@
                             "$and": [
                                 {
                                     "data": {
-                                        "$gt": 0.6283678507530881
+                                        "$gt": "?"
                                     }
                                 },
                                 {
                                     "message": {
                                         "$regularExpression": {
-                                            "pattern": "log",
+                                            "pattern": "?",
                                             "options": ""
                                         }
                                     }
@@ -177,13 +177,13 @@
                                 "$and": [
                                     {
                                         "data": {
-                                            "$gt": 0.6283678507530881
+                                            "$gt": "?"
                                         }
                                     },
                                     {
                                         "message": {
                                             "$regularExpression": {
-                                                "pattern": "log",
+                                                "pattern": "?",
                                                 "options": ""
                                             }
                                         }
@@ -206,13 +206,13 @@
                                 "$and": [
                                     {
                                         "data": {
-                                            "$gt": 0.6283678507530881
+                                            "$gt": "?"
                                         }
                                     },
                                     {
                                         "message": {
                                             "$regularExpression": {
-                                                "pattern": "log",
+                                                "pattern": "?",
                                                 "options": ""
                                             }
                                         }
@@ -234,7 +234,7 @@
                         "allPlansExecution": []
                     }
                 },
-                "signature": "466d69277a94ff1f"
+                "signature": "6f93ef1b4ea189ab"
             },
             "query_signature": "2e0dfc1416f51975",
             "application": null,
@@ -298,13 +298,13 @@
                             "$and": [
                                 {
                                     "data": {
-                                        "$gt": 0.6283678507530881
+                                        "$gt": "?"
                                     }
                                 },
                                 {
                                     "message": {
                                         "$regularExpression": {
-                                            "pattern": "log",
+                                            "pattern": "?",
                                             "options": ""
                                         }
                                     }
@@ -322,13 +322,13 @@
                                 "$and": [
                                     {
                                         "data": {
-                                            "$gt": 0.6283678507530881
+                                            "$gt": "?"
                                         }
                                     },
                                     {
                                         "message": {
                                             "$regularExpression": {
-                                                "pattern": "log",
+                                                "pattern": "?",
                                                 "options": ""
                                             }
                                         }
@@ -351,13 +351,13 @@
                                 "$and": [
                                     {
                                         "data": {
-                                            "$gt": 0.6283678507530881
+                                            "$gt": "?"
                                         }
                                     },
                                     {
                                         "message": {
                                             "$regularExpression": {
-                                                "pattern": "log",
+                                                "pattern": "?",
                                                 "options": ""
                                             }
                                         }
@@ -379,7 +379,7 @@
                         "allPlansExecution": []
                     }
                 },
-                "signature": "466d69277a94ff1f"
+                "signature": "6f93ef1b4ea189ab"
             },
             "query_signature": "6f544fbdad56d0dc",
             "application": null,


### PR DESCRIPTION
### What does this PR do?
This PR obfuscates parsed query filters and indexBounds in MongoDB explain plan.

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4498

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
