### PR TITLE
Sy/fix flaky downloader test

### DIFF
--- a/datadog_checks_downloader/tests/test_downloader.py
+++ b/datadog_checks_downloader/tests/test_downloader.py
@@ -54,6 +54,7 @@ EXCLUDED_INTEGRATIONS = [
     "datadog-kubernetes",  # excluding this since `kubernetes` check is Agent v5 only
     "datadog-go-metro",  # excluding this since `go-metro` check is Agent v5 only
     "datadog-agent-metrics",  # excluding this since `agent-metrics` check is Agent v5 only
+    "datadog-amazon-kafka", # excluding this since `amazon-kafka` wasn't an official release
 ]
 
 # Specific integration versions released for the last time by a revoked developer but not shipped anymore.

--- a/datadog_checks_downloader/tests/test_downloader.py
+++ b/datadog_checks_downloader/tests/test_downloader.py
@@ -53,6 +53,7 @@ EXCLUDED_INTEGRATIONS = [
     "datadog-dd-cluster-agent",  # excluding this since actual integration is called `datadog-cluster-agent`
     "datadog-kubernetes",  # excluding this since `kubernetes` check is Agent v5 only
     "datadog-go-metro",  # excluding this since `go-metro` check is Agent v5 only
+    "datadog-agent-metrics",  # excluding this since `agent-metrics` check is Agent v5 only
 ]
 
 # Specific integration versions released for the last time by a revoked developer but not shipped anymore.

--- a/datadog_checks_downloader/tests/test_downloader.py
+++ b/datadog_checks_downloader/tests/test_downloader.py
@@ -54,7 +54,8 @@ EXCLUDED_INTEGRATIONS = [
     "datadog-kubernetes",  # excluding this since `kubernetes` check is Agent v5 only
     "datadog-go-metro",  # excluding this since `go-metro` check is Agent v5 only
     "datadog-agent-metrics",  # excluding this since `agent-metrics` check is Agent v5 only
-    "datadog-amazon-kafka", # excluding this since `amazon-kafka` wasn't an official release
+    "datadog-amazon-kafka",  # excluding this since `amazon-kafka` wasn't an official release
+    "datadog-tokumx",  # excluding this since `tokumx` was dropped in py3
 ]
 
 # Specific integration versions released for the last time by a revoked developer but not shipped anymore.


### PR DESCRIPTION
### What does this PR do?
The test that is currently failing selects a random integration and tries to install it to ensure that the downloader works well with TUF. The CI recently been failing because out of sheer coincidence, it selected 2 integrations that were both deprecated and was released by some that is revoked in the recent cleaning.

agent-metrics:
- [CI Run](https://github.com/DataDog/integrations-core/actions/runs/12206464945/job/34056022723#:~:text=759-,ERROR%20%20%20%3A%20in%2Dtoto%20failed%20to%20verify%20simple/datadog%2Dagent%2Dmetrics/datadog_agent_metrics%2D1.5.0%2Dpy2.py3%2Dnone%2Dany.whl,-760)
- Deprecated since it was agent 5 only and the last release was Ofek.


amazon-kafka:
- [CI Run](https://github.com/DataDog/integrations-core/actions/runs/12200890065/job/34045287965#:~:text=ERROR%20%20%20%3A%20in%2Dtoto%20failed%20to%20verify%20simple/datadog%2Damazon%2Dkafka/datadog_amazon_kafka%2D0.1.0rc1%2Dpy2.py3%2Dnone%2Dany.whl)
- This integration I think was renamed to amazon_msk? Released last by Ofek

Both of these should be excluded since they're no longer getting releases. I also added tokumx since that was also deprecated in py3.
