### PR TITLE
[mongo] add config option to enable search indexes collection

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -275,6 +275,13 @@ files:
           value:
             type: number
             example: 5
+        - name: collect_search_indexes
+          description: |
+            Set to `true` to collect search indexes for each collection.
+            NOTE: This option is only applicable to MongoDB Atlas clusters.
+          value:
+            type: boolean
+            example: false
     - name: replica_check
       description: |
         Whether or not to read from available replicas.

--- a/mongo/changelog.d/19396.added
+++ b/mongo/changelog.d/19396.added
@@ -1,0 +1,1 @@
+Make MongoDB Atlas search indexes collection configurable and disable it by default for improved performance.

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -221,6 +221,7 @@ class MongoConfig(object):
             'sample_size': int(self._schemas_config.get('sample_size', 10)),
             'max_collections': int(max_collections) if max_collections else None,
             'max_depth': int(self._schemas_config.get('max_depth', 5)),  # Default to 5
+            'collect_search_indexes': is_affirmative(self._schemas_config.get('collect_search_indexes', False)),
         }
 
     def _get_database_autodiscovery_config(self, instance):

--- a/mongo/datadog_checks/mongo/config_models/instance.py
+++ b/mongo/datadog_checks/mongo/config_models/instance.py
@@ -97,6 +97,7 @@ class Schemas(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    collect_search_indexes: Optional[bool] = None
     collection_interval: Optional[float] = None
     enabled: Optional[bool] = None
     max_collections: Optional[float] = None

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -234,6 +234,12 @@ instances:
         #
         # max_depth: 5
 
+        ## @param collect_search_indexes - boolean - optional - default: false
+        ## Set to `true` to collect search indexes for each collection.
+        ## NOTE: This option is only applicable to MongoDB Atlas clusters.
+        #
+        # collect_search_indexes: false
+
     ## @param replica_check - boolean - optional - default: true
     ## Whether or not to read from available replicas.
     ## Disable this if any replicas are inaccessible to the Agent. This option is not supported for sharded clusters.

--- a/mongo/datadog_checks/mongo/dbm/schemas.py
+++ b/mongo/datadog_checks/mongo/dbm/schemas.py
@@ -32,6 +32,7 @@ class MongoSchemas(DBMAsyncJob):
         self._max_collections = self._schemas_config["max_collections"]
         self._sample_size = self._schemas_config["sample_size"]
         self._max_depth = self._schemas_config["max_depth"]
+        self._collect_search_indexes = self._schemas_config["collect_search_indexes"]
         self._max_collections_per_database = check._config.database_autodiscovery_config['max_collections_per_database']
 
         super(MongoSchemas, self).__init__(
@@ -210,6 +211,10 @@ class MongoSchemas(DBMAsyncJob):
         return "regular"
 
     def _discover_collection_search_indexes(self, dbname, collname):
+        if not self._collect_search_indexes:
+            self._check.log.debug("Search indexes collection is disabled")
+            return []
+
         if not self._check.deployment_type.hosting_type == HostingType.ATLAS:
             self._check.log.debug("Search indexes are only supported for Atlas deployments")
             return []

--- a/mongo/tests/results/schemas-standalone-atlas-search-indexes.json
+++ b/mongo/tests/results/schemas-standalone-atlas-search-indexes.json
@@ -314,7 +314,24 @@
                                 "case_insensitive": true
                             }
                         ],
-                        "search_indexes": []
+                        "search_indexes": [
+                            {
+                                "mappings": {
+                                    "dynamic": true,
+                                    "fields": [
+                                        {
+                                            "field": "highlight",
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "name": "cast_fullplot_genres_title",
+                                "queryable": true,
+                                "status": "READY",
+                                "type": "search",
+                                "version": "1"
+                            }
+                        ]
                     },
                     {
                         "name": "bar",
@@ -583,7 +600,24 @@
                                 "case_insensitive": true
                             }
                         ],
-                        "search_indexes": []
+                        "search_indexes": [
+                            {
+                                "mappings": {
+                                    "dynamic": true,
+                                    "fields": [
+                                        {
+                                            "field": "highlight",
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "name": "cast_fullplot_genres_title",
+                                "queryable": true,
+                                "status": "READY",
+                                "type": "search",
+                                "version": "1"
+                            }
+                        ]
                     }
                 ]
             }
@@ -904,7 +938,24 @@
                                 "case_insensitive": true
                             }
                         ],
-                        "search_indexes": []
+                        "search_indexes": [
+                            {
+                                "mappings": {
+                                    "dynamic": true,
+                                    "fields": [
+                                        {
+                                            "field": "highlight",
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "name": "cast_fullplot_genres_title",
+                                "queryable": true,
+                                "status": "READY",
+                                "type": "search",
+                                "version": "1"
+                            }
+                        ]
                     },
                     {
                         "name": "bar",
@@ -1173,7 +1224,24 @@
                                 "case_insensitive": true
                             }
                         ],
-                        "search_indexes": []
+                        "search_indexes": [
+                            {
+                                "mappings": {
+                                    "dynamic": true,
+                                    "fields": [
+                                        {
+                                            "field": "highlight",
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "name": "cast_fullplot_genres_title",
+                                "queryable": true,
+                                "status": "READY",
+                                "type": "search",
+                                "version": "1"
+                            }
+                        ]
                     }
                 ]
             }

--- a/mongo/tests/test_dbm_schemas.py
+++ b/mongo/tests/test_dbm_schemas.py
@@ -87,10 +87,17 @@ def test_mongo_schemas_arbiter(aggregator, instance_arbiter, check, dd_run_check
 
 @mock_now(1715911398.1112723)
 @common.standalone
-def test_mongo_schemas_standalone_atlas(aggregator, instance_integration_cluster_autodiscovery, check, dd_run_check):
+@pytest.mark.parametrize("collect_search_indexes", [True, False])
+def test_mongo_schemas_standalone_atlas(
+    aggregator, instance_integration_cluster_autodiscovery, check, dd_run_check, collect_search_indexes
+):
     instance_integration_cluster_autodiscovery['reported_database_hostname'] = "mongohost"
     instance_integration_cluster_autodiscovery['dbm'] = True
-    instance_integration_cluster_autodiscovery['schemas'] = {'enabled': True, 'run_sync': True}
+    instance_integration_cluster_autodiscovery['schemas'] = {
+        'enabled': True,
+        'run_sync': True,
+        'collect_search_indexes': collect_search_indexes,
+    }
     instance_integration_cluster_autodiscovery['database_autodiscovery']['include'] = ['integration$', 'test$']
     instance_integration_cluster_autodiscovery['operation_samples'] = {'enabled': False}
     instance_integration_cluster_autodiscovery['slow_operations'] = {'enabled': False}
@@ -105,7 +112,10 @@ def test_mongo_schemas_standalone_atlas(aggregator, instance_integration_cluster
     dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
     mongodb_databases = [e for e in dbm_metadata if e['kind'] == 'mongodb_databases']
 
-    with open(os.path.join(HERE, "results", "schemas-standalone-atlas.json"), 'r') as f:
+    expected_result = (
+        "schemas-standalone-atlas-search-indexes.json" if collect_search_indexes else "schemas-standalone-atlas.json"
+    )
+    with open(os.path.join(HERE, "results", expected_result), 'r') as f:
         expected_mongodb_databases = json.load(f)
         assert len(mongodb_databases) == len(expected_mongodb_databases)
         for i, db in enumerate(mongodb_databases):


### PR DESCRIPTION
### What does this PR do?
This PR introduces a configuration option to control the collection of MongoDB Atlas search indexes via the `$listSearchIndexes` aggregation pipeline. By default, this feature is now disabled.

### Motivation
The change is motivated by performance considerations, as the `$listSearchIndexes` aggregation can run slowly and impact database performance. 

https://datadoghq.atlassian.net/browse/DBMON-4910

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
