### PR TITLE
Update Karpenter documentation, update default metrics port

### DIFF
--- a/karpenter/README.md
+++ b/karpenter/README.md
@@ -23,7 +23,7 @@ Make sure that the Prometheus-formatted metrics are exposed in your Karpenter cl
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the `karpenter.nodes.terminated` metric is exposed only after a node is terminated.
 
 The only parameter required for configuring the Karpenter check is:
-- `openmetrics_endpoint`: This parameter should be set to the location where the Prometheus-formatted metrics are exposed. The default port is `8000`, but it can be configured using the `METRICS_PORT` [environment variable][10]. In containerized environments, `%%host%%` should be used for [host autodetection][3]. 
+- `openmetrics_endpoint`: This parameter should be set to the location where the Prometheus-formatted metrics are exposed. The default port is `8080`, but it can be configured using the `METRICS_PORT` [environment variable][10]. In containerized environments, `%%host%%` should be used for [host autodetection][3]. 
 
 ```yaml
 apiVersion: v1
@@ -38,7 +38,7 @@ metadata:
           "init_config": {},
           "instances": [
             {
-              "openmetrics_endpoint": "http://%%host%%:8000/metrics"
+              "openmetrics_endpoint": "http://%%host%%:8080/metrics"
             }
           ]
         }


### PR DESCRIPTION
### What does this PR do?
Update the default Karpenter metrics port to `8080`
*Note*: Feel free to give feedback on whether or not we would like to keep documentation around for any <1.0.0 release. Could not find any similar changes here. 

### Motivation
The documentation does not reflect this change in [Karpenter v1.0.0](https://github.com/aws/karpenter-provider-aws/pull/6578)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged