### PR TITLE
Don't trigger agent build for GitHub MergeQueue branches

### DIFF
--- a/.gitlab/build_agent.yaml
+++ b/.gitlab/build_agent.yaml
@@ -21,7 +21,8 @@
 build-agent-auto:
   extends: .build-agent-tpl
   rules:
-    - changes:
+    - if: $CI_COMMIT_BRANCH !~ "/gh-readonly-queue/"
+      changes:
         # We don't yet support variable expansion in `compare_to`. It was added in gitlab 17.2:
         # https://gitlab.com/gitlab-org/gitlab/-/issues/369916#note_1972773223
         compare_to: "master"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Save some $$ for the agent build folks :)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
