### PR TITLE
Allow upgrading rethinkdb

### DIFF
--- a/.ddev/config.toml
+++ b/.ddev/config.toml
@@ -172,8 +172,6 @@ exclude = [
     # We're not ready to switch to v3 of the postgres library, see:
     # https://github.com/DataDog/integrations-core/pull/15859
     'psycopg2-binary',
-    # 2.4.10 is broken on py2 and they did not yank the version
-    'rethinkdb',
     'psutil',
 ]
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
The broken rethinkdb version was only relevant for Python 2, which we don't support anymore.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
