### PR TITLE
Fix test_template_array test in datadog_checks_dev

### DIFF
--- a/datadog_checks_dev/tests/tooling/configuration/test_load.py
+++ b/datadog_checks_dev/tests/tooling/configuration/test_load.py
@@ -2883,6 +2883,7 @@ def test_template_array():
         'tls_private_key',
         'tls_ca_cert',
         'tls_protocols_allowed',
+        'tls_ciphers',
         'headers',
         'extra_headers',
         'timeout',


### PR DESCRIPTION
### What does this PR do?
Fix the test_template_array test in datadog_checks_dev by adding the missing tls_cipher entry.
Failing test log: https://github.com/DataDog/integrations-core/actions/runs/12922653850/job/36054579755#step:15:1082

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
