### PR TITLE
MySQL 8.4

### DIFF
--- a/mysql/changelog.d/18571.fixed
+++ b/mysql/changelog.d/18571.fixed
@@ -1,0 +1,1 @@
+Fixed a bug in MySQL 8.4 where `SHOW MASTER STATUS` would fail

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -1075,7 +1075,11 @@ class MySql(AgentCheck):
 
         try:
             with closing(db.cursor(CommenterDictCursor)) as cursor:
-                cursor.execute("SHOW MASTER STATUS;")
+                if self.version.version_compatible((8, 4, 0)):
+                    cursor.execute("SHOW BINARY LOG STATUS;")
+                else:
+                    cursor.execute("SHOW MASTER STATUS;")
+                    
                 binlog_results = cursor.fetchone()
                 if binlog_results:
                     replica_results.update({'Binlog_enabled': True})

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -1075,7 +1075,7 @@ class MySql(AgentCheck):
 
         try:
             with closing(db.cursor(CommenterDictCursor)) as cursor:
-                if self.version.version_compatible((8, 4, 0)):
+                if not self.is_mariadb and self.version.version_compatible((8, 4, 0)):
                     cursor.execute("SHOW BINARY LOG STATUS;")
                 else:
                     cursor.execute("SHOW MASTER STATUS;")

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -1079,7 +1079,7 @@ class MySql(AgentCheck):
                     cursor.execute("SHOW BINARY LOG STATUS;")
                 else:
                     cursor.execute("SHOW MASTER STATUS;")
-                    
+
                 binlog_results = cursor.fetchone()
                 if binlog_results:
                     replica_results.update({'Binlog_enabled': True})

--- a/mysql/hatch.toml
+++ b/mysql/hatch.toml
@@ -23,7 +23,7 @@ version = [
 
 [[envs.default.matrix]]
 python = ["3.11"]
-version = ["8.0", "8.4"]
+version = ["8.0"]
 replication = ["group"]
 
 [[envs.default.matrix]]
@@ -44,9 +44,6 @@ matrix.version.env-vars = [
   { key = "COMPOSE_FILE", value = "mysql8.yaml", if = ["8.4.0"] },
 ]
 name."8.0-group".env-vars = [
-  { key = "COMPOSE_FILE", value = "mysql8-group.yaml" },
-]
-name."8.4-group".env-vars = [
   { key = "COMPOSE_FILE", value = "mysql8-group.yaml" },
 ]
 

--- a/mysql/hatch.toml
+++ b/mysql/hatch.toml
@@ -18,11 +18,12 @@ python = ["3.11"]
 version = [
   "5.7",  # EOL October 21, 2023
   "8.0.36",  # EOL April, 2026
+  "8.4.0",
 ]
 
 [[envs.default.matrix]]
 python = ["3.11"]
-version = ["8.0"]
+version = ["8.0", "8.4"]
 replication = ["group"]
 
 [[envs.default.matrix]]
@@ -40,10 +41,15 @@ version = [
 [envs.default.overrides]
 matrix.version.env-vars = [
   { key = "COMPOSE_FILE", value = "mysql8.yaml", if = ["8.0.36"] },
+  { key = "COMPOSE_FILE", value = "mysql8.yaml", if = ["8.4.0"] },
 ]
 name."8.0-group".env-vars = [
   { key = "COMPOSE_FILE", value = "mysql8-group.yaml" },
 ]
+name."8.4-group".env-vars = [
+  { key = "COMPOSE_FILE", value = "mysql8-group.yaml" },
+]
+
 
 [envs.default.env-vars]
 COMPOSE_FILE = "{matrix:flavor:mysql}.yaml"

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -297,7 +297,6 @@ class PostgresMetadata(DBMAsyncJob):
 
             # Tuned from experiments on staging, we may want to make this dynamic based on schema size in the future
             chunk_size = 50
-            start_time = time.time()
 
             for database in schema_metadata:
                 dbname = database["name"]
@@ -330,7 +329,6 @@ class PostgresMetadata(DBMAsyncJob):
 
                             if len(tables_buffer) > 0:
                                 self._flush_schema(base_event, database, schema, tables_buffer)
-            datadog_agent.emit_agent_telemetry("postgres", "schema_collection_elapsed", (time.time() - start_time) * 1000)
             self._is_schemas_collection_in_progress = False
 
     def _should_collect_metadata(self, name, metadata_type):

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -297,6 +297,7 @@ class PostgresMetadata(DBMAsyncJob):
 
             # Tuned from experiments on staging, we may want to make this dynamic based on schema size in the future
             chunk_size = 50
+            start_time = time.time()
 
             for database in schema_metadata:
                 dbname = database["name"]
@@ -329,6 +330,7 @@ class PostgresMetadata(DBMAsyncJob):
 
                             if len(tables_buffer) > 0:
                                 self._flush_schema(base_event, database, schema, tables_buffer)
+            datadog_agent.emit_agent_telemetry("postgres", "schema_collection_elapsed", (time.time() - start_time) * 1000)
             self._is_schemas_collection_in_progress = False
 
     def _should_collect_metadata(self, name, metadata_type):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds MySQL 8.4 to testing suite and fixes bug in 8.4 due to change from `SHOW MASTER STATUS` to `SHOW BINARY LOG STATUS`.

### Motivation
<!-- What inspired you to submit this pull request? -->
MySQL changed the SQL for checking if binlog is enabled in 8.4

### Additional Notes
<!-- Anything else we should know when reviewing? -->
https://datadoghq.atlassian.net/browse/DBMON-4563

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
