### PR TITLE
[postgres] Fix duplicated rows returned from QUERY_PG_CLASS 

### DIFF
--- a/postgres/changelog.d/19351.fixed
+++ b/postgres/changelog.d/19351.fixed
@@ -1,0 +1,1 @@
+Resolved an issue in `QUERY_PG_CLASS` where multiple locks on the same table in `PG_LOCKS` caused duplicate rows, leading to inaccurate rate metric like `postgresql.rows_inserted`, `postgresql.rows_updated`, or `postgresql.rows_deleted`.

--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -128,9 +128,15 @@ FROM
     FROM pg_class C
     LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace)
     LEFT JOIN pg_inherits I ON (I.inhrelid = C.oid)
-    LEFT JOIN pg_locks L ON C.oid = L.relation AND L.locktype = 'relation'
     WHERE NOT (nspname = ANY('{{pg_catalog,information_schema}}')) AND
-      (L.relation IS NULL OR L.mode <> 'AccessExclusiveLock' OR NOT L.granted) AND
+        NOT EXISTS (
+            SELECT 1
+            from pg_locks
+            WHERE locktype = 'relation'
+            AND mode = 'AccessExclusiveLock'
+            AND granted = true
+            AND relation = C.oid
+      ) AND
       relkind = 'r' AND
       {relations} {limits}) as s""",
     'columns': [
@@ -191,7 +197,6 @@ SELECT
   C.xmin
 FROM pg_class C
 LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace)
-LEFT JOIN pg_locks L ON C.oid = L.relation AND L.locktype = 'relation'
 LEFT JOIN pg_index idx_toast ON (idx_toast.indrelid = C.reltoastrelid)
 LEFT JOIN LATERAL (
     SELECT sum(pg_stat_get_numscans(indexrelid))::bigint AS idx_scan,
@@ -200,7 +205,14 @@ LEFT JOIN LATERAL (
      WHERE pg_index.indrelid = C.oid) I ON true
 WHERE C.relkind = 'r'
     AND NOT (nspname = ANY('{{pg_catalog,information_schema}}'))
-    AND (L.relation IS NULL OR L.mode <> 'AccessExclusiveLock' OR NOT L.granted)
+    AND NOT EXISTS (
+        SELECT 1
+        from pg_locks
+        WHERE locktype = 'relation'
+        AND mode = 'AccessExclusiveLock'
+        AND granted = true
+        AND relation = C.oid
+    )
     AND {relations} {limits}
 """,
     'columns': [


### PR DESCRIPTION
### What does this PR do?
This PR resolves an issue where duplicate rows were returned for a single table in `QUERY_PG_CLASS`. The duplication occurred due to multiple locks (e.g., `AccessShareLock`, `RowShareLock`) being present for the same table in the `pg_locks` table during a LEFT JOIN operation. As a result, metrics like `postgresql.rows_inserted` (rate type) were submitted multiple times with identical values, causing rate calculations to incorrectly drop to zero. The fix ensures that each table is represented only once by deduplicating locks in the query, preventing incorrect metric submission.

### Motivation
https://datadoghq.atlassian.net/browse/SDBM-1298

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
