### PR TITLE
add partition_of metric tag

### DIFF
--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -160,6 +160,7 @@ SELECT
   current_database(),
   N.nspname,
   C.relname,
+  Inh.inhparent::regclass AS partition_of,
   pg_stat_get_numscans(C.oid),
   pg_stat_get_tuples_returned(C.oid),
   I.idx_scan,
@@ -191,6 +192,7 @@ SELECT
   C.xmin
 FROM pg_class C
 LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace)
+LEFT JOIN pg_inherits Inh ON (Inh.inhrelid = C.oid)
 LEFT JOIN pg_locks L ON C.oid = L.relation AND L.locktype = 'relation'
 LEFT JOIN pg_index idx_toast ON (idx_toast.indrelid = C.reltoastrelid)
 LEFT JOIN LATERAL (
@@ -207,6 +209,7 @@ WHERE C.relkind = 'r'
         {'name': 'db', 'type': 'tag'},
         {'name': 'schema', 'type': 'tag'},
         {'name': 'table', 'type': 'tag'},
+        {'name': 'partition_of', 'type': 'tag'},
         {'name': 'seq_scans', 'type': 'rate'},
         {'name': 'seq_rows_read', 'type': 'rate'},
         {'name': 'index_rel_scans', 'type': 'rate'},


### PR DESCRIPTION
### What does this PR do?

At Doctolib, we need the `partition_of` tag for metric `postgresql.seq_scans` and found out it's not available 😢

Doing a PR to have it now 🎉 

### Motivation

Using the `partition_of` tag in our monitors, dashboards and so on, of course! 😄 
And to make Datadog even better than it already is! 🎉

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
