### PR TITLE
Add `MAX_PAGES` to Sonarqube API request

### DIFF
--- a/sonarqube/changelog.d/19145.added
+++ b/sonarqube/changelog.d/19145.added
@@ -1,1 +1,0 @@
-Add MAX_PAGES to Sonarqube API request

--- a/sonarqube/changelog.d/19145.added
+++ b/sonarqube/changelog.d/19145.added
@@ -1,0 +1,1 @@
+Add MAX_PAGES to Sonarqube API request

--- a/sonarqube/changelog.d/19149.added
+++ b/sonarqube/changelog.d/19149.added
@@ -1,0 +1,1 @@
+Add `MAX_PAGES` to Sonarqube API request

--- a/sonarqube/datadog_checks/sonarqube/check.py
+++ b/sonarqube/datadog_checks/sonarqube/check.py
@@ -7,7 +7,7 @@ from requests.exceptions import RequestException
 
 from datadog_checks.base import AgentCheck, ConfigurationError
 
-from .constants import CATEGORIES, NUMERIC_TYPES
+from .constants import CATEGORIES, NUMERIC_TYPES, MAX_PAGES
 
 
 class SonarqubeCheck(AgentCheck):
@@ -111,7 +111,7 @@ class SonarqubeCheck(AgentCheck):
         page = 1
         seen = 0
         total = -1
-        while seen != total:
+        while seen != total and page <= MAX_PAGES:
             response = self.http.get('{}/api/metrics/search'.format(self._web_endpoint), params={'p': page})
             response.raise_for_status()
             self.log.debug('/api/metrics/search response: %s', response.json())
@@ -136,7 +136,7 @@ class SonarqubeCheck(AgentCheck):
         page = 1
         seen = 0
         total = -1
-        while seen != total:
+        while seen != total and page <= MAX_PAGES:
             response = self.http.get(
                 '{}/api/components/search'.format(self._web_endpoint), params={'qualifiers': 'TRK', 'p': page}
             )

--- a/sonarqube/datadog_checks/sonarqube/check.py
+++ b/sonarqube/datadog_checks/sonarqube/check.py
@@ -7,7 +7,7 @@ from requests.exceptions import RequestException
 
 from datadog_checks.base import AgentCheck, ConfigurationError
 
-from .constants import CATEGORIES, NUMERIC_TYPES, MAX_PAGES
+from .constants import CATEGORIES, MAX_PAGES, NUMERIC_TYPES
 
 
 class SonarqubeCheck(AgentCheck):

--- a/sonarqube/datadog_checks/sonarqube/constants.py
+++ b/sonarqube/datadog_checks/sonarqube/constants.py
@@ -5,6 +5,8 @@
 # <WEB_ENDPOINT>/api/metrics/types
 NUMERIC_TYPES = {'BOOL', 'FLOAT', 'INT', 'PERCENT', 'RATING'}
 
+MAX_PAGES = 100
+
 # All `domain` attributes found in: <WEB_ENDPOINT>/api/metrics/search
 CATEGORIES = {
     'Complexity': 'complexity',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR sets the max number of pages our Sonarqube integration can query through

### Motivation
<!-- What inspired you to submit this pull request? -->
It's not possible to browse more than 10,000 results. This limitation to 10000 results applies to web services that are backed by ElasticSearch index. Searching more than this results in the below error:
```
"message": "400 Client Error:  for url: http://[2600:1f18:1bbd:6503:f9cf::3]:9000/api/components/search?qualifiers=TRK\u0026p=101",
```
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
