### PR TITLE
Fix ddev create (README file gets overwritten) 

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -193,6 +193,8 @@ def create_template_files(template_name, new_root, config, repo_choice, read=Fal
         for template_file in template_files:
             if template_file.endswith('1.added') and repo_choice != 'core':
                 continue
+            if template_root == root and template_file == "README.md":
+                continue
             if not template_file.endswith(('.pyc', '.pyo')):
                 if template_file == 'README.md' and config.get('support_type') in ('partner', 'contrib'):
                     # Custom README for the marketplace/partner support_type integrations


### PR DESCRIPTION
### What does this PR do?
After adding the different check types description [here](https://github.com/DataDog/integrations-core/pull/18039) the ddev create command overrides the README.md from the integrations-core folder with the content from the description README, this is a fix for it.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
