### PR TITLE
Fix typo in airflow dogstatsd mapping

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -126,7 +126,6 @@ Connect Airflow to DogStatsD (included in the Datadog Agent) by using the Airflo
            tags:
              dag_id: "$1"
              task_id: "$2"
-         - match: "airflow.pool.open_slots.*"
          - match: "airflow.dagrun.*.first_task_scheduling_delay"
            name: "airflow.dagrun.first_task_scheduling_delay"
            tags:


### PR DESCRIPTION
### What does this PR do?
Fix typo of duplicate metric
### Motivation
I updated my mapping by copying from the airflow integration page, and noticed this metric disappeared

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
