### PR TITLE
Use forced metric type of gauge for nasuni-filer filerCacheTotal, filerCacheUsed, and filerCacheFree.

### DIFF
--- a/snmp/changelog.d/18501.fixed
+++ b/snmp/changelog.d/18501.fixed
@@ -1,0 +1,1 @@
+Use forced metric type of gauge for nasuni-filer filerCacheTotal, filerCacheUsed, and filerCacheFree so they are not incorrectly inferred to be rate types.

--- a/snmp/datadog_checks/snmp/data/default_profiles/nasuni-filer.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/nasuni-filer.yaml
@@ -54,14 +54,17 @@ metrics:
       OID: 1.3.6.1.4.1.42040.1.14.0
       name: nasuni.filerReadMisses
   - MIB: NASUNI-FILER-MIB
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.42040.1.100.1.0
       name: nasuni.filerCacheTotal
   - MIB: NASUNI-FILER-MIB
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.42040.1.100.2.0
       name: nasuni.filerCacheUsed
   - MIB: NASUNI-FILER-MIB
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.42040.1.100.3.0
       name: nasuni.filerCacheFree


### PR DESCRIPTION

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Use forced metric type of gauge for nasuni-filer filerCacheTotal, filerCacheUsed, and filerCacheFree.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
