### PR TITLE
Agent 5 only datadog-ntp needs to be excluded

### DIFF
--- a/datadog_checks_downloader/tests/test_downloader.py
+++ b/datadog_checks_downloader/tests/test_downloader.py
@@ -56,6 +56,7 @@ EXCLUDED_INTEGRATIONS = [
     "datadog-agent-metrics",  # excluding this since `agent-metrics` check is Agent v5 only
     "datadog-amazon-kafka",  # excluding this since `amazon-kafka` wasn't an official release
     "datadog-tokumx",  # excluding this since `tokumx` was dropped in py3
+    "datadog-ntp",  # excluding this since `ntp` was Agent 5 only
 ]
 
 # Specific integration versions released for the last time by a revoked developer but not shipped anymore.


### PR DESCRIPTION
### What does this PR do?
One more to be excluded

Should be the last one that needs to be excluded. The one remaining integration that is causing issue is zeek since that a log only integration released by a revoked key. I think we have to re-release zeek or also add that to an exlude list for another reason. 