### PR TITLE
Sy/slurm user

### DIFF
--- a/slurm/changelog.d/19182.fixed
+++ b/slurm/changelog.d/19182.fixed
@@ -1,0 +1,1 @@
+Add all user query param to the different queries

--- a/slurm/datadog_checks/slurm/constants.py
+++ b/slurm/datadog_checks/slurm/constants.py
@@ -2,16 +2,16 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 SINFO_PARTITION_PARAMS = [
-    "-hO",
+    "-ahO",
     "Partition:|,NodeList:|,CPUs:|,Available:|,Memory:|,Cluster:|,NodeAIOT:|,StateLong:|,Nodes:",
 ]
-SINFO_NODE_PARAMS = ["-hNO", "PartitionName:|,Available:|,NodeList:|,NodeAIOT:|,Memory:|,Cluster:"]
+SINFO_NODE_PARAMS = ["-haNO", "PartitionName:|,Available:|,NodeList:|,NodeAIOT:|,Memory:|,Cluster:"]
 SINFO_ADDITIONAL_NODE_PARAMS = "|,CPUsLoad:|,FreeMem:|,Disk:|,StateLong:|,Reason:|,features_act:|,Threads:"
 GPU_PARAMS = "|,Gres:|,GresUsed:"
-SQUEUE_PARAMS = ["-ho", "%A|%u|%j|%T|%N|%C|%R|%m"]
-SSHARE_PARAMS = ["-lnPU"]
+SQUEUE_PARAMS = ["-aho", "%A|%u|%j|%T|%N|%C|%R|%m"]
+SSHARE_PARAMS = ["-alnPU"]
 SACCT_PARAMS = [
-    "-npo",
+    "-anpo",
     "JobID,JobName%40,Partition,Account,AllocCPUs,AllocTRES%40,Elapsed,CPUTimeRAW,MaxRSS,MaxVMSize,AveCPU,AveRSS,State,ExitCode,Start,End,NodeList",
     "--units=M",
 ]


### PR DESCRIPTION
### What does this PR do?
The binaries are running user sensitive. Since the agent in Linux is ran as the dd-agent user, this will sometime result in empty outputs. By default the binaries will user the running user and return jobs etc only for the running user. dd-agent user in this case. By passing in the `-a` flag, this allows the dd-agent user to retrieve all user data.