### PR TITLE
[Cassandra] Thread names with spaces can now be parsed.

### DIFF
--- a/cassandra/assets/logs/cassandra.yaml
+++ b/cassandra/assets/logs/cassandra.yaml
@@ -65,7 +65,7 @@ pipeline:
       grok:
         supportRules: |
           _level %{word:db.severity}
-          _thread_name %{notSpace:logger.thread_name}
+          _thread_name %{data:logger.thread_name}
           _thread_id %{integer:logger.thread_id}
           _logger_name %{notSpace:logger.name}
           _table %{word:db.table}


### PR DESCRIPTION
### What does this PR do?

If the thread name contains a single-byte space, parsing will fail due to `notSpace`.


`[Service Thread] `
```
INFO  [Service Thread] 2017-07-31 16:17:35,655 GCInspector.java:258 - ParNew GC in 210ms.  CMS Old Gen: 562659176 -> 612323584; Par Eden Space: 411959296 -> 0; Par Survivor Space: 49544256 -> 51445760
```
Reference URL, content is irrelevant.
https://stackoverflow.com/questions/45421130/cassandra-lots-of-gc-on-specific-nodes

Therefore , I was changed `data`(Equivalent to .*).

```yaml
 _thread_name %{data:logger.thread_name}
 ```
https://docs.datadoghq.com/logs/log_configuration/parsing/?tab=matchers#matcher-and-filter


### Motivation
Cassandra Integration was implemented, but some logs were not parsed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
