### PR TITLE
Use specific databases for template on postgres ignore

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -71,12 +71,14 @@ files:
         items:
           type: string
         example:
-          - 'template%'
+          - 'template0'
+          - 'template1'
           - rdsadmin
           - azure_maintenance
           - cloudsqladmin
         default:
-          - 'template%'
+          - 'template0'
+          - 'template1'
           - rdsadmin
           - azure_maintenance
           - cloudsqladmin

--- a/postgres/changelog.d/18807.fixed
+++ b/postgres/changelog.d/18807.fixed
@@ -1,0 +1,1 @@
+Use specific databases for template on postgres ignore

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -12,7 +12,8 @@ SSL_MODES = {'disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full'
 TABLE_COUNT_LIMIT = 200
 
 DEFAULT_IGNORE_DATABASES = [
-    'template%',
+    'template0',
+    'template1',
     'rdsadmin',
     'azure_maintenance',
     'cloudsqladmin',

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -89,7 +89,7 @@ def instance_idle_connection_timeout():
 
 
 def instance_ignore_databases():
-    return ['template%', 'rdsadmin', 'azure_maintenance', 'cloudsqladmin']
+    return ['template0', 'template1', 'rdsadmin', 'azure_maintenance', 'cloudsqladmin']
 
 
 def instance_log_unobfuscated_plans():

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -78,7 +78,8 @@ instances:
     ## For more information on how patterns work, see https://www.postgresql.org/docs/12/functions-matching.html
     #
     # ignore_databases:
-    #   - template%
+    #   - template0
+    #   - template1
     #   - rdsadmin
     #   - azure_maintenance
     #   - cloudsqladmin


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Changes the default postgres `ignore_databases` from `template%` to specific databases (`template0` and `template1`)

### Motivation
<!-- What inspired you to submit this pull request? -->

In some scenarios we can have databases that start with template that should not be ignored, this default tries to target `template0` and `template1` which should be ignored but it can also target databases that should not be ignored.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
