### PR TITLE
Drop python2 requirements for deps builders

### DIFF
--- a/.builders/deps/build_dependencies.txt
+++ b/.builders/deps/build_dependencies.txt
@@ -1,13 +1,9 @@
-hatchling==1.21.1; python_version > '3.0'
-hatchling==0.25.1; python_version < '3.0'
-setuptools==75.6.0; python_version > '3.0'
-setuptools==40.9.0; python_version < '3.0'
-wheel==0.38.4; python_version > '3.0'
-wheel==0.37.1; python_version < '3.0'
-setuptools-scm; python_version > '3.0'
-setuptools-scm==5.0.2; python_version < '3.0'
-setuptools-rust>=1.7.0; python_version > '3.0'
-maturin; python_version > '3.0'
+hatchling==1.21.1
+setuptools==75.6.0
+wheel==0.38.4
+setuptools-scm
+setuptools-rust>=1.7.0
+maturin
 cffi>=1.12
 cython==3.0.11
-tomli>=2.0.1; python_version > '3.0'
+tomli>=2.0.1


### PR DESCRIPTION
### What does this PR do?

Removes build dependencies for Python 2, as they are not needed.

### Motivation

Cleanup.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
