### PR TITLE
Drop 'six' from some more checks.

### DIFF
--- a/activemq_xml/datadog_checks/activemq_xml/activemq_xml.py
+++ b/activemq_xml/datadog_checks/activemq_xml/activemq_xml.py
@@ -4,7 +4,6 @@
 from xml.etree import ElementTree
 
 import requests
-from six import iteritems
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.config import _is_affirmative
@@ -95,7 +94,7 @@ class ActiveMQXML(AgentCheck):
                 continue
 
             el_tags = tags + ["{0}:{1}".format(el_type, name)]
-            for attr_name, alias in iteritems(TOPIC_QUEUE_METRICS):
+            for attr_name, alias in TOPIC_QUEUE_METRICS.items():
                 metric_name = "activemq.{0}.{1}".format(el_type, alias)
                 value = stats.get(attr_name, 0)
                 self.gauge(metric_name, value, tags=el_tags)

--- a/ambari/datadog_checks/ambari/ambari.py
+++ b/ambari/datadog_checks/ambari/ambari.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from requests.exceptions import ConnectionError, HTTPError, Timeout
-from six import iteritems
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.constants import ServiceCheck
@@ -96,7 +95,7 @@ class AmbariCheck(AgentCheck):
                     continue
 
                 metrics = self.flatten_host_metrics(host_metrics)
-                for metric_name, value in iteritems(metrics):
+                for metric_name, value in metrics.items():
                     metric_tags = self.base_tags + [cluster_tag]
                     if isinstance(value, float):
                         self._submit_gauge(metric_name, value, metric_tags, hostname)
@@ -111,7 +110,7 @@ class AmbariCheck(AgentCheck):
 
         for cluster in clusters:
             tags = self.base_tags + [CLUSTER_TAG_TEMPLATE.format(cluster)]
-            for service, components in iteritems(self.included_services):
+            for service, components in self.included_services.items():
                 service_tags = tags + [SERVICE_TAG + service.lower()]
 
                 if collect_service_metrics:
@@ -144,7 +143,7 @@ class AmbariCheck(AgentCheck):
 
         component_metrics_endpoint = common.create_endpoint(self.base_url, cluster, service, COMPONENT_METRICS_QUERY)
         components_response = self._make_request(component_metrics_endpoint)
-        component_included = {k.upper(): v for k, v in iteritems(component_included)}
+        component_included = {k.upper(): v for k, v in component_included.items()}
 
         if components_response is None or 'items' not in components_response:
             self.log.warning("No components found for service %s.", service)
@@ -171,7 +170,7 @@ class AmbariCheck(AgentCheck):
 
                 metrics = self.flatten_service_metrics(component_metrics[header], header)
                 component_tag = COMPONENT_TAG + component_name.lower()
-                for metric_name, value in iteritems(metrics):
+                for metric_name, value in metrics.items():
                     metric_tags = base_tags + [component_tag]
                     if isinstance(value, float):
                         self._submit_gauge(metric_name, value, metric_tags)
@@ -206,7 +205,7 @@ class AmbariCheck(AgentCheck):
     @classmethod
     def flatten_service_metrics(cls, metric_dict, prefix):
         flat_metrics = {}
-        for raw_metric_name, metric_value in iteritems(metric_dict):
+        for raw_metric_name, metric_value in metric_dict.items():
             if isinstance(metric_value, dict):
                 flat_metrics.update(cls.flatten_service_metrics(metric_value, prefix))
             else:
@@ -217,7 +216,7 @@ class AmbariCheck(AgentCheck):
     @classmethod
     def flatten_host_metrics(cls, metric_dict, prefix=""):
         flat_metrics = {}
-        for raw_metric_name, metric_value in iteritems(metric_dict):
+        for raw_metric_name, metric_value in metric_dict.items():
             metric_name = '{}.{}'.format(prefix, raw_metric_name) if prefix else raw_metric_name
             if raw_metric_name == "boottime":
                 flat_metrics["boottime"] = metric_value

--- a/btrfs/datadog_checks/btrfs/btrfs.py
+++ b/btrfs/datadog_checks/btrfs/btrfs.py
@@ -11,8 +11,6 @@ import struct
 from collections import defaultdict
 
 import psutil
-from six import iteritems
-from six.moves import range
 
 from datadog_checks.base import AgentCheck
 
@@ -175,7 +173,7 @@ class BTRFS(AgentCheck):
         if len(btrfs_devices) == 0:
             raise Exception("No btrfs device found")
 
-        for device, mountpoint in iteritems(btrfs_devices):
+        for device, mountpoint in btrfs_devices.items():
             for flags, total_bytes, used_bytes in self.get_usage(mountpoint):
                 replication_type, usage_type = FLAGS_MAPPER[flags]
                 tags = [

--- a/ceph/datadog_checks/ceph/ceph.py
+++ b/ceph/datadog_checks/ceph/ceph.py
@@ -7,7 +7,6 @@ import os
 import re
 
 import simplejson as json
-from six import iteritems
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.config import _is_affirmative
@@ -149,7 +148,7 @@ class Ceph(AgentCheck):
             # so we won't send the metric osd.pct_used
             if 'checks' in raw['health_detail']:
                 checks = raw['health_detail']['checks']
-                for check_name, check_detail in iteritems(checks):
+                for check_name, check_detail in checks.items():
                     if check_name == 'OSD_NEARFULL':
                         health['num_near_full_osds'] = len(check_detail['detail'])
                     if check_name == 'OSD_FULL':

--- a/cisco_aci/datadog_checks/cisco_aci/aci_metrics.py
+++ b/cisco_aci/datadog_checks/cisco_aci/aci_metrics.py
@@ -2,8 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from six import iteritems
-
 METRIC_PREFIX = "cisco_aci"
 
 FABRIC_PREFIX = METRIC_PREFIX + ".fabric"
@@ -106,11 +104,11 @@ def make_tenant_metrics():
 
     tenant_metrics = {"tenant": {}, "application": {}, "endpoint_group": {}}
 
-    for cisco_metric, metric_map in iteritems(metrics):
+    for cisco_metric, metric_map in metrics.items():
         tenant_metrics["tenant"][cisco_metric] = {}
         tenant_metrics["application"][cisco_metric] = {}
         tenant_metrics["endpoint_group"][cisco_metric] = {}
-        for sub_metric, dd_metric in iteritems(metric_map):
+        for sub_metric, dd_metric in metric_map.items():
             dd_tenant_metric = dd_metric.format(TENANT_PREFIX)
             tenant_metrics["tenant"][cisco_metric][sub_metric] = dd_tenant_metric
             dd_app_metric = dd_metric.format(APPLICATION_PREFIX)
@@ -118,10 +116,10 @@ def make_tenant_metrics():
             dd_epg_metric = dd_metric.format(ENDPOINT_GROUP_PREFIX)
             tenant_metrics["endpoint_group"][cisco_metric][sub_metric] = dd_epg_metric
 
-    for cisco_metric, metric_map in iteritems(endpoint_metrics):
+    for cisco_metric, metric_map in endpoint_metrics.items():
         if not tenant_metrics.get("endpoint_group", {}).get(cisco_metric):
             tenant_metrics["endpoint_group"][cisco_metric] = {}
-        for sub_metric, dd_metric in iteritems(metric_map):
+        for sub_metric, dd_metric in metric_map.items():
             dd_epg_metric = dd_metric.format(TENANT_PREFIX)
             tenant_metrics["endpoint_group"][cisco_metric][sub_metric] = dd_epg_metric
 

--- a/cisco_aci/datadog_checks/cisco_aci/capacity.py
+++ b/cisco_aci/datadog_checks/cisco_aci/capacity.py
@@ -2,8 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from six import iteritems
-
 from . import aci_metrics, exceptions, helpers
 
 
@@ -49,7 +47,7 @@ class Capacity:
         self.log.info("finished collecting capacity data")
 
     def _get_eqpt_capacity(self):
-        for c, metric_dict in iteritems(aci_metrics.EQPT_CAPACITY_METRICS):
+        for c, metric_dict in aci_metrics.EQPT_CAPACITY_METRICS.items():
             data = self.api.get_eqpt_capacity(c)
             for d in data:
                 dn = d.get('attributes', {}).get('dn')
@@ -63,14 +61,14 @@ class Capacity:
                     child_attrs = child.get(c, {}).get('attributes')
                     if not child_attrs or type(child_attrs) is not dict:
                         continue
-                    for cisco_metric, dd_metric in iteritems(metric_dict):
+                    for cisco_metric, dd_metric in metric_dict.items():
                         value = child_attrs.get(cisco_metric)
                         if not value:
                             continue
                         self.gauge(dd_metric, value, tags=tags, hostname=hostname)
 
     def _get_contexts(self):
-        for c, metric_dict in iteritems(aci_metrics.CAPACITY_CONTEXT_METRICS):
+        for c, metric_dict in aci_metrics.CAPACITY_CONTEXT_METRICS.items():
             dd_metric = metric_dict.get("metric_name")
             utilized_metric_name = dd_metric + ".utilized"
             # These Values are, for some reason, hardcoded in the UI
@@ -105,7 +103,7 @@ class Capacity:
 
     def _get_apic_capacity_metrics(self):
         tags = self.user_tags + self.check_tags
-        for c, opts in iteritems(aci_metrics.APIC_CAPACITY_METRICS):
+        for c, opts in aci_metrics.APIC_CAPACITY_METRICS.items():
             dd_metric = opts.get("metric_name")
             data = self.api.get_apic_capacity_metrics(c, query=opts.get("query_string"))
             if c == "fabricNode":

--- a/cisco_aci/datadog_checks/cisco_aci/cisco.py
+++ b/cisco_aci/datadog_checks/cisco_aci/cisco.py
@@ -1,8 +1,6 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from six import iteritems
-
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.config import _is_affirmative
 from datadog_checks.base.utils.containers import hash_mutable
@@ -146,7 +144,7 @@ class CiscoACICheck(AgentCheck):
             instance = {}
 
         user_tags = instance.get('tags', [])
-        for mname, mval in iteritems(metrics):
+        for mname, mval in metrics.items():
             tags_to_send = []
             if mval:
                 if hostname:
@@ -162,7 +160,7 @@ class CiscoACICheck(AgentCheck):
 
     def get_external_host_tags(self):
         external_host_tags = []
-        for hostname, tags in iteritems(self.external_host_tags):
+        for hostname, tags in self.external_host_tags.items():
             host_tags = tags + self.check_tags
             external_host_tags.append((hostname, {SOURCE_TYPE: host_tags}))
         return external_host_tags

--- a/cisco_aci/datadog_checks/cisco_aci/fabric.py
+++ b/cisco_aci/datadog_checks/cisco_aci/fabric.py
@@ -1,14 +1,9 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
-
-from six import PY3, iteritems
+import time
 
 from datadog_checks.base.utils.serialization import json
-
-if PY3:
-    import time
 
 from . import aci_metrics, exceptions, helpers, ndm
 
@@ -43,7 +38,7 @@ class Fabric:
         self.event_platform_event = check.event_platform_event
 
     def ndm_enabled(self):
-        return PY3 and self.send_ndm_metadata
+        return self.send_ndm_metadata
 
     def collect(self):
         fabric_pods = self.api.get_fabric_pods()
@@ -170,10 +165,10 @@ class Fabric:
                 continue
 
             metrics = {}
-            for n, ms in iteritems(aci_metrics.FABRIC_METRICS):
+            for n, ms in aci_metrics.FABRIC_METRICS.items():
                 if n not in name:
                     continue
-                for cisco_metric, dd_metric in iteritems(ms):
+                for cisco_metric, dd_metric in ms.items():
                     mname = dd_metric.format(self.get_fabric_type(obj_type))
                     mval = s.get(name, {}).get("attributes", {}).get(cisco_metric)
                     json_attrs = s.get(name, {}).get("attributes", {})

--- a/cisco_aci/datadog_checks/cisco_aci/ndm.py
+++ b/cisco_aci/datadog_checks/cisco_aci/ndm.py
@@ -2,17 +2,13 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-
-from six import PY3
-
-if PY3:
-    from datadog_checks.cisco_aci.models import (
-        DeviceMetadata,
-        InterfaceMetadata,
-        NetworkDevicesMetadata,
-        Node,
-        PhysIf,
-    )
+from datadog_checks.cisco_aci.models import (
+    DeviceMetadata,
+    InterfaceMetadata,
+    NetworkDevicesMetadata,
+    Node,
+    PhysIf,
+)
 
 VENDOR_CISCO = 'cisco'
 PAYLOAD_METADATA_BATCH_SIZE = 100

--- a/cisco_aci/datadog_checks/cisco_aci/tags.py
+++ b/cisco_aci/datadog_checks/cisco_aci/tags.py
@@ -4,8 +4,6 @@
 
 import re
 
-from six import iteritems
-
 from datadog_checks.base.utils.containers import hash_mutable
 
 from . import exceptions, helpers
@@ -103,7 +101,7 @@ class CiscoTags:
 
         application_meta = []
         application_meta_map = self._edpt_tags_map(edpt)
-        for k, v in iteritems(application_meta_map):
+        for k, v in application_meta_map.items():
             application_meta.append(k + ":" + v)
         tenant_name = application_meta_map.get("tenant")
         app_name = application_meta_map.get("application")
@@ -112,7 +110,7 @@ class CiscoTags:
         # adding meta tags
         endpoint_meta = []
         endpoint_meta_map = self._get_epg_meta_tags_map(tenant_name, app_name, epg_name)
-        for k, v in iteritems(endpoint_meta_map):
+        for k, v in endpoint_meta_map.items():
             endpoint_meta.append(k + ":" + v)
 
         # adding application tags

--- a/cisco_aci/datadog_checks/cisco_aci/tenant.py
+++ b/cisco_aci/datadog_checks/cisco_aci/tenant.py
@@ -6,8 +6,6 @@ import datetime
 import re
 import time
 
-from six import iteritems
-
 from . import exceptions, helpers
 
 
@@ -112,10 +110,10 @@ class Tenant:
 
             tenant_metrics = self.tenant_metrics.get(obj_type, {})
 
-            for n, ms in iteritems(tenant_metrics):
+            for n, ms in tenant_metrics.items():
                 if n not in name:
                     continue
-                for cisco_metric, dd_metric in iteritems(ms):
+                for cisco_metric, dd_metric in ms.items():
                     mval = s.get(name, {}).get("attributes", {}).get(cisco_metric)
                     json_attrs = s.get(name, {}).get("attributes", {})
                     if mval and helpers.check_metric_can_be_zero(cisco_metric, mval, json_attrs):

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import clickhouse_driver
-from six import raise_from
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from datadog_checks.base.utils.db import QueryManager
@@ -119,10 +118,7 @@ class ClickhouseCheck(AgentCheck):
                 self._error_sanitizer.clean(self._error_sanitizer.scrub(str(e)))
             )
             self.service_check(self.SERVICE_CHECK_CONNECT, self.CRITICAL, message=error, tags=self._tags)
-
-            # When an exception is raised in the context of another one, both will be printed. To avoid
-            # this we set the context to None. https://www.python.org/dev/peps/pep-0409/
-            raise_from(type(e)(error), None)
+            raise type(e)(error) from None
         else:
             self.service_check(self.SERVICE_CHECK_CONNECT, self.OK, tags=self._tags)
             self._client = client

--- a/cloud_foundry_api/datadog_checks/cloud_foundry_api/cloud_foundry_api.py
+++ b/cloud_foundry_api/datadog_checks/cloud_foundry_api/cloud_foundry_api.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Generator, Tuple  # noqa: F401
 
 from requests.exceptions import HTTPError, RequestException
 from semver import VersionInfo
-from six.moves.urllib_parse import urlparse
+from urllib_parse import urlparse
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.errors import CheckException, ConfigurationError

--- a/cloud_foundry_api/datadog_checks/cloud_foundry_api/cloud_foundry_api.py
+++ b/cloud_foundry_api/datadog_checks/cloud_foundry_api/cloud_foundry_api.py
@@ -5,10 +5,10 @@ import copy
 import json
 import time
 from typing import Any, Dict, Generator, Tuple  # noqa: F401
+from urllib.parse import urlparse
 
 from requests.exceptions import HTTPError, RequestException
 from semver import VersionInfo
-from urllib_parse import urlparse
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.errors import CheckException, ConfigurationError

--- a/cloud_foundry_api/datadog_checks/cloud_foundry_api/utils.py
+++ b/cloud_foundry_api/datadog_checks/cloud_foundry_api/utils.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import Any, Dict  # noqa: F401
 
 from dateutil import parser, tz
-from six.moves.urllib_parse import urljoin
+from urllib_parse import urljoin
 
 
 def get_next_url(payload, version):

--- a/cloud_foundry_api/datadog_checks/cloud_foundry_api/utils.py
+++ b/cloud_foundry_api/datadog_checks/cloud_foundry_api/utils.py
@@ -3,9 +3,9 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from datetime import datetime
 from typing import Any, Dict  # noqa: F401
+from urllib.parse import urljoin
 
 from dateutil import parser, tz
-from urllib_parse import urljoin
 
 
 def get_next_url(payload, version):

--- a/cockroachdb/tests/legacy/common.py
+++ b/cockroachdb/tests/legacy/common.py
@@ -1,14 +1,12 @@
 # (C) Datadog, Inc. 2024-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from six import itervalues
-
 from datadog_checks.cockroachdb.metrics import METRIC_MAP
 from datadog_checks.dev.utils import assert_service_checks
 
 
 def assert_check(aggregator):
-    for metric in itervalues(METRIC_MAP):
+    for metric in METRIC_MAP.values():
         aggregator.assert_metric('cockroachdb.{}'.format(metric), at_least=0)
 
     assert aggregator.metrics_asserted_pct > 80, 'Missing metrics {}'.format(aggregator.not_asserted())

--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -8,11 +8,10 @@ from datetime import datetime, timedelta
 from itertools import islice
 from multiprocessing.pool import ThreadPool
 from time import time as timestamp
+from urllib.parse import urljoin
 
 import requests
 from requests import HTTPError
-from six import iteritems, iterkeys, itervalues
-from six.moves.urllib.parse import urljoin
 
 from datadog_checks.base import ConfigurationError, OpenMetricsBaseCheck, is_affirmative
 from datadog_checks.base.utils.serialization import json
@@ -309,7 +308,7 @@ class ConsulCheck(OpenMetricsBaseCheck):
                 )
                 self.warning(log_line)
 
-                services = {s: services[s] for s in list(islice(iterkeys(allowed_services), 0, self.max_services))}
+                services = {s: services[s] for s in list(islice(allowed_services, 0, self.max_services))}
 
         return services
 
@@ -381,7 +380,7 @@ class ConsulCheck(OpenMetricsBaseCheck):
                 elif STATUS_SEVERITY[status] > STATUS_SEVERITY[sc[sc_id]['status']]:
                     sc[sc_id]['status'] = status
 
-            for s in itervalues(sc):
+            for s in sc.values():
                 self.service_check(HEALTH_CHECK, s['status'], tags=main_tags + s['tags'])
 
         except Exception as e:
@@ -437,7 +436,7 @@ class ConsulCheck(OpenMetricsBaseCheck):
                     nodes_with_service[service] if self.thread_pool is None else nodes_with_service[service].get(),
                 )
 
-            for node, service_status in iteritems(nodes_to_service_status):
+            for node, service_status in nodes_to_service_status.items():
                 # For every node discovered for included services, gauge the following:
                 # `consul.catalog.services_up` : Total services registered on node
                 # `consul.catalog.services_passing` : Total passing services on node
@@ -455,7 +454,7 @@ class ConsulCheck(OpenMetricsBaseCheck):
                         tags=main_tags + node_tags,
                     )
 
-            for node_status, count in iteritems(nodes_per_service_tag_counts):
+            for node_status, count in nodes_per_service_tag_counts.items():
                 service_tags = [
                     'consul_{}_service_tag:{}'.format(node_status.service_name, tag)
                     for tag in node_status.service_tags_set

--- a/couchbase/datadog_checks/couchbase/couchbase.py
+++ b/couchbase/datadog_checks/couchbase/couchbase.py
@@ -7,10 +7,9 @@ from __future__ import division
 
 import re
 import time
+from urllib.parse import urljoin
 
 import requests
-from six import string_types
-from six.moves.urllib.parse import urljoin
 
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.couchbase.couchbase_consts import (
@@ -96,7 +95,7 @@ class Couchbase(AgentCheck):
                 norm_metric_name = self.camel_case_to_joined_lower(metric_name)
                 if norm_metric_name in QUERY_STATS:
                     # for query times, the unit is part of the value, we need to extract it
-                    if isinstance(val, string_types):
+                    if isinstance(val, str):
                         val = self.extract_seconds_value(val)
 
                     full_metric_name = 'couchbase.query.{}'.format(self.camel_case_to_joined_lower(norm_metric_name))

--- a/elastic/datadog_checks/elastic/config.py
+++ b/elastic/datadog_checks/elastic/config.py
@@ -2,8 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from collections import namedtuple
-
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 from datadog_checks.base import ConfigurationError, is_affirmative
 

--- a/envoy/datadog_checks/envoy/check.py
+++ b/envoy/datadog_checks/envoy/check.py
@@ -3,8 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import re
 from collections import defaultdict
-
-from six.moves.urllib.parse import urljoin, urlparse, urlunparse
+from urllib.parse import urljoin, urlparse, urlunparse
 
 from datadog_checks.base import AgentCheck, OpenMetricsBaseCheckV2
 

--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -3,10 +3,10 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import re
 from collections import defaultdict
+from urllib.parse import urljoin
 
 import requests
 from six import PY2
-from six.moves.urllib.parse import urljoin
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 

--- a/envoy/datadog_checks/envoy/parser.py
+++ b/envoy/datadog_checks/envoy/parser.py
@@ -6,8 +6,6 @@ import re
 from math import isnan
 from typing import Any, Dict, List, Tuple  # noqa: F401
 
-from six.moves import range, zip
-
 from .errors import UnknownMetric, UnknownTags
 from .metrics import LEGACY_TAG_OVERWRITE, METRIC_PREFIX, METRIC_TREE, MOD_METRICS
 

--- a/esxi/datadog_checks/esxi/check.py
+++ b/esxi/datadog_checks/esxi/check.py
@@ -11,7 +11,6 @@ from urllib.parse import urlparse
 import socks
 from pyVim import connect
 from pyVmomi import vim, vmodl
-from six import iteritems
 
 from datadog_checks.base import AgentCheck, is_affirmative
 from datadog_checks.base.utils.common import to_string
@@ -132,7 +131,7 @@ class EsxiCheck(AgentCheck):
     def _parse_metric_regex_filters(self, all_metric_filters):
         allowed_resource_types = RESOURCE_TYPE_TO_NAME.values()
         metric_filters = {}
-        for resource_type, filters in iteritems(all_metric_filters):
+        for resource_type, filters in all_metric_filters.items():
             if resource_type not in allowed_resource_types:
                 self.log.warning(
                     "Ignoring metric_filter for resource '%s'. It should be one of '%s'",
@@ -142,7 +141,7 @@ class EsxiCheck(AgentCheck):
                 continue
             metric_filters[resource_type] = filters
 
-        return {k: [re.compile(r) for r in v] for k, v in iteritems(metric_filters)}
+        return {k: [re.compile(r) for r in v] for k, v in metric_filters.items()}
 
     def _parse_resource_filters(self, all_resource_filters):
         # Keep a list of resource filters ids (tuple of resource, property and type) that are already registered.

--- a/esxi/datadog_checks/esxi/utils.py
+++ b/esxi/datadog_checks/esxi/utils.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 from pyVmomi import vim
-from six import iteritems
 
 from datadog_checks.base import to_string
 
@@ -76,7 +75,7 @@ def get_mapped_instance_tag(metric_name):
     tag cannot be guessed by looking at the api results and has to be inferred using documentation or experience.
     This method acts as a utility to map a metric_name to the meaning of its instance tag.
     """
-    for prefix, tag_key in iteritems(METRIC_TO_INSTANCE_TAG_MAPPING):
+    for prefix, tag_key in METRIC_TO_INSTANCE_TAG_MAPPING.items():
         if metric_name.startswith(prefix):
             return tag_key
     return 'instance'

--- a/etcd/datadog_checks/etcd/etcd.py
+++ b/etcd/datadog_checks/etcd/etcd.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 from datadog_checks.base import ConfigurationError, OpenMetricsBaseCheck, is_affirmative
 

--- a/fluentd/datadog_checks/fluentd/fluentd.py
+++ b/fluentd/datadog_checks/fluentd/fluentd.py
@@ -4,8 +4,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 import re
-
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.utils.subprocess_output import get_subprocess_output

--- a/fly_io/datadog_checks/fly_io/check.py
+++ b/fly_io/datadog_checks/fly_io/check.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from six.moves.urllib.parse import quote_plus
+from urllib.parse import quote_plus
 
 from datadog_checks.base import OpenMetricsBaseCheckV2
 

--- a/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py
@@ -3,9 +3,9 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 from copy import deepcopy
+from urllib.parse import urlparse
 
 import requests
-from six.moves.urllib.parse import urlparse
 
 from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.base.errors import CheckException

--- a/glusterfs/datadog_checks/glusterfs/check.py
+++ b/glusterfs/datadog_checks/glusterfs/check.py
@@ -12,8 +12,6 @@ import os
 import subprocess
 from typing import Dict, List  # noqa: F401
 
-from six import iteritems
-
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.config import is_affirmative
 
@@ -180,7 +178,7 @@ class GlusterfsCheck(AgentCheck):
         Parse a payload with a given metric_mapping and submit metric for valid values.
         Some values contain measurements like `GiB` which should be removed and only submitted if consistent
         """
-        for key, metric in iteritems(metric_mapping):
+        for key, metric in metric_mapping.items():
             if key in payload:
                 value = payload[key]
 

--- a/go_expvar/datadog_checks/go_expvar/go_expvar.py
+++ b/go_expvar/datadog_checks/go_expvar/go_expvar.py
@@ -5,9 +5,7 @@
 
 import re
 from collections import defaultdict
-
-from six import iteritems
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 from datadog_checks.base import AgentCheck
 
@@ -269,7 +267,7 @@ class GoExpvar(AgentCheck):
             for new_key, new_content in enumerate(object):
                 yield str(new_key), new_content
         elif isinstance(object, dict):
-            for new_key, new_content in iteritems(object):
+            for new_key, new_content in object.items():
                 yield str(new_key), new_content
         else:
             self.log.warning("Could not parse this object, check the json served by the expvar")

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/hdfs_datanode.py
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/hdfs_datanode.py
@@ -1,10 +1,10 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from urllib.parse import urljoin
+
 from requests.exceptions import ConnectionError, HTTPError, InvalidURL, Timeout
 from simplejson import JSONDecodeError
-from six import iteritems
-from six.moves.urllib.parse import urljoin
 
 from datadog_checks.base import AgentCheck
 
@@ -87,7 +87,7 @@ class HDFSDataNode(AgentCheck):
 
         self.log.debug("Bean name retrieved: %s", bean_name)
 
-        for metric, (metric_name, metric_type) in iteritems(self.HDFS_METRICS):
+        for metric, (metric_name, metric_type) in self.HDFS_METRICS.items():
             metric_value = bean.get(metric)
             if metric_value is not None:
                 self._set_metric(metric_name, metric_type, metric_value, tags)
@@ -110,7 +110,7 @@ class HDFSDataNode(AgentCheck):
 
         # Add query_params as arguments
         if query_params:
-            query = '&'.join(['{}={}'.format(key, value) for key, value in iteritems(query_params)])
+            query = '&'.join(['{}={}'.format(key, value) for key, value in query_params.items()])
             url = urljoin(url, '?' + query)
 
         self.log.debug('Attempting to connect to "%s"', url)

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
@@ -3,10 +3,10 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
 
+from urllib.parse import urljoin
+
 from requests.exceptions import ConnectionError, HTTPError, InvalidURL, Timeout
 from simplejson import JSONDecodeError
-from six import iteritems
-from six.moves.urllib.parse import urljoin
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.common import compute_percent
@@ -113,7 +113,7 @@ class HDFSNameNode(AgentCheck):
         if bean_name != bean_name:
             raise Exception("Unexpected bean name {}".format(bean_name))
 
-        for metric, (metric_name, metric_type) in iteritems(metrics):
+        for metric, (metric_name, metric_type) in metrics.items():
             metric_value = bean.get(metric)
 
             if metric_value is not None:
@@ -146,7 +146,7 @@ class HDFSNameNode(AgentCheck):
 
         # Add query_params as arguments
         if query_params:
-            query = '&'.join(['{}={}'.format(key, value) for key, value in iteritems(query_params)])
+            query = '&'.join(['{}={}'.format(key, value) for key, value in query_params.items()])
             url = urljoin(url, '?' + query)
 
         self.log.debug('Attempting to connect to "%s"', url)

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -8,21 +8,16 @@ import re
 import socket
 import time
 from datetime import datetime
+from urllib.parse import urlparse
 
 import requests
 from cryptography import x509
 from requests import Response  # noqa: F401
-from six import PY2, string_types
-from six.moves.urllib.parse import urlparse
 
 from datadog_checks.base import AgentCheck, ensure_unicode, is_affirmative
 
 from .config import DEFAULT_EXPECTED_CODE, from_instance
 from .utils import get_ca_certs_path
-
-# Apply thread-safety fix, see https://bugs.python.org/issue7980
-if PY2:
-    import _strptime  # noqa
 
 DEFAULT_EXPIRE_DAYS_WARNING = 14
 DEFAULT_EXPIRE_DAYS_CRITICAL = 7
@@ -132,7 +127,7 @@ class HTTPCheck(AgentCheck):
                 persist=True,
                 stream=stream,
                 json=data if method.upper() in DATA_METHODS and isinstance(data, dict) else None,
-                data=data if method.upper() in DATA_METHODS and isinstance(data, string_types) else None,
+                data=data if method.upper() in DATA_METHODS and isinstance(data, str) else None,
             )
         except (
             socket.timeout,

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
@@ -3,8 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from typing import Callable, Dict, List  # noqa: F401
 
-from six import iteritems
-
 from datadog_checks.base import AgentCheck, to_string
 from datadog_checks.base.log import CheckLoggingAdapter  # noqa: F401
 
@@ -168,7 +166,7 @@ class ChannelMetricCollector(object):
 
     def _submit_metrics_from_properties(self, channel_info, channel_name, metrics_map, tags):
         # type: (Dict, str, Dict[str, int], List[str] ) -> None
-        for metric_name, pymqi_type in iteritems(metrics_map):
+        for metric_name, pymqi_type in metrics_map.items():
             metric_full_name = '{}.channel.{}'.format(metrics.METRIC_PREFIX, metric_name)
             if pymqi_type not in channel_info:
                 self.log.debug("metric '%s' not found in channel: %s", metric_name, channel_name)
@@ -181,7 +179,7 @@ class ChannelMetricCollector(object):
             self.log.warning("Status `%s` not found for channel `%s`", channel_status, channel_name)
             channel_status = STATUS_MQCHS_UNKNOWN
 
-        for status, status_label in iteritems(CHANNEL_STATUS_NAME_MAPPING):
+        for status, status_label in CHANNEL_STATUS_NAME_MAPPING.items():
             status_active = int(status == channel_status)
             self.gauge(
                 self.CHANNEL_COUNT_CHECK,

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
@@ -4,8 +4,6 @@
 import logging  # noqa: F401
 from typing import Any, Callable, Dict, List, Set  # noqa: F401
 
-from six import iteritems
-
 from datadog_checks.base import AgentCheck, to_string
 from datadog_checks.base.types import ServiceCheck  # noqa: F401
 from datadog_checks.ibm_mq.metrics import GAUGE
@@ -150,7 +148,7 @@ class QueueMetricCollector(object):
         """
         Get stats from the queue manager
         """
-        for mname, pymqi_value in iteritems(metrics.queue_manager_metrics()):
+        for mname, pymqi_value in metrics.queue_manager_metrics().items():
             try:
                 m = queue_manager.inquire(pymqi_value)
                 mname = '{}.queue_manager.{}'.format(metrics.METRIC_PREFIX, mname)
@@ -198,7 +196,7 @@ class QueueMetricCollector(object):
         return enriched_tags
 
     def _submit_queue_stats(self, queue_info, queue_name, tags):
-        for metric_suffix, mq_attr in iteritems(metrics.queue_metrics()):
+        for metric_suffix, mq_attr in metrics.queue_metrics().items():
             metric_name = '{}.queue.{}'.format(metrics.METRIC_PREFIX, metric_suffix)
             if callable(mq_attr):
                 metric_value = mq_attr(queue_info)
@@ -235,7 +233,7 @@ class QueueMetricCollector(object):
         else:
             # Response is a list. It likely has only one member in it.
             for queue_info in response:
-                for mname, values in iteritems(metrics.pcf_metrics()):
+                for mname, values in metrics.pcf_metrics().items():
                     metric_name = '{}.queue.{}'.format(metrics.METRIC_PREFIX, mname)
                     try:
                         if callable(values):

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -6,7 +6,6 @@ import datetime as dt
 import re
 
 from dateutil.tz import UTC
-from six import PY2, iteritems
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from datadog_checks.base.constants import ServiceCheck
@@ -161,9 +160,6 @@ class IBMMQConfig:
 
         pattern = instance.get('queue_manager_process', init_config.get('queue_manager_process', ''))
         if pattern:
-            if PY2:
-                raise ConfigurationError('The `queue_manager_process` option is only supported on Agent 7')
-
             pattern = pattern.replace('<queue_manager>', re.escape(self.queue_manager_name))
             self.queue_manager_process_pattern = re.compile(pattern)
 
@@ -183,7 +179,7 @@ class IBMMQConfig:
         Compile regex strings from queue_tag_re option and return list of compiled regex/tag pairs
         """
         queue_tag_list = []
-        for regex_str, tags in iteritems(self._queue_tag_re):
+        for regex_str, tags in self._queue_tag_re.items():
             try:
                 queue_tag_list.append([re.compile(regex_str), [t.strip() for t in tags.split(',')]])
             except TypeError:

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -3,8 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import threading
 
-from six import iteritems
-
 from datadog_checks.base import AgentCheck
 from datadog_checks.ibm_mq.collectors.stats_collector import StatsCollector
 from datadog_checks.ibm_mq.metrics import COUNT, GAUGE
@@ -121,7 +119,7 @@ class IbmMqCheck(AgentCheck):
 
     def send_metrics_from_properties(self, properties, metrics_map, prefix, tags):
         # type: (Dict, Dict, str, List[str]) -> None
-        for metric_name, (pymqi_type, metric_type) in iteritems(metrics_map):
+        for metric_name, (pymqi_type, metric_type) in metrics_map.items():
             metric_full_name = '{}.{}'.format(prefix, metric_name)
             if pymqi_type not in properties:
                 self.log.debug("MQ type `%s` not found in properties for metric `%s` and tags `%s`", metric_name, tags)

--- a/ibm_was/datadog_checks/ibm_was/ibm_was.py
+++ b/ibm_was/datadog_checks/ibm_was/ibm_was.py
@@ -5,7 +5,6 @@ from xml.etree.ElementTree import ParseError
 
 import requests
 from lxml import etree
-from six import iteritems
 
 from datadog_checks.base import AgentCheck, ConfigurationError, ensure_unicode, is_affirmative
 
@@ -63,7 +62,7 @@ class IbmWasCheck(AgentCheck):
                 server_tags = ['server:{}'.format(server.get('name'))]
                 server_tags.extend(node_tags)
 
-                for category, prefix in iteritems(self.metric_categories):
+                for category, prefix in self.metric_categories.items():
                     if self.collect_stats.get(category):
                         self.log.debug("Collecting %s stats", category)
                         stats = self.get_node_from_name(server, category)
@@ -151,7 +150,7 @@ class IbmWasCheck(AgentCheck):
 
     def setup_configured_stats(self):
         collect_stats = {}
-        for category, prefix in iteritems(metrics.METRIC_CATEGORIES):
+        for category, prefix in metrics.METRIC_CATEGORIES.items():
             if is_affirmative(self.instance.get('collect_{}_stats'.format(prefix), True)):
                 collect_stats[category] = True
         return collect_stats

--- a/iis/datadog_checks/iis/iis.py
+++ b/iis/datadog_checks/iis/iis.py
@@ -1,8 +1,6 @@
 # (C) Datadog, Inc. 2010-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-from six import PY3, iteritems
-
 from datadog_checks.base import PDHBaseCheck, is_affirmative
 
 from .service_check import app_pool_service_check, site_service_check
@@ -49,7 +47,7 @@ class IIS(PDHBaseCheck):
     APP_POOL = 'app_pool'
 
     def __new__(cls, name, init_config, instances):
-        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False)):
+        if not is_affirmative(instances[0].get('use_legacy_check_version', False)):
             from .check import IISCheckV2
 
             return IISCheckV2(name, init_config, instances)
@@ -84,7 +82,7 @@ class IIS(PDHBaseCheck):
                     self.log.debug(
                         "Unknown IIS counter: %s. Falling back to default submission.", counter.english_class_name
                     )
-                    for instance_name, val in iteritems(counter_values):
+                    for instance_name, val in counter_values.items():
                         tags = list(self._tags.get(self.instance_hash, []))
 
                         if not counter.is_single_instance():
@@ -102,7 +100,7 @@ class IIS(PDHBaseCheck):
         namespace = self.SITE
         remaining_sites = self._remaining_data[namespace]
 
-        for site_name, value in iteritems(counter_values):
+        for site_name, value in counter_values.items():
             is_single_instance = counter.is_single_instance()
             if (
                 not is_single_instance
@@ -139,7 +137,7 @@ class IIS(PDHBaseCheck):
         namespace = self.APP_POOL
         remaining_app_pools = self._remaining_data[namespace]
 
-        for app_pool_name, value in iteritems(counter_values):
+        for app_pool_name, value in counter_values.items():
             is_single_instance = counter.is_single_instance()
             if (
                 not is_single_instance

--- a/kong/datadog_checks/kong/kong.py
+++ b/kong/datadog_checks/kong/kong.py
@@ -1,9 +1,10 @@
 # (C) Datadog, Inc. 2010-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+from urllib.parse import urlparse
+
 import simplejson as json
 from six import PY2
-from six.moves.urllib.parse import urlparse
 
 from datadog_checks.base import AgentCheck, ConfigurationError
 

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/kube_controller_manager.py
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/kube_controller_manager.py
@@ -5,7 +5,6 @@
 import re
 
 import requests
-from six import iteritems
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.checks.kube_leader import KubeLeaderElectionMixin
@@ -169,7 +168,7 @@ class KubeControllerManagerCheck(KubeLeaderElectionMixin, SliMetricsScraperMixin
             transformers[limiter + "_rate_limiter_use"] = self.rate_limiter_use
         queues = self.DEFAULT_QUEUES + instance.get("extra_queues", [])
         for queue in queues:
-            for metric, func in iteritems(self.QUEUE_METRICS_TRANSFORMERS):
+            for metric, func in self.QUEUE_METRICS_TRANSFORMERS.items():
                 transformers[queue + metric] = func
 
         # Support new metrics (introduced in v1.14.0)

--- a/kube_dns/datadog_checks/kube_dns/kube_dns.py
+++ b/kube_dns/datadog_checks/kube_dns/kube_dns.py
@@ -6,7 +6,6 @@ import re
 from copy import deepcopy
 
 import requests
-from six import iteritems
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
@@ -108,7 +107,7 @@ class KubeDNSCheck(OpenMetricsBaseCheck):
             # Explicit shallow copy of the instance tags
             _tags = list(scraper_config['custom_tags'])
 
-            for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
+            for label_name, label_value in sample[self.SAMPLE_LABELS].items():
                 _tags.append('{}:{}'.format(label_name, label_value))
             # submit raw metric
             self.gauge(metric_name, sample[self.SAMPLE_VALUE], _tags)

--- a/kubelet/datadog_checks/kubelet/cadvisor.py
+++ b/kubelet/datadog_checks/kubelet/cadvisor.py
@@ -6,10 +6,9 @@ from __future__ import division
 import logging
 import numbers
 from fnmatch import fnmatch
+from urllib.parse import urlparse
 
 import requests
-from six import iteritems
-from six.moves.urllib.parse import urlparse
 
 from datadog_checks.base.utils.tagging import tagger
 
@@ -118,7 +117,7 @@ class CadvisorScraper(object):
                 self.gauge(metric, float(dat), tags)
 
         elif isinstance(dat, dict):
-            for k, v in iteritems(dat):
+            for k, v in dat.items():
                 self._publish_raw_metrics(metric + '.%s' % k.lower(), v, tags, is_pod, depth + 1)
 
         elif isinstance(dat, list):

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -7,11 +7,10 @@ import re
 import sys
 from collections import defaultdict
 from copy import deepcopy
+from urllib.parse import urlparse
 
 import requests
 from kubeutil import get_connection_info
-from six import iteritems
-from six.moves.urllib.parse import urlparse
 
 from datadog_checks.base import AgentCheck, OpenMetricsBaseCheck
 from datadog_checks.base.checks.kubelet_base.base import KubeletBase, KubeletCredentials, urljoin
@@ -532,9 +531,9 @@ class KubeletCheck(
             tags += instance_tags
             hash_tags = tuple(sorted(tags))
             pods_tag_counter[hash_tags] += 1
-        for tags, count in iteritems(pods_tag_counter):
+        for tags, count in pods_tag_counter.items():
             self.gauge(self.NAMESPACE + '.pods.running', count, list(tags))
-        for tags, count in iteritems(containers_tag_counter):
+        for tags, count in containers_tag_counter.items():
             self.gauge(self.NAMESPACE + '.containers.running', count, list(tags))
 
     def _report_container_spec_metrics(self, pod_list, instance_tags):
@@ -578,14 +577,14 @@ class KubeletCheck(
                     tags += instance_tags
 
                     try:
-                        for resource, value_str in iteritems(ctr.get('resources', {}).get('requests', {})):
+                        for resource, value_str in ctr.get('resources', {}).get('requests', {}).items():
                             value = self.parse_quantity(value_str)
                             self.gauge('{}.{}.requests'.format(self.NAMESPACE, resource), value, tags)
                     except (KeyError, AttributeError) as e:
                         self.log.debug("Unable to retrieve container requests for %s: %s", c_name, e)
 
                     try:
-                        for resource, value_str in iteritems(ctr.get('resources', {}).get('limits', {})):
+                        for resource, value_str in ctr.get('resources', {}).get('limits', {}).items():
                             value = self.parse_quantity(value_str)
                             self.gauge('{}.{}.limits'.format(self.NAMESPACE, resource), value, tags)
                     except (KeyError, AttributeError) as e:
@@ -730,7 +729,7 @@ class KubeletCheck(
             # Determine the tags to send
             tags = self._metric_tags(metric.name, val, sample, scraper_config, hostname=custom_hostname)
             pvc_name, kube_ns = None, None
-            for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
+            for label_name, label_value in sample[self.SAMPLE_LABELS].items():
                 if label_name == "persistentvolumeclaim":
                     pvc_name = label_value
                 elif label_name == "namespace":

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -5,8 +5,6 @@ from __future__ import division
 
 from copy import deepcopy
 
-from six import iteritems
-
 from datadog_checks.base.checks.kubelet_base.base import urljoin
 from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.base.utils.tagging import tagger
@@ -294,7 +292,7 @@ class CadvisorPrometheusScraperMixin(object):
             return
 
         samples = self._sum_values_by_context(metric, self._get_entity_id_if_container_metric)
-        for c_id, sample in iteritems(samples):
+        for c_id, sample in samples.items():
             pod_uid = self._get_pod_uid(sample[self.SAMPLE_LABELS])
             if self.pod_list_utils.is_excluded(c_id, pod_uid):
                 continue
@@ -340,7 +338,7 @@ class CadvisorPrometheusScraperMixin(object):
             return
 
         samples = self._sum_values_by_context(metric, self._get_pod_uid_if_pod_metric)
-        for pod_uid, sample in iteritems(samples):
+        for pod_uid, sample in samples.items():
             pod = get_pod_by_uid(pod_uid, self.pod_list)
             namespace = pod.get('metadata', {}).get('namespace', None)
             if self.pod_list_utils.is_namespace_excluded(namespace):
@@ -372,7 +370,7 @@ class CadvisorPrometheusScraperMixin(object):
         seen_keys = {k: False for k in cache}
 
         samples = self._sum_values_by_context(metric, self._get_entity_id_if_container_metric)
-        for c_id, sample in iteritems(samples):
+        for c_id, sample in samples.items():
             c_name = get_container_label(sample[self.SAMPLE_LABELS], 'name')
             if not c_name:
                 continue
@@ -407,7 +405,7 @@ class CadvisorPrometheusScraperMixin(object):
             self.gauge(m_name, val, tags)
 
         # purge the cache
-        for k, seen in iteritems(seen_keys):
+        for k, seen in seen_keys.items():
             if not seen:
                 del cache[k]
 
@@ -418,7 +416,7 @@ class CadvisorPrometheusScraperMixin(object):
         for each sample in the metric and reports the usage_pct
         """
         samples = self._latest_value_by_context(metric, self._get_entity_id_if_container_metric)
-        for c_id, sample in iteritems(samples):
+        for c_id, sample in samples.items():
             limit = sample[self.SAMPLE_VALUE]
             pod_uid = self._get_pod_uid(sample[self.SAMPLE_LABELS])
             if self.pod_list_utils.is_excluded(c_id, pod_uid):

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -7,8 +7,6 @@ import time
 from collections import Counter, defaultdict
 from copy import deepcopy
 
-from six import iteritems
-
 from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.base.config import is_affirmative
 from datadog_checks.base.errors import CheckException
@@ -175,18 +173,18 @@ class KubernetesState(OpenMetricsBaseCheck):
         self.process(scraper_config, metric_transformers=self.METRIC_TRANSFORMERS)
 
         # Logic for Cron Jobs
-        for job_tags, job in iteritems(self.failed_cron_job_counts):
+        for job_tags, job in self.failed_cron_job_counts.items():
             self.monotonic_count(scraper_config['namespace'] + '.job.failed', job.count, list(job_tags))
             job.set_previous_and_reset_current_ts()
 
-        for job_tags, job in iteritems(self.succeeded_cron_job_counts):
+        for job_tags, job in self.succeeded_cron_job_counts.items():
             self.monotonic_count(scraper_config['namespace'] + '.job.succeeded', job.count, list(job_tags))
             job.set_previous_and_reset_current_ts()
 
         # Logic for Jobs
-        for job_tags, job_count in iteritems(self.job_succeeded_count):
+        for job_tags, job_count in self.job_succeeded_count.items():
             self.monotonic_count(scraper_config['namespace'] + '.job.succeeded', job_count, list(job_tags))
-        for job_tags, job_count in iteritems(self.job_failed_count):
+        for job_tags, job_count in self.job_failed_count.items():
             self.monotonic_count(scraper_config['namespace'] + '.job.failed', job_count, list(job_tags))
 
     def _filter_metric(self, metric, scraper_config):
@@ -508,7 +506,7 @@ class KubernetesState(OpenMetricsBaseCheck):
 
         metric_name = scraper_config['namespace'] + '.node.by_condition'
         metric_tags = []
-        for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
+        for label_name, label_value in sample[self.SAMPLE_LABELS].items():
             metric_tags += self._build_tags(label_name, label_value, scraper_config)
         self.gauge(
             metric_name,
@@ -632,7 +630,7 @@ class KubernetesState(OpenMetricsBaseCheck):
             )
             status_phase_counter[tuple(sorted(tags))] += sample[self.SAMPLE_VALUE]
 
-        for tags, count in iteritems(status_phase_counter):
+        for tags, count in status_phase_counter.items():
             self.gauge(metric_name, count, tags=list(tags))
 
     def _submit_metric_kube_pod_container_status_reason(
@@ -650,7 +648,7 @@ class KubernetesState(OpenMetricsBaseCheck):
             else:
                 continue
 
-            for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
+            for label_name, label_value in sample[self.SAMPLE_LABELS].items():
                 if label_name == "reason":
                     continue
 
@@ -687,7 +685,7 @@ class KubernetesState(OpenMetricsBaseCheck):
         for sample in metric.samples:
             on_schedule = int(sample[self.SAMPLE_VALUE]) - curr_time
             tags = []
-            for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
+            for label_name, label_value in sample[self.SAMPLE_LABELS].items():
                 tags += self._build_tags(label_name, label_value, scraper_config)
 
             tags += scraper_config['custom_tags']
@@ -703,7 +701,7 @@ class KubernetesState(OpenMetricsBaseCheck):
         service_check_name = scraper_config['namespace'] + '.job.complete'
         for sample in metric.samples:
             tags = []
-            for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
+            for label_name, label_value in sample[self.SAMPLE_LABELS].items():
                 if label_name == 'job' or label_name == 'job_name':
                     tags += self._get_job_tags(label_name, label_value, scraper_config)
                 else:
@@ -714,7 +712,7 @@ class KubernetesState(OpenMetricsBaseCheck):
         service_check_name = scraper_config['namespace'] + '.job.complete'
         for sample in metric.samples:
             tags = []
-            for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
+            for label_name, label_value in sample[self.SAMPLE_LABELS].items():
                 if label_name == 'job' or label_name == 'job_name':
                     tags += self._get_job_tags(label_name, label_value, scraper_config)
                 else:
@@ -725,7 +723,7 @@ class KubernetesState(OpenMetricsBaseCheck):
         for sample in metric.samples:
             job_ts = None
             tags = [] + scraper_config['custom_tags']
-            for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
+            for label_name, label_value in sample[self.SAMPLE_LABELS].items():
                 if label_name == 'job' or label_name == 'job_name':
                     tags += self._get_job_tags(label_name, label_value, scraper_config)
                     job_ts = self._extract_job_timestamp(label_value)
@@ -742,7 +740,7 @@ class KubernetesState(OpenMetricsBaseCheck):
         for sample in metric.samples:
             job_ts = None
             tags = [] + scraper_config['custom_tags']
-            for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
+            for label_name, label_value in sample[self.SAMPLE_LABELS].items():
                 if label_name == 'job' or label_name == 'job_name':
                     tags += self._get_job_tags(label_name, label_value, scraper_config)
                     job_ts = self._extract_job_timestamp(label_value)
@@ -780,7 +778,7 @@ class KubernetesState(OpenMetricsBaseCheck):
             )
             by_condition_counter[tuple(sorted(tags))] += sample[self.SAMPLE_VALUE]
 
-        for tags, count in iteritems(by_condition_counter):
+        for tags, count in by_condition_counter.items():
             self.gauge(metric_name, count, tags=list(tags))
 
     def kube_node_status_ready(self, metric, scraper_config):
@@ -850,7 +848,7 @@ class KubernetesState(OpenMetricsBaseCheck):
         if metric.type in METRIC_TYPES:
             for sample in metric.samples:
                 tags = []
-                for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
+                for label_name, label_value in sample[self.SAMPLE_LABELS].items():
                     tags += self._build_tags(label_name, label_value, scraper_config)
                 tags += scraper_config['custom_tags']
                 status = statuses[int(sample[self.SAMPLE_VALUE])]  # value can be 0 or 1
@@ -920,7 +918,7 @@ class KubernetesState(OpenMetricsBaseCheck):
             tags = self._tags_for_count(sample, config, scraper_config)
             object_counter[tuple(sorted(tags))] += sample[self.SAMPLE_VALUE]
 
-        for tags, count in iteritems(object_counter):
+        for tags, count in object_counter.items():
             self.gauge(metric_name, count, tags=list(tags))
 
     def count_objects_by_tags(self, metric, scraper_config):
@@ -933,7 +931,7 @@ class KubernetesState(OpenMetricsBaseCheck):
             tags = self._tags_for_count(sample, config, scraper_config)
             object_counter[tuple(sorted(tags))] += 1
 
-        for tags, count in iteritems(object_counter):
+        for tags, count in object_counter.items():
             self.gauge(metric_name, count, tags=list(tags))
 
     def _tags_for_count(self, sample, count_config, scraper_config):
@@ -980,7 +978,7 @@ class KubernetesState(OpenMetricsBaseCheck):
         custom_tags = scraper_config['custom_tags']
         _tags = list(custom_tags)
         _tags += scraper_config['_metric_tags']
-        for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
+        for label_name, label_value in sample[self.SAMPLE_LABELS].items():
             if label_name not in scraper_config['exclude_labels']:
                 _tags += self._build_tags(label_name, label_value, scraper_config)
         return self._finalize_tags_to_submit(

--- a/lighttpd/datadog_checks/lighttpd/lighttpd.py
+++ b/lighttpd/datadog_checks/lighttpd/lighttpd.py
@@ -3,8 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 import re
-
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 from datadog_checks.base import AgentCheck
 

--- a/linux_proc_extras/datadog_checks/linux_proc_extras/linux_proc_extras.py
+++ b/linux_proc_extras/datadog_checks/linux_proc_extras/linux_proc_extras.py
@@ -5,8 +5,6 @@
 
 from collections import defaultdict
 
-from six import iteritems
-
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
@@ -53,7 +51,7 @@ class MoreUnixCheck(AgentCheck):
             "interrupts_info": "interrupts",
         }
 
-        for key, path in iteritems(self.proc_path_map):
+        for key, path in self.proc_path_map.items():
             self.proc_path_map[key] = "{procfs}/{path}".format(procfs=proc_location, path=path)
 
     def get_inode_info(self):

--- a/mapr/datadog_checks/mapr/mapr.py
+++ b/mapr/datadog_checks/mapr/mapr.py
@@ -6,8 +6,6 @@ import json
 import os
 import re
 
-from six import iteritems
-
 from datadog_checks.base import AgentCheck, ensure_unicode, is_affirmative
 from datadog_checks.base.errors import CheckException
 
@@ -191,7 +189,7 @@ class MaprCheck(AgentCheck):
     def submit_metric(self, metric):
         metric_name = metric['metric']
         tags = copy.deepcopy(self.custom_tags)
-        for k, v in iteritems(metric['tags']):
+        for k, v in metric['tags'].items():
             if k == 'clustername':
                 tags.append("{}:{}".format('mapr_cluster', v))
                 if not self._disable_legacy_cluster_tag:

--- a/marathon/datadog_checks/marathon/marathon.py
+++ b/marathon/datadog_checks/marathon/marathon.py
@@ -2,10 +2,9 @@
 # (C)  graemej <graeme.johnson@jadedpixel.com> 2014
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from urllib.parse import urljoin
 
 import requests
-from six import iteritems
-from six.moves.urllib.parse import urljoin
 
 from datadog_checks.base import AgentCheck
 
@@ -217,7 +216,7 @@ class Marathon(AgentCheck):
 
             queued.add(queue['app']['id'])
 
-            for m_type, sub_metric in iteritems(self.QUEUE_METRICS):
+            for m_type, sub_metric in self.QUEUE_METRICS.items():
                 if isinstance(sub_metric, list):
                     for attr, name in sub_metric:
                         try:

--- a/marklogic/datadog_checks/marklogic/parsers/request.py
+++ b/marklogic/datadog_checks/marklogic/parsers/request.py
@@ -3,8 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from typing import Any, Dict, Generator, List, Tuple  # noqa: F401
 
-from six import iteritems
-
 from .common import build_metric_to_submit, is_metric
 
 
@@ -22,7 +20,7 @@ def _parse_request_metrics(data, tags):
     # type: (Dict[str, Any], List[str]) -> Generator[Tuple, None, None]
     list_summary = data['request-default-list']['list-summary']
 
-    for key, value in iteritems(list_summary):
+    for key, value in list_summary.items():
         if is_metric(value):
             metric = build_metric_to_submit("requests.{}".format(key), value, tags)
             if metric is not None:

--- a/marklogic/datadog_checks/marklogic/parsers/status.py
+++ b/marklogic/datadog_checks/marklogic/parsers/status.py
@@ -3,8 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from typing import Any, Dict, Generator, List, Tuple  # noqa: F401
 
-from six import iteritems
-
 from ..constants import RESOURCE_TYPES
 from .common import build_metric_to_submit, is_metric
 
@@ -26,7 +24,7 @@ def parse_per_resource_status_metrics(resource_type, data, tags):
 def parse_summary_status_base_metrics(data, tags):
     #  type: (Dict[str, Any], List[str]) -> Generator[Tuple, None, None]
     relations = data['local-cluster-status']['status-relations']
-    for key, resource_data in iteritems(relations):
+    for key, resource_data in relations.items():
         if not key.endswith('-status'):
             continue
         resource_type = resource_data['typeref']
@@ -40,7 +38,7 @@ def parse_summary_status_base_metrics(data, tags):
 
 def _parse_status_metrics(metric_prefix, metrics, tags):
     #  type: (str, Dict[str, Any], List[str]) -> Generator[Tuple, None, None]
-    for key, data in iteritems(metrics):
+    for key, data in metrics.items():
         if key in ['rate-properties', 'load-properties']:
             prop_type = key[: key.index('-properties')]
             total_key = 'total-' + prop_type

--- a/marklogic/datadog_checks/marklogic/parsers/storage.py
+++ b/marklogic/datadog_checks/marklogic/parsers/storage.py
@@ -3,8 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from typing import Any, Dict, Generator, List, Tuple  # noqa: F401
 
-from six import iteritems
-
 from .common import build_metric_to_submit, is_metric
 
 
@@ -39,7 +37,7 @@ def _parse_storage_metrics(data, tags, include_location_forest):
         host_tags.append('marklogic_host_name:{}'.format(hosts_meta[host_id]))
         for location_data in host_data['locations']['location']:
             location_tags = host_tags + ['storage_path:{}'.format(location_data['path'])]
-            for host_key, host_value in iteritems(location_data):
+            for host_key, host_value in location_data.items():
                 if host_key == 'location-forests':
                     location_value = host_value['location-forest']
                     for forest_data in location_value:
@@ -48,7 +46,7 @@ def _parse_storage_metrics(data, tags, include_location_forest):
                             "forest_name:{}".format(forest_data['nameref']),
                         ]
                         if include_location_forest:
-                            for forest_key, forest_value in iteritems(forest_data):
+                            for forest_key, forest_value in forest_data.items():
                                 if forest_key == 'disk-size':
                                     metric = build_metric_to_submit(
                                         "forests.storage.{}".format(forest_key), forest_value, tags=forest_tags

--- a/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
+++ b/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
@@ -6,10 +6,9 @@
 
 Collects metrics from mesos slave node.
 """
+from urllib.parse import urlparse
 
 from requests.exceptions import Timeout
-from six import iteritems
-from six.moves.urllib.parse import urlparse
 
 from datadog_checks.base import AgentCheck, ConfigurationError
 
@@ -157,7 +156,7 @@ class MesosSlave(AgentCheck):
                     self.STATS_METRICS,
                 ]
                 for m in metrics:
-                    for key_name, (metric_name, metric_func) in iteritems(m):
+                    for key_name, (metric_name, metric_func) in m.items():
                         if key_name in stats_metrics:
                             metric_func(self, metric_name, stats_metrics[key_name], tags=stats_tags)
                 self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK, tags=stats_tags)
@@ -222,5 +221,5 @@ class MesosSlave(AgentCheck):
                             task_tags = ['task_name:' + t['name']]
                             task_tags.extend(tags)
                             self.service_check(t['name'] + '.ok', self.TASK_STATUS[t['state']], tags=task_tags)
-                            for key_name, (metric_name, metric_func) in iteritems(self.TASK_METRICS):
+                            for key_name, (metric_name, metric_func) in self.TASK_METRICS.items():
                                 metric_func(self, metric_name, t['resources'][key_name], tags=task_tags)

--- a/mongo/datadog_checks/mongo/collectors/replica.py
+++ b/mongo/datadog_checks/mongo/collectors/replica.py
@@ -3,8 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import time
-
-from six.moves.urllib.parse import urlsplit
+from urllib.parse import urlsplit
 
 from datadog_checks.mongo.api import MongoApi
 from datadog_checks.mongo.collectors.base import MongoCollector

--- a/mongo/datadog_checks/mongo/utils.py
+++ b/mongo/datadog_checks/mongo/utils.py
@@ -2,9 +2,9 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import re
+from urllib.parse import quote_plus, unquote_plus, urlencode, urlunparse
 
 import pymongo
-from six.moves.urllib.parse import quote_plus, unquote_plus, urlencode, urlunparse
 
 
 def build_connection_string(hosts, scheme, username=None, password=None, database=None, options=None):

--- a/network/datadog_checks/network/check_bsd.py
+++ b/network/datadog_checks/network/check_bsd.py
@@ -2,16 +2,11 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-from six import PY3, iteritems
-
 from datadog_checks.base.utils.platform import Platform
 from datadog_checks.base.utils.subprocess_output import SubprocessOutputEmptyError, get_subprocess_output
 
 from . import Network
 from .const import BSD_TCP_METRICS
-
-if PY3:
-    long = int
 
 
 class BSDNetwork(Network):
@@ -80,15 +75,15 @@ class BSDNetwork(Network):
                     current = iface
 
                 # Filter inactive interfaces
-                if self.parse_long(x[-5]) or self.parse_long(x[-2]):
+                if self.parse_int(x[-5]) or self.parse_int(x[-2]):
                     iface = current
                     metrics = {
-                        'bytes_rcvd': self.parse_long(x[-5]),
-                        'bytes_sent': self.parse_long(x[-2]),
-                        'packets_in.count': self.parse_long(x[-7]),
-                        'packets_in.error': self.parse_long(x[-6]),
-                        'packets_out.count': self.parse_long(x[-4]),
-                        'packets_out.error': self.parse_long(x[-3]),
+                        'bytes_rcvd': self.parse_int(x[-5]),
+                        'bytes_sent': self.parse_int(x[-2]),
+                        'packets_in.count': self.parse_int(x[-7]),
+                        'packets_in.error': self.parse_int(x[-6]),
+                        'packets_out.count': self.parse_int(x[-4]),
+                        'packets_out.error': self.parse_int(x[-3]),
                     }
                     self.submit_devicemetrics(iface, metrics, custom_tags)
         except SubprocessOutputEmptyError:
@@ -139,7 +134,7 @@ class BSDNetwork(Network):
                 # udp6       0      0 :::41458                :::*
 
                 metrics = self.parse_cx_state(lines[2:], self.tcp_states['netstat'], 5)
-                for metric, value in iteritems(metrics):
+                for metric, value in metrics.items():
                     self.gauge(metric, value, tags=custom_tags)
             except SubprocessOutputEmptyError:
                 self.log.exception("Error collecting connection states.")

--- a/network/datadog_checks/network/check_solaris.py
+++ b/network/datadog_checks/network/check_solaris.py
@@ -2,15 +2,10 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-from six import PY3, iteritems
-
 from datadog_checks.base.utils.subprocess_output import SubprocessOutputEmptyError, get_subprocess_output
 
 from . import Network
 from .const import SOLARIS_TCP_METRICS
-
-if PY3:
-    long = int
 
 
 class SolarisNetwork(Network):
@@ -25,7 +20,7 @@ class SolarisNetwork(Network):
         try:
             netstat, _, _ = get_subprocess_output(["kstat", "-p", "link:0:"], self.log)
             metrics_by_interface = self._parse_solaris_netstat(netstat)
-            for interface, metrics in iteritems(metrics_by_interface):
+            for interface, metrics in metrics_by_interface.items():
                 self.submit_devicemetrics(interface, metrics, custom_tags)
         except SubprocessOutputEmptyError:
             self.log.exception("Error collecting kstat stats.")
@@ -136,7 +131,7 @@ class SolarisNetwork(Network):
 
             # Add it to this interface's list of metrics.
             metrics = metrics_by_interface.get(iface, {})
-            metrics[ddname] = self.parse_long(cols[1])
+            metrics[ddname] = self.parse_int(cols[1])
             metrics_by_interface[iface] = metrics
 
         return metrics_by_interface

--- a/network/datadog_checks/network/check_windows.py
+++ b/network/datadog_checks/network/check_windows.py
@@ -7,13 +7,10 @@ from ctypes import Structure, byref, windll
 from ctypes.wintypes import DWORD
 
 import psutil
-from six import PY3, iteritems
 
 from . import Network
 
 Iphlpapi = windll.Iphlpapi
-if PY3:
-    long = int
 
 
 class TCPSTATS(Structure):
@@ -82,7 +79,7 @@ class WindowsNetwork(Network):
             else:
                 metrics[metric] += 1
 
-        for metric, value in iteritems(metrics):
+        for metric, value in metrics.items():
             self.gauge(metric, value, tags=tags)
 
     def _cx_counters_psutil(self, tags=None):
@@ -90,7 +87,7 @@ class WindowsNetwork(Network):
         Collect metrics about interfaces counters using psutil
         """
         tags = [] if tags is None else tags
-        for iface, counters in iteritems(psutil.net_io_counters(pernic=True)):
+        for iface, counters in psutil.net_io_counters(pernic=True).items():
             metrics = {
                 'bytes_rcvd': counters.bytes_recv,
                 'bytes_sent': counters.bytes_sent,

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -7,35 +7,24 @@ Collects network metrics.
 """
 
 import re
+import shutil
 import socket
 
 import psutil
-from six import PY3, iteritems, itervalues
 
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.errors import CheckException
 from datadog_checks.base.utils.platform import Platform
 
+# fcntl only available on Unix systems
 try:
     import fcntl
 except ImportError:
     fcntl = None
 
-if PY3:
-    long = int
 
-
-# Use a different find_executable implementation depending on Python version,
-# because we want to avoid depending on distutils.
-if PY3:
-    import shutil
-
-    def find_executable(name):
-        return shutil.which(name)
-
-else:
-    # Fallback to distutils for Python 2 as shutil.which was added on Python 3.3
-    from distutils.spawn import find_executable
+def find_executable(name):
+    return shutil.which(name)
 
 
 class Network(AgentCheck):
@@ -257,7 +246,7 @@ class Network(AgentCheck):
         )
 
         count = 0
-        for metric, val in iteritems(vals_by_metric):
+        for metric, val in vals_by_metric.items():
             self.rate('system.net.%s' % metric, val, tags=metric_tags)
             count += 1
         self.log.debug("tracked %s network metrics for interface %s", count, iface)
@@ -273,9 +262,9 @@ class Network(AgentCheck):
         ]
         return expected_metrics
 
-    def parse_long(self, v):
+    def parse_int(self, v):
         try:
-            return long(v)
+            return int(v)
         except ValueError:
             return 0
 
@@ -291,7 +280,7 @@ class Network(AgentCheck):
             for regex, metric in regex_list:
                 value = re.match(regex, line)
                 if value:
-                    self.submit_netmetric(metric, self.parse_long(value.group(1)), tags=tags)
+                    self.submit_netmetric(metric, self.parse_int(value.group(1)), tags=tags)
 
     def is_collect_cx_state_runnable(self, proc_location):
         """
@@ -325,7 +314,7 @@ class Network(AgentCheck):
         return net_proc_base_location
 
     def _get_metrics(self):
-        return {val: 0 for val in itervalues(self.cx_state_gauge)}
+        return {val: 0 for val in self.cx_state_gauge.values()}
 
     def parse_cx_state(self, lines, tcp_states, state_col, protocol=None, ip_version=None):
         """

--- a/openstack/datadog_checks/openstack/openstack.py
+++ b/openstack/datadog_checks/openstack/openstack.py
@@ -8,11 +8,10 @@ import random
 import re
 import time
 from datetime import datetime, timedelta
+from urllib.parse import urljoin
 
 import requests
 import simplejson as json
-from six import iteritems
-from six.moves.urllib.parse import urljoin
 
 from datadog_checks.base import AgentCheck, is_affirmative
 
@@ -852,7 +851,7 @@ class OpenStackCheck(AgentCheck):
         else:
             self.service_check(self.HYPERVISOR_SC, AgentCheck.OK, tags=service_check_tags)
 
-        for label, val in iteritems(hyp):
+        for label, val in hyp.items():
             if label in NOVA_HYPERVISOR_METRICS:
                 metric_label = "openstack.nova.{0}".format(label)
                 self.gauge(metric_label, val, tags=tags)
@@ -1196,7 +1195,7 @@ class OpenStackCheck(AgentCheck):
             #  The scopes we iterate over should all be OpenStackProjectScope
             #  instances
             projects = []
-            for _, scope in iteritems(scope_map):
+            for _, scope in scope_map.items():
                 # Store the scope on the object so we don't have to keep passing it around
                 self._current_scope = scope
 
@@ -1408,7 +1407,7 @@ class OpenStackCheck(AgentCheck):
         """
         self.log.debug("Collecting external_host_tags now")
         external_host_tags = []
-        for k, v in iteritems(self.external_host_tags):
+        for k, v in self.external_host_tags.items():
             external_host_tags.append((k, {SOURCE_TYPE: v}))
 
         self.log.debug("Sending external_host_tags: %s", external_host_tags)

--- a/openstack_controller/datadog_checks/openstack_controller/legacy/api.py
+++ b/openstack_controller/datadog_checks/openstack_controller/legacy/api.py
@@ -4,11 +4,10 @@
 
 import copy
 from os import environ
+from urllib.parse import urljoin
 
 import requests
 from openstack import connection
-from six import PY3
-from six.moves.urllib.parse import urljoin
 
 from .exceptions import (
     AuthenticationNeeded,
@@ -215,15 +214,10 @@ class OpenstackSDKApi(AbstractApi):
         return self.connection.list_hypervisors()
 
     def get_os_hypervisor_uptime(self, hypervisor):
-        if PY3:
-            if hypervisor.uptime is None:
-                self._check_authentication()
-                self.connection.compute.get_hypervisor_uptime(hypervisor)
-            return hypervisor.uptime
-        else:
-            # Hypervisor uptime is not available in openstacksdk 0.24.0.
-            self.logger.warning("Hypervisor uptime is not available with this version of openstacksdk")
-            raise NotImplementedError()
+        if hypervisor.uptime is None:
+            self._check_authentication()
+            self.connection.compute.get_hypervisor_uptime(hypervisor)
+        return hypervisor.uptime
 
     def get_os_aggregates(self):
         # Each aggregate is missing the 'uuid' attribute compared to what is returned by SimpleApi

--- a/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
+++ b/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
@@ -3,10 +3,10 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import re
 import time
+from urllib.parse import urlparse
 
 import psycopg2 as pg
 from psycopg2 import extras as pgextras
-from six.moves.urllib.parse import urlparse
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from datadog_checks.pgbouncer.metrics import (

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -4,8 +4,6 @@
 # https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
 from typing import Optional
 
-from six import PY2, PY3, iteritems
-
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from datadog_checks.base.utils.aws import rds_parse_tags_from_endpoint
 from datadog_checks.base.utils.db.utils import get_agent_host_tags
@@ -51,7 +49,7 @@ class PostgresConfig:
             )
 
         self.application_name = instance.get('application_name', 'datadog-agent')
-        if not self.isascii(self.application_name):
+        if not self.application_name.isascii():
             raise ConfigurationError("Application name can include only ASCII characters: %s", self.application_name)
 
         self.query_timeout = int(instance.get('query_timeout', 5000))
@@ -220,7 +218,7 @@ class PostgresConfig:
                 m['query'] = m['query'] % '{metrics_columns}'
 
             try:
-                for ref, (_, mtype) in iteritems(m['metrics']):
+                for ref, (_, mtype) in m['metrics'].items():
                     cap_mtype = mtype.upper()
                     if cap_mtype not in ('RATE', 'GAUGE', 'MONOTONIC'):
                         raise ConfigurationError(
@@ -232,17 +230,6 @@ class PostgresConfig:
             except Exception as e:
                 raise Exception('Error processing custom metric `{}`: {}'.format(m, e))
         return custom_metrics
-
-    @staticmethod
-    def isascii(application_name):
-        if PY3:
-            return application_name.isascii()
-        elif PY2:
-            try:
-                application_name.encode('ascii')
-                return True
-            except UnicodeEncodeError:
-                return False
 
     @staticmethod
     def _aws_managed_authentication(aws, password):

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -9,7 +9,6 @@ from time import time
 
 import psycopg2
 from cachetools import TTLCache
-from six import iteritems
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.db import QueryExecutor
@@ -595,7 +594,7 @@ class PostgreSql(AgentCheck):
                 tags = copy.copy(instance_tags)
 
             # Add tags from descriptors.
-            tags += [("%s:%s" % (k, v)) for (k, v) in iteritems(desc_map)]
+            tags += [("%s:%s" % (k, v)) for (k, v) in desc_map.items()]
 
             # Submit metrics to the Agent.
             for column, value in zip(cols, column_values):

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -10,7 +10,6 @@ import time
 from collections import defaultdict
 
 import psutil
-from six import iteritems
 
 from datadog_checks.base import AgentCheck, is_affirmative
 from datadog_checks.base.utils.platform import Platform
@@ -464,7 +463,7 @@ class ProcessCheck(AgentCheck):
             self.last_pid_cache_ts[self.name] = 0
             self.process_list_cache.reset()
 
-        for attr, mname in iteritems(ATTR_TO_METRIC):
+        for attr, mname in ATTR_TO_METRIC.items():
             vals = [x for x in proc_state[attr] if x is not None]
             # skip []
             if vals:
@@ -480,7 +479,7 @@ class ProcessCheck(AgentCheck):
                     if mname in ['ioread_bytes', 'iowrite_bytes']:
                         self.monotonic_count('system.processes.{}_count'.format(mname), sum_vals, tags=tags)
 
-        for attr, mname in iteritems(ATTR_TO_METRIC_RATE):
+        for attr, mname in ATTR_TO_METRIC_RATE.items():
             vals = [x for x in proc_state[attr] if x is not None]
             if vals:
                 self.rate('system.processes.{}'.format(mname), sum(vals), tags=tags)

--- a/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
+++ b/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
@@ -5,10 +5,9 @@
 import re
 import time
 from collections import defaultdict
+from urllib.parse import quote_plus, urljoin, urlparse
 
 from requests.exceptions import RequestException
-from six import iteritems
-from six.moves.urllib.parse import quote_plus, urljoin, urlparse
 
 from datadog_checks.base import AgentCheck, is_affirmative, to_native_string
 
@@ -88,8 +87,8 @@ class RabbitMQManagement(AgentCheck):
             NODE_TYPE: {'explicit': instance.get('nodes', []), 'regexes': instance.get('nodes_regexes', [])},
         }
 
-        for object_type, filters in iteritems(specified):
-            for _, filter_objects in iteritems(filters):
+        for object_type, filters in specified.items():
+            for _, filter_objects in filters.items():
                 if type(filter_objects) != list:
                     raise TypeError("{0} / {0}_regexes parameter must be a list".format(object_type))
 
@@ -499,10 +498,10 @@ class RabbitMQManagement(AgentCheck):
                 # 'state' does not exist for direct type connections.
                 connection_states[conn.get('state', 'direct')] += 1
 
-        for vhost, nb_conn in iteritems(stats):
+        for vhost, nb_conn in stats.items():
             self.gauge('rabbitmq.connections', nb_conn, tags=['{}_vhost:{}'.format(TAG_PREFIX, vhost)] + custom_tags)
 
-        for conn_state, nb_conn in iteritems(connection_states):
+        for conn_state, nb_conn in connection_states.items():
             self.gauge(
                 'rabbitmq.connections.state',
                 nb_conn,

--- a/silk/datadog_checks/silk/check.py
+++ b/silk/datadog_checks/silk/check.py
@@ -2,8 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from copy import deepcopy
-
-from six.moves.urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin, urlparse
 
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.utils.time import get_timestamp

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -14,8 +14,6 @@ from collections import defaultdict
 from concurrent import futures
 from typing import Any, DefaultDict, Dict, List, Optional, Pattern, Tuple  # noqa: F401
 
-from six import iteritems
-
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from datadog_checks.base.errors import CheckException
 from datadog_checks.snmp.utils import extract_value
@@ -515,7 +513,7 @@ class SnmpCheck(AgentCheck):
                 self.log.debug('Ignoring metric %s', name)
                 continue
             if isinstance(metric, ParsedTableMetric):
-                for index, val in iteritems(results[name]):
+                for index, val in results[name].items():
                     metric_tags = tags + self.get_index_tags(index, results, metric.index_tags, metric.column_tags)
                     self.submit_metric(
                         name, val, metric.forced_type, metric_tags, metric.options, metric.extract_value_pattern

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -5,8 +5,6 @@ import logging
 import socket
 from contextlib import closing, contextmanager
 
-from six import raise_from
-
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.log import get_check_logger
 from datadog_checks.sqlserver.cursor import CommenterCursorWrapper
@@ -316,7 +314,7 @@ class Connection(object):
             if is_default:
                 # the message that is raised here (along with the exception stack trace)
                 # is what will be seen in the agent status output.
-                raise_from(SQLConnectionError(check_err_message), None)
+                raise SQLConnectionError(check_err_message) from None
             else:
                 # if not the default db, we should still log this exception
                 # to give the customer an opportunity to fix the issue

--- a/statsd/datadog_checks/statsd/statsd.py
+++ b/statsd/datadog_checks/statsd/statsd.py
@@ -4,8 +4,7 @@
 
 import re
 import socket
-
-from six import BytesIO
+from io import BytesIO
 
 from datadog_checks.base import AgentCheck, ensure_bytes, ensure_unicode
 

--- a/tls/datadog_checks/tls/tls.py
+++ b/tls/datadog_checks/tls/tls.py
@@ -4,10 +4,9 @@
 import socket
 import ssl
 from datetime import datetime
+from urllib.parse import urlparse
 
 import service_identity
-from six import text_type
-from six.moves.urllib.parse import urlparse
 
 from datadog_checks.base import AgentCheck, is_affirmative
 
@@ -149,7 +148,7 @@ class TLSCheck(AgentCheck):
             validator, host_type = self.validation_data
 
             try:
-                validator(cert, text_type(self._server_hostname))
+                validator(cert, str(self._server_hostname))
             except service_identity.VerificationError:
                 message = 'The {} on the certificate does not match the given host'.format(host_type)
                 self.log.debug(message)

--- a/voltdb/datadog_checks/voltdb/check.py
+++ b/voltdb/datadog_checks/voltdb/check.py
@@ -4,7 +4,6 @@
 from typing import Any, List, Optional, cast  # noqa: F401
 
 import requests  # noqa: F401
-from six import raise_from
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.db import QueryManager
@@ -52,7 +51,7 @@ class VoltDBCheck(AgentCheck):
                 pass
             else:
                 message += ' (details: {})'.format(details)
-            raise_from(Exception(message), exc)
+            raise Exception(message) from exc
 
     def _fetch_version(self):
         # type: () -> Optional[str]

--- a/voltdb/datadog_checks/voltdb/client.py
+++ b/voltdb/datadog_checks/voltdb/client.py
@@ -3,9 +3,9 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import json
 from typing import Callable, Union  # noqa: F401
+from urllib.parse import urljoin
 
 import requests
-from six.moves.urllib.parse import urljoin
 
 
 class Client(object):

--- a/voltdb/datadog_checks/voltdb/config.py
+++ b/voltdb/datadog_checks/voltdb/config.py
@@ -2,8 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from typing import Callable, List, Optional  # noqa: F401
-
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 from datadog_checks.base import ConfigurationError, is_affirmative
 

--- a/vsphere/datadog_checks/vsphere/api.py
+++ b/vsphere/datadog_checks/vsphere/api.py
@@ -8,7 +8,6 @@ from typing import Any, Callable, List, TypeVar, cast  # noqa: F401
 
 from pyVim import connect
 from pyVmomi import vim, vmodl
-from six import itervalues
 
 from datadog_checks.base.log import CheckLoggingAdapter  # noqa: F401
 from datadog_checks.vsphere.config import VSphereConfig  # noqa: F401
@@ -286,7 +285,7 @@ class VSphereAPI(object):
             # at this point they are custom pyvmomi objects and the attribute keys are not resolved.
 
             attribute_keys = {x.key: x.name for x in self._fetch_all_attributes()}
-            for props in itervalues(infrastructure_data):
+            for props in infrastructure_data.values():
                 mor_attributes = []
                 if self.config.collect_property_metrics:
                     all_properties = {}

--- a/vsphere/datadog_checks/vsphere/cache.py
+++ b/vsphere/datadog_checks/vsphere/cache.py
@@ -6,7 +6,6 @@ from contextlib import contextmanager
 from typing import Any, Dict, Generator, Iterator, List, Type  # noqa: F401
 
 from pyVmomi import vim  # noqa: F401
-from six import iterkeys
 
 from datadog_checks.vsphere.types import CounterId, MetricName, ResourceTags  # noqa: F401
 
@@ -140,7 +139,7 @@ class InfrastructureCache(VSphereCache):
 
     def get_mors(self, resource_type):
         # type: (Type[vim.ManagedEntity]) -> Iterator[vim.ManagedEntity]
-        return iterkeys(self._mors.get(resource_type, {}))
+        return iter(self._mors.get(resource_type, {}).keys())
 
     def set_mor_props(self, mor, mor_data):
         # type: (vim.ManagedEntity, Dict[str, Any]) -> None

--- a/vsphere/datadog_checks/vsphere/legacy/vsphere_legacy.py
+++ b/vsphere/datadog_checks/vsphere/legacy/vsphere_legacy.py
@@ -17,8 +17,6 @@ from pyVmomi import (
     vim,  # pylint: disable=E0611
     vmodl,  # pylint: disable=E0611
 )
-from six import itervalues
-from six.moves import range
 
 from datadog_checks.base import AgentCheck, ensure_unicode, to_string
 from datadog_checks.base.checks.libs.thread_pool import SENTINEL, Pool
@@ -951,7 +949,7 @@ class VSphereLegacyCheck(AgentCheck):
         batch_size = self.batch_morlist_size or n_mors
         for batch in mors_batch_method(i_key, batch_size, max_historical_metrics):
             query_specs = []
-            for mor in itervalues(batch):
+            for mor in batch.values():
                 if mor['mor_type'] == 'vm':
                     vm_count += 1
                 if mor['mor_type'] not in REALTIME_RESOURCES and ('metrics' not in mor or not mor['metrics']):

--- a/vsphere/tests/legacy/test_mor_cache.py
+++ b/vsphere/tests/legacy/test_mor_cache.py
@@ -5,7 +5,6 @@ import time
 
 import pytest
 from mock import MagicMock
-from six.moves import range
 
 from datadog_checks.vsphere.legacy.mor_cache import MorCache, MorNotFoundError
 

--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -7,7 +7,6 @@ import re
 import pywintypes
 import win32service
 import winerror
-from six import raise_from
 
 from datadog_checks.base import AgentCheck
 
@@ -42,7 +41,7 @@ class ServiceFilter(object):
                 pattern = self.name
                 self._name_re = re.compile(pattern, SERVICE_PATTERN_FLAGS)
         except re.error as e:
-            raise_from(Exception("Regular expression syntax error in '{}': {}".format(pattern, str(e))), None)
+            raise Exception("Regular expression syntax error in '{}': {}".format(pattern, str(e))) from None
 
     def match(self, service_view):
         if self.name is not None:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Here we focus mostly on the different compatibility crutches in use by integrations themselves.

One or two tests crept in that we missed earlier.

For the most part we're not touching yet the dispatching logic that switches between versions of the check used in Python2 or 3 only.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
