### PR TITLE
[mongo] Add warnings when agent user is not authorized to run collStats and indexStats on collections

### DIFF
--- a/mongo/changelog.d/18506.added
+++ b/mongo/changelog.d/18506.added
@@ -1,0 +1,1 @@
+Add warning logs when agent user is not authorized to run $collStats and $indexStats on collections.

--- a/mongo/datadog_checks/mongo/collectors/coll_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/coll_stats.py
@@ -44,11 +44,14 @@ class CollStatsCollector(MongoCollector):
         try:
             return api.coll_stats(self.db_name, coll_name)
         except OperationFailure as e:
+            if e.code == 13:
+                # Unauthorized to run $collStats, raise the exception
+                raise e
             # Failed to get collection stats using $collStats aggregation
             self.log.debug(
                 "Failed not collect stats for collection %s with $collStats, fallback to collStats command",
                 coll_name,
-                e,
+                e.details,
             )
             self.coll_stats_pipeline_supported = False
             return [api.coll_stats_compatable(self.db_name, coll_name)]
@@ -61,7 +64,7 @@ class CollStatsCollector(MongoCollector):
                 collection_stats = self._get_collection_stats(api, coll_name)
             except OperationFailure as e:
                 # Atlas restricts $collStats on system collections
-                self.log.warning("Could not collect stats for collection %s: %s", coll_name, e)
+                self.log.warning("Could not collect stats for collection %s: %s", coll_name, e.details)
                 continue
 
             for coll_stats in collection_stats:

--- a/mongo/datadog_checks/mongo/collectors/coll_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/coll_stats.py
@@ -65,9 +65,14 @@ class CollStatsCollector(MongoCollector):
             except OperationFailure as e:
                 # Atlas restricts $collStats on system collections
                 if e.code == 13:
-                    self.log.warning("Unauthorized to run $collStats on collection %s", coll_name)
+                    self.log.warning("Unauthorized to run $collStats on collection %s.%s", self.db_name, coll_name)
                 else:
-                    self.log.warning("Could not collect stats for collection %s: %s", coll_name, e.details)
+                    self.log.warning(
+                        "Could not collect stats for collection %s.%s: %s", self.db_name, coll_name, e.details
+                    )
+                continue
+            except Exception as e:
+                self.log.error("Unexpected error when fetch stats for collection %s.%s: %s", self.db_name, coll_name, e)
                 continue
 
             for coll_stats in collection_stats:

--- a/mongo/datadog_checks/mongo/collectors/index_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/index_stats.py
@@ -42,9 +42,13 @@ class IndexStatsCollector(MongoCollector):
             except OperationFailure as e:
                 # Atlas restricts $indexStats on system collections
                 if e.code == 13:
-                    self.log.warning("Unauthorized to run $indexStats on collection %s", coll_name)
+                    self.log.warning("Unauthorized to run $indexStats on collection %s.%s", self.db_name, coll_name)
                 else:
-                    self.log.warning("Could not collect index stats for collection %s: %s", coll_name, e.details)
+                    self.log.warning(
+                        "Could not collect index stats for collection %s.%s: %s", self.db_name, coll_name, e.details
+                    )
             except Exception as e:
-                self.log.error("Could not fetch indexes stats for collection %s: %s", coll_name, e)
+                self.log.error(
+                    "Unexpected error when fetch indexes stats for collection %s.%s: %s", self.db_name, coll_name, e
+                )
                 raise e

--- a/mongo/datadog_checks/mongo/collectors/index_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/index_stats.py
@@ -41,7 +41,7 @@ class IndexStatsCollector(MongoCollector):
                     self._submit_payload({"indexes": stats}, additional_tags, INDEX_METRICS, "collection")
             except OperationFailure as e:
                 # Atlas restricts $indexStats on system collections
-                self.log.warning("Could not collect index stats for collection %s: %s", coll_name, e)
+                self.log.warning("Could not collect index stats for collection %s: %s", coll_name, e.details)
             except Exception as e:
                 self.log.error("Could not fetch indexes stats for collection %s: %s", coll_name, e)
                 raise e

--- a/mongo/datadog_checks/mongo/collectors/index_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/index_stats.py
@@ -41,7 +41,10 @@ class IndexStatsCollector(MongoCollector):
                     self._submit_payload({"indexes": stats}, additional_tags, INDEX_METRICS, "collection")
             except OperationFailure as e:
                 # Atlas restricts $indexStats on system collections
-                self.log.warning("Could not collect index stats for collection %s: %s", coll_name, e.details)
+                if e.code == 13:
+                    self.log.warning("Unauthorized to run $indexStats on collection %s", coll_name)
+                else:
+                    self.log.warning("Could not collect index stats for collection %s: %s", coll_name, e.details)
             except Exception as e:
                 self.log.error("Could not fetch indexes stats for collection %s: %s", coll_name, e)
                 raise e


### PR DESCRIPTION
### What does this PR do?
This PR adds warnings when agent user is not authorized to run collStats and indexStats on collections.

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4500

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
