### PR TITLE
Fix test for license validation

### DIFF
--- a/ddev/tests/cli/validate/test_licenses.py
+++ b/ddev/tests/cli/validate/test_licenses.py
@@ -81,7 +81,7 @@ def test_invalid_requirement(repository, ddev, helpers):
     with agent_requirements_path.open(encoding='utf-8') as file:
         requirements = file.readlines()
 
-    requirements[0] = requirements[0].replace('==', '==^')
+    requirements[0] = "aerospike==^4.0.0; sys_platform != 'win32' and sys_platform != 'darwin'\n"
 
     with agent_requirements_path.open(mode='w', encoding='utf-8') as file:
         file.writelines(requirements[:3])


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes the mock fixture data for a ddev test.

### Motivation
<!-- What inspired you to submit this pull request? -->
The test is relying on real data **in the master branch**. So it passed when for the [PR that changed this data](https://github.com/DataDog/integrations-core/pull/18417) but as soon as we merged to master it started failing.

I have it on my radar to fix this testing setup, it's a drag.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
