### PR TITLE
Remove python2-only spec for pika client

### DIFF
--- a/rabbitmq/hatch.toml
+++ b/rabbitmq/hatch.toml
@@ -2,8 +2,7 @@
 
 [envs.default]
 dependencies = [
-  "pika==0.13.0; python_version < '3.0'",
-  "pika==1.3.2; python_version > '3.0'",
+  "pika==1.3.2",
 ]
 
 # Rabbitmq versions 3.8+ introduce the Prometheus plugin. This is the preferred way to collect metrics.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
We don't need the python2 spec anymore

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
