### PR TITLE
Loosen pin for github action that uploads ddev to PYPI

### DIFF
--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -577,7 +577,7 @@ jobs:
 
     permissions:
       contents: write
-      
+
     steps:
     - name: Download Python artifacts
       uses: actions/download-artifact@v4
@@ -600,7 +600,7 @@ jobs:
         merge-multiple: true
 
     - name: Push Python artifacts to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.8.14
+      uses: pypa/gh-action-pypi-publish@v1
       with:
         skip-existing: true
         user: __token__


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Status quo: hatch is not pinned, but the tooling to publish to PYPI is hard pinned.

They can become out of sync, which is what caused one release of ddev not to be uploaded:
https://github.com/DataDog/integrations-core/actions/runs/12890858404

To be exact, `hatch` [produced metadata v2.4](https://github.com/pypa/hatch/releases/tag/hatchling-v1.27.0), but twine from the github action was too old to support that (that support added [in 1.12.3](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.12.3)). So the upload failed.


We have 2 options: either pin both or relax the pin for PYPI upload tooling.
Pinning hatch sounds like more maintenance.

Having `v1` will be enough to make sure we don't get breaking changes for this action while getting the latest stuff that's compatible with hatch updates.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
