### PR TITLE
Skip test job for pull requests in merge queue if it's flaky

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,10 @@ on:
     - datadog_checks_base/datadog_checks/**
     - datadog_checks_dev/datadog_checks/dev/*.py
   merge_group:
+    # We require this workflow to pass in order to merge a PR to master.
+    # This means Github's Merge Queue also requires it to pass.
+    # We must add the Merge Queue trigger in this configuration, otherwise Merge Queue
+    # times out waiting for this check that never triggers.
     types: [checks_requested]
 
 concurrency:
@@ -14,6 +18,11 @@ concurrency:
 
 jobs:
   test:
+    # In integrations-core repo the tests are flaky enough that it would be a pain
+    # to merge PRs with the Merge Queue enabled.
+    # While we work on the tests, we skip the job if it's triggered by Merge Queue.
+    # Github treats skipped jobs as successful, thus we unblock the Merge Queue.
+    if: 'github.repository != "DataDog/integrations-core"  || github.event_name != "merge_group"'
     uses: ./.github/workflows/pr-test.yml
     with:
       repo: core

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,11 +18,11 @@ concurrency:
 
 jobs:
   test:
-    # In integrations-core repo the tests are flaky enough that it would be a pain
-    # to merge PRs with the Merge Queue enabled.
+    # In integrations-core and integrations-extras repos the tests are flaky enough that
+    # it would be a pain to merge PRs with the Merge Queue enabled.
     # While we work on the tests, we skip the job if it's triggered by Merge Queue.
     # Github treats skipped jobs as successful, thus we unblock the Merge Queue.
-    if: 'github.repository != "DataDog/integrations-core"  || github.event_name != "merge_group"'
+    if: 'github.repository == "DataDog/marketplace" || github.event_name != "merge_group"'
     uses: ./.github/workflows/pr-test.yml
     with:
       repo: core


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Skip the `test` job of the `pr.yml` github action workflow for `integrations-core` repo and Merge Queue trigger.

### Motivation
<!-- What inspired you to submit this pull request? -->
Lets us enable Github's Merge Queue for this repo without making developer experience worse.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
