### PR TITLE
Add more unit tests for empty include lists in Discovery

### DIFF
--- a/datadog_checks_base/tests/base/utils/discovery/test_discovery.py
+++ b/datadog_checks_base/tests/base/utils/discovery/test_discovery.py
@@ -16,6 +16,20 @@ def test_include_empty():
     assert mock_get_items.call_count == 1
 
 
+def test_include_empty_exclude_non_empty():
+    mock_get_items = mock.Mock(return_value=['a', 'b', 'c', 'd', 'e', 'f', 'g'])
+    d = Discovery(mock_get_items, exclude=['b.*'])
+    assert list(d.get_items()) == []
+    assert mock_get_items.call_count == 1
+
+
+def test_include_empty_limit():
+    mock_get_items = mock.Mock(return_value=['a', 'b', 'c', 'd', 'e', 'f', 'g'])
+    d = Discovery(mock_get_items, limit=1)
+    assert list(d.get_items()) == []
+    assert mock_get_items.call_count == 1
+
+
 @pytest.mark.parametrize(
     'pattern',
     [

--- a/datadog_checks_base/tests/base/utils/discovery/test_discovery.py
+++ b/datadog_checks_base/tests/base/utils/discovery/test_discovery.py
@@ -13,21 +13,21 @@ def test_include_empty():
     mock_get_items = mock.Mock(return_value=['a', 'b', 'c', 'd', 'e', 'f', 'g'])
     d = Discovery(mock_get_items)
     assert list(d.get_items()) == []
-    assert mock_get_items.call_count == 1
+    assert mock_get_items.mock_calls == [mock.call()]
 
 
 def test_include_empty_exclude_non_empty():
     mock_get_items = mock.Mock(return_value=['a', 'b', 'c', 'd', 'e', 'f', 'g'])
     d = Discovery(mock_get_items, exclude=['b.*'])
     assert list(d.get_items()) == []
-    assert mock_get_items.call_count == 1
+    assert mock_get_items.mock_calls == [mock.call()]
 
 
 def test_include_empty_limit():
     mock_get_items = mock.Mock(return_value=['a', 'b', 'c', 'd', 'e', 'f', 'g'])
     d = Discovery(mock_get_items, limit=1)
     assert list(d.get_items()) == []
-    assert mock_get_items.call_count == 1
+    assert mock_get_items.mock_calls == [mock.call()]
 
 
 @pytest.mark.parametrize(
@@ -47,21 +47,21 @@ def test_include_not_empty(pattern):
     mock_get_items = mock.Mock(return_value=['a', 'b', 'c', 'd', 'e', 'f', 'g'])
     d = Discovery(mock_get_items, include={pattern: None})
     assert list(d.get_items()) == [(pattern, 'a', 'a', None)]
-    assert mock_get_items.call_count == 1
+    assert mock_get_items.mock_calls == [mock.call()]
 
 
 def test_include_processed_in_order():
     mock_get_items = mock.Mock(return_value=['a', 'b', 'c', 'd', 'e', 'f', 'g'])
     d = Discovery(mock_get_items, include={'c.*': {'value': 5}, 'a.*': {'value': 10}})
     assert list(d.get_items()) == [('c.*', 'c', 'c', {'value': 5}), ('a.*', 'a', 'a', {'value': 10})]
-    assert mock_get_items.call_count == 1
+    assert mock_get_items.mock_calls == [mock.call()]
 
 
 def test_exclude_and_include_intersection_is_empty():
     mock_get_items = mock.Mock(return_value=['a', 'b', 'c', 'd', 'e', 'f', 'g'])
     d = Discovery(mock_get_items, include={'a.*': None}, exclude=['b.*'])
     assert list(d.get_items()) == [('a.*', 'a', 'a', None)]
-    assert mock_get_items.call_count == 1
+    assert mock_get_items.mock_calls == [mock.call()]
 
 
 def test_exclude_is_subset_of_include():
@@ -75,21 +75,21 @@ def test_exclude_is_subset_of_include():
         ('.*', 'f', 'f', None),
         ('.*', 'g', 'g', None),
     ]
-    assert mock_get_items.call_count == 1
+    assert mock_get_items.mock_calls == [mock.call()]
 
 
 def test_exclude_is_equals_to_include():
     mock_get_items = mock.Mock(return_value=['a', 'b', 'c', 'd', 'e', 'f', 'g'])
     d = Discovery(limit=10, include={'b.*': None}, exclude=['b.*'], interval=0, get_items_func=mock_get_items)
     assert list(d.get_items()) == []
-    assert mock_get_items.call_count == 1
+    assert mock_get_items.mock_calls == [mock.call()]
 
 
 def test_limit_zero():
     mock_get_items = mock.Mock(return_value=['a', 'b', 'c', 'd', 'e', 'f', 'g'])
     d = Discovery(mock_get_items, limit=0, include={'.*': None})
     assert list(d.get_items()) == []
-    assert mock_get_items.call_count == 1
+    assert mock_get_items.mock_calls == [mock.call()]
 
 
 def test_limit_none():
@@ -104,7 +104,7 @@ def test_limit_none():
         ('.*', 'f', 'f', None),
         ('.*', 'g', 'g', None),
     ]
-    assert mock_get_items.call_count == 1
+    assert mock_get_items.mock_calls == [mock.call()]
 
 
 def test_limit_greater_than_zero():
@@ -117,7 +117,7 @@ def test_limit_greater_than_zero():
         ('.*', 'd', 'd', {'value': 5}),
         ('.*', 'e', 'e', {'value': 5}),
     ]
-    assert mock_get_items.call_count == 1
+    assert mock_get_items.mock_calls == [mock.call()]
 
 
 def test_limit_greater_than_items_len():
@@ -132,7 +132,7 @@ def test_limit_greater_than_items_len():
         ('.*', 'f', 'f', None),
         ('.*', 'g', 'g', None),
     ]
-    assert mock_get_items.call_count == 1
+    assert mock_get_items.mock_calls == [mock.call()]
 
 
 def test_interval_none_two_calls_to_get_items_func():
@@ -145,7 +145,7 @@ def test_interval_none_two_calls_to_get_items_func():
         ('.*', 'c', 'c', None),
         ('.*', 'd', 'd', None),
     ]
-    assert mock_get_items.call_count == 2
+    assert mock_get_items.mock_calls == [mock.call(), mock.call()]
 
 
 def test_interval_zero_two_calls_to_get_items_func():
@@ -158,7 +158,7 @@ def test_interval_zero_two_calls_to_get_items_func():
         ('.*', 'c', 'c', None),
         ('.*', 'd', 'd', None),
     ]
-    assert mock_get_items.call_count == 2
+    assert mock_get_items.mock_calls == [mock.call(), mock.call()]
 
 
 def test_interval_not_exceeded():
@@ -167,7 +167,7 @@ def test_interval_not_exceeded():
         d = Discovery(mock_get_items, include={'.*': None}, interval=60)
         assert list(d.get_items()) == [('.*', 'a', 'a', None), ('.*', 'b', 'b', None)]
         assert list(d.get_items()) == [('.*', 'a', 'a', None), ('.*', 'b', 'b', None)]
-        assert mock_get_items.call_count == 1
+        assert mock_get_items.mock_calls == [mock.call()]
 
 
 def test_interval_exceeded():
@@ -181,11 +181,11 @@ def test_interval_exceeded():
             ('.*', 'c', 'c', None),
             ('.*', 'd', 'd', None),
         ]
-        assert mock_get_items.call_count == 2
+        assert mock_get_items.mock_calls == [mock.call(), mock.call()]
 
 
 def test_key_in_items():
     mock_get_items = mock.Mock(return_value=[{'key': 'a', 'value': 75}, {'key': 'b', 'value': 89}])
     d = Discovery(mock_get_items, include={'a.*': {'filter': 'xxxx'}}, key=lambda item: item['key'])
     assert list(d.get_items()) == [('a.*', 'a', {'key': 'a', 'value': 75}, {'filter': 'xxxx'})]
-    assert mock_get_items.call_count == 1
+    assert mock_get_items.mock_calls == [mock.call()]


### PR DESCRIPTION
### What does this PR do?
Add more unit tests for empty include lists in the Discovery class, while also increasing the specificity of the existing unit tests.
### Motivation
more documentation/test coverage to indicate that we expect an include list when using Discovery
### Additional Notes
maybe we can throw a configuration exception if this is the case?
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
