### PR TITLE
Add option to disable stage metrics and `stage_id` tags

### DIFF
--- a/spark/assets/configuration/spec.yaml
+++ b/spark/assets/configuration/spec.yaml
@@ -121,6 +121,20 @@ files:
           type: boolean
           display_default: false
           example: true
+      - name: disable_spark_job_stage_tags
+        description: |
+          Enable to stop submitting the tag `stage_id` for Spark jobs.
+        value:
+          type: boolean
+          display_default: false
+          example: true
+      - name: disable_spark_stage_metrics
+        description: |
+          Enable to stop collecting Spark stage metrics.
+        value:
+          type: boolean
+          display_default: false
+          example: true
       - template: instances/http
         overrides:
           auth_token.description: |

--- a/spark/changelog.d/18791.added
+++ b/spark/changelog.d/18791.added
@@ -1,2 +1,1 @@
-Add configuration option to disable `stage_id` tag on `spark.job` metrics
-Add configuration option to disable `spark.stage` metrics
+Add configuration option to disable `stage_id` tag on `spark.job` metrics and disable `spark.stage` metrics

--- a/spark/changelog.d/18791.added
+++ b/spark/changelog.d/18791.added
@@ -1,0 +1,2 @@
+Add configuration option to disable `stage_id` tag on `spark.job` metrics
+Add configuration option to disable `spark.stage` metrics

--- a/spark/datadog_checks/spark/config_models/defaults.py
+++ b/spark/datadog_checks/spark/config_models/defaults.py
@@ -32,6 +32,14 @@ def instance_disable_legacy_cluster_tag():
     return False
 
 
+def instance_disable_spark_job_stage_tags():
+    return False
+
+
+def instance_disable_spark_stage_metrics():
+    return False
+
+
 def instance_empty_default_hostname():
     return False
 

--- a/spark/datadog_checks/spark/config_models/instance.py
+++ b/spark/datadog_checks/spark/config_models/instance.py
@@ -64,6 +64,8 @@ class InstanceConfig(BaseModel):
     connect_timeout: Optional[float] = None
     disable_generic_tags: Optional[bool] = None
     disable_legacy_cluster_tag: Optional[bool] = None
+    disable_spark_job_stage_tags: Optional[bool] = None
+    disable_spark_stage_metrics: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
     enable_query_name_tag: Optional[bool] = None
     executor_level_metrics: Optional[bool] = None

--- a/spark/datadog_checks/spark/data/conf.yaml.example
+++ b/spark/datadog_checks/spark/data/conf.yaml.example
@@ -145,6 +145,16 @@ instances:
     #
     # enable_query_name_tag: true
 
+    ## @param disable_spark_job_stage_tags - boolean - optional - default: false
+    ## Enable to stop submitting the tag `stage_id` for Spark jobs.
+    #
+    # disable_spark_job_stage_tags: true
+
+    ## @param disable_spark_stage_metrics - boolean - optional - default: false
+    ## Enable to stop collecting Spark stage metrics.
+    #
+    # disable_spark_stage_metrics: true
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/spark/datadog_checks/spark/spark.py
+++ b/spark/datadog_checks/spark/spark.py
@@ -73,6 +73,8 @@ class SparkCheck(AgentCheck):
         self.metricsservlet_path = self.instance.get('metricsservlet_path', '/metrics/json')
 
         self._enable_query_name_tag = is_affirmative(self.instance.get('enable_query_name_tag', False))
+        self._disable_spark_job_stage_tags = is_affirmative(self.instance.get('disable_spark_job_stage_tags', False))
+        self._disable_spark_stage_metrics = is_affirmative(self.instance.get('disable_spark_stage_metrics', False))
 
         # Get the cluster name from the instance configuration
         self.cluster_name = self.instance.get('cluster_name')
@@ -97,8 +99,9 @@ class SparkCheck(AgentCheck):
         # Get the job metrics
         self._spark_job_metrics(spark_apps, tags)
 
+        if not self._disable_spark_stage_metrics:
         # Get the stage metrics
-        self._spark_stage_metrics(spark_apps, tags)
+            self._spark_stage_metrics(spark_apps, tags)
 
         # Get the executor metrics
         self._spark_executor_metrics(spark_apps, tags)
@@ -412,8 +415,9 @@ class SparkCheck(AgentCheck):
                 if job_id is not None:
                     tags.append('job_id:{}'.format(job_id))
 
-                for stage_id in job.get('stageIds', []):
-                    tags.append('stage_id:{}'.format(stage_id))
+                if not self._disable_spark_job_stage_tags:
+                    for stage_id in job.get('stageIds', []):
+                        tags.append('stage_id:{}'.format(stage_id))
 
                 self._set_metrics_from_json(tags, job, SPARK_JOB_METRICS)
                 self._set_metric('spark.job.count', COUNT, 1, tags)

--- a/spark/datadog_checks/spark/spark.py
+++ b/spark/datadog_checks/spark/spark.py
@@ -100,7 +100,7 @@ class SparkCheck(AgentCheck):
         self._spark_job_metrics(spark_apps, tags)
 
         if not self._disable_spark_stage_metrics:
-        # Get the stage metrics
+            # Get the stage metrics
             self._spark_stage_metrics(spark_apps, tags)
 
         # Get the executor metrics


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This adds an option to disable `stage_id` from being attached to `spark.job` metrics and adds an option to disable the collection of stage metrics as a whole.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
