### PR TITLE
[datadog_cluster_agent] Add local failover workload store metric

### DIFF
--- a/datadog_cluster_agent/changelog.d/19229.added
+++ b/datadog_cluster_agent/changelog.d/19229.added
@@ -1,0 +1,1 @@
+add telemetry for local load store in dca

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
@@ -35,6 +35,8 @@ DEFAULT_METRICS = {
     'autoscaling_workload_vertical_rollout_triggered': 'autoscaling.workload.vertical_rollout_triggered',
     'autoscaling_workload_vertical_scaling_received_limits': 'autoscaling.workload.vertical_scaling_received_limits',
     'autoscaling_workload_vertical_scaling_received_requests': 'autoscaling.workload.vertical_scaling_received_requests',  # noqa: E501
+    'autoscaling_workload_store_load_entities': 'autoscaling.workload.store_load_entities',
+    'autoscaling_workload_store_job_queue_length': 'autoscaling.workload.store_job_queue_length',
     'aggregator__flush': 'aggregator.flush',
     'aggregator__processed': 'aggregator.processed',
     'api_requests': 'api_requests',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Two metrics are added
    'datadog.cluster_agent.autoscaling_workload_store_load_entities' for tracking the total number of entities in autoscaling workload store
    'datadog.cluster_agent.autoscaling_workload_store_job_queue_length' for tracking the pending job queue len

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
