### PR TITLE
Sy/fix msk

### DIFF
--- a/amazon_msk/changelog.d/19552.added
+++ b/amazon_msk/changelog.d/19552.added
@@ -1,1 +1,1 @@
-Allow for check to skip over nodes with empty brokerinfo fields
+Allow for check to skip over nodes with empty `BrokerNodeInfo` fields

--- a/amazon_msk/changelog.d/19552.added
+++ b/amazon_msk/changelog.d/19552.added
@@ -1,1 +1,1 @@
-Allow for check to skip over nodes with brokerinfo
+Allow for check to skip over nodes with empty brokerinfo fields

--- a/amazon_msk/changelog.d/19552.added
+++ b/amazon_msk/changelog.d/19552.added
@@ -1,0 +1,1 @@
+Allow for check to skip over nodes with brokerinfo

--- a/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py
+++ b/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py
@@ -103,7 +103,11 @@ class AmazonMskCheck(OpenMetricsBaseCheck):
             self.service_check(self.SERVICE_CHECK_CONNECT, self.OK, tags=self._scraper_config['custom_tags'])
 
         for node_info in response['NodeInfoList']:
-            broker_info = node_info['BrokerNodeInfo']
+            broker_info = node_info.get('BrokerNodeInfo')
+            if not broker_info:
+                self.log.debug('NodeInfo does not contain BrokerNodeInfo, skipping')
+                continue
+
             self._scraper_config['_metric_tags'] = ['broker_id:{}'.format(broker_info['BrokerId'])]
 
             for endpoint in broker_info['Endpoints']:

--- a/amazon_msk/datadog_checks/amazon_msk/check.py
+++ b/amazon_msk/datadog_checks/amazon_msk/check.py
@@ -96,7 +96,11 @@ class AmazonMskCheckV2(OpenMetricsBaseCheckV2, ConfigMixin):
         scrapers = {}
 
         for node_info in response['NodeInfoList']:
-            broker_info = node_info['BrokerNodeInfo']
+            broker_info = node_info.get('BrokerNodeInfo')
+            if not broker_info:
+                self.log.debug('NodeInfo does not contain BrokerNodeInfo, skipping')
+                continue
+
             broker_id_tag = f'broker_id:{broker_info["BrokerId"]}'
 
             for endpoint in broker_info['Endpoints']:

--- a/amazon_msk/tests/fixtures/list_nodes.json
+++ b/amazon_msk/tests/fixtures/list_nodes.json
@@ -1,6 +1,14 @@
 {
   "NodeInfoList": [
     {
+      "nodeType": "CONTROLLER",
+      "controllerNodeInfo": {
+        "endpoints": [
+          "b-2.msk-integrate.ch6uni.c6.kafka.us-east-1.amazonaws.com"
+        ]
+      }
+    },
+    {
       "AddedToClusterTime": "2019-11-22T23:44:28.725Z",
       "BrokerNodeInfo": {
         "AttachedENIId": "eni-12a34b56c78d90e",

--- a/amazon_msk/tests/test_unit.py
+++ b/amazon_msk/tests/test_unit.py
@@ -29,7 +29,9 @@ def test_node_check_legacy(aggregator, instance_legacy, mock_client):
     aggregator.assert_service_check(c.SERVICE_CHECK_CONNECT, c.OK, tags=global_tags)
 
     for node_info in client.list_nodes()['NodeInfoList']:
-        broker_info = node_info['BrokerNodeInfo']
+        broker_info = node_info.get('BrokerNodeInfo')
+        if broker_info is None:
+            continue
         broker_tags = ['broker_id:{}'.format(broker_info['BrokerId'])]
         broker_tags.extend(global_tags)
 
@@ -99,7 +101,10 @@ def test_node_check(aggregator, dd_run_check, instance, mock_client):
     aggregator.assert_service_check('aws.msk.{}'.format(c.SERVICE_CHECK_CONNECT), c.OK, tags=global_tags)
 
     for node_info in client.list_nodes()['NodeInfoList']:
-        broker_info = node_info['BrokerNodeInfo']
+        broker_info = node_info.get('BrokerNodeInfo')
+        if broker_info is None:
+            continue
+
         broker_tags = ['broker_id:{}'.format(broker_info['BrokerId'])]
         broker_tags.extend(global_tags)
 
@@ -222,7 +227,9 @@ def test_custom_metric_path(aggregator, instance_legacy, mock_client):
     aggregator.assert_service_check(c.SERVICE_CHECK_CONNECT, c.OK, tags=global_tags)
 
     for node_info in client.list_nodes()['NodeInfoList']:
-        broker_info = node_info['BrokerNodeInfo']
+        broker_info = node_info.get('BrokerNodeInfo')
+        if broker_info is None:
+            continue
         broker_tags = ['broker_id:{}'.format(broker_info['BrokerId'])]
         broker_tags.extend(global_tags)
 


### PR DESCRIPTION
### What does this PR do?
It's been reported that certain msk clusters can contain entries for nodes that don't have a BrokerNodeInfo field. The check breaks on such scenarios because it's trying to access the field in a non graceful way. This change will skip over the nodes that fit such scenario so that data can be continued to be access in other nodes.

Motivation:
https://github.com/DataDog/integrations-core/issues/17743

Credit for fix to @jcarvalho
