### PR TITLE
[mongo] enable inferred schema collection by default

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -247,7 +247,7 @@ files:
             Enable collection of schemas. Requires `dbm: true`.
           value:
             type: boolean
-            example: false
+            example: true
         - name: collection_interval
           description: |
             Set the schemas collection interval in seconds. Each collection involves sampling documents

--- a/mongo/changelog.d/18502.added
+++ b/mongo/changelog.d/18502.added
@@ -1,0 +1,1 @@
+Enables MongoDB inferred schema collection by default (DBM only).

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -196,9 +196,8 @@ class MongoConfig(object):
     @property
     def schemas(self):
         enabled = False
-        if self.dbm_enabled is True and self._schemas_config.get('enabled') is True:
-            # if DBM is enabled and the schemas config is enabled, then it is enabled
-            # By default, schemas collection is disabled
+        if self.dbm_enabled is True and self._schemas_config.get('enabled') is not False:
+            # if DBM is enabled and the schemas config is not explicitly disabled, then it is enabled
             enabled = True
         max_collections = self._schemas_config.get('max_collections')
         return {

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -186,10 +186,10 @@ instances:
     #
     # schemas:
 
-        ## @param enabled - boolean - optional - default: false
+        ## @param enabled - boolean - optional - default: true
         ## Enable collection of schemas. Requires `dbm: true`.
         #
-        # enabled: false
+        # enabled: true
 
         ## @param collection_interval - number - optional - default: 600
         ## Set the schemas collection interval in seconds. Each collection involves sampling documents


### PR DESCRIPTION
### What does this PR do?
This PR enables MongoDB inferred schema collection by default (DBM only).

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
