### PR TITLE
Remove comment about merge events being for marketplace

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ on:
     paths-ignore:
     - datadog_checks_base/datadog_checks/**
     - datadog_checks_dev/datadog_checks/dev/*.py
-  merge_group: # Used by marketplace
+  merge_group:
     types: [checks_requested]
 
 concurrency:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Removes a comment that I've since realized isn't true. While the templates ARE all shared between integration repos, each repo has its own `on` clause. For example, here is a PR that enables the merge events in extras - https://github.com/DataDog/integrations-extras/pull/2503

### Motivation
<!-- What inspired you to submit this pull request? -->
The comment isn't actually valid, so I don't want to leave it around. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
