### PR TITLE
Add tls_cipher section to the octopus config.

### DIFF
--- a/octopus_deploy/datadog_checks/octopus_deploy/data/conf.yaml.example
+++ b/octopus_deploy/datadog_checks/octopus_deploy/data/conf.yaml.example
@@ -511,6 +511,16 @@ instances:
     #   - TLSv1.2
     #   - TLSv1.3
 
+    ## @param tls_ciphers - list of strings - optional
+    ## The list of ciphers suites to use when connecting to an endpoint. If not specified, 
+    ## `ALL` ciphers are used. For list of ciphers see: 
+    ## https://www.openssl.org/docs/man1.0.2/man1/ciphers.html
+    #
+    # tls_ciphers:
+    #   - TLS_AES_256_GCM_SHA384
+    #   - TLS_CHACHA20_POLY1305_SHA256
+    #   - TLS_AES_128_GCM_SHA256
+
     ## @param extra_headers - mapping - optional
     ## Additional headers to send with every request.
     #


### PR DESCRIPTION
### What does this PR do?
Adds the tls_ciphers param to the octopus integration config.
This was done for other integrations, but we missed this one until now. See https://github.com/DataDog/integrations-core/pull/19334 and https://github.com/DataDog/integrations-core/pull/19312.

Not adding a changelog update since the integration has not been part of a public release yet.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
