### PR TITLE
[MA-5658] Migrate monitor name in manifest to be aligned with monitor asset title for integrations-core apps

### DIFF
--- a/active_directory/manifest.json
+++ b/active_directory/manifest.json
@@ -47,9 +47,9 @@
       "Active Directory": "assets/dashboards/active_directory.json"
     },
     "monitors": {
-      "[Active Directory] Elevated LDAP binding duration for host {{host.name}}": "assets/monitors/ldap_binding.json",
-      "[Active Directory] Anomalous number of sessions for connected LDAP clients for host: {{host.name}}": "assets/monitors/ldap_client_sessions.json",
-      "[Active Directory] Anomalous number of successful LDAP bindings for host: {{host.name}}": "assets/monitors/ldap_binding_successful.json"
+      "LDAP binding duration is high": "assets/monitors/ldap_binding.json",
+      "Number of sessions for LDAP clients is anomalous": "assets/monitors/ldap_client_sessions.json",
+      "Number of LDAP bindings is anomalous": "assets/monitors/ldap_binding_successful.json"
     }
   }
 }

--- a/activemq/manifest.json
+++ b/activemq/manifest.json
@@ -67,8 +67,8 @@
       "artemis": "assets/dashboards/artemis_dashboard.json"
     },
     "monitors": {
-      "[ActiveMQ Artemis] High unrouted messages": "assets/monitors/activemq_artemis_unrouted_messages.json",
-      "[ActiveMQ Artemis] High disk store usage": "assets/monitors/activemq_artemis_high_disk_store.json"
+      "Number of unrouted messages is high": "assets/monitors/activemq_artemis_unrouted_messages.json",
+      "Host is running out of disk space": "assets/monitors/activemq_artemis_high_disk_store.json"
     },
     "saved_views": {
       "activemq_processes": "assets/saved_views/activemq_processes.json"

--- a/airbyte/manifest.json
+++ b/airbyte/manifest.json
@@ -50,7 +50,7 @@
       "airbyte_overview": "assets/dashboards/airbyte_overview.json"
     },
     "monitors": {
-      "long_running_jobs": "assets/monitors/long_running_jobs.json"
+      "Sync Jobs are taking a longer time than usual": "assets/monitors/long_running_jobs.json"
     }
   },
   "author": {

--- a/airflow/manifest.json
+++ b/airflow/manifest.json
@@ -56,8 +56,8 @@
       "airflow_overview": "assets/saved_views/airflow_overview.json"
     },
     "monitors": {
-      "Heartbeat Failure": "assets/monitors/heartbeat_failures.json",
-      "Ongoing Duration": "assets/monitors/ongoing_duration.json"
+      "Task instances are failing": "assets/monitors/heartbeat_failures.json",
+      "DAG task ongoing duration is high": "assets/monitors/ongoing_duration.json"
     }
   }
 }

--- a/apache/manifest.json
+++ b/apache/manifest.json
@@ -68,8 +68,8 @@
       "apache": "assets/dashboards/apache_dashboard.json"
     },
     "monitors": {
-      "[Apache] Low number of idle workers": "assets/monitors/apache_low_idle_workers.json",
-      "[Apache] resource utilization": "assets/monitors/high_keep_alive_and_cpu.json"
+      "Idle workers number is low": "assets/monitors/apache_low_idle_workers.json",
+      "CPU load is running high": "assets/monitors/high_keep_alive_and_cpu.json"
     },
     "saved_views": {
       "4xx_errors": "assets/saved_views/4xx_errors.json",

--- a/arangodb/manifest.json
+++ b/arangodb/manifest.json
@@ -51,8 +51,8 @@
       "ArangoDB Overview": "assets/dashboards/arangodb_overview.json"
     },
     "monitors": {
-      "[ArangoDB] High server Kernel mode percentage usage": "assets/monitors/high_server_kernel_mode.json",
-      "[ArangoDB] High server User mode percentage usage": "assets/monitors/high_server_user_mode.json"
+      "ArangoDB's server Kernel mode usage is higher": "assets/monitors/high_server_kernel_mode.json",
+      "ArangoDB's server User mode usage is higher": "assets/monitors/high_server_user_mode.json"
     }
   }
 }

--- a/argo_rollouts/manifest.json
+++ b/argo_rollouts/manifest.json
@@ -51,7 +51,7 @@
       "Argo Rollouts Overview": "assets/dashboards/argo_rollouts_overview.json"
     },
     "monitors": {
-      "Rollout Phase": "assets/monitors/rollout_phase.json"
+      "Argo Rollout is in Non Running or Completed State": "assets/monitors/rollout_phase.json"
     },
     "saved_views": {
       "Argo Rollouts Logs Overview": "assets/saved_views/logs_overview.json",

--- a/argo_workflows/manifest.json
+++ b/argo_workflows/manifest.json
@@ -49,7 +49,7 @@
       "Argo Workflows": "assets/dashboards/argo_workflows.json"
     },
     "monitors": {
-      "errors": "assets/monitors/errors.json"
+      "New errors detected in Argo Workflows": "assets/monitors/errors.json"
     },
     "saved_views": {
       "overview": "assets/saved_views/overview.json",

--- a/argocd/manifest.json
+++ b/argocd/manifest.json
@@ -61,7 +61,7 @@
       "Argo CD Overview": "assets/dashboards/argo_cd_overview.json"
     },
     "monitors": {
-      "Sync Status": "assets/monitors/application_sync_status.json"
+      "Applications sync status": "assets/monitors/application_sync_status.json"
     }
   },
   "author": {

--- a/avi_vantage/manifest.json
+++ b/avi_vantage/manifest.json
@@ -55,7 +55,7 @@
       "Avi Vantage - Overview": "assets/dashboards/overview.json"
     },
     "monitors": {
-      "Avi Vantage - Error Rate Monitor": "assets/monitors/error_rate_monitor.json"
+      "Virtual service has a high number of errors": "assets/monitors/error_rate_monitor.json"
     }
   }
 }

--- a/azure_iot_edge/manifest.json
+++ b/azure_iot_edge/manifest.json
@@ -58,10 +58,10 @@
       "azure_iot_edge": "assets/dashboards/overview.json"
     },
     "monitors": {
-      "Disk usage": "assets/monitors/disk_usage.json",
-      "Memory usage": "assets/monitors/memory_usage.json",
-      "IoT Hub syncs": "assets/monitors/iothub_syncs.json",
-      "Edge Hub retries": "assets/monitors/edgehub_retries.json"
+      "Device is running out of disk space": "assets/monitors/disk_usage.json",
+      "Device is running out of memory": "assets/monitors/memory_usage.json",
+      "Unsuccessful syncs are high": "assets/monitors/iothub_syncs.json",
+      "Edge Hub operation retries is higher than usual": "assets/monitors/edgehub_retries.json"
     }
   }
 }

--- a/boundary/manifest.json
+++ b/boundary/manifest.json
@@ -47,7 +47,7 @@
       "auto_install": true
     },
     "monitors": {
-      "[Boundary] High active connections": "assets/monitors/active_connections.json"
+      "Number of active connections is too high": "assets/monitors/active_connections.json"
     },
     "dashboards": {
       "Boundary Overview": "assets/dashboards/boundary_overview.json"

--- a/calico/manifest.json
+++ b/calico/manifest.json
@@ -64,10 +64,10 @@
       "[calico] dashboard overview": "./assets/dashboards/calico_overview.json"
     },
     "monitors": {
-      "[calico] monitor ipsets error": "assets/monitors/ipset_error.json",
-      "[calico] monitor iptables save errors": "assets/monitors/iptables_save_errors.json",
-      "[calico] monitor iptables restore errors": "assets/monitors/iptables_restore_errors.json",
-      "[calico] monitor dataplane failures": "assets/monitors/dataplane_failures.json"
+      "IPset is failing": "assets/monitors/ipset_error.json",
+      "IPtables save is failing": "assets/monitors/iptables_save_errors.json",
+      "IPtables restore is failing": "assets/monitors/iptables_restore_errors.json",
+      "Dataplane is failing": "assets/monitors/dataplane_failures.json"
     }
   }
 }

--- a/cisco_aci/manifest.json
+++ b/cisco_aci/manifest.json
@@ -49,8 +49,8 @@
       "cisco_aci": "assets/dashboards/cisco_aci_dashboard.json"
     },
     "monitors": {
-      "[Cisco ACI] Average CPU usage high alert": "assets/monitors/cpu_high.json",
-      "[Cisco ACI] Critical health alert": "assets/monitors/critical_health_score.json"
+      "CPU usage is high for Cisco ACI device": "assets/monitors/cpu_high.json",
+      "Health score of device is critical": "assets/monitors/critical_health_score.json"
     }
   }
 }

--- a/cisco_sdwan/manifest.json
+++ b/cisco_sdwan/manifest.json
@@ -41,9 +41,9 @@
       "Cisco SD-WAN": "assets/dashboards/cisco_sd-wan.json"
     },
     "monitors": {
-      "[Cisco SD-WAN] Device Unreachable Alert": "assets/monitors/device_unreachable.json",
-      "[Cisco SD-WAN] Tunnel Down Alert": "assets/monitors/tunnel_down.json",
-      "[Cisco SD-WAN] Device Reboot Alert": "assets/monitors/device_reboot.json"
+      "Cisco SD-WAN Device is unreachable": "assets/monitors/device_unreachable.json",
+      "Cisco SD-WAN Tunnel is down": "assets/monitors/tunnel_down.json",
+      "Cisco SD-WAN Device has rebooted several times": "assets/monitors/device_reboot.json"
     }
   },
   "author": {

--- a/citrix_hypervisor/manifest.json
+++ b/citrix_hypervisor/manifest.json
@@ -53,8 +53,8 @@
       "auto_install": true
     },
     "monitors": {
-      "VM CPU high": "assets/monitors/vm_cpu_high.json",
-      "Host CPU high": "assets/monitors/host_cpu_high.json"
+      "VM's CPU load is high": "assets/monitors/vm_cpu_high.json",
+      "CPU load is high": "assets/monitors/host_cpu_high.json"
     }
   }
 }

--- a/cloudera/manifest.json
+++ b/cloudera/manifest.json
@@ -54,7 +54,7 @@
       "Cloudera Data Platform Overview": "assets/dashboards/cloudera_overview.json"
     },
     "monitors": {
-      "Cloudera High CPU Usage": "assets/monitors/cloudera_high_cpu.json"
+      "Cloudera CPU usage is high": "assets/monitors/cloudera_high_cpu.json"
     }
   },
   "author": {

--- a/confluent_platform/manifest.json
+++ b/confluent_platform/manifest.json
@@ -49,8 +49,8 @@
       "Confluent Platform Overview": "assets/dashboards/overview.json"
     },
     "monitors": {
-      "[Confluent Platform] Unclean leader election": "assets/monitors/unclean_leader_election.json",
-      "[Confluent Platform] Unused topic partition": "assets/monitors/unused_partition.json"
+      "Unclean leader election detected": "assets/monitors/unclean_leader_election.json",
+      "Topic partition is not used": "assets/monitors/unused_partition.json"
     }
   }
 }

--- a/consul/assets/monitors/consul_status.json
+++ b/consul/assets/monitors/consul_status.json
@@ -2,7 +2,7 @@
     "version": 2,
     "created_at": "2024-03-01",
     "last_updated_at": "2024-03-01",
-    "title": "",
+    "title": "consul service status",
     "tags": [
       "integration:consul"
     ],

--- a/consul/manifest.json
+++ b/consul/manifest.json
@@ -85,7 +85,7 @@
       "consul": "assets/dashboards/consul_overview.json"
     },
     "monitors": {
-      "consul": "assets/monitors/consul_status.json"
+      "consul service status": "assets/monitors/consul_status.json"
     },
     "saved_views": {
       "consul_processes": "assets/saved_views/consul_processes.json",

--- a/coredns/manifest.json
+++ b/coredns/manifest.json
@@ -68,8 +68,8 @@
       "CoreDNS": "assets/dashboards/coredns.json"
     },
     "monitors": {
-      "[CoreDNS] Cache hits count low": "assets/monitors/coredns_cache_hits_low.json",
-      "[CoreDNS] Request duration high": "assets/monitors/coredns_request_duration_high.json"
+      "Cache hits count is low": "assets/monitors/coredns_cache_hits_low.json",
+      "Request duration is high": "assets/monitors/coredns_request_duration_high.json"
     }
   }
 }

--- a/dcgm/manifest.json
+++ b/dcgm/manifest.json
@@ -46,9 +46,9 @@
       "DCGM Exporter (Nvidia GPU Monitoring) Overview": "assets/dashboards/dcgm_overview.json"
     },
     "monitors": {
-      "gpu_temperature": "assets/monitors/gpu_temperature.json",
-      "memory_usage": "assets/monitors/memory_usage.json",
-      "xid_errors": "assets/monitors/xid_errors.json"
+      "GPU temperature is high": "assets/monitors/gpu_temperature.json",
+      "GPU memory usage is high": "assets/monitors/memory_usage.json",
+      "XID errors detected": "assets/monitors/xid_errors.json"
     }
   },
   "author": {

--- a/elastic/manifest.json
+++ b/elastic/manifest.json
@@ -65,12 +65,12 @@
       "elasticsearch_timeboard": "assets/dashboards/metrics.json"
     },
     "monitors": {
-      "[ElasticSearch] Unsuccessful requests rate is high": "assets/monitors/elastic_requests.json",
-      "[ElasticSearch] Query load is high": "assets/monitors/elastic_query_load_high.json",
-      "[ElasticSearch] Time spent on queries is high": "assets/monitors/elastic_query_latency_high.json",
-      "[ElasticSearch] Number of pending tasks is high": "assets/monitors/elastic_pending_tasks_high.json",
-      "[ElasticSearch] Current indexing load is high": "assets/monitors/elastic_indexing_load.json",
-      "[ElasticSearch] Average query latency is high": "assets/monitors/elastic_average_search_latency.json"
+      "Unsuccessful requests rate is high": "assets/monitors/elastic_requests.json",
+      "Query load is high": "assets/monitors/elastic_query_load_high.json",
+      "Latency is high": "assets/monitors/elastic_query_latency_high.json",
+      "Number of pending tasks is high": "assets/monitors/elastic_pending_tasks_high.json",
+      "Current Indexing Load is High": "assets/monitors/elastic_indexing_load.json",
+      "Average Search Query Latency is High": "assets/monitors/elastic_average_search_latency.json"
     },
     "saved_views": {
       "elasticsearch_processes": "assets/saved_views/elasticsearch_processes.json"

--- a/envoy/manifest.json
+++ b/envoy/manifest.json
@@ -57,7 +57,7 @@
       "Envoy Openmetrics Overview": "assets/dashboards/openmetrics_overview.json"
     },
     "monitors": {
-      "Envoy - connected state": "assets/monitors/connected_state.json"
+      "Envoy instance disconnected from control plane": "assets/monitors/connected_state.json"
     },
     "saved_views": {
       "envoy_overview": "assets/saved_views/envoy_overview.json",

--- a/fluxcd/manifest.json
+++ b/fluxcd/manifest.json
@@ -64,7 +64,7 @@
       "Fluxcd": "assets/dashboards/fluxcd.json"
     },
     "monitors": {
-      "Active Workers": "assets/monitors/active_workers.json",
+      "Active Workers Count": "assets/monitors/active_workers.json",
       "Error Count": "assets/monitors/error_count.json"
     },
     "saved_views": {

--- a/fly_io/manifest.json
+++ b/fly_io/manifest.json
@@ -48,7 +48,7 @@
       }
     },
     "monitors": {
-      "app_suspended": "assets/monitors/app_suspended.json"
+      "Fly.io App Suspended": "assets/monitors/app_suspended.json"
     },
     "dashboards": {
       "Fly.io Overview ": "assets/dashboards/overview.json"

--- a/foundationdb/manifest.json
+++ b/foundationdb/manifest.json
@@ -56,15 +56,15 @@
     },
     "monitors": {
       "FoundationDB Status Check": "assets/monitors/service_check.json",
-      "FoundationDB Errors Logged": "assets/monitors/errors_logged.json",
-      "FoundationDB High Durability Lag": "assets/monitors/high_durability_lag.json",
-      "FoundationDB Log Queue Reaching Spill Threshold": "assets/monitors/log_queue_spill.json",
-      "FoundationDB Low Disk Space": "assets/monitors/low_disk_space.json",
-      "FoundationDB High Level Of Conflicted Transactions": "assets/monitors/conflicts.json",
-      "FoundationDB High Level Of Rejected Transactions": "assets/monitors/rejections.json",
-      "FoundationDB Read Latency Probe": "assets/monitors/read_latency_probe.json",
-      "FoundationDB Transaction Commit Latency Probe": "assets/monitors/transaction_commit_latency.json",
-      "FoundationDB Transaction Start Latency Probe": "assets/monitors/transaction_start_latency.json"
+      "High severity errors logs are found": "assets/monitors/errors_logged.json",
+      "High durability lag is detected": "assets/monitors/high_durability_lag.json",
+      "Log queue is approaching the limit": "assets/monitors/log_queue_spill.json",
+      "Disk space is low": "assets/monitors/low_disk_space.json",
+      "Transactions are conflicting": "assets/monitors/conflicts.json",
+      "Transactions are rejected": "assets/monitors/rejections.json",
+      "Read operation took a long time": "assets/monitors/read_latency_probe.json",
+      "Transaction commit latency is high": "assets/monitors/transaction_commit_latency.json",
+      "Transaction start latency is high": "assets/monitors/transaction_start_latency.json"
     },
     "saved_views": {
       "errors": "assets/saved_views/errors.json",

--- a/glusterfs/manifest.json
+++ b/glusterfs/manifest.json
@@ -52,7 +52,7 @@
       "Red Hat Gluster Storage": "assets/dashboards/red_hat_gluster_storage.json"
     },
     "monitors": {
-      "brick status": "assets/monitors/brick_status.json"
+      "Number of offline bricks is high": "assets/monitors/brick_status.json"
     },
     "saved_views": {
       "glusterfs_processes": "assets/saved_views/glusterfs_processes.json"

--- a/haproxy/manifest.json
+++ b/haproxy/manifest.json
@@ -78,17 +78,17 @@
       "HAProxy - Overview (OpenMetrics)": "assets/dashboards/openmetrics_overview.json"
     },
     "monitors": {
-      "[HAProxy] Anomalous number of frontend 4xx HTTP responses for host: {{host.name}}": "assets/monitors/frontend_5xx.json",
-      "[HAProxy] Anomalous number of frontend 5xx HTTP responses for host: {{host.name}}": "assets/monitors/frontend_4xx.json",
-      "[HAProxy] High amount of frontend session usage for host: {{host.name}}": "assets/monitors/frontend_sessions.json",
-      "[HAProxy] High amount of backend session usage for host: {{host.name}}": "assets/monitors/backend_sessions.json",
-      "[HAProxy] High number of frontend denied requests for host: {{host.name}}": "assets/monitors/frontend_dreq.json",
-      "[HAProxy] High number of backend denied responses for host: {{host.name}}": "assets/monitors/backend_dreq.json",
-      "[HAProxy] Anomalous frontend request rate for host {{host.name}}": "assets/monitors/request_rate.json",
-      "[HAProxy] Number of client-side request error for {{host.name}} is above normal.": "assets/monitors/frontend_ereq.json",
-      "[HAProxy] Number of backend connection failures for host: {{host.name}} is above normal.": "assets/monitors/backend_econ.json",
-      "[HAProxy] Backend queue time went above 500ms for host: {{host.name}}": "assets/monitors/backend_queue_time.json",
-      "[HAProxy] Backend response time is above 500ms for host: {{host.name}}": "assets/monitors/backend_rtime.json"
+      "Number of frontend 5xx HTTP responses is high": "assets/monitors/frontend_5xx.json",
+      "Number of frontend 4xx HTTP responses is high": "assets/monitors/frontend_4xx.json",
+      "Frontend sessions usage is high": "assets/monitors/frontend_sessions.json",
+      "Backend sessions usage is high": "assets/monitors/backend_sessions.json",
+      "Number of frontend denied requests is high": "assets/monitors/frontend_dreq.json",
+      "Number of denied response is high": "assets/monitors/backend_dreq.json",
+      "Frontend request rate is anomalous": "assets/monitors/request_rate.json",
+      "Number of client-side request error is high": "assets/monitors/frontend_ereq.json",
+      "Number of backend connection failures is high": "assets/monitors/backend_econ.json",
+      "Backend queue time is high": "assets/monitors/backend_queue_time.json",
+      "Response time is high": "assets/monitors/backend_rtime.json"
     },
     "saved_views": {
       "4xx_errors": "assets/saved_views/4xx_errors.json",

--- a/helm/manifest.json
+++ b/helm/manifest.json
@@ -54,7 +54,7 @@
       "Helm - Overview": "assets/dashboards/overview.json"
     },
     "monitors": {
-      "[helm] Monitor Helm failed releases": "assets/monitors/monitor_failed_releases.json"
+      "Release is failed": "assets/monitors/monitor_failed_releases.json"
     }
   }
 }

--- a/hudi/manifest.json
+++ b/hudi/manifest.json
@@ -49,7 +49,7 @@
       "Hudi Overview": "assets/dashboards/overview.json"
     },
     "monitors": {
-      "commit_duration": "assets/monitors/commit_duration.json"
+      "Commit duration is high": "assets/monitors/commit_duration.json"
     },
     "saved_views": {
       "hudi_error_logs": "assets/saved_views/error_logs.json",

--- a/iis/manifest.json
+++ b/iis/manifest.json
@@ -49,9 +49,9 @@
       "IIS-Overview": "assets/dashboards/iis_overview.json"
     },
     "monitors": {
-      "[IIS] Anomalous amount of requests for site: {{site.name}}": "assets/monitors/req.json",
-      "[IIS] Increase of not found error per second for site: {{site.name}}": "assets/monitors/err.json",
-      "[IIS] Increase of locked error per second for site: {{site.name}}": "assets/monitors/lock.json"
+      "Request number is high": "assets/monitors/req.json",
+      "404 errors is high": "assets/monitors/err.json",
+      "Locked errors is high": "assets/monitors/lock.json"
     },
     "saved_views": {
       "4xx_errors": "assets/saved_views/4xx_errors.json",

--- a/istio/manifest.json
+++ b/istio/manifest.json
@@ -79,8 +79,8 @@
       "Istio Overview": "assets/dashboards/overview.json"
     },
     "monitors": {
-      "Failed sidecar injections": "assets/monitors/failed_sidecar_injection.json",
-      "xDS Push Error Rate": "assets/monitors/xds_push_error_rate.json",
+      "Number of failed Istio sidecar injection is high": "assets/monitors/failed_sidecar_injection.json",
+      "Istio xDS Push Error Rate": "assets/monitors/xds_push_error_rate.json",
       "Istio Proxy Requests Error Percentage": "assets/monitors/request_error_rate.json"
     },
     "saved_views": {

--- a/kafka/manifest.json
+++ b/kafka/manifest.json
@@ -76,9 +76,9 @@
       "kafka": "assets/dashboards/kafka_dashboard.json"
     },
     "monitors": {
-      "[Kafka] High produce latency on broker": "assets/monitors/broker_produce_latency.json",
-      "[Kafka] High producer request rate": "assets/monitors/kafka_high_producer_request_rate.json",
-      "[Kafka] Offline partition": "assets/monitors/kafka_offline_partition.json"
+      "Produce latency is high": "assets/monitors/broker_produce_latency.json",
+      "Produce request rate is high": "assets/monitors/kafka_high_producer_request_rate.json",
+      "Partition is offline": "assets/monitors/kafka_offline_partition.json"
     },
     "saved_views": {
       "error_warning_status": "assets/saved_views/error_warning_status.json",

--- a/karpenter/manifest.json
+++ b/karpenter/manifest.json
@@ -54,7 +54,7 @@
       "Karpenter Overview": "assets/dashboards/karpenter_overview.json"
     },
     "monitors": {
-      "pod states": "assets/monitors/pod_state.json"
+      "High percentage of pods reporting in a non Running or non Succeeded state": "assets/monitors/pod_state.json"
     },
     "saved_views": {
       "Karpenter Overview": "assets/saved_views/karpenter_overview.json",

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -66,13 +66,13 @@
       "Kubernetes CPU & Memory usage": "assets/dashboards/kubernetes_cpu_memory.json"
     },
     "monitors": {
-      "[kubernetes] Monitor Kubernetes Deployments Replica Pods": "assets/monitors/monitor_deployments_replicas.json",
-      "[kubernetes] Monitor Unschedulable Kubernetes Nodes": "assets/monitors/monitor_node_unavailable.json",
-      "[kubernetes] Pod {{pod_name.name}} is CrashloopBackOff on namespace {{kube_namespace.name}}": "assets/monitors/monitor_pod_crashloopbackoff.json",
-      "[kubernetes] Pod {{pod_name.name}} is ImagePullBackOff on namespace {{kube_namespace.name}}": "assets/monitors/monitor_pod_imagepullbackoff.json",
-      "[kubernetes] Monitor Kubernetes Failed Pods in Namespaces": "assets/monitors/monitor_pods_failed_state.json",
-      "[kubernetes] Monitor Kubernetes Pods Restarting": "assets/monitors/monitor_pods_restarting.json",
-      "[kubernetes] Monitor Kubernetes Statefulset Replicas": "assets/monitors/monitor_statefulset_replicas.json"
+      "Kubernetes Deployment Replicas are failing": "assets/monitors/monitor_deployments_replicas.json",
+      "Nodes are unavailable": "assets/monitors/monitor_node_unavailable.json",
+      "Pod is in a CrashloopBackOff state": "assets/monitors/monitor_pod_crashloopbackoff.json",
+      "Pod is in an ImagePullBackOff state": "assets/monitors/monitor_pod_imagepullbackoff.json",
+      "Pods are failing": "assets/monitors/monitor_pods_failed_state.json",
+      "Pods are restarting": "assets/monitors/monitor_pods_restarting.json",
+      "Kubernetes Statefulset Replicas are failing": "assets/monitors/monitor_statefulset_replicas.json"
     },
     "saved_views": {
       "non_ok_pods": "assets/saved_views/non_ok_pods.json",

--- a/kubernetes_cluster_autoscaler/manifest.json
+++ b/kubernetes_cluster_autoscaler/manifest.json
@@ -51,9 +51,9 @@
       "source": "kubernetes_cluster_autoscaler"
     },
     "monitors": {
-      "Not safe to autoscale": "assets/monitors/KCA_not_safe_to_autosclae.json",
-      "Reporting Errors": "assets/monitors/KCA_reporting_errors.json",
-      "Unused Nodes Forcast": "assets/monitors/KCA_unused_nodes_forecast.json"
+      "Kubernetes Cluster Autoscaler is not safe to autoscale": "assets/monitors/KCA_not_safe_to_autosclae.json",
+      "Kubernetes Cluster Autoscaler too many unused nodes forecast": "assets/monitors/KCA_reporting_errors.json",
+      "Kubernetes Cluster Autoscaler reporting errors": "assets/monitors/KCA_unused_nodes_forecast.json"
     }
   },
   "author": {

--- a/kyverno/manifest.json
+++ b/kyverno/manifest.json
@@ -49,7 +49,7 @@
       }
     },
     "monitors": {
-      "metadata_path": "assets/monitors/controller_drops.json"
+      "Controller element is dropped": "assets/monitors/controller_drops.json"
     },
     "saved_views": {
       "Kyverno Logs Overview": "assets/saved_views/logs_overview.json",

--- a/langchain/manifest.json
+++ b/langchain/manifest.json
@@ -46,8 +46,8 @@
       "LangChain Overview Dashboard": "assets/dashboards/overview_dashboard.json"
     },
     "monitors": {
-      "Request Latency": "assets/monitors/request_duration.json",
-      "Error Rate": "assets/monitors/error_rate.json"
+      "Request duration is increasing": "assets/monitors/request_duration.json",
+      "Error rate is high": "assets/monitors/error_rate.json"
     }
   },
   "author": {

--- a/marklogic/manifest.json
+++ b/marklogic/manifest.json
@@ -53,9 +53,9 @@
       "MarkLogic - Overview": "assets/dashboards/overview.json"
     },
     "monitors": {
-      "Marklogic low cache": "assets/monitors/marklogic_low_cache.json",
-      "Marklogic high load": "assets/monitors/marklogic_high_load.json",
-      "Marklogic long requests": "assets/monitors/marklogic_long_requests.json"
+      "Cache is not large enough": "assets/monitors/marklogic_low_cache.json",
+      "Forest processing load is high": "assets/monitors/marklogic_high_load.json",
+      "Active requests are taking too long": "assets/monitors/marklogic_long_requests.json"
     },
     "saved_views": {
       "marklogic_processes": "assets/saved_views/marklogic_processes.json"

--- a/mongo/manifest.json
+++ b/mongo/manifest.json
@@ -63,7 +63,7 @@
       "mongodb": "assets/dashboards/overview.json"
     },
     "monitors": {
-      "[MongoDB] High incoming connections": "assets/monitors/high_connections.json"
+      "Connection pool is reaching saturation": "assets/monitors/high_connections.json"
     },
     "saved_views": {
       "operations_by_type_overview": "assets/saved_views/operations_by_type_overview.json",

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -60,8 +60,8 @@
       "mysql-screenboard": "assets/dashboards/overview-screenboard.json"
     },
     "monitors": {
-      "select query rate": "assets/monitors/select_query_rate.json",
-      "replica running": "assets/monitors/replica_running.json"
+      "SELECT query volume is dropping": "assets/monitors/select_query_rate.json",
+      "MySQL database replica is not running properly": "assets/monitors/replica_running.json"
     },
     "saved_views": {
       "operations": "assets/saved_views/operations.json",

--- a/nginx/manifest.json
+++ b/nginx/manifest.json
@@ -72,9 +72,9 @@
       "NGINX-Overview": "assets/dashboards/NGINX-Overview_dashboard.json"
     },
     "monitors": {
-      "[NGINX] Upstream peers fails": "assets/monitors/upstream_peer_fails.json",
-      "[NGINX] 4xx Errors higher than usual": "assets/monitors/4xx.json",
-      "[NGINX] 5xx Errors higher than usual": "assets/monitors/5xx.json"
+      "Upstream peers are failing": "assets/monitors/upstream_peer_fails.json",
+      "Upstream 4xx errors are high": "assets/monitors/4xx.json",
+      "Upstream 5xx errors are high": "assets/monitors/5xx.json"
     },
     "saved_views": {
       "4xx_errors": "assets/saved_views/4xx_errors.json",

--- a/nvidia_triton/manifest.json
+++ b/nvidia_triton/manifest.json
@@ -48,8 +48,8 @@
       "Nvidia Triton Overview": "assets/dashboards/nvidia_triton_overview.json"
     },
     "monitors": {
-      "[Nvidia Triton] GPU utilization is high": "assets/monitors/gpu_utilization.json",
-      "[Nvidia Triton] CPU Memory Usage is high": "assets/monitors/cpu_memory.json"
+      "Nvidia Triton GPU Utilization is high!": "assets/monitors/gpu_utilization.json",
+      "Nvidia Triton CPU memory usage is high!": "assets/monitors/cpu_memory.json"
     }
   },
   "author": {

--- a/openai/manifest.json
+++ b/openai/manifest.json
@@ -76,9 +76,9 @@
       "OpenAI Usage Overview": "assets/dashboards/usage_overview_dashboard.json"
     },
     "monitors": {
-      "Request Limits": "assets/monitors/request_limits.json",
-      "Token per min Limits": "assets/monitors/tokens_limits.json",
-      "Abnormally High Token Usage": "assets/monitors/api_token_usage.json"
+      "OpenAI API usage is approaching rate limit": "assets/monitors/request_limits.json",
+      "OpenAI tokens usage is approaching rate limit": "assets/monitors/tokens_limits.json",
+      "Token usage is abnormally high": "assets/monitors/api_token_usage.json"
     }
   },
   "author": {

--- a/otel/manifest.json
+++ b/otel/manifest.json
@@ -53,7 +53,7 @@
       "OpenTelemetry Collector Metrics Dashboard": "assets/dashboards/otel_collector_metrics_dashboard.json"
     },
     "monitors": {
-      "OpenTelemetry Refused Spans": "assets/monitors/otel_refused_spans.json"
+      "Refused Spans": "assets/monitors/otel_refused_spans.json"
     }
   }
 }

--- a/postgres/manifest.json
+++ b/postgres/manifest.json
@@ -83,8 +83,8 @@
       "postgresql_screenboard": "assets/dashboards/postgresql_screenboard_dashboard.json"
     },
     "monitors": {
-      "percent_usage_connections": "assets/monitors/percent_usage_connections.json",
-      "replication_delay": "assets/monitors/replication_delay.json"
+      "Connection pool is reaching saturation point": "assets/monitors/percent_usage_connections.json",
+      "Replication delay is high": "assets/monitors/replication_delay.json"
     },
     "saved_views": {
       "operations": "assets/saved_views/operations.json",

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -69,12 +69,12 @@
       "rabbitmq": "assets/dashboards/rabbitmq_dashboard.json"
     },
     "monitors": {
-      "disk_usage": "assets/monitors/disk_usage.json",
-      "message_unacknowledge_rate_anomaly": "assets/monitors/message_unacknowledge_rate_anomaly.json",
-      "disk_usage_prometheus": "assets/monitors/disk_usage_prometheus.json",
-      "message_unack_prometheus": "assets/monitors/message_unack_prometheus.json",
-      "consumers_at_zero": "assets/monitors/consumers_at_zero.json",
-      "message_ready": "assets/monitors/message_ready.json"
+      "Level of disk usage is too high for host": "assets/monitors/disk_usage.json",
+      "Messages unacknowledged rate is higher than usual": "assets/monitors/message_unacknowledge_rate_anomaly.json",
+      "Disk space is low": "assets/monitors/disk_usage_prometheus.json",
+      "Unacknowledged Messages are higher than usual": "assets/monitors/message_unack_prometheus.json",
+      "RabbitMQ queue has 0 consumers": "assets/monitors/consumers_at_zero.json",
+      "Messages are ready in RabbitMQ queue": "assets/monitors/message_ready.json"
     },
     "saved_views": {
       "pid_overview": "assets/saved_views/status_overview.json",

--- a/ray/manifest.json
+++ b/ray/manifest.json
@@ -48,10 +48,10 @@
       "auto_install": true
     },
     "monitors": {
-      "high cpu utilization": "assets/monitors/cpu_utilization.json",
-      "low GPU utilization": "assets/monitors/gpu_utilization.json",
-      "high memory utilization": "assets/monitors/mem_utilization.json",
-      "high failed tasks": "assets/monitors/failed_task.json"
+      "High CPU Utilization on Ray.io node": "assets/monitors/cpu_utilization.json",
+      "Low GPU Utilization low on Ray.io Node": "assets/monitors/gpu_utilization.json",
+      "High Memory Usage": "assets/monitors/mem_utilization.json",
+      "High Number of Failed Tasks on Ray.io Node": "assets/monitors/failed_task.json"
     },
     "dashboards": {
       "Ray Overview Dashboard": "assets/dashboards/overview_dashboard.json"

--- a/redisdb/manifest.json
+++ b/redisdb/manifest.json
@@ -61,7 +61,7 @@
       "redis": "assets/dashboards/overview.json"
     },
     "monitors": {
-      "[Redis] High memory consumption": "assets/monitors/high_mem.json"
+      "Memory consumption is high": "assets/monitors/high_mem.json"
     },
     "saved_views": {
       "error_warning_status": "assets/saved_views/error_warning_status.json",

--- a/scylla/manifest.json
+++ b/scylla/manifest.json
@@ -51,7 +51,7 @@
       "Scylla Overview": "assets/dashboards/overview.json"
     },
     "monitors": {
-      "[Scylla] Server is shutting down": "assets/monitors/instance_down.json"
+      "Node State is abnormal": "assets/monitors/instance_down.json"
     }
   }
 }

--- a/silk/manifest.json
+++ b/silk/manifest.json
@@ -51,7 +51,7 @@
       "Silk - Overview": "assets/dashboards/silk_overview.json"
     },
     "monitors": {
-      "Latency high": "assets/monitors/latency_high.json"
+      "Latency is high": "assets/monitors/latency_high.json"
     }
   }
 }

--- a/singlestore/manifest.json
+++ b/singlestore/manifest.json
@@ -54,9 +54,9 @@
       "Singlestore Overview": "assets/dashboards/overview.json"
     },
     "monitors": {
-      "[SingleStore] License expiration": "assets/monitors/license_expiration.json",
-      "[SingleStore] Read failures rate": "assets/monitors/read_failures.json",
-      "[SingleStore] Write failures rate": "assets/monitors/write_failures.json"
+      "License will expire soon": "assets/monitors/license_expiration.json",
+      "Read queries failure rate is high": "assets/monitors/read_failures.json",
+      "Write queries failure rate is high": "assets/monitors/write_failures.json"
     }
   }
 }

--- a/snmp/assets/monitors/traps_linkDown.json
+++ b/snmp/assets/monitors/traps_linkDown.json
@@ -2,7 +2,7 @@
   "version": 2,
   "created_at": "2023-06-15",
   "last_updated_at": "2023-06-27",
-  "title": "Interface is down on SNMP device",
+  "title": "LinkDown Trap Interface is down on SNMP device",
   "tags": [
     "integration:snmp"
   ],

--- a/snmp/manifest.json
+++ b/snmp/manifest.json
@@ -65,15 +65,15 @@
       "BGP & OSPF Overview": "assets/dashboards/bgp_ospf_overview.json"
     },
     "monitors": {
-      "[SNMP] Device Down Alert": "assets/monitors/device_down.json",
-      "[SNMP] Device Unreachable Alert": "assets/monitors/device_unreachable.json",
-      "[SNMP] Interface Down Alert": "assets/monitors/interface_down.json",
-      "[SNMP] LinkDown Trap Alert": "assets/monitors/traps_linkDown.json",
-      "[SNMP] CPU usage high for {{snmp_device.name}} in namespace {{device_namespace.name}}": "assets/monitors/high_cpu.json",
-      "[SNMP] High memory usage for device {{snmp_device.name}} in namespace {{device_namespace.name}}": "assets/monitors/high_memory.json",
-      "[SNMP] High interface bandwidth usage for incoming traffic for device {{snmp_device.name}} on interface {{interface.name}} in {{device_namespace.name}}": "assets/monitors/high_interface_bandwidth_usage_in.json",
-      "[SNMP] High interface bandwidth usage for outgoing traffic for device {{snmp_device.name}} on interface {{interface.name}} in {{device_namespace.name}}": "assets/monitors/high_interface_bandwidth_usage_out.json",
-      "[SNMP] BGP peer state between {{snmp_device.name}} and neighbor {{neighbor.name}} is stuck in an unestablished state": "assets/monitors/bgp_peer_state_stuck.json"
+      "Device is down": "assets/monitors/device_down.json",
+      "SNMP Device is unreachable": "assets/monitors/device_unreachable.json",
+      "Interface is down on SNMP device": "assets/monitors/interface_down.json",
+      "LinkDown Trap Interface is down on SNMP device": "assets/monitors/traps_linkDown.json",
+      "SNMP device CPU usage is high": "assets/monitors/high_cpu.json",
+      "SNMP device memory usage is high": "assets/monitors/high_memory.json",
+      "Interface bandwidth usage for incoming traffic is high": "assets/monitors/high_interface_bandwidth_usage_in.json",
+      "Interface bandwidth usage for outgoing traffic is high": "assets/monitors/high_interface_bandwidth_usage_out.json",
+      "BGP peer state is stuck in an unestablished state": "assets/monitors/bgp_peer_state_stuck.json"
     }
   }
 }

--- a/snowflake/manifest.json
+++ b/snowflake/manifest.json
@@ -58,7 +58,7 @@
       "Snowflake Organization Metrics": "assets/dashboards/organization_metrics.json"
     },
     "monitors": {
-      "Snowflake failed logins": "assets/monitors/snowflake_failed_logins.json"
+      "Failed login attempts are increasing": "assets/monitors/snowflake_failed_logins.json"
     }
   }
 }

--- a/sonarqube/manifest.json
+++ b/sonarqube/manifest.json
@@ -55,7 +55,7 @@
       "Sonarqube Overview": "assets/dashboards/overview.json"
     },
     "monitors": {
-      "SonarQube vulnerabilities": "assets/monitors/vulnerabilities.json"
+      "Sonarqube has vulnerabilities": "assets/monitors/vulnerabilities.json"
     },
     "saved_views": {
       "status_overview": "assets/saved_views/status_overview.json"

--- a/sqlserver/manifest.json
+++ b/sqlserver/manifest.json
@@ -78,11 +78,11 @@
       "sqlserver": "assets/dashboards/sqlserver_dashboard.json"
     },
     "monitors": {
-      "SQLServer ao not healthy": "assets/monitors/sqlserver_ao_not_healthy.json",
-      "SQLServer high processes blocked": "assets/monitors/sqlserver_high_processes_blocked.json",
-      "SQLServer high failed auto param": "assets/monitors/sqlserver_high_number_failed_auto_param.json",
-      "SQLServer db not online": "assets/monitors/sqlserver_db_not_online.json",
-      "SQLServer db not in sync": "assets/monitors/sqlserver_db_not_sync.json"
+      "Availability Group is not healthy": "assets/monitors/sqlserver_ao_not_healthy.json",
+      "Processes are blocked": "assets/monitors/sqlserver_high_processes_blocked.json",
+      "Auto-parameterization attempts are failing": "assets/monitors/sqlserver_high_number_failed_auto_param.json",
+      "Database is not online": "assets/monitors/sqlserver_db_not_online.json",
+      "Database not in sync": "assets/monitors/sqlserver_db_not_sync.json"
     }
   }
 }

--- a/strimzi/manifest.json
+++ b/strimzi/manifest.json
@@ -58,8 +58,8 @@
       "auto_install": true
     },
     "monitors": {
-      "cluster_operate_resource_state": "assets/monitors/cluster_operator_resource.json",
-      "topic_operate_resource_state": "assets/monitors/topic_operator_resource.json"
+      "Strimzi Cluster Operator Resource on host is in a \"fail\" state\"": "assets/monitors/cluster_operator_resource.json",
+      "Strimzi Topic Operator Resource on host is in a \"fail\" state\"": "assets/monitors/topic_operator_resource.json"
     },
     "dashboards": {
       "strimzi": "assets/dashboards/overview.json"

--- a/teamcity/manifest.json
+++ b/teamcity/manifest.json
@@ -64,7 +64,7 @@
       "TeamCity Overview": "assets/dashboards/overview.json"
     },
     "monitors": {
-      "Build Status": "assets/monitors/build_status.json"
+      "Builds are failing": "assets/monitors/build_status.json"
     },
     "saved_views": {
       "teamcity_processes": "assets/saved_views/teamcity_processes.json"

--- a/tekton/manifest.json
+++ b/tekton/manifest.json
@@ -47,9 +47,9 @@
       "Tekton Overview": "assets/dashboards/overview.json"
     },
     "monitors": {
-      "[Tekton] High number of throttled TaskRuns": "assets/monitors/throttled_taskruns.json",
-      "[Tekton] Increasing number of failed TaskRuns": "assets/monitors/increasing_failed_taskruns.json",
-      "[Tekton] Increasing number of failed PieplineRuns": "assets/monitors/increasing_failed_pipelineruns.json"
+      "TaskRuns are throttled": "assets/monitors/throttled_taskruns.json",
+      "Increasing number of failed TaskRuns": "assets/monitors/increasing_failed_taskruns.json",
+      "Increasing number of failed PipelineRuns": "assets/monitors/increasing_failed_pipelineruns.json"
     },
     "saved_views": {
       "tekton_overview": "assets/saved_views/tekton_overview.json",

--- a/temporal/manifest.json
+++ b/temporal/manifest.json
@@ -55,10 +55,10 @@
       "Temporal Server Overview": "assets/dashboards/server_overview.json"
     },
     "monitors": {
-      "frontend latency": "assets/monitors/FrontendLatency.json",
-      "matching latency": "assets/monitors/MatchingLatency.json",
-      "history latency": "assets/monitors/HistoryLatency.json",
-      "persistence latency": "assets/monitors/PersistenceLatency.json"
+      "Frontend latency is elevated": "assets/monitors/FrontendLatency.json",
+      "Matching Service latency is elevated": "assets/monitors/MatchingLatency.json",
+      "History Service latency is elevated": "assets/monitors/HistoryLatency.json",
+      "Persistence latency is elevated": "assets/monitors/PersistenceLatency.json"
     }
   },
   "author": {

--- a/teradata/manifest.json
+++ b/teradata/manifest.json
@@ -49,8 +49,8 @@
       "Teradata Overview": "assets/dashboards/teradata_overview.json"
     },
     "monitors": {
-      "High disk space": "assets/monitors/high_disk_space.json",
-      "Low ready threads": "assets/monitors/low_ready_threads.json"
+      "Datadase disk space usage is high": "assets/monitors/high_disk_space.json",
+      "Database ready thread count is too low": "assets/monitors/low_ready_threads.json"
     }
   }
 }

--- a/tibco_ems/manifest.json
+++ b/tibco_ems/manifest.json
@@ -48,7 +48,7 @@
       "Tibco EMS Overview": "assets/dashboards/overview.json"
     },
     "monitors": {
-      "Server Uptime": "assets/monitors/server_uptime.json"
+      "Tibco EMS server uptime": "assets/monitors/server_uptime.json"
     },
     "saved_views": {
       "Tibco EMS Error Logs Overview": "assets/saved_views/error_logs_overview.json",

--- a/tomcat/manifest.json
+++ b/tomcat/manifest.json
@@ -68,12 +68,12 @@
       "tomcat": "assets/dashboards/metrics.json"
     },
     "monitors": {
-      "[Tomcat] Anomalous request rate for host {{host.name}}": "assets/monitors/req_count.json",
-      "[Tomcat] Anomalous max processing time for host {{host.name}}": "assets/monitors/max_proc_time.json",
-      "[Tomcat] Anomalous average processing time for host {{host.name}}": "assets/monitors/processing_time.json",
-      "[Tomcat] % of thread count managed by the thread pool is high for host: {{host.name}}": "assets/monitors/thread_count_max.json",
-      "[Tomcat] % of busy threads is high for host: {{host.name}}": "assets/monitors/thread_busy.json",
-      "[Tomcat] Increase of the errors/second rate for host: {{host.name}}": "assets/monitors/error_count.json"
+      "Request rate is anomalous": "assets/monitors/req_count.json",
+      "Processing time has a spike": "assets/monitors/max_proc_time.json",
+      "Processing time is anomalous": "assets/monitors/processing_time.json",
+      "All threads are busy": "assets/monitors/thread_count_max.json",
+      "Busy threads number is high": "assets/monitors/thread_busy.json",
+      "Error rate is high": "assets/monitors/error_count.json"
     },
     "saved_views": {
       "tomcat_processes": "assets/saved_views/tomcat_processes.json",

--- a/torchserve/manifest.json
+++ b/torchserve/manifest.json
@@ -50,7 +50,7 @@
       "auto_install": true
     },
     "monitors": {
-      "error_ratio": "assets/monitors/error_ratio.json"
+      "Request error ratio is high": "assets/monitors/error_ratio.json"
     },
     "dashboards": {
       "torchserve_overview": "assets/dashboards/overview.json"

--- a/traefik_mesh/manifest.json
+++ b/traefik_mesh/manifest.json
@@ -51,7 +51,7 @@
       "Traefik Mesh Overview": "assets/dashboards/traefik_mesh_overview.json"
     },
     "monitors": {
-      "High Request Count": "assets/monitors/high_request_count.json"
+      "Traefik Mesh entrypoint request count failures are high.": "assets/monitors/high_request_count.json"
     },
     "saved_views": {
       "Traefik Mesh Logs Overview": "assets/saved_views/traefik_mesh_log_overview.json",

--- a/traffic_server/manifest.json
+++ b/traffic_server/manifest.json
@@ -56,8 +56,8 @@
       "Traffic Server - Overview": "assets/dashboards/overview.json"
     },
     "monitors": {
-      "[Traffic Server] 4xx Errors higher than usual": "assets/monitors/4xx.json",
-      "[Traffic Server] 5xx Errors higher than usual": "assets/monitors/5xx.json"
+      "4xx errors number is high": "assets/monitors/4xx.json",
+      "5xx errors number is high": "assets/monitors/5xx.json"
     },
     "saved_views": {
       "traffic_server_error_logs": "assets/saved_views/traffic_server_error_logs.json",

--- a/vault/manifest.json
+++ b/vault/manifest.json
@@ -72,7 +72,7 @@
       "Vault - Overview (OpenMetricsV2)": "assets/dashboards/vault_overview.json"
     },
     "monitors": {
-      "[Vault] S3 time to access secrets is high": "assets/monitors/vault_S3_time_high.json"
+      "Time to access secrets is high": "assets/monitors/vault_S3_time_high.json"
     },
     "saved_views": {
       "error_warning_status": "assets/saved_views/error_warning_status.json",

--- a/vertica/manifest.json
+++ b/vertica/manifest.json
@@ -50,7 +50,7 @@
       "Vertica Overview": "assets/dashboards/overview.json"
     },
     "monitors": {
-      "[Vertica] Nodes down above K-safety level": "assets/monitors/vertica_replication_safety.json"
+      "Vertica Nodes down above K-safety level": "assets/monitors/vertica_replication_safety.json"
     }
   }
 }

--- a/vllm/manifest.json
+++ b/vllm/manifest.json
@@ -45,8 +45,8 @@
       ]
     },
     "monitors": {
-      "token_throughput": "assets/monitors/token_throughput.json",
-      "latency": "assets/monitors/latency.json"
+      "vLLM application token usage is high": "assets/monitors/token_throughput.json",
+      "Average Request Latency is High": "assets/monitors/latency.json"
     },
     "dashboards": {
       "vLLM Overview": "assets/dashboards/overview.json"

--- a/voltdb/manifest.json
+++ b/voltdb/manifest.json
@@ -53,7 +53,7 @@
       "VoltDB - Overview": "assets/dashboards/voltdb_overview.json"
     },
     "monitors": {
-      "CPU load": "assets/monitors/cpu_load.json"
+      "Voltdb Node CPU is high": "assets/monitors/cpu_load.json"
     },
     "saved_views": {
       "voltdb_processes": "assets/saved_views/voltdb_processes.json"

--- a/weaviate/manifest.json
+++ b/weaviate/manifest.json
@@ -52,7 +52,7 @@
       "auto_install": true
     },
     "monitors": {
-      "node_status": "assets/monitors/node_status.json"
+      "Weaviate Node in unhealthy state": "assets/monitors/node_status.json"
     },
     "dashboards": {
       "Weaviate Overview Dashboard": "assets/dashboards/overview_dashboard.json"

--- a/weblogic/manifest.json
+++ b/weblogic/manifest.json
@@ -54,8 +54,8 @@
       "metrics": "assets/dashboards/metrics.json"
     },
     "monitors": {
-      "active_threads": "assets/monitors/active_threads.json",
-      "stuck_threads": "assets/monitors/stuck_threads.json"
+      "Number of active thread is high": "assets/monitors/active_threads.json",
+      "Number of stuck thread is high": "assets/monitors/stuck_threads.json"
     },
     "saved_views": {
       "weblogic_error_logs": "assets/saved_views/error_logs.json",

--- a/wincrashdetect/manifest.json
+++ b/wincrashdetect/manifest.json
@@ -37,7 +37,7 @@
       "auto_install": true
     },
     "monitors": {
-      "windows_crash": "assets/monitors/windows_crash.json"
+      "Windows Crash Detection": "assets/monitors/windows_crash.json"
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
https://datadoghq.atlassian.net/browse/MA-5658


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
