### PR TITLE
[mongo] fix db name parsing when namespace has no collection

### DIFF
--- a/mongo/changelog.d/18953.fixed
+++ b/mongo/changelog.d/18953.fixed
@@ -1,0 +1,1 @@
+Fix bug in parsing database name from namespace when no collection name is present, affecting database-level commands in MongoDB versions 5 and earlier.

--- a/mongo/datadog_checks/mongo/dbm/operation_samples.py
+++ b/mongo/datadog_checks/mongo/dbm/operation_samples.py
@@ -12,6 +12,7 @@ from datadog_checks.mongo.dbm.utils import (
     format_key_name,
     get_command_collection,
     get_command_truncation_state,
+    get_db_from_namespace,
     get_explain_plan,
     obfuscate_command,
     should_explain_operation,
@@ -160,7 +161,7 @@ class MongoOperationSamples(DBMAsyncJob):
             self._check.log.debug("Skipping operation without namespace: %s", operation)
             return False
 
-        db, _ = namespace.split(".", 1)
+        db = get_db_from_namespace(namespace)
         if db not in databases_monitored:
             self._check.log.debug("Skipping operation for database %s because it is not configured to be monitored", db)
             return False
@@ -203,7 +204,7 @@ class MongoOperationSamples(DBMAsyncJob):
 
     def _get_operation_metadata(self, operation: dict) -> OperationSampleOperationMetadata:
         namespace = operation.get("ns")
-        db, _ = namespace.split(".", 1)
+        db = get_db_from_namespace(namespace)
         command = operation.get("command", {})
         return {
             "type": operation.get("type"),

--- a/mongo/datadog_checks/mongo/dbm/slow_operations.py
+++ b/mongo/datadog_checks/mongo/dbm/slow_operations.py
@@ -15,6 +15,7 @@ from datadog_checks.mongo.dbm.utils import (
     format_key_name,
     get_command_collection,
     get_command_truncation_state,
+    get_db_from_namespace,
     get_explain_plan,
     obfuscate_command,
     should_explain_operation,
@@ -222,7 +223,7 @@ class MongoSlowOperations(DBMAsyncJob):
         return slow_operation
 
     def _get_db_name(self, command, ns):
-        return command.get('$db') or ns.split('.', 1)[0]
+        return command.get('$db') or get_db_from_namespace(ns)
 
     def _binary_search(self, logs, ts):
         # Binary search to find the index of the first log line with timestamp >= ts

--- a/mongo/datadog_checks/mongo/dbm/utils.py
+++ b/mongo/datadog_checks/mongo/dbm/utils.py
@@ -125,12 +125,19 @@ def should_explain_operation(
         if any(stage in UNEXPLAINABLE_PIPELINE_STAGES for stage in stages):
             return False
 
-    db, _ = namespace.split(".", 1)
-    if db in MONGODB_SYSTEM_DATABASES:
-        return False
+    if namespace:
+        # namespace is in the form of db.collection
+        # however, some database level commands in earlier versions of MongoDB <= 5.0
+        # do not have a collection name in the namespace
+        # e.g. "admin.$cmd" vs. "admin"
+        db = get_db_from_namespace(namespace)
+        if db in MONGODB_SYSTEM_DATABASES:
+            return False
 
-    if not explain_plan_rate_limiter.acquire(explain_plan_cache_key):
-        # Skip operations that have been explained recently
+        if not explain_plan_rate_limiter.acquire(explain_plan_cache_key):
+            # Skip operations that have been explained recently
+            return False
+    else:
         return False
 
     return True
@@ -176,7 +183,7 @@ def get_command_truncation_state(command: dict) -> Optional[str]:
 
 def get_command_collection(command: dict, ns: str) -> Optional[str]:
     if ns:
-        _, collection = ns.split(".", 1)
+        collection = get_collection_from_namespace(ns)
         if collection != '$cmd':
             return collection
 
@@ -227,3 +234,16 @@ def obfuscate_literals(value):
         return regex.Regex("?", value.flags)
     else:
         return value
+
+
+def get_db_from_namespace(namespace: str) -> Optional[str]:
+    if not namespace:
+        return None
+    return namespace.split(".", 1)[0]
+
+
+def get_collection_from_namespace(namespace: str) -> Optional[str]:
+    if not namespace:
+        return None
+    splitted_ns = namespace.split(".", 1)
+    return splitted_ns[1] if len(splitted_ns) > 1 else None

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -878,6 +878,27 @@ def load_json_fixture(name):
             True,
             id='explain find',
         ),
+        pytest.param(
+            None,
+            "query",
+            {"find": "test", "filter": {}, "$db": "test", "$readPreference": {"mode": "?"}},
+            False,
+            id='missing ns',
+        ),
+        pytest.param(
+            "",
+            "query",
+            {"find": "test", "filter": {}, "$db": "test", "$readPreference": {"mode": "?"}},
+            False,
+            id='blank ns',
+        ),
+        pytest.param(
+            "db",
+            "query",
+            {"find": "test", "filter": {}, "$db": "test", "$readPreference": {"mode": "?"}},
+            True,
+            id='ns with no collection',
+        ),
     ],
 )
 def test_should_explain_operation(namespace, op, command, should_explain):


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug in parsing db name from namespace when namespace has no collection name, e.g. `admin.$cmd` vs. `admin`. This usually happens with database level administration command on earlier MongoDB version (version 5 or earlier). 

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4723

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
