### PR TITLE
Mark unit and integration tests for avi vantage integration

### DIFF
--- a/avi_vantage/tests/test_avi_vantage.py
+++ b/avi_vantage/tests/test_avi_vantage.py
@@ -7,6 +7,7 @@ from datadog_checks.avi_vantage import AviVantageCheck
 from datadog_checks.dev.utils import get_metadata_metrics
 
 
+@pytest.mark.unit
 def test_check(mock_client, get_expected_metrics, aggregator, unit_instance, dd_run_check):
     check = AviVantageCheck('avi_vantage', {}, [unit_instance])
     dd_run_check(check)
@@ -17,6 +18,7 @@ def test_check(mock_client, get_expected_metrics, aggregator, unit_instance, dd_
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 
 
+@pytest.mark.integration
 def test_integration(
     dd_environment, get_expected_metrics, aggregator, integration_instance, dd_run_check, datadog_agent
 ):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Explicitly mark unit and integration tests for the avi vantage integration.

There's only one of each test, it would be overkill to create 2 separate files to take advantage of our implicit marking mechanism.

### Motivation
<!-- What inspired you to submit this pull request? -->
Drive-by. Was looking at the integration and noticed this.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
