### PR TITLE
Add permissions to the test-results-master and test-results-pr workflows in GitHub Actions

### DIFF
--- a/.github/workflows/test-results-master.yml
+++ b/.github/workflows/test-results-master.yml
@@ -16,6 +16,11 @@ jobs:
       BADGES_BRANCH: badges
       BADGE_PATH: test-results.svg
 
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: write
+
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/test-results-pr.yml
+++ b/.github/workflows/test-results-pr.yml
@@ -12,6 +12,11 @@ jobs:
     name: Publish test results
     runs-on: ubuntu-22.04
 
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: write
+      
     steps:
     - name: Download and extract artifacts
       id: download


### PR DESCRIPTION
### What does this PR do?
Add permissions for the [EnricoMi/publish-unit-test-result-action@v2](https://github.com/EnricoMi/publish-unit-test-result-action) and the [emibcn/badge-action@v2.0.3 actions](https://github.com/emibcn/badge-action). They will be needed when we set default workflow permissions to *read-only* for the repo.

For the GitHub Action to Publish Test Results, the required permissions are documented.
For for Badge action, I ran an [experiment](https://github.com/nubtron/badge-action-experiment/actions/runs/11931462935/job/33254376136) to see which permissions are needed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
