### PR TITLE
[mongo] include explain operations in samples

### DIFF
--- a/mongo/changelog.d/19450.added
+++ b/mongo/changelog.d/19450.added
@@ -1,0 +1,1 @@
+Include explain operations in MongoDB activity samples.

--- a/mongo/datadog_checks/mongo/dbm/operation_samples.py
+++ b/mongo/datadog_checks/mongo/dbm/operation_samples.py
@@ -189,10 +189,6 @@ class MongoOperationSamples(DBMAsyncJob):
             # the replica set members and to discover additional members of a replica set.
             self._check.log.debug("Skipping hello operation: %s", operation)
             return False
-        if "explain" in command:
-            # Skip explain operations as explain cannot explain itself
-            self._check.log.debug("Skipping explain operation: %s", operation)
-            return False
 
         return True
 


### PR DESCRIPTION
### What does this PR do?
This PR adds support for capturing explain operations in MongoDB activity samples.

### Motivation
Previously, explain operations were excluded from activity samples, which could result in an incomplete count of active database operations. Including them ensures more accurate tracking and representation of database activity.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
