### PR TITLE
[postgres] collect index state attributes

### DIFF
--- a/postgres/changelog.d/19406.added
+++ b/postgres/changelog.d/19406.added
@@ -1,0 +1,1 @@
+Add index state attributes (is_unique, is_exclusion, is_immediate, is_clustered, is_valid, is_checkxmin, is_ready, is_live, is_replident, is_partial) from pg_index to PostgreSQL schema collection for enhanced index property visibility.

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -116,12 +116,28 @@ WHERE  nspname NOT IN ( 'information_schema', 'pg_catalog' )
 """
 
 PG_INDEXES_QUERY = """
-SELECT indexname AS NAME,
-       indexdef  AS definition,
-       schemaname,
-       tablename
-FROM   pg_indexes
-WHERE  schemaname='{schema_name}' AND ({table_names_like});
+SELECT
+    c.relname AS name,
+    ix.indrelid AS table_id,
+    pg_get_indexdef(c.oid) AS definition,
+    ix.indisunique AS is_unique,
+    ix.indisexclusion AS is_exclusion,
+    ix.indimmediate AS is_immediate,
+    ix.indisclustered AS is_clustered,
+    ix.indisvalid AS is_valid,
+    ix.indcheckxmin AS is_checkxmin,
+    ix.indisready AS is_ready,
+    ix.indislive AS is_live,
+    ix.indisreplident AS is_replident,
+    ix.indpred IS NOT NULL AS is_partial
+FROM
+    pg_index ix
+JOIN
+    pg_class c
+ON
+    c.oid = ix.indexrelid
+WHERE
+    ix.indrelid IN ({table_ids});
 """
 
 PG_CHECK_FOR_FOREIGN_KEY = """
@@ -598,6 +614,16 @@ class PostgresMetadata(DBMAsyncJob):
             "indexes": dict (if has indexes)
                 name: str
                 definition: str
+                is_unique: bool
+                is_exclusion: bool
+                is_immediate: bool
+                is_clustered: bool
+                is_valid: bool
+                is_checkxmin: bool
+                is_ready: bool
+                is_live: bool
+                is_replident: bool
+                is_partial: bool
             "columns": dict
                 name: str
                 data_type: str
@@ -610,14 +636,13 @@ class PostgresMetadata(DBMAsyncJob):
         tables = {t.get("name"): {**t, "num_partitions": 0} for t in table_info}
         table_name_lookup = {t.get("id"): t.get("name") for t in table_info}
         table_ids = ",".join(["'{}'".format(t.get("id")) for t in table_info])
-        table_names_like = " OR ".join(["tablename LIKE '{}%'".format(t.get("name")) for t in table_info])
 
         # Get indexes
-        cursor.execute(PG_INDEXES_QUERY.format(schema_name=schema_name, table_names_like=table_names_like))
+        cursor.execute(PG_INDEXES_QUERY.format(table_ids=table_ids))
         rows = cursor.fetchall()
         for row in rows:
             # Partition indexes in some versions of Postgres have appended digits for each partition
-            table_name = row.get("tablename")
+            table_name = table_name_lookup.get(str(row.get("table_id")))
             while tables.get(table_name) is None and len(table_name) > 1 and table_name[-1].isdigit():
                 table_name = table_name[0:-1]
             if tables.get(table_name) is not None:

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -123,7 +123,23 @@ def test_collect_schemas(integration_check, dbm_instance, aggregator):
                     keys = list(table.keys())
                     assert_fields(keys, ["indexes", "columns", "toast_table", "id", "name", "owner"])
                     assert len(table['indexes']) == 1
-                    assert_fields(list(table['indexes'][0].keys()), ['name', 'definition'])
+                    assert_fields(
+                        list(table['indexes'][0].keys()),
+                        [
+                            'name',
+                            'definition',
+                            'is_unique',
+                            'is_exclusion',
+                            'is_immediate',
+                            'is_clustered',
+                            'is_valid',
+                            'is_checkxmin',
+                            'is_ready',
+                            'is_live',
+                            'is_replident',
+                            'is_partial',
+                        ],
+                    )
                 if float(POSTGRES_VERSION) >= 11:
                     if table['name'] in ('test_part', 'test_part_no_activity'):
                         keys = list(table.keys())


### PR DESCRIPTION
### What does this PR do?
This PR enhances PostgreSQL schema collection by adding index state attributes from the pg_index system catalog. The newly collected attributes provide detailed insights into index properties and include:
- is_unique: Indicates if the index enforces uniqueness.
- is_exclusion: Specifies if the index is an exclusion constraint.
- is_immediate: States if the constraint enforcement is immediate.
- is_clustered: Indicates if the index is clustered.
- is_valid: Specifies if the index is valid for use.
- is_checkxmin: Indicates if the index must enforce a transaction’s visibility snapshot.
- is_ready: Shows if the index is ready for use.
- is_live: States if the index is live.
- is_replident: Indicates if the index is used as a replica identity.
- is_partial: Specifies if the index is a partial index.

These attributes provide greater visibility into index configurations and can help with debugging and optimization.

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4917

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
