### PR TITLE
[postgres]  Fix unicode decode error from Azure PostgreSQL Flexible Server

### DIFF
--- a/postgres/changelog.d/18938.fixed
+++ b/postgres/changelog.d/18938.fixed
@@ -1,0 +1,1 @@
+Fix unicode decode error from Azure PostgreSQL Flexible Server

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -41,7 +41,8 @@ MAX_CHARACTER_SIZE_IN_BYTES = 6
 
 TRACK_ACTIVITY_QUERY_SIZE_UNKNOWN_VALUE = -1
 
-SUPPORTED_EXPLAIN_STATEMENTS = frozenset({'select', 'table', 'delete', 'insert', 'replace', 'update', 'with'})
+SUPPORTED_EXPLAIN_STATEMENTS = frozenset(
+    {'select', 'table', 'delete', 'insert', 'replace', 'update', 'with'})
 
 # columns from pg_stat_activity which correspond to attributes common to all databases and are therefore stored in
 # under other standard keys
@@ -78,7 +79,7 @@ PG_STAT_ACTIVITY_COLS = [
     "backend_xid",
     "backend_xmin",
     "query",
-    "backend_type",
+    "backend_type::bytea",
 ]
 
 PG_BLOCKING_PIDS_FUNC = ",pg_blocking_pids(pid) as blocking_pids"
@@ -135,7 +136,8 @@ class PostgresStatementSamples(DBMAsyncJob):
 
     def __init__(self, check, config, shutdown_callback):
         collection_interval = float(
-            config.statement_samples_config.get('collection_interval', DEFAULT_COLLECTION_INTERVAL)
+            config.statement_samples_config.get(
+                'collection_interval', DEFAULT_COLLECTION_INTERVAL)
         )
         if collection_interval <= 0:
             collection_interval = DEFAULT_COLLECTION_INTERVAL
@@ -151,7 +153,8 @@ class PostgresStatementSamples(DBMAsyncJob):
         super(PostgresStatementSamples, self).__init__(
             check,
             rate_limit=1 / collection_interval,
-            run_sync=is_affirmative(config.statement_samples_config.get('run_sync', False)),
+            run_sync=is_affirmative(
+                config.statement_samples_config.get('run_sync', False)),
             enabled=is_affirmative(
                 config.statement_samples_config.get('enabled', True)
                 or is_affirmative(config.statement_activity_config.get('enabled', True))
@@ -169,44 +172,61 @@ class PostgresStatementSamples(DBMAsyncJob):
         self.tags = None
         self._activity_last_query_start = None
         # The value is loaded when connecting to the main database
-        self._explain_function = config.statement_samples_config.get('explain_function', 'datadog.explain_statement')
-        self._explain_parameterized_queries = ExplainParameterizedQueries(check, config, self._explain_function)
-        self._obfuscate_options = to_native_string(json.dumps(self._config.obfuscator_options))
+        self._explain_function = config.statement_samples_config.get(
+            'explain_function', 'datadog.explain_statement')
+        self._explain_parameterized_queries = ExplainParameterizedQueries(
+            check, config, self._explain_function)
+        self._obfuscate_options = to_native_string(
+            json.dumps(self._config.obfuscator_options))
 
         self._collection_strategy_cache = TTLCache(
-            maxsize=config.statement_samples_config.get('collection_strategy_cache_maxsize', 1000),
-            ttl=config.statement_samples_config.get('collection_strategy_cache_ttl', 300),
+            maxsize=config.statement_samples_config.get(
+                'collection_strategy_cache_maxsize', 1000),
+            ttl=config.statement_samples_config.get(
+                'collection_strategy_cache_ttl', 300),
         )
 
         self._explain_errors_cache = TTLCache(
-            maxsize=config.statement_samples_config.get('explain_errors_cache_maxsize', 5000),
+            maxsize=config.statement_samples_config.get(
+                'explain_errors_cache_maxsize', 5000),
             # only try to re-explain invalid statements once per day
-            ttl=config.statement_samples_config.get('explain_errors_cache_ttl', 24 * 60 * 60),
+            ttl=config.statement_samples_config.get(
+                'explain_errors_cache_ttl', 24 * 60 * 60),
         )
 
         # explained_statements_ratelimiter: limit how often we try to re-explain the same query
         self._explained_statements_ratelimiter = RateLimitingTTLCache(
-            maxsize=int(config.statement_samples_config.get('explained_queries_cache_maxsize', 5000)),
-            ttl=60 * 60 / int(config.statement_samples_config.get('explained_queries_per_hour_per_query', 60)),
+            maxsize=int(config.statement_samples_config.get(
+                'explained_queries_cache_maxsize', 5000)),
+            ttl=60 * 60 /
+            int(config.statement_samples_config.get(
+                'explained_queries_per_hour_per_query', 60)),
         )
 
         # seen_samples_ratelimiter: limit the ingestion rate per (query_signature, plan_signature)
         self._seen_samples_ratelimiter = RateLimitingTTLCache(
             # assuming ~100 bytes per entry (query & plan signature, key hash, 4 pointers (ordered dict), expiry time)
             # total size: 10k * 100 = 1 Mb
-            maxsize=int(config.statement_samples_config.get('seen_samples_cache_maxsize', 10000)),
-            ttl=60 * 60 / int(config.statement_samples_config.get('samples_per_hour_per_query', 15)),
+            maxsize=int(config.statement_samples_config.get(
+                'seen_samples_cache_maxsize', 10000)),
+            ttl=60 * 60 / \
+            int(config.statement_samples_config.get(
+                'samples_per_hour_per_query', 15)),
         )
 
-        self._activity_coll_enabled = is_affirmative(self._config.statement_activity_config.get('enabled', True))
-        self._explain_plan_coll_enabled = is_affirmative(self._config.statement_samples_config.get('enabled', True))
+        self._activity_coll_enabled = is_affirmative(
+            self._config.statement_activity_config.get('enabled', True))
+        self._explain_plan_coll_enabled = is_affirmative(
+            self._config.statement_samples_config.get('enabled', True))
 
         # activity events cannot be reported more often than regular samples
         self._activity_coll_interval = max(
-            self._config.statement_activity_config.get('collection_interval', DEFAULT_ACTIVITY_COLLECTION_INTERVAL),
+            self._config.statement_activity_config.get(
+                'collection_interval', DEFAULT_ACTIVITY_COLLECTION_INTERVAL),
             collection_interval,
         )
-        self._activity_max_rows = self._config.statement_activity_config.get('payload_row_limit', 3500)
+        self._activity_max_rows = self._config.statement_activity_config.get(
+            'payload_row_limit', 3500)
         # Keep track of last time we sent an activity event
         self._time_since_last_activity_event = 0
         self._pg_stat_activity_cols = None
@@ -235,14 +255,17 @@ class PostgresStatementSamples(DBMAsyncJob):
                 cursor.execute(query, params)
                 rows = cursor.fetchall()
 
-        self._report_check_hist_metrics(start_time, len(rows), "get_active_connections")
-        self._log.debug("Loaded %s rows from %s", len(rows), self._config.pg_stat_activity_view)
+        self._report_check_hist_metrics(
+            start_time, len(rows), "get_active_connections")
+        self._log.debug("Loaded %s rows from %s", len(
+            rows), self._config.pg_stat_activity_view)
         return [dict(row) for row in rows]
 
     @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
     def _get_new_pg_stat_activity(self, available_activity_columns):
         start_time = time.time()
-        extra_filters, params = self._get_extra_filters_and_params(filter_stale_idle_conn=True)
+        extra_filters, params = self._get_extra_filters_and_params(
+            filter_stale_idle_conn=True)
         report_activity = self._report_activity_event()
         cur_time_func = ""
         blocking_func = ""
@@ -270,15 +293,18 @@ class PostgresStatementSamples(DBMAsyncJob):
                 cursor.execute(query, params)
                 rows = cursor.fetchall()
 
-        self._report_check_hist_metrics(start_time, len(rows), "get_new_pg_stat_activity")
-        self._log.debug("Loaded %s rows from %s", len(rows), self._config.pg_stat_activity_view)
+        self._report_check_hist_metrics(
+            start_time, len(rows), "get_new_pg_stat_activity")
+        self._log.debug("Loaded %s rows from %s", len(
+            rows), self._config.pg_stat_activity_view)
         return rows
 
     def _get_pg_stat_activity_cols_cached(self, expected_cols):
         if self._pg_stat_activity_cols:
             return self._pg_stat_activity_cols
 
-        self._pg_stat_activity_cols = self._get_available_activity_columns(expected_cols)
+        self._pg_stat_activity_cols = self._get_available_activity_columns(
+            expected_cols)
         return self._pg_stat_activity_cols
 
     @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
@@ -292,16 +318,20 @@ class PostgresStatementSamples(DBMAsyncJob):
                         )
                     )
                     all_columns = {i[0] for i in cursor.description}
-                    available_columns = [c for c in all_expected_columns if c in all_columns]
-                    missing_columns = set(all_expected_columns) - set(available_columns)
+                    available_columns = [
+                        c for c in all_expected_columns if c in all_columns]
+                    missing_columns = set(
+                        all_expected_columns) - set(available_columns)
                     if missing_columns:
                         self._log.debug(
                             "missing the following expected columns from pg_stat_activity: %s", missing_columns
                         )
-                    self._log.debug("found available pg_stat_activity columns: %s", available_columns)
+                    self._log.debug(
+                        "found available pg_stat_activity columns: %s", available_columns)
                 except psycopg2.errors.InvalidSchemaName as e:
                     self._log.warning(
-                        "cannot collect activity due to invalid schema in dbname=%s: %s", self._config.dbname, repr(e)
+                        "cannot collect activity due to invalid schema in dbname=%s: %s", self._config.dbname, repr(
+                            e)
                     )
                     return None
                 except psycopg2.DatabaseError as e:
@@ -332,6 +362,12 @@ class PostgresStatementSamples(DBMAsyncJob):
         normalized_rows = []
         for row in rows:
             total_count += 1
+            try:
+                if 'backend_type' in row and row['backend_type'] is not None:
+                    row['backend_type'] = row['backend_type'].tobytes().decode(
+                        'utf-8')
+            except UnicodeDecodeError:
+                row['backend_type'] = 'unknown'
             if (not row['datname'] or not row['query']) and row.get(
                 'backend_type', 'client backend'
             ) == 'client backend':
@@ -357,7 +393,8 @@ class PostgresStatementSamples(DBMAsyncJob):
             self._check.count(
                 "dd.postgres.statement_samples.error",
                 insufficient_privilege_count,
-                tags=self.tags + ["error:insufficient-privilege"] + self._check._get_debug_tags(),
+                tags=self.tags + ["error:insufficient-privilege"] +
+                self._check._get_debug_tags(),
                 hostname=self._check.resolved_hostname,
                 raw=True,
             )
@@ -370,24 +407,29 @@ class PostgresStatementSamples(DBMAsyncJob):
         try:
             if backend_type != 'client backend':
                 obfuscated_query = backend_type
-                normalized_row['query_signature'] = compute_sql_signature(backend_type)
+                normalized_row['query_signature'] = compute_sql_signature(
+                    backend_type)
             else:
-                statement = obfuscate_sql_with_metadata(row['query'], self._obfuscate_options)
+                statement = obfuscate_sql_with_metadata(
+                    row['query'], self._obfuscate_options)
                 obfuscated_query = statement['query']
                 metadata = statement['metadata']
-                normalized_row['query_signature'] = compute_sql_signature(obfuscated_query)
+                normalized_row['query_signature'] = compute_sql_signature(
+                    obfuscated_query)
                 normalized_row['dd_tables'] = metadata.get('tables', None)
                 normalized_row['dd_commands'] = metadata.get('commands', None)
                 normalized_row['dd_comments'] = metadata.get('comments', None)
         except Exception as e:
             if self._config.log_unobfuscated_queries:
-                self._log.warning("Failed to obfuscate query=[%s] | err=[%s]", row['query'], e)
+                self._log.warning(
+                    "Failed to obfuscate query=[%s] | err=[%s]", row['query'], e)
             else:
                 self._log.debug("Failed to obfuscate query | err=[%s]", e)
             self._check.count(
                 "dd.postgres.statement_samples.error",
                 1,
-                tags=self._dbtags(row['datname'], "error:sql-obfuscate") + self._check._get_debug_tags(),
+                tags=self._dbtags(
+                    row['datname'], "error:sql-obfuscate") + self._check._get_debug_tags(),
                 hostname=self._check.resolved_hostname,
                 raw=True,
             )
@@ -401,11 +443,14 @@ class PostgresStatementSamples(DBMAsyncJob):
             extra_filters = " AND datname = %s"
             params = params + (self._config.dbname,)
         elif len(self._config.ignore_databases) > 0:
-            extra_filters = " AND " + " AND ".join("datname NOT ILIKE %s" for _ in self._config.ignore_databases)
+            extra_filters = " AND " + \
+                " AND ".join(
+                    "datname NOT ILIKE %s" for _ in self._config.ignore_databases)
             params = params + tuple(self._config.ignore_databases)
         if filter_stale_idle_conn and self._activity_last_query_start:
             # do not re-read old idle connections
-            extra_filters = extra_filters + " AND NOT (query_start < %s AND state = 'idle')"
+            extra_filters = extra_filters + \
+                " AND NOT (query_start < %s AND state = 'idle')"
             params = params + (self._activity_last_query_start,)
         return extra_filters, params
 
@@ -447,14 +492,17 @@ class PostgresStatementSamples(DBMAsyncJob):
     @tracked_method(agent_check_getter=agent_check_getter)
     def _collect_statement_samples(self):
         start_time = time.time()
-        pg_activity_cols = self._get_pg_stat_activity_cols_cached(PG_STAT_ACTIVITY_COLS)
+        pg_activity_cols = self._get_pg_stat_activity_cols_cached(
+            PG_STAT_ACTIVITY_COLS)
         # If we couldn't get activity columns it's likely we're missing schema access
         # Or critical functions are missing
         if pg_activity_cols is None:
             self._check.count(
                 "dd.postgres.statement_samples.error",
                 1,
-                tags=self.tags + ["error:explain-no_plans_possible"] + self._check._get_debug_tags(),
+                tags=self.tags +
+                ["error:explain-no_plans_possible"] +
+                self._check._get_debug_tags(),
                 hostname=self._check.resolved_hostname,
                 raw=True,
             )
@@ -465,12 +513,14 @@ class PostgresStatementSamples(DBMAsyncJob):
         if self._explain_plan_coll_enabled:
             event_samples = self._collect_plans(rows)
             for e in event_samples:
-                self._check.database_monitoring_query_sample(json.dumps(e, default=default_json_event_encoding))
+                self._check.database_monitoring_query_sample(
+                    json.dumps(e, default=default_json_event_encoding))
                 submitted_count += 1
 
         if self._report_activity_event():
             active_connections = self._get_active_connections()
-            activity_event = self._create_activity_event(rows, active_connections)
+            activity_event = self._create_activity_event(
+                rows, active_connections)
             self._check.database_monitoring_query_activity(
                 json.dumps(activity_event, default=default_json_event_encoding)
             )
@@ -541,7 +591,8 @@ class PostgresStatementSamples(DBMAsyncJob):
         if (row.get('backend_type', 'client backend') != 'client backend') or (
             row['state'] is not None and row['state'] != 'idle'
         ):
-            active_row = {key: val for key, val in row.items() if val is not None and key != 'query'}
+            active_row = {key: val for key, val in row.items(
+            ) if val is not None and key != 'query'}
             # Create an active_row, for each session by
             # 1. Removing all null key/value pairs and the original query
             # 2. if row['statement'] is none, replace with ERROR: failed to obfuscate so we can still collect activity
@@ -568,28 +619,35 @@ class PostgresStatementSamples(DBMAsyncJob):
             self.db_pool.get_connection(dbname, self._conn_ttl_ms)
         except psycopg2.OperationalError as e:
             self._log.warning(
-                "cannot collect execution plans due to failed DB connection to dbname=%s: %s", dbname, repr(e)
+                "cannot collect execution plans due to failed DB connection to dbname=%s: %s", dbname, repr(
+                    e)
             )
             return DBExplainError.connection_error, e
         except psycopg2.DatabaseError as e:
             self._log.warning(
-                "cannot collect execution plans due to a database error in dbname=%s: %s", dbname, repr(e)
+                "cannot collect execution plans due to a database error in dbname=%s: %s", dbname, repr(
+                    e)
             )
             return DBExplainError.database_error, e
 
         try:
-            result = self._run_explain(dbname, EXPLAIN_VALIDATION_QUERY, EXPLAIN_VALIDATION_QUERY)
+            result = self._run_explain(
+                dbname, EXPLAIN_VALIDATION_QUERY, EXPLAIN_VALIDATION_QUERY)
         except psycopg2.errors.InvalidSchemaName as e:
-            self._log.warning("cannot collect execution plans due to invalid schema in dbname=%s: %s", dbname, repr(e))
-            self._emit_run_explain_error(dbname, DBExplainError.invalid_schema, e)
+            self._log.warning(
+                "cannot collect execution plans due to invalid schema in dbname=%s: %s", dbname, repr(e))
+            self._emit_run_explain_error(
+                dbname, DBExplainError.invalid_schema, e)
             return DBExplainError.invalid_schema, e
         except psycopg2.errors.DatatypeMismatch as e:
-            self._emit_run_explain_error(dbname, DBExplainError.datatype_mismatch, e)
+            self._emit_run_explain_error(
+                dbname, DBExplainError.datatype_mismatch, e)
             return DBExplainError.datatype_mismatch, e
         except psycopg2.DatabaseError as e:
             # if the schema is valid then it's some problem with the function (missing, or invalid permissions,
             # incorrect definition)
-            self._emit_run_explain_error(dbname, DBExplainError.failed_function, e)
+            self._emit_run_explain_error(
+                dbname, DBExplainError.failed_function, e)
             self._check.record_warning(
                 DatabaseConfigurationError.undefined_explain_function,
                 warning_with_tags(
@@ -618,12 +676,14 @@ class PostgresStatementSamples(DBMAsyncJob):
         strategy_cache = self._collection_strategy_cache.get(dbname)
         if strategy_cache:
             db_explain_error, err = strategy_cache
-            self._log.debug("using cached explain_setup_state for DB '%s': %s", dbname, db_explain_error)
+            self._log.debug(
+                "using cached explain_setup_state for DB '%s': %s", dbname, db_explain_error)
             return db_explain_error, err
 
         db_explain_error, err = self._get_db_explain_setup_state(dbname)
         self._collection_strategy_cache[dbname] = (db_explain_error, err)
-        self._log.debug("caching new explain_setup_state for DB '%s': %s", dbname, db_explain_error)
+        self._log.debug(
+            "caching new explain_setup_state for DB '%s': %s", dbname, db_explain_error)
 
         return db_explain_error, err
 
@@ -658,13 +718,15 @@ class PostgresStatementSamples(DBMAsyncJob):
             dbname, statement, obfuscated_statement, query_signature
         )
         if explain_err_code and explain_err_code != DBExplainError.explained_with_prepared_statement:
-            err_tag = "error:explain-{}".format(explain_err_code.value if explain_err_code else None)
+            err_tag = "error:explain-{}".format(
+                explain_err_code.value if explain_err_code else None)
             if err_msg:
                 err_tag = err_tag + "-" + err_msg
             self._check.count(
                 "dd.postgres.statement_samples.error",
                 1,
-                tags=self._dbtags(dbname, err_tag) + self._check._get_debug_tags(),
+                tags=self._dbtags(dbname, err_tag) +
+                self._check._get_debug_tags(),
                 hostname=self._check.resolved_hostname,
                 raw=True,
             )
@@ -682,7 +744,8 @@ class PostgresStatementSamples(DBMAsyncJob):
             return (
                 None,
                 DBExplainError.query_truncated,
-                "track_activity_query_size={}".format(track_activity_query_size),
+                "track_activity_query_size={}".format(
+                    track_activity_query_size),
             )
 
         db_explain_error, err = self._get_db_explain_setup_state_cached(dbname)
@@ -702,27 +765,34 @@ class PostgresStatementSamples(DBMAsyncJob):
                     return self._explain_parameterized_queries.explain_statement(
                         dbname, statement, obfuscated_statement
                     )
-                e = psycopg2.errors.UndefinedParameter("Unable to explain parameterized query")
+                e = psycopg2.errors.UndefinedParameter(
+                    "Unable to explain parameterized query")
                 self._log.debug(
                     "Unable to collect execution plan, clients using the extended query protocol or prepared statements"
                     " can't be explained due to the separation of the parsed query and raw bind parameters: %s",
                     repr(e),
                 )
-                error_response = None, DBExplainError.parameterized_query, '{}'.format(type(e))
+                error_response = None, DBExplainError.parameterized_query, '{}'.format(
+                    type(e))
                 self._explain_errors_cache[query_signature] = error_response
-                self._emit_run_explain_error(dbname, DBExplainError.parameterized_query, e)
+                self._emit_run_explain_error(
+                    dbname, DBExplainError.parameterized_query, e)
                 return error_response
             return self._run_explain(dbname, statement, obfuscated_statement), None, None
         except psycopg2.errors.UndefinedTable as e:
             self._log.debug("Failed to collect execution plan: %s", repr(e))
-            error_response = None, DBExplainError.undefined_table, '{}'.format(type(e))
+            error_response = None, DBExplainError.undefined_table, '{}'.format(
+                type(e))
             self._explain_errors_cache[query_signature] = error_response
-            self._emit_run_explain_error(dbname, DBExplainError.undefined_table, e)
+            self._emit_run_explain_error(
+                dbname, DBExplainError.undefined_table, e)
             return error_response
         except psycopg2.errors.DatabaseError as e:
             self._log.debug("Failed to collect execution plan: %s", repr(e))
-            error_response = None, DBExplainError.database_error, '{}'.format(type(e))
-            self._emit_run_explain_error(dbname, DBExplainError.database_error, e)
+            error_response = None, DBExplainError.database_error, '{}'.format(
+                type(e))
+            self._emit_run_explain_error(
+                dbname, DBExplainError.database_error, e)
             if isinstance(e, psycopg2.errors.ProgrammingError) and not isinstance(
                 e, psycopg2.errors.InsufficientPrivilege
             ):
@@ -738,7 +808,8 @@ class PostgresStatementSamples(DBMAsyncJob):
         self._check.count(
             "dd.postgres.run_explain.error",
             1,
-            tags=self._dbtags(dbname, "error:explain-{}-{}".format(err_code.value, type(err)))
+            tags=self._dbtags(
+                dbname, "error:explain-{}-{}".format(err_code.value, type(err)))
             + self._check._get_debug_tags(),
             hostname=self._check.resolved_hostname,
             raw=True,
@@ -761,7 +832,8 @@ class PostgresStatementSamples(DBMAsyncJob):
         )
         collection_errors = None
         if explain_err_code:
-            collection_errors = [{'code': explain_err_code.value, 'message': err_msg if err_msg else None}]
+            collection_errors = [
+                {'code': explain_err_code.value, 'message': err_msg if err_msg else None}]
 
         plan, normalized_plan, obfuscated_plan, plan_signature = None, None, None, None
         if plan_dict:
@@ -769,11 +841,13 @@ class PostgresStatementSamples(DBMAsyncJob):
             # if we're using the orjson implementation then json.dumps returns bytes
             plan = plan.decode('utf-8') if isinstance(plan, bytes) else plan
             try:
-                normalized_plan = datadog_agent.obfuscate_sql_exec_plan(plan, normalize=True)
+                normalized_plan = datadog_agent.obfuscate_sql_exec_plan(
+                    plan, normalize=True)
                 obfuscated_plan = datadog_agent.obfuscate_sql_exec_plan(plan)
             except Exception as e:
                 if self._config.log_unobfuscated_plans:
-                    self._log.warning("Failed to obfuscate plan=[%s] | err=[%s]", plan, e)
+                    self._log.warning(
+                        "Failed to obfuscate plan=[%s] | err=[%s]", plan, e)
                 raise e
 
             plan_signature = compute_exec_plan_signature(normalized_plan)
@@ -821,7 +895,8 @@ class PostgresStatementSamples(DBMAsyncJob):
             }
             if row['state'] in {'idle', 'idle in transaction'}:
                 if row['state_change'] and row['query_start']:
-                    event['duration'] = (row['state_change'] - row['query_start']).total_seconds() * 1e9
+                    event['duration'] = (
+                        row['state_change'] - row['query_start']).total_seconds() * 1e9
                     # If the transaction is idle then we have a more specific "end time" than the current time at
                     # which we're collecting this event. According to the postgres docs, all of the timestamps in
                     # pg_stat_activity are `timestamp with time zone` so the timezone should always be present. However,
@@ -829,7 +904,8 @@ class PostgresStatementSamples(DBMAsyncJob):
                     # of the event else we risk the timestamp being significantly off and the event getting dropped
                     # during ingestion.
                     if row['state_change'].tzinfo:
-                        event['timestamp'] = get_timestamp(row['state_change']) * 1000
+                        event['timestamp'] = get_timestamp(
+                            row['state_change']) * 1000
             return event
         return None
 
@@ -844,12 +920,15 @@ class PostgresStatementSamples(DBMAsyncJob):
                     events.append(event)
             except Exception:
                 self._log.exception(
-                    "Crashed trying to collect execution plan for statement in dbname=%s", row['datname']
+                    "Crashed trying to collect execution plan for statement in dbname=%s", row[
+                        'datname']
                 )
                 self._check.count(
                     "dd.postgres.statement_samples.error",
                     1,
-                    tags=self.tags + ["error:collect-plan-for-statement-crash"] + self._check._get_debug_tags(),
+                    tags=self.tags +
+                    ["error:collect-plan-for-statement-crash"] +
+                    self._check._get_debug_tags(),
                     hostname=self._check.resolved_hostname,
                     raw=True,
                 )
@@ -859,11 +938,13 @@ class PostgresStatementSamples(DBMAsyncJob):
         self._time_since_last_activity_event = time.time()
         active_sessions = []
         for row in rows:
-            active_row = self._to_active_session(row, self._get_track_activity_query_size())
+            active_row = self._to_active_session(
+                row, self._get_track_activity_query_size())
             if active_row:
                 active_sessions.append(active_row)
         if len(active_sessions) > self._activity_max_rows:
-            active_sessions = self._truncate_activity_rows(active_sessions, self._activity_max_rows)
+            active_sessions = self._truncate_activity_rows(
+                active_sessions, self._activity_max_rows)
         event = {
             "host": self._check.resolved_hostname,
             "ddagentversion": datadog_agent.get_version(),
@@ -917,5 +998,6 @@ class PostgresStatementSamples(DBMAsyncJob):
         # happens to be greater or equal to the threshold below but isn't actually truncated, this
         # would falsely report it as a truncated statement
         statement_bytes = bytes(statement, "utf-8")
-        truncated = len(statement_bytes) >= track_activity_query_size - (MAX_CHARACTER_SIZE_IN_BYTES + 1)
+        truncated = len(statement_bytes) >= track_activity_query_size - \
+            (MAX_CHARACTER_SIZE_IN_BYTES + 1)
         return StatementTruncationState.truncated if truncated else StatementTruncationState.not_truncated

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -83,7 +83,7 @@ PG_STAT_ACTIVITY_COLS = [
 
 # PG_STAT_ACTIVITY_COLS_MAPPING applies additional data type casting to the columns
 PG_STAT_ACTIVITY_COLS_MAPPING = {
-    # use the bytea type to avoid unicode decode errors on Azure PostgreSQL 
+    # use the bytea type to avoid unicode decode errors on Azure PostgreSQL
     'backend_type': 'backend_type::bytea as backend_type',
 }
 

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -83,6 +83,7 @@ PG_STAT_ACTIVITY_COLS = [
 
 # PG_STAT_ACTIVITY_COLS_MAPPING applies additional data type casting to the columns
 PG_STAT_ACTIVITY_COLS_MAPPING = {
+    # use the bytea type to avoid unicode decode errors on Azure PostgreSQL 
     'backend_type': 'backend_type::bytea as backend_type',
 }
 
@@ -261,7 +262,6 @@ class PostgresStatementSamples(DBMAsyncJob):
         if report_activity:
             cur_time_func = CURRENT_TIME_FUNC
         activity_columns = [activity_columns_mapping.get(col, col) for col in available_activity_columns]
-        print(activity_columns)
         query = PG_STAT_ACTIVITY_QUERY.format(
             backend_type_predicate=backend_type_predicate,
             current_time_func=cur_time_func,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR fixes the bug encountered in Azure PostgreSQL Flexible Server in the `backend_type` column of `pg_stat_activity`.

There is a bug on Microsoft's side where they send a non valid utf-8 string in that column, leading to decoding errors when trying to fetch this column. 

The workaround is to query that same column with `::bytea `suffix to convert the field into bytes then parsing `backend_type` manually. The bug still exists but now we just handle those error cases instead of failing on the whole query. 

### Motivation
<!-- What inspired you to submit this pull request? -->

https://datadoghq.atlassian.net/browse/SDBM-1169
https://datadoghq.atlassian.net/browse/SDBM-1197

#incident-31599

A couple of customers where seeing errors utilizing DBM with Azure PG Flexible Server when agent tries to query `backend_type` from `pg_stat_activity`. We previously issued a fix but had to [revert](https://github.com/DataDog/integrations-core/pull/18866) due to many warnings being logged from the agent. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
