### PR TITLE
[NDM] [Cisco ACI] Utilize raw ID for interface metadata

### DIFF
--- a/cisco_aci/changelog.d/18842.added
+++ b/cisco_aci/changelog.d/18842.added
@@ -1,0 +1,1 @@
+[NDM] [Cisco ACI] Utilize raw ID for interface metadata

--- a/cisco_aci/datadog_checks/cisco_aci/models.py
+++ b/cisco_aci/datadog_checks/cisco_aci/models.py
@@ -135,8 +135,11 @@ class Status(StrEnum):
 class InterfaceMetadata(BaseModel):
     device_id: Optional[str] = Field(default=None)
     id_tags: list = Field(default_factory=list)
+    raw_id: Optional[str] = Field(default=None)
+    raw_id_type: Optional[str] = Field(default='cisco_aci')
     index: Optional[int] = Field(default=None)
     name: Optional[str] = Field(default=None)
+    alias: Optional[str] = Field(default=None)
     description: Optional[str] = Field(default=None)
     mac_address: Optional[str] = Field(default=None)
     admin_status: Optional[AdminStatus] = Field(default=None)

--- a/cisco_aci/datadog_checks/cisco_aci/ndm.py
+++ b/cisco_aci/datadog_checks/cisco_aci/ndm.py
@@ -48,9 +48,11 @@ def create_interface_metadata(phys_if, address, namespace):
     eth = PhysIf(**phys_if.get('l1PhysIf', {}))
     interface = InterfaceMetadata(
         device_id='{}:{}'.format(namespace, address),
-        id_tags=['interface:{}'.format(eth.attributes.name)],
+        raw_id=eth.attributes.id,
+        id_tags=['interface:{}'.format(eth.attributes.id)],
         index=eth.attributes.id,
         name=eth.attributes.name,
+        alias=eth.attributes.id,
         description=eth.attributes.desc,
         mac_address=eth.attributes.router_mac,
         admin_status=eth.attributes.admin_st,

--- a/cisco_aci/datadog_checks/cisco_aci/ndm.py
+++ b/cisco_aci/datadog_checks/cisco_aci/ndm.py
@@ -49,7 +49,7 @@ def create_interface_metadata(phys_if, address, namespace):
     interface = InterfaceMetadata(
         device_id='{}:{}'.format(namespace, address),
         raw_id=eth.attributes.id,
-        id_tags=['interface:{}'.format(eth.attributes.id)],
+        id_tags=['interface:{}'.format(eth.attributes.name)],
         index=eth.attributes.id,
         name=eth.attributes.name,
         alias=eth.attributes.id,

--- a/cisco_aci/tests/fixtures/metadata.py
+++ b/cisco_aci/tests/fixtures/metadata.py
@@ -137,6 +137,8 @@ DEVICE_METADATA = [
 INTERFACE_METADATA = [
     {
         'admin_status': 1,
+        'alias': 'eth1/1',
+        'raw_id': 'eth1/1',
         'device_id': 'default:10.0.200.0',
         'id_tags': [
             'interface:eth1/1',
@@ -150,6 +152,8 @@ INTERFACE_METADATA = [
     },
     {
         'admin_status': 1,
+        'alias': 'eth1/2',
+        'raw_id': 'eth1/2',
         'device_id': 'default:10.0.200.0',
         'id_tags': [
             'interface:eth1/2',
@@ -163,6 +167,8 @@ INTERFACE_METADATA = [
     },
     {
         'admin_status': 1,
+        'alias': 'eth1/3',
+        'raw_id': 'eth1/3',
         'device_id': 'default:10.0.200.0',
         'id_tags': [
             'interface:eth1/3',
@@ -176,6 +182,8 @@ INTERFACE_METADATA = [
     },
     {
         'admin_status': 1,
+        'alias': 'eth1/1',
+        'raw_id': 'eth1/1',
         'device_id': 'default:10.0.200.1',
         'id_tags': [
             'interface:eth1/1',
@@ -189,6 +197,8 @@ INTERFACE_METADATA = [
     },
     {
         'admin_status': 1,
+        'alias': 'eth1/2',
+        'raw_id': 'eth1/2',
         'device_id': 'default:10.0.200.1',
         'id_tags': [
             'interface:eth1/2',
@@ -202,6 +212,8 @@ INTERFACE_METADATA = [
     },
     {
         'admin_status': 1,
+        'alias': 'eth1/3',
+        'raw_id': 'eth1/3',
         'device_id': 'default:10.0.200.1',
         'id_tags': [
             'interface:eth1/3',
@@ -215,6 +227,8 @@ INTERFACE_METADATA = [
     },
     {
         'admin_status': 1,
+        'alias': 'eth5/1',
+        'raw_id': 'eth5/1',
         'device_id': 'default:10.0.200.5',
         'id_tags': [
             'interface:eth5/1',
@@ -228,6 +242,8 @@ INTERFACE_METADATA = [
     },
     {
         'admin_status': 1,
+        'alias': 'eth5/2',
+        'raw_id': 'eth5/2',
         'device_id': 'default:10.0.200.5',
         'id_tags': [
             'interface:eth5/2',
@@ -241,6 +257,8 @@ INTERFACE_METADATA = [
     },
     {
         'admin_status': 1,
+        'alias': 'eth7/1',
+        'raw_id': 'eth7/1',
         'device_id': 'default:10.0.200.5',
         'id_tags': [
             'interface:eth7/1',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Interfaces in Cisco ACI are uniquely identified by their `id` - for example: `eth1/1` for a leaf switch and `eth5/1` for a spine node. This does not correspond to the required `int` type that interface index is typed as. 
![image](https://github.com/user-attachments/assets/817b0844-d717-4f3b-b070-557fca10e15f)

Previously, the denominator for the number (i.e. 1 from `5/1` or 25 from `1/25`) but this doesn't work for spine nodes which can have different numerators which would have overlap (`5/1` and `7/1` interface IDs would end up both being index 1 for the device, which would overwrite one another). 

We are now utilizing the `raw_id` and `raw_id_type` fields that were introduced with the Cisco Meraki integration. Tests to reference expectations can be seen [here](https://github.com/DataDog/dd-go/blob/6646f200ed4166e41cf83837d0930d098ba1418a/apps/network-devices-writer/payload/payload_test.go#L63) from the writer.

We would then pass the `raw_id` as the identifier (e.g. `eth1/1`) and the `raw_id_type` as `cisco_aci` as a static constant for all devices with interfaces. An example interface ID would then look like: `default:10.1.2.3:cisco_aci-eth1/1`.

**Changes summary:**
* Add `raw_id`, `raw_id_type` and `alias` to `InterfaceMetadata` that gets sent to NDM intake

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

QA
https://datadoghq.atlassian.net/wiki/spaces/II/pages/4013621409/QA+for+Cisco+ACI+integration+public+private+sandbox
1. `ddev env start cisco_aci py3.12 --base`
2. `ddev env config edit cisco_aci py3.12`
```
instances:
  - aci_url: https://sandboxapicdc.cisco.com # public sandbox
    username: admin
    pwd: "!v3G@!4@Y" # double quotes are necessary here
    tls_verify: false
    namespace: zoe-qa-interface-raw-id
    send_ndm_metadata: true
```
3. `ddev env reload cisco_aci py3.12`
4. `ddev env agent cisco_aci py3.12 check > output-interface-raw-id.txt`

Snippet from the 

```
  {
    "EventType": "network-devices-metadata",
    "UnmarshalledEvent": {
      "collect_timestamp": 1729023789,
      "devices": [],
      "interfaces": [
        {
          "admin_status": 1,
          "alias": "eth1/23",
          "device_id": "zoe-qa-interface-raw-id:10.0.48.64",
          "id_tags": [
            "interface:eth1/23"
          ],
          "index": 23,
          "integration": "cisco-aci",
          "mac_address": "not-applicable",
          "name": "eth1/23",
          "oper_status": 2,
          "raw_id": "eth1/23",
          "raw_id_type": "cisco_aci",
          "status": "down"
        },
        {
          "admin_status": 1,
          "alias": "eth1/29",
          "device_id": "zoe-qa-interface-raw-id:10.0.48.64",
          "id_tags": [
            "interface:eth1/29"
          ],
          "index": 29,
          "integration": "cisco-aci",
          "mac_address": "not-applicable",
          "name": "eth1/29",
          "oper_status": 2,
          "raw_id": "eth1/29",
          "raw_id_type": "cisco_aci",
          "status": "down"
        },
....
```

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
