### PR TITLE
Remove Duckdb dependency 

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -22,7 +22,6 @@ cryptography,PyPI,BSD-3-Clause,Copyright (c) Individual contributors.
 cryptography,PyPI,PSF,Copyright (c) Individual contributors.
 ddtrace,PyPI,BSD-3-Clause,"Copyright 2016 Datadog, Inc."
 dnspython,PyPI,ISC,Copyright (C) Dnspython Contributors
-duckdb,PyPI,MIT,Copyright (c) Hannes Muehleisen
 flup,Vendor,BSD-3-Clause,Copyright (c) 2005 Allan Saddi. All Rights Reserved.
 flup-py3,Vendor,BSD-3-Clause,"Copyright (c) 2005, 2006 Allan Saddi <allan@saddi.com> All rights reserved."
 foundationdb,PyPI,Apache-2.0,Copyright 2017 FoundationDB

--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -13,7 +13,6 @@ confluent-kafka==2.8.0
 cryptography==43.0.1
 ddtrace==2.10.6
 dnspython==2.6.1
-duckdb==1.1.1
 foundationdb==6.3.24
 hazelcast-python-client==5.4.0
 in-toto==2.0.0

--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 * Added Postgres cross-org telemetry metrics. ([#18758](https://github.com/DataDog/integrations-core/pull/18758))
 
+## 37.0.0 / 2024-09-19 / Agent 7.58.0
 
 ***Removed***:
 

--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -35,7 +35,6 @@
 
 * Added Postgres cross-org telemetry metrics. ([#18758](https://github.com/DataDog/integrations-core/pull/18758))
 
-## 37.0.0 / 2024-09-19 / Agent 7.58.0
 
 ***Removed***:
 

--- a/duckdb/README.md
+++ b/duckdb/README.md
@@ -27,6 +27,21 @@ Follow the instructions below to install and configure this check for an Agent r
 The DuckDB check is included in the [Datadog Agent][2] package.
 No additional installation is needed on your server.
 
+#### Dependencies
+
+The [duckdb][10] client library is required. To install it, ensure you have a working compiler and run:
+
+##### Unix
+
+```text
+sudo -Hu dd-agent /opt/datadog-agent/embedded/bin/pip install duckdb==1.1.1
+```
+##### Windows
+
+```text
+"C:\Program Files\Datadog\Datadog Agent\embedded3\python.exe" -m pip install duckdb==1.1.1
+```
+
 ### Configuration
 
 1. Edit the `duckdb.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your duckdb performance data. See the [sample duckdb.d/conf.yaml][4] for all available configuration options.
@@ -65,3 +80,4 @@ Need help? Contact [Datadog support][8].
 [7]: https://github.com/DataDog/integrations-core/blob/master/duckdb/metadata.csv
 [8]: https://docs.datadoghq.com/help/
 [9]: https://duckdb.org/docs/
+[10]: https://pypi.org/project/duckdb/

--- a/duckdb/datadog_checks/duckdb/check.py
+++ b/duckdb/datadog_checks/duckdb/check.py
@@ -8,7 +8,10 @@ import time
 from contextlib import closing, contextmanager
 from copy import deepcopy
 
-import duckdb
+try:
+    import duckdb
+except ImportError:
+    duckdb = None
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.db import QueryManager

--- a/duckdb/datadog_checks/duckdb/check.py
+++ b/duckdb/datadog_checks/duckdb/check.py
@@ -8,10 +8,19 @@ import time
 from contextlib import closing, contextmanager
 from copy import deepcopy
 
+from datadog_checks.base.errors import CheckException
+
 try:
     import duckdb
-except ImportError:
+
+    dk_import_error = None
+except ImportError as e:
     duckdb = None
+    dk_import_error = e
+    raise CheckException(
+        "Duckdb was not imported correctly, make sure the library is installed."
+        "Please refer to datadog documentation for more details. Error is %s" % dk_import_error
+    )
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.db import QueryManager
@@ -49,21 +58,27 @@ class DuckdbCheck(AgentCheck):
         self.check_initializations.append(self._query_manager.compile_queries)
 
     def check(self, _):
-        retry_delay = 5
-        max_retries = self.connection_attempt
-        for attempt in range(1, max_retries + 1):
-            try:
-                with self.connect() as conn:
-                    if conn:
-                        self._connection = conn
-                        self._query_manager.execute()
-                        break
-            except Exception as e:
-                self.log.warning('Unable to connect to the database:  "%s" , retrying...', e)
-                if attempt < max_retries:
-                    time.sleep(retry_delay)
-                else:
-                    self.log.error('Max connection retries reached')
+        if duckdb is None:
+            raise CheckException(
+                "Duckdb was not imported correctly, make sure the library is installed."
+                "Please refer to datadog documentation for more details. Error is %s" % dk_import_error
+            )
+        else:
+            retry_delay = 5
+            max_retries = self.connection_attempt
+            for attempt in range(1, max_retries + 1):
+                try:
+                    with self.connect() as conn:
+                        if conn:
+                            self._connection = conn
+                            self._query_manager.execute()
+                            break
+                except Exception as e:
+                    self.log.warning('Unable to connect to the database:  "%s" , retrying...', e)
+                    if attempt < max_retries:
+                        time.sleep(retry_delay)
+                    else:
+                        self.log.error('Max connection retries reached')
 
     def _execute_query_raw(self, query):
         with closing(self._connection.cursor()) as cursor:

--- a/duckdb/hatch.toml
+++ b/duckdb/hatch.toml
@@ -1,5 +1,10 @@
 [env.collectors.datadog-checks]
 
+[envs.default]
+dependencies = [
+  "duckdb==1.1.1; python_version > '3.12'",
+]
+
 [[envs.default.matrix]]
 python = ["3.12"]
 version = ["1.1.1"]

--- a/duckdb/hatch.toml
+++ b/duckdb/hatch.toml
@@ -2,7 +2,7 @@
 
 [envs.default]
 dependencies = [
-  "duckdb==1.1.1; python_version > '3.12'",
+  "duckdb==1.1.1",
 ]
 
 [[envs.default.matrix]]

--- a/duckdb/pyproject.toml
+++ b/duckdb/pyproject.toml
@@ -36,9 +36,7 @@ dynamic = [
 ]
 
 [project.optional-dependencies]
-deps = [
-    "duckdb==1.1.1",
-]
+deps = []
 
 [project.urls]
 Source = "https://github.com/DataDog/integrations-core"

--- a/duckdb/tests/conftest.py
+++ b/duckdb/tests/conftest.py
@@ -7,10 +7,16 @@ import pytest
 
 from . import common
 
+E2E_METADATA = {
+    'start_commands': [
+        'pip install duckdb==1.1.1',
+    ]
+}
+
 
 @pytest.fixture(scope='session')
 def dd_environment():
-    yield common.DEFAULT_INSTANCE
+    yield common.DEFAULT_INSTANCE, E2E_METADATA
 
 
 @pytest.fixture

--- a/duckdb/tests/test_e2e.py
+++ b/duckdb/tests/test_e2e.py
@@ -5,6 +5,6 @@ import pytest
 
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check):
-    aggregator = dd_agent_check()
+def test_e2e(dd_agent_check, instance):
+    aggregator = dd_agent_check(instance)
     aggregator.assert_all_metrics_covered()

--- a/duckdb/tests/test_e2e.py
+++ b/duckdb/tests/test_e2e.py
@@ -5,6 +5,6 @@ import pytest
 
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check):
-    aggregator = dd_agent_check()
+def test_e2e(dd_agent_check, instance):
+    aggregator = dd_agent_check(instance, rate=True)
     aggregator.assert_all_metrics_covered()

--- a/duckdb/tests/test_e2e.py
+++ b/duckdb/tests/test_e2e.py
@@ -5,6 +5,6 @@ import pytest
 
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check, instance):
-    aggregator = dd_agent_check(instance, rate=True)
+def test_e2e(dd_agent_check):
+    aggregator = dd_agent_check()
     aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?

The duckdb python library seems to increase the agent package tremendously (around 50MB), so removing it from the agent dependencies to avoid impacting users who do not use the duckdb integration and making it a part of the installation steps.


### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
