### PR TITLE
Postgres cross-org telemetry

### DIFF
--- a/datadog_checks_base/changelog.d/18758.added
+++ b/datadog_checks_base/changelog.d/18758.added
@@ -1,0 +1,1 @@
+Added Postgres cross-org telemetry metrics.

--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -158,10 +158,9 @@ class DatadogAgentStub(object):
     def obfuscate_mongodb_string(self, command):
         # Passthrough stub: obfuscation implementation is in Go code.
         return command
-    
+
     def emit_agent_telemetry(self, check_name, metric_name, metric_value, metric_type):
         self._sent_telemetry[(check_name, metric_name, metric_type)].append(metric_value)
-
 
 
 # Use the stub as a singleton

--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -29,6 +29,7 @@ class DatadogAgentStub(object):
         self._process_start_time = 0
         self._external_tags = []
         self._host_tags = "{}"
+        self._sent_telemetry = defaultdict(list)
 
     def get_default_config(self):
         return {'enable_metadata_collection': True, 'disable_unsafe_yaml': True}
@@ -82,6 +83,12 @@ class DatadogAgentStub(object):
         tags_count = len(self._external_tags)
         assert tags_count == count, 'Expected {} external tags items, found {}. Submitted external tags: {}'.format(
             count, tags_count, repr(self._external_tags)
+        )
+
+    def assert_telemetry(self, check_name, metric_name, metric_type, metric_value):
+        values = self._sent_telemetry[(check_name, metric_name, metric_type)]
+        assert metric_value in values, 'Expected value {} for check {}, metric {}, type {}. Found {}.'.format(
+            metric_value, check_name, metric_name, metric_type, values
         )
 
     def get_hostname(self):
@@ -151,6 +158,10 @@ class DatadogAgentStub(object):
     def obfuscate_mongodb_string(self, command):
         # Passthrough stub: obfuscation implementation is in Go code.
         return command
+    
+    def emit_agent_telemetry(self, check_name, metric_name, metric_value, metric_type):
+        self._sent_telemetry[(check_name, metric_name, metric_type)].append(metric_value)
+
 
 
 # Use the stub as a singleton

--- a/postgres/changelog.d/18758.added
+++ b/postgres/changelog.d/18758.added
@@ -1,0 +1,1 @@
+Added Postgres cross-org telemetry metrics.

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -297,6 +297,8 @@ class PostgresMetadata(DBMAsyncJob):
 
             # Tuned from experiments on staging, we may want to make this dynamic based on schema size in the future
             chunk_size = 50
+            total_tables = 0
+            start_time = time.time()
 
             for database in schema_metadata:
                 dbname = database["name"]
@@ -324,11 +326,41 @@ class PostgresMetadata(DBMAsyncJob):
 
                                 if buffer_column_count >= 100_000:
                                     self._flush_schema(base_event, database, schema, tables_buffer)
+                                    total_tables += len(tables_buffer)
                                     tables_buffer = []
                                     buffer_column_count = 0
 
                             if len(tables_buffer) > 0:
                                 self._flush_schema(base_event, database, schema, tables_buffer)
+                                total_tables += len(tables_buffer)
+            elapsed_ms = (time.time() - start_time) * 1000
+            self._check.histogram(
+                "dd.postgres.schema.time",
+                elapsed_ms,
+                tags=self._check.tags,
+                hostname=self._check.resolved_hostname,
+                raw=True,
+            )
+            self._check.gauge(
+                "dd.postgres.schema.tables_total",
+                total_tables,
+                tags=self._check.tags,
+                hostname=self._check.resolved_hostname,
+                raw=True,
+            )
+            datadog_agent.emit_agent_telemetry(
+                "postgres",
+                "schema_tables_elapsed_ms",
+                 elapsed_ms,
+                 "gauge"
+            )
+            datadog_agent.emit_agent_telemetry(
+                "postgres",
+                "schema_tables_total",
+                 total_tables,
+                 "gauge"
+            )
+
             self._is_schemas_collection_in_progress = False
 
     def _should_collect_metadata(self, name, metadata_type):

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -348,18 +348,8 @@ class PostgresMetadata(DBMAsyncJob):
                 hostname=self._check.resolved_hostname,
                 raw=True,
             )
-            datadog_agent.emit_agent_telemetry(
-                "postgres",
-                "schema_tables_elapsed_ms",
-                 elapsed_ms,
-                 "gauge"
-            )
-            datadog_agent.emit_agent_telemetry(
-                "postgres",
-                "schema_tables_count",
-                 total_tables,
-                 "gauge"
-            )
+            datadog_agent.emit_agent_telemetry("postgres", "schema_tables_elapsed_ms", elapsed_ms, "gauge")
+            datadog_agent.emit_agent_telemetry("postgres", "schema_tables_count", total_tables, "gauge")
 
             self._is_schemas_collection_in_progress = False
 

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -342,7 +342,7 @@ class PostgresMetadata(DBMAsyncJob):
                 raw=True,
             )
             self._check.gauge(
-                "dd.postgres.schema.tables_total",
+                "dd.postgres.schema.tables_count",
                 total_tables,
                 tags=self._check.tags,
                 hostname=self._check.resolved_hostname,
@@ -356,7 +356,7 @@ class PostgresMetadata(DBMAsyncJob):
             )
             datadog_agent.emit_agent_telemetry(
                 "postgres",
-                "schema_tables_total",
+                "schema_tables_count",
                  total_tables,
                  "gauge"
             )

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -646,6 +646,8 @@ class PostgreSql(AgentCheck):
             hostname=self.resolved_hostname,
             raw=True,
         )
+        telemetry_metric = scope_type.replace("_","",1) # remove the first underscore to match telemetry convention
+        datadog_agent.emit_agent_telemetry("postgres", f"{telemetry_metric}_ms", elapsed_ms, "histogram")
         if elapsed_ms > self._config.min_collection_interval * 1000:
             self.record_warning(
                 DatabaseConfigurationError.autodiscovered_metrics_exceeds_collection_interval,

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -646,7 +646,7 @@ class PostgreSql(AgentCheck):
             hostname=self.resolved_hostname,
             raw=True,
         )
-        telemetry_metric = scope_type.replace("_","",1) # remove the first underscore to match telemetry convention
+        telemetry_metric = scope_type.replace("_", "", 1)  # remove the first underscore to match telemetry convention
         datadog_agent.emit_agent_telemetry("postgres", f"{telemetry_metric}_ms", elapsed_ms, "histogram")
         if elapsed_ms > self._config.min_collection_interval * 1000:
             self.record_warning(

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -481,6 +481,13 @@ class PostgresStatementSamples(DBMAsyncJob):
                 tags=self.tags,
                 raw=True,
             )
+            datadog_agent.emit_agent_telemetry(
+                "postgres",
+                "collect_activity_snapshot_ms",
+                (time.time() - start_time) * 1000,
+                "histogram",
+            )
+
         elapsed_ms = (time.time() - start_time) * 1000
         self._check.histogram(
             "dd.postgres.collect_statement_samples.time",
@@ -516,6 +523,18 @@ class PostgresStatementSamples(DBMAsyncJob):
             tags=self.tags + self._check._get_debug_tags(),
             hostname=self._check.resolved_hostname,
             raw=True,
+        )
+        datadog_agent.emit_agent_telemetry(
+            "postgres",
+            "collect_statement_samples_ms",
+            elapsed_ms,
+            "histogram",
+        )
+        datadog_agent.emit_agent_telemetry(
+            "postgres",
+            "collect_statement_samples_count",
+            submitted_count,
+            "gauge",
         )
 
     @staticmethod

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -437,7 +437,6 @@ class PostgresStatementSamples(DBMAsyncJob):
             "histogram",
         )
 
-
     def run_job(self):
         # do not emit any dd.internal metrics for DBM specific check code
         self.tags = [t for t in self._tags if not t.startswith('dd.internal')]

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -424,6 +424,19 @@ class PostgresStatementSamples(DBMAsyncJob):
             hostname=self._check.resolved_hostname,
             raw=True,
         )
+        datadog_agent.emit_agent_telemetry(
+            "postgres",
+            f"{method_name}_ms",
+            (time.time() - start_time) * 1000,
+            "histogram",
+        )
+        datadog_agent.emit_agent_telemetry(
+            "postgres",
+            f"{method_name}_count",
+            row_len,
+            "histogram",
+        )
+
 
     def run_job(self):
         # do not emit any dd.internal metrics for DBM specific check code


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
* Adds cross-org telemetry metrics for Postgres integration.
* Adds stubs for the new `emit_agent_telemetry` method on `datadog_agent`.

### Motivation
<!-- What inspired you to submit this pull request? -->
We want to use the new cross-org telemetry system to gather data on overall performance of the Postgres integration. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->
See [this PR](https://github.com/DataDog/datadog-agent/pull/29776) for adding the metrics to the whitelist for collection.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
