### PR TITLE
[mongo] always emit database_instance

### DIFF
--- a/mongo/changelog.d/18750.added
+++ b/mongo/changelog.d/18750.added
@@ -1,0 +1,1 @@
+Always emit `database_instance` metadata regardless of DBM status; previously emitted only when DBM was enabled.

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -264,10 +264,10 @@ class MongoDb(AgentCheck):
             self._refresh_metadata()
             self._refresh_deployment()
             self._collect_metrics()
+            self._send_database_instance_metadata()
 
             # DBM
             if self._config.dbm_enabled:
-                self._send_database_instance_metadata()
                 self._operation_samples.run_job_loop(tags=self._get_tags(include_internal_resource_tags=True))
                 self._slow_operations.run_job_loop(tags=self._get_tags(include_internal_resource_tags=True))
                 self._schemas.run_job_loop(tags=self._get_tags(include_internal_resource_tags=True))

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -38,10 +38,6 @@ def _assert_mongodb_instance_event(
     modules,
 ):
     mongodb_instance_event = _get_mongodb_instance_event(aggregator)
-    if not dbm:
-        assert mongodb_instance_event is None
-        return
-
     assert mongodb_instance_event is not None
     assert mongodb_instance_event['host'] == check._resolved_hostname
     assert mongodb_instance_event['host'] == check._resolved_hostname

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -612,6 +612,7 @@ def test_when_collections_indexes_stats_to_true_then_index_stats_metrics_reporte
 
 def test_when_version_lower_than_3_2_then_no_index_stats_metrics_reported(aggregator, check, instance, dd_run_check):
     # Given
+    instance["reported_database_hostname"] = "test-hostname:27017"
     instance["collections_indexes_stats"] = True
     instance["collections"] = ['bar', 'foo']
     check = check(instance)
@@ -625,6 +626,7 @@ def test_when_version_lower_than_3_2_then_no_index_stats_metrics_reported(aggreg
 
 def test_when_version_lower_than_3_6_then_no_session_metrics_reported(aggregator, check, instance, dd_run_check):
     # Given
+    instance["reported_database_hostname"] = "test-hostname:27017"
     check = check(instance)
     # When
     mocked_client = mock.MagicMock()
@@ -738,6 +740,7 @@ def test_refresh_role(instance_shard, aggregator, check, dd_run_check):
     Ideally we should be asserting that we emit an event for a change of role. That's the behavior users care about.
     It requires more mocking work though.
     """
+    instance_shard["reported_database_hostname"] = "test-hostname:27018"
     mongo_check = check(instance_shard)
     mc = seed_mock_client()
     mc.replset_get_status.return_value = load_json_fixture('replSetGetStatus-replica-primary-in-shard')


### PR DESCRIPTION
### What does this PR do?
Always emit `database_instance` metadata regardless of dbm status.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
