### PR TITLE
Port changelogs and version bumps from 7.63 RC3 to master.

### DIFF
--- a/pgbouncer/CHANGELOG.md
+++ b/pgbouncer/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 8.1.1 / 2025-01-29
+
+***Fixed***:
+
+* Revert "Upgrade PGBouncer to psycopg3" due to instability in testing ([#19497](https://github.com/DataDog/integrations-core/pull/19497))
+
 ## 8.1.0 / 2025-01-25
 
 ***Security***:

--- a/pgbouncer/changelog.d/19497.fixed
+++ b/pgbouncer/changelog.d/19497.fixed
@@ -1,1 +1,0 @@
-Revert "Upgrade PGBouncer to psycopg3" due to instability in testing

--- a/pgbouncer/datadog_checks/pgbouncer/__about__.py
+++ b/pgbouncer/datadog_checks/pgbouncer/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = "8.1.0"
+__version__ = "8.1.1"

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 22.5.1 / 2025-01-29
+
+***Fixed***:
+
+* Revert "Upgrade postgres to psycopg3" due to instability in testing ([#19499](https://github.com/DataDog/integrations-core/pull/19499))
+
 ## 22.5.0 / 2025-01-25
 
 ***Added***:

--- a/postgres/changelog.d/19499.fixed
+++ b/postgres/changelog.d/19499.fixed
@@ -1,1 +1,0 @@
-Revert "Upgrade postgres to psycopg3" due to instability in testing

--- a/postgres/datadog_checks/postgres/__about__.py
+++ b/postgres/datadog_checks/postgres/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "22.5.0"
+__version__ = "22.5.1"

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -142,11 +142,11 @@ datadog-ossec-security==2.0.0
 datadog-palo-alto-panorama==1.0.0
 datadog-pan-firewall==3.0.0
 datadog-pdh-check==4.1.0; sys_platform == 'win32'
-datadog-pgbouncer==8.1.0; sys_platform != 'win32'
+datadog-pgbouncer==8.1.1; sys_platform != 'win32'
 datadog-php-fpm==5.1.0
 datadog-ping-federate==2.0.0
 datadog-postfix==3.0.0; sys_platform != 'win32'
-datadog-postgres==22.5.0
+datadog-postgres==22.5.1
 datadog-powerdns-recursor==4.1.0
 datadog-presto==3.1.0
 datadog-process==5.0.0


### PR DESCRIPTION
Port changelogs and version bumps from [7.63.0-rc.3](https://github.com/DataDog/integrations-core/releases/tag/7.63.0-rc.3) to master.