### PR TITLE
Remove asset name in manifest monitor name

### DIFF
--- a/docusign/manifest.json
+++ b/docusign/manifest.json
@@ -63,9 +63,9 @@
       "Docusign - Alert" : "assets/dashboards/docusign_alert.json"
     },
     "monitors": {
-      "[Docusign] Credential Leak Detected" : "assets/monitors/credential_leak_activity.json",
-      "[Docusign] Too Many Login Attempts" : "assets/monitors/multiple_login_attempts.json",
-      "[Docusign] Unauthorized IP Address Activity" : "assets/monitors/unauthorized_ip_activity.json"
+      "Credential Leak Detected" : "assets/monitors/credential_leak_activity.json",
+      "Too Many Login Attempts" : "assets/monitors/multiple_login_attempts.json",
+      "Unauthorized IP Address Activity" : "assets/monitors/unauthorized_ip_activity.json"
     },
     "logs": {
       "source": "docusign"

--- a/mailchimp/manifest.json
+++ b/mailchimp/manifest.json
@@ -50,8 +50,8 @@
       "Mailchimp - Audiences" : "assets/dashboards/mailchimp_audience.json"
     },
     "monitors" : {
-      "[Mailchimp] Too Many Abuse Reports" : "assets/monitors/abuse_report_rate.json",
-      "[Mailchimp] Too Many Unsubscribes" : "assets/monitors/unsubscribe_rate.json"
+      "Too Many Abuse Reports" : "assets/monitors/abuse_report_rate.json",
+      "Too Many Unsubscribes" : "assets/monitors/unsubscribe_rate.json"
     }
   },
   "author": {


### PR DESCRIPTION
### What does this PR do?
Monitor name is manifest should not have app name again according to guideline https://docs.google.com/document/d/1q0ChqrEDNUVA3zA3ZP5p8MKCTWWAw9A-Gq_tnbsfaJQ/edit?pli=1&tab=t.0#heading=h.s0c5ovxeyzto


### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
