### PR TITLE
Fix pin for PYPI publish action

### DIFF
--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -600,7 +600,7 @@ jobs:
         merge-multiple: true
 
     - name: Push Python artifacts to PyPI
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         skip-existing: true
         user: __token__


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
This workflow uses a non-standard naming convention for their releases. I only noticed it in their docs after our workflow to publish ddev failed again.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
