### PR TITLE
[mongo] fix error CommandCursor is not subscriptable

### DIFF
--- a/mongo/datadog_checks/mongo/collectors/replication_info.py
+++ b/mongo/datadog_checks/mongo/collectors/replication_info.py
@@ -27,7 +27,9 @@ class ReplicationOpLogCollector(MongoCollector):
 
     def _get_oplog_size(self, api, oplog_collection_name):
         try:
-            oplog_storage_stats = api.get_collection_stats("local", oplog_collection_name, stats=["storageStats"])[0]
+            oplog_storage_stats = list(
+                api.get_collection_stats("local", oplog_collection_name, stats=["storageStats"])
+            )[0]
         except pymongo.errors.OperationFailure as e:
             self.log.warning(
                 "Could not collect oplog used size for collection %s: %s", oplog_collection_name, e.details

--- a/mongo/tests/mocked_api.py
+++ b/mongo/tests/mocked_api.py
@@ -59,13 +59,13 @@ class MockedCollection(object):
     def aggregate(self, pipeline, session=None, **kwargs):
         if '$indexStats' in pipeline[0]:
             with open(os.path.join(HERE, "fixtures", f"$indexStats-{self._coll_name}"), 'r') as f:
-                return json.load(f, object_hook=json_util.object_hook)
+                return iter(json.load(f, object_hook=json_util.object_hook))
         elif '$collStats' in pipeline[0]:
             with open(os.path.join(HERE, "fixtures", f"$collStats-{self._coll_name}"), 'r') as f:
-                return json.load(f, object_hook=json_util.object_hook)
+                return iter(json.load(f, object_hook=json_util.object_hook))
         elif '$sample' in pipeline[0]:
             with open(os.path.join(HERE, "fixtures", f"$sample-{self._coll_name}"), 'r') as f:
-                return json.load(f, object_hook=json_util.object_hook)
+                return iter(json.load(f, object_hook=json_util.object_hook))
 
 
 class MockedDB(object):
@@ -108,10 +108,10 @@ class MockedDB(object):
         if pipeline[0] == {'$currentOp': {'allUsers': True}}:
             # mock the $currentOp aggregation used for operation sampling
             with open(os.path.join(HERE, "fixtures", f"$currentOp-{self.deployment}"), 'r') as f:
-                return json.load(f, object_hook=json_util.object_hook)
+                return iter(json.load(f, object_hook=json_util.object_hook))
         elif pipeline[0] == {"$shardedDataDistribution": {}}:
             with open(os.path.join(HERE, "fixtures", "$shardedDataDistribution"), 'r') as f:
-                return json.load(f, object_hook=json_util.object_hook)
+                return iter(json.load(f, object_hook=json_util.object_hook))
         return []
 
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes error `CommandCursor is not subscriptable` in replication oplog size and oplog window collection. 

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4927

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
