### PR TITLE
[NDMII-3168] Fix Citrix Profile

### DIFF
--- a/snmp/datadog_checks/snmp/data/default_profiles/citrix-netscaler-sdx.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/citrix-netscaler-sdx.yaml
@@ -286,11 +286,13 @@ metrics:
           name: netscaler.sdx.nsHaSync
         tag: netscaler_sdx_ns_ha_sync
 metric_tags:
-  - OID: 1.3.6.1.4.1.5951.6.2.2.0
-    symbol: systemProduct
+  - symbol:
+      OID: 1.3.6.1.4.1.5951.6.2.2.0
+      name: systemProduct
     tag: netscaler_sdx_system_product
-  - OID: 1.3.6.1.4.1.5951.6.2.4.0
-    symbol: systemSvmIPAddressType
+  - symbol:
+      OID: 1.3.6.1.4.1.5951.6.2.4.0
+      name: systemSvmIPAddressType
     tag: netscaler_sdx_system_svm_ip_address_type
     mapping:
       0: unknown
@@ -300,12 +302,14 @@ metric_tags:
       4: ipv6z
       16: dns
       25: l2vpn
-  - OID: 1.3.6.1.4.1.5951.6.2.5.0
-    symbol: systemSvmIPAddress
-    format: ip_address
+  - symbol:
+      OID: 1.3.6.1.4.1.5951.6.2.5.0
+      name: systemSvmIPAddress
+      format: ip_address
     tag: netscaler_sdx_system_svm_ip_address
-  - OID: 1.3.6.1.4.1.5951.6.2.6.0
-    symbol: systemXenIPAddressType
+  - symbol:
+      OID: 1.3.6.1.4.1.5951.6.2.6.0
+      name: systemXenIPAddressType
     tag: netscaler_sdx_system_xen_ip_address_type
     mapping:
       0: unknown
@@ -315,12 +319,14 @@ metric_tags:
       4: ipv6z
       16: dns
       25: l2vpn
-  - OID: 1.3.6.1.4.1.5951.6.2.7.0
-    symbol: systemXenIPAddress
-    format: ip_address
+  - symbol:
+      OID: 1.3.6.1.4.1.5951.6.2.7.0
+      name: systemXenIPAddress
+      format: ip_address
     tag: netscaler_sdx_system_xen_ip_address
-  - OID: 1.3.6.1.4.1.5951.6.2.8.0
-    symbol: systemNetmaskType
+  - symbol:
+      OID: 1.3.6.1.4.1.5951.6.2.8.0
+      name: systemNetmaskType
     tag: netscaler_sdx_system_netmask_type
     mapping:
       0: unknown
@@ -330,12 +336,14 @@ metric_tags:
       4: ipv6z
       16: dns
       25: l2vpn
-  - OID: 1.3.6.1.4.1.5951.6.2.9.0
-    symbol: systemNetmask
-    format: ip_address
+  - symbol:
+      OID: 1.3.6.1.4.1.5951.6.2.9.0
+      name: systemNetmask
+      format: ip_address
     tag: netscaler_sdx_system_netmask
-  - OID: 1.3.6.1.4.1.5951.6.2.10.0
-    symbol: systemGatewayType
+  - symbol:
+      OID: 1.3.6.1.4.1.5951.6.2.10.0
+      name: systemGatewayType
     tag: netscaler_sdx_system_gateway_type
     mapping:
       0: unknown
@@ -345,9 +353,10 @@ metric_tags:
       4: ipv6z
       16: dns
       25: l2vpn
-  - OID: 1.3.6.1.4.1.5951.6.2.11.0
-    symbol: systemGateway
-    format: ip_address
+  - symbol:
+      OID: 1.3.6.1.4.1.5951.6.2.11.0
+      name: systemGateway
+      format: ip_address
     tag: netscaler_sdx_system_gateway
   - OID: 1.3.6.1.4.1.5951.6.2.12.0
     symbol: systemNetworkInterface

--- a/snmp/datadog_checks/snmp/data/default_profiles/citrix-netscaler-sdx.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/citrix-netscaler-sdx.yaml
@@ -286,13 +286,11 @@ metrics:
           name: netscaler.sdx.nsHaSync
         tag: netscaler_sdx_ns_ha_sync
 metric_tags:
-  - symbol:
-      OID: 1.3.6.1.4.1.5951.6.2.2.0
-      name: systemProduct
+  - OID: 1.3.6.1.4.1.5951.6.2.2.0
+    symbol: systemProduct
     tag: netscaler_sdx_system_product
-  - symbol:
-      OID: 1.3.6.1.4.1.5951.6.2.4.0
-      name: systemSvmIPAddressType
+  - OID: 1.3.6.1.4.1.5951.6.2.4.0
+    symbol: systemSvmIPAddressType
     tag: netscaler_sdx_system_svm_ip_address_type
     mapping:
       0: unknown
@@ -302,14 +300,13 @@ metric_tags:
       4: ipv6z
       16: dns
       25: l2vpn
-  - symbol:
-      OID: 1.3.6.1.4.1.5951.6.2.5.0
-      name: systemSvmIPAddress
-      format: ip_address
+  - OID: 1.3.6.1.4.1.5951.6.2.5.0
+    symbol: systemSvmIPAddress
+    # TODO update this to the modern syntax that supports format
+    # format: ip_address
     tag: netscaler_sdx_system_svm_ip_address
-  - symbol:
-      OID: 1.3.6.1.4.1.5951.6.2.6.0
-      name: systemXenIPAddressType
+  - OID: 1.3.6.1.4.1.5951.6.2.6.0
+    symbol: systemXenIPAddressType
     tag: netscaler_sdx_system_xen_ip_address_type
     mapping:
       0: unknown
@@ -319,14 +316,12 @@ metric_tags:
       4: ipv6z
       16: dns
       25: l2vpn
-  - symbol:
-      OID: 1.3.6.1.4.1.5951.6.2.7.0
-      name: systemXenIPAddress
-      format: ip_address
+  - OID: 1.3.6.1.4.1.5951.6.2.7.0
+    symbol: systemXenIPAddress
+    # format: ip_address
     tag: netscaler_sdx_system_xen_ip_address
-  - symbol:
-      OID: 1.3.6.1.4.1.5951.6.2.8.0
-      name: systemNetmaskType
+  - OID: 1.3.6.1.4.1.5951.6.2.8.0
+    symbol: systemNetmaskType
     tag: netscaler_sdx_system_netmask_type
     mapping:
       0: unknown
@@ -336,14 +331,12 @@ metric_tags:
       4: ipv6z
       16: dns
       25: l2vpn
-  - symbol:
-      OID: 1.3.6.1.4.1.5951.6.2.9.0
-      name: systemNetmask
-      format: ip_address
+  - OID: 1.3.6.1.4.1.5951.6.2.9.0
+    symbol: systemNetmask
+    # format: ip_address
     tag: netscaler_sdx_system_netmask
-  - symbol:
-      OID: 1.3.6.1.4.1.5951.6.2.10.0
-      name: systemGatewayType
+  - OID: 1.3.6.1.4.1.5951.6.2.10.0
+    symbol: systemGatewayType
     tag: netscaler_sdx_system_gateway_type
     mapping:
       0: unknown
@@ -353,10 +346,9 @@ metric_tags:
       4: ipv6z
       16: dns
       25: l2vpn
-  - symbol:
-      OID: 1.3.6.1.4.1.5951.6.2.11.0
-      name: systemGateway
-      format: ip_address
+  - OID: 1.3.6.1.4.1.5951.6.2.11.0
+    symbol: systemGateway
+    # format: ip_address
     tag: netscaler_sdx_system_gateway
   - OID: 1.3.6.1.4.1.5951.6.2.12.0
     symbol: systemNetworkInterface


### PR DESCRIPTION
### What does this PR do?
Fix a typo in one of our out-of-the-box SNMP profiles.

Metric tags using the old syntax (where OID and name are top-level instead part of Symbol) don't support the `format` specifier, and it gets silently ignored by the YAML loader.

From a user perspective, the only thing that will change is that anyone using citrix netscaler SDX devices will suddenly see a few tags that are IP addresses be formatted as such instead of as raw bytes.

### Motivation

https://github.com/DataDog/datadog-agent/pull/31054 revealed this issue.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
