### PR TITLE
[mongo] add zlib compression to agent client

### DIFF
--- a/mongo/changelog.d/19395.added
+++ b/mongo/changelog.d/19395.added
@@ -1,0 +1,1 @@
+Add support for `zlib` network compression in the MongoDB integration client with fallback to uncompressed connections.

--- a/mongo/datadog_checks/mongo/api.py
+++ b/mongo/datadog_checks/mongo/api.py
@@ -50,6 +50,7 @@ class MongoApi(object):
             'directConnection': True,
             'read_preference': ReadPreference.PRIMARY_PREFERRED,
             'appname': DD_APP_NAME,
+            'compressors': 'zlib',  # Enable zlib compression
         }
         if replicaset:
             options['replicaSet'] = replicaset


### PR DESCRIPTION
### What does this PR do?
This PR introduces support for `zlib` network compression in the MongoDB integration client. Starting from MongoDB v3.6, `zlib` compression is natively supported, and it is available in PyMongo without requiring additional dependencies.
- If network compression is disabled or `zlib` is unavailable on the server side, the integration connection gracefully falls back to connecting without compression.
- Users can customize the agent mongo client compressor settings by using the `options.compressors` configuration to override the default `zlib` compressor if needed.

This change enhances performance by reducing network overhead between agent and monitored mongodb database when `zlib` compression is supported by the server.

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4909

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
