### PR TITLE
[postgres] debug log when query is truncated

### DIFF
--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -556,9 +556,7 @@ class PostgresStatementSamples(DBMAsyncJob):
             # Create an active_row, for each session by
             # 1. Removing all null key/value pairs and the original query
             # 2. if row['statement'] is none, replace with ERROR: failed to obfuscate so we can still collect activity
-            active_row['query_truncated'] = self._get_truncation_state(
-                track_activity_query_size, row['query']
-            ).value
+            active_row['query_truncated'] = self._get_truncation_state(track_activity_query_size, row['query']).value
             if row['statement'] is None:
                 active_row['statement'] = "ERROR: failed to obfuscate"
             return active_row

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -41,6 +41,8 @@ MAX_CHARACTER_SIZE_IN_BYTES = 6
 
 TRACK_ACTIVITY_QUERY_SIZE_UNKNOWN_VALUE = -1
 
+TRACK_ACTIVITY_QUERY_SIZE_SUGGESTED_VALUE = 4096
+
 SUPPORTED_EXPLAIN_STATEMENTS = frozenset({'select', 'table', 'delete', 'insert', 'replace', 'update', 'with'})
 
 # columns from pg_stat_activity which correspond to attributes common to all databases and are therefore stored in
@@ -556,7 +558,9 @@ class PostgresStatementSamples(DBMAsyncJob):
             # Create an active_row, for each session by
             # 1. Removing all null key/value pairs and the original query
             # 2. if row['statement'] is none, replace with ERROR: failed to obfuscate so we can still collect activity
-            active_row['query_truncated'] = self._get_truncation_state(track_activity_query_size, row['query']).value
+            active_row['query_truncated'] = self._get_truncation_state(
+                track_activity_query_size, row['query'], row['query_signature']
+            ).value
             if row['statement'] is None:
                 active_row['statement'] = "ERROR: failed to obfuscate"
             return active_row
@@ -687,7 +691,10 @@ class PostgresStatementSamples(DBMAsyncJob):
 
         track_activity_query_size = self._get_track_activity_query_size()
 
-        if self._get_truncation_state(track_activity_query_size, statement) == StatementTruncationState.truncated:
+        if (
+            self._get_truncation_state(track_activity_query_size, statement, query_signature)
+            == StatementTruncationState.truncated
+        ):
             return (
                 None,
                 DBExplainError.query_truncated,
@@ -823,7 +830,7 @@ class PostgresStatementSamples(DBMAsyncJob):
                         "comments": row['dd_comments'],
                     },
                     "query_truncated": self._get_truncation_state(
-                        self._get_track_activity_query_size(), row['query']
+                        self._get_track_activity_query_size(), row['query'], row['query_signature']
                     ).value,
                 },
                 'postgres': {k: v for k, v in row.items() if k not in pg_stat_activity_sample_exclude_keys},
@@ -912,7 +919,7 @@ class PostgresStatementSamples(DBMAsyncJob):
     def _get_track_activity_query_size(self):
         return int(self._check.pg_settings.get("track_activity_query_size", TRACK_ACTIVITY_QUERY_SIZE_UNKNOWN_VALUE))
 
-    def _get_truncation_state(self, track_activity_query_size, statement):
+    def _get_truncation_state(self, track_activity_query_size, statement, query_signature):
         # Only check is a statement is truncated if the value of track_activity_query_size was loaded correctly
         # to avoid confusingly reporting a wrong indicator by using a default that might be wrong for the database
         if track_activity_query_size == TRACK_ACTIVITY_QUERY_SIZE_UNKNOWN_VALUE:
@@ -927,11 +934,22 @@ class PostgresStatementSamples(DBMAsyncJob):
         statement_bytes = bytes(statement, "utf-8")
         truncated = len(statement_bytes) >= track_activity_query_size - (MAX_CHARACTER_SIZE_IN_BYTES + 1)
         if truncated:
-            self._log.debug(
-                "Statement with query_signature=%s was truncated. Query size: %d, track_activity_query_size: %d",
-                compute_sql_signature(statement),
-                len(statement_bytes),
-                track_activity_query_size,
-            )
+            if track_activity_query_size < TRACK_ACTIVITY_QUERY_SIZE_SUGGESTED_VALUE:
+                self._log.warning(
+                    "Statement with query_signature=%s was truncated. Query size: %d, track_activity_query_size: %d ",
+                    "See https://docs.datadoghq.com/database_monitoring/setup_postgres/troubleshooting%s ",
+                    "for more details on how to increase the track_activity_query_size setting.",
+                    query_signature,
+                    len(statement_bytes),
+                    track_activity_query_size,
+                    "#query-samples-are-truncated",
+                )
+            else:
+                self._log.debug(
+                    "Statement with query_signature=%s was truncated. Query size: %d, track_activity_query_size: %d",
+                    query_signature,
+                    len(statement_bytes),
+                    track_activity_query_size,
+                )
             return StatementTruncationState.truncated
         return StatementTruncationState.not_truncated

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -936,8 +936,8 @@ class PostgresStatementSamples(DBMAsyncJob):
         if truncated:
             if track_activity_query_size < TRACK_ACTIVITY_QUERY_SIZE_SUGGESTED_VALUE:
                 self._log.warning(
-                    "Statement with query_signature=%s was truncated. Query size: %d, track_activity_query_size: %d ",
-                    "See https://docs.datadoghq.com/database_monitoring/setup_postgres/troubleshooting%s ",
+                    "Statement with query_signature=%s was truncated. Query size: %d, track_activity_query_size: %d "
+                    "See https://docs.datadoghq.com/database_monitoring/setup_postgres/troubleshooting%s "
                     "for more details on how to increase the track_activity_query_size setting.",
                     query_signature,
                     len(statement_bytes),


### PR DESCRIPTION
### What does this PR do?
This PR adds a debug log when a query from activity sampling is truncated due to exceeding `track_activity_query_size`. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
