### PR TITLE
[sqlserver] Emit raw query statements and plans for non prepared statements

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -846,6 +846,9 @@ files:
       hidden: true
       description: |
         Configure the collection of raw query statements in query activity and execution plans.
+        Raw query statements and execution plans may contain sensitive information in query text.
+        Enabling this option will allow the collection and ingestion of raw query statements and
+        execution plans into Datadog. This option is disabled by default.
         Note: This option only applies when `dbm` is enabled.
       options:
         - name: enabled

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -842,6 +842,19 @@ files:
             type: boolean
             example: false
             display_default: false
+    - name: collect_raw_statement
+      hidden: true
+      description: |
+        Configure the collection of raw query statements in query activity and execution plans.
+        Note: This option only applies when `dbm` is enabled.
+      options:
+        - name: enabled
+          description: |
+            Set to `true` to collect the raw query statements.
+          value:
+            type: boolean
+            example: false
+            display_default: false
     - name: log_unobfuscated_queries
       hidden: true
       description: |

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -842,7 +842,7 @@ files:
             type: boolean
             example: false
             display_default: false
-    - name: collect_raw_statement
+    - name: collect_raw_query_statement
       hidden: true
       description: |
         Configure the collection of raw query statements in query activity and execution plans.

--- a/sqlserver/changelog.d/19421.added
+++ b/sqlserver/changelog.d/19421.added
@@ -1,0 +1,1 @@
+Add support for collecting raw query statements and explain plans when `collect_raw_query_statement.enabled` is true.

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -308,7 +308,7 @@ class SqlserverActivity(DBMAsyncJob):
                 "ddagentversion": datadog_agent.get_version(),
                 "ddsource": "sqlserver",
                 "dbm_type": "rqt",
-                "ddtags": self.tags,
+                "ddtags": ",".join(self.tags),
                 'service': self._config.service,
                 "db": {
                     "instance": row.get('database_name', None),

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -311,6 +311,7 @@ class SqlserverActivity(DBMAsyncJob):
                 "ddtags": self.tags,
                 'service': self._config.service,
                 "db": {
+                    "instance": row.get('database_name', None),
                     "query_signature": query_signature,
                     "raw_query_signature": raw_query_signature,
                     "statement": raw_statement,

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -290,7 +290,7 @@ class SqlserverActivity(DBMAsyncJob):
             if not query_signature:
                 continue
 
-            raw_statement = row.get("raw_statement")
+            raw_statement = row.pop("raw_statement", None)
             if not raw_statement:
                 self.log.debug("No raw statement found for query_signature=%s", query_signature)
                 continue
@@ -299,7 +299,7 @@ class SqlserverActivity(DBMAsyncJob):
             row["raw_query_signature"] = raw_query_signature
             raw_statement_key = (query_signature, raw_query_signature)
 
-            if not self._raw_statement_text_cache.accquire(raw_statement_key):
+            if not self._raw_statement_text_cache.acquire(raw_statement_key):
                 continue
 
             yield {

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -7,6 +7,8 @@ import datetime
 import re
 import time
 
+from datadog_checks_base.datadog_checks.base.utils.db.utils import RateLimitingTTLCache
+
 from datadog_checks.base import is_affirmative
 from datadog_checks.base.utils.db.sql import compute_sql_signature
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding, obfuscate_sql_with_metadata
@@ -70,6 +72,7 @@ SELECT
     sess.host_name as host_name,
     sess.program_name as program_name,
     sess.is_user_process as is_user_process,
+    {input_buffer_columns}
     {exec_request_columns}
 FROM sys.dm_exec_sessions sess
     INNER JOIN sys.dm_exec_connections c
@@ -77,6 +80,7 @@ FROM sys.dm_exec_sessions sess
     INNER JOIN sys.dm_exec_requests req
         ON c.connection_id = req.connection_id
     CROSS APPLY sys.dm_exec_sql_text(req.sql_handle) qt
+    {input_buffer_join}
 WHERE
     sess.session_id != @@spid AND
     sess.status != 'sleeping'
@@ -145,6 +149,12 @@ DM_EXEC_REQUESTS_COLS = [
     "context_info",
 ]
 
+INPUT_BUFFER_COLUMNS = [
+    "input_buffer.event_info as raw_statement",
+]
+
+INPUT_BUFFER_JOIN = "OUTER APPLY sys.dm_exec_input_buffer(req.session_id, req.request_id) input_buffer"
+
 
 def _hash_to_hex(hash) -> str:
     return binascii.hexlify(hash).decode("utf-8")
@@ -183,6 +193,12 @@ class SqlserverActivity(DBMAsyncJob):
         self._activity_payload_max_bytes = MAX_PAYLOAD_BYTES
         self._exec_requests_cols_cached = None
 
+        self._collect_raw_statement = self._config.collect_raw_statement.get("enabled", False)
+        self._raw_statement_text_cache = RateLimitingTTLCache(
+            maxsize=self._config.collect_raw_statement["cache_max_size"],
+            ttl=60 * 60 / self._config.collect_raw_statement["samples_per_hour_per_query"],
+        )
+
     def _close_db_conn(self):
         pass
 
@@ -214,12 +230,14 @@ class SqlserverActivity(DBMAsyncJob):
         return rows
 
     @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
-    def _get_activity(self, cursor, exec_request_columns):
+    def _get_activity(self, cursor, exec_request_columns, input_buffer_columns, input_buffer_join):
         self.log.debug("collecting sql server activity")
         query = ACTIVITY_QUERY.format(
             exec_request_columns=', '.join(['req.{}'.format(r) for r in exec_request_columns]),
             proc_char_limit=self._config.stored_procedure_characters_limit,
             tail_text_size=TAIL_TEXT_SIZE,
+            input_buffer_columns=input_buffer_columns,
+            input_buffer_join=input_buffer_join,
         )
         self.log.debug("Running query [%s]", query)
         cursor.execute(query)
@@ -262,12 +280,67 @@ class SqlserverActivity(DBMAsyncJob):
             normalized_rows.append(row)
         return normalized_rows
 
+    @tracked_method(agent_check_getter=agent_check_getter)
+    def _rows_to_raw_statement_events(self, rows):
+        for row in rows:
+            query_signature = row.get('query_signature')
+            if not query_signature:
+                continue
+
+            raw_statement = row.get("raw_statement")
+            if not raw_statement:
+                self.log.debug("No raw statement found for query_signature=%s", query_signature)
+                continue
+
+            raw_query_signature = compute_sql_signature(raw_statement)
+            row["raw_query_signature"] = raw_query_signature
+            raw_statement_key = (query_signature, raw_query_signature)
+
+            if not self._raw_statement_text_cache.accquire(raw_statement_key):
+                continue
+
+            yield {
+                "timestamp": time.time() * 1000,
+                "host": self._check.resolved_hostname,
+                "ddagentversion": datadog_agent.get_version(),
+                "ddsource": "sqlserver",
+                "dbm_type": "rqt",
+                "ddtags": self.tags,
+                'service': self._config.service,
+                "db": {
+                    "query_signature": query_signature,
+                    "raw_query_signature": raw_query_signature,
+                    "statement": raw_statement,
+                    "metadata": {
+                        "tables": row['dd_tables'],
+                        "commands": row['dd_commands'],
+                        "comments": row.get('dd_comments', None),
+                    },
+                    "procedure_signature": row.get("procedure_signature"),
+                    "procedure_name": row.get("procedure_name"),
+                },
+                "sqlserver": {
+                    "query_hash": row.get("query_hash"),
+                    "query_plan_hash": row.get("query_plan_hash"),
+                },
+            }
+
     def _get_exec_requests_cols_cached(self, cursor, expected_cols):
         if self._exec_requests_cols_cached:
             return self._exec_requests_cols_cached
 
         self._exec_requests_cols_cached = self._get_available_requests_columns(cursor, expected_cols)
         return self._exec_requests_cols_cached
+
+    def _get_input_buffer_columns_and_join(self):
+        input_buffer_columns = ""
+        input_buffer_join = ""
+
+        if self._collect_raw_statement:
+            input_buffer_columns = ", ".join(INPUT_BUFFER_COLUMNS) + ","
+            input_buffer_join = INPUT_BUFFER_JOIN
+
+        return input_buffer_columns, input_buffer_join
 
     def _get_available_requests_columns(self, cursor, all_expected_columns):
         cursor.execute("select TOP 0 * from sys.dm_exec_requests")
@@ -386,8 +459,14 @@ class SqlserverActivity(DBMAsyncJob):
             with self._check.connection.get_managed_cursor(key_prefix=self._conn_key_prefix) as cursor:
                 connections = self._get_active_connections(cursor)
                 request_cols = self._get_exec_requests_cols_cached(cursor, DM_EXEC_REQUESTS_COLS)
-                rows = self._get_activity(cursor, request_cols)
+                input_buffer_columns, input_buffer_join = self._get_input_buffer_columns_and_join()
+                rows = self._get_activity(cursor, request_cols, input_buffer_columns, input_buffer_join)
                 normalized_rows = self._normalize_queries_and_filter_rows(rows, MAX_PAYLOAD_BYTES)
+                if self._collect_raw_statement:
+                    for raw_statement_event in self._rows_to_raw_statement_events(normalized_rows):
+                        self._check.database_monitoring_query_sample(
+                            json.dumps(raw_statement_event, default=default_json_event_encoding)
+                        )
                 event = self._create_activity_event(normalized_rows, connections)
                 payload = json.dumps(event, default=default_json_event_encoding)
                 self._check.database_monitoring_query_activity(payload)

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -7,11 +7,14 @@ import datetime
 import re
 import time
 
-from datadog_checks_base.datadog_checks.base.utils.db.utils import RateLimitingTTLCache
-
 from datadog_checks.base import is_affirmative
 from datadog_checks.base.utils.db.sql import compute_sql_signature
-from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding, obfuscate_sql_with_metadata
+from datadog_checks.base.utils.db.utils import (
+    DBMAsyncJob,
+    RateLimitingTTLCache,
+    default_json_event_encoding,
+    obfuscate_sql_with_metadata,
+)
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 from datadog_checks.sqlserver.config import SQLServerConfig

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -107,6 +107,12 @@ class SQLServerConfig:
                 }
             )
         )
+        collect_raw_statement_config: dict = instance.get('collect_raw_statement', {}) or {}
+        self.collect_raw_statement = {
+            "enabled": is_affirmative(collect_raw_statement_config.get('enabled', False)),
+            "cache_max_size": int(collect_raw_statement_config.get('cache_max_size', 10000)),
+            "samples_per_hour_per_query": int(collect_raw_statement_config.get('samples_per_hour_per_query', 1)),
+        }
         self.log_unobfuscated_queries: bool = is_affirmative(instance.get('log_unobfuscated_queries', False))
         self.log_unobfuscated_plans: bool = is_affirmative(instance.get('log_unobfuscated_plans', False))
         self.stored_procedure_characters_limit: int = instance.get('stored_procedure_characters_limit', PROC_CHAR_LIMIT)

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -18,10 +18,6 @@ from datadog_checks.sqlserver.const import (
 class SQLServerConfig:
     def __init__(self, init_config, instance, log):
         self.log = log
-        self.tags: list[str] = self._build_tags(
-            custom_tags=instance.get('tags', []),
-            propagate_agent_tags=self._should_propagate_agent_tags(instance, init_config),
-        )
         self.reported_hostname: str = instance.get('reported_hostname')
         self.autodiscovery: bool = is_affirmative(instance.get('database_autodiscovery'))
         self.autodiscovery_include: list[str] = instance.get('autodiscovery_include', ['.*']) or ['.*']
@@ -107,11 +103,11 @@ class SQLServerConfig:
                 }
             )
         )
-        collect_raw_statement_config: dict = instance.get('collect_raw_statement', {}) or {}
-        self.collect_raw_statement = {
-            "enabled": is_affirmative(collect_raw_statement_config.get('enabled', False)),
-            "cache_max_size": int(collect_raw_statement_config.get('cache_max_size', 10000)),
-            "samples_per_hour_per_query": int(collect_raw_statement_config.get('samples_per_hour_per_query', 1)),
+        collect_raw_query_statement_config: dict = instance.get('collect_raw_query_statement', {}) or {}
+        self.collect_raw_query_statement = {
+            "enabled": is_affirmative(collect_raw_query_statement_config.get('enabled', False)),
+            "cache_max_size": int(collect_raw_query_statement_config.get('cache_max_size', 10000)),
+            "samples_per_hour_per_query": int(collect_raw_query_statement_config.get('samples_per_hour_per_query', 1)),
         }
         self.log_unobfuscated_queries: bool = is_affirmative(instance.get('log_unobfuscated_queries', False))
         self.log_unobfuscated_plans: bool = is_affirmative(instance.get('log_unobfuscated_plans', False))
@@ -119,6 +115,12 @@ class SQLServerConfig:
         self.connection_host: str = instance['host']
         self.service = instance.get('service') or init_config.get('service') or ''
         self.db_fragmentation_object_names = instance.get('db_fragmentation_object_names', []) or []
+
+        self.tags: list[str] = self._build_tags(
+            custom_tags=instance.get('tags', []),
+            propagate_agent_tags=self._should_propagate_agent_tags(instance, init_config),
+            additional_tags=["raw_query_statement:enabled"] if self.collect_raw_query_statement["enabled"] else [],
+        )
 
     def _compile_valid_patterns(self, patterns: list[str]) -> re.Pattern:
         valid_patterns = []
@@ -141,7 +143,7 @@ class SQLServerConfig:
             # create unmatchable regex - https://stackoverflow.com/a/1845097/2157429
             return re.compile(r'(?!x)x')
 
-    def _build_tags(self, custom_tags, propagate_agent_tags):
+    def _build_tags(self, custom_tags, propagate_agent_tags, additional_tags):
         # Clean up tags in case there was a None entry in the instance
         # e.g. if the yaml contains tags: but no actual tags
         if custom_tags is None:
@@ -157,6 +159,9 @@ class SQLServerConfig:
                 raise ConfigurationError(
                     'propagate_agent_tags enabled but there was an error fetching agent tags {}'.format(e)
                 )
+
+        if additional_tags:
+            tags.extend(additional_tags)
         return tags
 
     @staticmethod

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -48,7 +48,7 @@ class Azure(BaseModel):
     fully_qualified_domain_name: Optional[str] = None
 
 
-class CollectRawStatement(BaseModel):
+class CollectRawQueryStatement(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
         frozen=True,
@@ -351,7 +351,7 @@ class InstanceConfig(BaseModel):
     autodiscovery_include: Optional[tuple[str, ...]] = None
     aws: Optional[Aws] = None
     azure: Optional[Azure] = None
-    collect_raw_query_statement: Optional[CollectRawStatement] = None
+    collect_raw_query_statement: Optional[CollectRawQueryStatement] = None
     collect_settings: Optional[CollectSettings] = None
     command_timeout: Optional[int] = None
     connection_string: Optional[str] = None

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -351,7 +351,7 @@ class InstanceConfig(BaseModel):
     autodiscovery_include: Optional[tuple[str, ...]] = None
     aws: Optional[Aws] = None
     azure: Optional[Azure] = None
-    collect_raw_statement: Optional[CollectRawStatement] = None
+    collect_raw_query_statement: Optional[CollectRawStatement] = None
     collect_settings: Optional[CollectSettings] = None
     command_timeout: Optional[int] = None
     connection_string: Optional[str] = None

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -48,6 +48,14 @@ class Azure(BaseModel):
     fully_qualified_domain_name: Optional[str] = None
 
 
+class CollectRawStatement(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    enabled: Optional[bool] = None
+
+
 class CollectSettings(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -343,6 +351,7 @@ class InstanceConfig(BaseModel):
     autodiscovery_include: Optional[tuple[str, ...]] = None
     aws: Optional[Aws] = None
     azure: Optional[Azure] = None
+    collect_raw_statement: Optional[CollectRawStatement] = None
     collect_settings: Optional[CollectSettings] = None
     command_timeout: Optional[int] = None
     connection_string: Optional[str] = None

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -470,10 +470,8 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                     self._check.database_monitoring_query_sample(json.dumps(event, default=default_json_event_encoding))
                 payload = self._to_metrics_payload(rows, self._max_query_metrics)
                 self._check.database_monitoring_query_metrics(json.dumps(payload, default=default_json_event_encoding))
-                for plan_event in self._collect_plans(rows, cursor, deadline):
-                    self._check.database_monitoring_query_sample(
-                        json.dumps(plan_event, default=default_json_event_encoding)
-                    )
+                for event in self._collect_plans(rows, cursor, deadline):
+                    self._check.database_monitoring_query_sample(json.dumps(event, default=default_json_event_encoding))
                     plans_submitted += 1
 
         self._check.count(

--- a/sqlserver/tests/compose-ha/sql/aoag_primary.sql
+++ b/sqlserver/tests/compose-ha/sql/aoag_primary.sql
@@ -154,8 +154,15 @@ BEGIN
 END;
 GO
 
+CREATE PROCEDURE fredProcParams @Name nvarchar(8) = NULL AS
+BEGIN
+    SELECT * FROM ϑings WHERE name like @Name;
+END;
+GO
+
 GRANT EXECUTE on bobProcParams to bob;
 GRANT EXECUTE on bobProc to bob;
+GRANT EXECUTE on fredProcParams to fred;
 GRANT EXECUTE on bobProc to fred;
 GO
 

--- a/sqlserver/tests/compose-high-cardinality-windows/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality-windows/setup.sql
@@ -151,8 +151,15 @@ BEGIN
 END;
 GO
 
+CREATE PROCEDURE fredProcParams @Name nvarchar(8) = NULL AS
+BEGIN
+    SELECT * FROM ϑings WHERE name like @Name;
+END;
+GO
+
 GRANT EXECUTE on bobProcParams to bob;
 GRANT EXECUTE on bobProc to bob;
+GRANT EXECUTE on fredProcParams to fred;
 GRANT EXECUTE on bobProc to fred;
 GO
 

--- a/sqlserver/tests/compose-high-cardinality/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality/setup.sql
@@ -223,8 +223,15 @@ BEGIN
 END;
 GO
 
+CREATE PROCEDURE fredProcParams @Name nvarchar(8) = NULL AS
+BEGIN
+    SELECT * FROM ϑings WHERE name like @Name;
+END;
+GO
+
 GRANT EXECUTE on bobProcParams to bob;
 GRANT EXECUTE on bobProc to bob;
+GRANT EXECUTE on fredProcParams to fred;
 GRANT EXECUTE on bobProc to fred;
 GO
 

--- a/sqlserver/tests/compose-windows/setup.sql
+++ b/sqlserver/tests/compose-windows/setup.sql
@@ -152,8 +152,16 @@ BEGIN
     SELECT id FROM ϑings WHERE name = @P2;
 END;
 GO
+
+CREATE PROCEDURE fredProcParams @Name nvarchar(8) = NULL AS
+BEGIN
+    SELECT * FROM ϑings WHERE name like @Name;
+END;
+GO
+
 GRANT EXECUTE on bobProcParams to bob;
 GRANT EXECUTE on bobProc to bob;
+GRANT EXECUTE on fredProcParams to fred;
 GRANT EXECUTE on bobProc to fred;
 GO
 

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -137,8 +137,15 @@ BEGIN
 END;
 GO
 
+CREATE PROCEDURE fredProcParams @Name nvarchar(8) = NULL AS
+BEGIN
+    SELECT * FROM ϑings WHERE name like @Name;
+END;
+GO
+
 GRANT EXECUTE on bobProcParams to bob;
 GRANT EXECUTE on bobProc to bob;
+GRANT EXECUTE on fredProcParams to fred;
 GRANT EXECUTE on bobProc to fred;
 GO
 

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -62,7 +62,7 @@ def dbm_instance(instance_docker):
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize("use_autocommit", [True, False])
 @pytest.mark.parametrize(
-    "database,query,match_pattern,is_proc,expected_comments",
+    "database,query,match_pattern,is_proc,expected_comments,collect_raw_statement,expected_raw_statement",
     [
         [
             "datadog_test-1",
@@ -70,6 +70,8 @@ def dbm_instance(instance_docker):
             r"SELECT \* FROM ϑings",
             False,
             ["/*test=foo*/"],
+            False,
+            None,
         ],
         [
             "datadog_test-1",
@@ -77,6 +79,26 @@ def dbm_instance(instance_docker):
             r"SELECT \* FROM ϑings",
             True,
             [],
+            False,
+            None,
+        ],
+        [
+            "datadog_test-1",
+            "SELECT * FROM ϑings WHERE name = 'test'",
+            r"SELECT \* FROM \[ϑings\] WHERE \[name\]=\@1",
+            False,
+            [],
+            True,
+            "SELECT * FROM ϑings WHERE name = 'test'",
+        ],
+        [
+            "datadog_test-1",
+            "EXEC fredProcParams @Name = 'test'",
+            r"SELECT \* FROM ϑings WHERE name like \@Name",
+            True,
+            [],
+            True,
+            "EXEC fredProcParams @Name = 'test'",
         ],
     ],
 )
@@ -91,8 +113,13 @@ def test_collect_load_activity(
     match_pattern,
     is_proc,
     expected_comments,
+    collect_raw_statement,
+    expected_raw_statement,
 ):
-    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
+    instance = copy(dbm_instance)
+    if collect_raw_statement:
+        instance["collect_raw_statement"] = {"enabled": True}
+    check = SQLServer(CHECK_NAME, {}, [instance])
     blocking_query = "INSERT INTO ϑings WITH (TABLOCK, HOLDLOCK) (name) VALUES ('puppy')"
     fred_conn = _get_conn_for_user(instance_docker, "fred", _autocommit=use_autocommit)
     bob_conn = _get_conn_for_user(instance_docker, "bob")
@@ -138,7 +165,7 @@ def test_collect_load_activity(
     fred_conn.close()
     executor.shutdown(wait=True)
 
-    instance_tags = set(dbm_instance.get('tags', []))
+    instance_tags = set(instance.get('tags', []))
     expected_instance_tags = {t for t in instance_tags if not t.startswith('dd.internal')}
 
     dbm_activity = aggregator.get_event_platform_events("dbm-activity")
@@ -181,6 +208,17 @@ def test_collect_load_activity(
     assert parser.isoparse(blocked_row["query_start"]).tzinfo, "query_start timestamp not formatted correctly"
     for r in DM_EXEC_REQUESTS_COLS:
         assert r in blocked_row
+    if collect_raw_statement:
+        dbm_samples = aggregator.get_event_platform_events("dbm-samples")
+        rqt_events = [s for s in dbm_samples if s['dbm_type'] == "rqt"]
+        assert rqt_events is not None
+        matched_rqt_event = [s for s in rqt_events if s['db']['statement'] == expected_raw_statement]
+        assert len(matched_rqt_event) == 1
+        assert matched_rqt_event[0]['db']['query_signature'], "missing query_signature"
+        assert matched_rqt_event[0]['db']['raw_query_signature'], "missing raw_query_signature"
+        assert matched_rqt_event[0]['sqlserver']['query_hash'], "missing query_hash"
+        assert blocked_row['raw_query_signature'] == matched_rqt_event[0]['db']['raw_query_signature']
+        assert 'raw_statement' not in blocked_row
 
     # assert connections collection
     assert len(event['sqlserver_connections']) > 0

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -123,7 +123,7 @@ def test_get_statement_metrics_query_cached(aggregator, dbm_instance, caplog):
 
 
 test_statement_metrics_and_plans_parameterized = (
-    "database,query,expected_queries_patterns,param_groups,exe_count,is_encrypted,is_proc,disable_secondary_tags",
+    "database,query,expected_queries_patterns,param_groups,exe_count,is_encrypted,is_proc,disable_secondary_tags,collect_raw_query_statement",
     [
         [
             "master",
@@ -137,6 +137,7 @@ test_statement_metrics_and_plans_parameterized = (
             False,
             True,
             True,
+            False,
         ],
         [
             "master",
@@ -150,6 +151,7 @@ test_statement_metrics_and_plans_parameterized = (
             False,
             True,
             True,
+            False,
         ],
         [
             "master",
@@ -160,6 +162,7 @@ test_statement_metrics_and_plans_parameterized = (
             True,
             True,
             True,
+            False,
         ],
         [
             "datadog_test-1",
@@ -167,6 +170,7 @@ test_statement_metrics_and_plans_parameterized = (
             [r"SELECT \* FROM ϑings"],
             ((),),
             1,
+            False,
             False,
             False,
             False,
@@ -184,6 +188,7 @@ test_statement_metrics_and_plans_parameterized = (
             False,
             False,
             False,
+            False,
         ],
         [
             "datadog_test-1",
@@ -194,6 +199,7 @@ test_statement_metrics_and_plans_parameterized = (
             False,
             True,
             True,
+            False,
         ],
         [
             "datadog_test-1",
@@ -204,6 +210,7 @@ test_statement_metrics_and_plans_parameterized = (
             False,
             True,
             True,
+            False,
         ],
         [
             "master",
@@ -215,6 +222,7 @@ test_statement_metrics_and_plans_parameterized = (
                 (3,),
             ),
             1,
+            False,
             False,
             False,
             False,
@@ -232,6 +240,7 @@ test_statement_metrics_and_plans_parameterized = (
             False,
             False,
             False,
+            False,
         ],
         [
             "datadog_test-1",
@@ -246,6 +255,7 @@ test_statement_metrics_and_plans_parameterized = (
             False,
             False,
             True,
+            False,
         ],
         [
             "datadog_test-1",
@@ -262,6 +272,7 @@ test_statement_metrics_and_plans_parameterized = (
             False,
             True,
             True,
+            False,
         ],
         [
             "datadog_test-1",
@@ -276,6 +287,24 @@ test_statement_metrics_and_plans_parameterized = (
             ),
             5,
             False,
+            True,
+            True,
+            False,
+        ],
+        [
+            "datadog_test-1",
+            "EXEC bobProcParams @P1 = ?, @P2 = ?",
+            [
+                r"SELECT \* FROM ϑings WHERE id = @P1",
+                r"SELECT id FROM ϑings WHERE name = @P2",
+            ],
+            (
+                (1, "foo"),
+                (2, "bar"),
+            ),
+            5,
+            False,
+            True,
             True,
             True,
         ],
@@ -299,6 +328,7 @@ def test_statement_metrics_and_plans(
     is_proc,
     disable_secondary_tags,
     expected_queries_patterns,
+    collect_raw_query_statement,
     caplog,
     datadog_agent,
 ):
@@ -306,6 +336,12 @@ def test_statement_metrics_and_plans(
     if disable_secondary_tags:
         dbm_instance['query_metrics']['disable_secondary_tags'] = True
     dbm_instance['query_activity'] = {'enabled': True, 'collection_interval': 2}
+    instance_tags = dbm_instance.get('tags', [])
+    expected_instance_tags = {t for t in instance_tags if not t.startswith('dd.internal')}
+    if collect_raw_query_statement:
+        dbm_instance["collect_raw_query_statement"] = {"enabled": True}
+        expected_instance_tags.add("raw_query_statement:enabled")
+    expected_instance_tags_with_db = expected_instance_tags | {"db:{}".format(database)}
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
 
     # the check must be run three times:
@@ -330,10 +366,6 @@ def test_statement_metrics_and_plans(
             available_query_metrics_columns = check.statement_metrics._get_available_query_metrics_columns(
                 cursor, SQL_SERVER_QUERY_METRICS_COLUMNS
             )
-
-    instance_tags = dbm_instance.get('tags', [])
-    expected_instance_tags = {t for t in instance_tags if not t.startswith('dd.internal')}
-    expected_instance_tags_with_db = expected_instance_tags | {"db:{}".format(database)}
 
     # dbm-metrics
     dbm_metrics = aggregator.get_event_platform_events("dbm-metrics")
@@ -429,6 +461,26 @@ def test_statement_metrics_and_plans(
             assert parsed_plan.tag.endswith("ShowPlanXML"), "plan does not match expected structure"
             assert not event['sqlserver']['is_plan_encrypted']
             assert not event['sqlserver']['is_statement_encrypted']
+
+    if collect_raw_query_statement:
+        raw_plan_events = [s for s in matching_samples if s['dbm_type'] == "rqp"]
+        # raw plan events should be one to one with the plan events
+        assert len(raw_plan_events) == 1, "should have collected exactly one raw plan event"
+        for event in plan_events:
+            if is_encrypted:
+                assert not event['db']['plan']['definition']
+                assert event['sqlserver']['is_plan_encrypted']
+                assert event['sqlserver']['is_statement_encrypted']
+            elif is_proc:
+                assert event['db']['procedure_signature'], "missing proc signature"
+                assert event['db']['procedure_name'], "missing proc name"
+                assert not event['db']['query_signature'], "procedure plans should not have query_signature field set"
+            else:
+                assert event['db']['plan']['definition'], "event plan definition missing"
+                parsed_plan = ET.fromstring(event['db']['plan']['definition'])
+                assert parsed_plan.tag.endswith("ShowPlanXML"), "plan does not match expected structure"
+                assert not event['sqlserver']['is_plan_encrypted']
+                assert not event['sqlserver']['is_statement_encrypted']
 
     fqt_events = [s for s in matching_samples if s['dbm_type'] == "fqt"]
     assert len(fqt_events) == len(


### PR DESCRIPTION
### What does this PR do?
This PR introduces a feature to ingest raw query statements and explain plans when the `collect_raw_query_statement.enabled` option is set to true. The raw query statement is collected alongside activity samples from `sys.dm_exec_input_buffer` using session_id and request_id, which provides the input text that triggers query execution.

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4952
This enhancement supplements obfuscated and normalized query statements with de-obfuscated query statements and execution plans, provides insights into query parameter values. 
Note that raw query statements include parameter values only for non-prepared statements.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
