### PR TITLE
Don't hardcode location of payload file in serving script.

### DIFF
--- a/ddev/changelog.d/18993.fixed
+++ b/ddev/changelog.d/18993.fixed
@@ -1,0 +1,1 @@
+Don't hardcode location of payload file in script that serves static OpenMetrics payloads.

--- a/ddev/src/ddev/cli/meta/scripts/scripts/serve.py
+++ b/ddev/src/ddev/cli/meta/scripts/scripts/serve.py
@@ -33,7 +33,7 @@ class OpenMetricsHandler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header('Content-Type', CONTENT_TYPE)
         self.end_headers()
-        with open(f"/tmp/{self.payloads[current_payload]}", 'rb') as f:
+        with open(self.payloads[current_payload], 'rb') as f:
             self.wfile.write(f.read())
 
         # Otherwise we keep using the last one


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
#### Before
`serve.py` can only work as part of the `ddev meta scripts serve-openmetrics-payload` command.

#### After
You can call `serve.py` directly to serve openmetrics payloads.

### Motivation
<!-- What inspired you to submit this pull request? -->
Some integrations, for instance `vllm` don't work with the `serve-openmetrics-payload` command. They require more than just the OM HTTP endpoint, they scrape some endpoints for metadata.

I found that I needed to hack something together for that case:

1. invoke `serve.py` directly to serve the OM payloads
2. modify the `vllm` source to skip crawling the metadata endpoint
3. run `ddev env start vllm...` and point the agent to the server exposed by `serve.py`


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
