### PR TITLE
Sy/dns change

### DIFF
--- a/dns_check/changelog.d/19276.fixed
+++ b/dns_check/changelog.d/19276.fixed
@@ -1,0 +1,1 @@
+Move timing to be more precise with calculating response times

--- a/dns_check/datadog_checks/dns_check/dns_check.py
+++ b/dns_check/datadog_checks/dns_check/dns_check.py
@@ -81,7 +81,7 @@ class DNSCheck(AgentCheck):
                 answer = resolver.query(self.hostname, rdtype=self.record_type)  # dns.resolver.Answer
                 assert any(it.to_text() for it in answer.rrset.items)
                 response_time = get_precise_time() - t0
-                
+
                 if self.resolves_as_ips:
                     self._check_answer(answer)
 

--- a/dns_check/datadog_checks/dns_check/dns_check.py
+++ b/dns_check/datadog_checks/dns_check/dns_check.py
@@ -79,7 +79,7 @@ class DNSCheck(AgentCheck):
                 t0 = get_precise_time()
                 answer = resolver.query(self.hostname, rdtype=self.record_type)  # dns.resolver.Answer
                 response_time = get_precise_time() - t0
-                
+
                 assert any(it.to_text() for it in answer.rrset.items)
 
                 if self.resolves_as_ips:

--- a/dns_check/datadog_checks/dns_check/dns_check.py
+++ b/dns_check/datadog_checks/dns_check/dns_check.py
@@ -72,6 +72,7 @@ class DNSCheck(AgentCheck):
                     t0 = get_precise_time()
                     resolver.query(self.hostname)
                 except dns.resolver.NXDOMAIN:
+                    # Timing here to get the time it takes for us to get the NXDOMAIN Exception
                     response_time = get_precise_time() - t0
                 else:
                     raise AssertionError("Expected an NXDOMAIN, got a result.")

--- a/dns_check/datadog_checks/dns_check/dns_check.py
+++ b/dns_check/datadog_checks/dns_check/dns_check.py
@@ -71,9 +71,8 @@ class DNSCheck(AgentCheck):
                 try:
                     t0 = get_precise_time()
                     resolver.query(self.hostname)
-                    response_time = get_precise_time() - t0
                 except dns.resolver.NXDOMAIN:
-                    pass
+                    response_time = get_precise_time() - t0
                 else:
                     raise AssertionError("Expected an NXDOMAIN, got a result.")
             else:

--- a/dns_check/datadog_checks/dns_check/dns_check.py
+++ b/dns_check/datadog_checks/dns_check/dns_check.py
@@ -79,8 +79,9 @@ class DNSCheck(AgentCheck):
             else:
                 t0 = get_precise_time()
                 answer = resolver.query(self.hostname, rdtype=self.record_type)  # dns.resolver.Answer
-                assert any(it.to_text() for it in answer.rrset.items)
                 response_time = get_precise_time() - t0
+                
+                assert any(it.to_text() for it in answer.rrset.items)
 
                 if self.resolves_as_ips:
                     self._check_answer(answer)


### PR DESCRIPTION
### What does this PR do?
We time response time by setting a timestamp then running some code and then calculate the time it took to ran that code. Setting the timestamp closer to the actual line of code that needs to be timed can help get a more accurate reading on the response time.
