### PR TITLE
Gracefully handle unavailable apps and their aspects

### DIFF
--- a/spark/changelog.d/19561.fixed
+++ b/spark/changelog.d/19561.fixed
@@ -1,0 +1,1 @@
+Gracefully handle unavailable apps and their aspects. Before we would throw an exception as soon as we encountered an error, which left a lot of available metrics uncollected.

--- a/spark/tests/common.py
+++ b/spark/tests/common.py
@@ -16,7 +16,6 @@ CLUSTER_TAGS = [
 EXPECTED_E2E_METRICS = [
     'spark.driver.total_shuffle_read',
     'spark.stage.num_active_tasks',
-    'spark.streaming.statistics.num_inactive_receivers',
     'spark.driver.max_memory',
     'spark.streaming.statistics.num_active_batches',
     'spark.driver.total_tasks',
@@ -91,6 +90,7 @@ FLAKY_E2E_METRICS = [
     'spark.structured_streaming.input_rate',
     'spark.streaming.statistics.avg_input_rate',
     'spark.streaming.statistics.avg_scheduling_delay',
+    'spark.streaming.statistics.num_inactive_receivers',
     # The peak memory metrics are only available in Spark 3.0+ and after one loop of garbage collection
     'spark.driver.peak_mem.jvm_heap_memory',
     'spark.driver.peak_mem.jvm_off_heap_memory',

--- a/spark/tests/test_spark.py
+++ b/spark/tests/test_spark.py
@@ -1248,6 +1248,42 @@ def test_no_running_apps(aggregator, dd_run_check, instance, service_check, capl
     assert 'No running apps found. No metrics will be collected.' in caplog.text
 
 
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    'aspect_url, missing_metrics',
+    [
+        pytest.param(YARN_SPARK_JOB_URL, SPARK_JOB_RUNNING_METRIC_VALUES, id='jobs'),
+        pytest.param(YARN_SPARK_STAGE_URL, SPARK_STAGE_RUNNING_METRIC_VALUES, id='stages'),
+        pytest.param(
+            YARN_SPARK_EXECUTOR_URL,
+            SPARK_EXECUTOR_METRIC_VALUES.keys() | SPARK_EXECUTOR_LEVEL_METRIC_VALUES.keys(),
+            id='executors',
+        ),
+        pytest.param(YARN_SPARK_RDD_URL, SPARK_RDD_METRIC_VALUES, id='storage/rdd'),
+        pytest.param(
+            YARN_SPARK_STREAMING_STATISTICS_URL, SPARK_STREAMING_STATISTICS_METRIC_VALUES, id='streaming/statistics'
+        ),
+    ],
+)
+def test_yarn_no_json_for_app_metrics(aggregator, dd_run_check, mocker, aspect_url, missing_metrics):
+    """
+    In some yarn deployments apps stop exposing aspects (such as jobs and stages) by the time we query them.
+
+    In these cases we skip only the specific missing apps and metrics while collecting all others.
+    """
+
+    def get_without_json(url, *args, **kwargs):
+        arg_url = Url(url)
+        if arg_url == aspect_url:
+            return MockResponse(content="")  # this should trigger json error
+        return yarn_requests_get_mock(url, *args, **kwargs)
+
+    mocker.patch('requests.get', get_without_json)
+    dd_run_check(SparkCheck('spark', {}, [YARN_CONFIG]))
+    for m in missing_metrics:
+        aggregator.assert_metric(m, count=0)
+
+
 class StandaloneAppsResponseHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     def do_GET(self):
         self.send_response(200)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Quick note on terms: "aspects" here refers to properties of an app like `jobs` or `stages`. I'm open to use the word "properties" instead.

#### Before
We would throw an exception if we couldn't parse the json for some aspect/property of an app. This meant that any available apps after an unavailable one would not get collected.

#### After
We gracefully skip the unavailable apps, keep collecting the available ones.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
