### PR TITLE
Fix sqlserver metric collection row_key

### DIFF
--- a/sqlserver/changelog.d/18882.fixed
+++ b/sqlserver/changelog.d/18882.fixed
@@ -1,0 +1,1 @@
+Update sqlserver metric collection row_key to prevent overwriting metric information for two queries with the same query_plan_hash but part of two different stored procedures.

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -153,12 +153,7 @@ def _row_key(row):
     :param row: a normalized row from STATEMENT_METRICS_QUERY
     :return: a tuple uniquely identifying this row
     """
-    return (
-        row.get('database_name'),
-        row['query_signature'],
-        row['query_hash'],
-        row.get('procedure_name')
-    )
+    return (row.get('database_name'), row['query_signature'], row['query_hash'], row.get('procedure_name'))
 
 
 XML_PLAN_OBFUSCATION_ATTRS = frozenset(

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -157,7 +157,7 @@ def _row_key(row):
         row.get('database_name'),
         row['query_signature'],
         row['query_hash'],
-        row['query_plan_hash'],
+        row.get('procedure_name')
     )
 
 


### PR DESCRIPTION
### What does this PR do?

Update sqlserver metric collection `row_key` to prevent overwriting metric information for two queries with the same query_plan_hash but part of two different stored procedures.

### Motivation
We noticed that while we separate queries by stored procedure names, the row_key used to aggregate metrics is using `query_plan_hash`. This value can be identical since it's a hash of the plan nodes specific to this query, which can be shared in two different stored procedures. Changing the row_key to use the procedure name should fix this edge case.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
