### PR TITLE
Fix dependency build for macOS

### DIFF
--- a/.builders/images/macos-x86_64/builder_setup.sh
+++ b/.builders/images/macos-x86_64/builder_setup.sh
@@ -6,10 +6,6 @@ set -euxo pipefail
 "${DD_PYTHON3}" -m pip install --no-warn-script-location virtualenv
 "${DD_PYTHON3}" -m virtualenv py3
 
-"${DD_PYTHON2}" -m pip install --no-warn-script-location --upgrade pip
-"${DD_PYTHON2}" -m pip install --no-warn-script-location virtualenv
-"${DD_PYTHON2}" -m virtualenv py2
-
 # Install always with our own prefix path
 mkdir -p "${DD_PREFIX_PATH}"
 cp "${DD_MOUNT_DIR}/build_context/install-from-source.sh" .

--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -15,6 +15,7 @@ on:
     - master
     - 7.*.*
     paths:
+    - .github/workflows/build-deps.yml
     - .builders/**
     - agent_requirements.in
 

--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -232,7 +232,7 @@ jobs:
       with:
         path: |
           ~/builder_root
-        key: macos-deps-builder-root-cache-${{ hashFiles('./.builders/images/macos/*', './.builders/images/*', './.builders/deps/*', './.builders/build.py') }}
+        key: macos-deps-builder-root-cache-${{ hashFiles('./.builders/images/macos/*', './.builders/images/*', './.builders/deps/*', './.builders/build.py', './.github/workflows/build-deps.yml') }}
 
     - name: Run the build
       env:


### PR DESCRIPTION
### What does this PR do?

- Removes references to DD_PYTHON_2 which is no longer defined at the job.
- Adds workflow file to cache key to prevent this kind of error from not being caught on the PR.
- Adds workflow files to triggers for pushes to master.

### Motivation

https://github.com/DataDog/integrations-core/pull/18577 breaks macOS builds as soon as there's a cache miss during builder setup: https://github.com/DataDog/integrations-core/actions/runs/10836797983/job/30071333931?pr=18212.

We missed this on #18577 because the cache key doesn't include the workflow key despite it potentially affecting the setup.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
