### PR TITLE
Utx only/openmetric target info 2

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
@@ -29,7 +29,7 @@ class OpenMetricsBaseCheckV2(AgentCheck):
 
     """
 
-    DEFAULT_METRIC_LIMIT = 20000
+    DEFAULT_METRIC_LIMIT = 2000
 
     # Allow tracing for openmetrics integrations
     def __init_subclass__(cls, **kwargs):

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
@@ -29,7 +29,7 @@ class OpenMetricsBaseCheckV2(AgentCheck):
 
     """
 
-    DEFAULT_METRIC_LIMIT = 2000
+    DEFAULT_METRIC_LIMIT = 20000
 
     # Allow tracing for openmetrics integrations
     def __init_subclass__(cls, **kwargs):
@@ -111,10 +111,6 @@ class OpenMetricsBaseCheckV2(AgentCheck):
 
     def refresh_scrapers(self):
         pass
-
-
-
-
 
     @contextmanager
     def adopt_namespace(self, namespace):

--- a/datadog_checks_base/tests/base/checks/logs/crawler/test_base.py
+++ b/datadog_checks_base/tests/base/checks/logs/crawler/test_base.py
@@ -6,7 +6,6 @@ from datadog_checks.base.checks.logs.crawler.stream import LogRecord, LogStream
 
 
 def test_submission(dd_run_check, datadog_agent):
-
     class TestLogStream(LogStream):
         def __init__(self, start, **kwargs):
             super().__init__(**kwargs)

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_info.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_info.py
@@ -1,0 +1,36 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from .utils import get_check
+
+
+def test_target_info_tags_propagation(aggregator, dd_run_check, mock_http_response):
+    # Initialize the check
+    check = get_check({'metrics': ['.+']})
+
+    # Mock the HTTP response with target_info and another metric
+    mock_http_response(
+        """
+        # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+        # TYPE go_memstats_alloc_bytes gauge
+        go_memstats_alloc_bytes{foo="bar"} 6.396288e+06
+        # HELP target Target metadata
+        # TYPE target info
+        target_info{env="prod", region="europe"} 1.0
+        """
+    )
+
+    # Run the check
+    dd_run_check(check)
+
+    # Assert that the tags from target_info are applied to the other metric
+    aggregator.assert_metric(
+        'test.go_memstats_alloc_bytes',
+        value=6396288,
+        tags=['endpoint:test', 'foo:bar', 'env:prod', 'region:europe'],
+        metric_type=aggregator.GAUGE,
+    )
+
+    # Assert all metrics are covered
+    aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

* Adds support for `target_info` metric type
* Adds tests to ensure tags are added to metrics

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
