### PR TITLE
Fix FIPS E2E workflow

### DIFF
--- a/.github/workflows/test-fips-e2e.yml
+++ b/.github/workflows/test-fips-e2e.yml
@@ -7,6 +7,10 @@ on:
         description: "Agent image to use"
         required: false
         type: string
+      agent-image-fips:
+        description: "FIPS Agent image to use"
+        required: false
+        type: string
       target:
         description: "Target to test"
         required: false
@@ -29,7 +33,6 @@ jobs:
     env:
       FORCE_COLOR: "1"
       PYTHON_VERSION: "3.12"
-      DDEV_E2E_AGENT: "${{ inputs.agent-image || 'datadog/agent-dev:master-fips' }}"
       # Test results for later processing
       TEST_RESULTS_BASE_DIR: "test-results"
       # Tracing to monitor our test suite
@@ -45,7 +48,7 @@ jobs:
 
     - name: Set environment variables with sanitized paths
       run: |
-        JOB_NAME="test-fips"
+        JOB_NAME="test-fips-e2e"
 
         echo "TEST_RESULTS_DIR=$TEST_RESULTS_BASE_DIR/$JOB_NAME" >> $GITHUB_ENV
         echo "TRACE_CAPTURE_FILE=$TRACE_CAPTURE_BASE_DIR/$JOB_NAME" >> $GITHUB_ENV
@@ -104,15 +107,17 @@ jobs:
 
     - name: Run E2E tests with FIPS disabled
       env:
+        DDEV_E2E_AGENT: "${{ inputs.agent-image || 'datadog/agent-dev:master-py3' }}"
         DD_API_KEY: "${{ secrets.DD_API_KEY }}"
       run: |
-        ddev env test -e GOFIPS=0 --base --new-env --junit ${{ inputs.target || 'tls' }} -- all -m "fips_off"
+        ddev env test --base --new-env --junit ${{ inputs.target || 'tls' }} -- all -m "fips_off"
 
     - name: Run E2E tests with FIPS enabled
       env:
+        DDEV_E2E_AGENT: "${{ inputs.agent-image-fips || 'datadog/agent-dev:master-fips' }}"
         DD_API_KEY: "${{ secrets.DD_API_KEY }}"
       run: |
-        ddev env test -e GOFIPS=1 --base --new-env --junit ${{ inputs.target || 'tls' }} -- all -k "fips_on"
+        ddev env test --base --new-env --junit ${{ inputs.target || 'tls' }} -- all -k "fips_on"
 
     - name: View trace log
       if: always()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR modifies the FIPS E2E test to use the standard Agent for the tests where FIPS is disabled.

### Motivation
<!-- What inspired you to submit this pull request? -->
Starting the FIPS Agent with `GOFIPS=0` does not impact the config loaded by the Agent's OpenSSL, which means it still operates in FIPS mode.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
