### PR TITLE
run sqlserver tests on ubuntu 20.04

### DIFF
--- a/.ddev/config.toml
+++ b/.ddev/config.toml
@@ -57,7 +57,7 @@ runners = { linux = ["ubuntu-20.04"] }
 
 [overrides.ci.sqlserver]
 platforms = ["windows", "linux"]
-runners = { windows = ["windows-2019"] }
+runners = { windows = ["windows-2019"], linux = ["ubuntu-20.04"] }
 
 [overrides.ci.tcp_check]
 platforms = ["linux", "windows"]

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -3280,7 +3280,7 @@ jobs:
       job-name: SQL Server on Linux
       target: sqlserver
       platform: linux
-      runner: '["ubuntu-22.04"]'
+      runner: '["ubuntu-20.04"]'
       repo: "${{ inputs.repo }}"
       python-version: "${{ inputs.python-version }}"
       standard: ${{ inputs.standard }}
@@ -3300,7 +3300,7 @@ jobs:
       job-name: Squid
       target: squid
       platform: linux
-      runner: '["ubuntu-20.04"]'
+      runner: '["ubuntu-22.04"]'
       repo: "${{ inputs.repo }}"
       python-version: "${{ inputs.python-version }}"
       standard: ${{ inputs.standard }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -3300,7 +3300,7 @@ jobs:
       job-name: Squid
       target: squid
       platform: linux
-      runner: '["ubuntu-22.04"]'
+      runner: '["ubuntu-20.04"]'
       repo: "${{ inputs.repo }}"
       python-version: "${{ inputs.python-version }}"
       standard: ${{ inputs.standard }}

--- a/sqlserver/tests/compose/Dockerfile
+++ b/sqlserver/tests/compose/Dockerfile
@@ -13,9 +13,6 @@ RUN apt-get update && apt-get install -y  \
 RUN mkdir -p /var/opt/mssql/backup
 WORKDIR /var/opt/mssql/backup
 
-# the AdventureWorks test database can be used as a source of test data if needed
-# RUN curl -L -o AdventureWorks2017.bak https://github.com/Microsoft/sql-server-samples/releases/download/adventureworks/AdventureWorks2017.bak
-
 WORKDIR /
 COPY *.sh /
 COPY *.sql /

--- a/sqlserver/tests/compose/Dockerfile
+++ b/sqlserver/tests/compose/Dockerfile
@@ -13,6 +13,9 @@ RUN apt-get update && apt-get install -y  \
 RUN mkdir -p /var/opt/mssql/backup
 WORKDIR /var/opt/mssql/backup
 
+# the AdventureWorks test database can be used as a source of test data if needed
+# RUN curl -L -o AdventureWorks2017.bak https://github.com/Microsoft/sql-server-samples/releases/download/adventureworks/AdventureWorks2017.bak
+
 WORKDIR /
 COPY *.sh /
 COPY *.sql /

--- a/sqlserver/tests/compose/docker-compose.yaml
+++ b/sqlserver/tests/compose/docker-compose.yaml
@@ -2,7 +2,6 @@ services:
   sqlserver:
     # https://hub.docker.com/_/microsoft-mssql-server
     # https://docs.microsoft.com/en-us/sql/linux/quickstart-install-connect-docker?view=sql-server-linux-2017
-    #image: mcr.microsoft.com/mssql/server:2017-latest-ubuntu
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
### What does this PR do?
`mssql` container seeing fatal error on starting with ubuntu 22.04 runner follow kernel [update](https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240915.1) on 9/15. This has caused sqlserver integration tests fail to connect to the test database. Change the test runner to ubuntu 20.04.
(i've tried updating mssql to 2017-latest, 2019-latest & 2022-latest but that doesn't work. i kept the image tag as it is for now even thought these image tags are old and we should probably update them)

### Motivation
Fix mssql container fatal error
```
E   Captured Output: sqlserver-1  | This program has encountered a fatal error and cannot continue running at Thu Sep 26 20:58:40 2024
E   sqlserver-1  | The following diagnostic information is available:
E   sqlserver-1  | 
E   sqlserver-1  |          Reason: 0x00000001
E   sqlserver-1  |          Signal: SIGABRT - Aborted (6)
E   sqlserver-1  |           Stack:
E   sqlserver-1  |                  IP               Function
E   sqlserver-1  |                  ---------------- --------------------------------------
E   sqlserver-1  |                  00005653c069549c <unknown>
E   sqlserver-1  |                  00005653c0694ee2 <unknown>
E   sqlserver-1  |                  00005653c06944f1 <unknown>
E   sqlserver-1  |                  00007fbf74715f10 killpg+0x40
E   sqlserver-1  |                  00007fbf74715e87 gsignal+0xc7
E   sqlserver-1  |                  00007fbf747177f1 abort+0x141
E   sqlserver-1  |                  00005653c061be42 <unknown>
E   sqlserver-1  |                  00005653c06a2cb4 <unknown>
E   sqlserver-1  |                  00005653c06d61f8 <unknown>
E   sqlserver-1  |                  00005653c06d5fda <unknown>
E   sqlserver-1  |                  00005653c0627cba <unknown>
E   sqlserver-1  |                  00005653c062790f <unknown>
E   sqlserver-1  |         Process: 13 - sqlservr
E   sqlserver-1  |          Thread: 86 (application thread 0x13c)
E   sqlserver-1  |     Instance Id: af15e99b-b1f1-4c2d-b194-677db0d75cda
E   sqlserver-1  |        Crash Id: 9dc641c6-4ba7-4970-b661-3fbf4fb164f9
E   sqlserver-1  |     Build stamp: a061e85be3fdd5c8d55a05c62bda0b9e1d6d267f3cac4d70d78ec1a9a6f57be0
E   sqlserver-1  |    Distribution: Ubuntu 18.04.6 LTS
E   sqlserver-1  |      Processors: 4
E   sqlserver-1  |    Total Memory: 16766763008 bytes
E   sqlserver-1  |       Timestamp: Thu Sep 26 20:58:40 2024
E   sqlserver-1  |      Last errno: 2
E   sqlserver-1  | Last errno text: No such file or directory
E   sqlserver-1  | Capturing a dump of 13
E   sqlserver-1  | Successfully captured dump: /var/opt/mssql/log/core.sqlservr.9_26_2024_20_58_40.13
E   sqlserver-1  | Executing: /opt/mssql/bin/handle-crash.sh with parameters
E   sqlserver-1  |      handle-crash.sh
E   sqlserver-1  |      /opt/mssql/bin/sqlservr
E   sqlserver-1  |      13
E   sqlserver-1  |      /opt/mssql/bin
E   sqlserver-1  |      /var/opt/mssql/log/
E   sqlserver-1  |      
E   sqlserver-1  |      af15e99b-b1f1-4c2d-b194-677db0d75cda
E   sqlserver-1  |      9dc641c6-4ba7-4970-b661-3fbf4fb164f9
E   sqlserver-1  |      
E   sqlserver-1  |      /var/opt/mssql/log/core.sqlservr.9_26_2024_20_58_40.13
E   sqlserver-1  | 
E   sqlserver-1  | Ubuntu 18.04.6 LTS
E   sqlserver-1  | Capturing core dump and information to /var/opt/mssql/log...
E   sqlserver-1  | dmesg: read kernel buffer failed: Operation not permitted
E   sqlserver-1  | /usr/bin/timeout: failed to run command '/bin/journalctl': No such file or directory
E   sqlserver-1  | /usr/bin/timeout: failed to run command '/bin/journalctl': No such file or directory
E   sqlserver-1  | Thu Sep 26 20:58:41 UTC 2024 Capturing program information
E   sqlserver-1  | Dump already generated: /var/opt/mssql/log/core.sqlservr.9_26_2024_20_58_40.13, moving to /var/opt/mssql/log/core.sqlservr.13.temp/core.sqlservr.13.gdmp
E   sqlserver-1  | Moving logs to /var/opt/mssql/log/core.sqlservr.13.temp/log/paldumper-debug.log
E   sqlserver-1  | Thu Sep 26 20:58:41 UTC 2024 Capturing program binaries
E   sqlserver-1  | Thu Sep 26 20:58:42 UTC 2024 Not compressing the dump files, moving instead to: /var/opt/mssql/log/core.sqlservr.09_26_2024_20_58_41.13.d
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
