### PR TITLE
adding mtu and speed tags to interfaces that support it

### DIFF
--- a/network/changelog.d/18819.added
+++ b/network/changelog.d/18819.added
@@ -1,0 +1,1 @@
+Add mtu and speed tags to interfaces that support it

--- a/network/datadog_checks/network/check_linux.py
+++ b/network/datadog_checks/network/check_linux.py
@@ -139,9 +139,9 @@ class LinuxNetwork(Network):
                 meta_tags = []
                 speed_path = os.path.join(sys_net_location, iface, 'speed')
                 mtu_path = os.path.join(sys_net_location, iface, 'mtu')
-                if (speed_value := self._read_int_file(speed_path)):
+                if speed_value := self._read_int_file(speed_path):
                     meta_tags.extend(['speed:' + str(speed_value)])
-                if (mtu_value := self._read_int_file(mtu_path)):
+                if mtu_value := self._read_int_file(mtu_path):
                     meta_tags.extend(['mtu:' + str(mtu_value)])
 
                 metrics = {

--- a/network/datadog_checks/network/check_linux.py
+++ b/network/datadog_checks/network/check_linux.py
@@ -127,12 +127,23 @@ class LinuxNetwork(Network):
         #     lo:45890956   112797   0    0    0     0          0         0    45890956   112797    0    0    0     0       0          0 # noqa: E501
         #   eth0:631947052 1042233   0   19    0   184          0      1206  1208625538  1320529    0    0    0     0       0          0 # noqa: E501
         #   eth1:       0        0   0    0    0     0          0         0           0        0    0    0    0     0       0          0 # noqa: E501
+        sys_net_location = '/sys/class/net'
         for line in lines[2:]:
             cols = line.split(':', 1)
             x = cols[1].split()
             # Filter inactive interfaces
             if self.parse_int(x[0]) or self.parse_int(x[8]):
                 iface = cols[0].strip()
+
+                # Try to get the NIC speed and MTU for additional tagging
+                meta_tags = []
+                speed_path = os.path.join(sys_net_location, iface, 'speed')
+                mtu_path = os.path.join(sys_net_location, iface, 'mtu')
+                if (speed_value := self._read_int_file(speed_path)):
+                    meta_tags.extend(['speed:' + str(speed_value)])
+                if (mtu_value := self._read_int_file(mtu_path)):
+                    meta_tags.extend(['mtu:' + str(mtu_value)])
+
                 metrics = {
                     'bytes_rcvd': self.parse_int(x[0]),
                     'bytes_sent': self.parse_int(x[8]),
@@ -143,7 +154,7 @@ class LinuxNetwork(Network):
                     'packets_out.drop': self.parse_int(x[11]),
                     'packets_out.error': self.parse_int(x[10]) + self.parse_int(x[11]),
                 }
-                self.submit_devicemetrics(iface, metrics, custom_tags)
+                self.submit_devicemetrics(iface, metrics, meta_tags + custom_tags)
                 self._handle_ethtool_stats(iface, custom_tags)
 
         netstat_data = {}


### PR DESCRIPTION
### What does this PR do?
This PR will add two new tags (mtu and speed) to any network device that supports that information out of /sys/class/net/<device>
 If the data cannot be determined it is skipped (for example, the `lo` interface has no speed).

The following `system.net` metrics will receive the new tags:
```
bytes_rcvd
bytes_sent
packets_in.count
packets_in.drop
packets_in.error
packets_out.count
packets_out.drop
packets_out.error
```

### Motivation
It's currently not possible to build host network device dashboards grouped by speed, unless you manually define which interfaces are which speed (this can be different between OS flavors, or just different server configurations).

There is an existing metric named `system.net.iface.mtu` which is tagged by `iface`, but in my opinion `mtu` makes more sense to be in a tag, MTU does not change often (or ever) in a server's lifetime. Graphing MTU in a timeseries is not very useful.

With this change, you could build dashboards where you can differentiate between your 1Gb interfaces vs. your 10Gb interfaces like this:
`avg:system.net.bytes_rcvd{host:$host, speed:10000} by {device}`
or
`avg:system.net.bytes_rcvd{host:$host} by {device,speed}`

### Additional Notes
This change is only tested on linux, but could be extended to the other OS specific network check files

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
