### PR TITLE
Remove the comment that deadlock is supported only with ODBC

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -777,7 +777,7 @@ files:
         type: boolean
     - name: deadlocks_collection
       description: |
-        Configure the collection of deadlock data. The feature is supported for odbc connector only.
+        Configure the collection of deadlock data.
       options:
         - name: enabled
           description: |

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -28,6 +28,7 @@ init_config:
     #   - query: <QUERY>
     #     columns: <COLUMNS>
     #     tags: <TAGS>
+    #     collection_interval: <COLLECTION_INTERVAL>
 
     ## @param service - string - optional
     ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
@@ -639,6 +640,14 @@ instances:
     ##              Columns without a name are ignored. To skip a column, enter:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
+    ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
+    ##     If collection_interval is not set, the query will be run every check run.
+    ##     If the collection interval is less than check collection interval, 
+    ##     the query will be run every check run.
+    ##     If the collection interval is greater than check collection interval, 
+    ##     the query will NOT BE RUN exactly at the collection interval.
+    ##     The query will be run at the next check run after the collection interval has passed.
+    ## 5. metric_prefix (optional) - The prefix to apply to each metric.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
@@ -649,6 +658,8 @@ instances:
     #       type: gauge
     #     tags:
     #     - test:<INTEGRATION>
+    #     collection_interval: 30
+    #     metric_prefix: foo_prefix
 
     ## @param stored_procedure - string - optional
     ## DEPRECATED - use `custom_queries` instead. For guidance, see:

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -28,7 +28,6 @@ init_config:
     #   - query: <QUERY>
     #     columns: <COLUMNS>
     #     tags: <TAGS>
-    #     collection_interval: <COLLECTION_INTERVAL>
 
     ## @param service - string - optional
     ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
@@ -640,14 +639,6 @@ instances:
     ##              Columns without a name are ignored. To skip a column, enter:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
-    ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
-    ##     If collection_interval is not set, the query will be run every check run.
-    ##     If the collection interval is less than check collection interval, 
-    ##     the query will be run every check run.
-    ##     If the collection interval is greater than check collection interval, 
-    ##     the query will NOT BE RUN exactly at the collection interval.
-    ##     The query will be run at the next check run after the collection interval has passed.
-    ## 5. metric_prefix (optional) - The prefix to apply to each metric.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
@@ -658,8 +649,6 @@ instances:
     #       type: gauge
     #     tags:
     #     - test:<INTEGRATION>
-    #     collection_interval: 30
-    #     metric_prefix: foo_prefix
 
     ## @param stored_procedure - string - optional
     ## DEPRECATED - use `custom_queries` instead. For guidance, see:
@@ -692,7 +681,7 @@ instances:
     #
     # propagate_agent_tags: false
 
-    ## Configure the collection of deadlock data. The feature is supported for odbc connector only.
+    ## Configure the collection of deadlock data.
     #
     # deadlocks_collection:
 


### PR DESCRIPTION
### What does this PR do?

Remove the commend that deadlocks collection is supported only with ODBC driver from the config.

### Motivation

In the meantime, we support MSOLEDB, but I forgot to update the config file to reflect this.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
