### PR TITLE
Bump base package dependency to get fixed pyyaml

### DIFF
--- a/kubevirt_handler/changelog.d/19156.fixed
+++ b/kubevirt_handler/changelog.d/19156.fixed
@@ -1,0 +1,1 @@
+Bump base package dependency to get fixed pyyaml.

--- a/kubevirt_handler/pyproject.toml
+++ b/kubevirt_handler/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=32.6.0",
+    "datadog-checks-base>=33.0.0",
 ]
 dynamic = [
     "version",

--- a/kubevirt_handler/pyproject.toml
+++ b/kubevirt_handler/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=33.0.0",
+    "datadog-checks-base>=36.5.0",
 ]
 dynamic = [
     "version",

--- a/nvidia_nim/changelog.d/19156.fixed
+++ b/nvidia_nim/changelog.d/19156.fixed
@@ -1,0 +1,1 @@
+Bump base package dependency to get fixed pyyaml.

--- a/nvidia_nim/pyproject.toml
+++ b/nvidia_nim/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=32.6.0",
+    "datadog-checks-base>=33.0.0",
 ]
 dynamic = [
     "version",

--- a/slurm/changelog.d/19156.fixed
+++ b/slurm/changelog.d/19156.fixed
@@ -1,0 +1,1 @@
+Bump base package dependency to get fixed pyyaml.

--- a/slurm/pyproject.toml
+++ b/slurm/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=32.6.0",
+    "datadog-checks-base>=33.0.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

We also bump the base package in `kubevirt_handler` to use a test function.
Tested with [this pipeline](https://github.com/DataDog/integrations-core/actions/runs/12065933428).

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
