### PR TITLE
[mongo] include clustername & database_instance in service check tags

### DIFF
--- a/mongo/changelog.d/18751.added
+++ b/mongo/changelog.d/18751.added
@@ -1,1 +1,1 @@
-Includes tag `clustername` & `database_instance` to mongo service check tags
+Include tag `clustername` & `database_instance` in mongo service check tags

--- a/mongo/changelog.d/18751.added
+++ b/mongo/changelog.d/18751.added
@@ -1,0 +1,1 @@
+Includes tag `clustername` in mongo service check tags

--- a/mongo/changelog.d/18751.added
+++ b/mongo/changelog.d/18751.added
@@ -1,1 +1,1 @@
-Includes tag `clustername` in mongo service check tags
+Includes tag `clustername` & `database_instance` to mongo service check tags

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -148,6 +148,8 @@ class MongoConfig(object):
             main_host, main_port = main_host.split(':')
 
         service_check_tags = ["db:%s" % self.db_name, "host:%s" % main_host, "port:%s" % main_port] + self._base_tags
+        if self.cluster_name:
+            service_check_tags.append('clustername:%s' % self.cluster_name)
         return service_check_tags
 
     def _compute_metric_tags(self):

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -258,6 +258,12 @@ class MongoDb(AgentCheck):
         if isinstance(self.deployment_type, ReplicaSetDeployment):
             tags.extend(self.deployment_type.replset_tags)
         return tags
+    
+    def _get_service_check_tags(self):
+        tags = deepcopy(self._config.service_check_tags)
+        if self._resolved_hostname:
+            tags.append(f"database_instance:{self._resolved_hostname}")
+        return tags
 
     def check(self, _):
         try:

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -258,7 +258,7 @@ class MongoDb(AgentCheck):
         if isinstance(self.deployment_type, ReplicaSetDeployment):
             tags.extend(self.deployment_type.replset_tags)
         return tags
-    
+
     def _get_service_check_tags(self):
         tags = deepcopy(self._config.service_check_tags)
         if self._resolved_hostname:


### PR DESCRIPTION
### What does this PR do?
This PR adds tag `clustername` & `database_instance` to mongo service check tags.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
