### PR TITLE
fix(mongo) fix typo in configuration example and schema (`max_collection"s"_per_database`)

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -149,7 +149,7 @@ files:
               - "admin$"
               - "config$"
               - "local$"
-        - name: max_collection_per_database
+        - name: max_collections_per_database
           description: |
             The maximum number of collections to collect metrics from per database.
             Defaults to 100.
@@ -266,7 +266,7 @@ files:
         - name: max_collections
           description: |
             Set the maximum number of collections to collect schemas from per interval. The maxium number of collections
-            per database is bounded by `database_autodiscovery.max_collection_per_database`. By setting this option, you
+            per database is bounded by `database_autodiscovery.max_collections_per_database`. By setting this option, you
             are adding an additional limit to the total number of collections across all monitored databases that schemas
             will be collected from. By default, this option is not set.
           value:

--- a/mongo/datadog_checks/mongo/config_models/instance.py
+++ b/mongo/datadog_checks/mongo/config_models/instance.py
@@ -50,7 +50,7 @@ class DatabaseAutodiscovery(BaseModel):
     enabled: Optional[bool] = None
     exclude: Optional[tuple[str, ...]] = None
     include: Optional[tuple[str, ...]] = None
-    max_collection_per_database: Optional[int] = None
+    max_collections_per_database: Optional[int] = None
     max_databases: Optional[int] = None
     refresh_interval: Optional[int] = None
 

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -132,11 +132,11 @@ instances:
         #   - config$
         #   - local$
 
-        ## @param max_collection_per_database - integer - optional - default: 100
+        ## @param max_collections_per_database - integer - optional - default: 100
         ## The maximum number of collections to collect metrics from per database.
         ## Defaults to 100.
         #
-        # max_collection_per_database: 100
+        # max_collections_per_database: 100
 
         ## @param refresh_interval - integer - optional - default: 600
         ## Frequency in seconds of scans for new databases. Defaults to 10 minutes.
@@ -206,7 +206,7 @@ instances:
 
         ## @param max_collections - number - optional
         ## Set the maximum number of collections to collect schemas from per interval. The maxium number of collections
-        ## per database is bounded by `database_autodiscovery.max_collection_per_database`. By setting this option, you
+        ## per database is bounded by `database_autodiscovery.max_collections_per_database`. By setting this option, you
         ## are adding an additional limit to the total number of collections across all monitored databases that schemas
         ## will be collected from. By default, this option is not set.
         #


### PR DESCRIPTION
### What does this PR do?

Fix typo

The proper spelling is `max_collections_per_database`, but some documentation (and implementation) used `max_collection_per_database`.
https://github.com/DataDog/integrations-core/blob/fcbaaa1cefe2363b2ac22f10a7ebe22cd2107ad3/mongo/CHANGELOG.md?plain=1#L61

### Motivation

I first found the configuration example and followed that but won't worked...

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
