### PR TITLE
[mongo] collect mongodb activity lsid and transaction

### DIFF
--- a/mongo/datadog_checks/mongo/dbm/slow_operations.py
+++ b/mongo/datadog_checks/mongo/dbm/slow_operations.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 
+import binascii
 import time
 from datetime import datetime
 
@@ -353,6 +354,7 @@ class MongoSlowOperations(DBMAsyncJob):
                     "lock_stats": self._get_slow_operation_lock_stats(slow_operation),
                     "flow_control_stats": self._get_slow_operation_flow_control_stats(slow_operation),
                     "cursor": self._get_slow_operation_cursor(slow_operation),
+                    "lsid": self._get_slow_operation_lsid(slow_operation["command"]),
                 }
             ),
         }
@@ -377,6 +379,15 @@ class MongoSlowOperations(DBMAsyncJob):
                 "comment": slow_operation.get("originatingCommandComment"),
             }
         return None
+
+    def _get_slow_operation_lsid(self, command):
+        lsid = command.get("lsid")
+        if not lsid or not lsid.get("id"):
+            return None
+
+        return {
+            "id": binascii.hexlify(lsid['id']).decode(),
+        }
 
     def _get_slow_operation_lock_stats(self, slow_operation):
         lock_stats = slow_operation.get("locks")

--- a/mongo/datadog_checks/mongo/dbm/types.py
+++ b/mongo/datadog_checks/mongo/dbm/types.py
@@ -125,6 +125,18 @@ class OperationSampleOperationStatsCursor(TypedDict, total=False):
     operation_using_cursor_id: Optional[str]
 
 
+class OperationSampleOperationStatsTransaction(TypedDict, total=False):
+    txn_number: int
+    txn_retry_counter: int
+    time_open_micros: int
+    time_active_micros: int
+    time_inactive_micros: int
+
+
+class OperationSampleOperationStatsLsid(TypedDict, total=False):
+    id: str
+
+
 class OperationSampleOperationStats(TypedDict, total=False):
     active: bool
     desc: Optional[str]
@@ -134,7 +146,6 @@ class OperationSampleOperationStats(TypedDict, total=False):
     query_framework: Optional[str]
     current_op_time: str
     microsecs_running: Optional[int]
-    transaction_time_open_micros: Optional[int]
     prepare_read_conflicts: Optional[int]
     write_conflicts: Optional[int]
     num_yields: Optional[int]
@@ -145,6 +156,8 @@ class OperationSampleOperationStats(TypedDict, total=False):
     flow_control_stats: Optional[OperationSampleOperationStatsFlowControlStats]
     waiting_for_latch: Optional[OperationSampleOperationStatsWaitingForLatch]
     cursor = Optional[OperationSampleOperationStatsCursor]
+    transaction = Optional[OperationSampleOperationStatsTransaction]
+    lsid = Optional[OperationSampleOperationStatsLsid]
 
 
 class OperationSampleActivityBase(TypedDict, total=False):

--- a/mongo/tests/fixtures/$currentOp-mongos
+++ b/mongo/tests/fixtures/$currentOp-mongos
@@ -54,6 +54,28 @@
                 }
             }
         },
+        "transaction": {
+            "parameters": {
+                "txnNumber": 392,
+                "txnRetryCounter": 0,
+                "autocommit": false,
+                "readConcern": {
+                    "level": "local",
+                    "provenance": "implicitDefault"
+                }
+            },
+            "readTimestamp": {
+                "$timestamp": {
+                    "t": 0,
+                    "i": 0
+                }
+            },
+            "startWallClockTime": "2025-02-04T18:45:22.915+00:00",
+            "timeOpenMicros": 1750,
+            "timeActiveMicros": 435,
+            "timeInactiveMicros": 1315,
+            "expiryTime": "2025-02-04T18:46:22.915+00:00"
+        },
         "secs_running": 0,
         "microsecs_running": 29232,
         "op": "query",

--- a/mongo/tests/results/operation-activities-mongos.json
+++ b/mongo/tests/results/operation-activities-mongos.json
@@ -27,11 +27,13 @@
                 "query_framework": null,
                 "current_op_time": "2024-05-20T14:36:56.231+00:00",
                 "microsecs_running": 29232,
-                "transaction_time_open_micros": null,
                 "prepare_read_conflicts": 0,
                 "write_conflicts": 0,
                 "num_yields": 0,
                 "waiting_for_lock": false,
+                "lsid": {
+                    "id": "ff95bad791504c36ab749ae8c640d54e"
+                },
                 "locks": {
                     "feature_compatibility_version": "r",
                     "global": "r"
@@ -63,6 +65,13 @@
                 "type": "op",
                 "op": "query",
                 "shard": "shard04",
+                "transaction": {
+                    "time_active_micros": 435,
+                    "time_inactive_micros": 1315,
+                    "time_open_micros": 1750,
+                    "txn_number": 392,
+                    "txn_retry_counter": 0
+                },
                 "dbname": "integration",
                 "application": null,
                 "collection": "users",
@@ -96,11 +105,13 @@
                 "query_framework": "classic",
                 "current_op_time": "2024-06-13T20:50:10.834+00:00",
                 "microsecs_running": 26789,
-                "transaction_time_open_micros": null,
                 "prepare_read_conflicts": 0,
                 "write_conflicts": 0,
                 "num_yields": 1,
                 "waiting_for_lock": false,
+                "lsid": {
+                    "id": "ccb77e0cda6441daa458dd4067cdbc48"
+                },
                 "locks": {
                     "feature_compatibility_version": "r",
                     "global": "r"
@@ -142,6 +153,7 @@
                 "type": "op",
                 "op": "getmore",
                 "shard": null,
+                "transaction": null,
                 "dbname": "integration",
                 "application": "orders-mongo",
                 "collection": "movies",
@@ -173,11 +185,11 @@
                 "query_framework": "classic",
                 "current_op_time": "2024-08-06T20:59:35.394+00:00",
                 "microsecs_running": 13134,
-                "transaction_time_open_micros": null,
                 "prepare_read_conflicts": 0,
                 "write_conflicts": 0,
                 "num_yields": 2,
                 "waiting_for_lock": false,
+                "lsid": null,
                 "locks": {},
                 "lock_stats": {
                     "feature_compatibility_version": {
@@ -211,6 +223,7 @@
                 "type": "op",
                 "op": "getmore",
                 "shard": null,
+                "transaction": null,
                 "dbname": "local",
                 "application": "OplogFetcher",
                 "collection": "oplog.rs",

--- a/mongo/tests/results/operation-activities-standalone.json
+++ b/mongo/tests/results/operation-activities-standalone.json
@@ -26,11 +26,13 @@
                 "query_framework": null,
                 "current_op_time": "2024-05-16T18:06:38.419+00:00",
                 "microsecs_running": 167,
-                "transaction_time_open_micros": null,
                 "prepare_read_conflicts": 0,
                 "write_conflicts": 0,
                 "num_yields": 0,
                 "waiting_for_lock": false,
+                "lsid": {
+                    "id": "fe7f64529521475ca6263130bc2c926e"
+                },
                 "locks": {
                     "feature_compatibility_version": "r",
                     "global": "r"
@@ -64,6 +66,7 @@
                 "type": "op",
                 "op": "query",
                 "shard": null,
+                "transaction": null,
                 "dbname": "integration",
                 "application": null,
                 "collection": "products",
@@ -97,12 +100,12 @@
                 "query_framework": "classic",
                 "current_op_time": "2024-08-06T20:59:35.394+00:00",
                 "microsecs_running": 13134,
-                "transaction_time_open_micros": null,
                 "prepare_read_conflicts": 0,
                 "write_conflicts": 0,
                 "num_yields": 2,
                 "waiting_for_lock": false,
                 "locks": {},
+                "lsid": null,
                 "lock_stats": {
                     "feature_compatibility_version": {
                         "acquire_count": {
@@ -135,6 +138,7 @@
                 "type": "op",
                 "op": "getmore",
                 "shard": null,
+                "transaction": null,
                 "dbname": "local",
                 "application": "OplogFetcher",
                 "collection": "oplog.rs",

--- a/mongo/tests/results/operation-samples-mongos.json
+++ b/mongo/tests/results/operation-samples-mongos.json
@@ -723,11 +723,20 @@
             "query_framework": null,
             "current_op_time": "2024-05-20T14:36:56.231+00:00",
             "microsecs_running": 29232,
-            "transaction_time_open_micros": null,
+            "transaction": {
+                "time_active_micros": 435,
+                "time_inactive_micros": 1315,
+                "time_open_micros": 1750,
+                "txn_number": 392,
+                "txn_retry_counter": 0
+            },
             "prepare_read_conflicts": 0,
             "write_conflicts": 0,
             "num_yields": 0,
             "waiting_for_lock": false,
+            "lsid": {
+                "id": "ff95bad791504c36ab749ae8c640d54e"
+            },
             "locks": {
                 "feature_compatibility_version": "r",
                 "global": "r"

--- a/mongo/tests/results/operation-samples-standalone.json
+++ b/mongo/tests/results/operation-samples-standalone.json
@@ -144,11 +144,13 @@
             "query_framework": null,
             "current_op_time": "2024-05-16T18:06:38.419+00:00",
             "microsecs_running": 167,
-            "transaction_time_open_micros": null,
             "prepare_read_conflicts": 0,
             "write_conflicts": 0,
             "num_yields": 0,
             "waiting_for_lock": false,
+            "lsid": {
+                "id": "fe7f64529521475ca6263130bc2c926e"
+            },
             "locks": {
                 "feature_compatibility_version": "r",
                 "global": "r"
@@ -182,6 +184,7 @@
             "type": "op",
             "op": "query",
             "shard": null,
+            "transaction": null,
             "collection": "products",
             "comment": "find",
             "truncated": "not_truncated"


### PR DESCRIPTION
### What does this PR do?
This PR enhances MongoDB activity sampling by collecting lsid (logical session ID) and transaction details from the $currentOp response. These fields provide insights into session-based operations and multi-document transactions, improving visibility into active database operations.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
