### PR TITLE
SAASINT-3232 Turn off Vonage public docs

### DIFF
--- a/vonage/manifest.json
+++ b/vonage/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "af03738b-a2a3-4d90-bbc8-5c6bdccfa0a5",
   "app_id": "vonage",
-  "display_on_public_website": true,
+  "display_on_public_website": false,
   "tile": {
       "overview": "README.md#Overview",
       "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?
Public docs were turned on by mistake before the integration was ready, they should not be visible yet.

### Motivation
Support request

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
