### PR TITLE
[PLINT-485] Add support for events 

### DIFF
--- a/octopus_deploy/tests/constants.py
+++ b/octopus_deploy/tests/constants.py
@@ -37,3 +37,18 @@ ALL_METRICS = [
     "octopus_deploy.server_node.in_maintenance_mode",
     "octopus_deploy.server_node.max_concurrent_tasks",
 ]
+
+ALL_EVENTS = [
+    {
+        'message': 'Machine test is unhealthy',
+        'tags': ['space_name:Default'],
+    },
+    {
+        'message': 'Deploy to dev failed for new-project-from-group release 0.0.2 to dev',
+        'tags': ['space_name:Default'],
+    },
+    {
+        'message': 'Deploy to dev failed for project-new-2 release 0.0.2 to dev',
+        'tags': ['space_name:Default'],
+    },
+]

--- a/octopus_deploy/tests/fixtures/GET/api/Spaces-1/events/from=2024-09-23 14:45:00.123000+00:00/to=2024-09-23 14:45:00.123000+00:00/eventCategories=MachineHealthy,MachineUnhealthy,MachineUnavailable,CertificateExpired,DeploymentFailed,DeploymentSucceeded,LoginFailed,MachineAdded,MachineDeleted/response.json
+++ b/octopus_deploy/tests/fixtures/GET/api/Spaces-1/events/from=2024-09-23 14:45:00.123000+00:00/to=2024-09-23 14:45:00.123000+00:00/eventCategories=MachineHealthy,MachineUnhealthy,MachineUnavailable,CertificateExpired,DeploymentFailed,DeploymentSucceeded,LoginFailed,MachineAdded,MachineDeleted/response.json
@@ -1,0 +1,16 @@
+{
+    "ItemType": "Event",
+    "TotalResults": 1,
+    "ItemsPerPage": 0,
+    "NumberOfPages": 1,
+    "LastPageNumber": 0,
+    "Items": [],
+    "Links": {
+      "Self": "/api/events?from=2024-09-23 14:45:00.123000+00:00&to=2024-09-23 14:45:00.123000+00:00&eventCategories=MachineUnhealthy,MachineUnavailable,MachineHealthy,CertificateExpired,DeploymentFailed,DeploymentSucceeded,LoginFailed,MachineAdded,MachineDeleted",
+      "Template": "/api/events{?skip,regarding,regardingAny,user,users,projects,projectGroups,environments,eventGroups,eventCategories,eventAgents,tags,tenants,from,to,internal,fromAutoId,toAutoId,documentTypes,asCsv,take,ids,spaces,includeSystem,excludeDifference}",
+      "Page.All": "/api/events?from=2024-09-23 14:45:00.123000+00:00&to=2024-09-23 14:45:00.123000+00:00&eventCategories=MachineUnhealthy,MachineUnavailable,MachineHealthy,CertificateExpired,DeploymentFailed,DeploymentSucceeded,LoginFailed,MachineAdded,MachineDeleted",
+      "Page.Next": "/api/events?from=2024-09-23 14:45:00.123000+00:00&to=2024-09-23 14:45:00.123000+00:00&eventCategories=MachineUnhealthy,MachineUnavailable,MachineHealthy,CertificateExpired,DeploymentFailed,DeploymentSucceeded,LoginFailed,MachineAdded,MachineDeleted",
+      "Page.Current": "/api/events?from=2024-09-23 14:45:00.123000+00:00&to=2024-09-23 14:45:00.123000+00:00&eventCategories=MachineUnhealthy,MachineUnavailable,MachineHealthy,CertificateExpired,DeploymentFailed,DeploymentSucceeded,LoginFailed,MachineAdded,MachineDeleted",
+      "Page.Last": "/api/events?from=2024-09-23 14:45:00.123000+00:00&to=2024-09-23 14:45:00.123000+00:00&eventCategories=MachineUnhealthy,MachineUnavailable,MachineHealthy,CertificateExpired,DeploymentFailed,DeploymentSucceeded,LoginFailed,MachineAdded,MachineDeleted"
+    }
+  }

--- a/octopus_deploy/tests/fixtures/GET/api/Spaces-1/events/from=2024-09-23 14:45:00.123000+00:00/to=2024-09-23 14:45:15.123000+00:00/eventCategories=MachineHealthy,MachineUnhealthy,MachineUnavailable,CertificateExpired,DeploymentFailed,DeploymentSucceeded,LoginFailed,MachineAdded,MachineDeleted/response.json
+++ b/octopus_deploy/tests/fixtures/GET/api/Spaces-1/events/from=2024-09-23 14:45:00.123000+00:00/to=2024-09-23 14:45:15.123000+00:00/eventCategories=MachineHealthy,MachineUnhealthy,MachineUnavailable,CertificateExpired,DeploymentFailed,DeploymentSucceeded,LoginFailed,MachineAdded,MachineDeleted/response.json
@@ -1,0 +1,161 @@
+{
+    "ItemType": "Event",
+    "TotalResults": 7,
+    "ItemsPerPage": 30,
+    "NumberOfPages": 1,
+    "LastPageNumber": 0,
+    "Items": [
+        {
+            "Id": "Events-4873",
+            "RelatedDocumentIds": [
+                "Deployments-206",
+                "Projects-1",
+                "Releases-164",
+                "Environments-1",
+                "ServerTasks-118976",
+                "Channels-61"
+            ],
+            "Category": "MachineUnhealthy",
+            "UserId": "users-system",
+            "Username": "system",
+            "IsService": false,
+            "IdentityEstablishedWith": "",
+            "UserAgent": "Server",
+            "Occurred": "2024-09-23T14:45:38.109+00:00",
+            "Message": "Machine test is unhealthy",
+            "MessageHtml": "Machine <a href='#/machines/Machines-1'>test</a> is unhealthy",
+            "MessageReferences": [
+                {
+                    "ReferencedDocumentId": "Machines-1",
+                    "StartIndex": 65,
+                    "Length": 3
+                }
+            ],
+            "Comments": null,
+            "Details": null,
+            "ChangeDetails": {
+                "DocumentContext": null,
+                "Differences": null
+            },
+            "IpAddress": null,
+            "SpaceId": "Spaces-1",
+            "Links": {
+                "Self": "/api/events/Events-4873"
+            }
+        },
+        {
+            "Id": "Events-4865",
+            "RelatedDocumentIds": [
+                "Deployments-204",
+                "Projects-1",
+                "Releases-163",
+                "Environments-1",
+                "ServerTasks-118973",
+                "Channels-61"
+            ],
+            "Category": "DeploymentFailed",
+            "UserId": "users-system",
+            "Username": "system",
+            "IsService": false,
+            "IdentityEstablishedWith": "",
+            "UserAgent": "Server",
+            "Occurred": "2024-09-23T14:45:12.391+00:00",
+            "Message": "Deploy to dev failed for new-project-from-group release 0.0.2 to dev",
+            "MessageHtml": "<a href='#/deployments/Deployments-204'>Deploy to dev</a> failed for <a href='#/projects/Projects-61'>new-project-from-group</a> release <a href='#/releases/Releases-163'>0.0.2</a> to <a href='#/environments/Environments-1'>dev</a>",
+            "MessageReferences": [
+                {
+                    "ReferencedDocumentId": "Deployments-204",
+                    "StartIndex": 0,
+                    "Length": 13
+                },
+                {
+                    "ReferencedDocumentId": "Projects-61",
+                    "StartIndex": 25,
+                    "Length": 22
+                },
+                {
+                    "ReferencedDocumentId": "Releases-163",
+                    "StartIndex": 56,
+                    "Length": 5
+                },
+                {
+                    "ReferencedDocumentId": "Environments-1",
+                    "StartIndex": 65,
+                    "Length": 3
+                }
+            ],
+            "Comments": null,
+            "Details": null,
+            "ChangeDetails": {
+                "DocumentContext": null,
+                "Differences": null
+            },
+            "IpAddress": null,
+            "SpaceId": "Spaces-1",
+            "Links": {
+                "Self": "/api/events/Events-4865"
+            }
+        },
+        {
+            "Id": "Events-4070",
+            "RelatedDocumentIds": [
+                "Deployments-144",
+                "Projects-2",
+                "Releases-104",
+                "Environments-1",
+                "ServerTasks-118143",
+                "Channels-63"
+            ],
+            "Category": "DeploymentFailed",
+            "UserId": "users-system",
+            "Username": "system",
+            "IsService": false,
+            "IdentityEstablishedWith": "",
+            "UserAgent": "Server",
+            "Occurred": "2024-09-23T14:45:11.123+00:00",
+            "Message": "Deploy to dev failed for project-new-2 release 0.0.2 to dev",
+            "MessageHtml": "<a href='#/deployments/Deployments-144'>Deploy to dev</a> failed for <a href='#/projects/Projects-63'>project-new-2</a> release <a href='#/releases/Releases-104'>0.0.2</a> to <a href='#/environments/Environments-1'>dev</a>",
+            "MessageReferences": [
+                {
+                    "ReferencedDocumentId": "Deployments-144",
+                    "StartIndex": 0,
+                    "Length": 13
+                },
+                {
+                    "ReferencedDocumentId": "Projects-63",
+                    "StartIndex": 25,
+                    "Length": 13
+                },
+                {
+                    "ReferencedDocumentId": "Releases-104",
+                    "StartIndex": 47,
+                    "Length": 5
+                },
+                {
+                    "ReferencedDocumentId": "Environments-1",
+                    "StartIndex": 56,
+                    "Length": 3
+                }
+            ],
+            "Comments": null,
+            "Details": null,
+            "ChangeDetails": {
+                "DocumentContext": null,
+                "Differences": null
+            },
+            "IpAddress": null,
+            "SpaceId": "Spaces-1",
+            "Links": {
+                "Self": "/api/events/Events-4070"
+            }
+        }
+    ],
+    "Links": {
+        "Self": "/api/events?from=2024-09-23 14:45:00.123000+00:00&to=2024-09-23 14:45:15.123000+00:00&eventCategories=MachineUnhealthy,MachineUnavailable,MachineHealthy,CertificateExpired,DeploymentFailed,DeploymentSucceeded,LoginFailed,MachineAdded,MachineDeleted",
+        "Template": "/api/events{?skip,regarding,regardingAny,user,users,projects,projectGroups,environments,eventGroups,eventCategories,eventAgents,tags,tenants,from,to,internal,fromAutoId,toAutoId,documentTypes,asCsv,take,ids,spaces,includeSystem,excludeDifference}",
+        "Page.All": "/api/events?from=2024-09-23 14:45:00.123000+00:00&to=2024-09-23 14:45:15.123000+00:00&eventCategories=MachineUnhealthy,MachineUnavailable,MachineHealthy,CertificateExpired,DeploymentFailed,DeploymentSucceeded,LoginFailed,MachineAdded,MachineDeleted",
+        "Page.Next": "/api/events?from=2024-09-23 14:45:00.123000+00:00&to=2024-09-23 14:45:15.123000+00:00&eventCategories=MachineUnhealthy,MachineUnavailable,MachineHealthy,CertificateExpired,DeploymentFailed,DeploymentSucceeded,LoginFailed,MachineAdded,MachineDeleted",
+        "Page.Current": "/api/events?from=2024-09-23 14:45:00.123000+00:00&to=2024-09-23 14:45:15.123000+00:00&eventCategories=MachineUnhealthy,MachineUnavailable,MachineHealthy,CertificateExpired,DeploymentFailed,DeploymentSucceeded,LoginFailed,MachineAdded,MachineDeleted",
+        "Page.Last": "/api/events?from=2024-09-23 14:45:00.123000+00:00&to=2024-09-23 14:45:15.123000+00:00&eventCategories=MachineUnhealthy,MachineUnavailable,MachineHealthy,CertificateExpired,DeploymentFailed,DeploymentSucceeded,LoginFailed,MachineAdded,MachineDeleted"
+    }
+}


### PR DESCRIPTION
### What does this PR do?
Adds support for audit events in octopus integration.

### Motivation
currently, we only support a few event categories. Later we may add support for customizing what event categories to emit and add more tags to the events.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
