### PR TITLE
[sqlserver] add raw_signature to plan event

### DIFF
--- a/sqlserver/changelog.d/19495.added
+++ b/sqlserver/changelog.d/19495.added
@@ -1,0 +1,1 @@
+Add `raw_signature` to raw query plan event payload.

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -626,9 +626,12 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                         'total_elapsed_time': row.get('total_elapsed_time', None),
                     },
                 }
-                yield obfuscated_plan_event
                 if self._collect_raw_query_statement:
                     raw_plan_event = copy.deepcopy(obfuscated_plan_event)
                     raw_plan_event["dbm_type"] = "rqp"  # raw query plan
                     raw_plan_event["db"]["plan"]["definition"] = raw_plan
+                    # add the raw signature to the event so we can use it to look up the raw plan
+                    raw_plan_event["db"]["plan"]["raw_signature"] = row['query_plan_hash']
+                    obfuscated_plan_event["db"]["plan"]["raw_signature"] = row['query_plan_hash']
                     yield raw_plan_event
+                yield obfuscated_plan_event

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -477,6 +477,7 @@ def test_statement_metrics_and_plans(
                 assert not event['db']['query_signature'], "procedure plans should not have query_signature field set"
             else:
                 assert event['db']['plan']['definition'], "event plan definition missing"
+                assert event['db']['plan']['raw_signature'], "event plan raw signature missing"
                 parsed_plan = ET.fromstring(event['db']['plan']['definition'])
                 assert parsed_plan.tag.endswith("ShowPlanXML"), "plan does not match expected structure"
                 assert not event['sqlserver']['is_plan_encrypted']


### PR DESCRIPTION
### What does this PR do?
This PR adds `raw_signature` to `rqp` (raw query plan) event. `raw_signature` can be used to lookup de-obfuscated explain plan. 

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4952

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
