### PR TITLE
Fall back to system_health/event_file when querying deadlocks

### DIFF
--- a/sqlserver/changelog.d/19189.changed
+++ b/sqlserver/changelog.d/19189.changed
@@ -1,0 +1,1 @@
+Fall back to ``system_health/event_file`` when querying deadlocks if `datadog` XE session wasn't created.

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/xe_session_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/xe_session_metrics.py
@@ -6,6 +6,8 @@ from datadog_checks.base.config import is_affirmative
 
 from .base import SqlserverDatabaseMetricsBase
 
+XE_RING_BUFFER = "ring_buffer"
+
 XE_SESSION_STATUS_QUERY = {
     "name": "sys.dm_xe_sessions",
     "query": """SELECT

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/xe_session_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/xe_session_metrics.py
@@ -7,6 +7,7 @@ from datadog_checks.base.config import is_affirmative
 from .base import SqlserverDatabaseMetricsBase
 
 XE_RING_BUFFER = "ring_buffer"
+XE_EVENT_FILE = "event_file"
 
 XE_SESSION_STATUS_QUERY = {
     "name": "sys.dm_xe_sessions",

--- a/sqlserver/datadog_checks/sqlserver/deadlocks.py
+++ b/sqlserver/datadog_checks/sqlserver/deadlocks.py
@@ -147,7 +147,7 @@ class Deadlocks(DBMAsyncJob):
                             xe_system_found = True
                             if target == XE_EVENT_FILE:
                                 xe_system_xe_file_found = True
-                            
+
                     if xe_system_found:
                         self._xe_session_name = XE_SESSION_SYSTEM
                         if xe_system_xe_file_found:
@@ -164,7 +164,9 @@ class Deadlocks(DBMAsyncJob):
             except NoXESessionError as e:
                 self._log.error(str(e))
                 return
-            self._log.info(f'Using XE session [{self._xe_session_name}], target [{self._xe_session_target}] to collect deadlocks')
+            self._log.info(
+                f'Using XE session [{self._xe_session_name}], target [{self._xe_session_target}] to collect deadlocks'
+            )
 
         with self._check.connection.open_managed_default_connection(key_prefix=self._conn_key_prefix):
             with self._check.connection.get_managed_cursor(key_prefix=self._conn_key_prefix) as cursor:
@@ -172,7 +174,9 @@ class Deadlocks(DBMAsyncJob):
                 if self._force_convert_xml_to_str or self._get_connector() == "adodbapi":
                     convert_xml_to_str = True
                 query = get_deadlocks_query(
-                    convert_xml_to_str=convert_xml_to_str, xe_session_name=self._xe_session_name, xe_target_name=self._xe_session_target
+                    convert_xml_to_str=convert_xml_to_str,
+                    xe_session_name=self._xe_session_name,
+                    xe_target_name=self._xe_session_target,
                 )
                 lookback = self._get_lookback_seconds()
                 self._log.debug(
@@ -192,7 +196,7 @@ class Deadlocks(DBMAsyncJob):
                 return [dict(zip(columns, row)) for row in cursor.fetchall()]
 
     def _create_deadlock_rows(self):
-        db_rows = self._query_deadlocks()        
+        db_rows = self._query_deadlocks()
         deadlock_events = []
         total_number_of_characters = 0
         for i, row in enumerate(db_rows):

--- a/sqlserver/datadog_checks/sqlserver/deadlocks.py
+++ b/sqlserver/datadog_checks/sqlserver/deadlocks.py
@@ -172,7 +172,7 @@ class Deadlocks(DBMAsyncJob):
                 if self._force_convert_xml_to_str or self._get_connector() == "adodbapi":
                     convert_xml_to_str = True
                 query = get_deadlocks_query(
-                    convert_xml_to_str=convert_xml_to_str, xe_session_name=self._xe_session_name
+                    convert_xml_to_str=convert_xml_to_str, xe_session_name=self._xe_session_name, xe_target_name=self._xe_session_target
                 )
                 lookback = self._get_lookback_seconds()
                 self._log.debug(

--- a/sqlserver/datadog_checks/sqlserver/deadlocks.py
+++ b/sqlserver/datadog_checks/sqlserver/deadlocks.py
@@ -53,6 +53,7 @@ class Deadlocks(DBMAsyncJob):
         self.collection_interval = config.deadlocks_config.get("collection_interval", DEFAULT_COLLECTION_INTERVAL)
         self._force_convert_xml_to_str = False
         self._xe_session_name = None
+        self._xe_session_target = None
         super(Deadlocks, self).__init__(
             check,
             run_sync=True,

--- a/sqlserver/datadog_checks/sqlserver/deadlocks.py
+++ b/sqlserver/datadog_checks/sqlserver/deadlocks.py
@@ -192,7 +192,7 @@ class Deadlocks(DBMAsyncJob):
                 return [dict(zip(columns, row)) for row in cursor.fetchall()]
 
     def _create_deadlock_rows(self):
-        db_rows = self._query_deadlocks()
+        db_rows = self._query_deadlocks()        
         deadlock_events = []
         total_number_of_characters = 0
         for i, row in enumerate(db_rows):

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -172,14 +172,16 @@ def get_deadlocks_query(convert_xml_to_str=False, xe_session_name=XE_SESSION_DAT
         ) AS XML_Data
     CROSS APPLY Target_Data.nodes('RingBufferTarget/event[@name="xml_deadlock_report"]') AS XEventData(xdr)
     WHERE xdr.value('@timestamp', 'datetime')
-        >= DATEADD(SECOND, ?, TODATETIMEOFFSET(GETDATE(), DATEPART(TZOFFSET, SYSDATETIMEOFFSET())) AT TIME ZONE 'UTC');"""
-        
+        >= DATEADD(SECOND, ?, TODATETIMEOFFSET(GETDATE(), DATEPART(TZOFFSET, SYSDATETIMEOFFSET())) AT TIME ZONE 'UTC')
+    ;"""
+
     return f"""SELECT TOP(?)
 event_data AS [{DEADLOCK_XML_ALIAS}],
-CONVERT(xml, event_data).value('(event[@name="xml_deadlock_report"]/@timestamp)[1]','datetime') AS [{DEADLOCK_TIMESTAMP_ALIAS}]
-FROM 
+CONVERT(xml, event_data).value('(event[@name="xml_deadlock_report"]/@timestamp)[1]','datetime')
+    AS [{DEADLOCK_TIMESTAMP_ALIAS}]
+FROM
 sys.fn_xe_file_target_read_file
 ('system_health*.xel', null, null, null)
-WHERE object_name like 'xml_deadlock_report' 
-  and CONVERT(xml, event_data).value('(event[@name="xml_deadlock_report"]/@timestamp)[1]','datetime') 
+WHERE object_name like 'xml_deadlock_report'
+  and CONVERT(xml, event_data).value('(event[@name="xml_deadlock_report"]/@timestamp)[1]','datetime')
     >= DATEADD(SECOND, ?, TODATETIMEOFFSET(GETDATE(), DATEPART(TZOFFSET, SYSDATETIMEOFFSET())) AT TIME ZONE 'UTC');"""

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -136,15 +136,14 @@ XE_SESSION_DATADOG = "datadog"
 XE_SESSION_SYSTEM = "system_health"
 XE_SESSIONS_QUERY = f"""
 SELECT
-    s.name AS session_name
+    s.name AS session_name, t.target_name AS target_name
 FROM
     sys.dm_xe_sessions s
 JOIN
     sys.dm_xe_session_targets t
     ON s.address = t.event_session_address
 WHERE
-    t.target_name = 'ring_buffer'
-    AND s.name IN ('{XE_SESSION_DATADOG}', '{XE_SESSION_SYSTEM}');
+    s.name IN ('{XE_SESSION_DATADOG}', '{XE_SESSION_SYSTEM}');
 """
 
 DEADLOCK_TIMESTAMP_ALIAS = "timestamp"

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+from datadog_checks.sqlserver.database_metrics.xe_session_metrics import XE_RING_BUFFER
 
 DB_QUERY = """
 SELECT
@@ -150,7 +151,7 @@ DEADLOCK_TIMESTAMP_ALIAS = "timestamp"
 DEADLOCK_XML_ALIAS = "event_xml"
 
 
-def get_deadlocks_query(convert_xml_to_str=False, xe_session_name="datadog"):
+def get_deadlocks_query(convert_xml_to_str=False, xe_session_name=XE_SESSION_DATADOG, xe_target_name=XE_RING_BUFFER):
     """
     Construct the query to fetch deadlocks from the system_health extended event session
     :param convert_xml_to_str: Whether to convert the XML to a string. This option is for MSOLEDB drivers
@@ -168,7 +169,7 @@ def get_deadlocks_query(convert_xml_to_str=False, xe_session_name="datadog"):
                 FROM sys.dm_xe_session_targets AS xt
                 INNER JOIN sys.dm_xe_sessions AS xs ON xs.address = xt.event_session_address
                 WHERE xs.name = N'{xe_session_name}'
-                AND xt.target_name = N'ring_buffer'
+                AND xt.target_name = N'{xe_target_name}'
         ) AS XML_Data
     CROSS APPLY Target_Data.nodes('RingBufferTarget/event[@name="xml_deadlock_report"]') AS XEventData(xdr)
     WHERE xdr.value('@timestamp', 'datetime')

--- a/sqlserver/tests/test_deadlocks.py
+++ b/sqlserver/tests/test_deadlocks.py
@@ -22,7 +22,8 @@ from datadog_checks.sqlserver.deadlocks import (
     XE_SESSION_DATADOG,
     Deadlocks,
 )
-from datadog_checks.sqlserver.queries import DEADLOCK_TIMESTAMP_ALIAS, DEADLOCK_XML_ALIAS
+from datadog_checks.sqlserver.database_metrics.xe_session_metrics import XE_EVENT_FILE, XE_RING_BUFFER
+from datadog_checks.sqlserver.queries import DEADLOCK_TIMESTAMP_ALIAS, DEADLOCK_XML_ALIAS, XE_SESSION_DATADOG, XE_SESSION_SYSTEM
 
 from .common import CHECK_NAME
 
@@ -137,9 +138,17 @@ def _create_deadlock(dd_environment, dbm_instance):
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.usefixtures('_create_deadlock')
 @pytest.mark.parametrize("convert_xml_to_str", [False, True])
-def test_deadlocks(aggregator, dd_run_check, dbm_instance, convert_xml_to_str):
+@pytest.mark.parametrize("xe_session_name, xe_session_target", 
+    [
+        [XE_SESSION_DATADOG, XE_RING_BUFFER],
+        [XE_SESSION_SYSTEM, XE_EVENT_FILE],
+    ]
+)
+def test_deadlocks(aggregator, dd_run_check, dbm_instance, convert_xml_to_str, xe_session_name, xe_session_target):
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
     check.deadlocks._force_convert_xml_to_str = convert_xml_to_str
+    check.deadlocks._xe_session_name = xe_session_name
+    check.deadlocks._xe_session_target = xe_session_target
 
     dbm_instance['dbm_enabled'] = True
     deadlock_payloads = _run_check_and_get_deadlock_payloads(dd_run_check, check, aggregator)

--- a/sqlserver/tests/test_deadlocks.py
+++ b/sqlserver/tests/test_deadlocks.py
@@ -16,14 +16,18 @@ import pytest
 from mock import patch
 
 from datadog_checks.sqlserver import SQLServer
+from datadog_checks.sqlserver.database_metrics.xe_session_metrics import XE_EVENT_FILE, XE_RING_BUFFER
 from datadog_checks.sqlserver.deadlocks import (
     PAYLOAD_QUERY_SIGNATURE,
     PAYLOAD_TIMESTAMP,
-    XE_SESSION_DATADOG,
     Deadlocks,
 )
-from datadog_checks.sqlserver.database_metrics.xe_session_metrics import XE_EVENT_FILE, XE_RING_BUFFER
-from datadog_checks.sqlserver.queries import DEADLOCK_TIMESTAMP_ALIAS, DEADLOCK_XML_ALIAS, XE_SESSION_DATADOG, XE_SESSION_SYSTEM
+from datadog_checks.sqlserver.queries import (
+    DEADLOCK_TIMESTAMP_ALIAS,
+    DEADLOCK_XML_ALIAS,
+    XE_SESSION_DATADOG,
+    XE_SESSION_SYSTEM,
+)
 
 from .common import CHECK_NAME
 
@@ -138,11 +142,12 @@ def _create_deadlock(dd_environment, dbm_instance):
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.usefixtures('_create_deadlock')
 @pytest.mark.parametrize("convert_xml_to_str", [False, True])
-@pytest.mark.parametrize("xe_session_name, xe_session_target", 
+@pytest.mark.parametrize(
+    "xe_session_name, xe_session_target",
     [
         [XE_SESSION_DATADOG, XE_RING_BUFFER],
         [XE_SESSION_SYSTEM, XE_EVENT_FILE],
-    ]
+    ],
 )
 def test_deadlocks(aggregator, dd_run_check, dbm_instance, convert_xml_to_str, xe_session_name, xe_session_target):
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])


### PR DESCRIPTION
### What does this PR do?

If the `datadog` XE session isn't created, the agent will retrieve deadlocks from `system_health/event_file`.

### Motivation

Some customers can't or prefer not to create dedicated XE sessions. We use event_file over ring_buffer to avoid truncating recent events, but `datadog` XE session remains the preferred option for better performance.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
