### PR TITLE
Stop setting up Python2 for PRs in ints-core repo

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -46,7 +46,9 @@ jobs:
 
       # Options
       standard: true
-      test-py2: ${{ !matrix.python-support || contains(matrix.python-support, '2') }}
+      # We never test Python in integrations-core, but some partners may want to keep testing it
+      # in marketplace and integrations-extras.
+      test-py2: ${{ inputs.repo != 'core' && (!matrix.python-support || contains(matrix.python-support, '2')) }}
       test-py3: ${{ !matrix.python-support || contains(matrix.python-support, '3') }}
 
       # For other repositories

--- a/rabbitmq/datadog_checks/rabbitmq/openmetrics/check.py
+++ b/rabbitmq/datadog_checks/rabbitmq/openmetrics/check.py
@@ -5,6 +5,8 @@ from datadog_checks.base import OpenMetricsBaseCheckV2
 
 from . import metrics
 
+# test
+
 
 class RabbitMQOpenMetrics(OpenMetricsBaseCheckV2):
     __NAMESPACE__ = "rabbitmq"

--- a/rabbitmq/datadog_checks/rabbitmq/openmetrics/check.py
+++ b/rabbitmq/datadog_checks/rabbitmq/openmetrics/check.py
@@ -5,8 +5,6 @@ from datadog_checks.base import OpenMetricsBaseCheckV2
 
 from . import metrics
 
-# test
-
 
 class RabbitMQOpenMetrics(OpenMetricsBaseCheckV2):
     __NAMESPACE__ = "rabbitmq"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
All in the title.
validated with this run: https://github.com/DataDog/integrations-core/actions/runs/11854331621/job/33036295900?pr=19066

### Motivation
<!-- What inspired you to submit this pull request? -->
Simplest way to stop setting up Python 2 in integrations core.

I suspect the `compute_matrix.py` script may need a facelift, but I'll deal with that separately.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
