### PR TITLE
Unhide schemas_collection and write agent version

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -759,8 +759,8 @@ files:
         example: 1800
         display_default: false
     - name: schemas_collection
-      hidden: True
       description: |
+        Available for Agent 7.56 and newer.
         Configure collection of schemas. If `database_autodiscovery` is not enabled, data is collected
         only for the database configured with `database` parameter.
       options:

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -698,6 +698,28 @@ instances:
     #
     # ignore_missing_database: false
 
+    ## Available for Agent 7.56 and newer.
+    ## Configure collection of schemas. If `database_autodiscovery` is not enabled, data is collected
+    ## only for the database configured with `database` parameter.
+    #
+    # schemas_collection:
+
+        ## @param enabled - boolean - optional - default: false
+        ## Enable schema collection. Requires `dbm: true`. Defaults to false.
+        #
+        # enabled: false
+
+        ## @param collection_interval - number - optional - default: 600
+        ## Set the database schema collection interval (in seconds). Defaults to 600 seconds.
+        #
+        # collection_interval: 600
+
+        ## @param max_execution_time - number - optional - default: 10
+        ## Set the maximum time for schema collection (in seconds). Defaults to 10 seconds.
+        ## Capped by `schemas_collection.collection_interval`
+        #
+        # max_execution_time: 10
+
     ## @param propagate_agent_tags - boolean - optional - default: false
     ## Set to `true` to propagate the tags from `datadog.yaml` and the agent host tags to the check.
     ## When set to `true`, the tags from the agent host are added to the check's tags for all instances.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Unhide the `schemas_collection` parameter as it's now available in the frontend.

### Motivation
<!-- What inspired you to submit this pull request? -->

[Link to feature release](https://datadoghq.atlassian.net/wiki/spaces/DM/pages/4368302348/2024-11-11+-+SQLServer+Host+Detail+Schema+Tab)

 We want this option exposed to customers now that there's a frontend for it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
