### PR TITLE
Bump cython

### DIFF
--- a/.builders/deps/build_dependencies.txt
+++ b/.builders/deps/build_dependencies.txt
@@ -9,5 +9,5 @@ setuptools-scm==5.0.2; python_version < '3.0'
 setuptools-rust>=1.7.0; python_version > '3.0'
 maturin; python_version > '3.0'
 cffi>=1.12
-cython<3.0.0
+cython==3.0.11
 tomli>=2.0.1; python_version > '3.0'


### PR DESCRIPTION
### What does this PR do?

Use the most recent version of cython, hopefully making it possible to bump pykrb5.

### Motivation

Can't build recently released pykrb5 0.7.0 with the current version of cython we use for builds (https://github.com/jborean93/pykrb5/issues/57)

### Additional Notes

If this doesn't work we'll have to look into alternatives such as:
- Capping pykrb5 version
- Building pykrb5 with build isolation to use the version of cython that it needs

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
