### PR TITLE
[sqlserver] fix azure_sql_server_database resource

### DIFF
--- a/sqlserver/changelog.d/19014.fixed
+++ b/sqlserver/changelog.d/19014.fixed
@@ -1,0 +1,1 @@
+Fix `azure_sql_server_database` resource tag to use Azure SQL Database `{fully_qualified_doman_name}/{database_name}`.

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -224,10 +224,10 @@ class SQLServer(AgentCheck):
             name = self._config.cloud_metadata.get("azure")["name"]
             db_instance = None
             if "sql_database" in deployment_type and self._config.dbm_enabled:
-                # azure sql databases have a special format, which is set for DBM
-                # customers in the resolved_hostname.
-                # If user is not DBM customer, the resource_name should just be set to the `name`
-                db_instance = self._resolved_hostname
+                # azure_sql_server_database resource should be set to {fully_qualified_server_name}/{database_name}
+                # for correct resource aliasing
+                dbname = self.instance.get("database", "master")
+                db_instance = f"{name}/{dbname}"
             # some `deployment_type`s map to multiple `resource_type`s
             resource_types = AZURE_DEPLOYMENT_TYPE_TO_RESOURCE_TYPES.get(deployment_type).split(",")
             for r_type in resource_types:

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -601,12 +601,12 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
             {
                 'azure': {
                     'deployment_type': 'sql_database',
-                    'name': 'my-instance',
+                    'name': 'my-instance.database.windows.net',
                 },
             },
             [
-                "dd.internal.resource:azure_sql_server_database:forced_hostname",
-                "dd.internal.resource:azure_sql_server:my-instance",
+                "dd.internal.resource:azure_sql_server_database:my-instance.database.windows.net/datadog_test-1",
+                "dd.internal.resource:azure_sql_server:my-instance.database.windows.net",
             ],
         ),
         (
@@ -618,12 +618,12 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
             {
                 'azure': {
                     'deployment_type': 'sql_database',
-                    'name': 'my-instance',
+                    'name': 'my-instance.database.windows.net',
                 },
             },
             [
-                "dd.internal.resource:azure_sql_server_database:localhost/datadog_test-1",
-                "dd.internal.resource:azure_sql_server:my-instance",
+                "dd.internal.resource:azure_sql_server_database:my-instance.database.windows.net/datadog_test-1",
+                "dd.internal.resource:azure_sql_server:my-instance.database.windows.net",
             ],
         ),
         (
@@ -656,13 +656,13 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
                 },
                 'azure': {
                     'deployment_type': 'sql_database',
-                    'name': 'my-instance',
+                    'name': 'my-instance.database.windows.net',
                 },
             },
             [
                 "dd.internal.resource:aws_rds_instance:foo.aws.com",
-                "dd.internal.resource:azure_sql_server_database:my-instance",
-                "dd.internal.resource:azure_sql_server:my-instance",
+                "dd.internal.resource:azure_sql_server_database:my-instance.database.windows.net",
+                "dd.internal.resource:azure_sql_server:my-instance.database.windows.net",
             ],
         ),
         (


### PR DESCRIPTION
### What does this PR do?
This PR fixes the `azure_sql_server_database` internal resource aliasing. Previously the `azure_sql_server_database` resource is set to the resolved hostname, which can be overwritten to any user preferred hostname. The `azure_sql_server_database` resource should be independent from the resolved database hostname, and always follow the format of `{fully_qualified_doman_name}/{database}`. This ensures the correct resource aliasing in unified instance tagging. 

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4756

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
