### PR TITLE
Fix duplicate deadlock events

### DIFF
--- a/sqlserver/changelog.d/19139.fixed
+++ b/sqlserver/changelog.d/19139.fixed
@@ -1,0 +1,1 @@
+Fix duplicate deadlock events

--- a/sqlserver/datadog_checks/sqlserver/deadlocks.py
+++ b/sqlserver/datadog_checks/sqlserver/deadlocks.py
@@ -151,14 +151,15 @@ class Deadlocks(DBMAsyncJob):
                 query = get_deadlocks_query(
                     convert_xml_to_str=convert_xml_to_str, xe_session_name=self._xe_session_name
                 )
+                lookback = self._get_lookback_seconds()
                 self._log.debug(
-                    "Running query [%s] with max deadlocks %s and timestamp %s",
+                    "Running query %s with max deadlocks %s and timestamp %s",
                     query,
                     self._max_deadlocks,
-                    self._last_deadlock_timestamp,
+                    lookback,
                 )
                 try:
-                    cursor.execute(query, (self._max_deadlocks, self._get_lookback_seconds()))
+                    cursor.execute(query, (self._max_deadlocks, lookback))
                 except Exception as e:
                     if "Data column of Unknown ADO type" in str(e):
                         raise Exception(f"{str(e)} | cursor.description: {cursor.description} | query: {query}")

--- a/sqlserver/datadog_checks/sqlserver/deadlocks.py
+++ b/sqlserver/datadog_checks/sqlserver/deadlocks.py
@@ -153,7 +153,7 @@ class Deadlocks(DBMAsyncJob):
                 )
                 lookback = self._get_lookback_seconds()
                 self._log.debug(
-                    "Running query %s with max deadlocks %s and timestamp %s",
+                    "Running query %s with max deadlocks %s and lookback %s",
                     query,
                     self._max_deadlocks,
                     lookback,

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -171,5 +171,6 @@ def get_deadlocks_query(convert_xml_to_str=False, xe_session_name="datadog"):
                 AND xt.target_name = N'ring_buffer'
         ) AS XML_Data
     CROSS APPLY Target_Data.nodes('RingBufferTarget/event[@name="xml_deadlock_report"]') AS XEventData(xdr)
-    WHERE xdr.value('@timestamp', 'datetime') >= DATEADD(SECOND, ?, GETDATE())
+    WHERE xdr.value('@timestamp', 'datetime') 
+        >= DATEADD(SECOND, ?, TODATETIMEOFFSET(GETDATE(), DATEPART(TZOFFSET, SYSDATETIMEOFFSET())) AT TIME ZONE 'UTC')
     ;"""

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -171,6 +171,6 @@ def get_deadlocks_query(convert_xml_to_str=False, xe_session_name="datadog"):
                 AND xt.target_name = N'ring_buffer'
         ) AS XML_Data
     CROSS APPLY Target_Data.nodes('RingBufferTarget/event[@name="xml_deadlock_report"]') AS XEventData(xdr)
-    WHERE xdr.value('@timestamp', 'datetime') 
+    WHERE xdr.value('@timestamp', 'datetime')
         >= DATEADD(SECOND, ?, TODATETIMEOFFSET(GETDATE(), DATEPART(TZOFFSET, SYSDATETIMEOFFSET())) AT TIME ZONE 'UTC')
     ;"""


### PR DESCRIPTION
### What does this PR do?
Fix duplicate deadlock events.

### Motivation
The deadlock query compares the UTC deadlock timestamp with the local time, which can cause duplicate events in non-UTC databases

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
