### PR TITLE
[mongo] skip explain administrative aggregation pipeline

### DIFF
--- a/mongo/changelog.d/18844.fixed
+++ b/mongo/changelog.d/18844.fixed
@@ -1,1 +1,1 @@
-Skip explain plan collection for mongo administrative aggregation pipeline, including `$collStats`, `$currentOp`, `$indexStats` and `$sample`.
+Skip explain plan collection for mongo administrative aggregation pipeline, including `$collStats`, `$currentOp`, `$indexStats`, `$listSearchIndexes`, `$sample` and `$shardedDataDistribution`.

--- a/mongo/changelog.d/18844.fixed
+++ b/mongo/changelog.d/18844.fixed
@@ -1,0 +1,1 @@
+Skip explain plan collection for mongo administrative aggregation pipeline, including `$collStats`, `$currentOp`, `$indexStats` and `$sample`.

--- a/mongo/datadog_checks/mongo/dbm/utils.py
+++ b/mongo/datadog_checks/mongo/dbm/utils.py
@@ -62,7 +62,9 @@ UNEXPLAINABLE_PIPELINE_STAGES = frozenset(
         "$collStats",
         "$currentOp",
         "$indexStats",
+        "$listSearchIndexes",
         "$sample",
+        "$shardedDataDistribution",
     ]
 )
 

--- a/mongo/datadog_checks/mongo/dbm/utils.py
+++ b/mongo/datadog_checks/mongo/dbm/utils.py
@@ -57,6 +57,15 @@ UNEXPLAINABLE_COMMANDS = frozenset(
     ]
 )
 
+UNEXPLAINABLE_PIPELINE_STAGES = frozenset(
+    [
+        "$collStats",
+        "$currentOp",
+        "$indexStats",
+        "$sample",
+    ]
+)
+
 COMMAND_KEYS_TO_REMOVE = frozenset(["comment", "lsid", "$clusterTime"])
 
 EXPLAIN_PLAN_KEYS_TO_REMOVE = frozenset(
@@ -107,6 +116,12 @@ def should_explain_operation(
     # if UNEXPLAINABLE_COMMANDS in command, skip
     if any(command.get(key) for key in UNEXPLAINABLE_COMMANDS):
         return False
+
+    # if UNEXPLAINABLE_PIPELINE_STAGES in command pipeline stages, skip
+    if pipeline := command.get("pipeline"):
+        stages = [list(stage.keys())[0] for stage in pipeline if isinstance(stage, dict)]
+        if any(stage in UNEXPLAINABLE_PIPELINE_STAGES for stage in stages):
+            return False
 
     db, _ = namespace.split(".", 1)
     if db in MONGODB_SYSTEM_DATABASES:

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -10,12 +10,15 @@ from urllib.parse import quote_plus
 
 import mock
 import pytest
+from bson import json_util
 from pymongo.errors import ConnectionFailure, OperationFailure
 
 from datadog_checks.base import ConfigurationError
+from datadog_checks.base.utils.db.sql import compute_exec_plan_signature
 from datadog_checks.mongo.api import CRITICAL_FAILURE, MongoApi
 from datadog_checks.mongo.collectors import MongoCollector
 from datadog_checks.mongo.common import MongosDeployment, ReplicaSetDeployment, get_state_name
+from datadog_checks.mongo.dbm.utils import should_explain_operation
 from datadog_checks.mongo.mongo import HostingType, MongoDb, metrics
 from datadog_checks.mongo.utils import parse_mongo_uri
 
@@ -778,3 +781,114 @@ def seed_mock_client():
 def load_json_fixture(name):
     with open(os.path.join(common.HERE, "fixtures", name), 'r') as f:
         return json.load(f)
+
+
+@pytest.mark.parametrize(
+    'namespace,op,command,should_explain',
+    [
+        pytest.param(
+            "test.test",
+            "command",
+            {
+                "aggregate": "test",
+                "pipeline": [{"$collStats": {"latencyStats": {}, "storageStats": {}, "queryExecStats": {}}}],
+                "cursor": {},
+                "$db": "test",
+                "$readPreference": {"mode": "?"},
+            },
+            False,
+            id='no-explain $collStats',
+        ),
+        pytest.param(
+            "test.test",
+            "command",
+            {
+                "aggregate": "test",
+                "pipeline": [{"$sample": {"size": "?"}}],
+                "cursor": {},
+                "$db": "test",
+                "$readPreference": {"mode": "?"},
+            },
+            False,
+            id='no explain $sample',
+        ),
+        pytest.param(
+            "test.test",
+            "command",
+            {
+                "aggregate": "test",
+                "pipeline": [{"$indexStats": {}}],
+                "cursor": {},
+                "$db": "test",
+                "$readPreference": {"mode": "?"},
+            },
+            False,
+            id='no explain $indexStats',
+        ),
+        pytest.param(
+            "test.test",
+            "command",
+            {"getMore": "?", "collection": "test", "$db": "test", "$readPreference": {"mode": "?"}},
+            False,
+            id='no explain getMore',
+        ),
+        pytest.param(
+            "test.test",
+            "update",
+            {
+                "update": "test",
+                "updates": [{"q": {}, "u": {}, "multi": False, "upsert": False}],
+                "ordered": True,
+                "$db": "test",
+                "$readPreference": {"mode": "?"},
+            },
+            False,
+            id='no explain update',
+        ),
+        pytest.param(
+            "test.test",
+            "insert",
+            {
+                "insert": "test",
+                "documents": [{"_id": "?", "a": 1}],
+                "ordered": True,
+                "$db": "test",
+                "$readPreference": {"mode": "?"},
+            },
+            False,
+            id='no explain insert',
+        ),
+        pytest.param(
+            "test.test",
+            "remove",
+            {
+                "delete": "test",
+                "deletes": [{"q": {}, "limit": 1}],
+                "ordered": True,
+                "$db": "test",
+                "$readPreference": {"mode": "?"},
+            },
+            False,
+            id='no explain delete',
+        ),
+        pytest.param(
+            "test.test",
+            "query",
+            {"find": "test", "filter": {}, "$db": "test", "$readPreference": {"mode": "?"}},
+            True,
+            id='explain find',
+        ),
+    ],
+)
+def test_should_explain_operation(namespace, op, command, should_explain):
+    check = MongoDb('mongo', {}, [{'hosts': ['localhost']}])
+    assert (
+        should_explain_operation(
+            namespace,
+            op,
+            command,
+            explain_plan_rate_limiter=check._operation_samples._explained_operations_ratelimiter,
+            explain_plan_cache_key=(namespace, op, compute_exec_plan_signature(json_util.dumps(command))),
+        )
+        == should_explain
+    )


### PR DESCRIPTION
### What does this PR do?
This PR skips explain plan collection for mongo administrative aggregation pipeline, including `$collStats`, `$currentOp`, `$indexStats` and `$sample`. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
