### PR TITLE
[cloudera] Configure the number of connection pools to cache

### DIFF
--- a/cloudera/assets/configuration/spec.yaml
+++ b/cloudera/assets/configuration/spec.yaml
@@ -55,6 +55,14 @@ files:
       value:
         example: <KEY_FILE_PATH>
         type: string
+    - name: pools_size
+      description: |
+        Number of connection pools to cache before discarding the least recently used pool.
+      hidden: true
+      value:
+        default: 4
+        type: integer
+        example: 10
     - name: max_parallel_requests
       description: |
         The maximum number of requests to Cloudera Manager that are allowed in parallel.

--- a/cloudera/changelog.d/18886.added
+++ b/cloudera/changelog.d/18886.added
@@ -1,0 +1,1 @@
+[cloudera] Configure the number of connection pools to cache

--- a/cloudera/datadog_checks/cloudera/api/factory.py
+++ b/cloudera/datadog_checks/cloudera/api/factory.py
@@ -18,6 +18,7 @@ def make_api(check) -> Api:
             'api_url': check.config.api_url,
             'workload_username': check.shared_config.workload_username,
             'workload_password': check.shared_config.workload_password,
+            'pools_size': check.config.pools_size,
             'max_parallel_requests': check.config.max_parallel_requests,
             'verify_ssl': check.config.verify_ssl,
             'ssl_ca_cert': check.config.ssl_ca_cert,

--- a/cloudera/datadog_checks/cloudera/client/cm_client.py
+++ b/cloudera/datadog_checks/cloudera/client/cm_client.py
@@ -29,7 +29,9 @@ class CmClient(Client):
         cm_client.configuration.ssl_ca_cert = kwargs.get('ssl_ca_cert')
         cm_client.configuration.cert_file = kwargs.get('cert_file')
         cm_client.configuration.key_file = kwargs.get('key_file')
-        self._client.rest_client = RESTClientObject(pools_size=kwargs.get('pools_size'), maxsize=kwargs.get('max_parallel_requests'))
+        self._client.rest_client = RESTClientObject(
+            pools_size=kwargs.get('pools_size'), maxsize=kwargs.get('max_parallel_requests')
+        )
 
     def get_version(self) -> Version:
         self._log.debug('getting version from cloudera')

--- a/cloudera/datadog_checks/cloudera/client/cm_client.py
+++ b/cloudera/datadog_checks/cloudera/client/cm_client.py
@@ -29,7 +29,7 @@ class CmClient(Client):
         cm_client.configuration.ssl_ca_cert = kwargs.get('ssl_ca_cert')
         cm_client.configuration.cert_file = kwargs.get('cert_file')
         cm_client.configuration.key_file = kwargs.get('key_file')
-        self._client.rest_client = RESTClientObject(maxsize=kwargs.get('max_parallel_requests'))
+        self._client.rest_client = RESTClientObject(pools_size=kwargs.get('pools_size'), maxsize=kwargs.get('max_parallel_requests'))
 
     def get_version(self) -> Version:
         self._log.debug('getting version from cloudera')

--- a/cloudera/datadog_checks/cloudera/config_models/defaults.py
+++ b/cloudera/datadog_checks/cloudera/config_models/defaults.py
@@ -28,5 +28,9 @@ def instance_min_collection_interval():
     return 15
 
 
+def instance_pools_size():
+    return 4
+
+
 def instance_verify_ssl():
     return True

--- a/cloudera/datadog_checks/cloudera/config_models/instance.py
+++ b/cloudera/datadog_checks/cloudera/config_models/instance.py
@@ -66,6 +66,7 @@ class InstanceConfig(BaseModel):
     max_parallel_requests: Optional[int] = None
     metric_patterns: Optional[MetricPatterns] = None
     min_collection_interval: Optional[float] = None
+    pools_size: Optional[int] = None
     service: Optional[str] = None
     ssl_ca_cert: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None

--- a/cloudera/tests/test_unit_client.py
+++ b/cloudera/tests/test_unit_client.py
@@ -137,6 +137,7 @@ def test_client_ssl(dd_run_check, cloudera_check, cloudera_cm_client):
         api_url='http://localhost:8080/api/v48/',
         workload_username='~',
         workload_password='~',
+        pools_size=4,
         max_parallel_requests=4,
         verify_ssl=True,
         ssl_ca_cert='ssl_ca_cert_path',


### PR DESCRIPTION
### What does this PR do?
Add a config key option `pools_size` for the number of connection pools to cache before discarding the least recently used pool. Default value: 4

### Motivation
https://datadoghq.atlassian.net/browse/AGENT-12498

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
