### PR TITLE
update monitor

### DIFF
--- a/argocd/assets/monitors/application_sync_status.json
+++ b/argocd/assets/monitors/application_sync_status.json
@@ -22,7 +22,7 @@
       }
     },
     "priority": null,
-    "query": "max(last_30m):default_zero(avg:argocd.app_controller.app.info{!sync_status:synced} by {sync_status,name}) >= 1",
+    "query": "min(last_30m):avg:argocd.app_controller.app.info{!sync_status:synced} by {sync_status,name} >= 1",
     "restricted_roles": null,
     "tags": [
       "integration:argocd"


### PR DESCRIPTION
### What does this PR do?
This monitor template I think was too sensitive. It checks for the last 30 minutes and if atleast one data point is above 1 (max) then it alerts. I think it should be a bit more conservative for a recommended monitor. 

The new criteria is that if in the last 30 mins the value is 1 for the whole duration