### PR TITLE
[sqlserver] Fix odbc.ini config handling for Linux (SDBM-1171)

### DIFF
--- a/sqlserver/changelog.d/18586.fixed
+++ b/sqlserver/changelog.d/18586.fixed
@@ -1,0 +1,1 @@
+[sqlserver] Fix ODBC config handling for Linux

--- a/sqlserver/datadog_checks/sqlserver/utils.py
+++ b/sqlserver/datadog_checks/sqlserver/utils.py
@@ -62,7 +62,17 @@ def set_default_driver_conf():
         # by getting the path to the python executable and get the directory above /bin/python
         linux_unixodbc_sysconfig = get_unixodbc_sysconfig(sys.executable)
         odbc_ini = os.path.join(linux_unixodbc_sysconfig, 'odbc.ini')
-        if os.path.exists(odbc_ini) and os.path.getsize(odbc_ini) > 0:
+        if os.path.exists(odbc_ini):
+            exists = False
+            try:
+                if os.path.getsize(odbc_ini) > 0:
+                    exists = True
+            # exists and getsize aren't atomic 
+            except FileNotFoundError as e:
+                exists = False
+            if not exists:
+                return
+            
             os.environ.setdefault('ODBCSYSINI', linux_unixodbc_sysconfig)
             odbc_inst_ini_sysconfig = os.path.join(linux_unixodbc_sysconfig, ODBC_INST_INI)
             if not os.path.exists(odbc_inst_ini_sysconfig) or os.path.getsize(odbc_inst_ini_sysconfig) == 0:

--- a/sqlserver/datadog_checks/sqlserver/utils.py
+++ b/sqlserver/datadog_checks/sqlserver/utils.py
@@ -74,16 +74,17 @@ def set_default_driver_conf():
         # by getting the path to the python executable and get the directory above /bin/python
         linux_unixodbc_sysconfig = get_unixodbc_sysconfig(sys.executable)
         odbc_ini = os.path.join(linux_unixodbc_sysconfig, 'odbc.ini')
-        if not is_non_empty_file(odbc_ini):
-            return
+        if is_non_empty_file(odbc_ini):
+            os.environ.setdefault('ODBCSYSINI', linux_unixodbc_sysconfig)
+            odbc_inst_ini_sysconfig = os.path.join(linux_unixodbc_sysconfig, ODBC_INST_INI)
+            if not is_non_empty_file(odbc_inst_ini_sysconfig):
+                shutil.copy(os.path.join(DRIVER_CONFIG_DIR, ODBC_INST_INI), odbc_inst_ini_sysconfig)
+                # If there are already drivers or dataSources installed, don't override the ODBCSYSINI
+                # This means user has copied odbcinst.ini and odbc.ini to the unixODBC sysconfig location
+                return
 
-        os.environ.setdefault('ODBCSYSINI', linux_unixodbc_sysconfig)
-        odbc_inst_ini_sysconfig = os.path.join(linux_unixodbc_sysconfig, ODBC_INST_INI)
-        if not is_non_empty_file(odbc_inst_ini_sysconfig):
-            shutil.copy(os.path.join(DRIVER_CONFIG_DIR, ODBC_INST_INI), odbc_inst_ini_sysconfig)
-            # If there are already drivers or dataSources installed, don't override the ODBCSYSINI
-            # This means user has copied odbcinst.ini and odbc.ini to the unixODBC sysconfig location
-            return
+        # Use default `./driver_config/odbcinst.ini` to let the integration use agent embedded odbc driver.
+        os.environ.setdefault('ODBCSYSINI', DRIVER_CONFIG_DIR)
 
         # required when using pyodbc with FreeTDS on Ubuntu 18.04
         # see https://stackoverflow.com/a/22988748/1258743

--- a/sqlserver/datadog_checks/sqlserver/utils.py
+++ b/sqlserver/datadog_checks/sqlserver/utils.py
@@ -40,14 +40,14 @@ def get_unixodbc_sysconfig(python_executable):
 
 def is_non_empty_file(path):
     if not os.path.exists(path):
-        return
+        return False
     try:
         if os.path.getsize(path) > 0:
             return True
     # exists and getsize aren't atomic
     except FileNotFoundError:
-        return
-    return
+        return False
+    return False
 
 
 def set_default_driver_conf():

--- a/sqlserver/datadog_checks/sqlserver/utils.py
+++ b/sqlserver/datadog_checks/sqlserver/utils.py
@@ -33,8 +33,10 @@ class Database:
     def __str__(self):
         return "name:{}, physical_db_name:{}".format(self.name, self.physical_db_name)
 
+
 def get_unixodbc_sysconfig(python_executable):
-    return os.path.join(os.path.dirname(os.path.dirname(python_executable)),"etc")
+    return os.path.join(os.path.dirname(os.path.dirname(python_executable)), "etc")
+
 
 def set_default_driver_conf():
     if Platform.is_containerized():

--- a/sqlserver/datadog_checks/sqlserver/utils.py
+++ b/sqlserver/datadog_checks/sqlserver/utils.py
@@ -37,16 +37,18 @@ class Database:
 def get_unixodbc_sysconfig(python_executable):
     return os.path.join(os.path.dirname(os.path.dirname(python_executable)), "etc")
 
+
 def is_non_empty_file(path):
     if not os.path.exists(path):
         return
     try:
         if os.path.getsize(path) > 0:
             return True
-    # exists and getsize aren't atomic 
-    except FileNotFoundError as e:
+    # exists and getsize aren't atomic
+    except FileNotFoundError:
         return
     return
+
 
 def set_default_driver_conf():
     if Platform.is_containerized():
@@ -74,7 +76,7 @@ def set_default_driver_conf():
         odbc_ini = os.path.join(linux_unixodbc_sysconfig, 'odbc.ini')
         if not is_non_empty_file(odbc_ini):
             return
-            
+
         os.environ.setdefault('ODBCSYSINI', linux_unixodbc_sysconfig)
         odbc_inst_ini_sysconfig = os.path.join(linux_unixodbc_sysconfig, ODBC_INST_INI)
         if not is_non_empty_file(odbc_inst_ini_sysconfig):

--- a/sqlserver/datadog_checks/sqlserver/utils.py
+++ b/sqlserver/datadog_checks/sqlserver/utils.py
@@ -31,6 +31,8 @@ class Database:
     def __str__(self):
         return "name:{}, physical_db_name:{}".format(self.name, self.physical_db_name)
 
+def get_unixodbc_sysconfig(python_executable):
+    return os.path.join(os.path.dirname(os.path.dirname(python_executable)),"etc")
 
 def set_default_driver_conf():
     if Platform.is_containerized():

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -645,3 +645,14 @@ def test_obfuscate_error_msg(
 ):
     obfuscated_error_message = obfuscate_error_msg(error_message, password)
     assert obfuscated_error_message == expected_error_message
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_linux_connection(instance_docker):
+    check = SQLServer(CHECK_NAME, {}, [instance_docker])
+    check.initialize_connection()
+    with check.connection.open_managed_default_connection():
+        with check.connection.get_managed_cursor() as cursor:
+            # should complete quickly
+            cursor.execute("select 1")
+            assert cursor.fetchall(), "should have a result here"

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import importlib
 import os
 import re
 
@@ -8,7 +9,9 @@ import mock
 import pyodbc
 import pytest
 
+import datadog_checks.sqlserver
 from datadog_checks.base import ConfigurationError
+from datadog_checks.dev import EnvVars
 from datadog_checks.dev.utils import running_on_windows_ci
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.connection import (
@@ -645,14 +648,3 @@ def test_obfuscate_error_msg(
 ):
     obfuscated_error_message = obfuscate_error_msg(error_message, password)
     assert obfuscated_error_message == expected_error_message
-
-@pytest.mark.integration
-@pytest.mark.usefixtures('dd_environment')
-def test_linux_connection(instance_docker):
-    check = SQLServer(CHECK_NAME, {}, [instance_docker])
-    check.initialize_connection()
-    with check.connection.open_managed_default_connection():
-        with check.connection.get_managed_cursor() as cursor:
-            # should complete quickly
-            cursor.execute("select 1")
-            assert cursor.fetchall(), "should have a result here"

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -1,7 +1,6 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import importlib
 import os
 import re
 
@@ -9,9 +8,7 @@ import mock
 import pyodbc
 import pytest
 
-import datadog_checks.sqlserver
 from datadog_checks.base import ConfigurationError
-from datadog_checks.dev import EnvVars
 from datadog_checks.dev.utils import running_on_windows_ci
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.connection import (

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -12,7 +12,7 @@ import mock
 import pytest
 
 from datadog_checks.dev import EnvVars
-from datadog_checks.dev.ci import running_on_linux_ci
+from datadog_checks.dev.ci import running_on_windows_ci
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.connection import split_sqlserver_host_port
 from datadog_checks.sqlserver.metrics import SqlFractionMetric, SqlMasterDatabaseFileStats
@@ -870,7 +870,7 @@ def test_exception_handling_by_do_for_dbs(instance_docker):
         schemas._fetch_for_databases()
 
 
-@pytest.mark.skipif(running_on_linux_ci(), reason='Relevant only for Linux')
+@pytest.mark.skipif(running_on_windows_ci(), reason='Relevant only for Linux')
 def test_get_unixodbc_sysconfig():
     assert (
         get_unixodbc_sysconfig("/opt/datadog-agent/embedded/bin/python") == "/opt/datadog-agent/embedded/etc"

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -7,12 +7,12 @@ import os
 import re
 import time
 from collections import namedtuple
-from datadog_checks.dev.utils import running_on_linux_ci
 
 import mock
 import pytest
 
 from datadog_checks.dev import EnvVars
+from datadog_checks.dev.utils import running_on_linux_ci
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.connection import split_sqlserver_host_port
 from datadog_checks.sqlserver.metrics import SqlFractionMetric, SqlMasterDatabaseFileStats
@@ -868,6 +868,7 @@ def test_exception_handling_by_do_for_dbs(instance_docker):
         'datadog_checks.sqlserver.utils.is_azure_sql_database', return_value={}
     ):
         schemas._fetch_for_databases()
+
 
 @pytest.mark.skipif(running_on_linux_ci(), reason='Relevant only for Linux')
 def test_get_unixodbc_sysconfig():

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -12,7 +12,7 @@ import mock
 import pytest
 
 from datadog_checks.dev import EnvVars
-from datadog_checks.dev.utils import running_on_linux_ci
+from datadog_checks.dev.ci import running_on_linux_ci
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.connection import split_sqlserver_host_port
 from datadog_checks.sqlserver.metrics import SqlFractionMetric, SqlMasterDatabaseFileStats

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -27,7 +27,7 @@ from datadog_checks.sqlserver.utils import (
 )
 
 from .common import CHECK_NAME, DOCKER_SERVER, assert_metrics
-from .utils import deep_compare, windows_ci
+from .utils import deep_compare, not_windows_ci, windows_ci
 
 try:
     import pyodbc
@@ -458,6 +458,9 @@ def test_set_default_driver_conf():
             set_default_driver_conf()
             assert os.environ['ODBCSYSINI'] == 'ABC'
 
+
+@not_windows_ci
+def test_set_default_driver_conf_linux():
     odbc_config_dir = os.path.expanduser('~')
     with mock.patch("datadog_checks.sqlserver.utils.get_unixodbc_sysconfig", return_value=odbc_config_dir):
         with EnvVars({}, ignore=['ODBCSYSINI']):

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -878,7 +878,10 @@ def test_exception_handling_by_do_for_dbs(instance_docker):
 
 
 def test_get_unixodbc_sysconfig():
-    assert get_unixodbc_sysconfig("/opt/datadog-agent/embedded/bin/python").split(os.path.sep) == [
+    etc_dir = "/opt"
+    for dir in ["datadog-agent", "embedded", "bin", "python"]:
+        etc_dir = os.path.join(etc_dir, dir)
+    assert get_unixodbc_sysconfig(etc_dir).split(os.path.sep) == [
         "",
         "opt",
         "datadog-agent",

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -20,6 +20,7 @@ from datadog_checks.sqlserver.sqlserver import SQLConnectionError
 from datadog_checks.sqlserver.utils import (
     Database,
     extract_sql_comments_and_procedure_name,
+    get_unixodbc_sysconfig,
     parse_sqlserver_major_version,
     set_default_driver_conf,
 )
@@ -866,3 +867,6 @@ def test_exception_handling_by_do_for_dbs(instance_docker):
         'datadog_checks.sqlserver.utils.is_azure_sql_database', return_value={}
     ):
         schemas._fetch_for_databases()
+        
+def test_get_unixodbc_sysconfig():
+    assert get_unixodbc_sysconfig("/opt/datadog-agent/embedded/bin/python") == "/opt/datadog-agent/embedded/etc", "incorrect unix odbc config dir"

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -864,7 +864,7 @@ def test_exception_handling_by_do_for_dbs(instance_docker):
         schemas._fetch_for_databases()
 
 
-@pytest.mark.skipif(running_on_linux_ci(), reason='Relevant only for Linux')
+@pytest.mark.skipif(not running_on_linux_ci(), reason='Relevant only for Linux')
 def test_get_unixodbc_sysconfig():
     assert (
         get_unixodbc_sysconfig("/opt/datadog-agent/embedded/bin/python") == "/opt/datadog-agent/embedded/etc"

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -5,12 +5,12 @@ import copy
 import json
 import os
 import re
+import sys
 import time
 from collections import namedtuple
 
 import mock
 import pytest
-import sys
 
 from datadog_checks.dev import EnvVars
 from datadog_checks.sqlserver import SQLServer
@@ -458,7 +458,7 @@ def test_set_default_driver_conf():
         with EnvVars({'ODBCSYSINI': 'ABC'}):
             set_default_driver_conf()
             assert os.environ['ODBCSYSINI'] == 'ABC'
-    
+
     odbc_config_dir = os.path.expanduser('~')
     with mock.patch("datadog_checks.sqlserver.utils.get_unixodbc_sysconfig", return_value=odbc_config_dir):
         with EnvVars({}, ignore=['ODBCSYSINI']):
@@ -471,7 +471,7 @@ def test_set_default_driver_conf():
                 file.write("dummy-content")
             set_default_driver_conf()
             assert is_non_empty_file(odbc_inst), "odbc_inst should have been created"
-        
+
 
 @windows_ci
 def test_check_local(aggregator, dd_run_check, init_config, instance_docker):
@@ -886,5 +886,3 @@ def test_get_unixodbc_sysconfig():
         "embedded",
         "etc",
     ], "incorrect unix odbc config dir"
-
-    

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -7,6 +7,7 @@ import os
 import re
 import time
 from collections import namedtuple
+from datadog_checks.dev.utils import running_on_linux_ci
 
 import mock
 import pytest
@@ -868,7 +869,7 @@ def test_exception_handling_by_do_for_dbs(instance_docker):
     ):
         schemas._fetch_for_databases()
 
-
+@pytest.mark.skipif(running_on_linux_ci(), reason='Relevant only for Linux')
 def test_get_unixodbc_sysconfig():
     assert (
         get_unixodbc_sysconfig("/opt/datadog-agent/embedded/bin/python") == "/opt/datadog-agent/embedded/etc"

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -867,6 +867,9 @@ def test_exception_handling_by_do_for_dbs(instance_docker):
         'datadog_checks.sqlserver.utils.is_azure_sql_database', return_value={}
     ):
         schemas._fetch_for_databases()
-        
+
+
 def test_get_unixodbc_sysconfig():
-    assert get_unixodbc_sysconfig("/opt/datadog-agent/embedded/bin/python") == "/opt/datadog-agent/embedded/etc", "incorrect unix odbc config dir"
+    assert (
+        get_unixodbc_sysconfig("/opt/datadog-agent/embedded/bin/python") == "/opt/datadog-agent/embedded/etc"
+    ), "incorrect unix odbc config dir"

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -12,7 +12,7 @@ import mock
 import pytest
 
 from datadog_checks.dev import EnvVars
-from datadog_checks.dev.ci import running_on_windows_ci
+from datadog_checks.dev.ci import running_on_linux_ci
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.connection import split_sqlserver_host_port
 from datadog_checks.sqlserver.metrics import SqlFractionMetric, SqlMasterDatabaseFileStats
@@ -454,12 +454,6 @@ def test_set_default_driver_conf():
                 set_default_driver_conf()
                 assert 'ODBCSYSINI' not in os.environ
 
-        with EnvVars({}, ignore=['ODBCSYSINI']):
-            set_default_driver_conf()
-            assert 'ODBCSYSINI' in os.environ  # ODBCSYSINI is set by the integration
-            if pyodbc is not None:
-                assert pyodbc.drivers() is not None
-
         with EnvVars({'ODBCSYSINI': 'ABC'}):
             set_default_driver_conf()
             assert os.environ['ODBCSYSINI'] == 'ABC'
@@ -870,7 +864,7 @@ def test_exception_handling_by_do_for_dbs(instance_docker):
         schemas._fetch_for_databases()
 
 
-@pytest.mark.skipif(running_on_windows_ci(), reason='Relevant only for Linux')
+@pytest.mark.skipif(running_on_linux_ci(), reason='Relevant only for Linux')
 def test_get_unixodbc_sysconfig():
     assert (
         get_unixodbc_sysconfig("/opt/datadog-agent/embedded/bin/python") == "/opt/datadog-agent/embedded/etc"

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -5,7 +5,6 @@ import copy
 import json
 import os
 import re
-import sys
 import time
 from collections import namedtuple
 


### PR DESCRIPTION
### What does this PR do?
Fix `odbc.ini` config handling for Linux.

### Motivation
With some recent changes, `/opt/datadog-agent/embedded/etc` wasn't in the ODBC config search path anymore. For example, in [this escalation](https://datadoghq.atlassian.net/browse/), the customer upgraded from `7.53` to `7.56.2` and `odbc.ini` stored in `/opt/datadog-agent/embedded/etc` was ignored.

### Additional Notes
`odbc.ini` is looked for in the directory configured in the `ODBCSYSINI` environment variable. `odbcinst.ini` have to be in the same directory.

The algorithm:
1. If the environment variable `ODBCSYSINI` is set externally, we don't do anything - that step remained unchanged.
2. Change: if `ODBCSYSINI` isn't set  and there's a non-empty `odbc.ini` in `/opt/datadog-agent/embedded/etc`, the Agent sets `ODBCSYSINI` to `/opt/datadog-agent/embedded/etc`. If `odbcinst.ini` is missing or it exists, but it's empty, the Agent copy's `/opt/datadog-agent/embedded/lib/python3.11/sitepackages/datadog_checks/sqlserver/data/driver_config/odbcinst.ini` to `/opt/datadog-agent/embedded/etc/odbcinst.ini`. `/opt/datadog-agent/embedded/etc` is the default ODBC configuration directory for the Agent.
3. Change: The agent never sets `ODBCSYSINI` to `/opt/datadog-agent/embedded/lib/python3.11/sitepackages/datadog_checks/sqlserver/data/driver_config/odbcinst.ini` because a customer would never create `odbc.ini` in this directory.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
