### PR TITLE
Add lookback_window param.

### DIFF
--- a/sqlserver/changelog.d/18979.added
+++ b/sqlserver/changelog.d/18979.added
@@ -1,0 +1,7 @@
+Add lookback_window config parameter to query_metrics.
+
+The current lookback window defaults to 2 times the collection interval, and is not able to be overridden.
+This means that infrequently-run queries are unlikely to have metrics captured for them. One common
+use case that falls into this bucket is ETL queries which can run hourly or even daily. These have
+a very small chance of having metrics captured for them. In that case, we will support setting a lookback
+window that will include such queries.

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -348,6 +348,13 @@ instances:
         #
         # samples_per_hour_per_query: 4
 
+        ## @param lookback_window - boolean - optional - default: 2 * collection_interval
+        ## Queries whose last execution completed after the lookback window are excluded from
+        ## metrics collection. Set a longer lookback window (in seconds) to capture infrequently
+        ## run queries.
+        #
+        # lookback_window: 3600
+
     ## Configure collection of procedure metrics
     #
     # procedure_metrics:

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -286,12 +286,17 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         )
         return self._statement_metrics_query
 
+    def lookback_window(self):
+        return self._config.statement_metrics_config.get('lookback_window', None)
+
     @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
     def _load_raw_query_metrics_rows(self, cursor):
         self.log.debug("collecting sql server statement metrics")
         statement_metrics_query = self._get_statement_metrics_query_cached(cursor)
         now = time.time()
         query_interval = self.collection_interval * 2
+        if self.lookback_window():
+            query_interval = self.lookback_window()
         if self._last_stats_query_time:
             query_interval = max(query_interval, now - self._last_stats_query_time)
         self._last_stats_query_time = now

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -1020,6 +1020,15 @@ def test_metrics_lookback_multiplier(instance_docker):
     check.statement_metrics._load_raw_query_metrics_rows(mock_cursor)
     mock_cursor.execute.assert_called_with(ANY, (6,))
 
+@pytest.mark.unit
+def test_metrics_lookback_window_config(instance_docker):
+    instance_docker['query_metrics'] = {'lookback_window': 86400}
+    check = SQLServer(CHECK_NAME, {}, [instance_docker])
+    _, mock_cursor = _mock_database_list()
+
+    check.statement_metrics._load_raw_query_metrics_rows(mock_cursor)
+    mock_cursor.execute.assert_called_with(ANY, (86400,))
+
 
 @pytest.mark.flaky
 @pytest.mark.integration


### PR DESCRIPTION
### What does this PR do?

Adds a `lookback_window` param to `query_metrics`.

### Motivation

The current lookback window defaults to 2 times the collection interval, and is not able to be overridden.
This means that infrequently-run queries are unlikely to have metrics captured for them. One common
use case that falls into this bucket is ETL queries which can run hourly or even daily. These have
a very small chance of having metrics captured for them. In that case, we will support setting a lookback
window that will include such queries.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
