### PR TITLE
Use `start_date` instead of `execution_date` for ongoing duration metrics

### DIFF
--- a/airflow/assets/configuration/spec.yaml
+++ b/airflow/assets/configuration/spec.yaml
@@ -13,6 +13,12 @@ files:
       description: The URL used to connect to the Airflow instance (use the Airflow web server REST API endpoint).
       value:
         type: string
+    - name: collect_ongoing_duration
+      required: false
+      description: Collect ongoing duration metric for DAG task instances.
+      value:
+        type: boolean
+        example: true
     - template: instances/http
     - template: instances/default
   - template: logs

--- a/airflow/changelog.d/19278.added
+++ b/airflow/changelog.d/19278.added
@@ -1,0 +1,1 @@
+Use `start_date` instead of `execution_date` for ongoing duration metrics

--- a/airflow/datadog_checks/airflow/config_models/defaults.py
+++ b/airflow/datadog_checks/airflow/config_models/defaults.py
@@ -24,6 +24,10 @@ def instance_auth_type():
     return 'basic'
 
 
+def instance_collect_ongoing_duration():
+    return True
+
+
 def instance_disable_generic_tags():
     return False
 

--- a/airflow/datadog_checks/airflow/config_models/instance.py
+++ b/airflow/datadog_checks/airflow/config_models/instance.py
@@ -60,6 +60,7 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str] = None
     aws_region: Optional[str] = None
     aws_service: Optional[str] = None
+    collect_ongoing_duration: Optional[bool] = None
     connect_timeout: Optional[float] = None
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None

--- a/airflow/datadog_checks/airflow/data/conf.yaml.example
+++ b/airflow/datadog_checks/airflow/data/conf.yaml.example
@@ -50,6 +50,11 @@ instances:
     #
   - url: <URL>
 
+    ## @param collect_ongoing_duration - boolean - optional - default: true
+    ## Collect ongoing duration metric for DAG task instances.
+    #
+    # collect_ongoing_duration: true
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/airflow/tests/test_unit.py
+++ b/airflow/tests/test_unit.py
@@ -95,8 +95,17 @@ def test_dag_total_tasks(aggregator, task_instance):
     aggregator.assert_metric('airflow.dag.task.total_running', value=1, count=1)
 
 
-def test_dag_task_ongoing_duration(aggregator, task_instance):
-    instance = common.FULL_CONFIG['instances'][0]
+@pytest.mark.parametrize(
+    "collect_ongoing_duration, expected_metric_count, should_call_method",
+    [
+        (True, 1, True),  # `collect_task_duration=True`: metric is collected, method is called
+        (False, 0, False),  # `collect_task_duration=False`: metric is NOT collected, method is NOT called
+    ],
+)
+def test_dag_task_ongoing_duration(
+    aggregator, task_instance, collect_ongoing_duration, expected_metric_count, should_call_method
+):
+    instance = {**common.FULL_CONFIG['instances'][0], 'collect_ongoing_duration': collect_ongoing_duration}
     check = AirflowCheck('airflow', common.FULL_CONFIG, [instance])
 
     with mock.patch('datadog_checks.airflow.airflow.AirflowCheck._get_version', return_value='2.6.2'):
@@ -107,14 +116,22 @@ def test_dag_task_ongoing_duration(aggregator, task_instance):
                 {'metadatabase': {'status': 'healthy'}, 'scheduler': {'status': 'healthy'}},
             ]
             req.get.return_value = mock_resp
-            with mock.patch(
-                'datadog_checks.airflow.airflow.AirflowCheck._get_all_task_instances',
-                return_value=task_instance.get('task_instances'),
-            ):
-                check.check(None)
 
+            if should_call_method:
+                with mock.patch(
+                    'datadog_checks.airflow.airflow.AirflowCheck._get_all_task_instances',
+                    return_value=task_instance.get('task_instances'),
+                ):
+                    check.check(None)
+            else:
+                with mock.patch(
+                    'datadog_checks.airflow.airflow.AirflowCheck._get_all_task_instances'
+                ) as mock_get_all_task_instances:
+                    check.check(None)
+                    mock_get_all_task_instances.assert_not_called()
+
+    # Assert the metric count
     aggregator.assert_metric(
         'airflow.dag.task.ongoing_duration',
-        tags=['key:my-tag', 'url:http://localhost:8080', 'dag_id:tutorial', 'task_id:sleep'],
-        count=1,
+        count=expected_metric_count,
     )


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR uses the `start_date` instead of `execution_date` for ongoing duration metrics
### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
