### PR TITLE
add bit family as valid units

### DIFF
--- a/ddev/changelog.d/18845.added
+++ b/ddev/changelog.d/18845.added
@@ -1,0 +1,1 @@
+add bit family as valid units

--- a/ddev/src/ddev/cli/validate/metadata_utils.py
+++ b/ddev/src/ddev/cli/validate/metadata_utils.py
@@ -221,6 +221,14 @@ VALID_UNIT_NAMES = {
     'joule',
     'kilojoule',
     'megajoule',
+    "bit_in_bits_family",
+    "byte_in_bits_family",
+    "kilobit",
+    "megabit",
+    "gigabit",
+    "terabit",
+    "petabit",
+    "exabit",
 }
 
 ALLOWED_PREFIXES = ('system.', 'jvm.', 'http.', 'datadog.', 'sftp.', 'process.', 'runtime.', 'otelcol_')


### PR DESCRIPTION
### What does this PR do?
add the bit family as valid units 
### Motivation

https://datadoghq.atlassian.net/wiki/spaces/GE/pages/2671673472/Splitting+bytes+families+disambiguation

### Additional Notes
already added to dogweb
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
