### PR TITLE
[mongo] add index tag to index stats metrics

### DIFF
--- a/mongo/datadog_checks/mongo/collectors/index_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/index_stats.py
@@ -31,13 +31,15 @@ class IndexStatsCollector(MongoCollector):
         for coll_name in coll_names:
             try:
                 for stats in api.index_stats(self.db_name, coll_name):
+                    idx_name = stats.get('name', 'unknown')
                     additional_tags = [
-                        "name:{0}".format(stats.get('name', 'unknown')),
-                        "collection:{0}".format(coll_name),
-                        "db:{0}".format(self.db_name),
+                        f"name:{idx_name}",  # deprecated but kept for backward compatability, use index instead
+                        f"index:{idx_name}",
+                        f"collection:{coll_name}",
+                        f"db:{self.db_name}",
                     ]
                     if stats.get('shard'):
-                        additional_tags.append("shard:{0}".format(stats['shard']))
+                        additional_tags.append(f"shard:{stats['shard']}")
                     self._submit_payload({"indexes": stats}, additional_tags, INDEX_METRICS, "collection")
             except OperationFailure as e:
                 # Atlas restricts $indexStats on system collections

--- a/mongo/tests/results/metrics-indexes-stats-autodiscover.json
+++ b/mongo/tests/results/metrics-indexes-stats-autodiscover.json
@@ -6,6 +6,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "name:_id_",
+            "index:_id_",
             "collection:foo",
             "db:test"
         ]
@@ -17,6 +18,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "name:_id_",
+            "index:_id_",
             "collection:bar",
             "db:test"
         ]
@@ -28,6 +30,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "name:_id_",
+            "index:_id_",
             "collection:foo",
             "db:admin"
         ]
@@ -39,6 +42,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "name:_id_",
+            "index:_id_",
             "collection:bar",
             "db:admin"
         ]
@@ -50,6 +54,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "name:_id_",
+            "index:_id_",
             "collection:foo",
             "db:config"
         ]
@@ -61,6 +66,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "name:_id_",
+            "index:_id_",
             "collection:bar",
             "db:config"
         ]
@@ -72,6 +78,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "name:_id_",
+            "index:_id_",
             "collection:foo",
             "db:integration"
         ]
@@ -83,6 +90,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "name:_id_",
+            "index:_id_",
             "collection:bar",
             "db:integration"
         ]
@@ -94,6 +102,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "name:_id_",
+            "index:_id_",
             "collection:foo",
             "db:test"
         ]
@@ -105,6 +114,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "name:_id_",
+            "index:_id_",
             "collection:bar",
             "db:test"
         ]
@@ -116,6 +126,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "name:_id_",
+            "index:_id_",
             "collection:foo",
             "db:admin"
         ]
@@ -127,6 +138,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "name:_id_",
+            "index:_id_",
             "collection:bar",
             "db:admin"
         ]
@@ -138,6 +150,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "name:_id_",
+            "index:_id_",
             "collection:foo",
             "db:config"
         ]
@@ -149,6 +162,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "name:_id_",
+            "index:_id_",
             "collection:bar",
             "db:config"
         ]
@@ -160,6 +174,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "name:_id_",
+            "index:_id_",
             "collection:foo",
             "db:integration"
         ]
@@ -171,6 +186,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "name:_id_",
+            "index:_id_",
             "collection:bar",
             "db:integration"
         ]

--- a/mongo/tests/results/metrics-indexes-stats.json
+++ b/mongo/tests/results/metrics-indexes-stats.json
@@ -6,6 +6,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "name:_id_",
+            "index:_id_",
             "collection:foo",
             "db:test"
         ]
@@ -17,6 +18,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "name:_id_",
+            "index:_id_",
             "collection:bar",
             "db:test"
         ]
@@ -28,6 +30,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "name:_id_",
+            "index:_id_",
             "collection:foo",
             "db:test"
         ]
@@ -39,6 +42,7 @@
         "tags": [
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "name:_id_",
+            "index:_id_",
             "collection:bar",
             "db:test"
         ]


### PR DESCRIPTION
### What does this PR do?
This PR adds `index` tag to index access ops metric `mongodb.collection.indexes.accesses.opsps` collected from `$indexStats`. The change is to keep the tag name and value consistent with `mongodb.collection.indexsizes` metric. The legacy index name tag `name` is kept for backward compatibility  but will be deprecated in future releases. 

### Motivation
Keep index metrics tag consistent.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
