### PR TITLE
[mongo] increase mongo schema and index definition default collection interval to 1 hour

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -250,7 +250,7 @@ files:
             from collections and inferring schemas.
           value:
             type: number
-            example: 600
+            example: 3600
         - name: sample_size
           description: |
             Set the sample size for each collection. The sample size is the number of documents to sample

--- a/mongo/changelog.d/19445.added
+++ b/mongo/changelog.d/19445.added
@@ -1,0 +1,1 @@
+Increased the default collection interval for MongoDB inferred schema and index definitions to 1 hour to reduce resource overhead.

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -216,7 +216,7 @@ class MongoConfig(object):
         max_collections = self._schemas_config.get('max_collections')
         return {
             'enabled': enabled,
-            'collection_interval': self._schemas_config.get('collection_interval', 600),
+            'collection_interval': self._schemas_config.get('collection_interval', 3600),
             'run_sync': is_affirmative(self._schemas_config.get('run_sync', True)),
             'sample_size': int(self._schemas_config.get('sample_size', 10)),
             'max_collections': int(max_collections) if max_collections else None,

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -208,11 +208,11 @@ instances:
         #
         # enabled: true
 
-        ## @param collection_interval - number - optional - default: 600
+        ## @param collection_interval - number - optional - default: 3600
         ## Set the schemas collection interval in seconds. Each collection involves sampling documents
         ## from collections and inferring schemas.
         #
-        # collection_interval: 600
+        # collection_interval: 3600
 
         ## @param sample_size - number - optional - default: 10
         ## Set the sample size for each collection. The sample size is the number of documents to sample

--- a/mongo/tests/results/schemas-mongos.json
+++ b/mongo/tests/results/schemas-mongos.json
@@ -4,7 +4,7 @@
         "agent_version": "0.0.0",
         "dbms": "mongo",
         "kind": "mongodb_databases",
-        "collection_interval": 600,
+        "collection_interval": 3600,
         "dbms_version": "4.1.13",
         "cloud_metadata": {},
         "tags": [
@@ -595,7 +595,7 @@
         "agent_version": "0.0.0",
         "dbms": "mongo",
         "kind": "mongodb_databases",
-        "collection_interval": 600,
+        "collection_interval": 3600,
         "dbms_version": "4.1.13",
         "cloud_metadata": {},
         "tags": [

--- a/mongo/tests/results/schemas-standalone-atlas-search-indexes.json
+++ b/mongo/tests/results/schemas-standalone-atlas-search-indexes.json
@@ -4,7 +4,7 @@
         "agent_version": "0.0.0",
         "dbms": "mongo",
         "kind": "mongodb_databases",
-        "collection_interval": 600,
+        "collection_interval": 3600,
         "dbms_version": "4.1.13",
         "cloud_metadata": {},
         "tags": [
@@ -628,7 +628,7 @@
         "agent_version": "0.0.0",
         "dbms": "mongo",
         "kind": "mongodb_databases",
-        "collection_interval": 600,
+        "collection_interval": 3600,
         "dbms_version": "4.1.13",
         "cloud_metadata": {},
         "tags": [

--- a/mongo/tests/results/schemas-standalone-atlas.json
+++ b/mongo/tests/results/schemas-standalone-atlas.json
@@ -4,7 +4,7 @@
         "agent_version": "0.0.0",
         "dbms": "mongo",
         "kind": "mongodb_databases",
-        "collection_interval": 600,
+        "collection_interval": 3600,
         "dbms_version": "4.1.13",
         "cloud_metadata": {},
         "tags": [
@@ -594,7 +594,7 @@
         "agent_version": "0.0.0",
         "dbms": "mongo",
         "kind": "mongodb_databases",
-        "collection_interval": 600,
+        "collection_interval": 3600,
         "dbms_version": "4.1.13",
         "cloud_metadata": {},
         "tags": [

--- a/mongo/tests/results/schemas-standalone.json
+++ b/mongo/tests/results/schemas-standalone.json
@@ -4,7 +4,7 @@
         "agent_version": "0.0.0",
         "dbms": "mongo",
         "kind": "mongodb_databases",
-        "collection_interval": 600,
+        "collection_interval": 3600,
         "dbms_version": "4.1.13",
         "cloud_metadata": {},
         "tags": [
@@ -594,7 +594,7 @@
         "agent_version": "0.0.0",
         "dbms": "mongo",
         "kind": "mongodb_databases",
-        "collection_interval": 600,
+        "collection_interval": 3600,
         "dbms_version": "4.1.13",
         "cloud_metadata": {},
         "tags": [


### PR DESCRIPTION
### What does this PR do?
This PR increases the default collection interval for MongoDB inferred schema and index definitions to 1 hour.

### Motivation
The inferred schema for MongoDB collections is gathered using the `$sample` aggregation pipeline, which can be resource-intensive for large collections, even with the default sampling size of 10 documents. This operation often exceeds 100ms and is categorized as a slow query by MongoDB. By extending the default collection interval, this change reduces the monitoring overhead on the database while maintaining a balance between data freshness and resource consumption.

https://datadoghq.atlassian.net/browse/DBMON-4928

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
