### PR TITLE
[sqlserver] Add option to aggregate azure sql database into one db host

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -566,7 +566,7 @@ files:
           value:
             type: string
             example: my-sqlserver-database.database.windows.net
-        - name: aggregate_azure_sql_databases
+        - name: aggregate_sql_databases
           description: |
             Aggregate individual Azure SQL Databases under a single logical SQL server database instance.
             Only applicable when `deployment_type` is set to `sql_database`.

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -71,6 +71,12 @@ files:
         and can be useful to set a custom hostname when connecting to a remote database through a proxy.
       value:
         type: string
+    - name: group_azure_sql_database
+      description: |
+        Group individual Azure SQL Databases under a single logical database instance.
+      value:
+        type: boolean
+        example: false
     - name: database_autodiscovery
       description: |
         Auto-discover and monitor databases. Supported for the metrics check.

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -566,9 +566,9 @@ files:
           value:
             type: string
             example: my-sqlserver-database.database.windows.net
-        - name: group_azure_sql_databases
+        - name: aggregate_azure_sql_databases
           description: |
-            Group individual Azure SQL Databases under a single logical database instance.
+            Aggregate individual Azure SQL Databases under a single logical SQL server database instance.
             Only applicable when `deployment_type` is set to `sql_database`.
           value:
             type: boolean

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -71,12 +71,6 @@ files:
         and can be useful to set a custom hostname when connecting to a remote database through a proxy.
       value:
         type: string
-    - name: group_azure_sql_database
-      description: |
-        Group individual Azure SQL Databases under a single logical database instance.
-      value:
-        type: boolean
-        example: false
     - name: database_autodiscovery
       description: |
         Auto-discover and monitor databases. Supported for the metrics check.
@@ -572,6 +566,13 @@ files:
           value:
             type: string
             example: my-sqlserver-database.database.windows.net
+        - name: group_azure_sql_databases
+          description: |
+            Group individual Azure SQL Databases under a single logical database instance.
+            Only applicable when `deployment_type` is set to `sql_database`.
+          value:
+            type: boolean
+            example: false
 
     - name: managed_identity
       description: |

--- a/sqlserver/changelog.d/19032.added
+++ b/sqlserver/changelog.d/19032.added
@@ -1,1 +1,1 @@
-Add config option `azure.group_azure_sql_database` to group multiple azure sql databases into one database host.
+Add config option `azure.aggregate_sql_databases` to report multiple azure sql databases as one database host. This is an opted in feature and is disabled by default. 

--- a/sqlserver/changelog.d/19032.added
+++ b/sqlserver/changelog.d/19032.added
@@ -1,1 +1,1 @@
-Add config option `group_azure_sql_database` to group multiple azure sql databases into one database host.
+Add config option `azure.group_azure_sql_database` to group multiple azure sql databases into one database host.

--- a/sqlserver/changelog.d/19032.added
+++ b/sqlserver/changelog.d/19032.added
@@ -1,0 +1,1 @@
+Add config option `group_azure_sql_database` to group multiple azure sql databases into one database host.

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -67,7 +67,7 @@ class SQLServerConfig:
             # Remap fully_qualified_domain_name to name
             if 'fully_qualified_domain_name' in azure:
                 azure['name'] = azure.pop('fully_qualified_domain_name')
-            azure['group_azure_sql_databases'] = is_affirmative(azure.get('group_azure_sql_databases', False))
+            azure['aggregate_azure_sql_databases'] = is_affirmative(azure.get('aggregate_azure_sql_databases', False))
             self.cloud_metadata.update({'azure': azure})
 
         obfuscator_options_config: dict = instance.get('obfuscator_options', {}) or {}

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -59,13 +59,15 @@ class SQLServerConfig:
         aws: dict = instance.get('aws', {}) or {}
         gcp: dict = instance.get('gcp', {}) or {}
         azure: dict = instance.get('azure', {}) or {}
-        # Remap fully_qualified_domain_name to name
-        azure = {k if k != 'fully_qualified_domain_name' else 'name': v for k, v in azure.items()}
         if aws:
             self.cloud_metadata.update({'aws': aws})
         if gcp:
             self.cloud_metadata.update({'gcp': gcp})
         if azure:
+            # Remap fully_qualified_domain_name to name
+            if 'fully_qualified_domain_name' in azure:
+                azure['name'] = azure.pop('fully_qualified_domain_name')
+            azure['group_azure_sql_database'] = is_affirmative(azure.get('group_azure_sql_database', False))
             self.cloud_metadata.update({'azure': azure})
 
         obfuscator_options_config: dict = instance.get('obfuscator_options', {}) or {}
@@ -112,7 +114,6 @@ class SQLServerConfig:
         self.stored_procedure_characters_limit: int = instance.get('stored_procedure_characters_limit', PROC_CHAR_LIMIT)
         self.connection_host: str = instance['host']
         self.service = instance.get('service') or init_config.get('service') or ''
-        self.group_azure_sql_database = is_affirmative(instance.get('group_azure_sql_database', False))
 
     def _compile_valid_patterns(self, patterns: list[str]) -> re.Pattern:
         valid_patterns = []

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -67,7 +67,7 @@ class SQLServerConfig:
             # Remap fully_qualified_domain_name to name
             if 'fully_qualified_domain_name' in azure:
                 azure['name'] = azure.pop('fully_qualified_domain_name')
-            azure['aggregate_azure_sql_databases'] = is_affirmative(azure.get('aggregate_azure_sql_databases', False))
+            azure['aggregate_sql_databases'] = is_affirmative(azure.get('aggregate_sql_databases', False))
             self.cloud_metadata.update({'azure': azure})
 
         obfuscator_options_config: dict = instance.get('obfuscator_options', {}) or {}

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -112,6 +112,7 @@ class SQLServerConfig:
         self.stored_procedure_characters_limit: int = instance.get('stored_procedure_characters_limit', PROC_CHAR_LIMIT)
         self.connection_host: str = instance['host']
         self.service = instance.get('service') or init_config.get('service') or ''
+        self.group_azure_sql_database = is_affirmative(instance.get('group_azure_sql_database', False))
 
     def _compile_valid_patterns(self, patterns: list[str]) -> re.Pattern:
         valid_patterns = []

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -67,7 +67,7 @@ class SQLServerConfig:
             # Remap fully_qualified_domain_name to name
             if 'fully_qualified_domain_name' in azure:
                 azure['name'] = azure.pop('fully_qualified_domain_name')
-            azure['group_azure_sql_database'] = is_affirmative(azure.get('group_azure_sql_database', False))
+            azure['group_azure_sql_databases'] = is_affirmative(azure.get('group_azure_sql_databases', False))
             self.cloud_metadata.update({'azure': azure})
 
         obfuscator_options_config: dict = instance.get('obfuscator_options', {}) or {}

--- a/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
@@ -60,10 +60,6 @@ def instance_empty_default_hostname():
     return False
 
 
-def instance_group_azure_sql_database():
-    return False
-
-
 def instance_ignore_missing_database():
     return False
 

--- a/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
@@ -60,6 +60,10 @@ def instance_empty_default_hostname():
     return False
 
 
+def instance_group_azure_sql_database():
+    return False
+
+
 def instance_ignore_missing_database():
     return False
 

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -45,6 +45,7 @@ class Azure(BaseModel):
     )
     deployment_type: Optional[str] = None
     fully_qualified_domain_name: Optional[str] = None
+    group_azure_sql_databases: Optional[bool] = None
 
 
 class CollectSettings(BaseModel):
@@ -202,7 +203,6 @@ class InstanceConfig(BaseModel):
     dsn: Optional[str] = None
     empty_default_hostname: Optional[bool] = None
     gcp: Optional[Gcp] = None
-    group_azure_sql_database: Optional[bool] = None
     host: str
     ignore_missing_database: Optional[bool] = None
     include_ao_metrics: Optional[bool] = None

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -202,6 +202,7 @@ class InstanceConfig(BaseModel):
     dsn: Optional[str] = None
     empty_default_hostname: Optional[bool] = None
     gcp: Optional[Gcp] = None
+    group_azure_sql_database: Optional[bool] = None
     host: str
     ignore_missing_database: Optional[bool] = None
     include_ao_metrics: Optional[bool] = None

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -43,7 +43,7 @@ class Azure(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
-    aggregate_azure_sql_databases: Optional[bool] = None
+    aggregate_sql_databases: Optional[bool] = None
     deployment_type: Optional[str] = None
     fully_qualified_domain_name: Optional[str] = None
 

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -43,9 +43,9 @@ class Azure(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    aggregate_azure_sql_databases: Optional[bool] = None
     deployment_type: Optional[str] = None
     fully_qualified_domain_name: Optional[str] = None
-    group_azure_sql_databases: Optional[bool] = None
 
 
 class CollectSettings(BaseModel):

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -80,6 +80,11 @@ instances:
     #
     # reported_hostname: <REPORTED_HOSTNAME>
 
+    ## @param group_azure_sql_database - boolean - optional - default: false
+    ## Group individual Azure SQL Databases under a single logical database instance.
+    #
+    # group_azure_sql_database: false
+
     ## @param database_autodiscovery - boolean - optional - default: false
     ## Auto-discover and monitor databases. Supported for the metrics check.
     ## If `true`, overrides `database` option.

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -484,11 +484,11 @@ instances:
         #
         # fully_qualified_domain_name: my-sqlserver-database.database.windows.net
 
-        ## @param aggregate_azure_sql_databases - boolean - optional - default: false
+        ## @param aggregate_sql_databases - boolean - optional - default: false
         ## Aggregate individual Azure SQL Databases under a single logical SQL server database instance.
         ## Only applicable when `deployment_type` is set to `sql_database`.
         #
-        # aggregate_azure_sql_databases: false
+        # aggregate_sql_databases: false
 
     ## Configuration section used for Azure AD Authentication.
     ##

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -484,11 +484,11 @@ instances:
         #
         # fully_qualified_domain_name: my-sqlserver-database.database.windows.net
 
-        ## @param group_azure_sql_databases - boolean - optional - default: false
-        ## Group individual Azure SQL Databases under a single logical database instance.
+        ## @param aggregate_azure_sql_databases - boolean - optional - default: false
+        ## Aggregate individual Azure SQL Databases under a single logical SQL server database instance.
         ## Only applicable when `deployment_type` is set to `sql_database`.
         #
-        # group_azure_sql_databases: false
+        # aggregate_azure_sql_databases: false
 
     ## Configuration section used for Azure AD Authentication.
     ##

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -80,11 +80,6 @@ instances:
     #
     # reported_hostname: <REPORTED_HOSTNAME>
 
-    ## @param group_azure_sql_database - boolean - optional - default: false
-    ## Group individual Azure SQL Databases under a single logical database instance.
-    #
-    # group_azure_sql_database: false
-
     ## @param database_autodiscovery - boolean - optional - default: false
     ## Auto-discover and monitor databases. Supported for the metrics check.
     ## If `true`, overrides `database` option.
@@ -488,6 +483,12 @@ instances:
         ## This value is optional if the value of `host` is already configured to the fully qualified domain name.
         #
         # fully_qualified_domain_name: my-sqlserver-database.database.windows.net
+
+        ## @param group_azure_sql_databases - boolean - optional - default: false
+        ## Group individual Azure SQL Databases under a single logical database instance.
+        ## Only applicable when `deployment_type` is set to `sql_database`.
+        #
+        # group_azure_sql_databases: false
 
     ## Configuration section used for Azure AD Authentication.
     ##

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -271,8 +271,8 @@ class SQLServer(AgentCheck):
                     # meaning that the agent is only able to see query activity for the specific database it's
                     # connected to. For this reason, each Azure SQL database is modeled as an independent host.
                     azure = self._config.cloud_metadata.get("azure")
-                    if azure and azure.get("aggregate_azure_sql_databases"):
-                        # If the aggregate_azure_sql_databases option is enabled, the agent will group all Azure SQL
+                    if azure and azure.get("aggregate_sql_databases"):
+                        # If the aggregate_sql_databases option is enabled, the agent will group all Azure SQL
                         # databases and report them as a single database instance.
                         self._resolved_hostname = host
                     else:

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -270,7 +270,12 @@ class SQLServer(AgentCheck):
                     # for Azure SQL Database, each database on a given "server" has isolated compute resources,
                     # meaning that the agent is only able to see query activity for the specific database it's
                     # connected to. For this reason, each Azure SQL database is modeled as an independent host.
-                    self._resolved_hostname = "{}/{}".format(host, configured_database)
+                    if self._config.group_azure_sql_database:
+                        # If the group_azure_sql_database option is enabled, the agent will group all Azure SQL
+                        # databases and report them as a single database instance.
+                        self._resolved_hostname = host
+                    else:
+                        self._resolved_hostname = "{}/{}".format(host, configured_database)
         # set resource tags to properly tag with updated hostname
         self.set_resource_tags()
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -271,8 +271,8 @@ class SQLServer(AgentCheck):
                     # meaning that the agent is only able to see query activity for the specific database it's
                     # connected to. For this reason, each Azure SQL database is modeled as an independent host.
                     azure = self._config.cloud_metadata.get("azure")
-                    if azure and azure.get("group_azure_sql_databases"):
-                        # If the group_azure_sql_databases option is enabled, the agent will group all Azure SQL
+                    if azure and azure.get("aggregate_azure_sql_databases"):
+                        # If the aggregate_azure_sql_databases option is enabled, the agent will group all Azure SQL
                         # databases and report them as a single database instance.
                         self._resolved_hostname = host
                     else:

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -270,8 +270,9 @@ class SQLServer(AgentCheck):
                     # for Azure SQL Database, each database on a given "server" has isolated compute resources,
                     # meaning that the agent is only able to see query activity for the specific database it's
                     # connected to. For this reason, each Azure SQL database is modeled as an independent host.
-                    if self._config.group_azure_sql_database:
-                        # If the group_azure_sql_database option is enabled, the agent will group all Azure SQL
+                    azure = self._config.cloud_metadata.get("azure")
+                    if azure and azure.get("group_azure_sql_databases"):
+                        # If the group_azure_sql_databases option is enabled, the agent will group all Azure SQL
                         # databases and report them as a single database instance.
                         self._resolved_hostname = host
                     else:

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -535,7 +535,7 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    "dbm_enabled, database, reported_hostname, engine_edition, expected_hostname, cloud_metadata, metric_names",
+    "dbm_enabled,database,reported_hostname,engine_edition,expected_hostname,cloud_metadata,metric_names,group_azure_sql_database",
     [
         (
             True,
@@ -545,6 +545,7 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
             'stubbed.hostname',
             {},
             [],
+            None,
         ),
         (
             False,
@@ -559,6 +560,7 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
                 },
             },
             ["dd.internal.resource:azure_sql_server_managed_instance:my-instance"],
+            None,
         ),
         (
             True,
@@ -573,6 +575,7 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
                 },
             },
             ["dd.internal.resource:azure_sql_server_managed_instance:my-instance"],
+            None,
         ),
         (
             True,
@@ -582,6 +585,7 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
             'forced_hostname',
             {},
             [],
+            None,
         ),
         (
             False,
@@ -591,6 +595,7 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
             'forced_hostname',
             {},
             [],
+            None,
         ),
         (
             True,
@@ -608,6 +613,7 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
                 "dd.internal.resource:azure_sql_server_database:my-instance.database.windows.net/datadog_test-1",
                 "dd.internal.resource:azure_sql_server:my-instance.database.windows.net",
             ],
+            None,
         ),
         (
             True,
@@ -625,6 +631,25 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
                 "dd.internal.resource:azure_sql_server_database:my-instance.database.windows.net/datadog_test-1",
                 "dd.internal.resource:azure_sql_server:my-instance.database.windows.net",
             ],
+            None,
+        ),
+        (
+            True,
+            'datadog_test-1',
+            None,
+            ENGINE_EDITION_SQL_DATABASE,
+            'localhost',
+            {
+                'azure': {
+                    'deployment_type': 'sql_database',
+                    'name': 'my-instance.database.windows.net',
+                },
+            },
+            [
+                "dd.internal.resource:azure_sql_server_database:my-instance.database.windows.net/datadog_test-1",
+                "dd.internal.resource:azure_sql_server:my-instance.database.windows.net",
+            ],
+            True,
         ),
         (
             True,
@@ -634,6 +659,7 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
             'localhost/master',
             {},
             [],
+            None,
         ),
         (
             False,
@@ -643,6 +669,7 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
             'localhost/master',
             {},
             [],
+            None,
         ),
         (
             False,
@@ -664,6 +691,7 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
                 "dd.internal.resource:azure_sql_server_database:my-instance.database.windows.net",
                 "dd.internal.resource:azure_sql_server:my-instance.database.windows.net",
             ],
+            None,
         ),
         (
             False,
@@ -681,6 +709,7 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
             [
                 "dd.internal.resource:gcp_sql_database_instance:foo-project:bar",
             ],
+            None,
         ),
     ],
 )
@@ -696,6 +725,7 @@ def test_resolved_hostname_set(
     expected_hostname,
     cloud_metadata,
     metric_names,
+    group_azure_sql_database,
 ):
     if cloud_metadata:
         for k, v in cloud_metadata.items():
@@ -711,6 +741,8 @@ def test_resolved_hostname_set(
         instance_docker['database'] = database
     if reported_hostname:
         instance_docker['reported_hostname'] = reported_hostname
+    if group_azure_sql_database is not None:
+        instance_docker['group_azure_sql_database'] = group_azure_sql_database
     sqlserver_check = SQLServer(CHECK_NAME, {}, [instance_docker])
     if engine_edition:
         sqlserver_check.static_info_cache[STATIC_INFO_VERSION] = "Microsoft SQL Server 2019"

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -653,7 +653,7 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
                 'azure': {
                     'deployment_type': 'sql_database',
                     'fully_qualified_domain_name': 'my-instance.database.windows.net',
-                    'aggregate_azure_sql_databases': True,
+                    'aggregate_sql_databases': True,
                 },
             },
             [

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -535,7 +535,7 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    "dbm_enabled,database,reported_hostname,engine_edition,expected_hostname,cloud_metadata,metric_names,group_azure_sql_database",
+    "dbm_enabled, database, reported_hostname, engine_edition, expected_hostname, cloud_metadata, metric_names",
     [
         (
             True,
@@ -545,7 +545,6 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
             'stubbed.hostname',
             {},
             [],
-            None,
         ),
         (
             False,
@@ -560,7 +559,6 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
                 },
             },
             ["dd.internal.resource:azure_sql_server_managed_instance:my-instance"],
-            None,
         ),
         (
             True,
@@ -575,7 +573,6 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
                 },
             },
             ["dd.internal.resource:azure_sql_server_managed_instance:my-instance"],
-            None,
         ),
         (
             True,
@@ -585,7 +582,6 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
             'forced_hostname',
             {},
             [],
-            None,
         ),
         (
             False,
@@ -595,7 +591,6 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
             'forced_hostname',
             {},
             [],
-            None,
         ),
         (
             True,
@@ -613,7 +608,6 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
                 "dd.internal.resource:azure_sql_server_database:my-instance.database.windows.net/datadog_test-1",
                 "dd.internal.resource:azure_sql_server:my-instance.database.windows.net",
             ],
-            None,
         ),
         (
             True,
@@ -631,7 +625,23 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
                 "dd.internal.resource:azure_sql_server_database:my-instance.database.windows.net/datadog_test-1",
                 "dd.internal.resource:azure_sql_server:my-instance.database.windows.net",
             ],
+        ),
+        (
+            True,
+            'datadog_test-1',
             None,
+            ENGINE_EDITION_SQL_DATABASE,
+            'localhost/datadog_test-1',
+            {
+                'azure': {
+                    'deployment_type': 'sql_database',
+                    'fully_qualified_domain_name': 'my-instance.database.windows.net',
+                },
+            },
+            [
+                "dd.internal.resource:azure_sql_server_database:my-instance.database.windows.net/datadog_test-1",
+                "dd.internal.resource:azure_sql_server:my-instance.database.windows.net",
+            ],
         ),
         (
             True,
@@ -642,14 +652,14 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
             {
                 'azure': {
                     'deployment_type': 'sql_database',
-                    'name': 'my-instance.database.windows.net',
+                    'fully_qualified_domain_name': 'my-instance.database.windows.net',
+                    'group_azure_sql_databases': True,
                 },
             },
             [
                 "dd.internal.resource:azure_sql_server_database:my-instance.database.windows.net/datadog_test-1",
                 "dd.internal.resource:azure_sql_server:my-instance.database.windows.net",
             ],
-            True,
         ),
         (
             True,
@@ -659,7 +669,6 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
             'localhost/master',
             {},
             [],
-            None,
         ),
         (
             False,
@@ -669,7 +678,6 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
             'localhost/master',
             {},
             [],
-            None,
         ),
         (
             False,
@@ -691,7 +699,6 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
                 "dd.internal.resource:azure_sql_server_database:my-instance.database.windows.net",
                 "dd.internal.resource:azure_sql_server:my-instance.database.windows.net",
             ],
-            None,
         ),
         (
             False,
@@ -709,7 +716,6 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
             [
                 "dd.internal.resource:gcp_sql_database_instance:foo-project:bar",
             ],
-            None,
         ),
     ],
 )
@@ -725,7 +731,6 @@ def test_resolved_hostname_set(
     expected_hostname,
     cloud_metadata,
     metric_names,
-    group_azure_sql_database,
 ):
     if cloud_metadata:
         for k, v in cloud_metadata.items():
@@ -741,8 +746,6 @@ def test_resolved_hostname_set(
         instance_docker['database'] = database
     if reported_hostname:
         instance_docker['reported_hostname'] = reported_hostname
-    if group_azure_sql_database is not None:
-        instance_docker['group_azure_sql_database'] = group_azure_sql_database
     sqlserver_check = SQLServer(CHECK_NAME, {}, [instance_docker])
     if engine_edition:
         sqlserver_check.static_info_cache[STATIC_INFO_VERSION] = "Microsoft SQL Server 2019"

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -653,7 +653,7 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
                 'azure': {
                     'deployment_type': 'sql_database',
                     'fully_qualified_domain_name': 'my-instance.database.windows.net',
-                    'group_azure_sql_databases': True,
+                    'aggregate_azure_sql_databases': True,
                 },
             },
             [

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -572,7 +572,7 @@ def test_statement_metadata(
                 'azure': {
                     'deployment_type': 'managed_instance',
                     'name': 'my-instance.abcea3661b20.database.windows.net',
-                    'group_azure_sql_database': False,
+                    'group_azure_sql_databases': False,
                 },
             },
         ),
@@ -587,7 +587,7 @@ def test_statement_metadata(
                 'azure': {
                     'deployment_type': 'managed_instance',
                     'name': 'my-instance.abcea3661b20.database.windows.net',
-                    'group_azure_sql_database': False,
+                    'group_azure_sql_databases': False,
                 },
             },
         ),
@@ -608,7 +608,7 @@ def test_statement_metadata(
                 'azure': {
                     'deployment_type': 'managed_instance',
                     'name': 'my-instance.abcea3661b20.database.windows.net',
-                    'group_azure_sql_database': False,
+                    'group_azure_sql_databases': False,
                 },
             },
         ),

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -572,6 +572,7 @@ def test_statement_metadata(
                 'azure': {
                     'deployment_type': 'managed_instance',
                     'name': 'my-instance.abcea3661b20.database.windows.net',
+                    'group_azure_sql_database': False,
                 },
             },
         ),
@@ -586,6 +587,7 @@ def test_statement_metadata(
                 'azure': {
                     'deployment_type': 'managed_instance',
                     'name': 'my-instance.abcea3661b20.database.windows.net',
+                    'group_azure_sql_database': False,
                 },
             },
         ),
@@ -606,6 +608,7 @@ def test_statement_metadata(
                 'azure': {
                     'deployment_type': 'managed_instance',
                     'name': 'my-instance.abcea3661b20.database.windows.net',
+                    'group_azure_sql_database': False,
                 },
             },
         ),

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -572,7 +572,7 @@ def test_statement_metadata(
                 'azure': {
                     'deployment_type': 'managed_instance',
                     'name': 'my-instance.abcea3661b20.database.windows.net',
-                    'group_azure_sql_databases': False,
+                    'aggregate_azure_sql_databases': False,
                 },
             },
         ),
@@ -587,7 +587,7 @@ def test_statement_metadata(
                 'azure': {
                     'deployment_type': 'managed_instance',
                     'name': 'my-instance.abcea3661b20.database.windows.net',
-                    'group_azure_sql_databases': False,
+                    'aggregate_azure_sql_databases': False,
                 },
             },
         ),
@@ -608,7 +608,7 @@ def test_statement_metadata(
                 'azure': {
                     'deployment_type': 'managed_instance',
                     'name': 'my-instance.abcea3661b20.database.windows.net',
-                    'group_azure_sql_databases': False,
+                    'aggregate_azure_sql_databases': False,
                 },
             },
         ),

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -572,7 +572,7 @@ def test_statement_metadata(
                 'azure': {
                     'deployment_type': 'managed_instance',
                     'name': 'my-instance.abcea3661b20.database.windows.net',
-                    'aggregate_azure_sql_databases': False,
+                    'aggregate_sql_databases': False,
                 },
             },
         ),
@@ -587,7 +587,7 @@ def test_statement_metadata(
                 'azure': {
                     'deployment_type': 'managed_instance',
                     'name': 'my-instance.abcea3661b20.database.windows.net',
-                    'aggregate_azure_sql_databases': False,
+                    'aggregate_sql_databases': False,
                 },
             },
         ),
@@ -608,7 +608,7 @@ def test_statement_metadata(
                 'azure': {
                     'deployment_type': 'managed_instance',
                     'name': 'my-instance.abcea3661b20.database.windows.net',
-                    'aggregate_azure_sql_databases': False,
+                    'aggregate_sql_databases': False,
                 },
             },
         ),


### PR DESCRIPTION
### What does this PR do?
This PR adds a new config option `azure.aggregate_sql_databases` to group multiple azure sql databases into one logical SQL Server database host. 
Prior to this change, Azure SQL databases are monitored and reported as independent database instances due to the it's network isolation between databases. With the new config, user has the option to continue monitor Azure SQL databases independently but have them aggregated into one single database host in DBM. 
This is an opted in option and not enabled by default. 

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4762

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
