### PR TITLE
Remove Python2 logic when loading checks

### DIFF
--- a/active_directory/datadog_checks/active_directory/active_directory.py
+++ b/active_directory/datadog_checks/active_directory/active_directory.py
@@ -1,18 +1,15 @@
 # (C) Datadog, Inc. 2013-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-from six import PY3
-
 from datadog_checks.base import PDHBaseCheck, is_affirmative
 
+from .check import ActiveDirectoryCheckV2
 from .metrics import DEFAULT_COUNTERS
 
 
 class ActiveDirectoryCheck(PDHBaseCheck):
     def __new__(cls, name, init_config, instances):
-        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False)):
-            from .check import ActiveDirectoryCheckV2
-
+        if not is_affirmative(instances[0].get('use_legacy_check_version', False)):
             return ActiveDirectoryCheckV2(name, init_config, instances)
         else:
             return super(ActiveDirectoryCheck, cls).__new__(cls)

--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -10,10 +10,10 @@ import re
 from collections import defaultdict
 from typing import List  # noqa: F401
 
-from six import PY2, iteritems
-
-from datadog_checks.base import AgentCheck, ConfigurationError
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.errors import CheckException
+
+from .check import AerospikeCheckV2
 
 try:
     import aerospike
@@ -78,15 +78,6 @@ class AerospikeCheck(AgentCheck):
         instance = instances[0]
 
         if 'openmetrics_endpoint' in instance:
-            if PY2:
-                raise ConfigurationError(
-                    "This version of the integration is only available when using py3. "
-                    "Check https://docs.datadoghq.com/agent/guide/agent-v6-python-3 "
-                    "for more information or use the older style config."
-                )
-            # TODO: when we drop Python 2 move this import up top
-            from .check import AerospikeCheckV2
-
             return AerospikeCheckV2(name, init_config, instances)
 
         else:
@@ -232,7 +223,7 @@ class AerospikeCheck(AgentCheck):
                 self.log.warning('Exceeded cap `%s` for metric type `%s` - please contact support', cap, metric_type)
                 return
 
-        for key, value in iteritems(required_data):
+        for key, value in required_data.items():
             self.send(metric_type, key, value, tags)
 
     def get_namespaces(self):
@@ -491,7 +482,7 @@ class AerospikeCheck(AgentCheck):
 
             ns_latencies[ns].setdefault("metric_names", []).extend(metric_names)
 
-        for ns, v in iteritems(ns_latencies):
+        for ns, v in ns_latencies.items():
             metric_names = v.get("metric_names", [])
             metric_values = v.get("metric_values", [])
             namespace_tags = ['namespace:{}'.format(ns)] if ns else []

--- a/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py
+++ b/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py
@@ -4,10 +4,10 @@
 import json
 
 import boto3
-from six import PY2
 
 from datadog_checks.base import ConfigurationError, OpenMetricsBaseCheck, is_affirmative
 
+from .check import AmazonMskCheckV2
 from .metrics import JMX_METRICS_MAP, JMX_METRICS_OVERRIDES, NODE_METRICS_MAP, NODE_METRICS_OVERRIDES
 from .utils import construct_boto_config
 
@@ -29,15 +29,6 @@ class AmazonMskCheck(OpenMetricsBaseCheck):
         instance = instances[0]
 
         if is_affirmative(instance.get('use_openmetrics', False)):
-            if PY2:
-                raise ConfigurationError(
-                    "Openmetrics on this integration is only available when using py3. "
-                    "Check https://docs.datadoghq.com/agent/guide/agent-v6-python-3 "
-                    "for more information"
-                )
-            # TODO: when we drop Python 2 move this import up top
-            from .check import AmazonMskCheckV2
-
             return AmazonMskCheckV2(name, init_config, instances)
         else:
             return super(AmazonMskCheck, cls).__new__(cls)

--- a/argocd/datadog_checks/argocd/check.py
+++ b/argocd/datadog_checks/argocd/check.py
@@ -3,8 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from collections import defaultdict
 
-from six import PY2
-
 from datadog_checks.base import ConfigurationError, OpenMetricsBaseCheckV2
 from datadog_checks.base.constants import ServiceCheck
 
@@ -36,12 +34,6 @@ class ArgocdCheck(OpenMetricsBaseCheckV2, ConfigMixin):
     DEFAULT_METRIC_LIMIT = 0
 
     def __init__(self, name, init_config, instances):
-        if PY2:
-            raise ConfigurationError(
-                "This version of the integration is only available when using py3. "
-                "Check https://docs.datadoghq.com/agent/guide/agent-v6-python-3 "
-                "for more information."
-            )
         super(ArgocdCheck, self).__init__(name, init_config, instances)
         self.check_initializations.appendleft(self.parse_config)
         self.check_initializations.append(self.configure_additional_transformers)

--- a/argocd/tests/test_argocd.py
+++ b/argocd/tests/test_argocd.py
@@ -3,11 +3,9 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import pytest
-from mock import patch
 
 from datadog_checks.argocd import ArgocdCheck
 from datadog_checks.base.constants import ServiceCheck
-from datadog_checks.base.errors import ConfigurationError
 from datadog_checks.dev.utils import get_metadata_metrics
 
 from .common import (
@@ -96,10 +94,3 @@ def test_app_controller_service_check(dd_run_check, aggregator, mock_http_respon
         ServiceCheck.UNKNOWN,
         tags=['endpoint:http://app_controller:8082', 'name:faz'],
     )
-
-
-@patch('datadog_checks.argocd.check.PY2', True)
-def test_py2():
-    # Test to ensure that a ConfigurationError is raised when running with Python 2.
-    with pytest.raises(ConfigurationError, match="This version of the integration is only available when using py3."):
-        ArgocdCheck('argocd', {}, [MOCKED_APP_CONTROLLER_INSTANCE])

--- a/aspdotnet/datadog_checks/aspdotnet/aspdotnet.py
+++ b/aspdotnet/datadog_checks/aspdotnet/aspdotnet.py
@@ -1,10 +1,9 @@
 # (C) Datadog, Inc. 2013-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-from six import PY3
-
 from datadog_checks.base import PDHBaseCheck, is_affirmative
 
+from .check import AspdotnetCheckV2
 from .metrics import DEFAULT_COUNTERS
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'aspdotnet'
@@ -13,9 +12,7 @@ EVENT_TYPE = SOURCE_TYPE_NAME = 'aspdotnet'
 class AspdotnetCheck(PDHBaseCheck):
     def __new__(cls, name, init_config, instances):
 
-        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False)):
-            from .check import AspdotnetCheckV2
-
+        if not is_affirmative(instances[0].get('use_legacy_check_version', False)):
             return AspdotnetCheckV2(name, init_config, instances)
         else:
             return super(AspdotnetCheck, cls).__new__(cls)

--- a/cilium/datadog_checks/cilium/cilium.py
+++ b/cilium/datadog_checks/cilium/cilium.py
@@ -1,10 +1,9 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from six import PY2
-
 from datadog_checks.base import ConfigurationError, OpenMetricsBaseCheck, is_affirmative
 
+from .check import CiliumCheckV2
 from .metrics import AGENT_METRICS, OPERATOR_METRICS
 
 
@@ -19,15 +18,6 @@ class CiliumCheck(OpenMetricsBaseCheck):
         instance = instances[0]
 
         if is_affirmative(instance.get('use_openmetrics', False)):
-            if PY2:
-                raise ConfigurationError(
-                    "This version of the integration is only available when using py3. "
-                    "Check https://docs.datadoghq.com/agent/guide/agent-v6-python-3 "
-                    "for more information or use the older style config."
-                )
-            # TODO: when we drop Python 2 move this import up top
-            from .check import CiliumCheckV2
-
             return CiliumCheckV2(name, init_config, instances)
         else:
             return super(CiliumCheck, cls).__new__(cls)

--- a/cockroachdb/datadog_checks/cockroachdb/cockroachdb.py
+++ b/cockroachdb/datadog_checks/cockroachdb/cockroachdb.py
@@ -1,10 +1,9 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from six import PY2
+from datadog_checks.base import OpenMetricsBaseCheck
 
-from datadog_checks.base import ConfigurationError, OpenMetricsBaseCheck
-
+from .check import CockroachdbCheckV2
 from .metrics import METRIC_MAP
 
 
@@ -16,15 +15,6 @@ class CockroachdbCheck(OpenMetricsBaseCheck):
         instance = instances[0]
 
         if 'openmetrics_endpoint' in instance:
-            if PY2:
-                raise ConfigurationError(
-                    'This version of the integration is only available when using Python 3. '
-                    'Check https://docs.datadoghq.com/agent/guide/agent-v6-python-3/ '
-                    'for more information or use the older style config.'
-                )
-            # TODO: when we drop Python 2 move this import up top
-            from .check import CockroachdbCheckV2
-
             return CockroachdbCheckV2(name, init_config, instances)
         else:
             return super(CockroachdbCheck, cls).__new__(cls)

--- a/coredns/datadog_checks/coredns/coredns.py
+++ b/coredns/datadog_checks/coredns/coredns.py
@@ -1,10 +1,9 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from six import PY2
-
 from datadog_checks.base import ConfigurationError, OpenMetricsBaseCheck
 
+from .check import CoreDNS
 from .metrics import DEFAULT_METRICS, GO_METRICS
 
 
@@ -25,15 +24,6 @@ class CoreDNSCheck(OpenMetricsBaseCheck):
         instance = instances[0]
 
         if 'openmetrics_endpoint' in instance:
-            if PY2:
-                raise ConfigurationError(
-                    "This version of the integration is only available when using py3. "
-                    "Check https://docs.datadoghq.com/agent/guide/agent-v6-python-3 "
-                    "for more information or use the older style config."
-                )
-            # TODO: when we drop Python 2 move this import up top
-            from .check import CoreDNS
-
             return CoreDNS(name, init_config, instances)
         else:
             return super(CoreDNSCheck, cls).__new__(cls)

--- a/dotnetclr/datadog_checks/dotnetclr/dotnetclr.py
+++ b/dotnetclr/datadog_checks/dotnetclr/dotnetclr.py
@@ -1,10 +1,9 @@
 # (C) Datadog, Inc. 2013-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-from six import PY3
-
 from datadog_checks.base import PDHBaseCheck, is_affirmative
 
+from .check import DotnetclrCheckV2
 from .metrics import DEFAULT_COUNTERS
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'dotnetclr'
@@ -12,9 +11,7 @@ EVENT_TYPE = SOURCE_TYPE_NAME = 'dotnetclr'
 
 class DotnetclrCheck(PDHBaseCheck):
     def __new__(cls, name, init_config, instances):
-        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False)):
-            from .check import DotnetclrCheckV2
-
+        if not is_affirmative(instances[0].get('use_legacy_check_version', False)):
             return DotnetclrCheckV2(name, init_config, instances)
         else:
             return super(DotnetclrCheck, cls).__new__(cls)

--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -6,10 +6,10 @@ from collections import defaultdict
 from urllib.parse import urljoin
 
 import requests
-from six import PY2
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 
+from .check import EnvoyCheckV2
 from .errors import UnknownMetric, UnknownTags
 from .parser import parse_histogram, parse_metric
 from .utils import _get_server_info
@@ -27,15 +27,6 @@ class Envoy(AgentCheck):
         instance = instances[0]
 
         if 'openmetrics_endpoint' in instance:
-            if PY2:
-                raise ConfigurationError(
-                    "This version of the integration is only available when using py3. "
-                    "Check https://docs.datadoghq.com/agent/guide/agent-v6-python-3 "
-                    "for more information or use the older style config."
-                )
-            # TODO: when we drop Python 2 move this import up top
-            from .check import EnvoyCheckV2
-
             return EnvoyCheckV2(name, init_config, instances)
         else:
             return super(Envoy, cls).__new__(cls)

--- a/exchange_server/datadog_checks/exchange_server/exchange_server.py
+++ b/exchange_server/datadog_checks/exchange_server/exchange_server.py
@@ -1,18 +1,15 @@
 # (C) Datadog, Inc. 2013-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-from six import PY3
-
 from datadog_checks.base import PDHBaseCheck, is_affirmative
 
+from .check import ExchangeCheckV2
 from .metrics import DEFAULT_COUNTERS
 
 
 class ExchangeCheck(PDHBaseCheck):
     def __new__(cls, name, init_config, instances):
-        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False)):
-            from .check import ExchangeCheckV2
-
+        if not is_affirmative(instances[0].get('use_legacy_check_version', False)):
             return ExchangeCheckV2(name, init_config, instances)
         else:
             return super(ExchangeCheck, cls).__new__(cls)

--- a/gitlab/datadog_checks/gitlab/gitlab.py
+++ b/gitlab/datadog_checks/gitlab/gitlab.py
@@ -4,13 +4,13 @@
 from copy import deepcopy
 
 import requests
-from six import PY2
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
-from datadog_checks.base.errors import CheckException, ConfigurationError
+from datadog_checks.base.errors import CheckException
 
 from .common import get_gitlab_version, get_tags
+from .gitlab_v2 import GitlabCheckV2
 from .metrics import METRICS_MAP
 
 
@@ -41,15 +41,6 @@ class GitlabCheck(OpenMetricsBaseCheck):
         instance = instances[0]
 
         if instance.get('openmetrics_endpoint'):
-            if PY2:
-                raise ConfigurationError(
-                    'This version of the integration is only available when using Python 3. '
-                    'Check https://docs.datadoghq.com/agent/guide/agent-v6-python-3/ '
-                    'for more information or use the older style config.'
-                )
-            # TODO: when we drop Python 2 move this import up top
-            from .gitlab_v2 import GitlabCheckV2
-
             return GitlabCheckV2(name, init_config, instances)
 
         return super(GitlabCheck, cls).__new__(cls)

--- a/haproxy/datadog_checks/haproxy/check.py
+++ b/haproxy/datadog_checks/haproxy/check.py
@@ -1,10 +1,9 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from six import PY2
+from datadog_checks.base import OpenMetricsBaseCheck, is_affirmative
 
-from datadog_checks.base import ConfigurationError, OpenMetricsBaseCheck, is_affirmative
-
+from .checkv2 import HaproxyCheckV2
 from .legacy.haproxy import HAProxyCheckLegacy
 from .metrics import METRIC_MAP
 
@@ -16,14 +15,6 @@ class HAProxyCheck(OpenMetricsBaseCheck):
         instance = instances[0]
 
         if is_affirmative(instance.get('use_openmetrics', False)):
-            if PY2:
-                raise ConfigurationError(
-                    "Openmetrics on this integration is only available when using py3. "
-                    "Check https://docs.datadoghq.com/agent/guide/agent-v6-python-3 "
-                    "for more information"
-                )
-            from .checkv2 import HaproxyCheckV2
-
             return HaproxyCheckV2(name, init_config, instances)
         elif is_affirmative(instance.get('use_prometheus', False)):
             return super(HAProxyCheck, cls).__new__(cls)

--- a/hyperv/datadog_checks/hyperv/hyperv.py
+++ b/hyperv/datadog_checks/hyperv/hyperv.py
@@ -1,18 +1,15 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from six import PY3
-
 from datadog_checks.base import PDHBaseCheck, is_affirmative
 
+from .check import HypervCheckV2
 from .metrics import DEFAULT_COUNTERS
 
 
 class HypervCheck(PDHBaseCheck):
     def __new__(cls, name, init_config, instances):
-        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False)):
-            from .check import HypervCheckV2
-
+        if not is_affirmative(instances[0].get('use_legacy_check_version', False)):
             return HypervCheckV2(name, init_config, instances)
         else:
             return super(HypervCheck, cls).__new__(cls)

--- a/kong/datadog_checks/kong/kong.py
+++ b/kong/datadog_checks/kong/kong.py
@@ -4,9 +4,10 @@
 from urllib.parse import urlparse
 
 import simplejson as json
-from six import PY2
 
-from datadog_checks.base import AgentCheck, ConfigurationError
+from datadog_checks.base import AgentCheck
+
+from .check import KongCheck
 
 
 class Kong(AgentCheck):
@@ -24,15 +25,6 @@ class Kong(AgentCheck):
         instance = instances[0]
 
         if 'openmetrics_endpoint' in instance:
-            if PY2:
-                raise ConfigurationError(
-                    "This version of the integration is only available when using py3. "
-                    "Check https://docs.datadoghq.com/agent/guide/agent-v6-python-3 "
-                    "for more information or use the older style config."
-                )
-            # TODO: when we drop Python 2 move this import up top
-            from .check import KongCheck
-
             return KongCheck(name, init_config, instances)
         else:
             return super(Kong, cls).__new__(cls)

--- a/linkerd/datadog_checks/linkerd/linkerd.py
+++ b/linkerd/datadog_checks/linkerd/linkerd.py
@@ -1,11 +1,9 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from six import PY2
-
-from datadog_checks.base import ConfigurationError
 from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 
+from .check import LinkerdCheckV2
 from .metrics import METRIC_MAP, TYPE_OVERRIDES
 
 
@@ -22,15 +20,6 @@ class LinkerdCheck(OpenMetricsBaseCheck):
         instance = instances[0]
 
         if 'openmetrics_endpoint' in instance:
-            if PY2:
-                raise ConfigurationError(
-                    "This version of the integration is only available when using py3. "
-                    "Check https://docs.datadoghq.com/agent/guide/agent-v6-python-3 "
-                    "for more information or use the older style config."
-                )
-            # TODO: when we drop Python 2 move this import up top
-            from .check import LinkerdCheckV2
-
             return LinkerdCheckV2(name, init_config, instances)
         else:
             return super(LinkerdCheck, cls).__new__(cls)

--- a/openmetrics/datadog_checks/openmetrics/config_models/validators.py
+++ b/openmetrics/datadog_checks/openmetrics/config_models/validators.py
@@ -1,19 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from six import PY2
 
 
 def initialize_instance(values, **kwargs):
     v2_endpoint = values.get('openmetrics_endpoint')
     v1_endpoint = values.get('prometheus_url')
-    if PY2 and v2_endpoint:
-        raise ValueError('`openmetrics_endpoint` cannot be used if the agent is running Python 2')
     if v1_endpoint and v2_endpoint:
         raise ValueError('`prometheus_url` cannot be used along `openmetrics_endpoint`')
     if not v1_endpoint and not v2_endpoint:
-        if PY2:
-            raise ValueError('`prometheus_url` is required')
-        else:
-            raise ValueError('`openmetrics_endpoint` is required')
+        raise ValueError('`openmetrics_endpoint` is required')
     return values

--- a/openmetrics/datadog_checks/openmetrics/openmetrics.py
+++ b/openmetrics/datadog_checks/openmetrics/openmetrics.py
@@ -1,8 +1,6 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from six import PY2
-
 from datadog_checks.base import OpenMetricsBaseCheck, OpenMetricsBaseCheckV2
 
 
@@ -10,7 +8,7 @@ class OpenMetricsCheck(OpenMetricsBaseCheck):
     def __new__(cls, name, init_config, instances):
         instance = instances[0]
 
-        if not PY2 and 'openmetrics_endpoint' in instance:
+        if 'openmetrics_endpoint' in instance:
             return OpenMetricsBaseCheckV2(name, init_config, instances)
         else:
             return super(OpenMetricsBaseCheck, cls).__new__(cls)

--- a/rabbitmq/datadog_checks/rabbitmq/check.py
+++ b/rabbitmq/datadog_checks/rabbitmq/check.py
@@ -1,9 +1,9 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from six import PY2
+from datadog_checks.base import AgentCheck
 
-from datadog_checks.base import AgentCheck, ConfigurationError
+from .openmetrics import RabbitMQOpenMetrics
 
 
 class RabbitMQ(AgentCheck):
@@ -13,13 +13,6 @@ class RabbitMQ(AgentCheck):
         instance = instances[0]
 
         if 'prometheus_plugin' in instance:
-            if PY2:
-                raise ConfigurationError(
-                    "This version of the integration is only available when using py3. "
-                    "Check https://docs.datadoghq.com/agent/guide/agent-v6-python-3 "
-                    "for more information or use the `rabbitmq_api_url` config."
-                )
-            from .openmetrics import RabbitMQOpenMetrics
 
             return RabbitMQOpenMetrics(name, init_config, instances)
         else:

--- a/scylla/datadog_checks/scylla/scylla.py
+++ b/scylla/datadog_checks/scylla/scylla.py
@@ -3,11 +3,10 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from urllib.parse import urlparse
 
-from six import PY2
-
 from datadog_checks.base import ConfigurationError, OpenMetricsBaseCheck
 
 from .metrics import ADDITIONAL_METRICS_MAP, INSTANCE_DEFAULT_METRICS
+from .scylla_v2 import ScyllaCheckV2
 
 
 class ScyllaCheck(OpenMetricsBaseCheck):
@@ -27,15 +26,6 @@ class ScyllaCheck(OpenMetricsBaseCheck):
         instance = instances[0]
 
         if instance.get('openmetrics_endpoint'):
-            if PY2:
-                raise ConfigurationError(
-                    'This version of the integration is only available when using Python 3. '
-                    'Check https://docs.datadoghq.com/agent/guide/agent-v6-python-3/ '
-                    'for more information or use the older style config.'
-                )
-            # TODO: when we drop Python 2 move this import up top
-            from .scylla_v2 import ScyllaCheckV2
-
             return ScyllaCheckV2(name, init_config, instances)
         else:
             return super(ScyllaCheck, cls).__new__(cls)

--- a/teamcity/datadog_checks/teamcity/check.py
+++ b/teamcity/datadog_checks/teamcity/check.py
@@ -1,9 +1,9 @@
 # (C) Datadog, Inc. 2014-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from six import PY2
+from datadog_checks.base import AgentCheck, is_affirmative
 
-from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
+from .teamcity_openmetrics import TeamCityOpenMetrics
 
 
 class TeamCityCheck(AgentCheck):
@@ -13,15 +13,6 @@ class TeamCityCheck(AgentCheck):
         instance = instances[0]
 
         if is_affirmative(instance.get('use_openmetrics', False)):
-            if PY2:
-                raise ConfigurationError(
-                    "This version of the integration is only available when using py3. "
-                    "Check https://docs.datadoghq.com/agent/guide/agent-v6-python-3 "
-                    "for more information or use the older style config."
-                )
-            # TODO: when we drop Python 2 move this import up top
-            from .teamcity_openmetrics import TeamCityOpenMetrics
-
             return TeamCityOpenMetrics(name, init_config, instances)
         else:
             from .teamcity_rest import TeamCityRest

--- a/teamcity/datadog_checks/teamcity/teamcity_rest.py
+++ b/teamcity/datadog_checks/teamcity/teamcity_rest.py
@@ -4,7 +4,6 @@
 from copy import deepcopy
 
 from requests.exceptions import HTTPError
-from six import PY2
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from datadog_checks.base.utils.time import get_precise_time
@@ -81,9 +80,6 @@ class TeamCityRest(AgentCheck):
         self.tags.update(instance_tags)
 
         self.bc_store = BuildConfigs()
-
-        if PY2:
-            self.check_initializations.append(self._validate_config)
 
     def _validate_config(self):
         if self.instance.get('projects'):
@@ -172,10 +168,6 @@ class TeamCityRest(AgentCheck):
             self._initialize_single_build_config()
 
         else:
-            if PY2:
-                raise self.CheckException(
-                    'Multi-build configuration monitoring is not currently supported in Python 2.'
-                )
             self.log.debug("Initializing multi-build configuration monitoring.")
             self._initialize_multi_build_config()
 

--- a/vault/datadog_checks/vault/vault.py
+++ b/vault/datadog_checks/vault/vault.py
@@ -4,10 +4,10 @@
 import time
 
 import requests
-from six import PY2
 
-from datadog_checks.base import ConfigurationError, OpenMetricsBaseCheck, is_affirmative
+from datadog_checks.base import OpenMetricsBaseCheck, is_affirmative
 
+from .check import VaultCheckV2
 from .common import API_METHODS, DEFAULT_API_VERSION, SYS_HEALTH_DEFAULT_CODES, SYS_LEADER_DEFAULT_CODES, Api, Leader
 from .errors import ApiUnreachable
 from .metrics import METRIC_MAP, METRIC_ROLLBACK_COMPAT_MAP, ROUTE_METRICS_TO_TRANSFORM
@@ -38,14 +38,6 @@ class Vault(OpenMetricsBaseCheck):
         instance = instances[0]
 
         if is_affirmative(instance.get('use_openmetrics', False)):
-            if PY2:
-                raise ConfigurationError(
-                    'This version of the integration is only available when using Python 3. '
-                    'Check https://docs.datadoghq.com/agent/guide/agent-v6-python-3/ '
-                    'for more information or use the older style config.'
-                )
-            # TODO: when we drop Python 2 move this import up top
-            from .check import VaultCheckV2
 
             return VaultCheckV2(name, init_config, instances)
         else:
@@ -278,9 +270,6 @@ class Vault(OpenMetricsBaseCheck):
         return json_data
 
     def parse_config(self):
-        if PY2 and not self._api_url:
-            raise ConfigurationError('Vault setting `api_url` is required')
-
         api_version = self._api_url[-1]
         if api_version not in ('1',):
             self.log.warning('Unknown Vault API version `%s`, using version `%s`', api_version, DEFAULT_API_VERSION)

--- a/win32_event_log/datadog_checks/win32_event_log/check.py
+++ b/win32_event_log/datadog_checks/win32_event_log/check.py
@@ -8,20 +8,15 @@ import win32con
 import win32event
 import win32evtlog
 import win32security
-from six import PY2
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from datadog_checks.base.errors import SkipInstanceError
 from datadog_checks.base.utils.common import exclude_undefined_keys
 from datadog_checks.base.utils.time import get_timestamp
 
+from .config_models import ConfigMixin
 from .filters import construct_xpath_query
 from .legacy import Win32EventLogWMI
-
-if PY2:
-    ConfigMixin = object
-else:
-    from .config_models import ConfigMixin
 
 
 class Win32EventLogCheck(AgentCheck, ConfigMixin):
@@ -91,12 +86,8 @@ class Win32EventLogCheck(AgentCheck, ConfigMixin):
             )
 
         if use_legacy_mode:
-            # Supports PY2 and PY3
             return Win32EventLogWMI(name, init_config, instances)
         elif use_legacy_mode_v2:
-            # Supports PY3
-            if PY2:
-                raise ConfigurationError("legacy_mode_v2 is not supported on Python2")
             return super(Win32EventLogCheck, cls).__new__(cls)
         else:
             raise SkipInstanceError(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR focuses on simplifying logic that loads integration classes. We no longer need anything related to Python 2, so we're dropping it. No changelog since we officially dropped Python 2 support already, so this isn't worth a separate changelog entry.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
