### PR TITLE
Omit null and empty values in mysql schema definition

### DIFF
--- a/mysql/datadog_checks/mysql/databases_data.py
+++ b/mysql/datadog_checks/mysql/databases_data.py
@@ -350,12 +350,7 @@ class DatabasesData:
         rows = cursor.fetchall()
         if not rows:
             return
-        table_index_dict = defaultdict(
-            lambda: defaultdict(
-                lambda: {
-                }
-            )
-        )
+        table_index_dict = defaultdict(lambda: defaultdict(lambda: {}))
         for row in rows:
             table_name = str(row["table_name"])
             table_list[table_name_to_table_index[table_name]].setdefault("indexes", [])
@@ -373,10 +368,7 @@ class DatabasesData:
             # Add column info, if exists
             if row["column_name"]:
                 index_data.setdefault("columns", [])
-                column = {
-                    "name": row["column_name"],
-                    "nullable": bool(row["nullable"].lower() == "yes")
-                }
+                column = {"name": row["column_name"], "nullable": bool(row["nullable"].lower() == "yes")}
                 if row["sub_part"]:
                     column["sub_part"] = int(row["sub_part"])
                 if row["collation"]:

--- a/mysql/datadog_checks/mysql/databases_data.py
+++ b/mysql/datadog_checks/mysql/databases_data.py
@@ -373,15 +373,15 @@ class DatabasesData:
             index_data["cardinality"] = int(row["cardinality"])
             index_data["index_type"] = str(row["index_type"])
             index_data["non_unique"] = bool(row["non_unique"])
-            index_data["expression"] = str(row["expression"]) if row["expression"] else None
+            index_data["expression"] = str(row["expression"]) if row["expression"] else ""
 
             # Add column info, if exists
             if row["column_name"]:
                 column = {
                     "name": row["column_name"],
-                    "sub_part": int(row["sub_part"]) if row["sub_part"] else None,
-                    "collation": str(row["collation"]) if row["collation"] else None,
-                    "packed": str(row["packed"]) if row["packed"] else None,
+                    "sub_part": int(row["sub_part"]) if row["sub_part"] else 0,
+                    "collation": str(row["collation"]) if row["collation"] else "",
+                    "packed": str(row["packed"]) if row["packed"] else "",
                     "nullable": bool(row["nullable"].lower() == "yes"),
                 }
                 index_data["columns"].append(column)

--- a/mysql/tests/test_metadata.py
+++ b/mysql/tests/test_metadata.py
@@ -166,21 +166,21 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                         "columns": [
                             {
                                 "name": "RestaurantName",
-                                "sub_part": None,
+                                "sub_part": 0,
                                 "collation": "A",
-                                "packed": None,
+                                "packed": "",
                                 "nullable": True,
                             },
                             {
                                 "name": "District",
-                                "sub_part": None,
+                                "sub_part": 0,
                                 "collation": "A",
-                                "packed": None,
+                                "packed": "",
                                 "nullable": True,
                             },
                         ],
                         "non_unique": True,
-                        "expression": None,
+                        "expression": "",
                     }
                 ],
             },
@@ -226,21 +226,21 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                         "columns": [
                             {
                                 "name": "RestaurantName",
-                                "sub_part": None,
+                                "sub_part": 0,
                                 "collation": "A",
-                                "packed": None,
+                                "packed": "",
                                 "nullable": True,
                             },
                             {
                                 "name": "District",
-                                "sub_part": None,
+                                "sub_part": 0,
                                 "collation": "A",
-                                "packed": None,
+                                "packed": "",
                                 "nullable": True,
                             },
                         ],
                         "non_unique": False,
-                        "expression": None,
+                        "expression": "",
                     }
                 ],
             },
@@ -286,14 +286,14 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                         "columns": [
                             {
                                 "name": "id",
-                                "sub_part": None,
+                                "sub_part": 0,
                                 "collation": "A",
-                                "packed": None,
+                                "packed": "",
                                 "nullable": False,
                             }
                         ],
                         "non_unique": False,
-                        "expression": None,
+                        "expression": "",
                     },
                     {
                         "name": "single_column_index",
@@ -302,14 +302,14 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                         "columns": [
                             {
                                 "name": "population",
-                                "sub_part": None,
+                                "sub_part": 0,
                                 "collation": "A",
-                                "packed": None,
+                                "packed": "",
                                 "nullable": False,
                             }
                         ],
                         "non_unique": True,
-                        "expression": None,
+                        "expression": "",
                     },
                     {
                         "name": "two_columns_index",
@@ -318,9 +318,9 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                         "columns": [
                             {
                                 "name": "id",
-                                "sub_part": None,
+                                "sub_part": 0,
                                 "collation": "A",
-                                "packed": None,
+                                "packed": "",
                                 "nullable": False,
                             },
                             {
@@ -334,12 +334,12 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                                     )
                                     else 'A'
                                 ),
-                                "packed": None,
+                                "packed": "",
                                 "nullable": True,
                             },
                         ],
                         "non_unique": True,
-                        "expression": None,
+                        "expression": "",
                     },
                     *(
                         [
@@ -441,14 +441,14 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                         "columns": [
                             {
                                 "name": "id",
-                                "sub_part": None,
+                                "sub_part": 0,
                                 "collation": "A",
-                                "packed": None,
+                                "packed": "",
                                 "nullable": False,
                             }
                         ],
                         "non_unique": False,
-                        "expression": None,
+                        "expression": "",
                     }
                 ],
             },
@@ -496,14 +496,14 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                         "columns": [
                             {
                                 "name": "city_id",
-                                "sub_part": None,
+                                "sub_part": 0,
                                 "collation": "A",
-                                "packed": None,
+                                "packed": "",
                                 "nullable": True,
                             },
                         ],
                         "non_unique": True,
-                        "expression": None,
+                        "expression": "",
                     }
                 ],
             },
@@ -547,14 +547,14 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                         "columns": [
                             {
                                 "name": "name",
-                                "sub_part": None,
+                                "sub_part": 0,
                                 "collation": "A",
-                                "packed": None,
+                                "packed": "",
                                 "nullable": True,
                             },
                         ],
                         "non_unique": False,
-                        "expression": None,
+                        "expression": "",
                     }
                 ],
             },

--- a/mysql/tests/test_metadata.py
+++ b/mysql/tests/test_metadata.py
@@ -682,11 +682,6 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
     for db_name, actual_payload in actual_payloads.items():
         normalize_values(actual_payload)
         assert db_name in databases_to_find
-        if not deep_compare(expected_data_for_db[db_name], actual_payload):
-            print("Expected:")
-            print(json.dumps(expected_data_for_db[db_name], indent=4))
-            print("Actual:")
-            print(json.dumps(actual_payload, indent=4))
         assert deep_compare(expected_data_for_db[db_name], actual_payload)
 
 

--- a/mysql/tests/test_metadata.py
+++ b/mysql/tests/test_metadata.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-import json
 import re
 from os import environ
 

--- a/mysql/tests/test_metadata.py
+++ b/mysql/tests/test_metadata.py
@@ -51,7 +51,7 @@ def normalize_values(actual_payload):
                     partition["partition_expression"] = (
                         partition["partition_expression"].replace("`", "").lower().strip()
                     )
-                if partition["subpartitions"] is not None:
+                if "subpartitions" in partition and partition["subpartitions"]:
                     for subpartition in partition["subpartitions"]:
                         if subpartition["subpartition_expression"] is not None:
                             subpartition["subpartition_expression"] = (
@@ -166,21 +166,16 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                         "columns": [
                             {
                                 "name": "RestaurantName",
-                                "sub_part": 0,
                                 "collation": "A",
-                                "packed": "",
                                 "nullable": True,
                             },
                             {
                                 "name": "District",
-                                "sub_part": 0,
                                 "collation": "A",
-                                "packed": "",
                                 "nullable": True,
                             },
                         ],
                         "non_unique": True,
-                        "expression": "",
                     }
                 ],
             },
@@ -226,21 +221,16 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                         "columns": [
                             {
                                 "name": "RestaurantName",
-                                "sub_part": 0,
                                 "collation": "A",
-                                "packed": "",
                                 "nullable": True,
                             },
                             {
                                 "name": "District",
-                                "sub_part": 0,
                                 "collation": "A",
-                                "packed": "",
                                 "nullable": True,
                             },
                         ],
                         "non_unique": False,
-                        "expression": "",
                     }
                 ],
             },
@@ -286,14 +276,11 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                         "columns": [
                             {
                                 "name": "id",
-                                "sub_part": 0,
                                 "collation": "A",
-                                "packed": "",
                                 "nullable": False,
                             }
                         ],
                         "non_unique": False,
-                        "expression": "",
                     },
                     {
                         "name": "single_column_index",
@@ -302,14 +289,11 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                         "columns": [
                             {
                                 "name": "population",
-                                "sub_part": 0,
                                 "collation": "A",
-                                "packed": "",
                                 "nullable": False,
                             }
                         ],
                         "non_unique": True,
-                        "expression": "",
                     },
                     {
                         "name": "two_columns_index",
@@ -318,9 +302,7 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                         "columns": [
                             {
                                 "name": "id",
-                                "sub_part": 0,
                                 "collation": "A",
-                                "packed": "",
                                 "nullable": False,
                             },
                             {
@@ -334,12 +316,10 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                                     )
                                     else 'A'
                                 ),
-                                "packed": "",
                                 "nullable": True,
                             },
                         ],
                         "non_unique": True,
-                        "expression": "",
                     },
                     *(
                         [
@@ -347,7 +327,6 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                                 "name": "functional_key_part_index",
                                 "index_type": "BTREE",
                                 "cardinality": 0,
-                                "columns": [],
                                 "non_unique": True,
                                 "expression": "(`population` + 1)",
                             }
@@ -394,7 +373,6 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                 "partitions": [
                     {
                         "name": "p0",
-                        "subpartitions": [],
                         "partition_ordinal_position": 1,
                         "partition_method": "RANGE",
                         "partition_expression": "id",
@@ -404,7 +382,6 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                     },
                     {
                         "name": "p1",
-                        "subpartitions": [],
                         "partition_ordinal_position": 2,
                         "partition_method": "RANGE",
                         "partition_expression": "id",
@@ -414,7 +391,6 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                     },
                     {
                         "name": "p2",
-                        "subpartitions": [],
                         "partition_ordinal_position": 3,
                         "partition_method": "RANGE",
                         "partition_expression": "id",
@@ -424,7 +400,6 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                     },
                     {
                         "name": "p3",
-                        "subpartitions": [],
                         "partition_ordinal_position": 4,
                         "partition_method": "RANGE",
                         "partition_expression": "id",
@@ -441,14 +416,11 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                         "columns": [
                             {
                                 "name": "id",
-                                "sub_part": 0,
                                 "collation": "A",
-                                "packed": "",
                                 "nullable": False,
                             }
                         ],
                         "non_unique": False,
-                        "expression": "",
                     }
                 ],
             },
@@ -496,14 +468,11 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                         "columns": [
                             {
                                 "name": "city_id",
-                                "sub_part": 0,
                                 "collation": "A",
-                                "packed": "",
                                 "nullable": True,
                             },
                         ],
                         "non_unique": True,
-                        "expression": "",
                     }
                 ],
             },
@@ -547,14 +516,11 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                         "columns": [
                             {
                                 "name": "name",
-                                "sub_part": 0,
                                 "collation": "A",
-                                "packed": "",
                                 "nullable": True,
                             },
                         ],
                         "non_unique": False,
-                        "expression": "",
                     }
                 ],
             },
@@ -715,6 +681,12 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
     for db_name, actual_payload in actual_payloads.items():
         normalize_values(actual_payload)
         assert db_name in databases_to_find
+        if not deep_compare(expected_data_for_db[db_name], actual_payload):
+            import json
+            print("Expected:")
+            print(json.dumps(expected_data_for_db[db_name], indent=4))
+            print("Actual:")
+            print(json.dumps(actual_payload, indent=4))
         assert deep_compare(expected_data_for_db[db_name], actual_payload)
 
 

--- a/mysql/tests/test_metadata.py
+++ b/mysql/tests/test_metadata.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import json
 import re
 from os import environ
 
@@ -682,7 +683,6 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
         normalize_values(actual_payload)
         assert db_name in databases_to_find
         if not deep_compare(expected_data_for_db[db_name], actual_payload):
-            import json
             print("Expected:")
             print(json.dumps(expected_data_for_db[db_name], indent=4))
             print("Actual:")


### PR DESCRIPTION
### What does this PR do?
Adjusting the mySQL schema definition outputted by the agent. We should not emit null values to avoid needing to make these adjustments further in the pipeline. 

### Motivation
Working with these null fields gone from the agent rather than null values greatly simplifies changes I'm making in dd-go to process these schemas. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
