### PR TITLE
[ECOS] Remove Product classifier tag from OpenAI

### DIFF
--- a/openai/manifest.json
+++ b/openai/manifest.json
@@ -42,8 +42,7 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS",
-      "Offering::Integration",
-      "Product::LLM Observability"
+      "Offering::Integration"
     ],
     "resources": [
       {


### PR DESCRIPTION
### What does this PR do?

We're remove the now-unused Product::LLM Observability classifier tag from the OpenAI integration since it is no longer used. 

### Motivation
<!-- What inspired you to submit this pull request? -->
Avoid confusion and potential side effects by removing unused classifier tag.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
