### PR TITLE
Build Cryptography wheel for Windows

### DIFF
--- a/.builders/images/helpers.ps1
+++ b/.builders/images/helpers.ps1
@@ -38,3 +38,12 @@ function Add-ToPath() {
     $target="$oldPath;$Append"
     [Environment]::SetEnvironmentVariable("Path", $target, [System.EnvironmentVariableTarget]::User)
 }
+
+function RunOnVSConsole() {
+    param(
+        [Parameter(Mandatory = $true)][string] $Command
+    )
+    Write-Host "Running $Command"
+    Start-Process -Wait -NoNewWindow "cmd.exe" -ArgumentList "/c ""$Env:VCVARSALL_BAT"" $Env:DD_TARGET_ARCH && $Command"
+}
+

--- a/.builders/images/windows-x86_64/Dockerfile
+++ b/.builders/images/windows-x86_64/Dockerfile
@@ -126,8 +126,6 @@ COPY build_script.ps1 C:\build_script.ps1
 COPY update_librdkafka_manifest.py C:\update_librdkafka_manifest.py
 ENV DD_BUILD_COMMAND="pwsh C:\build_script.ps1"
 
-# Python packages that we want to build regardless of whether prebuilt versions exist on PyPI
-ENV PIP_NO_BINARY="confluent_kafka"
 # Where to find native dependencies when building extensions and for wheel repairing
 RUN New-Item -Path "C:\include" -ItemType Directory
 RUN New-Item -Path "C:\lib" -ItemType Directory

--- a/.builders/images/windows-x86_64/Dockerfile
+++ b/.builders/images/windows-x86_64/Dockerfile
@@ -133,6 +133,8 @@ RUN Get-RemoteFile `
     -Hash '002a2d6b30b58bf4bea46c43bdd96365aaf8daa6c428782aa4feee06da197df3'; `
     7z x openssl-$Env:OPENSSL_VERSION.tar.gz -r -y && `
     7z x openssl-$Env:OPENSSL_VERSION.tar -oC:\openssl3-src && `
+    Remove-Item openssl-$Env:OPENSSL_VERSION.tar.gz && `
+    Remove-Item openssl-$Env:OPENSSL_VERSION.tar && `
     cd C:\openssl3-src\openssl-$Env:OPENSSL_VERSION && `
     RunOnVSConsole -Command `
     'C:\perl\perl\bin\perl.exe Configure `

--- a/.builders/images/windows-x86_64/Dockerfile
+++ b/.builders/images/windows-x86_64/Dockerfile
@@ -25,6 +25,7 @@ RUN curl -SL --output vs_buildtools.exe https://aka.ms/vs/17/release/vs_buildtoo
      --add Microsoft.VisualStudio.Workload.VCTools `
      || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
  && del /q vs_buildtools.exe
+ENV VCVARSALL_BAT="C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat"
 
 # Upgrade PowerShell
 ENV POWERSHELL_VERSION="7.4.0"
@@ -116,6 +117,32 @@ RUN Get-RemoteFile `
 
 ENV OPENSSL_VERSION="3.4.1"
 
+# Nasm
+ENV NASM_VERSION="2.16.03"
+RUN Get-RemoteFile `
+    -Uri https://www.nasm.us/pub/nasm/releasebuilds/$Env:NASM_VERSION/win64/nasm-$Env:NASM_VERSION-win64.zip `
+    -Path "nasm-$Env:NASM_VERSION-win64.zip" `
+    -Hash '3ee4782247bcb874378d02f7eab4e294a84d3d15f3f6ee2de2f47a46aa7226e6' && `
+    7z x "nasm-$Env:NASM_VERSION-win64.zip" -o"C:\nasm" && `
+    Add-ToPath -Append "C:\nasm\nasm-$Env:NASM_VERSION" && `
+    Remove-Item "nasm-$Env:NASM_VERSION-win64.zip"
+# openssl
+RUN Get-RemoteFile `
+    -Uri https://www.openssl.org/source/openssl-$Env:OPENSSL_VERSION.tar.gz `
+    -Path openssl-$Env:OPENSSL_VERSION.tar.gz `
+    -Hash '002a2d6b30b58bf4bea46c43bdd96365aaf8daa6c428782aa4feee06da197df3'; `
+    7z x openssl-$Env:OPENSSL_VERSION.tar.gz -r -y && `
+    7z x openssl-$Env:OPENSSL_VERSION.tar -oC:\openssl3-src && `
+    cd C:\openssl3-src\openssl-$Env:OPENSSL_VERSION && `
+    RunOnVSConsole -Command `
+    'C:\perl\perl\bin\perl.exe Configure `
+    "--prefix=C:\openssl" `
+    "--libdir=lib" `
+    no-module no-comp no-idea no-mdc2 no-rc5 no-ssl3 no-gost`
+    && `
+    nmake && `
+    nmake install_sw'
+
 ENV CURL_VERSION="8.12.1"
 
 # Set up runner
@@ -133,6 +160,9 @@ RUN New-Item -Path "C:\bin" -ItemType Directory
 ENV INCLUDE="C:\include"
 ENV LIB="C:\lib"
 RUN Add-ToPath -Append "C:\bin"
+
+# Environment variables to help openssl crate find OpenSSL
+ENV OPENSSL_DIR="C:\openssl"
 
 # Restore the default Windows shell for correct batch processing.
 SHELL ["cmd", "/S", "/C"]

--- a/.builders/images/windows-x86_64/build_script.ps1
+++ b/.builders/images/windows-x86_64/build_script.ps1
@@ -66,3 +66,16 @@ Copy-Item "${srcdir}\librdkafka.lib","${srcdir}\librdkafkacpp.lib" -Destination 
 New-Item -Path $includedir\librdkafka -ItemType Directory
 Copy-Item -Path ".\src\*" -Filter *.h -Destination $includedir\librdkafka
 
+# Copy the openssl files from the vcpkg build to reuse them for cryptography by setting OPENSSL_DIR
+Get-ChildItem -Path "${librdkafka_dir}\vcpkg_installed\x64-windows" -Recurse # Debug
+$openssldir="C:\openssl"
+New-Item -Path ${openssldir}\lib -ItemType Directory -Force
+New-Item -Path ${openssldir}\include -ItemType Directory -Force
+Copy-Item "${librdkafka_dir}\vcpkg_installed\x64-windows\lib\libcrypto.lib","${librdkafka_dir}\vcpkg_installed\x64-windows\x64-windows\lib\libssl.lib" -Destination "${openssldir}\lib"
+Copy-Item "${librdkafka_dir}\vcpkg_installed\x64-windows\include\openssl" -Destination "${openssldir}\include" -Recurse
+Get-ChildItem -Path "${openssldir}" -Recurse # Debug
+
+Add-Content -Path $Env:DD_ENV_FILE -Value "OPENSSL_DIR=${openssldir}"
+
+# Python packages that we want to build regardless of whether prebuilt versions exist on PyPI
+Add-Content -Path $Env:DD_ENV_FILE -Value "PIP_NO_BINARY=confluent_kafka,cryptography"

--- a/.builders/images/windows-x86_64/build_script.ps1
+++ b/.builders/images/windows-x86_64/build_script.ps1
@@ -66,16 +66,5 @@ Copy-Item "${srcdir}\librdkafka.lib","${srcdir}\librdkafkacpp.lib" -Destination 
 New-Item -Path $includedir\librdkafka -ItemType Directory
 Copy-Item -Path ".\src\*" -Filter *.h -Destination $includedir\librdkafka
 
-# Copy the openssl files from the vcpkg build to reuse them for cryptography by setting OPENSSL_DIR
-Get-ChildItem -Path "${librdkafka_dir}\vcpkg_installed\x64-windows" -Recurse # Debug
-$openssldir="C:\openssl"
-New-Item -Path ${openssldir}\lib -ItemType Directory -Force
-New-Item -Path ${openssldir}\include -ItemType Directory -Force
-Copy-Item "${librdkafka_dir}\vcpkg_installed\x64-windows\lib\libcrypto.lib","${librdkafka_dir}\vcpkg_installed\x64-windows\x64-windows\lib\libssl.lib" -Destination "${openssldir}\lib"
-Copy-Item "${librdkafka_dir}\vcpkg_installed\x64-windows\include\openssl" -Destination "${openssldir}\include" -Recurse
-Get-ChildItem -Path "${openssldir}" -Recurse # Debug
-
-Add-Content -Path $Env:DD_ENV_FILE -Value "OPENSSL_DIR=${openssldir}"
-
 # Python packages that we want to build regardless of whether prebuilt versions exist on PyPI
 Add-Content -Path $Env:DD_ENV_FILE -Value "PIP_NO_BINARY=confluent_kafka,cryptography"

--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -260,7 +260,7 @@ jobs:
 
   publish:
     name: Publish artifacts
-    #if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (github.ref == github.event.repository.default_branch || startsWith(github.ref, '7.')))
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (github.ref == github.event.repository.default_branch || startsWith(github.ref, '7.')))
     needs:
     - build
     - build-macos

--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -260,7 +260,7 @@ jobs:
 
   publish:
     name: Publish artifacts
-    if: github.event_name == 'push' # || (github.event_name == 'workflow_dispatch' && (github.ref == github.event.repository.default_branch || startsWith(github.ref, '7.')))
+    #if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (github.ref == github.event.repository.default_branch || startsWith(github.ref, '7.')))
     needs:
     - build
     - build-macos

--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -260,7 +260,7 @@ jobs:
 
   publish:
     name: Publish artifacts
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (github.ref == github.event.repository.default_branch || startsWith(github.ref, '7.')))
+    if: github.event_name == 'push' # || (github.event_name == 'workflow_dispatch' && (github.ref == github.event.repository.default_branch || startsWith(github.ref, '7.')))
     needs:
     - build
     - build-macos


### PR DESCRIPTION
### What does this PR do?

Forces the build of cryptography for Windows, so that we get our own wheels with dynamic linking to openssl.

I've done some testing on a Windows VM and this would seem to help us solve the current issue in a similar way that we do for Linux.

### Motivation

FIPS support.
[BARX-668](https://datadoghq.atlassian.net/browse/BARX-668)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[BARX-668]: https://datadoghq.atlassian.net/browse/BARX-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ