### PR TITLE
relax MEMORY_USAGE_THRESHOLD in test to account for slightly increased mem from tracing

### DIFF
--- a/datadog_checks_base/tests/base/utils/db/test_db_statements.py
+++ b/datadog_checks_base/tests/base/utils/db/test_db_statements.py
@@ -277,7 +277,7 @@ class TestStatementMetrics:
         Make sure we minimize the temporary objects created when computing the derivative
         This test is skipped if tracemalloc is not available
         '''
-        MEMORY_USAGE_THRESHOLD = 7 * 1024 * 1024  # 7 MB
+        MEMORY_USAGE_THRESHOLD = 8 * 1024 * 1024  # 8 MB
 
         try:
             import tracemalloc
@@ -285,7 +285,6 @@ class TestStatementMetrics:
             return
 
         tracemalloc.start()
-        tracemalloc.reset_peak()
 
         _, peak_before = tracemalloc.get_traced_memory()
         sm = StatementMetrics()

--- a/datadog_checks_base/tests/base/utils/db/test_db_statements.py
+++ b/datadog_checks_base/tests/base/utils/db/test_db_statements.py
@@ -285,6 +285,7 @@ class TestStatementMetrics:
             return
 
         tracemalloc.start()
+        tracemalloc.reset_peak()
 
         _, peak_before = tracemalloc.get_traced_memory()
         sm = StatementMetrics()

--- a/datadog_checks_base/tests/base/utils/db/test_db_statements.py
+++ b/datadog_checks_base/tests/base/utils/db/test_db_statements.py
@@ -277,6 +277,7 @@ class TestStatementMetrics:
         Make sure we minimize the temporary objects created when computing the derivative
         This test is skipped if tracemalloc is not available
         '''
+        # The memory usage threshold takes tracing overhead into account
         MEMORY_USAGE_THRESHOLD = 8 * 1024 * 1024  # 8 MB
 
         try:


### PR DESCRIPTION
### What does this PR do?
Relax `MEMORY_USAGE_THRESHOLD` in test to account for slightly increased mem from tracing.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
