### PR TITLE
add family specific byte units

### DIFF
--- a/ddev/changelog.d/19252.added
+++ b/ddev/changelog.d/19252.added
@@ -1,0 +1,1 @@
+add decimal/binary specific byte units

--- a/ddev/changelog.d/19252.added
+++ b/ddev/changelog.d/19252.added
@@ -1,1 +1,1 @@
-add decimal/binary specific byte units
+Add decimal/binary specific byte units

--- a/ddev/src/ddev/cli/validate/metadata_utils.py
+++ b/ddev/src/ddev/cli/validate/metadata_utils.py
@@ -392,6 +392,10 @@ VALID_UNIT_NAMES = {
     "yemeni rial",
     "zambian kwacha",
     "zimbabwe gold",
+    "bit_in_decimal_bytes_family",
+    "byte_in_decimal_bytes_family",
+    "bit_in_binary_bytes_family",
+    "byte_in_binary_bytes_family",
 }
 
 ALLOWED_PREFIXES = ('system.', 'jvm.', 'http.', 'datadog.', 'sftp.', 'process.', 'runtime.', 'otelcol_')


### PR DESCRIPTION
### What does this PR do?
[GXP-2329 
](https://datadoghq.atlassian.net/browse/GXP-2329)
add units for bytes and bit which funnel into separate bytes families 


### Motivation
https://datadoghq.atlassian.net/wiki/spaces/GE/pages/2671673472/Splitting+bytes+families+disambiguation

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
