### PR TITLE
[auth] add an OIDC auth reader

### DIFF
--- a/datadog_checks_base/changelog.d/18920.added
+++ b/datadog_checks_base/changelog.d/18920.added
@@ -1,0 +1,1 @@
+Add an OIDC auth token reader

--- a/datadog_checks_base/tests/base/utils/http/test_authtoken.py
+++ b/datadog_checks_base/tests/base/utils/http/test_authtoken.py
@@ -213,6 +213,53 @@ class TestAuthTokenOAuthReaderCreation:
         ):
             RequestsWrapper(instance, init_config)
 
+class TestAuthTokenOIDCReaderCreation:
+    def test_url_missing(self):
+        instance = {'auth_token': {'reader': {'type': 'oidc'}, 'writer': {'type': 'header'}}}
+        init_config = {}
+
+        with pytest.raises(ConfigurationError, match='^The `url` setting of `auth_token` reader is required$'):
+            RequestsWrapper(instance, init_config)
+
+    def test_url_not_string(self):
+        instance = {'auth_token': {'reader': {'type': 'oidc', 'url': {}}, 'writer': {'type': 'header'}}}
+        init_config = {}
+
+        with pytest.raises(ConfigurationError, match='^The `url` setting of `auth_token` reader must be a string$'):
+            RequestsWrapper(instance, init_config)
+
+    def test_role_missing(self):
+        instance = {'auth_token': {'reader': {'type': 'oidc', 'url': 'foo'}, 'writer': {'type': 'header'}}}
+        init_config = {}
+
+        with pytest.raises(ConfigurationError, match='^The `role` setting of `auth_token` reader is required$'):
+            RequestsWrapper(instance, init_config)
+
+    def test_role_not_string(self):
+        instance = {
+            'auth_token': {'reader': {'type': 'oauth', 'url': 'foo', 'role': {}}, 'writer': {'type': 'header'}}
+        }
+        init_config = {}
+
+        with pytest.raises(
+            ConfigurationError, match='^The `role` setting of `auth_token` reader must be a string$'
+        ):
+            RequestsWrapper(instance, init_config)
+
+    def test_headers_not_string(self):
+        instance = {
+            'auth_token': {
+                'reader': {'type': 'oauth', 'url': 'foo', 'role': 'bar', 'headers': ['header: value']},
+                'writer': {'type': 'header'},
+            }
+        }
+        init_config = {}
+
+        with pytest.raises(
+            ConfigurationError, match='^The `headers` setting of `auth_token` reader must be a dict$'
+        ):
+            RequestsWrapper(instance, init_config)
+
 
 class TestAuthTokenDCOSReaderCreation:
     def test_login_url_missing(self):

--- a/http_check/changelog.d/18920.added
+++ b/http_check/changelog.d/18920.added
@@ -1,0 +1,1 @@
+Add an OIDC auth token reader

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -393,6 +393,12 @@ instances:
     ##                 options:
     ##                   audience: https://example.com
     ##                   scope: read:example
+    ##   - type: oidc
+    ##     url (required): The full OIDC token provider endpoint
+    ##                     e.g. http://127.0.0.1:8200/v1/identity/oidc/token/
+    ##     role (required): The role against which to generate the token
+    ##     headers: Additional headers to include in the request
+    ##
     ##
     ## The available writers are:
     ##


### PR DESCRIPTION
Implements a reader that retrieves a signed token from an OIDC provider to be used in requests. This is useful, for example, if a monitored resource (e.g. HTTP check) requires a token auth that is dynamically generated by an OIDC provider

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
