### PR TITLE
[mongo] Apply configured timeout to timeoutMS connection option

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -287,8 +287,8 @@ files:
         example: true
     - name: timeout
       description: |
-        Controls connectTimeoutMS, serverSelectionTimeoutMS and socketTimeoutMS
-        see http://api.mongodb.com/python/3.4.0/api/pymongo/mongo_client.html
+        Controls connectTimeoutMS, serverSelectionTimeoutMS, socketTimeoutMS and timeoutMS
+        see https://pymongo.readthedocs.io/en/stable/api/pymongo/mongo_client.html
       value:
         type: integer
         example: 30

--- a/mongo/changelog.d/18843.added
+++ b/mongo/changelog.d/18843.added
@@ -1,0 +1,1 @@
+Apply `timeoutMS` to integration connection to ensure client-side operation timeouts terminate the server processes.

--- a/mongo/datadog_checks/mongo/api.py
+++ b/mongo/datadog_checks/mongo/api.py
@@ -46,6 +46,7 @@ class MongoApi(object):
             'socketTimeoutMS': self._config.timeout,
             'connectTimeoutMS': self._config.timeout,
             'serverSelectionTimeoutMS': self._config.timeout,
+            'timeoutMS': self._config.timeout,
             'directConnection': True,
             'read_preference': ReadPreference.PRIMARY_PREFERRED,
             'appname': DD_APP_NAME,

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -244,8 +244,8 @@ instances:
     # replica_check: true
 
     ## @param timeout - integer - optional - default: 30
-    ## Controls connectTimeoutMS, serverSelectionTimeoutMS and socketTimeoutMS
-    ## see http://api.mongodb.com/python/3.4.0/api/pymongo/mongo_client.html
+    ## Controls connectTimeoutMS, serverSelectionTimeoutMS, socketTimeoutMS and timeoutMS
+    ## see https://pymongo.readthedocs.io/en/stable/api/pymongo/mongo_client.html
     #
     # timeout: 30
 


### PR DESCRIPTION
### What does this PR do?
This PR applies the `timeout` config option (defaults to 30s) to `timeoutMS` connection option. With `timeoutMS`, a client-side operation timeout is properly specified. Prior to the change, long running integration command will get a network timeout due to `socketTimeoutMS`, however the operation will still be running on the server side. By setting `timeoutMS`, it ensures the operation is properly ended when exceeds defined timeout. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
