### PR TITLE
Fix Milvus process signature

### DIFF
--- a/milvus/manifest.json
+++ b/milvus/manifest.json
@@ -41,7 +41,7 @@
         "metadata_path": "assets/service_checks.json"
       },
       "process_signatures": [
-        "milvus run standalone"
+        "milvus"
       ]
     }
   },


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Previously, the process signature was `milvus run standalone` which is just an example of a possible cmdline entry for Milvus.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
