### PR TITLE
[dbm] add keep_json_path to obfuscator_options

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -945,6 +945,13 @@ files:
             type: boolean
             example: false
             display_default: false
+        - name: keep_json_path
+          description: |
+            Set to `true` to keep JSON path expressions (e.g. `data->'key'`) in your normalized SQL statements.
+          value:
+            type: boolean
+            example: false
+            display_default: false
     - name: log_unobfuscated_queries
       hidden: true
       description: |

--- a/postgres/changelog.d/18726.added
+++ b/postgres/changelog.d/18726.added
@@ -1,0 +1,1 @@
+Add `keep_json_path` to obfuscator_options to allow users to control whether JSON paths following JSON operators in SQL statements should be obfuscated. By default, these paths are treated as literals and are obfuscated to ?.

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -157,7 +157,7 @@ class PostgresConfig:
             'keep_identifier_quotation': is_affirmative(
                 obfuscator_options_config.get('keep_identifier_quotation', False)
             ),
-            'keep_json_path': is_affirmative(obfuscator_options_config.get('keep_json_path', False))
+            'keep_json_path': is_affirmative(obfuscator_options_config.get('keep_json_path', False)),
         }
         self.log_unobfuscated_queries = is_affirmative(instance.get('log_unobfuscated_queries', False))
         self.log_unobfuscated_plans = is_affirmative(instance.get('log_unobfuscated_plans', False))

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -157,6 +157,7 @@ class PostgresConfig:
             'keep_identifier_quotation': is_affirmative(
                 obfuscator_options_config.get('keep_identifier_quotation', False)
             ),
+            'keep_json_path': is_affirmative(obfuscator_options_config.get('keep_json_path', False))
         }
         self.log_unobfuscated_queries = is_affirmative(instance.get('log_unobfuscated_queries', False))
         self.log_unobfuscated_plans = is_affirmative(instance.get('log_unobfuscated_plans', False))

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -150,6 +150,7 @@ class ObfuscatorOptions(BaseModel):
     keep_boolean: Optional[bool] = None
     keep_dollar_quoted_func: Optional[bool] = None
     keep_identifier_quotation: Optional[bool] = None
+    keep_json_path: Optional[bool] = None
     keep_null: Optional[bool] = None
     keep_positional_parameter: Optional[bool] = None
     keep_sql_alias: Optional[bool] = None

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -822,6 +822,11 @@ instances:
         #
         # keep_identifier_quotation: false
 
+        ## @param keep_json_path - boolean - optional - default: false
+        ## Set to `true` to keep JSON path expressions (e.g. `data->'key'`) in your normalized SQL statements.
+        #
+        # keep_json_path: false
+
     ## @param propagate_agent_tags - boolean - optional - default: false
     ## Set to `true` to propagate the tags from `datadog.yaml` and the agent host tags to the check.
     ## When set to `true`, the tags from the agent host are added to the check's tags for all instances.


### PR DESCRIPTION
### What does this PR do?
This PR adds `keep_json_path` to obfuscator_options to allow users to control whether JSON paths following JSON operators in SQL statements should be obfuscated. By default, these paths are treated as literals and are obfuscated to ?.

For example, in the SQL statements
```SQL
-- Extracts JSON object field with the given key
SELECT data::jsonb -> 'name'
```
The JSON path `name` following the JSON operator -> would normally be obfuscated to `?`, resulting in:
```SQL
SELECT data::jsonb -> ?
```

With the `keep_json_path` option enabled, users can skip this obfuscation, preserving the original JSON path `name` in the query.

Related change: https://github.com/DataDog/datadog-agent/pull/29655

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
