### PR TITLE
Add credentials rabbitmq api in conf.yaml.example

### DIFF
--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -667,6 +667,8 @@ instances:
     ## url of the RabbitMQ Management Plugin (http://www.rabbitmq.com/management.html).
     #
     # rabbitmq_api_url: http://localhost:15672/api/
+    # rabbitmq_user: datadog
+    # rabbitmq_pass: some_password
 
     ## @param tag_families - boolean - optional - default: false
     ## To tag queue "families" based off of regex matching.
@@ -779,6 +781,7 @@ instances:
 #   - type: file
 #     path: /var/log/rabbitmq/*.log
 #     source: rabbitmq
+#     service: rabbitmq
 #     log_processing_rules:
 #     - type: multi_line
 #       name: logs_starts_with_equal_sign


### PR DESCRIPTION
It is necessary to add the fields rabbitmq_user and rabbitmq_pass so that the agent can authenticate to the rabbitmq api

### What does this PR do?
<!-- I added the necessary fields  rabbitmq_user and rabbitmq_pass so that the agent can authenticate to the rabbitmq api. -->

### Motivation
<!-- errors when trying to implement in rabbitmq with management plugin -->

### Additional Notes
<!-- I also added the service field to the logs -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
