### PR TITLE
Add `mysql.performance.performance_schema_digest_lost`

### DIFF
--- a/mysql/changelog.d/19121.added
+++ b/mysql/changelog.d/19121.added
@@ -1,0 +1,1 @@
+Add `mysql.performance.performance_schema_digest_lost`, the number of digest instances that could not be instrumented in the `events_statements_summary_by_digest` table.

--- a/mysql/datadog_checks/mysql/const.py
+++ b/mysql/datadog_checks/mysql/const.py
@@ -119,6 +119,7 @@ OPTIONAL_STATUS_VARS = {
     'Handler_update': ('mysql.performance.handler_update', RATE),
     'Handler_write': ('mysql.performance.handler_write', RATE),
     'Opened_tables': ('mysql.performance.opened_tables', RATE),
+    'Performance_schema_digest_lost': ('mysql.performance.performance_schema_digest_lost', GAUGE),
     'Qcache_total_blocks': ('mysql.performance.qcache_total_blocks', GAUGE),
     'Qcache_free_blocks': ('mysql.performance.qcache_free_blocks', GAUGE),
     'Qcache_free_memory': ('mysql.performance.qcache_free_memory', GAUGE),

--- a/mysql/datadog_checks/mysql/const.py
+++ b/mysql/datadog_checks/mysql/const.py
@@ -39,6 +39,8 @@ STATUS_VARS = {
     # Table Cache Metrics
     'Open_files': ('mysql.performance.open_files', GAUGE),
     'Open_tables': ('mysql.performance.open_tables', GAUGE),
+    # Performance schema metrics
+    'Performance_schema_digest_lost': ('mysql.performance.performance_schema_digest_lost', GAUGE),
     # Network Metrics
     'Bytes_sent': ('mysql.performance.bytes_sent', RATE),
     'Bytes_received': ('mysql.performance.bytes_received', RATE),
@@ -119,7 +121,6 @@ OPTIONAL_STATUS_VARS = {
     'Handler_update': ('mysql.performance.handler_update', RATE),
     'Handler_write': ('mysql.performance.handler_write', RATE),
     'Opened_tables': ('mysql.performance.opened_tables', RATE),
-    'Performance_schema_digest_lost': ('mysql.performance.performance_schema_digest_lost', GAUGE),
     'Qcache_total_blocks': ('mysql.performance.qcache_total_blocks', GAUGE),
     'Qcache_free_blocks': ('mysql.performance.qcache_free_blocks', GAUGE),
     'Qcache_free_memory': ('mysql.performance.qcache_free_memory', GAUGE),

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -170,6 +170,7 @@ mysql.performance.max_prepared_stmt_count,gauge,,,,The maximum allowed prepared 
 mysql.performance.open_files,gauge,,file,,The number of open files.,0,mysql,open files,
 mysql.performance.open_tables,gauge,,table,,The number of of tables that are open.,0,mysql,open tables,
 mysql.performance.opened_tables,gauge,,table,second,"The number of tables that have been opened. If `opened_tables` is big, your `table_open_cache` value is probably too small.",0,mysql,mysql performance opened_tables,
+mysql.performance.performance_schema_digest_lost,gauge,,,,The number of digest instances that could not be instrumented in the events_statements_summary_by_digest table. This can be nonzero if the value of performance_schema_digests_size is too small.,0,mysql,mysql performance performance schema digest lost,
 mysql.performance.prepared_stmt_count,gauge,,query,second,The current number of prepared statements.,0,mysql,current prepared statements,
 mysql.performance.qcache.utilization,gauge,,fraction,,Fraction of the query cache memory currently being used.,0,mysql,mysql performance qcache utilization,
 mysql.performance.qcache_free_blocks,gauge,,block,,The number of free memory blocks in the query cache.,0,mysql,mysql performance qcache_free_blocks,

--- a/mysql/tests/variables.py
+++ b/mysql/tests/variables.py
@@ -137,6 +137,7 @@ OPTIONAL_STATUS_VARS = [
     'mysql.performance.handler_update',
     'mysql.performance.handler_write',
     'mysql.performance.opened_tables',
+    'mysql.performance.performance_schema_digest_lost',
     'mysql.performance.qcache_total_blocks',
     'mysql.performance.qcache_free_blocks',
     'mysql.performance.qcache_free_memory',

--- a/mysql/tests/variables.py
+++ b/mysql/tests/variables.py
@@ -25,6 +25,8 @@ STATUS_VARS = [
     # Table Cache Metrics
     'mysql.performance.open_files',
     'mysql.performance.open_tables',
+    # Performance schema metrics
+    'mysql.performance.performance_schema_digest_lost',
     # Network Metrics
     'mysql.performance.bytes_sent',
     'mysql.performance.bytes_received',
@@ -137,7 +139,6 @@ OPTIONAL_STATUS_VARS = [
     'mysql.performance.handler_update',
     'mysql.performance.handler_write',
     'mysql.performance.opened_tables',
-    'mysql.performance.performance_schema_digest_lost',
     'mysql.performance.qcache_total_blocks',
     'mysql.performance.qcache_free_blocks',
     'mysql.performance.qcache_free_memory',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add new metrics.

> The number of digest instances that could not be instrumented in the [events_statements_summary_by_digest](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-statement-summary-tables.html) table. This can be nonzero if the value of [performance_schema_digests_size](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-system-variables.html#sysvar_performance_schema_digests_size) is too small.
https://dev.mysql.com/doc/refman/8.4/en/performance-schema-status-variables.html#statvar_Performance_schema_digest_lost

### Motivation
<!-- What inspired you to submit this pull request? -->

[Advanced Configuration for MySQL Database Monitoring](https://github.com/DataDog/documentation/blob/a8d2b8b22c173059c018e09076e8ff1326277f02/content/en/database_monitoring/setup_mysql/advanced_configuration.md?plain=1#L17-L21) in our doc says ...

> To determine the frequency of truncation, run the query below to determine the number of statements sent to this catch-all row per second. A value greater than zero means the table is full and should be truncated.
```sql
SHOW STATUS LIKE 'Performance_schema_digest_lost';
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
