### PR TITLE
Added 'case sensitive' to interface_configs in SNMP

### DIFF
--- a/snmp/assets/configuration/spec.yaml
+++ b/snmp/assets/configuration/spec.yaml
@@ -474,7 +474,7 @@ files:
           Example:
           interface_configs:
             - match_field: "name"  # (required) the field to match, can be `name` (interface name) or `index` (ifIndex)
-              match_value: "eth0"  # (required) the value to match
+              match_value: "eth0"  # (required, case sensitive) the value to match
               in_speed: 50         # (optional) inbound speed value in bits per sec, no value or 0 means no override
               out_speed: 25        # (optional) outbound speed value in bits per sec, no value or 0 means no override
               tags:                # (optional) interface level tags

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -374,7 +374,7 @@ instances:
     ## Example:
     ## interface_configs:
     ##   - match_field: "name"  # (required) the field to match, can be `name` (interface name) or `index` (ifIndex)
-    ##     match_value: "eth0"  # (required) the value to match
+    ##     match_value: "eth0"  # (required, case sensitive) the value to match
     ##     in_speed: 50         # (optional) inbound speed value in bits per sec, no value or 0 means no override
     ##     out_speed: 25        # (optional) outbound speed value in bits per sec, no value or 0 means no override
     ##     tags:                # (optional) interface level tags


### PR DESCRIPTION
### What does this PR do?
Clarified that the `match_value` for `interface_configs` is case sensitive in `conf.yaml.example`

### Motivation
[A customer support ticket](https://datadog.zendesk.com/agent/tickets/1826540)

### Additional Notes
Please merge when approved

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
