### PR TITLE
Fix missing permissions in GitHub Actions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -29,11 +29,18 @@ jobs:
     secrets: inherit
 
   publish-test-results:
+    
     needs:
     - test
+
     if: success() || failure()
     concurrency:
       group: test-results
+
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: write
 
     uses: ./.github/workflows/test-results-master.yml
     secrets: inherit

--- a/.github/workflows/pr-quick-check.yml
+++ b/.github/workflows/pr-quick-check.yml
@@ -22,7 +22,8 @@ jobs:
 
     permissions:
       pull-requests: write
-      
+      contents: read
+
     steps:
     # Uncomment for testing purposes
     # - uses: actions/checkout@v4


### PR DESCRIPTION
### What does this PR do?

This PR adds a couple of missing permissions:
 * Permissions from ./.github/workflows/test-results-master.yml in master.yml, because parent job needs to specify the permissions of a child job. This fixes `The workflow is not valid. .github/workflows/master.yml` in the master CI check.
 * Read permissions in pr-quick-check, because manually specifying a permission sets all others to 'none', including read ones.



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
