### PR TITLE
fix: Test command line result before comparing it to Gunicorn master name

### DIFF
--- a/gunicorn/datadog_checks/gunicorn/gunicorn.py
+++ b/gunicorn/datadog_checks/gunicorn/gunicorn.py
@@ -149,7 +149,7 @@ class GUnicornCheck(AgentCheck):
         master_procs = []
         for p in psutil.process_iter():
             try:
-                if p.cmdline()[0] == master_name:
+                if len(p.cmdline()) > 0 and p.cmdline()[0] == master_name:
                     master_procs.append(p)
             except (IndexError, psutil.Error) as e:
                 self.log.debug("Cannot read information from process %s: %s", p.name(), e, exc_info=True)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
It tests the result of `psutil.cmdline()` before comparing its first element to the Gunicorn master process name.

### Motivation
<!-- What inspired you to submit this pull request? -->
On Linux `psutil.cmdline()` may return an empty array (e.g. for kernel processes) making `cmdline()[0]` crash with an `IndexError: list index out of range` error.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
