### PR TITLE
Extended events (XE) session monitoring

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -282,6 +282,13 @@ files:
       value:
         type: boolean
         example: true
+    - name: include_xe_metrics
+      description: |
+        Include extended events (XE) metrics. The collection of XE metrics is automatically enabled
+        when `deadlocks_collection` is enabled.
+      value:
+        type: boolean
+        example: true
     - name: adoprovider
       description: |
         Choose the ADO provider.  Note that the (default) provider

--- a/sqlserver/changelog.d/18875.added
+++ b/sqlserver/changelog.d/18875.added
@@ -1,0 +1,1 @@
+Add extended events (XE) session monitoring

--- a/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
@@ -112,6 +112,10 @@ def instance_include_tempdb_file_space_usage_metrics():
     return True
 
 
+def instance_include_xe_metrics():
+    return True
+
+
 def instance_index_usage_metrics_interval():
     return 300
 

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -215,6 +215,7 @@ class InstanceConfig(BaseModel):
     include_secondary_log_shipping_metrics: Optional[bool] = None
     include_task_scheduler_metrics: Optional[bool] = None
     include_tempdb_file_space_usage_metrics: Optional[bool] = None
+    include_xe_metrics: Optional[bool] = None
     index_usage_metrics_interval: Optional[int] = None
     log_unobfuscated_plans: Optional[bool] = None
     log_unobfuscated_queries: Optional[bool] = None

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -262,6 +262,12 @@ instances:
     #
     # include_tempdb_file_space_usage_metrics: true
 
+    ## @param include_xe_metrics - boolean - optional - default: true
+    ## Include extended events (XE) metrics. The collection of XE metrics is automatically enabled
+    ## when `deadlocks_collection` is enabled.
+    #
+    # include_xe_metrics: true
+
     ## @param adoprovider - string - optional - default: SQLOLEDB
     ## Choose the ADO provider.  Note that the (default) provider
     ## SQLOLEDB is being deprecated.  To use the newer MSOLEDBSQL

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/__init__.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/__init__.py
@@ -5,3 +5,4 @@ from .database_backup_metrics import SqlserverDatabaseBackupMetrics
 from .db_fragmentation_metrics import SqlserverDBFragmentationMetrics
 from .index_usage_metrics import SqlserverIndexUsageMetrics
 from .database_agent_metrics import SqlserverAgentMetrics
+from .xe_session_metrics import SQLServerXESessionMetrics

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/xe_session_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/xe_session_metrics.py
@@ -1,0 +1,75 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from datadog_checks.base.config import is_affirmative
+
+from .base import SqlserverDatabaseMetricsBase
+
+XE_SESSION_STATUS_QUERY = {
+    "name": "sys.dm_xe_sessions",
+    "query": """SELECT
+s.name as session_name,
+CASE
+    WHEN r.event_session_id IS NULL THEN 0
+    ELSE 1
+END AS session_status
+FROM sys.dm_xe_sessions as s
+LEFT OUTER JOIN sys.server_event_sessions r
+    ON s.name = r.name""",
+    "columns": [
+        {"name": "session_name", "type": "tag"},
+        {"name": "xe.session_status", "type": "gauge"},
+    ],
+}
+
+XE_EVENTS_NOT_IN_XML = {
+    "name": "sys.dm_xe_session_targets",
+    "query": """SELECT name session_name,
+    target_data.value('(RingBufferTarget/@eventCount)[1]', 'int') -
+    target_data.value('count(RingBufferTarget/event)', 'int') AS events_not_in_xml
+    FROM
+    ( SELECT s.name, CAST(target_data AS XML) AS target_data
+        FROM sys.dm_xe_sessions as s
+        INNER JOIN sys.dm_xe_session_targets AS st
+           ON s.address = st.event_session_address
+       WHERE st.target_name = N'ring_buffer' ) AS n""",
+    "columns": [
+        {"name": "session_name", "type": "tag"},
+        {"name": "xe.events_not_in_xml", "type": "gauge"},
+    ],
+}
+
+
+class SQLServerXESessionMetrics(SqlserverDatabaseMetricsBase):
+    @property
+    def enabled(self):
+        self.deadlocks_config: dict = self.instance_config.get('deadlocks_collection', {}) or {}
+        return is_affirmative(self.instance_config.get("include_xe_metrics", False)) or is_affirmative(
+            self.deadlocks_config.get('enabled', False)
+        )
+
+    @property
+    def collection_interval(self) -> int:
+        '''
+        Returns the interval in seconds at which to collect XE sessopm metrics.
+        '''
+        return 60
+
+    @property
+    def queries(self):
+        # make copies of the query to avoid modifying the originals
+        # in case different instances have different collection intervals
+        query_status = XE_SESSION_STATUS_QUERY.copy()
+        query_status['collection_interval'] = self.collection_interval
+        query_events_not_in_xml = XE_EVENTS_NOT_IN_XML.copy()
+        query_events_not_in_xml['collection_interval'] = self.collection_interval
+        return [query_status, query_events_not_in_xml]
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"enabled={self.enabled}, "
+            f"engine_edition={self.engine_edition}, "
+            f"collection_interval={self.collection_interval})"
+        )

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -27,6 +27,7 @@ from datadog_checks.sqlserver.database_metrics import (
     SqlserverDatabaseBackupMetrics,
     SqlserverDBFragmentationMetrics,
     SqlserverIndexUsageMetrics,
+    SQLServerXESessionMetrics,
 )
 from datadog_checks.sqlserver.deadlocks import Deadlocks
 from datadog_checks.sqlserver.metadata import SqlserverMetadata
@@ -869,6 +870,12 @@ class SQLServer(AgentCheck):
             server_static_info=self.static_info_cache,
             execute_query_handler=self.execute_query_raw,
         )
+        xe_session_metrics = SQLServerXESessionMetrics(
+            instance_config=self.instance,
+            new_query_executor=self._new_query_executor,
+            server_static_info=self.static_info_cache,
+            execute_query_handler=self.execute_query_raw,
+        )
 
         # database level metrics
         index_usage_metrics = SqlserverIndexUsageMetrics(
@@ -898,6 +905,7 @@ class SQLServer(AgentCheck):
             # instance level metrics
             database_backup_metrics,
             database_agent_metrics,
+            xe_session_metrics,
             # database level metrics
             index_usage_metrics,
             db_fragmentation_metrics,

--- a/sqlserver/metadata.csv
+++ b/sqlserver/metadata.csv
@@ -154,3 +154,5 @@ sqlserver.transactions.longest_transaction_running_time,gauge,,second,,The time 
 sqlserver.transactions.version_cleanup_rate,gauge,,kibibyte,second,The cleanup rate of the version store in tempdb. (Perf. Counter: `Transactions - Version Cleanup rate (KB/s)`),0,sql_server,version cleanup rate,,
 sqlserver.transactions.version_generation_rate,gauge,,kibibyte,second,The generation rate of the version store in tempdb. (Perf. Counter: `Transactions - Version Generation rate (KB/s)`),0,sql_server,version generation rate,,
 sqlserver.transactions.version_store_size,gauge,,kibibyte,,The size of the version store in tempdb. (Perf. Counter: `Transactions - Version Store Size (KB)`),0,sql_server,version store size,,
+sqlserver.xe.events_not_in_xml,gauge,,event,,"Number of generated events that are missing in the XML representation of the ring buffer. Tags: `session_name`",0,sql_server,xe events not in xml,,
+sqlserver.xe.session_status,gauge,,,,"Status of the node in a SQL Server failover cluster instance. Tags: `session_name`",0,sql_server,xe session status,,

--- a/sqlserver/tests/test_database_metrics.py
+++ b/sqlserver/tests/test_database_metrics.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 
+from copy import deepcopy
 from unittest import mock
 
 import pytest
@@ -289,3 +290,29 @@ def test_sqlserver_database_backup_metrics(
     dd_run_check(sqlserver_check)
     for metric_name in database_backup_metrics.metric_names()[0]:
         aggregator.assert_metric(metric_name, count=0)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize(
+    'config_options',
+    [
+        {'include_xe_metrics': True},
+        {'deadlocks_collection': {'enabled': True}},
+    ],
+)
+def test_sqlserver_xe_session_metrics(
+    aggregator,
+    dd_run_check,
+    init_config,
+    instance_docker_metrics,
+    config_options,
+):
+    modified_instance = deepcopy(instance_docker_metrics)
+    for key, value in config_options.items():
+        modified_instance[key] = value
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [modified_instance])
+    dd_run_check(sqlserver_check)
+    expected_tags = sqlserver_check._config.tags
+    expected_tags.append('session_name:datadog')
+    aggregator.assert_metric("sqlserver.xe.session_status", value=1, tags=expected_tags)


### PR DESCRIPTION
### What does this PR do?
Add SQL Server XE session monitoring.

### Motivation
Since XE powers deadlock monitoring, it's important to monitor the service.

### Additional Notes
We are monitoring:

- Whether the XE session is running.
- The number of missing events in the ring buffer’s XML representation, due to a known [SQL Server issue](https://techcommunity.microsoft.com/t5/sql-server-support-blog/you-may-not-see-the-data-you-expect-in-extended-event-ring/ba-p/315838).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
