### PR TITLE
Update ecs_fargate docs to note DD_DOGSTATSD_TAG_CARDINALITY setting

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -258,7 +258,7 @@ Metrics are collected with [DogStatsD][13] through UDP port 8125.
 
 #### Other environment variables
 
-For environment variables available with the Docker Agent container, see the [Docker Agent][14] page. **Note**: Some variables are not be available for Fargate.
+For environment variables available with the Docker Agent container, see the [Docker Agent][14] and [Assigning Tags][64] pages. **Note**: Some variables are not be available for Fargate.
 
 
 | Environment Variable               | Description                                    |
@@ -266,6 +266,8 @@ For environment variables available with the Docker Agent container, see the [Do
 | `DD_DOCKER_LABELS_AS_TAGS`         | Extract docker container labels                |
 | `DD_CHECKS_TAG_CARDINALITY`        | Add tags to check metrics                      |
 | `DD_DOGSTATSD_TAG_CARDINALITY`     | Add tags to custom metrics                     |
+
+On Fargate, it is recommended to set `DD_DOGSTATSD_TAG_CARDINALITY=orchestrator` to add the `task_arn` tag to ensure count metrics are not [underreported][65].
 
 For global tagging, it is recommended to use `DD_DOCKER_LABELS_AS_TAGS`. With this method, the Agent pulls in tags from your container labels. This requires you to add the appropriate labels to your other containers. Labels can be added directly in the [task definition][15].
 
@@ -888,3 +890,5 @@ Need help? Contact [Datadog support][18].
 [61]: https://docs.datadoghq.com/resources/json/datadog-agent-aws-batch-ecs-fargate.json
 [62]: https://docs.datadoghq.com/containers/guide/aws-batch-ecs-fargate
 [63]: https://www.datadoghq.com/blog/monitor-aws-batch-on-fargate/
+[64]: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=noncontainerizedenvironments#environment-variables
+[65]: https://github.com/DataDog/datadog-agent/issues/3159


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Link to important information about running dd agent on fargate ecs

### Motivation
<!-- What inspired you to submit this pull request? -->
https://github.com/DataDog/datadog-agent/issues/3159
https://github.com/DataDog/datadog-agent/issues/7602

### Additional Notes
<!-- Anything else we should know when reviewing? -->
docs only change

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
