### PR TITLE
Specify curl version when building confluent-kafka-python on Windows

### DIFF
--- a/.builders/images/windows-x86_64/Dockerfile
+++ b/.builders/images/windows-x86_64/Dockerfile
@@ -116,6 +116,8 @@ RUN Get-RemoteFile `
 
 ENV OPENSSL_VERSION="3.3.2"
 
+ENV CURL_VERSION="8.11.1"
+
 # Set up runner
 COPY runner_dependencies.txt C:\runner_dependencies.txt
 RUN python -m pip install --no-warn-script-location -r C:\runner_dependencies.txt

--- a/.builders/images/windows-x86_64/build_script.ps1
+++ b/.builders/images/windows-x86_64/build_script.ps1
@@ -21,14 +21,25 @@ Remove-Item "librdkafka-${kafka_version}.tar.gz"
 # Based on this job from upstream:
 # https://github.com/confluentinc/librdkafka/blob/cb8c19c43011b66c4b08b25e5150455a247e1ff3/.semaphore/semaphore.yml#L265
 # Install vcpkg
-Set-Location "C:\"
 $triplet = "x64-windows"
+$vcpkg_dir = "C:\vcpkg"
 $librdkafka_dir = "C:\librdkafka\librdkafka-${kafka_version}"
+$desired_tag = "2024.12.16"
 
-& "${librdkafka_dir}\win32\setup-vcpkg.ps1"
+# Clone and configure vcpkg
+if (-Not (Test-Path -Path "$vcpkg_dir\.git")) {
+    git clone https://github.com/Microsoft/vcpkg.git $vcpkg_dir
+}
+
+Set-Location $vcpkg_dir
+git checkout $desired_tag
+
+Write-Host "Bootstrapping vcpkg..."
+.\bootstrap-vcpkg.bat
+
 # Get deps
 Set-Location "$librdkafka_dir"
-# Patch the the vcpkg manifest to to override the OpenSSL version
+# Patch the the vcpkg manifest to to override the OpenSSL version and CURL version
 python C:\update_librdkafka_manifest.py vcpkg.json --set-version openssl:${Env:OPENSSL_VERSION} --set-version curl:${Env:CURL_VERSION}
 
 C:\vcpkg\vcpkg integrate install

--- a/.builders/images/windows-x86_64/build_script.ps1
+++ b/.builders/images/windows-x86_64/build_script.ps1
@@ -29,7 +29,7 @@ $librdkafka_dir = "C:\librdkafka\librdkafka-${kafka_version}"
 # Get deps
 Set-Location "$librdkafka_dir"
 # Patch the the vcpkg manifest to to override the OpenSSL version
-python C:\update_librdkafka_manifest.py vcpkg.json --set-version openssl:${Env:OPENSSL_VERSION}
+python C:\update_librdkafka_manifest.py vcpkg.json --set-version openssl:${Env:OPENSSL_VERSION} --set-version curl:${Env:CURL_VERSION}
 
 C:\vcpkg\vcpkg integrate install
 C:\vcpkg\vcpkg --feature-flags=versions install --triplet $triplet


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds the ability to specify the version of CURL used when building `librdkafka`/`confluent-kafka` on Windows

### Motivation
<!-- What inspired you to submit this pull request? -->
It makes sense to also build CURL since there are CVE's that come up related it and waiting on a vendor fix is just as tedious as waiting for a vendor fix for OpenSSL.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
