### PR TITLE
[DBM] - Use alternative query for sqlserver 2016 and older

### DIFF
--- a/sqlserver/changelog.d/19110.fixed
+++ b/sqlserver/changelog.d/19110.fixed
@@ -1,0 +1,1 @@
+Use alternative schema collection query for sqlserver 2016 and older due to STRING_AGG not being supported until SQLServer 2017

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -79,6 +79,7 @@ WHERE
 GROUP BY
     i.object_id,
     i.name,
+    i.index_id,
     i.type,
     i.is_unique,
     i.is_primary_key,
@@ -126,6 +127,7 @@ WHERE
 GROUP BY
     FK.name,
     FK.parent_object_id,
+    FK.object_id,
     FK.referenced_object_id;
 """
 

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -57,6 +57,35 @@ WHERE
     i.is_unique, i.is_primary_key, i.is_unique_constraint, i.is_disabled;
 """
 
+INDEX_QUERY_PRE_2017 = """
+SELECT
+    i.object_id AS id,
+    i.name,
+    i.type,
+    i.is_unique,
+    i.is_primary_key,
+    i.is_unique_constraint,
+    i.is_disabled,
+    STUFF((
+        SELECT ',' + c.name
+        FROM sys.index_columns ic
+        JOIN sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id
+        WHERE ic.object_id = i.object_id AND ic.index_id = i.index_id
+        FOR XML PATH(''), TYPE).value('.', 'NVARCHAR(MAX)'), 1, 1, '') AS column_names
+FROM
+    sys.indexes i
+WHERE
+    i.object_id IN ({})
+GROUP BY
+    i.object_id,
+    i.name,
+    i.type,
+    i.is_unique,
+    i.is_primary_key,
+    i.is_unique_constraint,
+    i.is_disabled;
+"""
+
 FOREIGN_KEY_QUERY = """
 SELECT
     FK.parent_object_id AS id,
@@ -72,6 +101,32 @@ WHERE
     FK.parent_object_id IN ({})
 GROUP BY
     FK.name, FK.parent_object_id, FK.referenced_object_id;
+"""
+
+FOREIGN_KEY_QUERY_PRE_2017 = """
+SELECT
+    FK.parent_object_id AS id,
+    FK.name AS foreign_key_name,
+    OBJECT_NAME(FK.parent_object_id) AS referencing_table,
+    STUFF((
+        SELECT ',' + COL_NAME(FKC.parent_object_id, FKC.parent_column_id)
+        FROM sys.foreign_key_columns AS FKC
+        WHERE FKC.constraint_object_id = FK.object_id
+        FOR XML PATH(''), TYPE).value('.', 'NVARCHAR(MAX)'), 1, 1, '') AS referencing_column,
+    OBJECT_NAME(FK.referenced_object_id) AS referenced_table,
+    STUFF((
+        SELECT ',' + COL_NAME(FKC.referenced_object_id, FKC.referenced_column_id)
+        FROM sys.foreign_key_columns AS FKC
+        WHERE FKC.constraint_object_id = FK.object_id
+        FOR XML PATH(''), TYPE).value('.', 'NVARCHAR(MAX)'), 1, 1, '') AS referenced_column
+FROM
+    sys.foreign_keys AS FK
+WHERE
+    FK.parent_object_id IN ({})
+GROUP BY
+    FK.name,
+    FK.parent_object_id,
+    FK.referenced_object_id;
 """
 
 XE_SESSION_DATADOG = "datadog"


### PR DESCRIPTION
### What does this PR do?
Fixes the query for sqlserver versions <= 2016

Changes:
<img width="1208" alt="image" src="https://github.com/user-attachments/assets/dc378c47-b3ff-426f-9ebd-66d6b991db79">


### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
