### PR TITLE
Fix interface perf dashboard colors

### DIFF
--- a/snmp/assets/dashboards/interface_performance.json
+++ b/snmp/assets/dashboards/interface_performance.json
@@ -587,9 +587,9 @@
                   "cell_display_mode": ["bar"],
                   "conditional_formats": [
                     {
-                      "comparator": ">",
-                      "palette": "white_on_yellow",
-                      "value": 2
+                      "comparator": "<=",
+                      "palette": "white_on_green",
+                      "value": 1
                     },
                     {
                       "comparator": "<=",
@@ -598,8 +598,8 @@
                     },
                     {
                       "comparator": "<=",
-                      "palette": "white_on_green",
-                      "value": 1
+                      "palette": "white_on_yellow",
+                      "value": 3
                     }
                   ],
                   "q": "avg:snmp.ifAdminStatus{$snmp_host,$interface,$snmp_device} by {snmp_device,snmp_host,interface}",


### PR DESCRIPTION
Before 
![image](https://github.com/user-attachments/assets/2f3ef2e6-f66d-449b-943d-2b0edf420ba6)

Rules are treated in order, because 1 <= 2 then it shows as yellow