### PR TITLE
Use `time_elapsed` metric type for process start time and last GC time metrics

### DIFF
--- a/datadog_checks_base/changelog.d/19309.added
+++ b/datadog_checks_base/changelog.d/19309.added
@@ -1,0 +1,1 @@
+Use `time_elapsed` type for process start time metric

--- a/datadog_checks_base/changelog.d/19309.added
+++ b/datadog_checks_base/changelog.d/19309.added
@@ -1,1 +1,1 @@
-Use `time_elapsed` type for process start time metric
+Use `time_elapsed` metric type for process start time and last GC time metrics

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/metrics.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/metrics.py
@@ -28,7 +28,10 @@ DEFAULT_GO_METRICS = {
     'process_max_fds': 'process.max_fds',
     'process_open_fds': 'process.open_fds',
     'process_resident_memory_bytes': 'process.resident_memory.bytes',
-    'process_start_time_seconds': 'process.start_time.seconds',
+    'process_start_time_seconds': {
+        'name': 'process.start_time.seconds',
+        'type': 'time_elapsed',
+    },
     'process_virtual_memory_bytes': 'process.virtual_memory.bytes',
     'process_virtual_memory_max_bytes': 'process.virtual_memory.max_bytes',
 }

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/metrics.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/metrics.py
@@ -1,6 +1,7 @@
 DEFAULT_GO_METRICS = {
     'go_gc_duration_seconds': 'go.gc.duration.seconds',
     'go_goroutines': 'go.goroutines',
+    'go_memstats_alloc_bytes': 'go.memstats.alloc_bytes',
     'go_memstats_buck_hash_sys_bytes': 'go.memstats.buck_hash.sys_bytes',
     'go_memstats_frees': 'go.memstats.frees',
     'go_memstats_gc_cpu_fraction': 'go.memstats.gc.cpu_fraction',
@@ -11,7 +12,10 @@ DEFAULT_GO_METRICS = {
     'go_memstats_heap_objects': 'go.memstats.heap.objects',
     'go_memstats_heap_released_bytes': 'go.memstats.heap.released_bytes',
     'go_memstats_heap_sys_bytes': 'go.memstats.heap.sys_bytes',
-    'go_memstats_last_gc_time_seconds': 'go.memstats.last_gc_time.seconds',
+    'go_memstats_last_gc_time_seconds': {
+        'name': 'go.memstats.last_gc_time_seconds',
+        'type': 'time_elapsed',
+    },
     'go_memstats_lookups': 'go.memstats.lookups',
     'go_memstats_mallocs': 'go.memstats.mallocs',
     'go_memstats_mcache_inuse_bytes': 'go.memstats.mcache.inuse_bytes',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
