### PR TITLE
handle case insensitive db name in schema collection

### DIFF
--- a/sqlserver/changelog.d/19384.fixed
+++ b/sqlserver/changelog.d/19384.fixed
@@ -1,0 +1,1 @@
+Fix KeyError in SQL Server schema collection caused by case-insensitive database name mismatches.

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -8,7 +8,7 @@ from contextlib import closing, contextmanager
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.log import get_check_logger
 from datadog_checks.sqlserver.cursor import CommenterCursorWrapper
-from datadog_checks.sqlserver.utils import construct_use_statement
+from datadog_checks.sqlserver.utils import construct_use_statement, is_collation_case_insensitive
 
 try:
     import adodbapi
@@ -361,7 +361,7 @@ class Connection(object):
                 cursor.execute(DATABASE_EXISTS_QUERY)
                 for row in cursor.fetchall():
                     # collation_name can be NULL if db offline, in that case assume its case_insensitive
-                    case_insensitive = not row.collation_name or 'CI' in row.collation_name
+                    case_insensitive = is_collation_case_insensitive(row.collation_name)
                     self.existing_databases[row.name.lower()] = (
                         case_insensitive,
                         row.name,

--- a/sqlserver/datadog_checks/sqlserver/schemas.py
+++ b/sqlserver/datadog_checks/sqlserver/schemas.py
@@ -74,7 +74,7 @@ class SubmitData:
                     db_name = db_name_lower
                 else:
                     self._log.debug(
-                        "Skipping db {} as it is not in the databases list {} and collation is case sensitive".format(
+                        "Skipping db {} as it is not in the databases list {} or collation is case sensitive".format(
                             db_name, dbs
                         )
                     )

--- a/sqlserver/datadog_checks/sqlserver/schemas.py
+++ b/sqlserver/datadog_checks/sqlserver/schemas.py
@@ -31,7 +31,13 @@ from datadog_checks.sqlserver.queries import (
     SCHEMA_QUERY,
     TABLES_IN_SCHEMA_QUERY,
 )
-from datadog_checks.sqlserver.utils import convert_to_bool, execute_query, get_list_chunks, is_azure_sql_database
+from datadog_checks.sqlserver.utils import (
+    convert_to_bool,
+    execute_query,
+    get_list_chunks,
+    is_azure_sql_database,
+    is_collation_case_insensitive,
+)
 
 
 class SubmitData:
@@ -57,9 +63,23 @@ class SubmitData:
         self.db_to_schemas.clear()
         self.db_info.clear()
 
-    def store_db_infos(self, db_infos):
+    def store_db_infos(self, db_infos, databases):
+        dbs = set(databases)
         for db_info in db_infos:
-            self.db_info[db_info['name']] = db_info
+            case_insensitive = is_collation_case_insensitive(db_info.get('collation'))
+            db_name = db_info['name']
+            db_name_lower = db_name.lower()
+            if db_name not in dbs:
+                if db_name.lower() in dbs and case_insensitive:
+                    db_name = db_name_lower
+                else:
+                    self._log.debug(
+                        "Skipping db {} as it is not in the databases list {} and collation is case sensitive".format(
+                            db_name, dbs
+                        )
+                    )
+                    continue
+            self.db_info[db_name] = db_info
 
     def store(self, db_name, schema, tables, columns_count):
         self._columns_count += columns_count
@@ -277,7 +297,7 @@ class Schemas(DBMAsyncJob):
 
         databases = self._check.get_databases()
         db_infos = self._query_db_information(databases)
-        self._data_submitter.store_db_infos(db_infos)
+        self._data_submitter.store_db_infos(db_infos, databases)
         self._fetch_for_databases()
         self._data_submitter.submit()
         self._log.debug("Finished collect_schemas_data")

--- a/sqlserver/datadog_checks/sqlserver/utils.py
+++ b/sqlserver/datadog_checks/sqlserver/utils.py
@@ -215,3 +215,12 @@ def convert_to_bool(value):
         return bool(value)
     else:
         return value
+
+
+def is_collation_case_insensitive(collation):
+    """
+    Checks if the collation is case insensitive
+    :param collation: The collation string
+    :return: bool
+    """
+    return not collation or 'CI' in collation.upper()


### PR DESCRIPTION
### What does this PR do?
This PR fixes a `KeyError` bug in the SQL Server schema collection process. The issue occurred when the database name in `sys.databases` was uppercase in a case-insensitive collation, such as `SQL_Latin1_General_CP1_CI_AS`. 

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4901

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
