### PR TITLE
update processes integration doc 'Metrics notes'

### DIFF
--- a/process/README.md
+++ b/process/README.md
@@ -50,6 +50,7 @@ The following metrics are not available on Windows:
 - `system.processes.mem.page_faults.children_minor_faults`
 - `system.processes.mem.page_faults.major_faults`
 - `system.processes.mem.page_faults.children_major_faults`
+- `system.processes.mem.real`
 
 **Note**: Use a [WMI check][11] to gather page fault metrics on Windows.
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The [Processes integration doc](https://docs.datadoghq.com/integrations/process/?site=us) lists some specific metrics which are not available on Windows. `system.processes.mem.real` is not listed here, but we can see from the 'Data collected' (metadata.csv) that this metric is also not available on Windows.
This PR updates the note to include this metric

### Motivation
<!-- What inspired you to submit this pull request? -->
https://datadog.zendesk.com/agent/tickets/1832589


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
