### PR TITLE
Mark MongoDB integration test as flaky

### DIFF
--- a/mongo/tests/test_integration_shard.py
+++ b/mongo/tests/test_integration_shard.py
@@ -46,7 +46,7 @@ def test_mongo_arbiter(aggregator, check, instance_arbiter, dd_run_check):
     for metric, value in expected_metrics.items():
         aggregator.assert_metric(metric, value, expected_tags, count=1)
 
-
+@pytest.mark.flaky
 def test_mongo_replset(instance_shard, aggregator, check, dd_run_check):
     mongo_check = check(instance_shard)
     dd_run_check(mongo_check)

--- a/mongo/tests/test_integration_shard.py
+++ b/mongo/tests/test_integration_shard.py
@@ -46,6 +46,7 @@ def test_mongo_arbiter(aggregator, check, instance_arbiter, dd_run_check):
     for metric, value in expected_metrics.items():
         aggregator.assert_metric(metric, value, expected_tags, count=1)
 
+
 @pytest.mark.flaky
 def test_mongo_replset(instance_shard, aggregator, check, dd_run_check):
     mongo_check = check(instance_shard)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR marks a MongoDB integration test as flaky.

### Motivation
<!-- What inspired you to submit this pull request? -->
A [job](https://github.com/DataDog/integrations-core/actions/runs/12751733681/job/35539667470) MongoDB failed in our master pipeline. This failure happened once in the past month so marking the integration test as potentially flaky.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
