### PR TITLE
More attempts and wait to set up docker-compose

### DIFF
--- a/hudi/tests/conftest.py
+++ b/hudi/tests/conftest.py
@@ -17,5 +17,7 @@ def dd_environment():
     with docker_run(
         compose_file=compose_file,
         conditions=[CheckDockerLogs('spark-app-hudi', 'finished: show at script.scala:163')],
+        attempts=5,
+        attempts_wait=5,
     ):
         yield CHECK_CONFIG, {'use_jmx': True}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Hudi occasionally fails in master because the connection to apache archive times out. Some examples:

- https://github.com/DataDog/integrations-core/actions/runs/12712182319/job/35437303130#step:16:187
- https://github.com/DataDog/integrations-core/actions/runs/12712182319/job/35437303130#step:16:187

We hope that by waiting longer and retrying more we can make the test more robust.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
