### PR TITLE
[SonarQube] Re-enable collection of metrics related to "New Code"

### DIFF
--- a/sonarqube/datadog_checks/sonarqube/check.py
+++ b/sonarqube/datadog_checks/sonarqube/check.py
@@ -104,7 +104,9 @@ class SonarqubeCheck(AgentCheck):
         for measure in metric_data['component']['measures']:
             tags = ['{}:{}'.format(tag_name, component)]
             tags.extend(self._tags)
-            value = measure['value'] if 'value' in measure else measure['period']['value'] # fallback to period.value for metrics that start with 'new_'
+            value = (
+                measure['value'] if 'value' in measure else measure['period']['value']
+            )  # fallback to period.value for metrics that start with 'new_'
             self.gauge(available_metrics[measure['metric']], value, tags=tags)
 
     def discover_available_metrics(self):
@@ -308,7 +310,4 @@ class SonarqubeCheck(AgentCheck):
 
     @staticmethod
     def is_valid_metric(metric):
-        return (
-            not metric['hidden']
-            and metric['type'] in NUMERIC_TYPES
-        )
+        return not metric['hidden'] and metric['type'] in NUMERIC_TYPES

--- a/sonarqube/datadog_checks/sonarqube/check.py
+++ b/sonarqube/datadog_checks/sonarqube/check.py
@@ -104,7 +104,8 @@ class SonarqubeCheck(AgentCheck):
         for measure in metric_data['component']['measures']:
             tags = ['{}:{}'.format(tag_name, component)]
             tags.extend(self._tags)
-            self.gauge(available_metrics[measure['metric']], measure['value'], tags=tags)
+            value = measure['value'] if 'value' in measure else measure['period']['value'] # fallback to period.value for metrics that start with 'new_'
+            self.gauge(available_metrics[measure['metric']], value, tags=tags)
 
     def discover_available_metrics(self):
         available_metrics = {}
@@ -310,6 +311,4 @@ class SonarqubeCheck(AgentCheck):
         return (
             not metric['hidden']
             and metric['type'] in NUMERIC_TYPES
-            # https://github.com/DataDog/integrations-core/pull/8552
-            and not metric['key'].startswith('new_')
         )

--- a/sonarqube/tests/api_responses/measures_component
+++ b/sonarqube/tests/api_responses/measures_component
@@ -146,6 +146,12 @@
 			"metric": "vulnerabilities",
 			"value": "0",
 			"bestValue": true
+		}, {
+			"metric": "new_vulnerabilities",
+			"period": {
+				"value": "0",
+				"bestValue": true
+			}
 		}]
 	}
 }


### PR DESCRIPTION
### What does this PR do?
Re-enables the collection of metrics that start with `new_` (e.g., `new_vulnerabilities`), which have been skipped since the following PR was merged.
- https://github.com/DataDog/integrations-core/pull/8552

Additionally, it includes a change in the method of extracting the value to prevent errors.

### Motivation
We want to utilize the metrics provided by SonarQube.

The official Datadog documentation states that these metrics can be used, creating a discrepancy between the feature and the documentation.
- https://docs.datadoghq.com/integrations/sonarqube

<img src="https://github.com/user-attachments/assets/bc5a06de-766c-4d5a-b323-a972f510631f" width="60%">

### About the metrics
The metrics that start with `new_` are about the stats of ["New Code"](https://docs.sonarsource.com/sonarqube-server/latest/core-concepts/clean-as-you-code/about-new-code/).
You can check the response data structure of `GET api/measures/component`  in the "Response Example" of the following link.
https://next.sonarqube.com/sonarqube/web_api/api/measures/component
```
...
    "measures": [
      {
        "metric": "complexity",
        "value": "12"
      },
      {
        "metric": "new_violations",
        "period": {
          "value": "25",
          "bestValue": false
        }
      },
...
```
 (In [the PR that I linked above](https://github.com/DataDog/integrations-core/pull/8552) had `"periods"` in the response data, but that was deprecated and is gone now)
So, with metrics that start with `new_`, you have to extract the value from not `measure['value']` but from `measure['period']['value']`.

Testing this change with my local datadog-agent, I have confirmed that the new metrics were also sent to Datadog.
<img src="https://github.com/user-attachments/assets/ede6dc85-6a79-4c59-8e9d-01106f2ee955" width="60%">

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
