### PR TITLE
[postgres] Apply service option defined in config as service tag to metrics and service check

### DIFF
--- a/postgres/changelog.d/18841.fixed
+++ b/postgres/changelog.d/18841.fixed
@@ -1,0 +1,1 @@
+Apply the `service` option from config as a `service:<SERVICE>` tag to metrics, and service checks emitted by the integration.

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -199,7 +199,7 @@ class PostgresConfig:
                 raise ConfigurationError(
                     'propagate_agent_tags enabled but there was an error fetching agent tags {}'.format(e)
                 )
-            
+
         if service_tag:
             # append the service tag if `service:<service>` is not already in the tags
             if not any(tag.startswith('service:') for tag in tags):
@@ -299,9 +299,11 @@ class PostgresConfig:
         # if neither the instance nor the init_config has set the value, return False
         return False
 
+    @staticmethod
     def _get_service_tag(instance, init_config):
         '''
-        return the service tag
+        return the service tag defined in the instance or the init_config,
+        to be applied as `service:<service>` tag to the check
         '''
         service = instance.get('service')
         if service is not None:


### PR DESCRIPTION
### What does this PR do?
This PR ensures that the `service` option, when defined in either the integration `init_config` or `instance` config, is applied as a `service:<SERVICE>` tag to both metrics and service checks. If a `service` tag is already explicitly provided in the `tags` list, it will take precedence over the service option from the config, and the latter will be ignored to prevent tag conflicts.

### Motivation
https://datadoghq.atlassian.net/browse/SDBM-1225

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
