### PR TITLE
[AGENT-12890] Handle unexpected values for `expires_in` in OAuth Access response

### DIFF
--- a/datadog_checks_base/changelog.d/19371.fixed
+++ b/datadog_checks_base/changelog.d/19371.fixed
@@ -1,0 +1,1 @@
+Handle unexpected values for `expires_in` in OAuth Access response

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -863,7 +863,7 @@ class AuthTokenOAuthReader(object):
                 # According to https://www.rfc-editor.org/rfc/rfc6749#section-5.1, the `expires_in` field is optional
                 self._expiration += _parse_expires_in(response.get('expires_in'))
             except TypeError:
-                LOGGER.warning(
+                LOGGER.debug(
                     'The `expires_in` field of the OAuth2 response is not a number, defaulting to %s',
                     DEFAULT_EXPIRATION,
                 )
@@ -1008,9 +1008,9 @@ def _parse_expires_in(token_expiration):
         try:
             token_expiration = int(token_expiration)
         except ValueError:
-            LOGGER.warning('Could not convert %s to an integer', token_expiration)
+            LOGGER.debug('Could not convert %s to an integer', token_expiration)
     else:
-        LOGGER.warning('Unexpected type for `expires_in`: %s.', type(token_expiration))
+        LOGGER.debug('Unexpected type for `expires_in`: %s.', type(token_expiration))
         token_expiration = None
 
     return token_expiration

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -862,7 +862,7 @@ class AuthTokenOAuthReader(object):
                 token_expiration = response.get('expires_in', 0)
                 self._expiration += token_expiration
             except TypeError:
-                self.logger.warning('OAuth2 included an `expires_in` value of unexpected type %s.', type(token_expiration))
+                LOGGER.warning('OAuth2 included an `expires_in` value of unexpected type %s.', type(token_expiration))
 
             return self._token
 

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -856,7 +856,13 @@ class AuthTokenOAuthReader(object):
 
             # https://www.rfc-editor.org/rfc/rfc6749#section-4.4.3
             self._token = response['access_token']
-            self._expiration = get_timestamp() + response['expires_in']
+            self._expiration = get_timestamp()
+            try:
+                # According to https://www.rfc-editor.org/rfc/rfc6749#section-5.1, the `expires_in` field is optional
+                token_expiration = response.get('expires_in', 0)
+                self._expiration += token_expiration
+            except TypeError:
+                self.logger.warning('OAuth2 included an `expires_in` value of unexpected type %s.', type(token_expiration))
 
             return self._token
 

--- a/datadog_checks_base/tests/base/utils/http/test_authtoken.py
+++ b/datadog_checks_base/tests/base/utils/http/test_authtoken.py
@@ -468,8 +468,16 @@ class TestAuthTokenOAuth:
         ):
             with pytest.raises(Exception, match='OAuth2 client credentials grant error: unauthorized_client'):
                 http.get('https://www.google.com')
-
-    def test_success(self):
+    
+    @pytest.mark.parametrize(
+        'token_response',
+        [
+            pytest.param({'access_token': 'foo', 'expires_in': 9000}, id='With expires_in'),
+            pytest.param({'access_token': 'foo'}, id='Without expires_in'),
+            pytest.param({'access_token': 'foo', 'expires_in': 'two minutes'}, id='With string expires_in'),
+        ]
+        )
+    def test_success(self, token_response):
         instance = {
             'auth_token': {
                 'reader': {'type': 'oauth', 'url': 'foo', 'client_id': 'bar', 'client_secret': 'baz'},
@@ -487,7 +495,7 @@ class TestAuthTokenOAuth:
                 pass
 
             def fetch_token(self, *args, **kwargs):
-                return {'access_token': 'foo', 'expires_in': 9000}
+                return token_response
 
         with mock.patch('requests.get') as get, mock.patch('oauthlib.oauth2.BackendApplicationClient'), mock.patch(
             'requests_oauthlib.OAuth2Session', side_effect=MockOAuth2Session

--- a/datadog_checks_base/tests/base/utils/http/test_authtoken.py
+++ b/datadog_checks_base/tests/base/utils/http/test_authtoken.py
@@ -468,15 +468,15 @@ class TestAuthTokenOAuth:
         ):
             with pytest.raises(Exception, match='OAuth2 client credentials grant error: unauthorized_client'):
                 http.get('https://www.google.com')
-    
+
     @pytest.mark.parametrize(
         'token_response',
         [
             pytest.param({'access_token': 'foo', 'expires_in': 9000}, id='With expires_in'),
             pytest.param({'access_token': 'foo'}, id='Without expires_in'),
             pytest.param({'access_token': 'foo', 'expires_in': 'two minutes'}, id='With string expires_in'),
-        ]
-        )
+        ],
+    )
     def test_success(self, token_response):
         instance = {
             'auth_token': {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Allow for an empty `expires_in` field in OAuth Access Token response as detailed by [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749#section-5.1).
Handle unexpected type in `expires_in` field, e.g. string.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
