### PR TITLE
Deactivate sample_recently_active_idle_sessions

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -610,6 +610,7 @@ files:
             type: number
             example: 10
         - name: sample_recently_active_idle_sessions
+          hidden: true
           description: |
             This option enables the sampling of idle sessions that were active since the last collection.
             Recommended for APM customers to boost the APM/DBM correlation.

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -615,7 +615,7 @@ files:
             Recommended for APM customers to boost the APM/DBM correlation.
           value:
             type: boolean
-            example: true
+            example: false
 
     - name: stored_procedure_characters_limit
       description: |

--- a/sqlserver/changelog.d/19479.added
+++ b/sqlserver/changelog.d/19479.added
@@ -1,1 +1,1 @@
-Add option for sampling idle recently active sessions. If yuo're an APM customer, set ``sample_recently_active_idle_sessions`` to ``true`` to boost APM/DBM correlations.
+Add an option to sample idle but recently active sessions. If you're an APM customer, set ``sample_recently_active_idle_sessions`` to ``true`` to improve APM/DBM correlations.

--- a/sqlserver/changelog.d/19479.added
+++ b/sqlserver/changelog.d/19479.added
@@ -1,1 +1,0 @@
-Add an option to sample idle but recently active sessions. If you're an APM customer, set ``sample_recently_active_idle_sessions`` to ``true`` to improve APM/DBM correlations.

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -419,11 +419,11 @@ instances:
         #
         # collection_interval: 10
 
-        ## @param sample_recently_active_idle_sessions - boolean - optional - default: true
+        ## @param sample_recently_active_idle_sessions - boolean - optional - default: false
         ## This option enables the sampling of idle sessions that were active since the last collection.
         ## Recommended for APM customers to boost the APM/DBM correlation.
         #
-        # sample_recently_active_idle_sessions: true
+        # sample_recently_active_idle_sessions: false
 
     ## @param stored_procedure_characters_limit - integer - optional - default: 500
     ## Limit the number of characters of the text of a stored procedure that is collected.

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -419,12 +419,6 @@ instances:
         #
         # collection_interval: 10
 
-        ## @param sample_recently_active_idle_sessions - boolean - optional - default: false
-        ## This option enables the sampling of idle sessions that were active since the last collection.
-        ## Recommended for APM customers to boost the APM/DBM correlation.
-        #
-        # sample_recently_active_idle_sessions: false
-
     ## @param stored_procedure_characters_limit - integer - optional - default: 500
     ## Limit the number of characters of the text of a stored procedure that is collected.
     ## The characters limit is applicable to both query metrics and query samples.


### PR DESCRIPTION
### What does this PR do?

Hiding the feature:
- removing the `conf.yaml.example` entry
- deleting the change log entry
- setting default to `False`

### Motivation

We are considering sending idle events (except for idle blocker) as a separate `dbm_type` event.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
