### PR TITLE
Update vsphere_overview.json

### DIFF
--- a/vsphere/assets/dashboards/vsphere_overview.json
+++ b/vsphere/assets/dashboards/vsphere_overview.json
@@ -15,7 +15,7 @@
       "id": 1,
       "definition": {
         "type": "event_stream",
-        "query": "source:vsphere $vcenter_server.value $vcenter_datacenter.value",
+        "query": "source:vsphere $vcenter_server $vsphere_datacenter",
         "event_size": "l",
         "title": "vSphere events",
         "title_size": "16",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The out of the box dashboard does not show any event when template variable  $vcenter_server and $vcenter_datacenter is used 

### Motivation
<!-- What inspired you to submit this pull request? -->
https://datadog.zendesk.com/agent/tickets/1862372 
The code suggest $vcenter_server.value and $vcenter_datacenter.value is being used currently in for vSphere events widget defination. However, when we select a value for template variable $vcenter_server and $vcenter_datacenter, the widget shows no result. This is because the widget query is then scoped to `source:vsphere $vcenter_server.value $vcenter_datacenter.value`. This works when the query is changed to ` "source:vsphere $vcenter_server $vsphere_datacenter"`. The events that are ingested by Vsphere integration has a no tag named vcenter_datacenter but has vsphere_datacenter. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->
We can reproduce the error in demo org here https://app.datadoghq.com/screen/integration/249/vmware-vsphere---overview?_ga=2.36746720.1513437160.1727045382-1943259521.1724729273&_gl=1%2A18s4xm3%2A_gcl_au%2AODM5MTQzNTQ1LjE3MjUyMzYxMjk.%2A_ga%2AMTk0MzI1OTUyMS4xNzI0NzI5Mjcz%2A_ga_KN80RDFSQK%2AMTcyNzM5Nzk4Ni4xMTguMS4xNzI3NDAyOTA1LjAuMC4yNzA1OTkyNTQ.%2A_fplc%2AUHZGTTJDR21kSGhLTGI5S0VWWm5qS3hXYk1PUEhtZFQ5cGRmaGhtQjA5TFNHVGk0MzlOZnE4VHlnVTU0bVJQb3IlMkZ2R3hqZ0JDbmNsOHRPOUp1MzNGS0tET2I3T1VyOEcwQXNvRld1cElpaDNWRE5qSlhHNkFqNVRHS204ZlElM0QlM0Q.&fromUser=false&refresh_mode=sliding&from_ts=1727399315230&to_ts=1727402915230&live=true

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
