### PR TITLE
[PLINT-484]  Add support for deployment logs

### DIFF
--- a/octopus_deploy/assets/configuration/spec.yaml
+++ b/octopus_deploy/assets/configuration/spec.yaml
@@ -102,4 +102,8 @@ files:
         headers.value.example:
           X-Octopus-ApiKey: "<OCTOPUS_API_KEY>"
         auth_token.display_priority: 4
-
+  - template: logs
+    example:
+    - type: integration
+      source: octopus-deploy
+      service: <SERVICE_NAME>

--- a/octopus_deploy/datadog_checks/octopus_deploy/check.py
+++ b/octopus_deploy/datadog_checks/octopus_deploy/check.py
@@ -266,6 +266,7 @@ class OctopusDeployCheck(AgentCheck, ConfigMixin):
                 f'task_id:{task_id}',
                 f'task_name:{task_name}',
                 f'task_state:{task.get("State")}',
+                f'server_node:{task.get("ServerNode")}',
             ]
             self.log.debug("Processing task id %s for project %s", task_id, project_name)
             queued_time, executing_time, completed_time = self._calculate_task_times(task)

--- a/octopus_deploy/datadog_checks/octopus_deploy/check.py
+++ b/octopus_deploy/datadog_checks/octopus_deploy/check.py
@@ -260,13 +260,15 @@ class OctopusDeployCheck(AgentCheck, ConfigMixin):
         for task in tasks_json:
             task_id = task.get("Id")
             task_name = task.get("Name")
+            server_node = task.get("ServerNode")
+            task_state = task.get("State")
             tags = self._base_tags + [
                 f'space_name:{space_name}',
                 f'project_name:{project_name}',
                 f'task_id:{task_id}',
                 f'task_name:{task_name}',
-                f'task_state:{task.get("State")}',
-                f'server_node:{task.get("ServerNode")}',
+                f'task_state:{task_state}',
+                f'server_node:{server_node}',
             ]
             self.log.debug("Processing task id %s for project %s", task_id, project_name)
             queued_time, executing_time, completed_time = self._calculate_task_times(task)

--- a/octopus_deploy/datadog_checks/octopus_deploy/check.py
+++ b/octopus_deploy/datadog_checks/octopus_deploy/check.py
@@ -10,7 +10,7 @@ from requests.exceptions import ConnectionError, HTTPError, InvalidURL, Timeout
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.errors import CheckException
 from datadog_checks.base.utils.discovery.discovery import Discovery
-from datadog_checks.base.utils.time import get_current_datetime
+from datadog_checks.base.utils.time import get_current_datetime, get_timestamp
 from datadog_checks.octopus_deploy.config_models.instance import ProjectGroups, Projects
 
 from .config_models import ConfigMixin
@@ -216,7 +216,7 @@ class OctopusDeployCheck(AgentCheck, ConfigMixin):
         self.log.debug("Collecting running and queued tasks for project %s", project_name)
         params = {'project': project_id, 'states': ["Queued", "Executing"]}
         response_json = self._process_endpoint(f"api/{space_id}/tasks", params)
-        self._process_tasks(space_name, project_name, response_json.get('Items', []))
+        self._process_tasks(space_id, space_name, project_name, response_json.get('Items', []))
 
     def _process_completed_tasks(self, space_id, space_name, project_id, project_name):
         self.log.debug("Collecting completed tasks for project %s", project_name)
@@ -226,7 +226,7 @@ class OctopusDeployCheck(AgentCheck, ConfigMixin):
             'toCompletedDate': self._to_completed_time,
         }
         response_json = self._process_endpoint(f"api/{space_id}/tasks", params)
-        self._process_tasks(space_name, project_name, response_json.get('Items', []))
+        self._process_tasks(space_id, space_name, project_name, response_json.get('Items', []))
 
     def _calculate_task_times(self, task):
         task_queue_time = task.get("QueueTime")
@@ -255,15 +255,16 @@ class OctopusDeployCheck(AgentCheck, ConfigMixin):
             completed_time = -1
         return queued_time, executing_time, completed_time
 
-    def _process_tasks(self, space_name, project_name, tasks_json):
+    def _process_tasks(self, space_id, space_name, project_name, tasks_json):
         self.log.debug("Discovered %s tasks for project %s", len(tasks_json), project_name)
         for task in tasks_json:
             task_id = task.get("Id")
+            task_name = task.get("Name")
             tags = self._base_tags + [
                 f'space_name:{space_name}',
                 f'project_name:{project_name}',
                 f'task_id:{task_id}',
-                f'task_name:{task.get("Name")}',
+                f'task_name:{task_name}',
                 f'task_state:{task.get("State")}',
             ]
             self.log.debug("Processing task id %s for project %s", task_id, project_name)
@@ -272,8 +273,13 @@ class OctopusDeployCheck(AgentCheck, ConfigMixin):
             self.gauge("deployment.queued_time", queued_time, tags=tags)
             if executing_time != -1:
                 self.gauge("deployment.executing_time", executing_time, tags=tags)
-            if executing_time != -1:
+
+            if completed_time != -1:
                 self.gauge("deployment.completed_time", completed_time, tags=tags)
+
+                if self.logs_enabled:
+                    self.log.debug("Collecting logs for task %s, id: %s", task_name, task_id)
+                    self._collect_deployment_logs(space_id, task_id, tags)
 
     def _collect_server_nodes_metrics(self):
         self.log.debug("Collecting server node metrics.")
@@ -290,6 +296,28 @@ class OctopusDeployCheck(AgentCheck, ConfigMixin):
             self.gauge("server_node.count", 1, tags=self._base_tags + server_tags)
             self.gauge("server_node.in_maintenance_mode", maintenance_mode, tags=self._base_tags + server_tags)
             self.gauge("server_node.max_concurrent_tasks", max_tasks, tags=self._base_tags + server_tags)
+
+    def _collect_deployment_logs(self, space_id, task_id, tags):
+        url = f"api/{space_id}/tasks/{task_id}/details"
+        activity_logs = self._process_endpoint(url).get('ActivityLogs', [])
+        self._submit_activity_logs(activity_logs, tags)
+
+    def _submit_activity_logs(self, activity_logs, tags):
+        for log in activity_logs:
+            name = log.get("Name")
+            log_elements = log.get("LogElements", [])
+            children = log.get("Children", [])
+
+            for log_element in log_elements:
+                payload = {}
+                payload['ddtags'] = ",".join(tags)
+                payload['message'] = log_element.get("MessageText")
+                payload['timestamp'] = get_timestamp(datetime.datetime.fromisoformat(log_element.get("OccurredAt")))
+                payload['status'] = log_element.get("Category")
+                payload['stage_name'] = name
+                self.send_log(payload)
+
+            self._submit_activity_logs(children, tags)
 
 
 # Discovery class requires 'include' to be a dict, so this function is needed to normalize the config

--- a/octopus_deploy/datadog_checks/octopus_deploy/data/conf.yaml.example
+++ b/octopus_deploy/datadog_checks/octopus_deploy/data/conf.yaml.example
@@ -413,3 +413,23 @@ instances:
     ## Whether or not to allow URL redirection.
     #
     # allow_redirects: true
+
+## Log Section
+##
+## type - required - Type of log input source (tcp / udp / file / windows_event).
+## port / path / channel_path - required - Set port if type is tcp or udp.
+##                                         Set path if type is file.
+##                                         Set channel_path if type is windows_event.
+## source  - required - Attribute that defines which integration sent the logs.
+## encoding - optional - For file specifies the file encoding. Default is utf-8. Other
+##                       possible values are utf-16-le and utf-16-be.
+## service - optional - The name of the service that generates the log.
+##                      Overrides any `service` defined in the `init_config` section.
+## tags - optional - Add tags to the collected logs.
+##
+## Discover Datadog log collection: https://docs.datadoghq.com/logs/log_collection/
+#
+# logs:
+#   - type: integration
+#     source: octopus-deploy
+#     service: <SERVICE_NAME>

--- a/octopus_deploy/tests/constants.py
+++ b/octopus_deploy/tests/constants.py
@@ -44,7 +44,6 @@ E2E_METRICS = [
     "octopus_deploy.deployment.count",
     "octopus_deploy.deployment.queued_time",
     "octopus_deploy.deployment.executing_time",
-    "octopus_deploy.deployment.completed_time",
     "octopus_deploy.server_node.count",
     "octopus_deploy.server_node.in_maintenance_mode",
     "octopus_deploy.server_node.max_concurrent_tasks",

--- a/octopus_deploy/tests/constants.py
+++ b/octopus_deploy/tests/constants.py
@@ -24,7 +24,6 @@ LAB_INSTANCE = {
 BASE_TIME = ensure_aware_datetime(datetime.datetime.strptime("2024-09-23 14:45:58.888492", '%Y-%m-%d %H:%M:%S.%f'))
 MOCKED_TIMESTAMPS = [BASE_TIME] * 20
 
-
 ALL_METRICS = [
     "octopus_deploy.space.count",
     "octopus_deploy.project_group.count",
@@ -36,4 +35,336 @@ ALL_METRICS = [
     "octopus_deploy.server_node.count",
     "octopus_deploy.server_node.in_maintenance_mode",
     "octopus_deploy.server_node.max_concurrent_tasks",
+]
+
+ALL_DEPLOYMENT_LOGS = [
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'The deployment failed because one or more steps failed. Please see the deployment log for details.',
+        'timestamp': 1727104203218,
+        'status': 'Fatal',
+        'stage_name': 'Deploy test release 0.0.2 to Development',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'hello',
+        'timestamp': 1727104198525,
+        'status': 'Info',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': "The step failed: Activity Run a Script on the Octopus Server failed with error "
+        "'The remote script failed with exit code 1'.",
+        'timestamp': 1727104202767,
+        'status': 'Fatal',
+        'stage_name': 'Step 2: Run a Script',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'ParserError: At /home/octopus/.octopus/OctopusServer/Server/Work/'
+        '09234928998123-1847-68/Script.ps1:1 char:6',
+        'timestamp': 1727104202599,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': '+ echo "stop',
+        'timestamp': 1727104202599,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': '+      ~~~~~',
+        'timestamp': 1727104202599,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'The string is missing the terminator: ".',
+        'timestamp': 1727104202599,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'At /home/octopus/.octopus/OctopusServer/Server/Work/09234928998123-1847-68/Script.ps1:1 char:6',
+        'timestamp': 1727104202605,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': '+ echo "stop',
+        'timestamp': 1727104202605,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': '+      ~~~~~',
+        'timestamp': 1727104202605,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'at <ScriptBlock>, <No file>: line 1',
+        'timestamp': 1727104202606,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'at <ScriptBlock>, /home/octopus/.octopus/OctopusServer/Server/Work/09234928998123-1847-68/'
+        'Octopus.FunctionAppenderContext.ps1: line 258',
+        'timestamp': 1727104202606,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'at <ScriptBlock>, /home/octopus/.octopus/OctopusServer/Server/Work/09234928998123-1847-68/'
+        'Bootstrap.Octopus.FunctionAppenderContext.ps1: line 1505',
+        'timestamp': 1727104202607,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'at <ScriptBlock>, <No file>: line 1',
+        'timestamp': 1727104202607,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'at <ScriptBlock>, <No file>: line 1',
+        'timestamp': 1727104202607,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'The remote script failed with exit code 1',
+        'timestamp': 1727104202733,
+        'status': 'Fatal',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'The action Run a Script on the Octopus Server failed',
+        'timestamp': 1727104202758,
+        'status': 'Fatal',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1846,task_name:Deploy,task_state:Success',
+        'message': 'The deployment completed successfully.',
+        'timestamp': 1727103628255,
+        'status': 'Info',
+        'stage_name': 'Deploy test release 0.0.1 to Staging',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1846,task_name:Deploy,task_state:Success',
+        'message': 'hello',
+        'timestamp': 1727103627639,
+        'status': 'Info',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1845,task_name:Deploy,task_state:Success',
+        'message': 'The deployment completed successfully.',
+        'timestamp': 1727103621669,
+        'status': 'Info',
+        'stage_name': 'Deploy test release 0.0.1 to Development',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1845,task_name:Deploy,task_state:Success',
+        'message': 'hello',
+        'timestamp': 1727103621208,
+        'status': 'Info',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test-api,task_id:ServerTasks-1844,'
+        'task_name:Deploy,task_state:Success',
+        'message': 'The deployment completed successfully.',
+        'timestamp': 1727103442532,
+        'status': 'Info',
+        'stage_name': 'Deploy test-api release 0.1.5 to Development',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test-api,task_id:ServerTasks-1844,'
+        'task_name:Deploy,task_state:Success',
+        'message': 'Testing',
+        'timestamp': 1727103440967,
+        'status': 'Info',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test-api,task_id:ServerTasks-1844,'
+        'task_name:Deploy,task_state:Success',
+        'message': 'test',
+        'timestamp': 1727103442029,
+        'status': 'Info',
+        'stage_name': 'Octopus Server',
+    },
+]
+
+ONLY_TEST_LOGS = [
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'The deployment failed because one or more steps failed. Please see the deployment log for details.',
+        'timestamp': 1727104203218,
+        'status': 'Fatal',
+        'stage_name': 'Deploy test release 0.0.2 to Development',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'hello',
+        'timestamp': 1727104198525,
+        'status': 'Info',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': "The step failed: Activity Run a Script on the Octopus Server failed with error "
+        "'The remote script failed with exit code 1'.",
+        'timestamp': 1727104202767,
+        'status': 'Fatal',
+        'stage_name': 'Step 2: Run a Script',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'ParserError: At /home/octopus/.octopus/OctopusServer/Server/Work/09234928998123-1847-68/'
+        'Script.ps1:1 char:6',
+        'timestamp': 1727104202599,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': '+ echo "stop',
+        'timestamp': 1727104202599,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': '+      ~~~~~',
+        'timestamp': 1727104202599,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'The string is missing the terminator: ".',
+        'timestamp': 1727104202599,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'At /home/octopus/.octopus/OctopusServer/Server/Work/09234928998123-1847-68/Script.ps1:1 char:6',
+        'timestamp': 1727104202605,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': '+ echo "stop',
+        'timestamp': 1727104202605,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': '+      ~~~~~',
+        'timestamp': 1727104202605,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'at <ScriptBlock>, <No file>: line 1',
+        'timestamp': 1727104202606,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'at <ScriptBlock>, /home/octopus/.octopus/OctopusServer/Server/Work/09234928998123-1847-68/'
+        'Octopus.FunctionAppenderContext.ps1: line 258',
+        'timestamp': 1727104202606,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'at <ScriptBlock>, /home/octopus/.octopus/OctopusServer/Server/Work/09234928998123-1847-68/'
+        'Bootstrap.Octopus.FunctionAppenderContext.ps1: line 1505',
+        'timestamp': 1727104202607,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'at <ScriptBlock>, <No file>: line 1',
+        'timestamp': 1727104202607,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'at <ScriptBlock>, <No file>: line 1',
+        'timestamp': 1727104202607,
+        'status': 'Error',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'The remote script failed with exit code 1',
+        'timestamp': 1727104202733,
+        'status': 'Fatal',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'message': 'The action Run a Script on the Octopus Server failed',
+        'timestamp': 1727104202758,
+        'status': 'Fatal',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1846,task_name:Deploy,task_state:Success',
+        'message': 'The deployment completed successfully.',
+        'timestamp': 1727103628255,
+        'status': 'Info',
+        'stage_name': 'Deploy test release 0.0.1 to Staging',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1846,task_name:Deploy,task_state:Success',
+        'message': 'hello',
+        'timestamp': 1727103627639,
+        'status': 'Info',
+        'stage_name': 'Octopus Server',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1845,task_name:Deploy,task_state:Success',
+        'message': 'The deployment completed successfully.',
+        'timestamp': 1727103621669,
+        'status': 'Info',
+        'stage_name': 'Deploy test release 0.0.1 to Development',
+    },
+    {
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1845,task_name:Deploy,task_state:Success',
+        'message': 'hello',
+        'timestamp': 1727103621208,
+        'status': 'Info',
+        'stage_name': 'Octopus Server',
+    },
 ]

--- a/octopus_deploy/tests/constants.py
+++ b/octopus_deploy/tests/constants.py
@@ -37,6 +37,21 @@ ALL_METRICS = [
     "octopus_deploy.server_node.max_concurrent_tasks",
 ]
 
+E2E_METRICS = [
+    "octopus_deploy.space.count",
+    "octopus_deploy.project_group.count",
+    "octopus_deploy.project.count",
+    "octopus_deploy.deployment.count",
+    "octopus_deploy.deployment.queued_time",
+    "octopus_deploy.deployment.executing_time",
+    "octopus_deploy.deployment.completed_time",
+    "octopus_deploy.server_node.count",
+    "octopus_deploy.server_node.in_maintenance_mode",
+    "octopus_deploy.server_node.max_concurrent_tasks",
+]
+
+ALL_METRICS = ["octopus_deploy.deployment.completed_time"] + E2E_METRICS
+
 ALL_DEPLOYMENT_LOGS = [
     {
         'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'

--- a/octopus_deploy/tests/constants.py
+++ b/octopus_deploy/tests/constants.py
@@ -4,7 +4,6 @@
 import datetime
 import os
 
-from datadog_checks.base.utils.time import ensure_aware_datetime
 from datadog_checks.dev.fs import get_here
 
 USE_OCTOPUS_LAB = os.environ.get("USE_OCTOPUS_LAB")
@@ -20,9 +19,9 @@ LAB_INSTANCE = {
     'headers': {'X-Octopus-ApiKey': OCTOPUS_API_KEY},
 }
 
-
-BASE_TIME = ensure_aware_datetime(datetime.datetime.strptime("2024-09-23 14:45:58.888492", '%Y-%m-%d %H:%M:%S.%f'))
-MOCKED_TIMESTAMPS = [BASE_TIME] * 20
+DEFAULT_COLLECTION_INTERVAL = 15
+MOCKED_TIME1 = datetime.datetime.fromisoformat("2024-09-23T14:45:00.123+00:00")
+MOCKED_TIME2 = MOCKED_TIME1 + datetime.timedelta(seconds=DEFAULT_COLLECTION_INTERVAL)
 
 ALL_METRICS = [
     "octopus_deploy.space.count",

--- a/octopus_deploy/tests/constants.py
+++ b/octopus_deploy/tests/constants.py
@@ -39,21 +39,24 @@ ALL_METRICS = [
 
 ALL_DEPLOYMENT_LOGS = [
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'The deployment failed because one or more steps failed. Please see the deployment log for details.',
         'timestamp': 1727104203218,
         'status': 'Fatal',
         'stage_name': 'Deploy test release 0.0.2 to Development',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'hello',
         'timestamp': 1727104198525,
         'status': 'Info',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': "The step failed: Activity Run a Script on the Octopus Server failed with error "
         "'The remote script failed with exit code 1'.",
         'timestamp': 1727104202767,
@@ -61,7 +64,8 @@ ALL_DEPLOYMENT_LOGS = [
         'stage_name': 'Step 2: Run a Script',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'ParserError: At /home/octopus/.octopus/OctopusServer/Server/Work/'
         '09234928998123-1847-68/Script.ps1:1 char:6',
         'timestamp': 1727104202599,
@@ -69,56 +73,64 @@ ALL_DEPLOYMENT_LOGS = [
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': '+ echo "stop',
         'timestamp': 1727104202599,
         'status': 'Error',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': '+      ~~~~~',
         'timestamp': 1727104202599,
         'status': 'Error',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'The string is missing the terminator: ".',
         'timestamp': 1727104202599,
         'status': 'Error',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'At /home/octopus/.octopus/OctopusServer/Server/Work/09234928998123-1847-68/Script.ps1:1 char:6',
         'timestamp': 1727104202605,
         'status': 'Error',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': '+ echo "stop',
         'timestamp': 1727104202605,
         'status': 'Error',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': '+      ~~~~~',
         'timestamp': 1727104202605,
         'status': 'Error',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'at <ScriptBlock>, <No file>: line 1',
         'timestamp': 1727104202606,
         'status': 'Error',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'at <ScriptBlock>, /home/octopus/.octopus/OctopusServer/Server/Work/09234928998123-1847-68/'
         'Octopus.FunctionAppenderContext.ps1: line 258',
         'timestamp': 1727104202606,
@@ -126,7 +138,8 @@ ALL_DEPLOYMENT_LOGS = [
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'at <ScriptBlock>, /home/octopus/.octopus/OctopusServer/Server/Work/09234928998123-1847-68/'
         'Bootstrap.Octopus.FunctionAppenderContext.ps1: line 1505',
         'timestamp': 1727104202607,
@@ -134,56 +147,64 @@ ALL_DEPLOYMENT_LOGS = [
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'at <ScriptBlock>, <No file>: line 1',
         'timestamp': 1727104202607,
         'status': 'Error',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'at <ScriptBlock>, <No file>: line 1',
         'timestamp': 1727104202607,
         'status': 'Error',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'The remote script failed with exit code 1',
         'timestamp': 1727104202733,
         'status': 'Fatal',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'The action Run a Script on the Octopus Server failed',
         'timestamp': 1727104202758,
         'status': 'Fatal',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1846,task_name:Deploy,task_state:Success',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1846,'
+        'task_name:Deploy,task_state:Success,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'The deployment completed successfully.',
         'timestamp': 1727103628255,
         'status': 'Info',
         'stage_name': 'Deploy test release 0.0.1 to Staging',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1846,task_name:Deploy,task_state:Success',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1846,'
+        'task_name:Deploy,task_state:Success,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'hello',
         'timestamp': 1727103627639,
         'status': 'Info',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1845,task_name:Deploy,task_state:Success',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1845,'
+        'task_name:Deploy,task_state:Success,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'The deployment completed successfully.',
         'timestamp': 1727103621669,
         'status': 'Info',
         'stage_name': 'Deploy test release 0.0.1 to Development',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1845,task_name:Deploy,task_state:Success',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1845,'
+        'task_name:Deploy,task_state:Success,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'hello',
         'timestamp': 1727103621208,
         'status': 'Info',
@@ -191,7 +212,7 @@ ALL_DEPLOYMENT_LOGS = [
     },
     {
         'ddtags': 'space_name:Default,project_name:test-api,task_id:ServerTasks-1844,'
-        'task_name:Deploy,task_state:Success',
+        'task_name:Deploy,task_state:Success,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'The deployment completed successfully.',
         'timestamp': 1727103442532,
         'status': 'Info',
@@ -199,7 +220,7 @@ ALL_DEPLOYMENT_LOGS = [
     },
     {
         'ddtags': 'space_name:Default,project_name:test-api,task_id:ServerTasks-1844,'
-        'task_name:Deploy,task_state:Success',
+        'task_name:Deploy,task_state:Success,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'Testing',
         'timestamp': 1727103440967,
         'status': 'Info',
@@ -207,7 +228,7 @@ ALL_DEPLOYMENT_LOGS = [
     },
     {
         'ddtags': 'space_name:Default,project_name:test-api,task_id:ServerTasks-1844,'
-        'task_name:Deploy,task_state:Success',
+        'task_name:Deploy,task_state:Success,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'test',
         'timestamp': 1727103442029,
         'status': 'Info',
@@ -217,21 +238,24 @@ ALL_DEPLOYMENT_LOGS = [
 
 ONLY_TEST_LOGS = [
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'The deployment failed because one or more steps failed. Please see the deployment log for details.',
         'timestamp': 1727104203218,
         'status': 'Fatal',
         'stage_name': 'Deploy test release 0.0.2 to Development',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'hello',
         'timestamp': 1727104198525,
         'status': 'Info',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': "The step failed: Activity Run a Script on the Octopus Server failed with error "
         "'The remote script failed with exit code 1'.",
         'timestamp': 1727104202767,
@@ -239,7 +263,8 @@ ONLY_TEST_LOGS = [
         'stage_name': 'Step 2: Run a Script',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'ParserError: At /home/octopus/.octopus/OctopusServer/Server/Work/09234928998123-1847-68/'
         'Script.ps1:1 char:6',
         'timestamp': 1727104202599,
@@ -247,56 +272,64 @@ ONLY_TEST_LOGS = [
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': '+ echo "stop',
         'timestamp': 1727104202599,
         'status': 'Error',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': '+      ~~~~~',
         'timestamp': 1727104202599,
         'status': 'Error',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'The string is missing the terminator: ".',
         'timestamp': 1727104202599,
         'status': 'Error',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'At /home/octopus/.octopus/OctopusServer/Server/Work/09234928998123-1847-68/Script.ps1:1 char:6',
         'timestamp': 1727104202605,
         'status': 'Error',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': '+ echo "stop',
         'timestamp': 1727104202605,
         'status': 'Error',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': '+      ~~~~~',
         'timestamp': 1727104202605,
         'status': 'Error',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'at <ScriptBlock>, <No file>: line 1',
         'timestamp': 1727104202606,
         'status': 'Error',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'at <ScriptBlock>, /home/octopus/.octopus/OctopusServer/Server/Work/09234928998123-1847-68/'
         'Octopus.FunctionAppenderContext.ps1: line 258',
         'timestamp': 1727104202606,
@@ -304,7 +337,8 @@ ONLY_TEST_LOGS = [
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'at <ScriptBlock>, /home/octopus/.octopus/OctopusServer/Server/Work/09234928998123-1847-68/'
         'Bootstrap.Octopus.FunctionAppenderContext.ps1: line 1505',
         'timestamp': 1727104202607,
@@ -312,56 +346,64 @@ ONLY_TEST_LOGS = [
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'at <ScriptBlock>, <No file>: line 1',
         'timestamp': 1727104202607,
         'status': 'Error',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'at <ScriptBlock>, <No file>: line 1',
         'timestamp': 1727104202607,
         'status': 'Error',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'The remote script failed with exit code 1',
         'timestamp': 1727104202733,
         'status': 'Fatal',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,task_name:Deploy,task_state:Failed',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1847,'
+        'task_name:Deploy,task_state:Failed,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'The action Run a Script on the Octopus Server failed',
         'timestamp': 1727104202758,
         'status': 'Fatal',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1846,task_name:Deploy,task_state:Success',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1846,'
+        'task_name:Deploy,task_state:Success,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'The deployment completed successfully.',
         'timestamp': 1727103628255,
         'status': 'Info',
         'stage_name': 'Deploy test release 0.0.1 to Staging',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1846,task_name:Deploy,task_state:Success',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1846,'
+        'task_name:Deploy,task_state:Success,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'hello',
         'timestamp': 1727103627639,
         'status': 'Info',
         'stage_name': 'Octopus Server',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1845,task_name:Deploy,task_state:Success',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1845,'
+        'task_name:Deploy,task_state:Success,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'The deployment completed successfully.',
         'timestamp': 1727103621669,
         'status': 'Info',
         'stage_name': 'Deploy test release 0.0.1 to Development',
     },
     {
-        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1845,task_name:Deploy,task_state:Success',
+        'ddtags': 'space_name:Default,project_name:test,task_id:ServerTasks-1845,'
+        'task_name:Deploy,task_state:Success,server_node:OctopusServerNodes-50c3dfbarc82',
         'message': 'hello',
         'timestamp': 1727103621208,
         'status': 'Info',

--- a/octopus_deploy/tests/docker/Caddyfile
+++ b/octopus_deploy/tests/docker/Caddyfile
@@ -124,6 +124,38 @@
         rewrite * /GET/api/octopusservernodes/response.json
         file_server
     }
+        @get_tasks_1844 {
+        method GET
+        path /api/Spaces-1/tasks/ServerTasks-1844/details
+    }
+    route @get_tasks_1844 {
+        rewrite * /GET/api/Spaces-1/tasks/ServerTasks-1844/details/response.json
+        file_server
+    }
+    @get_tasks_1845 {
+        method GET
+        path /api/Spaces-1/tasks/ServerTasks-1845/details
+    }
+    route @get_tasks_1845 {
+        rewrite * /GET/api/Spaces-1/tasks/ServerTasks-1845/details/response.json
+        file_server
+    }
+    @get_tasks_1846 {
+        method GET
+        path /api/Spaces-1/tasks/ServerTasks-1846/details
+    }
+    route @get_tasks_1846 {
+        rewrite * /GET/api/Spaces-1/tasks/ServerTasks-1846/details/response.json
+        file_server
+    }
+    @get_tasks_1847 {
+        method GET
+        path /api/Spaces-1/tasks/ServerTasks-1847/details
+    }
+    route @get_tasks_1847 {
+        rewrite * /GET/api/Spaces-1/tasks/ServerTasks-1847/details/response.json
+        file_server
+    }
 
     file_server browse
 }

--- a/octopus_deploy/tests/fixtures/GET/api/Spaces-1/tasks/ServerTasks-1844/details/response.json
+++ b/octopus_deploy/tests/fixtures/GET/api/Spaces-1/tasks/ServerTasks-1844/details/response.json
@@ -1,0 +1,131 @@
+{
+    "Task": {
+      "Id": "ServerTasks-1844",
+      "SpaceId": "Spaces-1",
+      "Name": "Deploy",
+      "Description": "Deploy test-api release 0.1.5 to Development",
+      "Arguments": {
+        "DeploymentId": "Deployments-16"
+      },
+      "State": "Success",
+      "Completed": "Monday, 23 September 2024 2:57:22 PM +00:00",
+      "QueueTime": "2024-09-23T14:57:18.798+00:00",
+      "QueueTimeExpiry": null,
+      "StartTime": "2024-09-23T14:57:19.411+00:00",
+      "LastUpdatedTime": "2024-09-23T14:57:22.603+00:00",
+      "CompletedTime": "2024-09-23T14:57:22.603+00:00",
+      "ServerNode": "OctopusServerNodes-50c3dfbarc82",
+      "Duration": "3 seconds",
+      "ErrorMessage": "",
+      "HasBeenPickedUpByProcessor": true,
+      "IsCompleted": true,
+      "FinishedSuccessfully": true,
+      "HasPendingInterruptions": false,
+      "CanRerun": false,
+      "HasWarningsOrErrors": false,
+      "UnmetPreconditions": null,
+      "ProjectId": "Projects-1",
+      "Links": {
+        "Self": "/api/tasks/ServerTasks-1844",
+        "Web": "/app#/Spaces-1/tasks/ServerTasks-1844",
+        "Raw": "/api/tasks/ServerTasks-1844/raw",
+        "Rerun": "/api/tasks/rerun/ServerTasks-1844",
+        "Cancel": "/api/tasks/ServerTasks-1844/cancel",
+        "State": "/api/tasks/ServerTasks-1844/state",
+        "BlockedBy": "/api/tasks/ServerTasks-1844/blockedby",
+        "QueuedBehind": "/api/tasks/ServerTasks-1844/queued-behind{?skip,take}",
+        "Details": "/api/tasks/ServerTasks-1844/details{?verbose,tail,ranges}",
+        "StatusMessages": "/api/tasks/ServerTasks-1844/status/messages",
+        "Prioritize": "/api/tasks/ServerTasks-1844/prioritize",
+        "Artifacts": "/api/Spaces-1/artifacts?regarding=ServerTasks-1844",
+        "Interruptions": "/api/Spaces-1/interruptions?regarding=ServerTasks-1844"
+      }
+    },
+    "ActivityLogs": [
+      {
+        "Id": "ServerTasks-1844_9JHSA77SGD",
+        "Name": "Deploy test-api release 0.1.5 to Development",
+        "Started": "2024-09-23T14:57:19.448+00:00",
+        "Ended": "2024-09-23T14:57:22.532+00:00",
+        "Status": "Success",
+        "ShowAtSummaryLevel": true,
+        "Children": [
+          {
+            "Id": "ServerTasks-1844_9JHSA77SGD/9bbbc7623baac23498923",
+            "Name": "Step 1: echo",
+            "Started": "2024-09-23T14:57:20.181+00:00",
+            "Ended": "2024-09-23T14:57:21.005+00:00",
+            "Status": "Success",
+            "ShowAtSummaryLevel": true,
+            "Children": [
+              {
+                "Id": "ServerTasks-1844_9JHSA77SGD/9bbbc7623baac23498923/817324bb1232abc95729712aa",
+                "Name": "Octopus Server",
+                "Started": "2024-09-23T14:57:20.181+00:00",
+                "Ended": "2024-09-23T14:57:21.004+00:00",
+                "Status": "Success",
+                "ShowAtSummaryLevel": true,
+                "Children": [],
+                "LogElements": [
+                  {
+                    "OccurredAt": "2024-09-23T14:57:20.967+00:00",
+                    "Category": "Info",
+                    "MessageText": "Testing",
+                    "Number": 44
+                  }
+                ]
+              }
+            ],
+            "LogElements": []
+          },
+          {
+            "Id": "ServerTasks-1844_9JHSA77SGD/17994a8f71c4461ea8153d43675f3c8f",
+            "Name": "Step 2: Run a Script",
+            "Started": "2024-09-23T14:57:21.224+00:00",
+            "Ended": "2024-09-23T14:57:22.068+00:00",
+            "Status": "Success",
+            "ShowAtSummaryLevel": true,
+            "Children": [
+              {
+                "Id": "ServerTasks-1844_9JHSA77SGD/17994a8f71c4461ea8153d43675f3c8f/0977b10aabs213d1234",
+                "Name": "Octopus Server",
+                "Started": "2024-09-23T14:57:21.224+00:00",
+                "Ended": "2024-09-23T14:57:22.067+00:00",
+                "Status": "Success",
+                "ShowAtSummaryLevel": true,
+                "Children": [],
+                "LogElements": [
+                  {
+                    "OccurredAt": "2024-09-23T14:57:22.029+00:00",
+                    "Category": "Info",
+                    "MessageText": "test",
+                    "Number": 44
+                  }
+                ]
+              }
+            ],
+            "LogElements": []
+          }
+        ],
+        "LogElements": [
+          {
+            "OccurredAt": "2024-09-23T14:57:22.532+00:00",
+            "Category": "Info",
+            "MessageText": "The deployment completed successfully.",
+            "Number": 3
+          }
+        ]
+      }
+    ],
+    "PhysicalLogSize": 23360,
+    "Progress": {
+      "ProgressPercentage": 0,
+      "EstimatedTimeRemaining": null
+    },
+    "Links": {
+      "Self": "/api/tasks/ServerTasks-1844/details",
+      "Task": "/api/tasks/ServerTasks-1844",
+      "Web": "/app#/Spaces-1/tasks/ServerTasks-1844",
+      "Raw": "/api/tasks/ServerTasks-1844/raw"
+    }
+}

--- a/octopus_deploy/tests/fixtures/GET/api/Spaces-1/tasks/ServerTasks-1845/details/response.json
+++ b/octopus_deploy/tests/fixtures/GET/api/Spaces-1/tasks/ServerTasks-1845/details/response.json
@@ -1,0 +1,103 @@
+{
+    "Task": {
+        "Id": "ServerTasks-1845",
+        "SpaceId": "Spaces-1",
+        "Name": "Deploy",
+        "Description": "Deploy test release 0.0.1 to Development",
+        "Arguments": {
+            "DeploymentId": "Deployments-17"
+        },
+        "State": "Success",
+        "Completed": "Monday, 23 September 2024 3:00:21 PM +00:00",
+        "QueueTime": "2024-09-23T14:44:02.123+00:00",
+        "QueueTimeExpiry": null,
+        "StartTime": "2024-09-23T14:44:20.123+00:00",
+        "LastUpdatedTime": "2024-09-23T15:00:21.752+00:00",
+        "CompletedTime": "2024-09-23T14:45:01.123+00:00",
+        "ServerNode": "OctopusServerNodes-50c3dfbarc82",
+        "Duration": "2 seconds",
+        "ErrorMessage": "",
+        "HasBeenPickedUpByProcessor": true,
+        "IsCompleted": true,
+        "FinishedSuccessfully": true,
+        "HasPendingInterruptions": false,
+        "CanRerun": false,
+        "HasWarningsOrErrors": false,
+        "UnmetPreconditions": null,
+        "ProjectId": "Projects-3",
+        "Links": {
+            "Self": "/api/tasks/ServerTasks-1845",
+            "Web": "/app#/Spaces-1/tasks/ServerTasks-1845",
+            "Raw": "/api/tasks/ServerTasks-1845/raw",
+            "Rerun": "/api/tasks/rerun/ServerTasks-1845",
+            "Cancel": "/api/tasks/ServerTasks-1845/cancel",
+            "State": "/api/tasks/ServerTasks-1845/state",
+            "BlockedBy": "/api/tasks/ServerTasks-1845/blockedby",
+            "QueuedBehind": "/api/tasks/ServerTasks-1845/queued-behind{?skip,take}",
+            "Details": "/api/tasks/ServerTasks-1845/details{?verbose,tail,ranges}",
+            "StatusMessages": "/api/tasks/ServerTasks-1845/status/messages",
+            "Prioritize": "/api/tasks/ServerTasks-1845/prioritize",
+            "Artifacts": "/api/Spaces-1/artifacts?regarding=ServerTasks-1845",
+            "Interruptions": "/api/Spaces-1/interruptions?regarding=ServerTasks-1845"
+        }
+    },
+    "ActivityLogs": [
+        {
+            "Id": "ServerTasks-1845_99012CHY23",
+            "Name": "Deploy test release 0.0.1 to Development",
+            "Started": "2024-09-23T15:00:19.712+00:00",
+            "Ended": "2024-09-23T15:00:21.670+00:00",
+            "Status": "Success",
+            "ShowAtSummaryLevel": true,
+            "Children": [
+                {
+                    "Id": "ServerTasks-1845_99012CHY23/9123ba12321bbcd2343209",
+                    "Name": "Step 1: run hello",
+                    "Started": "2024-09-23T15:00:20.417+00:00",
+                    "Ended": "2024-09-23T15:00:21.246+00:00",
+                    "Status": "Success",
+                    "ShowAtSummaryLevel": true,
+                    "Children": [
+                        {
+                            "Id": "ServerTasks-1845_99012CHY23/9123ba12321bbcd2343209/092308ee2341ba123cb1232",
+                            "Name": "Octopus Server",
+                            "Started": "2024-09-23T15:00:20.417+00:00",
+                            "Ended": "2024-09-23T15:00:21.244+00:00",
+                            "Status": "Success",
+                            "ShowAtSummaryLevel": true,
+                            "Children": [],
+                            "LogElements": [
+                                {
+                                    "OccurredAt": "2024-09-23T15:00:21.208+00:00",
+                                    "Category": "Info",
+                                    "MessageText": "hello",
+                                    "Number": 44
+                                }
+                            ]
+                        }
+                    ],
+                    "LogElements": []
+                }
+            ],
+            "LogElements": [
+                {
+                    "OccurredAt": "2024-09-23T15:00:21.669+00:00",
+                    "Category": "Info",
+                    "MessageText": "The deployment completed successfully.",
+                    "Number": 3
+                }
+            ]
+        }
+    ],
+    "PhysicalLogSize": 11963,
+    "Progress": {
+        "ProgressPercentage": 0,
+        "EstimatedTimeRemaining": null
+    },
+    "Links": {
+        "Self": "/api/tasks/ServerTasks-1845/details",
+        "Task": "/api/tasks/ServerTasks-1845",
+        "Web": "/app#/Spaces-1/tasks/ServerTasks-1845",
+        "Raw": "/api/tasks/ServerTasks-1845/raw"
+    }
+}

--- a/octopus_deploy/tests/fixtures/GET/api/Spaces-1/tasks/ServerTasks-1846/details/response.json
+++ b/octopus_deploy/tests/fixtures/GET/api/Spaces-1/tasks/ServerTasks-1846/details/response.json
@@ -1,0 +1,103 @@
+{
+    "Task": {
+      "Id": "ServerTasks-1846",
+      "SpaceId": "Spaces-1",
+      "Name": "Deploy",
+      "Description": "Deploy test release 0.0.1 to Staging",
+      "Arguments": {
+        "DeploymentId": "Deployments-18"
+      },
+      "State": "Success",
+      "Completed": "Monday, 23 September 2024 3:00:28 PM +00:00",
+      "QueueTime": "2024-09-23T14:42:50.123+00:00",
+      "QueueTimeExpiry": null,
+      "StartTime": "2024-09-23T14:44:20.123+00:00",
+      "LastUpdatedTime": "2024-09-23T15:00:28.272+00:00",
+      "CompletedTime": "2024-09-23T14:45:14.123+00:00",
+      "ServerNode": "OctopusServerNodes-50c3dfbarc82",
+      "Duration": "2 seconds",
+      "ErrorMessage": "",
+      "HasBeenPickedUpByProcessor": true,
+      "IsCompleted": true,
+      "FinishedSuccessfully": true,
+      "HasPendingInterruptions": false,
+      "CanRerun": false,
+      "HasWarningsOrErrors": false,
+      "UnmetPreconditions": null,
+      "ProjectId": "Projects-3",
+      "Links": {
+        "Self": "/api/tasks/ServerTasks-1846",
+        "Web": "/app#/Spaces-1/tasks/ServerTasks-1846",
+        "Raw": "/api/tasks/ServerTasks-1846/raw",
+        "Rerun": "/api/tasks/rerun/ServerTasks-1846",
+        "Cancel": "/api/tasks/ServerTasks-1846/cancel",
+        "State": "/api/tasks/ServerTasks-1846/state",
+        "BlockedBy": "/api/tasks/ServerTasks-1846/blockedby",
+        "QueuedBehind": "/api/tasks/ServerTasks-1846/queued-behind{?skip,take}",
+        "Details": "/api/tasks/ServerTasks-1846/details{?verbose,tail,ranges}",
+        "StatusMessages": "/api/tasks/ServerTasks-1846/status/messages",
+        "Prioritize": "/api/tasks/ServerTasks-1846/prioritize",
+        "Artifacts": "/api/Spaces-1/artifacts?regarding=ServerTasks-1846",
+        "Interruptions": "/api/Spaces-1/interruptions?regarding=ServerTasks-1846"
+      }
+    },
+    "ActivityLogs": [
+      {
+        "Id": "ServerTasks-1846_KASX88AJS2",
+        "Name": "Deploy test release 0.0.1 to Staging",
+        "Started": "2024-09-23T15:00:26.164+00:00",
+        "Ended": "2024-09-23T15:00:28.257+00:00",
+        "Status": "Success",
+        "ShowAtSummaryLevel": true,
+        "Children": [
+          {
+            "Id": "ServerTasks-1846_KASX88AJS2/98723ab9023cc1232eeffa1232",
+            "Name": "Step 1: run hello",
+            "Started": "2024-09-23T15:00:26.870+00:00",
+            "Ended": "2024-09-23T15:00:27.676+00:00",
+            "Status": "Success",
+            "ShowAtSummaryLevel": true,
+            "Children": [
+              {
+                "Id": "ServerTasks-1846_KASX88AJS2/98723ab9023cc1232eeffa1232/0932a234bb23eff43531ab12",
+                "Name": "Octopus Server",
+                "Started": "2024-09-23T15:00:26.870+00:00",
+                "Ended": "2024-09-23T15:00:27.676+00:00",
+                "Status": "Success",
+                "ShowAtSummaryLevel": true,
+                "Children": [],
+                "LogElements": [
+                  {
+                    "OccurredAt": "2024-09-23T15:00:27.639+00:00",
+                    "Category": "Info",
+                    "MessageText": "hello",
+                    "Number": 44
+                  }
+                ]
+              }
+            ],
+            "LogElements": []
+          }
+        ],
+        "LogElements": [
+          {
+            "OccurredAt": "2024-09-23T15:00:28.255+00:00",
+            "Category": "Info",
+            "MessageText": "The deployment completed successfully.",
+            "Number": 3
+          }
+        ]
+      }
+    ],
+    "PhysicalLogSize": 11959,
+    "Progress": {
+      "ProgressPercentage": 0,
+      "EstimatedTimeRemaining": null
+    },
+    "Links": {
+      "Self": "/api/tasks/ServerTasks-1846/details",
+      "Task": "/api/tasks/ServerTasks-1846",
+      "Web": "/app#/Spaces-1/tasks/ServerTasks-1846",
+      "Raw": "/api/tasks/ServerTasks-1846/raw"
+    }
+  }

--- a/octopus_deploy/tests/fixtures/GET/api/Spaces-1/tasks/ServerTasks-1847/details/response.json
+++ b/octopus_deploy/tests/fixtures/GET/api/Spaces-1/tasks/ServerTasks-1847/details/response.json
@@ -1,0 +1,216 @@
+{
+    "Task": {
+        "Id": "ServerTasks-1847",
+        "SpaceId": "Spaces-1",
+        "Name": "Deploy",
+        "Description": "Deploy test release 0.0.2 to Development",
+        "Arguments": {
+            "DeploymentId": "Deployments-19"
+        },
+        "State": "Failed",
+        "Completed": "Monday, 23 September 2024 3:10:03 PM +00:00",
+        "QueueTime": "2024-09-23T14:42:30.123+00:00",
+        "QueueTimeExpiry": null,
+        "StartTime": "2024-09-23T14:44:20.123+00:00",
+        "LastUpdatedTime": "2024-09-23T15:10:03.262+00:00",
+        "CompletedTime": "2024-09-23T14:45:10.123+00:00",
+        "ServerNode": "OctopusServerNodes-50c3dfbarc82",
+        "Duration": "6 seconds",
+        "ErrorMessage": "The deployment failed because one or more steps failed. Please see the deployment log for details.",
+        "HasBeenPickedUpByProcessor": true,
+        "IsCompleted": true,
+        "FinishedSuccessfully": false,
+        "HasPendingInterruptions": false,
+        "CanRerun": false,
+        "HasWarningsOrErrors": true,
+        "UnmetPreconditions": null,
+        "ProjectId": "Projects-3",
+        "Links": {
+            "Self": "/api/tasks/ServerTasks-1847",
+            "Web": "/app#/Spaces-1/tasks/ServerTasks-1847",
+            "Raw": "/api/tasks/ServerTasks-1847/raw",
+            "Rerun": "/api/tasks/rerun/ServerTasks-1847",
+            "Cancel": "/api/tasks/ServerTasks-1847/cancel",
+            "State": "/api/tasks/ServerTasks-1847/state",
+            "BlockedBy": "/api/tasks/ServerTasks-1847/blockedby",
+            "QueuedBehind": "/api/tasks/ServerTasks-1847/queued-behind{?skip,take}",
+            "Details": "/api/tasks/ServerTasks-1847/details{?verbose,tail,ranges}",
+            "StatusMessages": "/api/tasks/ServerTasks-1847/status/messages",
+            "Prioritize": "/api/tasks/ServerTasks-1847/prioritize",
+            "Artifacts": "/api/Spaces-1/artifacts?regarding=ServerTasks-1847",
+            "Interruptions": "/api/Spaces-1/interruptions?regarding=ServerTasks-1847"
+        }
+    },
+    "ActivityLogs": [
+        {
+            "Id": "ServerTasks-1847_093204AA234",
+            "Name": "Deploy test release 0.0.2 to Development",
+            "Started": "2024-09-23T15:09:57.023+00:00",
+            "Ended": "2024-09-23T15:10:03.218+00:00",
+            "Status": "Failed",
+            "ShowAtSummaryLevel": true,
+            "Children": [
+                {
+                    "Id": "ServerTasks-1847_093204AA234/bbasd091232ee32398yfa12321",
+                    "Name": "Step 1: run hello",
+                    "Started": "2024-09-23T15:09:57.776+00:00",
+                    "Ended": "2024-09-23T15:09:58.564+00:00",
+                    "Status": "Success",
+                    "ShowAtSummaryLevel": true,
+                    "Children": [
+                        {
+                            "Id": "ServerTasks-1847_093204AA234/bbasd091232ee32398yfa12321/1532abbe1231cc0998ae121",
+                            "Name": "Octopus Server",
+                            "Started": "2024-09-23T15:09:57.776+00:00",
+                            "Ended": "2024-09-23T15:09:58.564+00:00",
+                            "Status": "Success",
+                            "ShowAtSummaryLevel": true,
+                            "Children": [],
+                            "LogElements": [
+                                {
+                                    "OccurredAt": "2024-09-23T15:09:58.525+00:00",
+                                    "Category": "Info",
+                                    "MessageText": "hello",
+                                    "Number": 44
+                                }
+                            ]
+                        }
+                    ],
+                    "LogElements": []
+                },
+                {
+                    "Id": "ServerTasks-1847_093204AA234/0932432a12bc2198ab12321",
+                    "Name": "Step 2: Run a Script",
+                    "Started": "2024-09-23T15:09:58.823+00:00",
+                    "Ended": "2024-09-23T15:10:02.814+00:00",
+                    "Status": "Failed",
+                    "ShowAtSummaryLevel": true,
+                    "Children": [
+                        {
+                            "Id": "ServerTasks-1847_093204AA234/0932432a12bc2198ab12321/ab1231ebf3242342f23423",
+                            "Name": "Octopus Server",
+                            "Started": "2024-09-23T15:09:58.823+00:00",
+                            "Ended": "2024-09-23T15:10:02.758+00:00",
+                            "Status": "Failed",
+                            "ShowAtSummaryLevel": true,
+                            "Children": [],
+                            "LogElements": [
+                                {
+                                    "OccurredAt": "2024-09-23T15:10:02.599+00:00",
+                                    "Category": "Error",
+                                    "MessageText": "ParserError: At /home/octopus/.octopus/OctopusServer/Server/Work/09234928998123-1847-68/Script.ps1:1 char:6",
+                                    "Number": 56
+                                },
+                                {
+                                    "OccurredAt": "2024-09-23T15:10:02.599+00:00",
+                                    "Category": "Error",
+                                    "MessageText": "+ echo \"stop",
+                                    "Number": 57
+                                },
+                                {
+                                    "OccurredAt": "2024-09-23T15:10:02.599+00:00",
+                                    "Category": "Error",
+                                    "MessageText": "+      ~~~~~",
+                                    "Number": 58
+                                },
+                                {
+                                    "OccurredAt": "2024-09-23T15:10:02.599+00:00",
+                                    "Category": "Error",
+                                    "MessageText": "The string is missing the terminator: \".",
+                                    "Number": 59
+                                },
+                                {
+                                    "OccurredAt": "2024-09-23T15:10:02.605+00:00",
+                                    "Category": "Error",
+                                    "MessageText": "At /home/octopus/.octopus/OctopusServer/Server/Work/09234928998123-1847-68/Script.ps1:1 char:6",
+                                    "Number": 60
+                                },
+                                {
+                                    "OccurredAt": "2024-09-23T15:10:02.605+00:00",
+                                    "Category": "Error",
+                                    "MessageText": "+ echo \"stop",
+                                    "Number": 61
+                                },
+                                {
+                                    "OccurredAt": "2024-09-23T15:10:02.605+00:00",
+                                    "Category": "Error",
+                                    "MessageText": "+      ~~~~~",
+                                    "Number": 62
+                                },
+                                {
+                                    "OccurredAt": "2024-09-23T15:10:02.606+00:00",
+                                    "Category": "Error",
+                                    "MessageText": "at <ScriptBlock>, <No file>: line 1",
+                                    "Number": 63
+                                },
+                                {
+                                    "OccurredAt": "2024-09-23T15:10:02.606+00:00",
+                                    "Category": "Error",
+                                    "MessageText": "at <ScriptBlock>, /home/octopus/.octopus/OctopusServer/Server/Work/09234928998123-1847-68/Octopus.FunctionAppenderContext.ps1: line 258",
+                                    "Number": 64
+                                },
+                                {
+                                    "OccurredAt": "2024-09-23T15:10:02.607+00:00",
+                                    "Category": "Error",
+                                    "MessageText": "at <ScriptBlock>, /home/octopus/.octopus/OctopusServer/Server/Work/09234928998123-1847-68/Bootstrap.Octopus.FunctionAppenderContext.ps1: line 1505",
+                                    "Number": 65
+                                },
+                                {
+                                    "OccurredAt": "2024-09-23T15:10:02.607+00:00",
+                                    "Category": "Error",
+                                    "MessageText": "at <ScriptBlock>, <No file>: line 1",
+                                    "Number": 66
+                                },
+                                {
+                                    "OccurredAt": "2024-09-23T15:10:02.607+00:00",
+                                    "Category": "Error",
+                                    "MessageText": "at <ScriptBlock>, <No file>: line 1",
+                                    "Number": 67
+                                },
+                                {
+                                    "OccurredAt": "2024-09-23T15:10:02.733+00:00",
+                                    "Category": "Fatal",
+                                    "MessageText": "The remote script failed with exit code 1",
+                                    "Number": 73
+                                },
+                                {
+                                    "OccurredAt": "2024-09-23T15:10:02.758+00:00",
+                                    "Category": "Fatal",
+                                    "MessageText": "The action Run a Script on the Octopus Server failed",
+                                    "Number": 74
+                                }
+                            ]
+                        }
+                    ],
+                    "LogElements": [
+                        {
+                            "OccurredAt": "2024-09-23T15:10:02.767+00:00",
+                            "Category": "Fatal",
+                            "MessageText": "The step failed: Activity Run a Script on the Octopus Server failed with error 'The remote script failed with exit code 1'.",
+                            "Number": 1
+                        }
+                    ]
+                }
+            ],
+            "LogElements": [
+                {
+                    "OccurredAt": "2024-09-23T15:10:03.218+00:00",
+                    "Category": "Fatal",
+                    "MessageText": "The deployment failed because one or more steps failed. Please see the deployment log for details.",
+                    "Number": 3
+                }
+            ]
+        }
+    ],
+    "PhysicalLogSize": 28609,
+    "Progress": {
+        "ProgressPercentage": 0,
+        "EstimatedTimeRemaining": null
+    },
+    "Links": {
+        "Self": "/api/tasks/ServerTasks-1847/details",
+        "Task": "/api/tasks/ServerTasks-1847",
+        "Web": "/app#/Spaces-1/tasks/ServerTasks-1847",
+        "Raw": "/api/tasks/ServerTasks-1847/raw"
+    }
+}

--- a/octopus_deploy/tests/test_e2e.py
+++ b/octopus_deploy/tests/test_e2e.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
-from .constants import ALL_METRICS
+from .constants import E2E_METRICS
 
 
 @pytest.mark.e2e
@@ -11,7 +11,7 @@ def test_e2e(dd_agent_check, instance):
     aggregator = dd_agent_check(instance)
 
     aggregator.assert_metric('octopus_deploy.api.can_connect', 1, tags=[])
-    for metric in ALL_METRICS:
+    for metric in E2E_METRICS:
         aggregator.assert_metric(metric)
     aggregator.assert_no_duplicate_all()
     aggregator.assert_all_metrics_covered()

--- a/octopus_deploy/tests/test_unit.py
+++ b/octopus_deploy/tests/test_unit.py
@@ -919,6 +919,7 @@ def test_deployment_logs(
 
     get_current_datetime.return_value = MOCKED_TIME1
     dd_run_check(check)
+    datadog_agent.assert_logs(check.check_id, [])
     get_current_datetime.return_value = MOCKED_TIME2
     dd_run_check(check)
     datadog_agent.assert_logs(check.check_id, expected_logs)

--- a/octopus_deploy/tests/test_unit.py
+++ b/octopus_deploy/tests/test_unit.py
@@ -209,6 +209,7 @@ def test_queued_or_running_tasks(get_current_datetime, dd_run_check, aggregator)
             'task_state:Executing',
             'project_name:my-project',
             'space_name:Default',
+            'server_node:OctopusServerNodes-50c3dfbarc82',
         ],
     )
     aggregator.assert_metric(
@@ -220,6 +221,7 @@ def test_queued_or_running_tasks(get_current_datetime, dd_run_check, aggregator)
             'task_state:Executing',
             'project_name:my-project',
             'space_name:Default',
+            'server_node:OctopusServerNodes-50c3dfbarc82',
         ],
     )
     aggregator.assert_metric(
@@ -231,6 +233,7 @@ def test_queued_or_running_tasks(get_current_datetime, dd_run_check, aggregator)
             'task_state:Executing',
             'project_name:my-project',
             'space_name:Default',
+            'server_node:OctopusServerNodes-50c3dfbarc82',
         ],
     )
     aggregator.assert_metric(
@@ -243,6 +246,7 @@ def test_queued_or_running_tasks(get_current_datetime, dd_run_check, aggregator)
             'task_state:Executing',
             'project_name:my-project',
             'space_name:Default',
+            'server_node:OctopusServerNodes-50c3dfbarc82',
         ],
     )
     aggregator.assert_metric(
@@ -254,6 +258,7 @@ def test_queued_or_running_tasks(get_current_datetime, dd_run_check, aggregator)
             'task_state:Queued',
             'project_name:test',
             'space_name:Default',
+            'server_node:None',
         ],
     )
     aggregator.assert_metric(
@@ -265,6 +270,7 @@ def test_queued_or_running_tasks(get_current_datetime, dd_run_check, aggregator)
             'task_state:Queued',
             'project_name:test',
             'space_name:Default',
+            'server_node:None',
         ],
     )
     aggregator.assert_metric(
@@ -277,6 +283,7 @@ def test_queued_or_running_tasks(get_current_datetime, dd_run_check, aggregator)
             'task_state:Queued',
             'project_name:test',
             'space_name:Default',
+            'server_node:None',
         ],
     )
     aggregator.assert_metric(
@@ -289,6 +296,7 @@ def test_queued_or_running_tasks(get_current_datetime, dd_run_check, aggregator)
             'task_state:Queued',
             'project_name:test',
             'space_name:Default',
+            'server_node:None',
         ],
     )
 
@@ -318,6 +326,7 @@ def test_completed_tasks(get_current_datetime, dd_run_check, aggregator):
             'task_state:Failed',
             'project_name:test',
             'space_name:Default',
+            'server_node:OctopusServerNodes-50c3dfbarc82',
         ],
     )
     aggregator.assert_metric(
@@ -329,6 +338,7 @@ def test_completed_tasks(get_current_datetime, dd_run_check, aggregator):
             'task_state:Failed',
             'project_name:test',
             'space_name:Default',
+            'server_node:OctopusServerNodes-50c3dfbarc82',
         ],
     )
     aggregator.assert_metric(
@@ -340,6 +350,7 @@ def test_completed_tasks(get_current_datetime, dd_run_check, aggregator):
             'task_state:Failed',
             'project_name:test',
             'space_name:Default',
+            'server_node:OctopusServerNodes-50c3dfbarc82',
         ],
     )
     aggregator.assert_metric(
@@ -351,6 +362,7 @@ def test_completed_tasks(get_current_datetime, dd_run_check, aggregator):
             'task_state:Failed',
             'project_name:test',
             'space_name:Default',
+            'server_node:OctopusServerNodes-50c3dfbarc82',
         ],
     )
     aggregator.assert_metric(
@@ -362,6 +374,7 @@ def test_completed_tasks(get_current_datetime, dd_run_check, aggregator):
             'task_state:Success',
             'project_name:test',
             'space_name:Default',
+            'server_node:OctopusServerNodes-50c3dfbarc82',
         ],
     )
     aggregator.assert_metric(
@@ -373,6 +386,7 @@ def test_completed_tasks(get_current_datetime, dd_run_check, aggregator):
             'task_state:Success',
             'project_name:test',
             'space_name:Default',
+            'server_node:OctopusServerNodes-50c3dfbarc82',
         ],
     )
     aggregator.assert_metric(
@@ -384,6 +398,7 @@ def test_completed_tasks(get_current_datetime, dd_run_check, aggregator):
             'task_state:Success',
             'project_name:test',
             'space_name:Default',
+            'server_node:OctopusServerNodes-50c3dfbarc82',
         ],
     )
     aggregator.assert_metric(
@@ -395,6 +410,7 @@ def test_completed_tasks(get_current_datetime, dd_run_check, aggregator):
             'task_state:Success',
             'project_name:test',
             'space_name:Default',
+            'server_node:OctopusServerNodes-50c3dfbarc82',
         ],
     )
     aggregator.assert_metric(
@@ -405,6 +421,7 @@ def test_completed_tasks(get_current_datetime, dd_run_check, aggregator):
             'task_state:Success',
             'project_name:test',
             'space_name:Default',
+            'server_node:OctopusServerNodes-50c3dfbarc82',
         ],
     )
     aggregator.assert_metric(
@@ -416,6 +433,7 @@ def test_completed_tasks(get_current_datetime, dd_run_check, aggregator):
             'task_state:Success',
             'project_name:test',
             'space_name:Default',
+            'server_node:OctopusServerNodes-50c3dfbarc82',
         ],
     )
     aggregator.assert_metric(
@@ -427,6 +445,7 @@ def test_completed_tasks(get_current_datetime, dd_run_check, aggregator):
             'task_state:Success',
             'project_name:test',
             'space_name:Default',
+            'server_node:OctopusServerNodes-50c3dfbarc82',
         ],
     )
     aggregator.assert_metric(
@@ -438,6 +457,7 @@ def test_completed_tasks(get_current_datetime, dd_run_check, aggregator):
             'task_state:Success',
             'project_name:test',
             'space_name:Default',
+            'server_node:OctopusServerNodes-50c3dfbarc82',
         ],
     )
 

--- a/octopus_deploy/tests/test_unit.py
+++ b/octopus_deploy/tests/test_unit.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-import datetime
 import logging
 from contextlib import nullcontext as does_not_raise
 
@@ -13,10 +12,7 @@ from datadog_checks.dev.http import MockResponse
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.octopus_deploy import OctopusDeployCheck
 
-from .constants import ALL_DEPLOYMENT_LOGS, ALL_METRICS, ONLY_TEST_LOGS
-
-MOCKED_TIME1 = datetime.datetime.fromisoformat("2024-09-23T14:45:00.123+00:00")
-MOCKED_TIME2 = MOCKED_TIME1 + datetime.timedelta(seconds=15)
+from .constants import ALL_DEPLOYMENT_LOGS, ALL_METRICS, MOCKED_TIME1, MOCKED_TIME2, ONLY_TEST_LOGS
 
 
 @pytest.mark.parametrize(
@@ -901,7 +897,7 @@ def test_server_node_endpoint_failed(get_current_datetime, dd_run_check, aggrega
             True,
             {'include': [{'.*': {'projects': {'include': [r'^test$']}}}]},
             ONLY_TEST_LOGS,
-            id='logs enabled only test',
+            id='logs enabled only test logs',
         ),
     ],
 )


### PR DESCRIPTION
### What does this PR do?
Uses the new logs in integrations feature to support deployment logs in the octopus integration. Additionally adds the server_node tag to deployment metrics and logs.


### Motivation
Users may want a way to pull in logs from their deployments for debugging and to correlate with metrics about each deployment.

Open questions:

Should we attempt to handle multi-line logs now?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
