### PR TITLE
Update confluent-kafka-python to fix license metadata

### DIFF
--- a/.builders/images/linux-aarch64/build_script.sh
+++ b/.builders/images/linux-aarch64/build_script.sh
@@ -21,7 +21,7 @@ if [[ "${DD_BUILD_PYTHON_VERSION}" == "3" ]]; then
     LDFLAGS="${LDFLAGS} -L/usr/local/lib -lkrb5 -lgssapi_krb5 -llmdb" \
     DOWNLOAD_URL="https://github.com/confluentinc/librdkafka/archive/refs/tags/v{{version}}.tar.gz" \
         VERSION="${kafka_version}" \
-        SHA256="0ddf205ad8d36af0bc72a2fec20639ea02e1d583e353163bf7f4683d949e901b" \
+        SHA256="5bd1c46f63265f31c6bfcedcde78703f77d28238eadf23821c2b43fc30be3e25" \
         RELATIVE_PATH="librdkafka-{{version}}" \
         bash install-from-source.sh --enable-sasl --enable-curl
     always_build+=("confluent-kafka")

--- a/.builders/images/linux-x86_64/build_script.sh
+++ b/.builders/images/linux-x86_64/build_script.sh
@@ -18,7 +18,7 @@ if [[ "${DD_BUILD_PYTHON_VERSION}" == "3" ]]; then
     LDFLAGS="${LDFLAGS} -L/usr/local/lib -lkrb5 -lgssapi_krb5 -llmdb" \
     DOWNLOAD_URL="https://github.com/confluentinc/librdkafka/archive/refs/tags/v{{version}}.tar.gz" \
         VERSION="${kafka_version}" \
-        SHA256="0ddf205ad8d36af0bc72a2fec20639ea02e1d583e353163bf7f4683d949e901b" \
+        SHA256="5bd1c46f63265f31c6bfcedcde78703f77d28238eadf23821c2b43fc30be3e25" \
         RELATIVE_PATH="librdkafka-{{version}}" \
         bash install-from-source.sh --enable-sasl --enable-curl
     always_build+=("confluent-kafka")

--- a/.builders/images/macos-x86_64/extra_build.sh
+++ b/.builders/images/macos-x86_64/extra_build.sh
@@ -13,7 +13,7 @@ if [[ "${DD_BUILD_PYTHON_VERSION}" == "3" ]]; then
     LDFLAGS="${LDFLAGS} -L${DD_PREFIX_PATH}/lib -lgssapi_krb5 -llmdb" \
     DOWNLOAD_URL="https://github.com/confluentinc/librdkafka/archive/refs/tags/v{{version}}.tar.gz" \
       VERSION="${kafka_version}" \
-      SHA256="0ddf205ad8d36af0bc72a2fec20639ea02e1d583e353163bf7f4683d949e901b" \
+      SHA256="5bd1c46f63265f31c6bfcedcde78703f77d28238eadf23821c2b43fc30be3e25" \
       RELATIVE_PATH="librdkafka-{{version}}" \
       bash install-from-source.sh --prefix="${DD_PREFIX_PATH}" --enable-sasl --enable-curl
 

--- a/.builders/images/windows-x86_64/build_script.ps1
+++ b/.builders/images/windows-x86_64/build_script.ps1
@@ -12,7 +12,7 @@ Write-Host "Will build librdkafka $kafka_version"
 Get-RemoteFile `
   -Uri "https://github.com/confluentinc/librdkafka/archive/refs/tags/v${kafka_version}.tar.gz" `
   -Path "librdkafka-${kafka_version}.tar.gz" `
-  -Hash '0ddf205ad8d36af0bc72a2fec20639ea02e1d583e353163bf7f4683d949e901b'
+  -Hash '5bd1c46f63265f31c6bfcedcde78703f77d28238eadf23821c2b43fc30be3e25'
 7z x "librdkafka-${kafka_version}.tar.gz" -o"C:\"
 7z x "C:\librdkafka-${kafka_version}.tar" -o"C:\librdkafka"
 Remove-Item "librdkafka-${kafka_version}.tar.gz"
@@ -24,6 +24,8 @@ Remove-Item "librdkafka-${kafka_version}.tar.gz"
 $triplet = "x64-windows"
 $vcpkg_dir = "C:\vcpkg"
 $librdkafka_dir = "C:\librdkafka\librdkafka-${kafka_version}"
+# We set the desired tag to the latest release tag to ensure that we are building with the latest stable version.
+# The desired tag should be updated periodically or when critical fixes or features are released.
 $desired_tag = "2024.12.16"
 
 # Clone and configure vcpkg

--- a/.ddev/ci/scripts/kafka_consumer/linux/32_install_kerberos.sh
+++ b/.ddev/ci/scripts/kafka_consumer/linux/32_install_kerberos.sh
@@ -8,7 +8,7 @@ sudo apt install -y --no-install-recommends build-essential libkrb5-dev wget sof
 # Install librdkafka from source since no binaries are available for the distribution we use on the CI:
 git clone https://github.com/confluentinc/librdkafka
 cd librdkafka
-git checkout v2.6.1
+git checkout v2.8.0
 sudo ./configure --install-deps --prefix=/usr
 make
 sudo make install

--- a/.ddev/config.toml
+++ b/.ddev/config.toml
@@ -71,9 +71,6 @@ aerospike = ['Apache-2.0']
 # https://github.com/pyca/cryptography/blob/main/LICENSE
 cryptography = ['Apache-2.0', 'BSD-3-Clause', 'PSF']
 # https://github.com/confluentinc/confluent-kafka-python/blob/master/LICENSE
-# TODO: Remove once confluent-kafka license metadata is fixed:
-# https://github.com/confluentinc/confluent-kafka-python/issues/1857
-confluent-kafka = ['Apache-2.0']
 # https://github.com/rthalley/dnspython/blob/master/LICENSE
 dnspython = ['ISC']
 # https://github.com/cannatag/ldap3/blob/dev/COPYING.txt

--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -9,7 +9,7 @@ cachetools==5.5.0
 clickhouse-cityhash==1.0.2.4
 clickhouse-driver==0.2.9
 cm-client==45.0.4
-confluent-kafka==2.6.1
+confluent-kafka==2.8.0
 cryptography==43.0.1
 ddtrace==2.10.6
 dnspython==2.6.1

--- a/kafka_consumer/changelog.d/19370.added
+++ b/kafka_consumer/changelog.d/19370.added
@@ -1,0 +1,1 @@
+Bump version of confluent-kafk to 2.8.0

--- a/kafka_consumer/changelog.d/19370.added
+++ b/kafka_consumer/changelog.d/19370.added
@@ -1,1 +1,1 @@
-Bump version of confluent-kafk to 2.8.0
+Bump version of `confluent-kafka` to 2.8.0

--- a/kafka_consumer/hatch.toml
+++ b/kafka_consumer/hatch.toml
@@ -5,7 +5,7 @@
 # Also bump the LIBRDKAFKA_VERSION version in this file
 post-install-commands = [
   "python -m pip uninstall -y confluent-kafka",
-  "python -m pip install --no-binary confluent-kafka confluent-kafka==2.6.1",
+  "python -m pip install --no-binary confluent-kafka confluent-kafka==2.8.0",
 ]
 
 [envs.default.env-vars]

--- a/kafka_consumer/pyproject.toml
+++ b/kafka_consumer/pyproject.toml
@@ -36,7 +36,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "confluent-kafka==2.6.1",
+    "confluent-kafka==2.8.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The license metadata was fixed in version 2.8.0 of `confluent-kafka-python`. This PR removes the override so we validate from PyPI.

### Motivation
<!-- What inspired you to submit this pull request? -->
https://github.com/confluentinc/confluent-kafka-python/issues/1857

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
