### PR TITLE
Add opt-out flag to disable metrics from authenticated endpoints

### DIFF
--- a/airflow/assets/configuration/spec.yaml
+++ b/airflow/assets/configuration/spec.yaml
@@ -15,6 +15,11 @@ files:
         type: string
     - template: instances/http
     - template: instances/default
+    - name: omit_authenticated_metrics
+      description: Disable collection of metrics from the Airflow web server REST API endpoint that require authentication.
+      value:
+        type: boolean 
+        example: false
   - template: logs
     example:
     - type: file

--- a/airflow/assets/configuration/spec.yaml
+++ b/airflow/assets/configuration/spec.yaml
@@ -20,6 +20,9 @@ files:
       value:
         type: boolean 
         example: false
+        show_default: true
+      enabled: false
+
   - template: logs
     example:
     - type: file

--- a/airflow/changelog.d/18963.added
+++ b/airflow/changelog.d/18963.added
@@ -1,0 +1,1 @@
+Add opt-out flag to disable metrics from authenticated endpoints

--- a/airflow/datadog_checks/airflow/airflow.py
+++ b/airflow/datadog_checks/airflow/airflow.py
@@ -19,6 +19,7 @@ class AirflowCheck(AgentCheck):
 
         self._url = self.instance.get('url', '')
         self._tags = self.instance.get('tags', [])
+        self._omit_authenticated_metrics = self.instance.get("omit_authenticated_metrics")
 
         # The Agent only makes one attempt to instantiate each AgentCheck so any errors occurring
         # in `__init__` are logged just once, making it difficult to spot. Therefore, we emit
@@ -51,7 +52,7 @@ class AirflowCheck(AgentCheck):
         else:
             submit_metrics(resp, tags)
             # Only calculate task duration for stable API and when desired
-            if target_url is url_stable and not self.config.omit_authenticated_metrics:
+            if target_url is url_stable and not self._omit_authenticated_metrics:
                 task_instances = self._get_all_task_instances(url_stable_task_instances, tags)
                 if task_instances:
                     self._calculate_task_ongoing_duration(task_instances, tags)

--- a/airflow/datadog_checks/airflow/airflow.py
+++ b/airflow/datadog_checks/airflow/airflow.py
@@ -19,7 +19,6 @@ class AirflowCheck(AgentCheck):
 
         self._url = self.instance.get('url', '')
         self._tags = self.instance.get('tags', [])
-        self._omit_authenticated_metrics = self.instance.get('omit_authenticated_metrics')
 
         # The Agent only makes one attempt to instantiate each AgentCheck so any errors occurring
         # in `__init__` are logged just once, making it difficult to spot. Therefore, we emit
@@ -52,7 +51,7 @@ class AirflowCheck(AgentCheck):
         else:
             submit_metrics(resp, tags)
             # Only calculate task duration for stable API and when desired
-            if target_url is url_stable and not self._omit_authenticated_metrics:
+            if target_url is url_stable and not self.config.omit_authenticated_metrics:
                 task_instances = self._get_all_task_instances(url_stable_task_instances, tags)
                 if task_instances:
                     self._calculate_task_ongoing_duration(task_instances, tags)

--- a/airflow/datadog_checks/airflow/airflow.py
+++ b/airflow/datadog_checks/airflow/airflow.py
@@ -19,6 +19,7 @@ class AirflowCheck(AgentCheck):
 
         self._url = self.instance.get('url', '')
         self._tags = self.instance.get('tags', [])
+        self._omit_authenticated_metrics = self.instance.get('omit_authenticated_metrics')
 
         # The Agent only makes one attempt to instantiate each AgentCheck so any errors occurring
         # in `__init__` are logged just once, making it difficult to spot. Therefore, we emit
@@ -50,8 +51,8 @@ class AirflowCheck(AgentCheck):
             can_connect_status = AgentCheck.CRITICAL
         else:
             submit_metrics(resp, tags)
-            # Only calculate task duration for stable API
-            if target_url is url_stable:
+            # Only calculate task duration for stable API and when desired
+            if target_url is url_stable and not self._omit_authenticated_metrics:
                 task_instances = self._get_all_task_instances(url_stable_task_instances, tags)
                 if task_instances:
                     self._calculate_task_ongoing_duration(task_instances, tags)

--- a/airflow/datadog_checks/airflow/config_models/defaults.py
+++ b/airflow/datadog_checks/airflow/config_models/defaults.py
@@ -52,6 +52,10 @@ def instance_min_collection_interval():
     return 15
 
 
+def instance_omit_authenticated_metrics():
+    return False
+
+
 def instance_persist_connections():
     return False
 

--- a/airflow/datadog_checks/airflow/config_models/instance.py
+++ b/airflow/datadog_checks/airflow/config_models/instance.py
@@ -76,6 +76,7 @@ class InstanceConfig(BaseModel):
     metric_patterns: Optional[MetricPatterns] = None
     min_collection_interval: Optional[float] = None
     ntlm_domain: Optional[str] = None
+    omit_authenticated_metrics: Optional[bool] = None
     password: Optional[str] = None
     persist_connections: Optional[bool] = None
     proxy: Optional[Proxy] = None

--- a/airflow/datadog_checks/airflow/data/conf.yaml.example
+++ b/airflow/datadog_checks/airflow/data/conf.yaml.example
@@ -401,6 +401,10 @@ instances:
     #   exclude:
     #   - <EXCLUDE_REGEX>
 
+    ## Disable collection of metrics from the Airflow web server REST API endpoint that require authentication.
+    #
+    # omit_authenticated_metrics: {}
+
 ## Log Section
 ##
 ## type - required - Type of log input source (tcp / udp / file / windows_event).

--- a/airflow/datadog_checks/airflow/data/conf.yaml.example
+++ b/airflow/datadog_checks/airflow/data/conf.yaml.example
@@ -401,9 +401,10 @@ instances:
     #   exclude:
     #   - <EXCLUDE_REGEX>
 
+    ## @param omit_authenticated_metrics - boolean - optional - default: false
     ## Disable collection of metrics from the Airflow web server REST API endpoint that require authentication.
     #
-    # omit_authenticated_metrics: {}
+    # omit_authenticated_metrics: false
 
 ## Log Section
 ##


### PR DESCRIPTION
### What does this PR do?
This adds a configuration option `omit_authenticated_metrics` to disable agent collection of metrics from airflow webserver endpoints that require authentication, sitll allowing airflow service checks if customers don't wish to configure authentication in their agent setup.

### Motivation
Customer feedback/request: [AGENT-12565](https://datadoghq.atlassian.net/browse/AGENT-12565)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AGENT-12565]: https://datadoghq.atlassian.net/browse/AGENT-12565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ