### PR TITLE
Fix PR number in changelog entries

### DIFF
--- a/amazon_msk/CHANGELOG.md
+++ b/amazon_msk/CHANGELOG.md
@@ -32,7 +32,7 @@
 
 ***Added***:
 
-* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18187))
 
 ## 4.9.0 / 2024-07-05 / Agent 7.56.0
 

--- a/amazon_msk/CHANGELOG.md
+++ b/amazon_msk/CHANGELOG.md
@@ -32,7 +32,7 @@
 
 ***Added***:
 
-* Update dependencies ([#18185](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
 
 ## 4.9.0 / 2024-07-05 / Agent 7.56.0
 

--- a/cisco_aci/CHANGELOG.md
+++ b/cisco_aci/CHANGELOG.md
@@ -72,7 +72,7 @@
 * [NDM] Add NDM metadata support for Cisco ACI ([#17735](https://github.com/DataDog/integrations-core/pull/17735))
 * [NDM] [Cisco ACI] Add common NDM tags to metrics ([#18017](https://github.com/DataDog/integrations-core/pull/18017))
 * [NDM] [Cisco ACI] Add config flag for enabling sending metadata to NDM ([#18099](https://github.com/DataDog/integrations-core/pull/18099))
-* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18187))
 
 ## 2.9.0 / 2024-07-05 / Agent 7.56.0
 

--- a/cisco_aci/CHANGELOG.md
+++ b/cisco_aci/CHANGELOG.md
@@ -72,7 +72,7 @@
 * [NDM] Add NDM metadata support for Cisco ACI ([#17735](https://github.com/DataDog/integrations-core/pull/17735))
 * [NDM] [Cisco ACI] Add common NDM tags to metrics ([#18017](https://github.com/DataDog/integrations-core/pull/18017))
 * [NDM] [Cisco ACI] Add config flag for enabling sending metadata to NDM ([#18099](https://github.com/DataDog/integrations-core/pull/18099))
-* Update dependencies ([#18185](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
 
 ## 2.9.0 / 2024-07-05 / Agent 7.56.0
 

--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -73,7 +73,7 @@
 * Log invalid line when failing to parse OpenMetrics response ([#17514](https://github.com/DataDog/integrations-core/pull/17514))
 * Support log submission from checks ([#18019](https://github.com/DataDog/integrations-core/pull/18019))
 * Allow untyped metrics that we coerce to `counter` to be collected regardless if they have `_total` or not. ([#18054](https://github.com/DataDog/integrations-core/pull/18054))
-* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18187))
 
 ## 36.10.0 / 2024-07-11
 

--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -73,7 +73,7 @@
 * Log invalid line when failing to parse OpenMetrics response ([#17514](https://github.com/DataDog/integrations-core/pull/17514))
 * Support log submission from checks ([#18019](https://github.com/DataDog/integrations-core/pull/18019))
 * Allow untyped metrics that we coerce to `counter` to be collected regardless if they have `_total` or not. ([#18054](https://github.com/DataDog/integrations-core/pull/18054))
-* Update dependencies ([#18185](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
 
 ## 36.10.0 / 2024-07-11
 

--- a/http_check/CHANGELOG.md
+++ b/http_check/CHANGELOG.md
@@ -36,7 +36,7 @@
 
 ***Added***:
 
-* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18187))
 
 ## 9.7.0 / 2024-07-05 / Agent 7.56.0
 

--- a/http_check/CHANGELOG.md
+++ b/http_check/CHANGELOG.md
@@ -36,7 +36,7 @@
 
 ***Added***:
 
-* Update dependencies ([#18185](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
 
 ## 9.7.0 / 2024-07-05 / Agent 7.56.0
 

--- a/kafka_consumer/CHANGELOG.md
+++ b/kafka_consumer/CHANGELOG.md
@@ -38,7 +38,7 @@
 
 ***Added***:
 
-* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18187))
 
 ## 4.5.0 / 2024-07-05 / Agent 7.56.0
 

--- a/kafka_consumer/CHANGELOG.md
+++ b/kafka_consumer/CHANGELOG.md
@@ -38,7 +38,7 @@
 
 ***Added***:
 
-* Update dependencies ([#18185](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
 
 ## 4.5.0 / 2024-07-05 / Agent 7.56.0
 

--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -71,7 +71,7 @@
 
 * Adding databases (schemas) data collection to MySQL
   These data include information about the tables, their columns, indexes, foreign keys, and partitions. ([#17916](https://github.com/DataDog/integrations-core/pull/17916))
-* Update dependencies ([#18185](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
 
 ***Fixed***:
 

--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -71,7 +71,7 @@
 
 * Adding databases (schemas) data collection to MySQL
   These data include information about the tables, their columns, indexes, foreign keys, and partitions. ([#17916](https://github.com/DataDog/integrations-core/pull/17916))
-* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18187))
 
 ***Fixed***:
 

--- a/openstack_controller/CHANGELOG.md
+++ b/openstack_controller/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ***Added***:
 
-* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18187))
 
 ## 6.8.1 / 2024-07-24 / Agent 7.56.0
 

--- a/openstack_controller/CHANGELOG.md
+++ b/openstack_controller/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ***Added***:
 
-* Update dependencies ([#18185](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
 
 ## 6.8.1 / 2024-07-24 / Agent 7.56.0
 

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -99,7 +99,7 @@
 * Allow filtering of schema collection in Postgres using regexes to include or exclude objects ([#18145](https://github.com/DataDog/integrations-core/pull/18145))
 * Collect blk read/write time from pg_stat_database ([#18169](https://github.com/DataDog/integrations-core/pull/18169))
 * Use QueryManager to collect `custom_queries` and `global_custom_queries`. `custom_queries` now supports configurable `collection_interval`. ([#18183](https://github.com/DataDog/integrations-core/pull/18183))
-* Update dependencies ([#18185](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
 * Add new config option `role_arn` to AWS managed authentication to support cross account IAM auth. ([#18228](https://github.com/DataDog/integrations-core/pull/18228))
 
 ***Fixed***:

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -99,7 +99,7 @@
 * Allow filtering of schema collection in Postgres using regexes to include or exclude objects ([#18145](https://github.com/DataDog/integrations-core/pull/18145))
 * Collect blk read/write time from pg_stat_database ([#18169](https://github.com/DataDog/integrations-core/pull/18169))
 * Use QueryManager to collect `custom_queries` and `global_custom_queries`. `custom_queries` now supports configurable `collection_interval`. ([#18183](https://github.com/DataDog/integrations-core/pull/18183))
-* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18187))
 * Add new config option `role_arn` to AWS managed authentication to support cross account IAM auth. ([#18228](https://github.com/DataDog/integrations-core/pull/18228))
 
 ***Fixed***:

--- a/redisdb/CHANGELOG.md
+++ b/redisdb/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ***Added***:
 
-* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18187))
 
 ## 5.6.0 / 2024-07-05 / Agent 7.56.0
 

--- a/redisdb/CHANGELOG.md
+++ b/redisdb/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ***Added***:
 
-* Update dependencies ([#18185](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
 
 ## 5.6.0 / 2024-07-05 / Agent 7.56.0
 

--- a/snmp/CHANGELOG.md
+++ b/snmp/CHANGELOG.md
@@ -43,7 +43,7 @@
 
 ***Added***:
 
-* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18187))
 
 ## 7.3.1 / 2024-06-05 / Agent 7.55.0
 

--- a/snmp/CHANGELOG.md
+++ b/snmp/CHANGELOG.md
@@ -43,7 +43,7 @@
 
 ***Added***:
 
-* Update dependencies ([#18185](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
 
 ## 7.3.1 / 2024-06-05 / Agent 7.55.0
 

--- a/snowflake/CHANGELOG.md
+++ b/snowflake/CHANGELOG.md
@@ -38,7 +38,7 @@
 
 ***Added***:
 
-* Update dependencies ([#18185](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
 
 ## 5.7.0 / 2024-07-05 / Agent 7.56.0
 

--- a/snowflake/CHANGELOG.md
+++ b/snowflake/CHANGELOG.md
@@ -38,7 +38,7 @@
 
 ***Added***:
 
-* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18187))
 
 ## 5.7.0 / 2024-07-05 / Agent 7.56.0
 

--- a/tls/CHANGELOG.md
+++ b/tls/CHANGELOG.md
@@ -36,7 +36,7 @@
 
 ***Added***:
 
-* Update dependencies ([#18185](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
 
 ## 2.18.0 / 2024-07-05 / Agent 7.56.0
 

--- a/tls/CHANGELOG.md
+++ b/tls/CHANGELOG.md
@@ -36,7 +36,7 @@
 
 ***Added***:
 
-* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18187))
 
 ## 2.18.0 / 2024-07-05 / Agent 7.56.0
 

--- a/vertica/CHANGELOG.md
+++ b/vertica/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ***Added***:
 
-* Update dependencies ([#18185](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
 
 ## 4.5.0 / 2024-03-22 / Agent 7.53.0
 

--- a/vertica/CHANGELOG.md
+++ b/vertica/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ***Added***:
 
-* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18185))
+* Update dependencies ([#18187](https://github.com/DataDog/integrations-core/pull/18187))
 
 ## 4.5.0 / 2024-03-22 / Agent 7.53.0
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
When merging https://github.com/DataDog/integrations-core/pull/18187 we forgot to check that the changelog files were valid.

The bot had pointed them to the wrong PR.

### Motivation
<!-- What inspired you to submit this pull request? -->
I was looking at an affected changelog for a support case and got very confused when I clicked on the link that's in the Changelog.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
