### PR TITLE
Making the excluded_messages field optional

### DIFF
--- a/vsphere/assets/configuration/spec.yaml
+++ b/vsphere/assets/configuration/spec.yaml
@@ -305,8 +305,8 @@ files:
         description: |
           The events that should be collected by the vSphere integration.
 
-          The "event" specifies the event type you want to include, and the "excluded_messages" is a list of
-          messages of that event type you do not want to collect. For example, if the key
+          The "event" specifies the event type you want to include, and optionally, the "excluded_messages" is
+          a list of messages of that event type you do not want to collect. For example, if the key
           is 'AlarmStatusChangedEvent' and the values for this key are 'Gray to Green' and 'Green to Gray',
           then all events named 'AlarmStatusChangedEvent' that don't have the message 'Gray to Green'
           and 'Green to Gray' will be included.

--- a/vsphere/datadog_checks/vsphere/config.py
+++ b/vsphere/datadog_checks/vsphere/config.py
@@ -134,10 +134,7 @@ class VSphereConfig(object):
             self.exclude_filters = {}
             for item in self.include_events:
                 event_name = item["event"]
-                if "excluded_messages" in item:
-                    excluded_messages = [r'{}'.format(msg) for msg in item["excluded_messages"]]
-                else:
-                    excluded_messages = []
+                excluded_messages = [r'{}'.format(msg) for msg in item.get("excluded_messages", [])]
                 self.exclude_filters[event_name] = excluded_messages
 
         # Since `collect_per_instance_filters` have the same structure as `metric_filters` we use the same parser

--- a/vsphere/datadog_checks/vsphere/config.py
+++ b/vsphere/datadog_checks/vsphere/config.py
@@ -134,7 +134,10 @@ class VSphereConfig(object):
             self.exclude_filters = {}
             for item in self.include_events:
                 event_name = item["event"]
-                excluded_messages = [r'{}'.format(msg) for msg in item["excluded_messages"]]
+                if "excluded_messages" in item:
+                    excluded_messages = [r'{}'.format(msg) for msg in item["excluded_messages"]]
+                else:
+                    excluded_messages = []
                 self.exclude_filters[event_name] = excluded_messages
 
         # Since `collect_per_instance_filters` have the same structure as `metric_filters` we use the same parser

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -271,8 +271,8 @@ instances:
     ## @param include_events - list of mappings - optional
     ## The events that should be collected by the vSphere integration.
     ##
-    ## The "event" specifies the event type you want to include, and the "excluded_messages" is a list of
-    ## messages of that event type you do not want to collect. For example, if the key
+    ## The "event" specifies the event type you want to include, and optionally, the "excluded_messages" is
+    ## a list of messages of that event type you do not want to collect. For example, if the key
     ## is 'AlarmStatusChangedEvent' and the values for this key are 'Gray to Green' and 'Green to Gray',
     ## then all events named 'AlarmStatusChangedEvent' that don't have the message 'Gray to Green'
     ## and 'Green to Gray' will be included.

--- a/vsphere/tests/test_event.py
+++ b/vsphere/tests/test_event.py
@@ -370,9 +370,7 @@ def test_include_events_ok(aggregator, realtime_instance, dd_run_check, mock_api
 
 @pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_rest_api')
 def test_include_events_no_excluded_message(aggregator, realtime_instance, dd_run_check, mock_api):
-    realtime_instance['include_events'] = [
-        {"event": "AlarmStatusChangedEvent"}
-    ]
+    realtime_instance['include_events'] = [{"event": "AlarmStatusChangedEvent"}]
     check = VSphereCheck('vsphere', {}, [realtime_instance])
     event1 = vim.event.AlarmStatusChangedEvent()
     event1.createdTime = dt.datetime.now()

--- a/vsphere/tests/test_event.py
+++ b/vsphere/tests/test_event.py
@@ -369,6 +369,32 @@ def test_include_events_ok(aggregator, realtime_instance, dd_run_check, mock_api
 
 
 @pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_rest_api')
+def test_include_events_no_excluded_message(aggregator, realtime_instance, dd_run_check, mock_api):
+    realtime_instance['include_events'] = [
+        {"event": "AlarmStatusChangedEvent"}
+    ]
+    check = VSphereCheck('vsphere', {}, [realtime_instance])
+    event1 = vim.event.AlarmStatusChangedEvent()
+    event1.createdTime = dt.datetime.now()
+    event1.entity = vim.event.ManagedEntityEventArgument()
+    event1.entity.entity = vim.VirtualMachine(moId="vm1")
+    event1.entity.name = "vm1"
+    event1.alarm = vim.event.AlarmEventArgument()
+    event1.alarm.name = "alarm1"
+    setattr(event1, 'from', 'green')
+    event1.to = 'red'
+    event1.datacenter = vim.event.DatacenterEventArgument()
+    event1.datacenter.name = "dc1"
+    event1.fullFormattedMessage = "Green to Red"
+    mock_api.side_effect = mock_api_with_events([event1])
+
+    dd_run_check(check)
+
+    assert len(aggregator.events) == 1
+    assert aggregator.events[0]['msg_title'] == "[Triggered] alarm1 on VM vm1 is now red"
+
+
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_rest_api')
 def test_include_events_filtered(aggregator, realtime_instance, dd_run_check, mock_api):
     realtime_instance['include_events'] = [
         {"event": "AlarmStatusChangedEvent", "excluded_messages": ["Gray to Green", "Green to Gray"]}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The include_events config option requires specifying "excluded messages" (i.e. not pulling events with the specified messages). We want to allow customers to not have to specify the excluded message, and just pull in all events of that event type.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
