### PR TITLE
Stop git from ignoring zip files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
-*.zip
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Git no longer ignores `.zip` files.

### Motivation
<!-- What inspired you to submit this pull request? -->
We have some test data committed that's in zipfiles. For instance, `datadog_checks_downloader/tests/data`. I have no idea how it made it past the ignore file [when it got added at first](https://github.com/DataDog/integrations-core/pull/12584). Now I need to add another zip file to that folder and I'm blocked by `.gitignore`.

I can't find why zipfiles are being ignored. The PR that introduces this together with an integration gives no explanation.

Just to be sure I ran some `redisdb` tests and those didn't add any stray zipfiles.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
