### PR TITLE
Update Python version in ddev setup docs

### DIFF
--- a/docs/developer/setup.md
+++ b/docs/developer/setup.md
@@ -203,11 +203,11 @@ After downloading the archive corresponding to your platform and architecture, e
 
     === "ARM"
         ```
-        pipx install ddev --python /opt/homebrew/bin/python3.11
+        pipx install ddev --python /opt/homebrew/bin/python3.12
         ```
     === "Intel"
         ```
-        pipx install ddev --python /usr/local/bin/python3.11
+        pipx install ddev --python /usr/local/bin/python3.12
         ```
 
     !!! warning


### PR DESCRIPTION
### What does this PR do?
I noticed that a couple of lines in the docs still reference Python 3.11. We're now using Python 3.12.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
