### PR TITLE
[INTPLAT-356] Specifically avoid running 'test / check' on merge group events, which is the required status check

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -73,7 +73,11 @@ jobs:
   check:
     needs:
     - test
-    if: always()
+    # In integrations-core and integrations-extras repos the tests are flaky enough that
+    # it would be a pain to merge PRs with the Merge Queue enabled.
+    # While we work on the tests, we skip the job if it's triggered by Merge Queue.
+    # Github treats skipped jobs as successful, thus we unblock the Merge Queue.
+    if: always() && github.event_name != 'merge_group'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -30,7 +30,7 @@ jobs:
   test:
     needs:
     - compute-matrix
-    if: needs.compute-matrix.outputs.matrix != '[]'
+    if: needs.compute-matrix.outputs.matrix != '[]' && github.event_name != 'merge_group'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,11 +18,6 @@ concurrency:
 
 jobs:
   test:
-    # In integrations-core and integrations-extras repos the tests are flaky enough that
-    # it would be a pain to merge PRs with the Merge Queue enabled.
-    # While we work on the tests, we skip the job if it's triggered by Merge Queue.
-    # Github treats skipped jobs as successful, thus we unblock the Merge Queue.
-    if: ${{ github.repository == 'DataDog/marketplace' || github.event_name != 'merge_group' }}
     uses: ./.github/workflows/pr-test.yml
     with:
       repo: core


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR moves the "check if merge group event is the trigger" check to be a step below where it is now. GitHub docs state that they treat "skipped" checks as "success". I believe the reason this didn't work before was that the skip was happening at the top level and not at the specific `test / check` status check. The `test / check` is what the branch protection has set to be a "required check". 

### Motivation
<!-- What inspired you to submit this pull request? -->
Continue iterating so that we can enable Merge Queues in this repository. 

<img width="1596" alt="skipped_stage (2)" src="https://github.com/user-attachments/assets/06157bc3-168e-4874-a0fe-dea8ded580bf">

Github docs on "skipped == success" - https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/using-conditions-to-control-job-execution#overview

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
