### PR TITLE
[AGENT-12890] Handle un-initialized expiration for oauth token

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -837,7 +837,7 @@ class AuthTokenOAuthReader(object):
         self._expiration = None
 
     def read(self, **request):
-        if self._token is None or get_timestamp() >= self._expiration or 'error' in request:
+        if self._token is None or self._expiration is None or get_timestamp() >= self._expiration or 'error' in request:
             global oauth2
             if oauth2 is None:
                 from oauthlib import oauth2


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds a condition where the read function can handle the case `self._expiration is None`

### Motivation
<!-- What inspired you to submit this pull request? -->
The self._expiration attribute is not initialized, so the `get_timestamp() >= self._expiration` would fail as it compares `int` to `None`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
