### PR TITLE
Add option for sampling idle recently active sessions

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -609,6 +609,15 @@ files:
           value:
             type: number
             example: 10
+      - name: sample_recently_active_idle_sessions
+          description: |
+            This option will enable sampling idle sessions that were active since the last collection.
+            This is useful enhancing APM/DBM correlation.
+          value:
+            type: boolean
+            example: true
+            hidden: true
+
     - name: stored_procedure_characters_limit
       description: |
         Limit the number of characters of the text of a stored procedure that is collected.

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -609,14 +609,13 @@ files:
           value:
             type: number
             example: 10
-      - name: sample_recently_active_idle_sessions
+        - name: sample_recently_active_idle_sessions
           description: |
-            This option will enable sampling idle sessions that were active since the last collection.
-            This is useful enhancing APM/DBM correlation.
+            This option enables the sampling of idle sessions that were active since the last collection.
+            Recommended for APM customers to boost the APM/DBM correlation.
           value:
             type: boolean
             example: true
-            hidden: true
 
     - name: stored_procedure_characters_limit
       description: |

--- a/sqlserver/changelog.d/19479.added
+++ b/sqlserver/changelog.d/19479.added
@@ -1,0 +1,1 @@
+Add option for sampling idle recently active sessions. If yuo're an APM customer, set ``sample_recently_active_idle_sessions`` to ``true`` to boost APM/DBM correlations.

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -113,7 +113,7 @@ FROM sys.dm_exec_sessions sess
     INNER JOIN sys.dm_exec_connections c
         ON sess.session_id = c.session_id
     CROSS APPLY sys.dm_exec_sql_text(c.most_recent_sql_handle) lqt
-WHERE 
+WHERE
 """,
 ).strip()
 

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -107,7 +107,8 @@ SELECT
     c.client_net_address as client_address,
     sess.host_name as host_name,
     sess.program_name as program_name,
-    sess.is_user_process as is_user_process
+    sess.is_user_process as is_user_process,
+    sess.context_info as context_info
 FROM sys.dm_exec_sessions sess
     INNER JOIN sys.dm_exec_connections c
         ON sess.session_id = c.session_id

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -121,7 +121,9 @@ IDLE_BLOCKERS_FILTER = """(sess.status = 'sleeping'
     AND sess.session_id IN ({blocking_session_ids})
     AND c.session_id IN ({blocking_session_ids}))"""
 
-IDLE_RECENTLY_ACTIVE_FILTER = "(sess.status = 'sleeping' AND sess.last_request_start_time > DATEADD(SECOND, - ?, GETDATE()))"
+IDLE_RECENTLY_ACTIVE_FILTER = (
+    "(sess.status = 'sleeping' AND sess.last_request_start_time > DATEADD(SECOND, - ?, GETDATE()))"
+)
 
 
 # enumeration of the columns we collect
@@ -188,7 +190,9 @@ class SqlserverActivity(DBMAsyncJob):
         self._conn_key_prefix = "dbm-activity-"
         self._activity_payload_max_bytes = MAX_PAYLOAD_BYTES
         self._exec_requests_cols_cached = None
-        self._sample_recently_active_idle_sessions=is_affirmative(self._config.activity_config.get('sample_recently_active_idle_sessions', False))
+        self._sample_recently_active_idle_sessions = is_affirmative(
+            self._config.activity_config.get('sample_recently_active_idle_sessions', False)
+        )
         self._time_since_last_activity_event = 0
 
     def _close_db_conn(self):
@@ -210,7 +214,7 @@ class SqlserverActivity(DBMAsyncJob):
 
     def _is_sample_idle_recently_active_sessions(self) -> bool:
         return self._sample_recently_active_idle_sessions and self._time_since_last_activity_event
-    
+
     @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
     def _get_idle_sessions(self, cursor, blocking_session_ids):
         query = IDLE_SESSIONS_QUERY.format(
@@ -223,8 +227,11 @@ class SqlserverActivity(DBMAsyncJob):
             if idle_filter:
                 return f"{idle_filter} OR {filter}"
             return filter
+
         if blocking_session_ids:
-            idle_filter = _append_filter(IDLE_BLOCKERS_FILTER.format(blocking_session_ids=",".join(map(str, blocking_session_ids))))
+            idle_filter = _append_filter(
+                IDLE_BLOCKERS_FILTER.format(blocking_session_ids=",".join(map(str, blocking_session_ids)))
+            )
         if self._is_sample_idle_recently_active_sessions():
             idle_filter = _append_filter(IDLE_RECENTLY_ACTIVE_FILTER)
         query += idle_filter

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -237,7 +237,7 @@ class SqlserverActivity(DBMAsyncJob):
         query += idle_filter
         self.log.debug("Running query [%s]", query)
         if self._is_sample_idle_recently_active_sessions():
-            cursor.execute(query, (time.time() - self._time_since_last_activity_event))
+            cursor.execute(query, (int(time.time() - self._time_since_last_activity_event),))
         else:
             cursor.execute(query)
         columns = [i[0] for i in cursor.description]

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -237,7 +237,7 @@ class SqlserverActivity(DBMAsyncJob):
         query += idle_filter
         self.log.debug("Running query [%s]", query)
         if self._is_sample_idle_recently_active_sessions():
-            cursor.execute(query, int((time.time() - self._time_since_last_activity_event)))
+            cursor.execute(query, (time.time() - self._time_since_last_activity_event))
         else:
             cursor.execute(query)
         columns = [i[0] for i in cursor.description]

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -303,6 +303,7 @@ class QueryActivity(BaseModel):
     )
     collection_interval: Optional[float] = None
     enabled: Optional[bool] = None
+    sample_recently_active_idle_sessions: Optional[bool] = None
 
 
 class QueryMetrics(BaseModel):

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -419,6 +419,12 @@ instances:
         #
         # collection_interval: 10
 
+        ## @param sample_recently_active_idle_sessions - boolean - optional - default: true
+        ## This option enables the sampling of idle sessions that were active since the last collection.
+        ## Recommended for APM customers to boost the APM/DBM correlation.
+        #
+        # sample_recently_active_idle_sessions: true
+
     ## @param stored_procedure_characters_limit - integer - optional - default: 500
     ## Limit the number of characters of the text of a stored procedure that is collected.
     ## The characters limit is applicable to both query metrics and query samples.

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -58,7 +58,7 @@ def dbm_instance(instance_docker):
 
 def test_idle_sessions_sampling(dbm_instance, dd_run_check):
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
-    assert check.activity._sample_recently_active_idle_sessions, "Sample recently active idle sessions switched off by default"
+    assert not check.activity._sample_recently_active_idle_sessions, "Sample recently active idle sessions switched off by default"
     check.activity._sample_recently_active_idle_sessions = True
     check.activity._time_since_last_activity_event = 10
     dd_run_check(check)

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -56,6 +56,12 @@ def dbm_instance(instance_docker):
     instance_docker['collect_settings'] = {'enabled': False}
     return copy(instance_docker)
 
+def test_idle_sessions_sampling(dbm_instance, dd_run_check):
+    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
+    assert check.activity._sample_recently_active_idle_sessions, "Sample recently active idle sessions switched off by default"
+    check.activity._sample_recently_active_idle_sessions = True
+    check.activity._time_since_last_activity_event = 10
+    dd_run_check(check)
 
 @pytest.mark.flaky
 @pytest.mark.integration
@@ -908,3 +914,5 @@ def test_sanitize_activity_row(dbm_instance, row):
     row = check.activity._obfuscate_and_sanitize_row(row)
     assert isinstance(row['query_hash'], str)
     assert isinstance(row['query_plan_hash'], str)
+
+    

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -56,12 +56,16 @@ def dbm_instance(instance_docker):
     instance_docker['collect_settings'] = {'enabled': False}
     return copy(instance_docker)
 
+
 def test_idle_sessions_sampling(dbm_instance, dd_run_check):
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
-    assert not check.activity._sample_recently_active_idle_sessions, "Sample recently active idle sessions switched off by default"
+    assert (
+        not check.activity._sample_recently_active_idle_sessions
+    ), "Sample recently active idle sessions switched off by default"
     check.activity._sample_recently_active_idle_sessions = True
     check.activity._time_since_last_activity_event = 10
     dd_run_check(check)
+
 
 @pytest.mark.flaky
 @pytest.mark.integration
@@ -914,5 +918,3 @@ def test_sanitize_activity_row(dbm_instance, row):
     row = check.activity._obfuscate_and_sanitize_row(row)
     assert isinstance(row['query_hash'], str)
     assert isinstance(row['query_plan_hash'], str)
-
-    

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -57,6 +57,7 @@ def dbm_instance(instance_docker):
     return copy(instance_docker)
 
 
+@pytest.mark.usefixtures('dd_environment')
 def test_idle_sessions_sampling(dbm_instance, dd_run_check):
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
     assert (


### PR DESCRIPTION
### What does this PR do?
Adds an option to sample recently active idle sessions.

### Motivation
Improve APM/DBM correlation by ~3x.

For example, the execution plan for the query below, which ran in 2ms, was captured only after several executions:

![image](https://github.com/user-attachments/assets/3d0f6d7e-e721-47bb-b020-8db33bcbc4d7)

### Details
Capturing queries is essential for APM/DBM correlation. Currently, only active sessions are sampled, missing many fast queries. By sampling idle sessions that were recently active, we can significantly increase the number of captured queries.

### Trade off
The option is disabled by default because, in SQL Server, identifying queries from idle sessions requires a second scan, doubling activity collection time.

### Dependencies

Sampled idle sessions are excluded from the active sessions graph but appear in the samples with the `Wait Event` set to `Other`. If we don't filter them, they should be marked as `Idle`.

![image](https://github.com/user-attachments/assets/f1c5a976-cc4e-4281-aee2-751ad5eb7d18)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
