### PR TITLE
[PLINT-508] Fixed excluded host tags for property metrics in vSphere

### DIFF
--- a/vsphere/changelog.d/18601.fixed
+++ b/vsphere/changelog.d/18601.fixed
@@ -1,0 +1,1 @@
+Fixed excluded host tags for property metrics

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -903,10 +903,10 @@ class VSphereCheck(AgentCheck):
             return
 
         base_tags = []
-        for tag in resource_tags:
-            if self._config.excluded_host_tags and tag.split(':', 1)[0] not in self._config.excluded_host_tags:
-                continue
-            base_tags.append(tag)
+        if self._config.excluded_host_tags:
+            base_tags.extend([t for t in resource_tags if t.split(":", 1)[0] in self._config.excluded_host_tags])
+        else:
+            base_tags.extend(resource_tags)
         base_tags.extend(self._config.base_tags)
 
         if resource_type == vim.VirtualMachine:

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -902,7 +902,12 @@ class VSphereCheck(AgentCheck):
             )
             return
 
-        base_tags = self._config.base_tags + resource_tags
+        base_tags = []
+        for tag in resource_tags:
+            if self._config.excluded_host_tags and tag.split(':', 1)[0] not in self._config.excluded_host_tags:
+                continue
+            base_tags.append(tag)
+        base_tags.extend(self._config.base_tags)
 
         if resource_type == vim.VirtualMachine:
             object_properties = self._config.object_properties_to_collect_by_mor.get(resource_metric_suffix, [])

--- a/vsphere/tests/test_unit.py
+++ b/vsphere/tests/test_unit.py
@@ -3181,7 +3181,9 @@ def test_property_metrics_invalid_ip_route_config_gateway(
     )
 
 
-def test_property_metrics_excluded_host_tags(aggregator, realtime_instance, dd_run_check, caplog, service_instance, vm_properties_ex):
+def test_property_metrics_excluded_host_tags(
+    aggregator, realtime_instance, dd_run_check, caplog, service_instance, vm_properties_ex
+):
     realtime_instance['collect_property_metrics'] = True
 
     service_instance.content.propertyCollector.RetrievePropertiesEx = vm_properties_ex


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR just takes the logic for excluded host tags [already being used](https://github.com/DataDog/integrations-core/blob/master/vsphere/datadog_checks/vsphere/vsphere.py#L442) for non-property metrics, and applies it to property metrics.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
