### PR TITLE
Add process_cpu_seconds_total to kube_apiserver_metrics check

### DIFF
--- a/kube_apiserver_metrics/changelog.d/19415.added
+++ b/kube_apiserver_metrics/changelog.d/19415.added
@@ -1,0 +1,1 @@
+Add process_cpu_seconds_total to kube_apiserver_metrics check

--- a/kube_apiserver_metrics/changelog.d/19415.added
+++ b/kube_apiserver_metrics/changelog.d/19415.added
@@ -1,1 +1,1 @@
-Add process_cpu_seconds_total to kube_apiserver_metrics check
+Add process_cpu_total to kube_apiserver_metrics check

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
@@ -24,7 +24,7 @@ METRICS = {
     'apiserver_request_duration_seconds': 'request_duration_seconds',
     'apiserver_request_latencies': 'request_latencies',
     'apiserver_request_latency_seconds': 'request_latencies',
-    'process_cpu_seconds_total': 'process_cpu_seconds_total',
+    'process_cpu_seconds_total': 'process_cpu_total',
     'process_resident_memory_bytes': 'process_resident_memory_bytes',
     'process_virtual_memory_bytes': 'process_virtual_memory_bytes',
     'grpc_client_started_total': 'grpc_client_started_total',

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
@@ -24,6 +24,7 @@ METRICS = {
     'apiserver_request_duration_seconds': 'request_duration_seconds',
     'apiserver_request_latencies': 'request_latencies',
     'apiserver_request_latency_seconds': 'request_latencies',
+    'process_cpu_seconds_total': 'process_cpu_seconds_total',
     'process_resident_memory_bytes': 'process_resident_memory_bytes',
     'process_virtual_memory_bytes': 'process_virtual_memory_bytes',
     'grpc_client_started_total': 'grpc_client_started_total',

--- a/kube_apiserver_metrics/metadata.csv
+++ b/kube_apiserver_metrics/metadata.csv
@@ -51,6 +51,7 @@ kube_apiserver.http_requests_total,gauge,,request,,The accumulated number of HTT
 kube_apiserver.http_requests_total.count,count,,request,,The monotonic count of the number of HTTP requests made,0,kubernetes_api_server_metrics,total count of requests,
 kube_apiserver.kubernetes_feature_enabled,gauge,,,,"Whether a Kubernetes feature gate is enabled or not, identified by name and stage (alpha; Kubernetes 1.26+)",0,kubernetes_api_server_metrics,kubernetes feature enabled,
 kube_apiserver.longrunning_gauge,gauge,,request,,"The gauge of all active long-running apiserver requests broken out by verb, group, version, resource, scope, and component. Not all requests are tracked this way.",-1,kubernetes_api_server_metrics,long running gauges,
+kube_apiserver.process_cpu_seconds_total,count,,second,,"Total user and system CPU time spent in seconds.",0,kubernetes_api_server_metrics,process cpu seconds total,
 kube_apiserver.process_resident_memory_bytes,gauge,,byte,,The resident memory size in bytes,0,kubernetes_api_server_metrics,process rss,
 kube_apiserver.process_virtual_memory_bytes,gauge,,byte,,The virtual memory size in bytes,0,kubernetes_api_server_metrics,process virtual memory,
 kube_apiserver.registered_watchers,gauge,,object,,The number of currently registered watchers for a given resource,0,kubernetes_api_server_metrics,number of watchers,

--- a/kube_apiserver_metrics/metadata.csv
+++ b/kube_apiserver_metrics/metadata.csv
@@ -51,7 +51,7 @@ kube_apiserver.http_requests_total,gauge,,request,,The accumulated number of HTT
 kube_apiserver.http_requests_total.count,count,,request,,The monotonic count of the number of HTTP requests made,0,kubernetes_api_server_metrics,total count of requests,
 kube_apiserver.kubernetes_feature_enabled,gauge,,,,"Whether a Kubernetes feature gate is enabled or not, identified by name and stage (alpha; Kubernetes 1.26+)",0,kubernetes_api_server_metrics,kubernetes feature enabled,
 kube_apiserver.longrunning_gauge,gauge,,request,,"The gauge of all active long-running apiserver requests broken out by verb, group, version, resource, scope, and component. Not all requests are tracked this way.",-1,kubernetes_api_server_metrics,long running gauges,
-kube_apiserver.process_cpu_seconds_total,count,,second,,"Total user and system CPU time spent in seconds.",0,kubernetes_api_server_metrics,process cpu seconds total,
+kube_apiserver.process_cpu_total,count,,second,,"Total user and system CPU time spent in seconds.",0,kubernetes_api_server_metrics,process cpu total,
 kube_apiserver.process_resident_memory_bytes,gauge,,byte,,The resident memory size in bytes,0,kubernetes_api_server_metrics,process rss,
 kube_apiserver.process_virtual_memory_bytes,gauge,,byte,,The virtual memory size in bytes,0,kubernetes_api_server_metrics,process virtual memory,
 kube_apiserver.registered_watchers,gauge,,object,,The number of currently registered watchers for a given resource,0,kubernetes_api_server_metrics,number of watchers,

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
@@ -66,7 +66,7 @@ class TestKubeAPIServerMetrics:
         'admission_controller_admission_duration_seconds.count',
         'request_latencies.sum',
         'request_latencies.count',
-        'process_cpu_seconds_total',
+        'process_cpu_total',
         'process_resident_memory_bytes',
         'process_virtual_memory_bytes',
     ]

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
@@ -66,6 +66,7 @@ class TestKubeAPIServerMetrics:
         'admission_controller_admission_duration_seconds.count',
         'request_latencies.sum',
         'request_latencies.count',
+        'process_cpu_seconds_total',
         'process_resident_memory_bytes',
         'process_virtual_memory_bytes',
     ]

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_15.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_15.py
@@ -53,6 +53,7 @@ class TestKubeAPIServerMetrics:
         'request_duration_seconds.sum',
         'request_duration_seconds.count',
         'registered_watchers',
+        'process_cpu_seconds_total',
         'process_resident_memory_bytes',
         'process_virtual_memory_bytes',
         'etcd_request_duration_seconds.sum',

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_15.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_15.py
@@ -53,7 +53,7 @@ class TestKubeAPIServerMetrics:
         'request_duration_seconds.sum',
         'request_duration_seconds.count',
         'registered_watchers',
-        'process_cpu_seconds_total',
+        'process_cpu_total',
         'process_resident_memory_bytes',
         'process_virtual_memory_bytes',
         'etcd_request_duration_seconds.sum',

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_19.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_19.py
@@ -49,6 +49,7 @@ class TestKubeAPIServerMetrics:
         'request_duration_seconds.sum',
         'request_duration_seconds.count',
         'registered_watchers',
+        'process_cpu_seconds_total',
         'process_resident_memory_bytes',
         'process_virtual_memory_bytes',
         'etcd_request_duration_seconds.sum',

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_19.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_19.py
@@ -49,7 +49,7 @@ class TestKubeAPIServerMetrics:
         'request_duration_seconds.sum',
         'request_duration_seconds.count',
         'registered_watchers',
-        'process_cpu_seconds_total',
+        'process_cpu_total',
         'process_resident_memory_bytes',
         'process_virtual_memory_bytes',
         'etcd_request_duration_seconds.sum',

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_23.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_23.py
@@ -49,6 +49,7 @@ class TestKubeAPIServerMetrics:
         'request_duration_seconds.sum',
         'request_duration_seconds.count',
         'registered_watchers',
+        'process_cpu_seconds_total',
         'process_resident_memory_bytes',
         'process_virtual_memory_bytes',
         'etcd_request_duration_seconds.sum',

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_23.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_23.py
@@ -49,7 +49,7 @@ class TestKubeAPIServerMetrics:
         'request_duration_seconds.sum',
         'request_duration_seconds.count',
         'registered_watchers',
-        'process_cpu_seconds_total',
+        'process_cpu_total',
         'process_resident_memory_bytes',
         'process_virtual_memory_bytes',
         'etcd_request_duration_seconds.sum',

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_24.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_24.py
@@ -47,6 +47,7 @@ class TestKubeAPIServerMetrics:
         'admission_controller_admission_duration_seconds.count',
         'request_duration_seconds.sum',
         'request_duration_seconds.count',
+        'process_cpu_seconds_total',
         'process_resident_memory_bytes',
         'process_virtual_memory_bytes',
         'etcd_request_duration_seconds.sum',

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_24.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_24.py
@@ -47,7 +47,7 @@ class TestKubeAPIServerMetrics:
         'admission_controller_admission_duration_seconds.count',
         'request_duration_seconds.sum',
         'request_duration_seconds.count',
-        'process_cpu_seconds_total',
+        'process_cpu_total',
         'process_resident_memory_bytes',
         'process_virtual_memory_bytes',
         'etcd_request_duration_seconds.sum',

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_25.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_25.py
@@ -66,7 +66,7 @@ class TestKubeAPIServerMetrics:
         NAMESPACE + '.admission_controller_admission_duration_seconds.count',
         NAMESPACE + '.request_duration_seconds.sum',
         NAMESPACE + '.request_duration_seconds.count',
-        NAMESPACE + '.process_cpu_seconds_total',
+        NAMESPACE + '.process_cpu_total',
         NAMESPACE + '.process_resident_memory_bytes',
         NAMESPACE + '.process_virtual_memory_bytes',
         NAMESPACE + '.etcd_request_duration_seconds.sum',

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_25.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_25.py
@@ -66,6 +66,7 @@ class TestKubeAPIServerMetrics:
         NAMESPACE + '.admission_controller_admission_duration_seconds.count',
         NAMESPACE + '.request_duration_seconds.sum',
         NAMESPACE + '.request_duration_seconds.count',
+        NAMESPACE + '.process_cpu_seconds_total',
         NAMESPACE + '.process_resident_memory_bytes',
         NAMESPACE + '.process_virtual_memory_bytes',
         NAMESPACE + '.etcd_request_duration_seconds.sum',

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_26.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_26.py
@@ -47,7 +47,7 @@ class TestKubeAPIServerMetrics:
         'admission_controller_admission_duration_seconds.count',
         'request_duration_seconds.sum',
         'request_duration_seconds.count',
-        'process_cpu_seconds_total',
+        'process_cpu_total',
         'process_resident_memory_bytes',
         'process_virtual_memory_bytes',
         'etcd.db.total_size',

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_26.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_26.py
@@ -47,6 +47,7 @@ class TestKubeAPIServerMetrics:
         'admission_controller_admission_duration_seconds.count',
         'request_duration_seconds.sum',
         'request_duration_seconds.count',
+        'process_cpu_seconds_total',
         'process_resident_memory_bytes',
         'process_virtual_memory_bytes',
         'etcd.db.total_size',

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_27.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_27.py
@@ -47,7 +47,7 @@ class TestKubeAPIServerMetrics:
         'admission_controller_admission_duration_seconds.count',
         'request_duration_seconds.sum',
         'request_duration_seconds.count',
-        'process_cpu_seconds_total',
+        'process_cpu_total',
         'process_resident_memory_bytes',
         'process_virtual_memory_bytes',
         'etcd.db.total_size',

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_27.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_27.py
@@ -47,6 +47,7 @@ class TestKubeAPIServerMetrics:
         'admission_controller_admission_duration_seconds.count',
         'request_duration_seconds.sum',
         'request_duration_seconds.count',
+        'process_cpu_seconds_total',
         'process_resident_memory_bytes',
         'process_virtual_memory_bytes',
         'etcd.db.total_size',

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_28.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_28.py
@@ -47,7 +47,7 @@ class TestKubeAPIServerMetrics:
         'admission_controller_admission_duration_seconds.count',
         'request_duration_seconds.sum',
         'request_duration_seconds.count',
-        'process_cpu_seconds_total',
+        'process_cpu_total',
         'process_resident_memory_bytes',
         'process_virtual_memory_bytes',
         'etcd.db.total_size',

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_28.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_28.py
@@ -47,6 +47,7 @@ class TestKubeAPIServerMetrics:
         'admission_controller_admission_duration_seconds.count',
         'request_duration_seconds.sum',
         'request_duration_seconds.count',
+        'process_cpu_seconds_total',
         'process_resident_memory_bytes',
         'process_virtual_memory_bytes',
         'etcd.db.total_size',


### PR DESCRIPTION
### What does this PR do?
This PR adds `process_cpu_seconds_total` to the list of metrics collected by the kube_apiserver_metrics check and remaps it to `process_cpu_total`

### Motivation
GitHub issue: https://github.com/DataDog/integrations-core/issues/18219

### QA
Tested with a custom built datadog-agent container that includes this change.


<img width="1240" alt="Screenshot 2025-01-17 at 10 43 34 AM" src="https://github.com/user-attachments/assets/0c7b05e8-b0fe-4c56-893b-f51fcb036a37" />


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
