### PR TITLE
[AGENT-12451] Add ciphers option for fetch_intermediate_certs

### DIFF
--- a/datadog_checks_base/changelog.d/19469.added
+++ b/datadog_checks_base/changelog.d/19469.added
@@ -1,0 +1,1 @@
+Add tls_ciphers option for http

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -351,7 +351,13 @@ class RequestsWrapper(object):
         if config['kerberos_cache']:
             self.request_hooks.append(lambda: handle_kerberos_cache(config['kerberos_cache']))
 
-        self.tls_ciphers_allowed = config.get('tls_ciphers')
+        ciphers = config.get('tls_ciphers')
+        if ciphers:
+            if 'ALL' in ciphers:
+                updated_ciphers = "ALL"
+            else:
+                updated_ciphers = ":".join(ciphers)
+        self.tls_ciphers_allowed = updated_ciphers
 
     def get(self, url, **options):
         return self._request('get', url, options)

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -94,6 +94,7 @@ STANDARD_FIELDS = {
     'tls_private_key': None,
     'tls_protocols_allowed': DEFAULT_PROTOCOL_VERSIONS,
     'tls_verify': True,
+    'tls_ciphers': 'ALL',
     'timeout': DEFAULT_TIMEOUT,
     'use_legacy_auth_encoding': True,
     'username': None,
@@ -349,6 +350,8 @@ class RequestsWrapper(object):
         if config['kerberos_cache']:
             self.request_hooks.append(lambda: handle_kerberos_cache(config['kerberos_cache']))
 
+        self.ciphers = config.get('tls_ciphers')
+
     def get(self, url, **options):
         return self._request('get', url, options)
 
@@ -467,6 +470,7 @@ class RequestsWrapper(object):
             try:
                 context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS)
                 context.verify_mode = ssl.CERT_NONE
+                context.set_ciphers(self.ciphers)
 
                 with context.wrap_socket(sock, server_hostname=hostname) as secure_sock:
                     der_cert = secure_sock.getpeercert(binary_form=True)

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -156,7 +156,7 @@ class RequestsWrapper(object):
         'auth_token_handler',
         'request_size',
         'tls_protocols_allowed',
-        'ciphers',
+        'tls_ciphers_allowed',
     )
 
     def __init__(self, instance, init_config, remapper=None, logger=None, session=None):
@@ -351,7 +351,7 @@ class RequestsWrapper(object):
         if config['kerberos_cache']:
             self.request_hooks.append(lambda: handle_kerberos_cache(config['kerberos_cache']))
 
-        self.ciphers = config.get('tls_ciphers')
+        self.tls_ciphers_allowed = config.get('tls_ciphers')
 
     def get(self, url, **options):
         return self._request('get', url, options)
@@ -471,7 +471,7 @@ class RequestsWrapper(object):
             try:
                 context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS)
                 context.verify_mode = ssl.CERT_NONE
-                context.set_ciphers(self.ciphers)
+                context.set_ciphers(self.tls_ciphers_allowed)
 
                 with context.wrap_socket(sock, server_hostname=hostname) as secure_sock:
                     der_cert = secure_sock.getpeercert(binary_form=True)

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -156,6 +156,7 @@ class RequestsWrapper(object):
         'auth_token_handler',
         'request_size',
         'tls_protocols_allowed',
+        'ciphers',
     )
 
     def __init__(self, instance, init_config, remapper=None, logger=None, session=None):

--- a/datadog_checks_base/tests/base/utils/http/test_http.py
+++ b/datadog_checks_base/tests/base/utils/http/test_http.py
@@ -2,12 +2,12 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
+import ssl
 
 import mock
 import pytest
 import requests
 import requests_unixsocket
-import ssl
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.http import RequestsWrapper, is_uds_url, quote_uds_url
@@ -53,10 +53,12 @@ class TestTLSCiphers:
         http = RequestsWrapper(instance, init_config)
         mock_socket = mock.MagicMock()
 
-        with mock.patch.object(ssl.SSLContext, 'set_ciphers') as mock_set_ciphers, mock.patch('datadog_checks.base.utils.http.create_socket_connection', return_value=mock_socket):
+        with mock.patch.object(ssl.SSLContext, 'set_ciphers') as mock_set_ciphers, mock.patch(
+            'datadog_checks.base.utils.http.create_socket_connection', return_value=mock_socket
+        ):
             http.fetch_intermediate_certs('https://www.google.com')
             mock_set_ciphers.assert_called_once_with(expected_ciphers)
-    
+
 
 class TestRequestSize:
     def test_behavior_correct(self, mock_http_response):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
