### PR TITLE
Remove unused distutils-related envvar

### DIFF
--- a/sqlserver/hatch.toml
+++ b/sqlserver/hatch.toml
@@ -46,10 +46,6 @@ PIP_EXTRA_INDEX_URL = "https://datadoghq.dev/ci-wheels/bin"
 env.GITHUB_ACTIONS.e2e-env = { value = false, if = ["true"], platform = ["windows"] }
 platform.windows.env-vars = [
   "COMPOSE_FOLDER=compose-windows",
-  # we need SETUPTOOLS_USE_DISTUTILS=stdlib for setuptools versions 60+ in order for adodbapi to be able to install
-  # correctly for python3 on windows. If not set installation fails with the following error:
-  #    in ImportError: cannot import name 'build_py_2to3' from 'distutils.command.build_py'
-  "SETUPTOOLS_USE_DISTUTILS=stdlib",
 ]
 matrix.os.platforms = [
   { value = "windows", if = ["windows"] },


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
We removed equivalent envvar setting in the agent. While investigating I saw this and thought we can remove it too.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
