### PR TITLE
Bump datadog-checks-base version

### DIFF
--- a/mysql/changelog.d/19478.fixed
+++ b/mysql/changelog.d/19478.fixed
@@ -1,0 +1,1 @@
+Bump datadog-checks-base version

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=36.14.0",
+    "datadog-checks-base>=37.4.0",
 ]
 dynamic = [
     "version",

--- a/postgres/changelog.d/19478.fixed
+++ b/postgres/changelog.d/19478.fixed
@@ -1,0 +1,1 @@
+Bump datadog-checks-base version

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=36.14.0",
+    "datadog-checks-base>=37.4.0",
 ]
 dynamic = [
     "version",

--- a/sqlserver/changelog.d/19478.fixed
+++ b/sqlserver/changelog.d/19478.fixed
@@ -1,0 +1,1 @@
+Bump datadog-checks-base version

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.0.0",
+    "datadog-checks-base>=37.4.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Bumps the dependency for DBM checks to properly include stub for emit_agent_telemetry.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
