### PR TITLE
Add extended events (XE) session monitoring

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -282,6 +282,13 @@ files:
       value:
         type: boolean
         example: true
+    - name: include_xe_metrics
+      description: |
+        Include extended events (XE) metrics. The collection of XE metrics is automatically enabled
+        when `deadlocks_collection` is enabled.
+      value:
+        type: boolean
+        example: true
     - name: adoprovider
       description: |
         Choose the ADO provider.  Note that the (default) provider

--- a/sqlserver/changelog.d/18857.added
+++ b/sqlserver/changelog.d/18857.added
@@ -1,0 +1,1 @@
+Add extended events (XE) session monitoring

--- a/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
@@ -112,6 +112,10 @@ def instance_include_tempdb_file_space_usage_metrics():
     return True
 
 
+def instance_include_xe_metrics():
+    return True
+
+
 def instance_index_usage_metrics_interval():
     return 300
 

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -215,6 +215,7 @@ class InstanceConfig(BaseModel):
     include_secondary_log_shipping_metrics: Optional[bool] = None
     include_task_scheduler_metrics: Optional[bool] = None
     include_tempdb_file_space_usage_metrics: Optional[bool] = None
+    include_xe_metrics: Optional[bool] = None
     index_usage_metrics_interval: Optional[int] = None
     log_unobfuscated_plans: Optional[bool] = None
     log_unobfuscated_queries: Optional[bool] = None

--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -268,6 +268,14 @@ TEMPDB_FILE_SPACE_USAGE_METRICS = [
     ('sqlserver.tempdb.file_space_usage.mixed_extent_space', 'sys.dm_db_file_space_usage', 'mixed_extent_space'),
 ]
 
+XE_MISSING_EVENTS_METRICS = [
+    ('sqlserver.xe.events_not_in_xml', 'sys.dm_xe_session_targets', 'events_not_in_xml'),
+]
+XE_SESSION_STATUS_METRICS = [
+    ('sqlserver.xe.session_status', 'sys.dm_xe_sessions', 'session_status'),
+]
+XE_METRICS = XE_MISSING_EVENTS_METRICS + XE_SESSION_STATUS_METRICS
+
 PROC_CHAR_LIMIT = 500
 
 DEFAULT_SCHEMAS_COLLECTION_INTERVAL = 600

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -262,6 +262,12 @@ instances:
     #
     # include_tempdb_file_space_usage_metrics: true
 
+    ## @param include_xe_metrics - boolean - optional - default: true
+    ## Include extended events (XE) metrics. The collection of XE metrics is automatically enabled
+    ## when `deadlocks_collection` is enabled.
+    #
+    # include_xe_metrics: true
+
     ## @param adoprovider - string - optional - default: SQLOLEDB
     ## Choose the ADO provider.  Note that the (default) provider
     ## SQLOLEDB is being deprecated.  To use the newer MSOLEDBSQL

--- a/sqlserver/datadog_checks/sqlserver/deadlocks.py
+++ b/sqlserver/datadog_checks/sqlserver/deadlocks.py
@@ -71,7 +71,7 @@ class Deadlocks(DBMAsyncJob):
 
     def is_deadlock_collection_enabled(self):
         return is_affirmative(self._config.deadlocks_config.get('enabled', False))
-    
+
     def obfuscate_no_except_wrapper(self, sql_text):
         try:
             sql_text = obfuscate_sql_with_metadata(

--- a/sqlserver/datadog_checks/sqlserver/deadlocks.py
+++ b/sqlserver/datadog_checks/sqlserver/deadlocks.py
@@ -5,6 +5,7 @@
 import xml.etree.ElementTree as ET
 from time import time
 
+from datadog_checks.base.config import is_affirmative
 from datadog_checks.base.utils.db.sql import compute_sql_signature
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding, obfuscate_sql_with_metadata
 from datadog_checks.base.utils.serialization import json
@@ -68,6 +69,9 @@ class Deadlocks(DBMAsyncJob):
     def _close_db_conn(self):
         pass
 
+    def is_deadlock_collection_enabled(self):
+        return is_affirmative(self._config.deadlocks_config.get('enabled', False))
+    
     def obfuscate_no_except_wrapper(self, sql_text):
         try:
             sql_text = obfuscate_sql_with_metadata(

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -1040,6 +1040,65 @@ class SqlDbFileSpaceUsage(BaseSqlServerMetric):
             self.report_function(metric_name, column_val, tags=metric_tags)
 
 
+class SqlExtendedEventsNotInXml(BaseSqlServerMetric):
+    TABLE = 'sys.dm_xe_session_targets'
+    DEFAULT_METRIC_TYPE = 'gauge'
+    QUERY_BASE = f"""SELECT name session_name, 
+    target_data.value('(RingBufferTarget/@eventCount)[1]', 'int') -
+    target_data.value('count(RingBufferTarget/event)', 'int') AS events_not_in_xml
+    FROM
+    ( SELECT s.name, CAST(target_data AS XML) AS target_data 
+        FROM sys.dm_xe_sessions as s
+        INNER JOIN {TABLE} AS st
+           ON s.address = st.event_session_address
+       WHERE st.target_name = N'ring_buffer' ) AS n"""
+    OPERATION_NAME = 'xe_events_not_in_xml_metrics'
+
+    @classmethod
+    def fetch_all_values(cls, cursor, counters_list, logger, databases=None, engine_edition=None):
+        return cls._fetch_generic_values(cursor, None, logger)
+    
+    def fetch_metric(self, rows, columns, values_cache=None):
+        value_column_index = columns.index(self.column)
+        session_name_index = columns.index('session_name')
+        for row in rows:
+            metric_name = f'{self.metric_name}'
+            column_val = row[value_column_index]
+            session_name = row[session_name_index]
+            metric_tags = [f'session_name:{session_name}']
+            self.report_function(metric_name, column_val, tags=metric_tags)
+
+
+class SqlExtendedEventsSessionState(BaseSqlServerMetric):
+    TABLE = 'sys.dm_xe_sessions'
+    DEFAULT_METRIC_TYPE = 'gauge'
+    QUERY_BASE = f"""SELECT 
+    s.name as session_name, 
+    CASE 
+        WHEN r.event_session_id IS NULL THEN 0 
+        ELSE 1 
+    END AS session_status
+    FROM {TABLE} as s 
+    LEFT OUTER JOIN sys.server_event_sessions r
+        ON s.name = r.name"""
+    OPERATION_NAME = 'xe_session_status_metrics'
+
+    @classmethod
+    def fetch_all_values(cls, cursor, counters_list, logger, databases=None, engine_edition=None):
+        return cls._fetch_generic_values(cursor, None, logger)
+    
+    def fetch_metric(self, rows, columns, values_cache=None):
+        value_column_index = columns.index(self.column)
+        session_name_index = columns.index('session_name')
+        for row in rows:
+            metric_name = f'{self.metric_name}'
+            column_val = row[value_column_index]
+            session_name = row[session_name_index]
+            metric_tags = [f'session_name:{session_name}']
+            self.log.debug(f"ReportingXE {self.metric_name} for session {session_name}")
+            self.report_function(metric_name, column_val, tags=metric_tags)
+
+
 DEFAULT_PERFORMANCE_TABLE = "sys.dm_os_performance_counters"
 VALID_TABLES = {cls.TABLE for cls in BaseSqlServerMetric.__subclasses__() if cls.CUSTOM_QUERIES_AVAILABLE}
 TABLE_MAPPING = {

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -1043,11 +1043,11 @@ class SqlDbFileSpaceUsage(BaseSqlServerMetric):
 class SqlExtendedEventsNotInXml(BaseSqlServerMetric):
     TABLE = 'sys.dm_xe_session_targets'
     DEFAULT_METRIC_TYPE = 'gauge'
-    QUERY_BASE = f"""SELECT name session_name, 
+    QUERY_BASE = f"""SELECT name session_name,
     target_data.value('(RingBufferTarget/@eventCount)[1]', 'int') -
     target_data.value('count(RingBufferTarget/event)', 'int') AS events_not_in_xml
     FROM
-    ( SELECT s.name, CAST(target_data AS XML) AS target_data 
+    ( SELECT s.name, CAST(target_data AS XML) AS target_data
         FROM sys.dm_xe_sessions as s
         INNER JOIN {TABLE} AS st
            ON s.address = st.event_session_address
@@ -1057,7 +1057,7 @@ class SqlExtendedEventsNotInXml(BaseSqlServerMetric):
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger, databases=None, engine_edition=None):
         return cls._fetch_generic_values(cursor, None, logger)
-    
+
     def fetch_metric(self, rows, columns, values_cache=None):
         value_column_index = columns.index(self.column)
         session_name_index = columns.index('session_name')
@@ -1072,13 +1072,13 @@ class SqlExtendedEventsNotInXml(BaseSqlServerMetric):
 class SqlExtendedEventsSessionState(BaseSqlServerMetric):
     TABLE = 'sys.dm_xe_sessions'
     DEFAULT_METRIC_TYPE = 'gauge'
-    QUERY_BASE = f"""SELECT 
-    s.name as session_name, 
-    CASE 
-        WHEN r.event_session_id IS NULL THEN 0 
-        ELSE 1 
+    QUERY_BASE = f"""SELECT
+    s.name as session_name,
+    CASE
+        WHEN r.event_session_id IS NULL THEN 0
+        ELSE 1
     END AS session_status
-    FROM {TABLE} as s 
+    FROM {TABLE} as s
     LEFT OUTER JOIN sys.server_event_sessions r
         ON s.name = r.name"""
     OPERATION_NAME = 'xe_session_status_metrics'
@@ -1086,7 +1086,7 @@ class SqlExtendedEventsSessionState(BaseSqlServerMetric):
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger, databases=None, engine_edition=None):
         return cls._fetch_generic_values(cursor, None, logger)
-    
+
     def fetch_metric(self, rows, columns, values_cache=None):
         value_column_index = columns.index(self.column)
         session_name_index = columns.index('session_name')
@@ -1095,7 +1095,6 @@ class SqlExtendedEventsSessionState(BaseSqlServerMetric):
             column_val = row[value_column_index]
             session_name = row[session_name_index]
             metric_tags = [f'session_name:{session_name}']
-            self.log.debug(f"ReportingXE {self.metric_name} for session {session_name}")
             self.report_function(metric_name, column_val, tags=metric_tags)
 
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -548,11 +548,12 @@ class SQLServer(AgentCheck):
                     "tags": self.tags,
                 }
                 metrics_to_collect.append(self.typed_metric(cfg_inst=cfg, table=table, column=column))
-                
+
         # Load extended events metrics, if enabled
-        if is_affirmative(
-            self.instance.get("include_xe_metrics", False)
-        ) or self.deadlocks.is_deadlock_collection_enabled():
+        if (
+            is_affirmative(self.instance.get("include_xe_metrics", False))
+            or self.deadlocks.is_deadlock_collection_enabled()
+        ):
             for name, table, column in XE_METRICS:
                 cfg = {"name": name, "table": table, "column": column, "tags": self.tags}
                 metrics_to_collect.append(self.typed_metric(cfg_inst=cfg, table=table, column=column))

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -76,6 +76,7 @@ from datadog_checks.sqlserver.const import (
     TASK_SCHEDULER_METRICS,
     TEMPDB_FILE_SPACE_USAGE_METRICS,
     VALID_METRIC_TYPES,
+    XE_METRICS,
     expected_sys_databases_columns,
 )
 from datadog_checks.sqlserver.metrics import DEFAULT_PERFORMANCE_TABLE, VALID_TABLES
@@ -546,6 +547,14 @@ class SQLServer(AgentCheck):
                     "instance_name": "tempdb",
                     "tags": self.tags,
                 }
+                metrics_to_collect.append(self.typed_metric(cfg_inst=cfg, table=table, column=column))
+                
+        # Load extended events metrics, if enabled
+        if is_affirmative(
+            self.instance.get("include_xe_metrics", False)
+        ) or self.deadlocks.is_deadlock_collection_enabled():
+            for name, table, column in XE_METRICS:
+                cfg = {"name": name, "table": table, "column": column, "tags": self.tags}
                 metrics_to_collect.append(self.typed_metric(cfg_inst=cfg, table=table, column=column))
 
         # Load any custom metrics from conf.d/sqlserver.yaml

--- a/sqlserver/metadata.csv
+++ b/sqlserver/metadata.csv
@@ -154,3 +154,6 @@ sqlserver.transactions.longest_transaction_running_time,gauge,,second,,The time 
 sqlserver.transactions.version_cleanup_rate,gauge,,kibibyte,second,The cleanup rate of the version store in tempdb. (Perf. Counter: `Transactions - Version Cleanup rate (KB/s)`),0,sql_server,version cleanup rate,,
 sqlserver.transactions.version_generation_rate,gauge,,kibibyte,second,The generation rate of the version store in tempdb. (Perf. Counter: `Transactions - Version Generation rate (KB/s)`),0,sql_server,version generation rate,,
 sqlserver.transactions.version_store_size,gauge,,kibibyte,,The size of the version store in tempdb. (Perf. Counter: `Transactions - Version Store Size (KB)`),0,sql_server,version store size,,
+sqlserver.xe.events_not_in_xml,gauge,,event,,"Number of generated events that are missing in the XML representation of the ring buffer. Tags: `session_name`",0,sql_server,xe events not in xml,,
+sqlserver.xe.session_status,gauge,,,,"Status of the node in a SQL Server failover cluster instance. Tags: `session_name`",0,sql_server,xe session status,,
+

--- a/sqlserver/tests/conftest.py
+++ b/sqlserver/tests/conftest.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 
 import pytest
 
-from datadog_checks.dev import WaitFor, docker_run, run_command
+from datadog_checks.dev import WaitFor, docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs
 from datadog_checks.dev.docker import using_windows_containers
 from datadog_checks.sqlserver.const import SWITCH_DB_STATEMENT
@@ -328,11 +328,5 @@ def dd_environment(full_e2e_config):
 
     conditions += [CheckDockerLogs(compose_file, completion_message)]
 
-    try:
-        with docker_run(compose_file=compose_file, conditions=conditions, mount_logs=True, build=True, attempts=3):
-            yield full_e2e_config, E2E_METADATA
-    except Exception as SubprocessError:
-        compose_error = str(SubprocessError)
-        log_command = ['docker', 'compose', '-f', compose_file, 'logs']
-        compose_logs = run_command(log_command, check=True)
-        raise SubprocessError(f"compose error: {compose_error} |  compose logs: {compose_logs}")
+    with docker_run(compose_file=compose_file, conditions=conditions, mount_logs=True, build=True, attempts=3):
+        yield full_e2e_config, E2E_METADATA


### PR DESCRIPTION
### What does this PR do?

Add SQL Server XE session monitoring.

### Motivation

Since XE powers deadlock monitoring, it's important to monitor the service.

### Additional Notes

We are monitoring:

Whether the XE session is running.
The number of missing events in the ring buffer’s XML representation, due to a known [SQL Server issue](https://techcommunity.microsoft.com/t5/sql-server-support-blog/you-may-not-see-the-data-you-expect-in-extended-event-ring/ba-p/315838).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
