### PR TITLE
Fix vLLM dashboard widget for prefilled token percentage

### DIFF
--- a/vllm/assets/dashboards/overview.json
+++ b/vllm/assets/dashboards/overview.json
@@ -448,7 +448,7 @@
                                             "aggregator": "avg",
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:vllm.avg.generation_throughput.toks_per_s{$model_name}"
+                                            "query": "sum:vllm.avg.generation_throughput.toks_per_s{$model_name}"
                                         }
                                     ],
                                     "response_format": "scalar"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
In one of our widgets for vLLM we calculate a percentage by dividing the average value for a metric by its sum. We mistakenly were dividing the average by the average to get 100% all the time.

We now have the sum in the denominator.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
