### PR TITLE
Omit .* regex filter

### DIFF
--- a/postgres/changelog.d/19470.fixed
+++ b/postgres/changelog.d/19470.fixed
@@ -1,0 +1,1 @@
+Omit .* regex filter to avoid unnecessary work in query

--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -420,10 +420,12 @@ class RelationsManager(object):
                 relkind_filter = ','.join("'{}'".format(s) for s in r[RELKIND])
                 relation_filter.append('AND relkind = ANY(array[{}])'.format(relkind_filter))
 
-            relation_filter.append(')')
-            relations_filter.append(' '.join(relation_filter))
+            if relation_filter:
+                relation_filter.append(')')
+                relations_filter.append(' '.join(relation_filter))
 
-        relations_filter = '(' + ' OR '.join(relations_filter) + ')'
+        if relations_filter:
+            relations_filter = '(' + ' OR '.join(relations_filter) + ')'
         limits_filter = 'LIMIT {}'.format(self.max_relations)
         self.log.debug(
             "Running query: %s with relations matching: %s, limits %s", str(query), relations_filter, self.max_relations

--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -410,6 +410,9 @@ class RelationsManager(object):
                 relation_filter.append("( relname = '{}'".format(r[RELATION_NAME]))
             elif r.get(RELATION_REGEX) and r.get(RELATION_REGEX) != ".*":
                 relation_filter.append("( relname ~ '{}'".format(r[RELATION_REGEX]))
+            else:
+                # Stub filter to allow for appending
+                relation_filter.append("( 1=1")
 
             if ALL_SCHEMAS not in r[SCHEMAS]:
                 schema_filter = ','.join("'{}'".format(s) for s in r[SCHEMAS])
@@ -420,12 +423,10 @@ class RelationsManager(object):
                 relkind_filter = ','.join("'{}'".format(s) for s in r[RELKIND])
                 relation_filter.append('AND relkind = ANY(array[{}])'.format(relkind_filter))
 
-            if relation_filter:
-                relation_filter.append(')')
-                relations_filter.append(' '.join(relation_filter))
+            relation_filter.append(')')
+            relations_filter.append(' '.join(relation_filter))
 
-        if relations_filter:
-            relations_filter = '(' + ' OR '.join(relations_filter) + ')'
+        relations_filter = '(' + ' OR '.join(relations_filter) + ')'
         limits_filter = 'LIMIT {}'.format(self.max_relations)
         self.log.debug(
             "Running query: %s with relations matching: %s, limits %s", str(query), relations_filter, self.max_relations

--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -408,7 +408,7 @@ class RelationsManager(object):
             relation_filter = []
             if r.get(RELATION_NAME):
                 relation_filter.append("( relname = '{}'".format(r[RELATION_NAME]))
-            elif r.get(RELATION_REGEX):
+            elif r.get(RELATION_REGEX) and r.get(RELATION_REGEX) != ".*":
                 relation_filter.append("( relname ~ '{}'".format(r[RELATION_REGEX]))
 
             if ALL_SCHEMAS not in r[SCHEMAS]:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Omits the relation name filter when the regex is equal to `.*`.

### Motivation
<!-- What inspired you to submit this pull request? -->
This filter will match all but force the query to evaluate all rows for the match. Omitting it should improve performance.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
