### PR TITLE
Debug log on the same line as the timestamp.

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
@@ -241,10 +241,10 @@ class QueueMetricCollector(object):
                             if metric_value is not None:
                                 self.send_metric(GAUGE, metric_name, metric_value, tags=tags)
                             else:
-                                msg = """
-                                    Unable to get %s. Turn on queue level monitoring to access these metrics for %s.
-                                    Check `DISPLAY QSTATUS(%s) MONITOR`.
-                                    """
+                                msg = (
+                                    "Unable to get %s. Turn on queue level monitoring to access these metrics for %s."
+                                    " Check `DISPLAY QSTATUS(%s) MONITOR`."
+                                )
                                 self.log.debug(msg, metric_name, queue_name, queue_name)
                         else:
                             failure_value = values['failure']


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

#### Before
```
2025-01-08 10:01:56 EST | CORE | DEBUG | (pkg/collector/python/datadog_agent.go:149 in LogMessage) | ibm_mq:e2ffdbf676c471d7 | (queue_metric_collector.py:248) |
                                    Unable to get ibm_mq.queue.last_get_time. Turn on queue level monitoring to access these metrics for ICE.MINITMC.REPLYDISPATCHER.IN.
```
#### After
```
2025-01-08 10:01:56 EST | CORE | DEBUG | (pkg/collector/python/datadog_agent.go:149 in LogMessage) | ibm_mq:e2ffdbf676c471d7 | (queue_metric_collector.py:248) | Unable to get ibm_mq.queue.last_get_time. Turn on queue level monitoring to access these metrics for ICE.MINITMC.REPLYDISPATCHER.IN.
```

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
