### PR TITLE
Disable collecting consumer group state behind a feature flag

### DIFF
--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 * Added Postgres cross-org telemetry metrics. ([#18758](https://github.com/DataDog/integrations-core/pull/18758))
 
+## 37.0.0 / 2024-09-19 / Agent 7.58.0
 
 ***Removed***:
 

--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -35,7 +35,6 @@
 
 * Added Postgres cross-org telemetry metrics. ([#18758](https://github.com/DataDog/integrations-core/pull/18758))
 
-## 37.0.0 / 2024-09-19 / Agent 7.58.0
 
 ***Removed***:
 

--- a/kafka_consumer/assets/configuration/spec.yaml
+++ b/kafka_consumer/assets/configuration/spec.yaml
@@ -97,7 +97,7 @@ files:
           Setting the collect_consumer_group_state to true collects the 
           consumer group state as a tag. 
 
-          WARNING: Enabling this feature might cause some increase in agent ressource consumption.
+          WARNING: Enabling this feature might cause some increase in Agent resource consumption.
         value:
           type: boolean
           example: false

--- a/kafka_consumer/assets/configuration/spec.yaml
+++ b/kafka_consumer/assets/configuration/spec.yaml
@@ -92,6 +92,16 @@ files:
             my_cons.+:
               <TOPIC_NAME_2>: []
             test_consumer.+: {}
+      - name: collect_consumer_group_state
+        description: |
+          Setting the collect_consumer_group_state to true collects the 
+          consumer group state as a tag. 
+
+          WARNING: Enabling this feature might cause some increase in agent ressource consumption.
+        value:
+          type: boolean
+          example: false
+          display_default: false
       - name: monitor_unlisted_consumer_groups
         description: |
           Setting `monitor_unlisted_consumer_groups` to `true` tells the check to discover all consumer groups

--- a/kafka_consumer/datadog_checks/kafka_consumer/config.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config.py
@@ -19,7 +19,7 @@ class KafkaConfig:
         self.log = log
         self._custom_tags = instance.get('tags', [])
         self._monitor_unlisted_consumer_groups = is_affirmative(instance.get('monitor_unlisted_consumer_groups', False))
-        self._collect_consumer_group_state = is_affirmative(instance.get('collect_consumer_group_state', False))
+        self._collect_consumer_group_state = instance.get('collect_consumer_group_state', False)
         self._monitor_all_broker_highwatermarks = is_affirmative(
             instance.get('monitor_all_broker_highwatermarks', False)
         )

--- a/kafka_consumer/datadog_checks/kafka_consumer/config.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config.py
@@ -19,6 +19,7 @@ class KafkaConfig:
         self.log = log
         self._custom_tags = instance.get('tags', [])
         self._monitor_unlisted_consumer_groups = is_affirmative(instance.get('monitor_unlisted_consumer_groups', False))
+        self._collect_consumer_group_state = is_affirmative(instance.get('collect_consumer_group_state', False))
         self._monitor_all_broker_highwatermarks = is_affirmative(
             instance.get('monitor_all_broker_highwatermarks', False)
         )

--- a/kafka_consumer/datadog_checks/kafka_consumer/config_models/defaults.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config_models/defaults.py
@@ -16,6 +16,10 @@ def instance_close_admin_client():
     return True
 
 
+def instance_collect_consumer_group_state():
+    return False
+
+
 def instance_consumer_queued_max_messages_kbytes():
     return 1024
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
@@ -46,6 +46,7 @@ class InstanceConfig(BaseModel):
         frozen=True,
     )
     close_admin_client: Optional[bool] = None
+    collect_consumer_group_state: Optional[bool] = None
     consumer_groups: Optional[MappingProxyType[str, Any]] = None
     consumer_groups_regex: Optional[MappingProxyType[str, Any]] = None
     consumer_queued_max_messages_kbytes: Optional[int] = None

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -97,7 +97,7 @@ instances:
     ## Setting the collect_consumer_group_state to true collects the 
     ## consumer group state as a tag. 
     ##
-    ## WARNING: Enabling this feature might cause some increase in agent ressource consumption.
+    ## WARNING: Enabling this feature might cause some increase in Agent resource consumption.
     #
     # collect_consumer_group_state: false
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -93,6 +93,14 @@ instances:
     #     <TOPIC_NAME_2>: []
     #   test_consumer.+: {}
 
+    ## @param collect_consumer_group_state - boolean - optional - default: false
+    ## Setting the collect_consumer_group_state to true collects the 
+    ## consumer group state as a tag. 
+    ##
+    ## WARNING: Enabling this feature might cause some increase in agent ressource consumption.
+    #
+    # collect_consumer_group_state: false
+
     ## @param monitor_unlisted_consumer_groups - boolean - optional - default: false
     ## Setting `monitor_unlisted_consumer_groups` to `true` tells the check to discover all consumer groups
     ## and fetch all their known offsets. If this is not set to true, you must specify `consumer_groups`.

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -293,15 +293,15 @@ class KafkaCheck(AgentCheck):
         self.log.debug('%s consumer offsets reported', reported_contexts)
 
     def get_consumer_group_state(self, consumer_group):
-            consumer_group_state = ""
-            # Get the consumer group state if present
-            group_id, consumer_group_state = self.client.describe_consumer_groups(consumer_group)
-            self.log.debug(
-                "Consumer group: %s in state %s",
-                group_id,
-                consumer_group_state,
-            )
-            return consumer_group_state
+        consumer_group_state = ""
+        # Get the consumer group state if present
+        group_id, consumer_group_state = self.client.describe_consumer_groups(consumer_group)
+        self.log.debug(
+            "Consumer group: %s in state %s",
+            group_id,
+            consumer_group_state,
+        )
+        return consumer_group_state
 
     def get_highwater_offsets(self, consumer_offsets):
         self.log.debug('Getting highwater offsets')

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -225,7 +225,7 @@ class KafkaCheck(AgentCheck):
             ]
             if self.config._collect_consumer_group_state:
                 consumer_group_state = self.get_consumer_group_state(consumer_group)
-                consumer_group_tags.extend(['consumer_group_state:%s' % consumer_group_state])
+                consumer_group_tags.append(f'consumer_group_state:{consumer_group_state}')
             consumer_group_tags.extend(self.config._custom_tags)
 
             partitions = self.client.get_partitions_for_topic(topic)

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -293,13 +293,14 @@ class KafkaCheck(AgentCheck):
 
     def get_consumer_group_state(self, consumer_group):
         consumer_group_state = ""
-        # Get the consumer group state if present
-        group_id, consumer_group_state = self.client.describe_consumer_groups(consumer_group)
-        self.log.debug(
-            "Consumer group: %s in state %s",
-            group_id,
-            consumer_group_state,
-        )
+        if self.config._collect_consumer_group_state:
+            # Get the consumer group state if present
+            group_id, consumer_group_state = self.client.describe_consumer_groups(consumer_group)
+            self.log.debug(
+                "Consumer group: %s in state %s",
+                group_id,
+                consumer_group_state,
+            )
         return consumer_group_state
 
     def get_highwater_offsets(self, consumer_offsets):

--- a/kafka_consumer/tests/common.py
+++ b/kafka_consumer/tests/common.py
@@ -114,7 +114,7 @@ def assert_check_kafka(aggregator, consumer_groups):
 def assert_check_kafka_has_consumer_group_state_tag(aggregator, consumer_groups):
     for _, _ in consumer_groups.items():
         for mname in CONSUMER_METRICS:
-            # Check for the tag prefix consumer_group_state
+            # Check for the tag prefix consumer_group_state if collect_consumer_group_state is enabled
             aggregator.assert_metric_has_tag_prefix(mname, tag_prefix='consumer_group_state')
 
 

--- a/kafka_consumer/tests/common.py
+++ b/kafka_consumer/tests/common.py
@@ -111,13 +111,6 @@ def assert_check_kafka(aggregator, consumer_groups):
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 
 
-def assert_check_kafka_has_consumer_group_state_tag(aggregator, consumer_groups):
-    for _, _ in consumer_groups.items():
-        for mname in CONSUMER_METRICS:
-            # Check for the tag prefix consumer_group_state if collect_consumer_group_state is enabled
-            aggregator.assert_metric_has_tag_prefix(mname, tag_prefix='consumer_group_state')
-
-
 def get_authentication_configuration(instance):
     config = {}
 

--- a/kafka_consumer/tests/test_integration.py
+++ b/kafka_consumer/tests/test_integration.py
@@ -12,7 +12,7 @@ import pytest
 from datadog_checks.dev.utils import get_metadata_metrics
 
 from . import common
-from .common import assert_check_kafka, assert_check_kafka_has_consumer_group_state_tag, metrics
+from .common import assert_check_kafka, metrics
 
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]
 
@@ -40,12 +40,6 @@ def test_check_kafka(aggregator, check, kafka_instance, dd_run_check):
     """
     dd_run_check(check(kafka_instance))
     assert_check_kafka(aggregator, kafka_instance['consumer_groups'])
-
-
-def test_collect_consumer_group_state(aggregator, check, kafka_instance, dd_run_check):
-    kafka_instance['collect_consumer_group_state'] = True
-    dd_run_check(check(kafka_instance))
-    assert_check_kafka_has_consumer_group_state_tag(aggregator, kafka_instance['consumer_groups'])
 
 
 def test_can_send_event(aggregator, check, kafka_instance, dd_run_check):

--- a/kafka_consumer/tests/test_integration.py
+++ b/kafka_consumer/tests/test_integration.py
@@ -41,11 +41,11 @@ def test_check_kafka(aggregator, check, kafka_instance, dd_run_check):
     dd_run_check(check(kafka_instance))
     assert_check_kafka(aggregator, kafka_instance['consumer_groups'])
 
+
 def test_collect_consumer_group_state(aggregator, check, kafka_instance, dd_run_check):
     kafka_instance['collect_consumer_group_state'] = True
     dd_run_check(check(kafka_instance))
     assert_check_kafka_has_consumer_group_state_tag(aggregator, kafka_instance['consumer_groups'])
-
 
 
 def test_can_send_event(aggregator, check, kafka_instance, dd_run_check):

--- a/kafka_consumer/tests/test_integration.py
+++ b/kafka_consumer/tests/test_integration.py
@@ -40,7 +40,12 @@ def test_check_kafka(aggregator, check, kafka_instance, dd_run_check):
     """
     dd_run_check(check(kafka_instance))
     assert_check_kafka(aggregator, kafka_instance['consumer_groups'])
+
+def test_collect_consumer_group_state(aggregator, check, kafka_instance, dd_run_check):
+    kafka_instance['collect_consumer_group_state'] = True
+    dd_run_check(check(kafka_instance))
     assert_check_kafka_has_consumer_group_state_tag(aggregator, kafka_instance['consumer_groups'])
+
 
 
 def test_can_send_event(aggregator, check, kafka_instance, dd_run_check):

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -233,12 +233,13 @@ def test_when_consumer_lag_less_than_zero_then_emit_event(check, kafka_instance,
         ],
     )
 
+
 def test_when_collect_consumer_group_state_is_enabled(check, kafka_instance, dd_run_check, aggregator):
     mock_client = seed_mock_client()
-    kafka_instance["collect_consumer_group_state"] = True 
+    kafka_instance["collect_consumer_group_state"] = True
     kafka_consumer_check = check(kafka_instance)
     kafka_consumer_check.client = mock_client
-    
+
     dd_run_check(kafka_consumer_check)
 
     aggregator.assert_metric(
@@ -265,7 +266,7 @@ def test_when_collect_consumer_group_state_is_enabled(check, kafka_instance, dd_
             'consumer_group_state:STABLE',
         ],
     )
- 
+
 
 def test_when_no_partitions_then_emit_warning_log(check, kafka_instance, dd_run_check, aggregator, caplog):
     # Given

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -184,7 +184,6 @@ def test_when_consumer_lag_less_than_zero_then_emit_event(check, kafka_instance,
     mock_client = seed_mock_client()
     # We need the consumer offset to be higher than the highwater offset.
     mock_client.list_consumer_group_offsets.return_value = [("consumer_group1", [("topic1", "partition1", 81)])]
-    kafka_instance["collect_consumer_group_state"] = True
     kafka_consumer_check = check(kafka_instance)
     kafka_consumer_check.client = mock_client
 
@@ -197,6 +196,51 @@ def test_when_consumer_lag_less_than_zero_then_emit_event(check, kafka_instance,
         count=1,
         tags=['optional:tag1', 'partition:partition1', 'topic:topic1', 'kafka_cluster_id:cluster_id'],
     )
+    aggregator.assert_metric(
+        "kafka.consumer_offset",
+        count=1,
+        tags=[
+            'consumer_group:consumer_group1',
+            'optional:tag1',
+            'partition:partition1',
+            'topic:topic1',
+            'kafka_cluster_id:cluster_id',
+        ],
+    )
+    aggregator.assert_metric(
+        "kafka.consumer_lag",
+        count=1,
+        tags=[
+            'consumer_group:consumer_group1',
+            'optional:tag1',
+            'partition:partition1',
+            'topic:topic1',
+            'kafka_cluster_id:cluster_id',
+        ],
+    )
+    aggregator.assert_event(
+        "Consumer group: consumer_group1, "
+        "topic: topic1, partition: partition1 has negative consumer lag. "
+        "This should never happen and will result in the consumer skipping new messages "
+        "until the lag turns positive.",
+        count=1,
+        tags=[
+            'consumer_group:consumer_group1',
+            'optional:tag1',
+            'partition:partition1',
+            'topic:topic1',
+            'kafka_cluster_id:cluster_id',
+        ],
+    )
+
+def test_when_collect_consumer_group_state_is_enabled(check, kafka_instance, dd_run_check, aggregator):
+    mock_client = seed_mock_client()
+    kafka_instance["collect_consumer_group_state"] = True 
+    kafka_consumer_check = check(kafka_instance)
+    kafka_consumer_check.client = mock_client
+    
+    dd_run_check(kafka_consumer_check)
+
     aggregator.assert_metric(
         "kafka.consumer_offset",
         count=1,
@@ -221,22 +265,7 @@ def test_when_consumer_lag_less_than_zero_then_emit_event(check, kafka_instance,
             'consumer_group_state:STABLE',
         ],
     )
-    aggregator.assert_event(
-        "Consumer group: consumer_group1, "
-        "topic: topic1, partition: partition1 has negative consumer lag. "
-        "This should never happen and will result in the consumer skipping new messages "
-        "until the lag turns positive.",
-        count=1,
-        tags=[
-            'consumer_group:consumer_group1',
-            'optional:tag1',
-            'partition:partition1',
-            'topic:topic1',
-            'kafka_cluster_id:cluster_id',
-            'consumer_group_state:STABLE',
-        ],
-    )
-
+ 
 
 def test_when_no_partitions_then_emit_warning_log(check, kafka_instance, dd_run_check, aggregator, caplog):
     # Given

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -184,6 +184,7 @@ def test_when_consumer_lag_less_than_zero_then_emit_event(check, kafka_instance,
     mock_client = seed_mock_client()
     # We need the consumer offset to be higher than the highwater offset.
     mock_client.list_consumer_group_offsets.return_value = [("consumer_group1", [("topic1", "partition1", 81)])]
+    kafka_instance["collect_consumer_group_state"] = True
     kafka_consumer_check = check(kafka_instance)
     kafka_consumer_check.client = mock_client
 


### PR DESCRIPTION
### What does this PR do?
Collect group state tag (introduced in https://github.com/DataDog/integrations-core/pull/17686) only when a configuration variable is set.

### Motivation
<!-- What inspired you to submit this pull request? -->
Collecting the consumer group state seems to increase the agent resources usage.

Some support cases:
- https://datadoghq.atlassian.net/browse/AGENT-13057
- https://datadoghq.atlassian.net/browse/AGENT-12832

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
