### PR TITLE
Add `datadog.cluster_agent.leader_election.is_leader`

### DIFF
--- a/datadog_cluster_agent/changelog.d/19308.added
+++ b/datadog_cluster_agent/changelog.d/19308.added
@@ -1,0 +1,1 @@
+Add `datadog.cluster_agent.leader_election.is_leader`.

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
@@ -68,6 +68,7 @@ DEFAULT_METRICS = {
     'kubernetes_apiserver_kube_events': 'kubernetes_apiserver.kube_events',
     'language_detection_dca_handler_processed_requests': 'language_detection_dca_handler.processed_requests',
     'language_detection_patcher_patches': 'language_detection_patcher.patches',
+    'leader_election_is_leader': 'leader_election.is_leader',
     'rate_limit_queries_limit': 'datadog.rate_limit_queries.limit',
     'rate_limit_queries_period': 'datadog.rate_limit_queries.period',
     'rate_limit_queries_remaining': 'datadog.rate_limit_queries.remaining',

--- a/datadog_cluster_agent/metadata.csv
+++ b/datadog_cluster_agent/metadata.csv
@@ -57,6 +57,7 @@ datadog.cluster_agent.kubernetes_apiserver.emitted_events,count,,,,"Datadog even
 datadog.cluster_agent.kubernetes_apiserver.kube_events,count,,,,"Kubernetes events processed by the kubernetes_apiserver check",0,datadog_cluster_agent,apiserver events,
 datadog.cluster_agent.language_detection_dca_handler.processed_requests,count,,,,"The number of process language detection requests processed by the handler",0,datadog_cluster_agent,language detection processed requests,
 datadog.cluster_agent.language_detection_patcher.patches,count,,,,"The number of patch requests sent by the patcher to the kube api server",0,datadog_cluster_agent,language detection patches,
+datadog.cluster_agent.leader_election.is_leader,count,,,,"he label is_leader is true if the reporting pod is leader, equals false otherwise",0,datadog_cluster_agent,leader election is leader,
 datadog.cluster_agent.secret_backend.elapsed,gauge,,millisecond,,The elapsed time of secret backend invocation,0,datadog_cluster_agent,secret backend elapsed time duration,
 datadog.cluster_agent.tagger.stored_entities,gauge,,,,Number of entities stored in the tagger,0,datadog_cluster_agent,tagger stored entities,
 datadog.cluster_agent.tagger.updated_entities,count,,,,Number of updates made to entities in the tagger,0,datadog_cluster_agent,tagger updated entities,

--- a/datadog_cluster_agent/metadata.csv
+++ b/datadog_cluster_agent/metadata.csv
@@ -57,7 +57,7 @@ datadog.cluster_agent.kubernetes_apiserver.emitted_events,count,,,,"Datadog even
 datadog.cluster_agent.kubernetes_apiserver.kube_events,count,,,,"Kubernetes events processed by the kubernetes_apiserver check",0,datadog_cluster_agent,apiserver events,
 datadog.cluster_agent.language_detection_dca_handler.processed_requests,count,,,,"The number of process language detection requests processed by the handler",0,datadog_cluster_agent,language detection processed requests,
 datadog.cluster_agent.language_detection_patcher.patches,count,,,,"The number of patch requests sent by the patcher to the kube api server",0,datadog_cluster_agent,language detection patches,
-datadog.cluster_agent.leader_election.is_leader,count,,,,"he label is_leader is true if the reporting pod is leader, equals false otherwise",0,datadog_cluster_agent,leader election is leader,
+datadog.cluster_agent.leader_election.is_leader,gauge,,,,"The label is_leader is true if the reporting pod is leader, equals false otherwise",0,datadog_cluster_agent,leader election is leader,
 datadog.cluster_agent.secret_backend.elapsed,gauge,,millisecond,,The elapsed time of secret backend invocation,0,datadog_cluster_agent,secret backend elapsed time duration,
 datadog.cluster_agent.tagger.stored_entities,gauge,,,,Number of entities stored in the tagger,0,datadog_cluster_agent,tagger stored entities,
 datadog.cluster_agent.tagger.updated_entities,count,,,,Number of updates made to entities in the tagger,0,datadog_cluster_agent,tagger updated entities,

--- a/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
+++ b/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
@@ -70,6 +70,7 @@ METRICS = [
     'kubernetes_apiserver.kube_events',
     'language_detection_dca_handler.processed_requests',
     'language_detection_patcher.patches',
+    'leader_election.is_leader',
     'secret_backend.elapsed',
     'tagger.stored_entities',
     'tagger.updated_entities',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Datadog Cluster Agent exposes `leader_election_is_leader`.

https://github.com/DataDog/datadog-agent/blob/c7f4f4e228f546dfb60fdceb6cb6ae92a14bca88/pkg/util/kubernetes/apiserver/leaderelection/metrics/metrics.go#L24-L32

### Motivation
<!-- What inspired you to submit this pull request? -->

This metric is useful for troubleshooting the issue regarding leader election.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
