### PR TITLE
Unhide SQL Server deadlocks collection config

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -776,7 +776,6 @@ files:
         example: false
         type: boolean
     - name: deadlocks_collection
-      hidden: True
       description: |
         Configure the collection of deadlock data. The feature is supported for odbc connector only.
       options:

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -692,6 +692,25 @@ instances:
     #
     # propagate_agent_tags: false
 
+    ## Configure the collection of deadlock data. The feature is supported for odbc connector only.
+    #
+    # deadlocks_collection:
+
+        ## @param enabled - boolean - optional - default: false
+        ## Enable the collection of deadlock data. Requires `dbm: true`. Disabled by default.
+        #
+        # enabled: false
+
+        ## @param collection_interval - number - optional - default: 600
+        ## Set the interval for collecting deadlock data, in seconds. Defaults to 600 seconds.
+        #
+        # collection_interval: 600
+
+        ## @param max_deadlocks - number - optional - default: 100
+        ## Set the maximum number of deadlocks to retrieve per collection.
+        #
+        # max_deadlocks: 100
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##


### PR DESCRIPTION
### What does this PR do?

Unhide SQL Server deadlocks collection config.

### Motivation

The agent and backend are ready. Frontend will be ready by the time the next agent version  is released.

### Additional Notes

The deadlocks collection remains disabled by default for now.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
