### PR TITLE
Add FIPS case for Windows registry

### DIFF
--- a/datadog_checks_base/changelog.d/19457.fixed
+++ b/datadog_checks_base/changelog.d/19457.fixed
@@ -1,0 +1,1 @@
+Add FIPS case for Windows registry

--- a/datadog_checks_base/changelog.d/19457.fixed
+++ b/datadog_checks_base/changelog.d/19457.fixed
@@ -1,1 +1,1 @@
-Add FIPS case for Windows registry
+Enable FIPS mode in integrations if Windows has FIPS mode enabled in the registry

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -94,7 +94,7 @@ if TYPE_CHECKING:
 ONE_PER_CONTEXT_METRIC_TYPES = [aggregator.GAUGE, aggregator.RATE, aggregator.MONOTONIC_COUNT]
 TYPO_SIMILARITY_THRESHOLD = 0.95
 
-FIPS_REGISTRY_KEY = "FipsAlgorithmPolicy"
+FIPS_REGISTRY_KEY = "FIPSAlgorithmPolicy"
 
 
 @traced_class
@@ -318,8 +318,8 @@ class AgentCheck(object):
         if sys.platform == "win32":
             try:
                 import winreg
-                with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, "HKLM\System\CurrentControlSet\Control\Lsa\FIPSAlgorithmPolicy\STE") as key:
-                    fips_registry, _ = winreg.QueryValueEx(key, FIPS_REGISTRY_KEY)
+                with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, f"System\CurrentControlSet\Control\Lsa\{FIPS_REGISTRY_KEY}") as key:
+                    fips_registry, _ = winreg.QueryValueEx(key, "Enabled")
                 if isinstance(fips_registry, int):
                     self.__fips_mode = fips_registry
             except:  # noqa: E722, B001

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -94,8 +94,6 @@ if TYPE_CHECKING:
 ONE_PER_CONTEXT_METRIC_TYPES = [aggregator.GAUGE, aggregator.RATE, aggregator.MONOTONIC_COUNT]
 TYPO_SIMILARITY_THRESHOLD = 0.95
 
-FIPS_REGISTRY_KEY = "FIPSAlgorithmPolicy"
-
 
 @traced_class
 class AgentCheck(object):
@@ -320,13 +318,13 @@ class AgentCheck(object):
                 import winreg
 
                 with winreg.OpenKey(
-                    winreg.HKEY_LOCAL_MACHINE, rf"System\CurrentControlSet\Control\Lsa\{FIPS_REGISTRY_KEY}"
+                    winreg.HKEY_LOCAL_MACHINE, r"System\CurrentControlSet\Control\Lsa\FIPSAlgorithmPolicy"
                 ) as key:
                     fips_registry, _ = winreg.QueryValueEx(key, "Enabled")
                 if isinstance(fips_registry, int):
                     self.__fips_mode = fips_registry
             except Exception as e:
-                self.log.debug("Windows error encountered when fetching %s registry key: %s", FIPS_REGISTRY_KEY, e)
+                self.log.debug("Windows error encountered when fetching FIPSAlgorithmPolicy registry key: %s", e)
         if os.environ.get("GOFIPS", "0") == "1":
             self.__fips_mode = 1
 

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -318,12 +318,15 @@ class AgentCheck(object):
         if sys.platform == "win32":
             try:
                 import winreg
-                with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, f"System\CurrentControlSet\Control\Lsa\{FIPS_REGISTRY_KEY}") as key:
+
+                with winreg.OpenKey(
+                    winreg.HKEY_LOCAL_MACHINE, rf"System\CurrentControlSet\Control\Lsa\{FIPS_REGISTRY_KEY}"
+                ) as key:
                     fips_registry, _ = winreg.QueryValueEx(key, "Enabled")
                 if isinstance(fips_registry, int):
                     self.__fips_mode = fips_registry
-            except:  # noqa: E722, B001
-                self.logger.debug("Windows error encountered when fetching registry key %s", FIPS_REGISTRY_KEY)
+            except Exception as e:
+                self.log.debug("Windows error encountered when fetching %s registry key: %s", FIPS_REGISTRY_KEY, e)
         if os.environ.get("GOFIPS", "0") == "1":
             self.__fips_mode = 1
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds a condition to enable FIPS on Windows without the need of the GOFIPS environment variable.

### Motivation
<!-- What inspired you to submit this pull request? -->
On Windows, FIPS is enabled through a registry. ([source](https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp4825.pdf))

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
