### PR TITLE
Bump version of cryptography to address CVE

### DIFF
--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -10,7 +10,7 @@ clickhouse-cityhash==1.0.2.4
 clickhouse-driver==0.2.9
 cm-client==45.0.4
 confluent-kafka==2.5.0
-cryptography==43.0.0
+cryptography==43.0.1
 ddtrace==2.10.6
 dnspython==2.6.1
 foundationdb==6.3.24

--- a/cisco_aci/pyproject.toml
+++ b/cisco_aci/pyproject.toml
@@ -36,7 +36,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "cryptography==43.0.0",
+    "cryptography==43.0.1",
 ]
 
 [project.urls]

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -36,7 +36,7 @@ db = [
 deps = [
     "binary==1.0.0",
     "cachetools==5.5.0",
-    "cryptography==43.0.0",
+    "cryptography==43.0.1",
     "ddtrace==2.10.6",
     "importlib-metadata==2.1.3; python_version < '3.8'",
     "jellyfish==1.1.0",

--- a/http_check/pyproject.toml
+++ b/http_check/pyproject.toml
@@ -36,7 +36,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "cryptography==43.0.0",
+    "cryptography==43.0.1",
     "requests-ntlm==1.3.0",
 ]
 

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -37,7 +37,7 @@ license = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "cachetools==5.5.0",
-    "cryptography==43.0.0",
+    "cryptography==43.0.1",
     "pymysql==1.1.1",
 ]
 

--- a/tls/pyproject.toml
+++ b/tls/pyproject.toml
@@ -36,7 +36,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "cryptography==43.0.0",
+    "cryptography==43.0.1",
     "service-identity[idna]==24.1.0",
 ]
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR bumps the version of cryptography.

### Motivation
<!-- What inspired you to submit this pull request? -->
https://github.com/advisories/GHSA-h4gh-qq45-vh27
> pyca/cryptography's wheels include a statically linked copy of OpenSSL. The versions of OpenSSL included in cryptography 37.0.0-43.0.0 are vulnerable to a security issue. More details about the vulnerability itself can be found in https://openssl-library.org/news/secadv/20240903.txt.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
