### PR TITLE
Send port as part of database instance for MySQL and Postgres

### DIFF
--- a/mysql/changelog.d/18966.added
+++ b/mysql/changelog.d/18966.added
@@ -1,0 +1,1 @@
+Include port as part of database instance metadata for MySQL and Postgres

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -1295,6 +1295,7 @@ class MySql(AgentCheck):
         if self.resolved_hostname not in self._database_instance_emitted:
             event = {
                 "host": self.resolved_hostname,
+                "port": self._config.port,
                 "agent_version": datadog_agent.get_version(),
                 "dbms": "mysql",
                 "kind": "database_instance",

--- a/postgres/changelog.d/18966.added
+++ b/postgres/changelog.d/18966.added
@@ -1,0 +1,1 @@
+Include port as part of database instance metadata for MySQL and Postgres

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -911,6 +911,7 @@ class PostgreSql(AgentCheck):
         if self.resolved_hostname not in self._database_instance_emitted:
             event = {
                 "host": self.resolved_hostname,
+                "port": self._config.port,
                 "agent_version": datadog_agent.get_version(),
                 "dbms": "postgres",
                 "kind": "database_instance",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds `port` to database instance metadata for MySQL and Postgres.

### Motivation
<!-- What inspired you to submit this pull request? -->
For hosts with multiple instances port can be used to distinguish between them.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
