### PR TITLE
[INTPLAT-182] Support merge group events in Workflow "Test"

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ on:
     paths-ignore:
     - datadog_checks_base/datadog_checks/**
     - datadog_checks_dev/datadog_checks/dev/*.py
-  merge_group:
+  merge_group: # Used by marketplace
     types: [checks_requested]
 
 concurrency:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,8 @@ on:
     paths-ignore:
     - datadog_checks_base/datadog_checks/**
     - datadog_checks_dev/datadog_checks/dev/*.py
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref }}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds "merge_group" as a trigger type for the "pr" workflow. 

### Motivation
<!-- What inspired you to submit this pull request? -->
The `PR test / check` status check is required for the `master` branch of this repo. In order to support Merge Queues, this check needs to support being triggered from the `merge_group` event. See GH docs:
* https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request-with-a-merge-queue?tool=webui
* https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

If Merge Queues are enabled and this required check isn't configured to be triggered, it'll time out, and the queued PR will be "dropped" off the queue. 

Since this is the only required check, and the `pr_test` gets triggered from `pr.yml`, I _think_ this is the only place that needs to be updated with this event type. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
