### PR TITLE
Fix jmx based integrations test

### DIFF
--- a/datadog_checks_dev/changelog.d/18914.fixed
+++ b/datadog_checks_dev/changelog.d/18914.fixed
@@ -1,0 +1,1 @@
+Fix jmx based integrations test failing due to a missing jvm metric

--- a/datadog_checks_dev/datadog_checks/dev/jmx.py
+++ b/datadog_checks_dev/datadog_checks/dev/jmx.py
@@ -28,6 +28,7 @@ JVM_E2E_METRICS = [
     'jvm.non_heap_memory_max',
     'jvm.os.open_file_descriptors',
     'jvm.thread_count',
+    'jvm.unloaded_classes',
 ]
 
 JMX_E2E_METRICS = [


### PR DESCRIPTION
### What does this PR do?
Add this metric (jvm.unloaded_classes) to the JVM_E2E_METRICS list we test against the jmx based metrics.
The metric was added [here](https://github.com/DataDog/jmxfetch/pull/540).
 
### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
