### PR TITLE
Revert "Parse each row of pg_stat_activity separately inside a try/catch (#18762)"

### DIFF
--- a/postgres/changelog.d/18866.fixed
+++ b/postgres/changelog.d/18866.fixed
@@ -1,0 +1,1 @@
+Revert "Parse each row of pg_stat_activity separately inside a try/catch (#18762)"

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -268,17 +268,7 @@ class PostgresStatementSamples(DBMAsyncJob):
             with conn.cursor(cursor_factory=CommenterDictCursor) as cursor:
                 self._log.debug("Running query [%s] %s", query, params)
                 cursor.execute(query, params)
-                rows = []
-                while True:
-                    try:
-                        row = cursor.fetchone()
-                        if row is None:
-                            break
-                        rows.append(row)
-                    except UnicodeDecodeError:
-                        self._log.debug("Invalid unicode in row from pg_stat_activity")
-                    except:
-                        self._log.warning("Unknown error fetching row from pg_stat_activity")
+                rows = cursor.fetchall()
 
         self._report_check_hist_metrics(start_time, len(rows), "get_new_pg_stat_activity")
         self._log.debug("Loaded %s rows from %s", len(rows), self._config.pg_stat_activity_view)


### PR DESCRIPTION
### What does this PR do?
Revert "Parse each row of pg_stat_activity separately inside a try/catch (#18762)"

### Motivation
#incident-31599
We see unexpected high warnings during fetchone (not unicode decode error). Reverting the change for now and investigate the cause.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
