### PR TITLE
[Release] Bumped sqlserver version to 17.5.3

### DIFF
--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -159,7 +159,7 @@ datadog-snowflake==5.9.0
 datadog-solr==1.13.0
 datadog-sonarqube==3.2.2
 datadog-spark==4.3.1
-datadog-sqlserver==17.5.2
+datadog-sqlserver==17.5.3
 datadog-squid==2.5.1
 datadog-ssh-check==2.10.0
 datadog-statsd==1.12.0

--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 17.5.3 / 2024-09-17
+
+***Fixed***:
+
+* Fix ODBC config handling for Linux ([#18586](https://github.com/DataDog/integrations-core/pull/18586))
+
 ## 17.5.2 / 2024-08-28 / Agent 7.57.0
 
 ***Fixed***:

--- a/sqlserver/changelog.d/18586.fixed
+++ b/sqlserver/changelog.d/18586.fixed
@@ -1,1 +1,1 @@
-[sqlserver] Fix ODBC config handling for Linux
+Fix ODBC config handling for Linux

--- a/sqlserver/changelog.d/18586.fixed
+++ b/sqlserver/changelog.d/18586.fixed
@@ -1,1 +1,0 @@
-Fix ODBC config handling for Linux

--- a/sqlserver/datadog_checks/sqlserver/__about__.py
+++ b/sqlserver/datadog_checks/sqlserver/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = '17.5.2'
+__version__ = '17.5.3'


### PR DESCRIPTION
### What does this PR do?
Porting changelog and versions from 7.58.x release
