### PR TITLE
Remove Private Beta label from Mongo conf

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -166,9 +166,6 @@ files:
     - name: dbm
       description: |
         Set to `true` enable Database Monitoring.
-        
-        NOTE: Database Monitoring for MongoDB is currently in private beta.
-        If you are interested in participating, please reach out to your Datadog Customer Success Manager.
       enabled: false
       value:
         type: boolean

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -145,9 +145,6 @@ instances:
 
     ## @param dbm - boolean - optional - default: false
     ## Set to `true` enable Database Monitoring.
-    ##
-    ## NOTE: Database Monitoring for MongoDB is currently in private beta.
-    ## If you are interested in participating, please reach out to your Datadog Customer Success Manager.
     #
     # dbm: false
 


### PR DESCRIPTION
### What does this PR do?
Removes "Private Beta" label from DBM Mongo conf setting since Mongo is GA since October 2024

### Motivation
Customer question

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
