### PR TITLE
Support Postgres 17

### DIFF
--- a/ddev/src/ddev/plugin/external/hatch/environment_collector.py
+++ b/ddev/src/ddev/plugin/external/hatch/environment_collector.py
@@ -147,7 +147,7 @@ class DatadogChecksEnvironmentCollector(EnvironmentCollectorInterface):
                 'black==24.10.0',
                 'ruff==0.8.0',
                 # Keep in sync with: /datadog_checks_base/pyproject.toml
-                'pydantic==2.7.3',
+                'pydantic==2.10.5',
             ],
         }
         config = {'lint': lint_env}

--- a/postgres/datadog_checks/postgres/metrics_cache.py
+++ b/postgres/datadog_checks/postgres/metrics_cache.py
@@ -15,20 +15,21 @@ from .util import (
     ACTIVITY_QUERY_LT_10,
     CHECKSUM_METRICS,
     COMMON_ARCHIVER_METRICS,
-    COMMON_BGW_METRICS,
+    COMMON_BGW_METRICS_LT_17,
     COMMON_METRICS,
     DATABASE_SIZE_METRICS,
     DBM_MIGRATED_METRICS,
     NEWER_14_METRICS,
-    NEWER_91_BGW_METRICS,
-    NEWER_92_BGW_METRICS,
+    NEWER_91_BGW_METRICS_LT_17,
+    NEWER_92_BGW_METRICS_LT_17,
     NEWER_92_METRICS,
+    QUERY_PG_BGWRITER_CHECKPOINTER,
     REPLICATION_METRICS_9_1,
     REPLICATION_METRICS_9_2,
     REPLICATION_METRICS_10,
     REPLICATION_STATS_METRICS,
 )
-from .version_utils import V8_3, V9, V9_1, V9_2, V9_4, V9_6, V10, V12, V14
+from .version_utils import V8_3, V9, V9_1, V9_2, V9_4, V9_6, V10, V12, V14, V17
 
 logger = logging.getLogger(__name__)
 
@@ -117,14 +118,17 @@ class PostgresMetricsCache:
         depending on the postgres version.
         Uses a dictionary to save the result for each instance
         """
+        if version >= V17:
+            return QUERY_PG_BGWRITER_CHECKPOINTER
+
         # Extended 9.2+ metrics if needed
         if self.bgw_metrics is None:
-            self.bgw_metrics = dict(COMMON_BGW_METRICS)
+            self.bgw_metrics = dict(COMMON_BGW_METRICS_LT_17)
 
             if version >= V9_1:
-                self.bgw_metrics.update(NEWER_91_BGW_METRICS)
+                self.bgw_metrics.update(NEWER_91_BGW_METRICS_LT_17)
             if version >= V9_2:
-                self.bgw_metrics.update(NEWER_92_BGW_METRICS)
+                self.bgw_metrics.update(NEWER_92_BGW_METRICS_LT_17)
 
         if not self.bgw_metrics:
             return None

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -64,6 +64,7 @@ from .util import (
     STAT_WAL_METRICS,
     SUBSCRIPTION_STATE_METRICS,
     VACUUM_PROGRESS_METRICS,
+    VACUUM_PROGRESS_METRICS_LT_17,
     WAL_FILE_METRICS,
     DatabaseConfigurationError,
     DatabaseHealthCheckError,  # noqa: F401
@@ -72,7 +73,7 @@ from .util import (
     payload_pg_version,
     warning_with_tags,
 )
-from .version_utils import V9, V9_2, V10, V12, V13, V14, V15, V16, VersionUtils
+from .version_utils import V9, V9_2, V10, V12, V13, V14, V15, V16, V17, VersionUtils
 
 try:
     import datadog_agent
@@ -314,7 +315,7 @@ class PostgreSql(AgentCheck):
             if self._config.collect_buffercache_metrics:
                 queries.append(BUFFERCACHE_METRICS)
             queries.append(QUERY_PG_REPLICATION_SLOTS)
-            queries.append(VACUUM_PROGRESS_METRICS)
+            queries.append(VACUUM_PROGRESS_METRICS if self.version >= V17 else VACUUM_PROGRESS_METRICS_LT_17)
             queries.append(STAT_SUBSCRIPTION_METRICS)
 
         if self.version >= V12:

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -81,6 +81,12 @@ PG_STAT_STATEMENTS_REQUIRED_COLUMNS = frozenset({'calls', 'query', 'rows'})
 
 PG_STAT_STATEMENTS_TIMING_COLUMNS = frozenset(
     {
+        'shared_blk_read_time',
+        'shared_blk_write_time',
+    }
+)
+PG_STAT_STATEMENTS_TIMING_COLUMNS_LT_17 = frozenset(
+    {
         'blk_read_time',
         'blk_write_time',
     }
@@ -114,6 +120,7 @@ PG_STAT_STATEMENTS_METRICS_COLUMNS = (
         }
     )
     | PG_STAT_STATEMENTS_TIMING_COLUMNS
+    | PG_STAT_STATEMENTS_TIMING_COLUMNS_LT_17
 )
 
 PG_STAT_STATEMENTS_TAG_COLUMNS = frozenset(
@@ -310,6 +317,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
 
             if self._check.pg_settings.get("track_io_timing") != "on":
                 desired_columns -= PG_STAT_STATEMENTS_TIMING_COLUMNS
+                desired_columns -= PG_STAT_STATEMENTS_TIMING_COLUMNS_LT_17
 
             pg_stat_statements_max_setting = self._check.pg_settings.get("pg_stat_statements.max")
             pg_stat_statements_max = int(

--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -21,6 +21,7 @@ V13 = VersionInfo.parse("13.0.0")
 V14 = VersionInfo.parse("14.0.0")
 V15 = VersionInfo.parse("15.0.0")
 V16 = VersionInfo.parse("16.0.0")
+V17 = VersionInfo.parse("17.0.0")
 
 
 class VersionUtils(object):

--- a/postgres/hatch.toml
+++ b/postgres/hatch.toml
@@ -12,7 +12,7 @@ mypy-deps = [
 
 [[envs.default.matrix]]
 python = ["3.12"]
-version = ["9.6", "10.0", "11.0", "12.17", "13.0", "14.0", "15.0", "16.0"]
+version = ["9.6", "10.0", "11.0", "12.17", "13.0", "14.0", "15.0", "16.0", "17.0"]
 
 [envs.default.overrides]
 matrix.version.env-vars = [
@@ -23,6 +23,7 @@ matrix.version.env-vars = [
   { key = "POSTGRES_VERSION", value = "14", if = ["14.0"] },
   { key = "POSTGRES_VERSION", value = "15", if = ["15.0"] },
   { key = "POSTGRES_VERSION", value = "16", if = ["16.0"] },
+  { key = "POSTGRES_VERSION", value = "17", if = ["17.0"] },
 ]
 
 [envs.latest.env-vars]

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -1080,7 +1080,8 @@ def assert_state_clean(check):
 
 def assert_state_set(check):
     assert check.metrics_cache.instance_metrics
-    assert check.metrics_cache.bgw_metrics
+    if float(POSTGRES_VERSION) < 17.0:
+        assert check.metrics_cache.bgw_metrics
     if POSTGRES_VERSION != '9.3':
         assert check.metrics_cache.archiver_metrics
     assert check.metrics_cache.replication_metrics

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -22,7 +22,11 @@ from datadog_checks.postgres.statement_samples import (
     DBExplainError,
     StatementTruncationState,
 )
-from datadog_checks.postgres.statements import PG_STAT_STATEMENTS_METRICS_COLUMNS, PG_STAT_STATEMENTS_TIMING_COLUMNS
+from datadog_checks.postgres.statements import (
+    PG_STAT_STATEMENTS_METRICS_COLUMNS,
+    PG_STAT_STATEMENTS_TIMING_COLUMNS,
+    PG_STAT_STATEMENTS_TIMING_COLUMNS_LT_17,
+)
 from datadog_checks.postgres.util import payload_pg_version
 from datadog_checks.postgres.version_utils import V12
 
@@ -292,7 +296,12 @@ def test_statement_metrics(
         available_columns = set(row.keys())
         metric_columns = available_columns & PG_STAT_STATEMENTS_METRICS_COLUMNS
         if track_io_timing_enabled:
-            assert (available_columns & PG_STAT_STATEMENTS_TIMING_COLUMNS) == PG_STAT_STATEMENTS_TIMING_COLUMNS
+            if float(POSTGRES_VERSION) >= 17.0:
+                assert (available_columns & PG_STAT_STATEMENTS_TIMING_COLUMNS) == PG_STAT_STATEMENTS_TIMING_COLUMNS
+            else:
+                assert (
+                    available_columns & PG_STAT_STATEMENTS_TIMING_COLUMNS_LT_17
+                ) == PG_STAT_STATEMENTS_TIMING_COLUMNS_LT_17
         else:
             assert (available_columns & PG_STAT_STATEMENTS_TIMING_COLUMNS) == set()
         for col in metric_columns:

--- a/postgres/tests/utils.py
+++ b/postgres/tests/utils.py
@@ -37,6 +37,14 @@ requires_over_16 = pytest.mark.skipif(
     POSTGRES_VERSION is None or float(POSTGRES_VERSION) < 16,
     reason='This test is for over 16 only (make sure POSTGRES_VERSION is set)',
 )
+requires_under_17 = pytest.mark.skipif(
+    POSTGRES_VERSION is None or float(POSTGRES_VERSION) >= 17,
+    reason='This test is for under 17 only (make sure POSTGRES_VERSION is set)',
+)
+requires_over_17 = pytest.mark.skipif(
+    POSTGRES_VERSION is None or float(POSTGRES_VERSION) < 17,
+    reason='This test is for over 17 only (make sure POSTGRES_VERSION is set)',
+)
 
 
 def _get_conn(db_instance, dbname=None, user=None, password=None, application_name='test'):


### PR DESCRIPTION
I'm not sure what your policy is regarding changing metric names when the postgres side is renamed. I did my best to keep the changes small and reasonable. No metrics are renamed or added. I'm happy to make changes as needed or let this just be a reference for someone at DataDog to implement PG17 support.

---

Postgres changes are noted in the [release notes](https://www.postgresql.org/docs/current/release-17.html#RELEASE-17-MIGRATION). I've included links to the commits as they provide more detail.

Fixes for the following Postgres changes:
* Columns moved and renamed from `pg_stat_bgwriter` to new `pg_stat_checkpointer`. ([96f052613](https://postgr.es/c/96f052613))
* `buffers_backend` and `buffers_backend_fsync` columns removed from `pg_stat_checkpointer`. The PG commit explains that they're not actually checkpointer properties and `pg_stat_io` provides the equivalent and more accurate information. ([74604a37f](https://postgr.es/c/74604a37f))
* `max_dead_tuples` renamed to `max_dead_tuple_bytes` and `num_dead_tuples` renamed to `num_dead_item_ids` in the `pg_stat_progress_vacuum` view. ([667e65aac](https://postgr.es/c/667e65aac), [f1affb670](https://postgr.es/c/f1affb670))
  * Note that `dead_tuple_bytes` was also added to the view.
* `pg_stat_slru` names changed. ([bcdfa5f2e](https://postgr.es/c/bcdfa5f2e))
* `blk_read_time` renamed to `shared_blk_read_time` and `blk_write_time` renamed to `shared_blk_write_time` in the `pg_stat_statements` view. ([13d00729d](https://postgr.es/c/13d00729d))

Additional changes:
* Updated hatch pydantic dependency to 2.10.5, matching datadog_checks_base. ddev wouldn't work with my local Python 3.13 install without this.

### What does this PR do?
Updates postgres integration for changes in Postgres 17.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
