### PR TITLE
Enforce Python 3.12 requirement, drop tomli dependency

### DIFF
--- a/ddev/changelog.d/19067.removed
+++ b/ddev/changelog.d/19067.removed
@@ -1,0 +1,1 @@
+Drop support for Python versions older than 3.12 and remove tomli dependency

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "ddev"
 description = "The Datadog Agent integration developer tool"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 license = "BSD-3-Clause"
 keywords = [
     "datadog",
@@ -36,7 +36,6 @@ dependencies = [
     "pluggy",
     "rich>=12.5.1",
     "stamina==23.2.0",
-    "tomli; python_version < '3.11'",
     "tomli-w",
     "tomlkit",
     "tqdm",

--- a/ddev/src/ddev/integration/core.py
+++ b/ddev/src/ddev/integration/core.py
@@ -174,10 +174,10 @@ class Integration:
 
     @property
     def project_metadata(self) -> dict:
-        import tomli
+        import tomllib
 
         with open(self.project_file, 'rb') as f:
-            return tomli.load(f)
+            return tomllib.load(f)
 
     @cached_property
     def is_valid(self) -> bool:

--- a/ddev/src/ddev/utils/scripts/ci_matrix.py
+++ b/ddev/src/ddev/utils/scripts/ci_matrix.py
@@ -15,16 +15,11 @@ import os
 import re
 import subprocess
 import sys
+import tomllib
 from collections import defaultdict, namedtuple
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
-
-if sys.version_info[:2] >= (3, 11):
-    import tomllib
-# TODO: remove this once ddev drops versions less than 3.11
-else:
-    import tomli as tomllib
 
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idoutputs
 OUTPUT_LIMIT = 1024 * 1024

--- a/ddev/src/ddev/utils/toml.py
+++ b/ddev/src/ddev/utils/toml.py
@@ -1,12 +1,7 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import sys
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
+import tomllib
 
 
 def load_toml_data(data):

--- a/ddev/tests/cli/test_dep.py
+++ b/ddev/tests/cli/test_dep.py
@@ -2,10 +2,10 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import json
+import tomllib
 from unittest import mock
 
 import pytest
-import tomli
 import tomli_w
 
 
@@ -304,7 +304,7 @@ def fake_repo(tmp_path, config_file):
 
 def assert_dependencies(root, name, dependencies):
     with open(root / name / 'pyproject.toml', 'rb') as f:
-        assert tomli.load(f)['project']['optional-dependencies']['deps'] == dependencies
+        assert tomllib.load(f)['project']['optional-dependencies']['deps'] == dependencies
 
 
 def create_integration(root, name, dependencies):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
