### PR TITLE
Add tab for NTP containerized config

### DIFF
--- a/ntp/README.md
+++ b/ntp/README.md
@@ -27,11 +27,36 @@ The NTP check is included in the [Datadog Agent][1] package, so you don't need t
 
 ### Configuration
 
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Host" xxx -->
+
+#### Host
+
 The Agent enables the NTP check by default. To configure the check yourself, edit the file `ntp.d/conf.yaml` in the `conf.d/` folder at the root of your [Agent's configuration directory][2]. See the [sample ntp.d/conf.yaml][3] for all available configuration options.
 
 Outgoing UDP traffic over the port `123` should be allowed so the Agent can confirm that the local server time is reasonably accurate according to the Datadog NTP servers.
 
 **Note**: If you edit the Datadog-NTP check configuration file, [restart the Agent][4] to effect any configuration changes.
+
+<!-- xxz tab xxx -->
+
+<!-- xxx tab "Containerized" xxx -->
+
+#### Containerized
+
+For containerized environments, see the documentation concerning [Autodiscovery configurations][9] for guidance on applying the parameters below. See the sample [ntp.d/conf.yaml][10] for all available configuration options.
+
+##### Metric collection
+
+| Parameter            | Value                        |
+|----------------------|------------------------------|
+| `<INTEGRATION_NAME>` | `["ntp"]`                    |
+| `<INIT_CONFIG>`      | `[{}]`                       |
+| `<INSTANCE_CONFIG>`  | `[{"host": "<NTP_SERVER>"}]` |
+
+<!-- xxz tab xxx -->
+
+<!-- xxz tabs xxx -->
 
 ### Validation
 
@@ -62,3 +87,5 @@ Need help? Contact [Datadog support][8].
 [6]: https://github.com/DataDog/integrations-core/blob/master/ntp/metadata.csv
 [7]: https://github.com/DataDog/integrations-core/blob/master/ntp/assets/service_checks.json
 [8]: https://docs.datadoghq.com/help/
+[9]: https://docs.datadoghq.com/containers/kubernetes/integrations/?tab=annotations#configuration
+[10]: https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/dist/conf.d/ntp.d/conf.yaml.default


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adding a tab for containerized config: https://datadoghq.atlassian.net/browse/DOCS-9517

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
