### PR TITLE
SDBM-1193 Sqlserver agent jobs: reduce querying time for large histories

### DIFF
--- a/sqlserver/changelog.d/18760.fixed
+++ b/sqlserver/changelog.d/18760.fixed
@@ -1,0 +1,1 @@
+Updated SQL Server Agent job query for completed jobs, significantly reducing query times for large job history logs 

--- a/sqlserver/datadog_checks/sqlserver/agent_history.py
+++ b/sqlserver/datadog_checks/sqlserver/agent_history.py
@@ -18,37 +18,26 @@ DEFAULT_COLLECTION_INTERVAL = 15
 DEFAULT_ROW_LIMIT = 10000
 
 AGENT_HISTORY_QUERY = """\
-WITH HISTORY_ENTRIES AS (
-    SELECT {history_row_limit_filter}
+WITH BASE AS (
+    SELECT TOP {history_row_limit_filter}
         j.name AS job_name,
-        CAST(sjh1.job_id AS char(36)) AS job_id,
-        sjh1.step_name,
-        sjh1.step_id,
-        sjh1.instance_id AS step_instance_id,
-        (
-            SELECT MIN(sjh2.instance_id)
-            FROM msdb.dbo.sysjobhistory AS sjh2
-            WHERE sjh2.job_id = sjh1.job_id
-            AND sjh2.step_id = 0
-            AND sjh2.instance_id >= sjh1.instance_id
-        ) AS completion_instance_id,
-        (
-            SELECT DATEDIFF(SECOND, '19700101',
-                DATEADD(HOUR, sjh1.run_time / 10000,
-                    DATEADD(MINUTE, (sjh1.run_time / 100) % 100,
-                        DATEADD(SECOND, sjh1.run_time % 100,
-                            CAST(CAST(sjh1.run_date AS CHAR(8)) AS DATETIME)
-                        )
+        CAST(sjh.job_id AS CHAR(36)) AS job_id,
+        sjh.step_name,
+        sjh.step_id,
+        sjh.instance_id AS step_instance_id,
+        DATEDIFF(SECOND, '19700101',
+            DATEADD(HOUR, sjh.run_time / 10000,
+                DATEADD(MINUTE, (sjh.run_time / 100) % 100,
+                    DATEADD(SECOND, sjh.run_time % 100,
+                        CAST(CAST(sjh.run_date AS CHAR(8)) AS DATETIME)
                     )
                 )
-            ) - DATEPART(tzoffset, SYSDATETIMEOFFSET()) * 60
-        ) AS run_epoch_time,
-        (
-            (sjh1.run_duration / 10000) * 3600
-            + ((sjh1.run_duration % 10000) / 100) * 60
-            + (sjh1.run_duration % 100)
-        ) AS run_duration_seconds,
-        CASE sjh1.run_status
+            )
+        ) - DATEPART(TZOFFSET, SYSDATETIMEOFFSET()) * 60 AS run_epoch_time,
+        (sjh.run_duration / 10000) * 3600
+        + ((sjh.run_duration % 10000) / 100) * 60
+        + (sjh.run_duration % 100) AS run_duration_seconds,
+        CASE sjh.run_status
             WHEN 0 THEN 'Failed'
             WHEN 1 THEN 'Succeeded'
             WHEN 2 THEN 'Retry'
@@ -56,32 +45,45 @@ WITH HISTORY_ENTRIES AS (
             WHEN 4 THEN 'In Progress'
             ELSE 'Unknown'
         END AS step_run_status,
-        sjh1.message
-    FROM
-        msdb.dbo.sysjobhistory AS sjh1
-    INNER JOIN msdb.dbo.sysjobs AS j
-    ON j.job_id = sjh1.job_id
-    ORDER BY completion_instance_id DESC
-)
-SELECT * FROM HISTORY_ENTRIES
-WHERE
-    EXISTS (
-        SELECT 1
-        FROM msdb.dbo.sysjobhistory AS sjh2
-        WHERE sjh2.instance_id = HISTORY_ENTRIES.completion_instance_id
-        AND (DATEDIFF(SECOND, '19700101',
-                DATEADD(HOUR, sjh2.run_time / 10000,
-                    DATEADD(MINUTE, (sjh2.run_time / 100) % 100,
-                        DATEADD(SECOND, sjh2.run_time % 100,
-                            CAST(CAST(sjh2.run_date AS CHAR(8)) AS DATETIME)
-                        )
+        sjh.message
+    FROM msdb.dbo.sysjobhistory AS sjh
+    INNER JOIN msdb.dbo.sysjobs AS j ON j.job_id = sjh.job_id
+	ORDER BY step_instance_id DESC
+),
+COMPLETION_CTE AS (
+    SELECT
+        BASE.*,
+        MIN(CASE WHEN BASE.step_id = 0 THEN BASE.step_instance_id END) OVER (
+            PARTITION BY BASE.job_id
+            ORDER BY BASE.step_instance_id 
+            ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+        ) AS completion_instance_id
+    FROM BASE
+),
+HISTORY_ENTRIES AS (
+    SELECT
+        C.*,
+        DATEDIFF(SECOND, '19700101',
+            DATEADD(HOUR, c_sjh.run_time / 10000,
+                DATEADD(MINUTE, (c_sjh.run_time / 100) % 100,
+                    DATEADD(SECOND, c_sjh.run_time % 100,
+                        CAST(CAST(c_sjh.run_date AS CHAR(8)) AS DATETIME)
                     )
                 )
-            ) - DATEPART(tzoffset, SYSDATETIMEOFFSET()) * 60
-        + (sjh2.run_duration / 10000) * 3600
-        + ((sjh2.run_duration % 10000) / 100) * 60
-        + (sjh2.run_duration % 100)) > 0 + {last_collection_time_filter}
-    )
+            )
+        ) - DATEPART(TZOFFSET, SYSDATETIMEOFFSET()) * 60
+        + (c_sjh.run_duration / 10000) * 3600
+        + ((c_sjh.run_duration % 10000) / 100) * 60
+        + (c_sjh.run_duration % 100) AS completion_epoch_time
+    FROM COMPLETION_CTE AS C
+    LEFT JOIN msdb.dbo.sysjobhistory AS c_sjh
+        ON c_sjh.instance_id = C.completion_instance_id
+		WHERE C.completion_instance_id IS NOT NULL
+)
+SELECT *
+FROM HISTORY_ENTRIES
+WHERE
+    completion_epoch_time > {last_collection_time_filter};
 """
 
 

--- a/sqlserver/datadog_checks/sqlserver/agent_history.py
+++ b/sqlserver/datadog_checks/sqlserver/agent_history.py
@@ -19,7 +19,7 @@ DEFAULT_ROW_LIMIT = 10000
 
 AGENT_HISTORY_QUERY = """\
 WITH BASE AS (
-    SELECT TOP {history_row_limit_filter}
+    SELECT {history_row_limit_filter}
         j.name AS job_name,
         CAST(sjh.job_id AS CHAR(36)) AS job_id,
         sjh.step_name,
@@ -55,7 +55,7 @@ COMPLETION_CTE AS (
         BASE.*,
         MIN(CASE WHEN BASE.step_id = 0 THEN BASE.step_instance_id END) OVER (
             PARTITION BY BASE.job_id
-            ORDER BY BASE.step_instance_id 
+            ORDER BY BASE.step_instance_id
             ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
         ) AS completion_instance_id
     FROM BASE
@@ -80,7 +80,17 @@ HISTORY_ENTRIES AS (
         ON c_sjh.instance_id = C.completion_instance_id
 		WHERE C.completion_instance_id IS NOT NULL
 )
-SELECT *
+SELECT
+	job_name,
+	job_id,
+	step_name,
+	step_id,
+	step_instance_id,
+	completion_instance_id,
+	run_epoch_time,
+	run_duration_seconds,
+	step_run_status,
+	message
 FROM HISTORY_ENTRIES
 WHERE
     completion_epoch_time > {last_collection_time_filter};

--- a/sqlserver/tests/test_agent_jobs.py
+++ b/sqlserver/tests/test_agent_jobs.py
@@ -21,37 +21,26 @@ pytestmark = [pytest.mark.integration]
 
 
 AGENT_HISTORY_QUERY = """\
-WITH HISTORY_ENTRIES AS (
+WITH BASE AS (
     SELECT {history_row_limit_filter}
         j.name AS job_name,
-        CAST(sjh1.job_id AS char(36)) AS job_id,
-        sjh1.step_name,
-        sjh1.step_id,
-        sjh1.instance_id AS step_instance_id,
-        (
-            SELECT MIN(sjh2.instance_id)
-            FROM msdb.dbo.sysjobhistory AS sjh2
-            WHERE sjh2.job_id = sjh1.job_id
-            AND sjh2.step_id = 0
-            AND sjh2.instance_id >= sjh1.instance_id
-        ) AS completion_instance_id,
-        (
-            SELECT DATEDIFF(SECOND, '19700101',
-                DATEADD(HOUR, sjh1.run_time / 10000,
-                    DATEADD(MINUTE, (sjh1.run_time / 100) % 100,
-                        DATEADD(SECOND, sjh1.run_time % 100,
-                            CAST(CAST(sjh1.run_date AS CHAR(8)) AS DATETIME)
-                        )
+        CAST(sjh.job_id AS CHAR(36)) AS job_id,
+        sjh.step_name,
+        sjh.step_id,
+        sjh.instance_id AS step_instance_id,
+        DATEDIFF(SECOND, '19700101',
+            DATEADD(HOUR, sjh.run_time / 10000,
+                DATEADD(MINUTE, (sjh.run_time / 100) % 100,
+                    DATEADD(SECOND, sjh.run_time % 100,
+                        CAST(CAST(sjh.run_date AS CHAR(8)) AS DATETIME)
                     )
                 )
-            ) - DATEPART(tzoffset, SYSDATETIMEOFFSET()) * 60
-        ) AS run_epoch_time,
-        (
-            (sjh1.run_duration / 10000) * 3600
-            + ((sjh1.run_duration % 10000) / 100) * 60
-            + (sjh1.run_duration % 100)
-        ) AS run_duration_seconds,
-        CASE sjh1.run_status
+            )
+        ) - DATEPART(TZOFFSET, SYSDATETIMEOFFSET()) * 60 AS run_epoch_time,
+        (sjh.run_duration / 10000) * 3600
+        + ((sjh.run_duration % 10000) / 100) * 60
+        + (sjh.run_duration % 100) AS run_duration_seconds,
+        CASE sjh.run_status
             WHEN 0 THEN 'Failed'
             WHEN 1 THEN 'Succeeded'
             WHEN 2 THEN 'Retry'
@@ -59,66 +48,79 @@ WITH HISTORY_ENTRIES AS (
             WHEN 4 THEN 'In Progress'
             ELSE 'Unknown'
         END AS step_run_status,
-        sjh1.message
-    FROM
-        msdb.dbo.sysjobhistory AS sjh1
-    INNER JOIN msdb.dbo.sysjobs AS j
-    ON j.job_id = sjh1.job_id
-    ORDER BY completion_instance_id DESC
-)
-SELECT * FROM HISTORY_ENTRIES
-WHERE
-    EXISTS (
-        SELECT 1
-        FROM msdb.dbo.sysjobhistory AS sjh2
-        WHERE sjh2.instance_id = HISTORY_ENTRIES.completion_instance_id
-        AND (DATEDIFF(SECOND, '19700101',
-                DATEADD(HOUR, sjh2.run_time / 10000,
-                    DATEADD(MINUTE, (sjh2.run_time / 100) % 100,
-                        DATEADD(SECOND, sjh2.run_time % 100,
-                            CAST(CAST(sjh2.run_date AS CHAR(8)) AS DATETIME)
-                        )
+        sjh.message
+    FROM msdb.dbo.sysjobhistory AS sjh
+    INNER JOIN msdb.dbo.sysjobs AS j ON j.job_id = sjh.job_id
+	ORDER BY step_instance_id DESC
+),
+COMPLETION_CTE AS (
+    SELECT
+        BASE.*,
+        MIN(CASE WHEN BASE.step_id = 0 THEN BASE.step_instance_id END) OVER (
+            PARTITION BY BASE.job_id
+            ORDER BY BASE.step_instance_id
+            ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+        ) AS completion_instance_id
+    FROM BASE
+),
+HISTORY_ENTRIES AS (
+    SELECT
+        C.*,
+        DATEDIFF(SECOND, '19700101',
+            DATEADD(HOUR, c_sjh.run_time / 10000,
+                DATEADD(MINUTE, (c_sjh.run_time / 100) % 100,
+                    DATEADD(SECOND, c_sjh.run_time % 100,
+                        CAST(CAST(c_sjh.run_date AS CHAR(8)) AS DATETIME)
                     )
                 )
-            ) - DATEPART(tzoffset, SYSDATETIMEOFFSET()) * 60
-        + (sjh2.run_duration / 10000) * 3600
-        + ((sjh2.run_duration % 10000) / 100) * 60
-        + (sjh2.run_duration % 100)) > 0 + {last_collection_time_filter}
-    )
+            )
+        ) - DATEPART(TZOFFSET, SYSDATETIMEOFFSET()) * 60
+        + (c_sjh.run_duration / 10000) * 3600
+        + ((c_sjh.run_duration % 10000) / 100) * 60
+        + (c_sjh.run_duration % 100) AS completion_epoch_time
+    FROM COMPLETION_CTE AS C
+    LEFT JOIN msdb.dbo.sysjobhistory AS c_sjh
+        ON c_sjh.instance_id = C.completion_instance_id
+		WHERE C.completion_instance_id IS NOT NULL
+)
+SELECT
+	job_name,
+	job_id,
+	step_name,
+	step_id,
+	step_instance_id,
+	completion_instance_id,
+	run_epoch_time,
+	run_duration_seconds,
+	step_run_status,
+	message
+FROM HISTORY_ENTRIES
+WHERE
+    completion_epoch_time > {last_collection_time_filter};
 """
 
+
 FORMATTED_HISTORY_QUERY = """\
-WITH HISTORY_ENTRIES AS (
+WITH BASE AS (
     SELECT TOP 10000
         j.name AS job_name,
-        CAST(sjh1.job_id AS char(36)) AS job_id,
-        sjh1.step_name,
-        sjh1.step_id,
-        sjh1.instance_id AS step_instance_id,
-        (
-            SELECT MIN(sjh2.instance_id)
-            FROM msdb.dbo.sysjobhistory AS sjh2
-            WHERE sjh2.job_id = sjh1.job_id
-            AND sjh2.step_id = 0
-            AND sjh2.instance_id >= sjh1.instance_id
-        ) AS completion_instance_id,
-        (
-            SELECT DATEDIFF(SECOND, '19700101',
-                DATEADD(HOUR, sjh1.run_time / 10000,
-                    DATEADD(MINUTE, (sjh1.run_time / 100) % 100,
-                        DATEADD(SECOND, sjh1.run_time % 100,
-                            CAST(CAST(sjh1.run_date AS CHAR(8)) AS DATETIME)
-                        )
+        CAST(sjh.job_id AS CHAR(36)) AS job_id,
+        sjh.step_name,
+        sjh.step_id,
+        sjh.instance_id AS step_instance_id,
+        DATEDIFF(SECOND, '19700101',
+            DATEADD(HOUR, sjh.run_time / 10000,
+                DATEADD(MINUTE, (sjh.run_time / 100) % 100,
+                    DATEADD(SECOND, sjh.run_time % 100,
+                        CAST(CAST(sjh.run_date AS CHAR(8)) AS DATETIME)
                     )
                 )
-            ) - DATEPART(tzoffset, SYSDATETIMEOFFSET()) * 60
-        ) AS run_epoch_time,
-        (
-            (sjh1.run_duration / 10000) * 3600
-            + ((sjh1.run_duration % 10000) / 100) * 60
-            + (sjh1.run_duration % 100)
-        ) AS run_duration_seconds,
-        CASE sjh1.run_status
+            )
+        ) - DATEPART(TZOFFSET, SYSDATETIMEOFFSET()) * 60 AS run_epoch_time,
+        (sjh.run_duration / 10000) * 3600
+        + ((sjh.run_duration % 10000) / 100) * 60
+        + (sjh.run_duration % 100) AS run_duration_seconds,
+        CASE sjh.run_status
             WHEN 0 THEN 'Failed'
             WHEN 1 THEN 'Succeeded'
             WHEN 2 THEN 'Retry'
@@ -126,32 +128,55 @@ WITH HISTORY_ENTRIES AS (
             WHEN 4 THEN 'In Progress'
             ELSE 'Unknown'
         END AS step_run_status,
-        sjh1.message
-    FROM
-        msdb.dbo.sysjobhistory AS sjh1
-    INNER JOIN msdb.dbo.sysjobs AS j
-    ON j.job_id = sjh1.job_id
-    ORDER BY completion_instance_id DESC
-)
-SELECT * FROM HISTORY_ENTRIES
-WHERE
-    EXISTS (
-        SELECT 1
-        FROM msdb.dbo.sysjobhistory AS sjh2
-        WHERE sjh2.instance_id = HISTORY_ENTRIES.completion_instance_id
-        AND (DATEDIFF(SECOND, '19700101',
-                DATEADD(HOUR, sjh2.run_time / 10000,
-                    DATEADD(MINUTE, (sjh2.run_time / 100) % 100,
-                        DATEADD(SECOND, sjh2.run_time % 100,
-                            CAST(CAST(sjh2.run_date AS CHAR(8)) AS DATETIME)
-                        )
+        sjh.message
+    FROM msdb.dbo.sysjobhistory AS sjh
+    INNER JOIN msdb.dbo.sysjobs AS j ON j.job_id = sjh.job_id
+	ORDER BY step_instance_id DESC
+),
+COMPLETION_CTE AS (
+    SELECT
+        BASE.*,
+        MIN(CASE WHEN BASE.step_id = 0 THEN BASE.step_instance_id END) OVER (
+            PARTITION BY BASE.job_id
+            ORDER BY BASE.step_instance_id
+            ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+        ) AS completion_instance_id
+    FROM BASE
+),
+HISTORY_ENTRIES AS (
+    SELECT
+        C.*,
+        DATEDIFF(SECOND, '19700101',
+            DATEADD(HOUR, c_sjh.run_time / 10000,
+                DATEADD(MINUTE, (c_sjh.run_time / 100) % 100,
+                    DATEADD(SECOND, c_sjh.run_time % 100,
+                        CAST(CAST(c_sjh.run_date AS CHAR(8)) AS DATETIME)
                     )
                 )
-            ) - DATEPART(tzoffset, SYSDATETIMEOFFSET()) * 60
-        + (sjh2.run_duration / 10000) * 3600
-        + ((sjh2.run_duration % 10000) / 100) * 60
-        + (sjh2.run_duration % 100)) > 0 + 10000
-    )
+            )
+        ) - DATEPART(TZOFFSET, SYSDATETIMEOFFSET()) * 60
+        + (c_sjh.run_duration / 10000) * 3600
+        + ((c_sjh.run_duration % 10000) / 100) * 60
+        + (c_sjh.run_duration % 100) AS completion_epoch_time
+    FROM COMPLETION_CTE AS C
+    LEFT JOIN msdb.dbo.sysjobhistory AS c_sjh
+        ON c_sjh.instance_id = C.completion_instance_id
+		WHERE C.completion_instance_id IS NOT NULL
+)
+SELECT
+	job_name,
+	job_id,
+	step_name,
+	step_id,
+	step_instance_id,
+	completion_instance_id,
+	run_epoch_time,
+	run_duration_seconds,
+	step_run_status,
+	message
+FROM HISTORY_ENTRIES
+WHERE
+    completion_epoch_time > 10000;
 """
 
 AGENT_ACTIVITY_DURATION_QUERY = """\


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR adds an optimization to the sqlserver agent job query, which queries `msdb.dbo.sysjobhistory` for a list of completed jobs + job steps since the last collection time. 

We were seeing customer issues like [SDBM-1193](https://datadoghq.atlassian.net/browse/SDBM-1193) with query times getting up to 7-8 minutes on job history logs of lengths 40k or 50k rows. 
This is because the original query included a n^2 subquery to calculate the `completion_instance_id` of the job associated with each job step:
```
SELECT 
    job_id,
   .....
(
            SELECT MIN(sjh2.instance_id)
            FROM msdb.dbo.sysjobhistory AS sjh2
            WHERE sjh2.job_id = sjh1.job_id
            AND sjh2.step_id = 0
            AND sjh2.instance_id >= sjh1.instance_id
        ) AS completion_instance_id,
....
```
i.e. for each row, we re-run this subquery to scan ahead for the job completion step (step_id=0).
The updated query creates a CTE of completion IDs instead, using a window function partitioning on job_id.
```
COMPLETION_CTE AS (
    SELECT
        BASE.*,
        MIN(CASE WHEN BASE.step_id = 0 THEN BASE.step_instance_id END) OVER (
            PARTITION BY BASE.job_id
            ORDER BY BASE.step_instance_id 
            ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
        ) AS completion_instance_id
    FROM BASE
),
```
On an example job history with 2000 steps, the updated query takes ~200ms and the original query takes ~10 seconds. The customer in the support ticket has job history retention set to 1k, 5k, and 10k per job on some instances.
### Motivation
<!-- What inspired you to submit this pull request? -->
 [SDBM-1193](https://datadoghq.atlassian.net/browse/SDBM-1193) 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[SDBM-1193]: https://datadoghq.atlassian.net/browse/SDBM-1193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ