### PR TITLE
Update README.md

### DIFF
--- a/dcgm/README.md
+++ b/dcgm/README.md
@@ -97,7 +97,7 @@ To configure the exporter in a Docker environment:
 1. Create the file `$PWD/default-counters.csv` which contains the default fields from NVIDIA `etc/default-counters.csv` as well as additional Datadog-recommended fields. To add more fields for collection, follow [these instructions][9]. For the complete list of fields, see the [DCGM API reference manual][10].
 2. Run the Docker container using the following command:
    ```shell
-   sudo docker run --pid=host --privileged -e DCGM_EXPORTER_INTERVAL=3 --gpus all -d -v /proc:/proc -v $PWD/default-counters.csv:/etc/dcgm-exporter/default-counters.csv -p 9400:9400 --name dcgm-exporter nvcr.io/nvidia/k8s/dcgm-exporter:3.1.7-3.1.4-ubuntu20.04
+   sudo docker run --pid=host --privileged -e DCGM_EXPORTER_INTERVAL=30000 --gpus all -d -v /proc:/proc -v $PWD/default-counters.csv:/etc/dcgm-exporter/default-counters.csv -p 9400:9400 --name dcgm-exporter nvcr.io/nvidia/k8s/dcgm-exporter:3.1.7-3.1.4-ubuntu20.04
    ```
 
 <!-- xxz tab xxx -->


### PR DESCRIPTION
A value of 3 in DCGM_EXPORTER_INTERVAL means it pulls updates every 3ms, which is quite high and can cause high CPU usage. 

Default is 30000 (30s): 
See: https://github.com/NVIDIA/dcgm-exporter/issues/311 
And: https://docs.nvidia.com/datacenter/cloud-native/gpu-telemetry/latest/dcgm-exporter.html#dcgm-exporter-customization

### What does this PR do?
Change proposed value to sane number.

### Motivation
Applying this configuration can cause high CPU usage and unforeseen results.

### Additional Notes
No

### Review checklist (to be filled by reviewers)

- [X ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [X ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [X ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
