### PR TITLE
[ddqa/config] Exclude Cédric and Haïssam from container-integrations QA

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -54,6 +54,10 @@ jira_statuses = [
   "Done",
 ]
 github_team = "container-integrations"
+exclude_members = [
+  "clamoriniere",
+  "hkaj",
+]
 github_labels = ["team/container-integrations"]
 
 [teams."Database Monitoring"]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Exclude Cédric and Haïssam from container-integrations QA

### Motivation
<!-- What inspired you to submit this pull request? -->
Cédric recently got auto-assigned one of the QA cards from this repo meant for our team and we didn't notice until quite late into the release cycle.

I have never actually seen Haïssam be assigned one of the cards but he is a part of the @DataDog/container-integrations team on GitHub; if this isn't used and there's another place that should be updated please let me know!

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [x] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
