### PR TITLE
Cilium: fix metric table

### DIFF
--- a/cilium/metadata.csv
+++ b/cilium/metadata.csv
@@ -1,5 +1,4 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric,sample_tags
-cilium.,gauge,,event,,[OpenMetrics V1 and V2] How many seconds has the longest running processor for workqueue been running.,0,cilium,k8s workqueue running processor,,
 cilium.agent.api_process_time.seconds.bucket,count,,second,,[OpenMetrics V2] Amount of processing time for all API calls,0,cilium,api proc time bucket,,
 cilium.agent.api_process_time.seconds.count,count,,request,,[OpenMetrics V1 and V2] Count of processing time for all API calls,0,cilium,api proc time count,,
 cilium.agent.api_process_time.seconds.sum,count,,second,,[OpenMetrics V1 and V2] Sum of processing time for all API calls,0,cilium,api proc time sum,,


### PR DESCRIPTION
### What does this PR do?
Tiny formatting fix for the Cilium metric table in the documentation. Right now it is not rendered properly because of the corrupted first row (probably due to a bad copy-paste):
https://docs.datadoghq.com/integrations/cilium/?tab=host#data-collected
![image](https://github.com/user-attachments/assets/e37a45ac-0b3d-4e76-833d-5286030f915b)
