### PR TITLE
Add note about required obfuscator option for APM linking in DBM integrations

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -665,6 +665,7 @@ files:
                 description: |
                   Set to `false` to disable the collection of comments in your SQL statements.
                   Requires `collect_metadata: true`.
+                  Note: This option must be `true` in order to propagate APM traces.
                 value:
                   type: boolean
                   example: true

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -665,7 +665,8 @@ files:
                 description: |
                   Set to `false` to disable the collection of comments in your SQL statements.
                   Requires `collect_metadata: true`.
-                  Note: This option must be `true` in order to correlate Database Monitoring samples and APM traces. See https://docs.datadoghq.com/database_monitoring/connect_dbm_and_apm
+                  Note: This option must be `true` in order to correlate Database Monitoring samples and APM traces.
+                  See https://docs.datadoghq.com/database_monitoring/connect_dbm_and_apm
                 value:
                   type: boolean
                   example: true

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -665,7 +665,7 @@ files:
                 description: |
                   Set to `false` to disable the collection of comments in your SQL statements.
                   Requires `collect_metadata: true`.
-                  Note: This option must be `true` in order to propagate APM traces.
+                  Note: This option must be `true` in order to correlate Database Monitoring samples and APM traces. See https://docs.datadoghq.com/database_monitoring/connect_dbm_and_apm
                 value:
                   type: boolean
                   example: true

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -609,7 +609,8 @@ instances:
         ## @param collect_comments - boolean - optional - default: true
         ## Set to `false` to disable the collection of comments in your SQL statements.
         ## Requires `collect_metadata: true`.
-        ## Note: This option must be `true` in order to correlate Database Monitoring samples and APM traces. See https://docs.datadoghq.com/database_monitoring/connect_dbm_and_apm
+        ## Note: This option must be `true` in order to correlate Database Monitoring samples and APM traces.
+        ## See https://docs.datadoghq.com/database_monitoring/connect_dbm_and_apm
         #
         # collect_comments: true
 

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -609,7 +609,7 @@ instances:
         ## @param collect_comments - boolean - optional - default: true
         ## Set to `false` to disable the collection of comments in your SQL statements.
         ## Requires `collect_metadata: true`.
-        ## Note: This option must be `true` in order to propagate APM traces.
+        ## Note: This option must be `true` in order to correlate Database Monitoring samples and APM traces. See https://docs.datadoghq.com/database_monitoring/connect_dbm_and_apm
         #
         # collect_comments: true
 

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -609,6 +609,7 @@ instances:
         ## @param collect_comments - boolean - optional - default: true
         ## Set to `false` to disable the collection of comments in your SQL statements.
         ## Requires `collect_metadata: true`.
+        ## Note: This option must be `true` in order to propagate APM traces.
         #
         # collect_comments: true
 

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -888,6 +888,7 @@ files:
           description: |
             Set to `false` to disable the collection of comments in your SQL statements.
             Requires `collect_metadata: true`.
+            Note: This option must be `true` in order to propagate APM traces.
           value:
             type: boolean
             example: true

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -888,7 +888,7 @@ files:
           description: |
             Set to `false` to disable the collection of comments in your SQL statements.
             Requires `collect_metadata: true`.
-            Note: This option must be `true` in order to propagate APM traces.
+            Note: This option must be `true` in order to correlate Database Monitoring samples and APM traces. See https://docs.datadoghq.com/database_monitoring/connect_dbm_and_apm
           value:
             type: boolean
             example: true

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -888,7 +888,8 @@ files:
           description: |
             Set to `false` to disable the collection of comments in your SQL statements.
             Requires `collect_metadata: true`.
-            Note: This option must be `true` in order to correlate Database Monitoring samples and APM traces. See https://docs.datadoghq.com/database_monitoring/connect_dbm_and_apm
+            Note: This option must be `true` in order to correlate Database Monitoring samples and APM traces.
+            See https://docs.datadoghq.com/database_monitoring/connect_dbm_and_apm
           value:
             type: boolean
             example: true

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -778,7 +778,8 @@ instances:
         ## @param collect_comments - boolean - optional - default: true
         ## Set to `false` to disable the collection of comments in your SQL statements.
         ## Requires `collect_metadata: true`.
-        ## Note: This option must be `true` in order to correlate Database Monitoring samples and APM traces. See https://docs.datadoghq.com/database_monitoring/connect_dbm_and_apm
+        ## Note: This option must be `true` in order to correlate Database Monitoring samples and APM traces.
+        ## See https://docs.datadoghq.com/database_monitoring/connect_dbm_and_apm
         #
         # collect_comments: true
 

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -778,7 +778,7 @@ instances:
         ## @param collect_comments - boolean - optional - default: true
         ## Set to `false` to disable the collection of comments in your SQL statements.
         ## Requires `collect_metadata: true`.
-        ## Note: This option must be `true` in order to propagate APM traces.
+        ## Note: This option must be `true` in order to correlate Database Monitoring samples and APM traces. See https://docs.datadoghq.com/database_monitoring/connect_dbm_and_apm
         #
         # collect_comments: true
 

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -778,6 +778,7 @@ instances:
         ## @param collect_comments - boolean - optional - default: true
         ## Set to `false` to disable the collection of comments in your SQL statements.
         ## Requires `collect_metadata: true`.
+        ## Note: This option must be `true` in order to propagate APM traces.
         #
         # collect_comments: true
 

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -744,7 +744,7 @@ files:
           description: |
             Set to `false` to disable the collection of comments in your SQL statements.
             Requires `collect_metadata: true`.
-            Note: This option must be `true` in order to propagate APM traces.
+            Note: This option must be `true` in order to correlate Database Monitoring samples and APM traces. See https://docs.datadoghq.com/database_monitoring/connect_dbm_and_apm
           value:
             type: boolean
             example: true

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -744,6 +744,7 @@ files:
           description: |
             Set to `false` to disable the collection of comments in your SQL statements.
             Requires `collect_metadata: true`.
+            Note: This option must be `true` in order to propagate APM traces.
           value:
             type: boolean
             example: true

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -744,7 +744,8 @@ files:
           description: |
             Set to `false` to disable the collection of comments in your SQL statements.
             Requires `collect_metadata: true`.
-            Note: This option must be `true` in order to correlate Database Monitoring samples and APM traces. See https://docs.datadoghq.com/database_monitoring/connect_dbm_and_apm
+            Note: This option must be `true` in order to correlate Database Monitoring samples and APM traces.
+            See https://docs.datadoghq.com/database_monitoring/connect_dbm_and_apm
           value:
             type: boolean
             example: true

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -544,6 +544,7 @@ instances:
         ## @param collect_comments - boolean - optional - default: true
         ## Set to `false` to disable the collection of comments in your SQL statements.
         ## Requires `collect_metadata: true`.
+        ## Note: This option must be `true` in order to propagate APM traces.
         #
         # collect_comments: true
 

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -544,7 +544,8 @@ instances:
         ## @param collect_comments - boolean - optional - default: true
         ## Set to `false` to disable the collection of comments in your SQL statements.
         ## Requires `collect_metadata: true`.
-        ## Note: This option must be `true` in order to correlate Database Monitoring samples and APM traces. See https://docs.datadoghq.com/database_monitoring/connect_dbm_and_apm
+        ## Note: This option must be `true` in order to correlate Database Monitoring samples and APM traces.
+        ## See https://docs.datadoghq.com/database_monitoring/connect_dbm_and_apm
         #
         # collect_comments: true
 

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -544,7 +544,7 @@ instances:
         ## @param collect_comments - boolean - optional - default: true
         ## Set to `false` to disable the collection of comments in your SQL statements.
         ## Requires `collect_metadata: true`.
-        ## Note: This option must be `true` in order to propagate APM traces.
+        ## Note: This option must be `true` in order to correlate Database Monitoring samples and APM traces. See https://docs.datadoghq.com/database_monitoring/connect_dbm_and_apm
         #
         # collect_comments: true
 


### PR DESCRIPTION
### What does this PR do?
Adds a note to the `collect_commands` query obfuscator options stating that this option must remain `true` in order for proper propagation of APM traces into DBM query sample collection. If this option is false then we won't extract and submit comments to be processed on the backend leading to incomplete APM <> DBM linking

### Motivation
The default option is already to have this enabled. We want to documentation to be clear that disabling this will affect APM linking

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
