### PR TITLE
[postgres] add alloydbadmin & alloydbmetadata to default exclusion list

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -76,12 +76,16 @@ files:
           - rdsadmin
           - azure_maintenance
           - cloudsqladmin
+          - alloydbadmin
+          - alloydbmetadata
         default:
           - 'template0'
           - 'template1'
           - rdsadmin
           - azure_maintenance
           - cloudsqladmin
+          - alloydbadmin
+          - alloydbmetadata
     - name: ssl
       description: |
         This option determines whether or not and with what priority a secure SSL TCP/IP connection

--- a/postgres/changelog.d/19061.fixed
+++ b/postgres/changelog.d/19061.fixed
@@ -1,0 +1,1 @@
+Add alloydbadmin & alloydbmetadata to default list of databases to exclude from autodiscovery and databases to ignore to prevent failures on GCP AlloyDB for PostgreSQL.

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -17,6 +17,8 @@ DEFAULT_IGNORE_DATABASES = [
     'rdsadmin',
     'azure_maintenance',
     'cloudsqladmin',
+    'alloydbadmin',
+    'alloydbmetadata',
     'postgres',
 ]
 

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -89,7 +89,15 @@ def instance_idle_connection_timeout():
 
 
 def instance_ignore_databases():
-    return ['template0', 'template1', 'rdsadmin', 'azure_maintenance', 'cloudsqladmin']
+    return [
+        'template0',
+        'template1',
+        'rdsadmin',
+        'azure_maintenance',
+        'cloudsqladmin',
+        'alloydbadmin',
+        'alloydbmetadata',
+    ]
 
 
 def instance_log_unobfuscated_plans():

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -83,6 +83,8 @@ instances:
     #   - rdsadmin
     #   - azure_maintenance
     #   - cloudsqladmin
+    #   - alloydbadmin
+    #   - alloydbmetadata
 
     ## @param ssl - string - optional - default: allow
     ## This option determines whether or not and with what priority a secure SSL TCP/IP connection

--- a/postgres/datadog_checks/postgres/discovery.py
+++ b/postgres/datadog_checks/postgres/discovery.py
@@ -10,7 +10,7 @@ from datadog_checks.postgres.cursor import CommenterCursor
 from datadog_checks.postgres.util import DatabaseConfigurationError, warning_with_tags
 
 AUTODISCOVERY_QUERY: str = """select datname from pg_catalog.pg_database where datistemplate = false;"""
-DEFAULT_EXCLUDES = ["cloudsqladmin", "rdsadmin"]
+DEFAULT_EXCLUDES = ["cloudsqladmin", "rdsadmin", "alloydbadmin", "alloydbmetadata"]
 DEFAULT_MAX_DATABASES = 100
 DEFAULT_REFRESH = 600
 


### PR DESCRIPTION
### What does this PR do?
Similar to `cloudsqladmin`, this PR adds `alloydbadmin` & `alloydbmetadata` to default list of databases to exclude from autodiscovery and databases to ignore to prevent failures on Postgres on GCP AlloyDB.

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4770

https://github.com/DataDog/integrations-core/issues/18783

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
