### PR TITLE
Add ability to pass a CA cert to Clickhouse

### DIFF
--- a/clickhouse/assets/configuration/spec.yaml
+++ b/clickhouse/assets/configuration/spec.yaml
@@ -57,6 +57,10 @@ files:
           - lz4hc
       value:
         type: string
+    - name: tls_ca_cert
+      description: The path to the CA certificate file.
+      value:
+        type: string
     - name: tls_verify
       description: Whether or not to connect securely using TLS. The server must also support this.
       value:

--- a/clickhouse/changelog.d/18677.added
+++ b/clickhouse/changelog.d/18677.added
@@ -1,0 +1,1 @@
+Add ability to pass a CA cert to Clickhouse

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -109,7 +109,7 @@ class ClickhouseCheck(AgentCheck):
                 sync_request_timeout=self._connect_timeout,
                 compression=self._compression,
                 secure=self._tls_verify,
-                ca_certs=self.tls_ca_cert,
+                ca_certs=self._tls_ca_cert,
                 settings={},
                 # Make every client unique for server logs
                 client_name='datadog-{}'.format(self.check_id),

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -26,6 +26,7 @@ class ClickhouseCheck(AgentCheck):
         self._read_timeout = float(self.instance.get('read_timeout', 10))
         self._compression = self.instance.get('compression', False)
         self._tls_verify = is_affirmative(self.instance.get('tls_verify', False))
+        self._tls_ca_cert = self.instance.get('tls_ca_cert', None)
         self._tags = self.instance.get('tags', [])
 
         # Add global tags
@@ -108,6 +109,7 @@ class ClickhouseCheck(AgentCheck):
                 sync_request_timeout=self._connect_timeout,
                 compression=self._compression,
                 secure=self._tls_verify,
+                ca_certs=self.tls_ca_cert,
                 settings={},
                 # Make every client unique for server logs
                 client_name='datadog-{}'.format(self.check_id),

--- a/clickhouse/datadog_checks/clickhouse/config_models/instance.py
+++ b/clickhouse/datadog_checks/clickhouse/config_models/instance.py
@@ -62,6 +62,7 @@ class InstanceConfig(BaseModel):
     server: str
     service: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None
+    tls_ca_cert: Optional[str] = None
     tls_verify: Optional[bool] = None
     use_global_custom_queries: Optional[str] = None
     username: Optional[str] = None

--- a/clickhouse/datadog_checks/clickhouse/data/conf.yaml.example
+++ b/clickhouse/datadog_checks/clickhouse/data/conf.yaml.example
@@ -69,6 +69,11 @@ instances:
     #
     # compression: <COMPRESSION>
 
+    ## @param tls_ca_cert - string - optional
+    ## The path to the CA certificate file.
+    #
+    # tls_ca_cert: <TLS_CA_CERT>
+
     ## @param tls_verify - boolean - optional - default: false
     ## Whether or not to connect securely using TLS. The server must also support this.
     #

--- a/clickhouse/tests/test_unit.py
+++ b/clickhouse/tests/test_unit.py
@@ -29,6 +29,7 @@ def test_config(instance):
             sync_request_timeout=10,
             compression=False,
             secure=False,
+            ca_certs=None,
             settings={},
             client_name='datadog-test-clickhouse',
         )


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds ability to pass a CA cert to Clickhouse 
### Motivation
<!-- What inspired you to submit this pull request? -->
Customer request

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
