### PR TITLE
Drop unused importlib-metadata dependency

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -27,7 +27,6 @@ flup,Vendor,BSD-3-Clause,Copyright (c) 2005 Allan Saddi. All Rights Reserved.
 flup-py3,Vendor,BSD-3-Clause,"Copyright (c) 2005, 2006 Allan Saddi <allan@saddi.com> All rights reserved."
 foundationdb,PyPI,Apache-2.0,Copyright 2017 FoundationDB
 hazelcast-python-client,PyPI,Apache-2.0,"Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved."
-importlib-metadata,PyPI,Apache-2.0,"Copyright 2017-2019 Jason R. Coombs, Barry Warsaw"
 in-toto,PyPI,Apache-2.0,Copyright 2018 New York University
 jellyfish,PyPI,MIT,Copyright (c) 2015 James Turk
 kentik-snmp-profiles,"https://github.com/kentik/snmp-profiles",Apache-2.0,

--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -16,7 +16,6 @@ dnspython==2.6.1
 duckdb==1.1.1
 foundationdb==6.3.24
 hazelcast-python-client==5.4.0
-importlib-metadata==2.1.3; python_version < '3.8'
 in-toto==2.0.0
 jellyfish==1.1.0
 kubernetes==30.1.0

--- a/datadog_checks_base/datadog_checks/base/utils/agent/packages.py
+++ b/datadog_checks_base/datadog_checks/base/utils/agent/packages.py
@@ -1,12 +1,7 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import sys
-
-if sys.version_info >= (3, 8):
-    from importlib.metadata import distributions
-else:
-    from importlib_metadata import distributions
+from importlib.metadata import distributions
 
 DATADOG_CHECK_PREFIX = 'datadog-'
 

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -38,7 +38,6 @@ deps = [
     "cachetools==5.5.0",
     "cryptography==43.0.1",
     "ddtrace==2.10.6",
-    "importlib-metadata==2.1.3; python_version < '3.8'",
     "jellyfish==1.1.0",
     "prometheus-client==0.20.0",
     "protobuf==5.27.3",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
We no longer ship Python less than 3.8.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
