### PR TITLE
Fix agent release annotations in changelog

### DIFF
--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 <!-- towncrier release notes start -->
 
-## 37.3.0 / 2024-12-26 / Agent 7.61.0
+## 37.3.0 / 2024-12-26
 
 ***Security***:
 
@@ -35,13 +35,13 @@
 
 * Added Postgres cross-org telemetry metrics. ([#18758](https://github.com/DataDog/integrations-core/pull/18758))
 
-## 37.0.0 / 2024-09-19
+## 37.0.0 / 2024-09-19 / Agent 7.58.0
 
 ***Removed***:
 
 * Remove support for Python 2. ([#18580](https://github.com/DataDog/integrations-core/pull/18580))
 
-## 36.16.0 / 2024-09-30 / Agent 7.58.0
+## 36.16.0 / 2024-09-30
 
 ***Security***:
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
1. We didn't release a new version of the base check in Agent 7.61.0.
2. We had the 7.58.0 annotation on the wrong release.

### Motivation
<!-- What inspired you to submit this pull request? -->

Correct changelog doesn't confuse our automation.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
