### PR TITLE
Sy/elastic sc tags

### DIFF
--- a/elastic/assets/configuration/spec.yaml
+++ b/elastic/assets/configuration/spec.yaml
@@ -113,7 +113,7 @@ files:
     - name: disable_legacy_service_check_tags
       description: |
         Disable the submission of the elasticsearch `host` and `port` as tags in service checks. 
-        Submit them as `elastic_host` and `elastic_port` instead.
+        Submit them as `url` instead.
       value:
         type: boolean
         display_default: false

--- a/elastic/assets/configuration/spec.yaml
+++ b/elastic/assets/configuration/spec.yaml
@@ -109,7 +109,7 @@ files:
         type: boolean
         display_default: false
         example: true
-      enabled: true
+      enabled: false
     - name: disable_legacy_service_check_tags
       description: |
         Disable the submission of the elasticsearch `host` and `port` as tags in service checks. 

--- a/elastic/assets/configuration/spec.yaml
+++ b/elastic/assets/configuration/spec.yaml
@@ -110,6 +110,15 @@ files:
         display_default: false
         example: true
       enabled: true
+    - name: disable_legacy_service_check_tags
+      description: |
+        Disable the submission of the elasticsearch `host` and `port` as tags in service checks. 
+        Submit them as `elastic_host` and `elastic_port` instead.
+      value:
+        type: boolean
+        display_default: false
+        example: true
+      enabled: true
     - name: custom_queries
       description: |
         Run custom queries for Elasticsearch. Each custom query endpoint can collect multiple metrics and tags.

--- a/elastic/changelog.d/18687.added
+++ b/elastic/changelog.d/18687.added
@@ -1,0 +1,1 @@
+Add functionality to not use `host` and `port` tags in service checks

--- a/elastic/datadog_checks/elastic/config.py
+++ b/elastic/datadog_checks/elastic/config.py
@@ -59,7 +59,7 @@ def from_instance(instance):
 
     custom_tags = instance.get('tags', [])
     if is_affirmative(instance.get('disable_legacy_service_check_tags', False)):
-        service_check_tags = ['elastic_host:{}'.format(host), 'elastic_port:{}'.format(port)]
+        service_check_tags = ['url:{}'.format(url)]
     else:
         service_check_tags = ['host:{}'.format(host), 'port:{}'.format(port)]
     service_check_tags.extend(custom_tags)

--- a/elastic/datadog_checks/elastic/config.py
+++ b/elastic/datadog_checks/elastic/config.py
@@ -58,7 +58,10 @@ def from_instance(instance):
     host = parsed.hostname
 
     custom_tags = instance.get('tags', [])
-    service_check_tags = ['host:{}'.format(host), 'port:{}'.format(port)]
+    if is_affirmative(instance.get('disable_legacy_service_check_tags', False)):
+        service_check_tags = ['elastic_host:{}'.format(host), 'elastic_port:{}'.format(port)]
+    else:
+        service_check_tags = ['host:{}'.format(host), 'port:{}'.format(port)]
     service_check_tags.extend(custom_tags)
 
     custom_queries = instance.get('custom_queries', [])

--- a/elastic/datadog_checks/elastic/config_models/defaults.py
+++ b/elastic/datadog_checks/elastic/config_models/defaults.py
@@ -48,6 +48,10 @@ def instance_disable_legacy_cluster_tag():
     return False
 
 
+def instance_disable_legacy_service_check_tags():
+    return False
+
+
 def instance_empty_default_hostname():
     return False
 

--- a/elastic/datadog_checks/elastic/config_models/instance.py
+++ b/elastic/datadog_checks/elastic/config_models/instance.py
@@ -90,6 +90,7 @@ class InstanceConfig(BaseModel):
     detailed_index_stats: Optional[bool] = None
     disable_generic_tags: Optional[bool] = None
     disable_legacy_cluster_tag: Optional[bool] = None
+    disable_legacy_service_check_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
     extra_headers: Optional[MappingProxyType[str, Any]] = None
     gc_collectors_as_rate: Optional[bool] = None

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -134,6 +134,12 @@ instances:
     #
     disable_legacy_cluster_tag: true
 
+    ## @param disable_legacy_service_check_tags - boolean - optional - default: false
+    ## Disable the submission of the elasticsearch `host` and `port` as tags in service checks. 
+    ## Submit them as `elastic_host` and `elastic_port` instead.
+    #
+    disable_legacy_service_check_tags: true
+
     ## @param custom_queries - list of mappings - optional
     ## Run custom queries for Elasticsearch. Each custom query endpoint can collect multiple metrics and tags.
     ## Note: Each custom query requires an `endpoint`, `data_path`, and `columns` parameter. Each `columns` parameter

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -136,7 +136,7 @@ instances:
 
     ## @param disable_legacy_service_check_tags - boolean - optional - default: false
     ## Disable the submission of the elasticsearch `host` and `port` as tags in service checks. 
-    ## Submit them as `elastic_host` and `elastic_port` instead.
+    ## Submit them as `url` instead.
     #
     disable_legacy_service_check_tags: true
 

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -132,7 +132,7 @@ instances:
     ## @param disable_legacy_cluster_tag - boolean - optional - default: false
     ## Enable to stop submitting the tag `cluster_name`, which has been renamed to `elastic_cluster`.
     #
-    disable_legacy_cluster_tag: true
+    # disable_legacy_cluster_tag: true
 
     ## @param disable_legacy_service_check_tags - boolean - optional - default: false
     ## Disable the submission of the elasticsearch `host` and `port` as tags in service checks. 

--- a/elastic/tests/test_unit.py
+++ b/elastic/tests/test_unit.py
@@ -7,7 +7,7 @@ import logging
 import mock
 import pytest
 
-from datadog_checks.base import ConfigurationError
+from datadog_checks.base import ConfigurationError, is_affirmative
 from datadog_checks.dev.http import MockResponse
 from datadog_checks.elastic import ESCheck
 from datadog_checks.elastic.elastic import AuthenticationError, get_value_from_path
@@ -174,6 +174,35 @@ def test__get_data_creates_critical_service_alert(aggregator, instance):
             check.SERVICE_CHECK_CONNECT_NAME,
             status=check.CRITICAL,
             tags=check._config.service_check_tags,
+            message="Error 500 Server Error: None for url: None when hitting test.com",
+        )
+
+@pytest.mark.parametrize(
+    'es_instance',
+    [
+        pytest.param({'url': 'http://localhost:9200', 'disable_legacy_service_check_tags': 'true'}, id="disable legacy service check behavior"),
+        pytest.param({'url': 'http://localhost:9200', 'disable_legacy_service_check_tags': 'false'}, id="use legacy service check behavior"),
+    ],
+)
+def test_disable_legacy_sc_tags(aggregator, es_instance):
+    with mock.patch(
+        'requests.get',
+        return_value=MockResponse(status_code=500),
+    ):
+        check = ESCheck('elastic', {}, instances=[es_instance])
+
+        with pytest.raises(Exception):
+            check._get_data(url='test.com')
+
+        if is_affirmative(es_instance['disable_legacy_service_check_tags']):
+            expected_tags = ['elastic_host:localhost', 'elastic_port:9200']
+        else:
+            expected_tags = ['host:localhost', 'port:9200']
+
+        aggregator.assert_service_check(
+            check.SERVICE_CHECK_CONNECT_NAME,
+            status=check.CRITICAL,
+            tags=expected_tags,
             message="Error 500 Server Error: None for url: None when hitting test.com",
         )
 

--- a/elastic/tests/test_unit.py
+++ b/elastic/tests/test_unit.py
@@ -177,11 +177,18 @@ def test__get_data_creates_critical_service_alert(aggregator, instance):
             message="Error 500 Server Error: None for url: None when hitting test.com",
         )
 
+
 @pytest.mark.parametrize(
     'es_instance',
     [
-        pytest.param({'url': 'http://localhost:9200', 'disable_legacy_service_check_tags': 'true'}, id="disable legacy service check behavior"),
-        pytest.param({'url': 'http://localhost:9200', 'disable_legacy_service_check_tags': 'false'}, id="use legacy service check behavior"),
+        pytest.param(
+            {'url': 'http://localhost:9200', 'disable_legacy_service_check_tags': 'true'},
+            id="disable legacy service check behavior",
+        ),
+        pytest.param(
+            {'url': 'http://localhost:9200', 'disable_legacy_service_check_tags': 'false'},
+            id="use legacy service check behavior",
+        ),
     ],
 )
 def test_disable_legacy_sc_tags(aggregator, es_instance):

--- a/elastic/tests/test_unit.py
+++ b/elastic/tests/test_unit.py
@@ -195,7 +195,7 @@ def test_disable_legacy_sc_tags(aggregator, es_instance):
             check._get_data(url='test.com')
 
         if is_affirmative(es_instance['disable_legacy_service_check_tags']):
-            expected_tags = ['elastic_host:localhost', 'elastic_port:9200']
+            expected_tags = ['url:http://localhost:9200']
         else:
             expected_tags = ['host:localhost', 'port:9200']
 


### PR DESCRIPTION
### What does this PR do?
The host tag should have been reserved since it's observed to create new hosts in the infra list. This change hopes to change that by removing it from the service checks. This will be opt in as to not break any backwards compatibility. 