### PR TITLE
Parse each row of pg_stat_activity separately inside a try/catch

### DIFF
--- a/postgres/changelog.d/18762.fixed
+++ b/postgres/changelog.d/18762.fixed
@@ -1,0 +1,1 @@
+Parse each row of pg_stat_activity separately inside a try/catch to avoid crashing on bad UTF8 data.

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -278,7 +278,7 @@ class PostgresStatementSamples(DBMAsyncJob):
                     except UnicodeDecodeError:
                         self._log.debug("Invalid unicode in row from pg_stat_activity")
                     except:
-                        self._log.debug("Error fetching row from pg_stat_activity")
+                        self._log.warning("Unknown error fetching row from pg_stat_activity")
 
         self._report_check_hist_metrics(start_time, len(rows), "get_new_pg_stat_activity")
         self._log.debug("Loaded %s rows from %s", len(rows), self._config.pg_stat_activity_view)

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -274,7 +274,7 @@ class PostgresStatementSamples(DBMAsyncJob):
                         row = cursor.fetchone()
                         if row is None:
                             break
-                        rows.append()
+                        rows.append(row)
                     except UnicodeDecodeError:
                         self._log.debug("Invalid unicode in row from pg_stat_activity")
                     except:

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -268,7 +268,17 @@ class PostgresStatementSamples(DBMAsyncJob):
             with conn.cursor(cursor_factory=CommenterDictCursor) as cursor:
                 self._log.debug("Running query [%s] %s", query, params)
                 cursor.execute(query, params)
-                rows = cursor.fetchall()
+                rows = []
+                while True:
+                    try:
+                        row = cursor.fetchone()
+                        if row is None:
+                            break
+                        rows.append()
+                    except UnicodeDecodeError:
+                        self._log.debug("Invalid unicode in row from pg_stat_activity")
+                    except:
+                        self._log.debug("Error fetching row from pg_stat_activity")
 
         self._report_check_hist_metrics(start_time, len(rows), "get_new_pg_stat_activity")
         self._log.debug("Loaded %s rows from %s", len(rows), self._config.pg_stat_activity_view)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Parses each row in `pg_stat_activity` individually.

### Motivation
<!-- What inspired you to submit this pull request? -->
Azure databases are inserting invalid UTF8 into the `pg_stat_activity` table. To avoid crashing we need to parse each row individually and skip rows with invalid UTF8.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
