### PR TITLE
[proxysql] Generate metric for all pairs of hostgroup/status (backend)

### DIFF
--- a/proxysql/datadog_checks/proxysql/queries.py
+++ b/proxysql/datadog_checks/proxysql/queries.py
@@ -236,7 +236,23 @@ STATS_MEMORY_METRICS = {
 
 STATS_MYSQL_BACKENDS = {
     'name': 'stats_mysql_backends',
-    'query': 'SELECT  hostgroup, status, COUNT(*) FROM stats_mysql_connection_pool GROUP BY hostgroup, status',
+    # Note: this query seems a bit complex, but it's basically:
+    #       SELECT  hostgroup, status, COUNT(*) FROM stats_mysql_connection_pool GROUP BY hostgroup, status
+    #       The complexity (JOIN, subquery) is only here to always generate a metric (at 0) for all combinations of
+    #       status&hostgroup, even when no server exists at the moment in that status & hostgroup.
+    'query': """
+             SELECT refpairs.hostgroup, refpairs.status, count(stats.srv_host) as count
+             FROM (
+                 SELECT DISTINCT(hostgroup), refstatuses.status
+                 FROM stats_mysql_connection_pool
+                 JOIN (
+                     select 'ONLINE' as status union all select 'SHUNNED' as status union all
+                     select 'OFFLINE_SOFT' as status union all select 'OFFLINE_HARD' as status
+                 ) refstatuses
+             ) refpairs
+             LEFT JOIN stats_mysql_connection_pool stats ON stats.hostgroup=refpairs.hostgroup and stats.status=refpairs.status
+             GROUP BY refpairs.hostgroup, refpairs.status;
+             """,
     'columns': [
         {'name': 'hostgroup', 'type': 'tag'},
         {'name': 'status', 'type': 'tag'},


### PR DESCRIPTION
## What does this PR do?
Ensure that the count metric is always generated, even when 0 backend exists in that status & hostgroup at the moment.

## Motivation
Today, when a hostgroup has no `online` backend server for example, the metric with tag `status=ONLINE`+`hostgroup=42` is not generated at all (no value for sometime, until a backend is online).
But having no online backend is an important piece of information to monitor a proxysql.
Example: a dashboard showing the nb of online backend servers per hostgroup is not giving a good observability if not showing the 0 value, because it has a different meaning than no value :(

NB: the list of hostgroups is dynamic (because it depends on config, thus different for each deployment), and the list of status is hardcoded (because fixed in proxysql, cf [doc](https://proxysql.com/documentation/stats-statistics/#stats_mysql_connection_pool))

## Tests
I've only tested the SQL query alone on a real proxysql:

### Before:
```
ProxySQLadm> SELECT hostgroup, status, COUNT(*)
FROM stats_mysql_connection_pool GROUP BY hostgroup, status;
+-----------+--------------+----------+
| hostgroup | status       | COUNT(*) |
+-----------+--------------+----------+
| 10        | ONLINE       | 1        |
| 10        | SHUNNED      | 2        |
| 20        | ONLINE       | 3        |
| 30        | ONLINE       | 2        |
| 9999      | OFFLINE_HARD | 3        |
+-----------+--------------+----------+
```

### Now:
```
ProxySQLadm> SELECT refpairs.hostgroup, refpairs.status, count(stats.srv_host) as count
             FROM (
                 SELECT DISTINCT(hostgroup), refstatuses.status
                 FROM stats_mysql_connection_pool
                 JOIN (
                     select 'ONLINE' as status union all select 'SHUNNED' as status union all
                     select 'OFFLINE_SOFT' as status union all select 'OFFLINE_HARD' as status
                 ) refstatuses
             ) refpairs
             LEFT JOIN stats_mysql_connection_pool stats ON stats.hostgroup=refpairs.hostgroup and stats.status=refpairs.status
             GROUP BY refpairs.hostgroup, refpairs.status;
+-----------+--------------+-------+
| hostgroup | status       | count |
+-----------+--------------+-------+
| 10        | OFFLINE_HARD | 0     |
| 10        | OFFLINE_SOFT | 0     |
| 10        | ONLINE       | 1     |
| 10        | SHUNNED      | 2     |
| 20        | OFFLINE_HARD | 0     |
| 20        | OFFLINE_SOFT | 0     |
| 20        | ONLINE       | 3     |
| 20        | SHUNNED      | 0     |
| 30        | OFFLINE_HARD | 0     |
| 30        | OFFLINE_SOFT | 0     |
| 30        | ONLINE       | 2     |
| 30        | SHUNNED      | 0     |
| 9999      | OFFLINE_HARD | 3     |
| 9999      | OFFLINE_SOFT | 0     |
| 9999      | ONLINE       | 0     |
| 9999      | SHUNNED      | 0     |
+-----------+--------------+-------+
```
=> same values than before (when not zero) ✅
=> and all other pairs of hostgroup+status are now also generated as 0 🆕 



## Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
