### PR TITLE
Fix unit parsing issue

### DIFF
--- a/tibco_ems/changelog.d/18840.added
+++ b/tibco_ems/changelog.d/18840.added
@@ -1,0 +1,1 @@
+Fix metric size unit parsing

--- a/tibco_ems/datadog_checks/tibco_ems/constants.py
+++ b/tibco_ems/datadog_checks/tibco_ems/constants.py
@@ -122,10 +122,10 @@ SHOW_METRIC_DATA = {
     },
     'show connections full': {
         'regex': re.compile(
-            r'^\s*(?P<client_type>[JC])\s+'
+            r'^\s*(?P<client_type>[-#JC])\s+'
             r'(?P<tibco_version>[\w.]+(?:\s+V\d+)?)\s+'
             r'(?P<id>\d+)\s+'
-            r'(?P<fsxt>[-A]+)\s+'
+            r'(?P<fsxt>[-A-Za-z]+)\s+'
             r'(?P<s>[+|-])\s+'
             r'(?P<tibco_host>\S+)\s+'
             r'(?P<ip_address>\S+)\s+'

--- a/tibco_ems/datadog_checks/tibco_ems/tibco_ems.py
+++ b/tibco_ems/datadog_checks/tibco_ems/tibco_ems.py
@@ -11,7 +11,7 @@ from .constants import SHOW_METRIC_DATA, UNIT_PATTERN
 
 DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = 7222
-TO_BYTES = {'B': 1, 'Kb': 1e3, 'Mb': 1e6, 'Gb': 1e9, 'Tb': 1e12}
+TO_BYTES = {'b': 1, 'kb': 1e3, 'mb': 1e6, 'gb': 1e9, 'tb': 1e12}
 CONNECTION_STRING = 'tcp://{}:{}'
 
 
@@ -112,7 +112,7 @@ class TibcoEMSCheck(AgentCheck):
                 if version_match:
                     server_data['version'] = version_match.group()
                 server_data[key] = value
-            elif key in ['topics', 'queues']:
+            elif key in ['topics', 'queues', 'client_connections']:
                 server_data[key] = int(value.split(' ')[0])
             elif "rate" in key:
                 parse_rate(server_data, key, value)
@@ -223,7 +223,7 @@ class TibcoEMSCheck(AgentCheck):
             if metric_name in metric_data:
                 if isinstance(metric_info, dict):
                     self.gauge(
-                        f"{prefix}.{metric_name}", (metric_info['value'] * TO_BYTES[metric_info['unit']]), tags=tags
+                        f"{prefix}.{metric_name}", (metric_info['value'] * TO_BYTES[metric_info['unit'].lower()]), tags=tags
                     )
                 else:
                     self.gauge(f"{prefix}.{metric_name}", metric_info, tags=tags)

--- a/tibco_ems/datadog_checks/tibco_ems/tibco_ems.py
+++ b/tibco_ems/datadog_checks/tibco_ems/tibco_ems.py
@@ -223,7 +223,9 @@ class TibcoEMSCheck(AgentCheck):
             if metric_name in metric_data:
                 if isinstance(metric_info, dict):
                     self.gauge(
-                        f"{prefix}.{metric_name}", (metric_info['value'] * TO_BYTES[metric_info['unit'].lower()]), tags=tags
+                        f"{prefix}.{metric_name}",
+                        (metric_info['value'] * TO_BYTES[metric_info['unit'].lower()]),
+                        tags=tags,
                     )
                 else:
                     self.gauge(f"{prefix}.{metric_name}", metric_info, tags=tags)

--- a/tibco_ems/tests/fixtures/show_all
+++ b/tibco_ems/tests/fixtures/show_all
@@ -64,12 +64,12 @@ L  Version   ID    FSXT  S  Host         IP address Port  User   ClientID Sess P
 C  10.1.0 V4 10630 ---A  +  d3ce69f9df4f 127.0.0.1  46418 admin              1    1    1    0    1      0     0.0 Kb      0.030
 Command: show durables
   Topic Name        Durable          Shared  User         Msgs    Size
-  sample            sample.durable   N       <offline>       0     0.0 Kb
+  sample            sample.durable   N       <offline>       0     0.0 MB
 Command: show stat consumers
                                                       Total Count      Rate/Second
   User       Conn  T  Destination                      Msgs   Size      Msgs   Size
-  admin         2  Q  $TMP$.tibemsd.1669EC51B3.1          1    2.4 Kb      0    0.6 Kb
+  admin         2  Q  $TMP$.tibemsd.1669EC51B3.1          1    2.4 Kb      0    0.6 TB
 Command: show stat producers
                                         Total Count      Rate/Second
   User       Conn  T  Destination       Msgs   Size      Msgs   Size
-  admin         2  Q  $sys.admin           3    0.5 Kb      0    0.0 Kb
+  admin         2  Q  $sys.admin           3    0.5 Kb      0    0.0 GB

--- a/tibco_ems/tests/fixtures/show_server
+++ b/tibco_ems/tests/fixtures/show_server
@@ -6,7 +6,7 @@ Command: show server
   Runtime Module Path:      /opt/tibco/ems/10.1/bin/lib:/opt/tibco/ems/10.1/lib
   Topics:                   3 (0 dynamic, 0 temporary)
   Queues:                   9 (0 dynamic, 2 temporary)
-  Client Connections:       0
+  Client Connections:       0 of 1000 maximum
   Admin Connections:        2
   Sessions:                 2
   Producers:                2
@@ -25,3 +25,4 @@ Command: show server
   Storage Read Rate:        0 reads/sec,  0.0 Kb per second
   Storage Write Rate:       0 writes/sec, 0.0 Kb per second
   Uptime:                   4 days 6 hours 19 minutes
+

--- a/tibco_ems/tests/fixtures/show_server
+++ b/tibco_ems/tests/fixtures/show_server
@@ -25,4 +25,3 @@ Command: show server
   Storage Read Rate:        0 reads/sec,  0.0 Kb per second
   Storage Write Rate:       0 writes/sec, 0.0 Kb per second
   Uptime:                   4 days 6 hours 19 minutes
-


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This generalizes the unit format for Tibco size metrics.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
