### PR TITLE
Remove beta label from Cisco SD-WAN

### DIFF
--- a/cisco_sdwan/README.md
+++ b/cisco_sdwan/README.md
@@ -1,4 +1,3 @@
-<div class="alert alert-info">The Cisco SD-WAN NDM integration is in public beta.</div>
 
 # Agent Check: Cisco SD-WAN
 

--- a/cisco_sdwan/README.md
+++ b/cisco_sdwan/README.md
@@ -1,3 +1,4 @@
+<div class="alert alert-info">The Cisco SD-WAN NDM integration is in Preview.</div>
 
 # Agent Check: Cisco SD-WAN
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
Remove beta label from Cisco SD-WAN and changing to "in Preview" - not quite ready for GA

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
