### PR TITLE
Update vsphere_overview.json

### DIFF
--- a/vsphere/assets/dashboards/vsphere_overview.json
+++ b/vsphere/assets/dashboards/vsphere_overview.json
@@ -15,7 +15,7 @@
       "id": 1,
       "definition": {
         "type": "event_stream",
-        "query": "source:vsphere $vcenter_server $vsphere_datacenter",
+        "query": "source:vsphere $vcenter_server $vcenter_datacenter",
         "event_size": "l",
         "title": "vSphere events",
         "title_size": "16",


### PR DESCRIPTION
### What does this PR do?
After merging this PR https://github.com/DataDog/integrations-core/pull/18684, the default 
[VMware vSphere - Overview](https://app.datadoghq.com/screen/integration/249/vmware-vsphere---overview) is not showing any events at all 


### Motivation
https://datadog.zendesk.com/agent/tickets/1862372 

The query for vSphere events was updated to "source:vsphere $vcenter_server $vsphere_datacenter". This although works [in notebook]( https://app.datadoghq.com/notebook/9920192/sayed-sep-27-2024-13-13?range=172800000&tpl_var_vcenter_server%5B0%5D=vcsa-nyc-01&tpl_var_vsphere_datacenter%5B0%5D=us-nyc-prod-01&start=1727234080463&live=true), the default dashboard does not show any events. This is because the OOTB vsphere overview dashboard has template variable configured with a different name vs prefix 
`    {
      "name": "vcenter_datacenter",
      "default": "*",
      "prefix": "vsphere_datacenter"
    },`
Hence, the query need to be updated to `"query": "source:vsphere $vcenter_server $vcenter_datacenter",`



### Additional Notes
<!-- Anything else we should know when reviewing? -->
Here is the demo org cloned dashboard that can be used to verify the query https://app.datadoghq.com/dashboard/iab-qfv-ent?fromUser=false&refresh_mode=sliding&from_ts=1727670071557&to_ts=1727673671557&live=true 


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
