### PR TITLE
[Release] Bumped karpenter version to 1.6.0

### DIFF
--- a/karpenter/CHANGELOG.md
+++ b/karpenter/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 1.6.0 / 2024-09-23
+
+***Added***:
+
+* Update Karpenter Metrics for Karpenter V1 ([#18448](https://github.com/DataDog/integrations-core/pull/18448))
+
 ## 1.5.0 / 2024-08-09 / Agent 7.57.0
 
 ***Added***:

--- a/karpenter/changelog.d/18448.added
+++ b/karpenter/changelog.d/18448.added
@@ -1,1 +1,0 @@
-Update Karpenter Metrics for Karpenter V1

--- a/karpenter/datadog_checks/karpenter/__about__.py
+++ b/karpenter/datadog_checks/karpenter/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '1.5.0'
+__version__ = '1.6.0'

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -92,7 +92,7 @@ datadog-jboss-wildfly==2.2.0
 datadog-journald==1.2.0
 datadog-kafka-consumer==4.6.1
 datadog-kafka==2.16.0
-datadog-karpenter==1.5.0
+datadog-karpenter==1.6.0
 datadog-kong==3.2.2
 datadog-kube-apiserver-metrics==4.3.1
 datadog-kube-controller-manager==5.1.1


### PR DESCRIPTION
### What does this PR do?
Changelog ports from 7.58 karpenter releases