### PR TITLE
Fix metric names to match Argo Workflow 3.6 update

### DIFF
--- a/argo_workflows/changelog.d/19357.fixed
+++ b/argo_workflows/changelog.d/19357.fixed
@@ -1,0 +1,1 @@
+Fix metric names to match Argo Workflow 3.6 update

--- a/argo_workflows/datadog_checks/argo_workflows/metrics.py
+++ b/argo_workflows/datadog_checks/argo_workflows/metrics.py
@@ -3,18 +3,18 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 METRIC_MAP = {
-    'argo_workflows_count': 'current_workflows',
+    'argo_workflows_gauge': 'current_workflows',
     'argo_workflows_error_count': 'error',
     'argo_workflows_k8s_request': 'k8s_request',
     'argo_workflows_operation_duration_seconds': 'operation_duration_seconds',
-    'argo_workflows_pods_count': 'pods',
+    'argo_workflows_pods_gauge': 'pods',
     'argo_workflows_queue_adds_count': 'queue_adds',
-    'argo_workflows_queue_depth_count': 'queue_depth',
+    'argo_workflows_queue_depth_gauge': 'queue_depth',
     'argo_workflows_queue_latency': 'queue_latency',
     'argo_workflows_workers_busy_count': 'workers_busy',
     'argo_workflows_workflow_condition': 'workflow_condition',
     'argo_workflows_workflows_processed_count': 'workflows_processed',
-    'log_messages': 'log_messages',
+    'argo_workflows_log_messages': 'log_messages',
     'go_gc_duration_seconds': 'go.gc.duration.seconds',
     'go_goroutines': 'go.goroutines',
     'go_info': "go.info",

--- a/argo_workflows/tests/fixtures/metrics.txt
+++ b/argo_workflows/tests/fixtures/metrics.txt
@@ -1,10 +1,10 @@
-# HELP argo_workflows_count Number of Workflows currently accessible by the controller by status (refreshed every 15s)
-# TYPE argo_workflows_count gauge
-argo_workflows_count{status="Error"} 0
-argo_workflows_count{status="Failed"} 0
-argo_workflows_count{status="Pending"} 0
-argo_workflows_count{status="Running"} 0
-argo_workflows_count{status="Succeeded"} 0
+# HELP argo_workflows_gauge Number of Workflows currently accessible by the controller by status (refreshed every 15s)
+# TYPE argo_workflows_gauge gauge
+argo_workflows_gauge{status="Error"} 0
+argo_workflows_gauge{status="Failed"} 0
+argo_workflows_gauge{status="Pending"} 0
+argo_workflows_gauge{status="Running"} 0
+argo_workflows_gauge{status="Succeeded"} 0
 # HELP argo_workflows_error_count Number of errors encountered by the controller by cause
 # TYPE argo_workflows_error_count counter
 argo_workflows_error_count{cause="CronWorkflowSpecError"} 0
@@ -48,22 +48,22 @@ argo_workflows_operation_duration_seconds_bucket{le="30"} 0
 argo_workflows_operation_duration_seconds_bucket{le="+Inf"} 0
 argo_workflows_operation_duration_seconds_sum 0
 argo_workflows_operation_duration_seconds_count 0
-# HELP argo_workflows_pods_count Number of Pods from Workflows currently accessible by the controller by status (refreshed every 15s)
-# TYPE argo_workflows_pods_count gauge
-argo_workflows_pods_count{status="Pending"} 0
-argo_workflows_pods_count{status="Running"} 0
+# HELP argo_workflows_pods_gauge Number of Pods from Workflows currently accessible by the controller by status (refreshed every 15s)
+# TYPE argo_workflows_pods_gauge gauge
+argo_workflows_pods_gauge{status="Pending"} 0
+argo_workflows_pods_gauge{status="Running"} 0
 # HELP argo_workflows_queue_adds_count Adds to the queue
 # TYPE argo_workflows_queue_adds_count counter
 argo_workflows_queue_adds_count{queue_name="cron_wf_queue"} 0
 argo_workflows_queue_adds_count{queue_name="pod_cleanup_queue"} 0
 argo_workflows_queue_adds_count{queue_name="workflow_queue"} 0
 argo_workflows_queue_adds_count{queue_name="workflow_ttl_queue"} 0
-# HELP argo_workflows_queue_depth_count Depth of the queue
-# TYPE argo_workflows_queue_depth_count gauge
-argo_workflows_queue_depth_count{queue_name="cron_wf_queue"} 0
-argo_workflows_queue_depth_count{queue_name="pod_cleanup_queue"} 0
-argo_workflows_queue_depth_count{queue_name="workflow_queue"} 0
-argo_workflows_queue_depth_count{queue_name="workflow_ttl_queue"} 0
+# HELP argo_workflows_queue_depth_gauge Depth of the queue
+# TYPE argo_workflows_queue_depth_gauge gauge
+argo_workflows_queue_depth_gauge{queue_name="cron_wf_queue"} 0
+argo_workflows_queue_depth_gauge{queue_name="pod_cleanup_queue"} 0
+argo_workflows_queue_depth_gauge{queue_name="workflow_queue"} 0
+argo_workflows_queue_depth_gauge{queue_name="workflow_ttl_queue"} 0
 # HELP argo_workflows_queue_latency Time objects spend waiting in the queue
 # TYPE argo_workflows_queue_latency histogram
 argo_workflows_queue_latency_bucket{queue_name="cron_wf_queue",le="1"} 0
@@ -198,8 +198,8 @@ go_memstats_sys_bytes 2.0026632e+07
 # HELP go_threads Number of OS threads created.
 # TYPE go_threads gauge
 go_threads 10
-# HELP log_messages Total number of log messages.
-# TYPE log_messages counter
-log_messages{level="error"} 0
-log_messages{level="info"} 136
-log_messages{level="warning"} 0
+# HELP argo_workflows_log_messages Total number of log messages.
+# TYPE argo_workflows_log_messages counter
+argo_workflows_log_messages{level="error"} 0
+argo_workflows_log_messages{level="info"} 136
+argo_workflows_log_messages{level="warning"} 0


### PR DESCRIPTION
### What does this PR do?
This PR updates the metric names in the Datadog integration for Argo Workflow to match the new naming convention introduced in Argo Workflow version 3.6. (https://argo-workflows.readthedocs.io/en/latest/upgrading/#renamed-metrics)
The changes ensure compatibility with the updated version.

### Motivation
Since the Argo Workflow version upgrade, we are unable to access the metrics, which are essential for creating monitors.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
