### PR TITLE
Speed Up Trace Uploads in GHA

### DIFF
--- a/.ddev/ci/scripts/traces.py
+++ b/.ddev/ci/scripts/traces.py
@@ -40,10 +40,8 @@ def replay(*, record_file: str, port: int) -> None:
             record = json.loads(line)
             path = record['path']
             body = b64decode(record['body'])
-
-            print(f'PUT {path} {len(body)} bytes: ', end='')
             conn.request('PUT', path, body=body, headers=record['headers'])
-            print(conn.getresponse().read().decode('utf-8'))
+            print(conn.getresponse().status, conn.getresponse().reason)
 
 
 def main():

--- a/.ddev/ci/scripts/traces.py
+++ b/.ddev/ci/scripts/traces.py
@@ -41,7 +41,8 @@ def replay(*, record_file: str, port: int) -> None:
             path = record['path']
             body = b64decode(record['body'])
             conn.request('PUT', path, body=body, headers=record['headers'])
-            print(conn.getresponse().status, conn.getresponse().reason)
+            response = conn.getresponse()
+            print(response.status, response.reason)
 
 
 def main():

--- a/.ddev/ci/scripts/traces.py
+++ b/.ddev/ci/scripts/traces.py
@@ -42,6 +42,7 @@ def replay(*, record_file: str, port: int) -> None:
             body = b64decode(record['body'])
             conn.request('PUT', path, body=body, headers=record['headers'])
             response = conn.getresponse()
+            response.read() # Needs to be done to prevent ResponseNotReady.
             print(response.status, response.reason)
 
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
     - master
-  pull_request: # DELETEME
-    branches:
-    - master
 
 jobs:
   cache:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
     - master
+  pull_request: # DELETEME
+    branches:
+    - master
 
 jobs:
   cache:

--- a/.github/workflows/submit-traces.yml
+++ b/.github/workflows/submit-traces.yml
@@ -21,7 +21,7 @@ jobs:
           DD_API_KEY: "${{ secrets.DD_API_KEY }}"
           DD_HOSTNAME: "none"
           DD_INSIDE_CI: "true"
-          DD_LOG_LEVEL: "trace"
+          DD_LOG_LEVEL: "warn"
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
### Motivation

@vivek-datadog noticed that the "Upload Traces" workflow in CI was taking half to two-thirds of the total test time, on master test runs. Optimizing that part is definitely a low-hanging fruit!
### What does this PR do?

This PR speeds up the "trace upload" workflow so that it runs in 2 minutes instead of 50 minutes, for the master test runs. The total test time was 1.5 - 2 hours before this change.

A large amount of logging was slowing down the GitHub actions job. 

The agent log level is now set to "warn" instead of "trace". Also, only the test name and the HTTP status code are now printed, instead of the full response from the Agent:

```
/// Replaying: Appgate SDP
200 OK
200 OK
/// Replaying: ArangoDB
200 OK
/// Replaying: Argo Rollouts
200 OK
/// Replaying: Argo Workflows
200 OK
/// Replaying: ArgoCD
200 OK
/// Replaying: Avi Vantage
200 OK
200 OK
200 OK
```

Example fast trace upload (with the changes in this PR): https://github.com/DataDog/integrations-core/actions/runs/11895100489/job/33147224198?pr=19078
Example slow speed (without the changes in this PR): https://github.com/DataDog/integrations-core/actions/runs/11862839027/job/33064564080

This PR probably won't have a big impact on PR test runs (unless a lot of integrations are modified).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
