### PR TITLE
[mongo] gracefully fail on operation samples colleciton when node is in recovering mode

### DIFF
--- a/mongo/changelog.d/19080.fixed
+++ b/mongo/changelog.d/19080.fixed
@@ -1,0 +1,2 @@
+Fix crash in DBM operation samples collection when a node is in recovering mode.
+

--- a/mongo/datadog_checks/mongo/dbm/operation_samples.py
+++ b/mongo/datadog_checks/mongo/dbm/operation_samples.py
@@ -108,6 +108,9 @@ class MongoOperationSamples(DBMAsyncJob):
         if isinstance(deployment, ReplicaSetDeployment) and deployment.is_arbiter:
             self._check.log.debug("Skipping operation samples collection on arbiter node")
             return False
+        elif isinstance(deployment, ReplicaSetDeployment) and deployment.replset_state == 3:
+            self._check.log.debug("Skipping operation samples collection on node in recovering state")
+            return False
         return True
 
     def _get_operation_samples(self, now, databases_monitored: List[str]):

--- a/mongo/tests/test_dbm_operation_samples.py
+++ b/mongo/tests/test_dbm_operation_samples.py
@@ -5,7 +5,9 @@
 import json
 import os
 
+import mock
 import pytest
+from pymongo.errors import NotPrimaryError
 
 from . import common
 from .common import HERE
@@ -105,3 +107,32 @@ def test_mongo_operation_samples_arbiter(aggregator, instance_arbiter, check, dd
 
     assert len(dbm_samples) == 0
     assert len(dbm_activities) == 0
+
+
+@mock_now(1715911398.1112723)
+@common.standalone
+def test_mongo_operation_samples_standalone_not_primary(
+    aggregator, instance_integration_cluster_autodiscovery, check, dd_run_check
+):
+    instance_integration_cluster_autodiscovery['dbm'] = True
+    instance_integration_cluster_autodiscovery['operation_samples'] = {'enabled': True, 'run_sync': True}
+    instance_integration_cluster_autodiscovery['slow_operations'] = {'enabled': False}
+    instance_integration_cluster_autodiscovery['schemas'] = {'enabled': False}
+
+    mongo_check = check(instance_integration_cluster_autodiscovery)
+    with mock_pymongo("standalone"):
+        with mock.patch(
+            'datadog_checks.mongo.api.MongoApi.current_op', new_callable=mock.PropertyMock
+        ) as mock_current_op:
+            mock_current_op.side_effect = NotPrimaryError("node is recovering")
+            aggregator.reset()
+            run_check_once(mongo_check, dd_run_check)
+
+    # we will not assert the metrics, as they are already tested in test_integration.py
+    # we will only assert the operation sample and activity events
+    dbm_activities = aggregator.get_event_platform_events("dbm-activity")
+
+    activity_samples = [event for event in dbm_activities if event['dbm_type'] == 'activity']
+
+    assert activity_samples is not None
+    assert len(activity_samples[0]['mongodb_activity']) == 0


### PR DESCRIPTION
### What does this PR do?
Fixes a bug that caused the MongoDB DBM operation samples collection to crash when a node is in recovering mode.

### Motivation
Previously, the DBM operation samples collection could crash with a `NotPrimaryError` if a node entered recovering mode. This situation often occurs when a MongoDB node is disconnected from the replica set for an extended period and is catching up on replication after rejoining the set. This PR ensures the integration can gracefully handle nodes in recovery, preventing unexpected crashes.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
