### PR TITLE
[Network Path] Add Windows support tag for 7.61

### DIFF
--- a/network_path/manifest.json
+++ b/network_path/manifest.json
@@ -13,6 +13,7 @@
     "media": [],
     "classifier_tags": [
       "Supported OS::Linux",
+      "Supported OS::Windows",
       "Category::Network",
       "Offering::Integration"
     ]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds the Windows support tag to go out with agent 7.61.

### Motivation
<!-- What inspired you to submit this pull request? -->
Windows support begins in agent 7.61

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [x] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
