### PR TITLE
[mongo] skip host info system metrics collection on arbiter

### DIFF
--- a/mongo/changelog.d/19571.fixed
+++ b/mongo/changelog.d/19571.fixed
@@ -1,0 +1,1 @@
+Skip host info system metrics collection on arbiter node due to `HostInfo` command cannot not be ran on arbiter without admin access.

--- a/mongo/datadog_checks/mongo/collectors/host_info.py
+++ b/mongo/datadog_checks/mongo/collectors/host_info.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 from datadog_checks.mongo.collectors.base import MongoCollector
+from datadog_checks.mongo.common import ReplicaSetDeployment
 
 
 class HostInfoCollector(MongoCollector):
@@ -11,7 +12,8 @@ class HostInfoCollector(MongoCollector):
     """
 
     def compatible_with(self, deployment):
-        # Can theoretically be run on any mongod or mongos node.
+        if isinstance(deployment, ReplicaSetDeployment) and deployment.is_arbiter:
+            return False
         return True
 
     def collect(self, api):

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -339,7 +339,7 @@ def test_integration_replicaset_arbiter_in_shard(instance_integration, aggregato
         'sharding_cluster_role:shardsvr',
         'hosting_type:self-hosted',
     ]
-    metrics_categories = ['serverStatus', 'replset-arbiter', 'hostinfo']
+    metrics_categories = ['serverStatus', 'replset-arbiter']
 
     assert_metrics(mongo_check, aggregator, metrics_categories, replica_tags)
 
@@ -836,7 +836,7 @@ def test_integration_replicaset_arbiter(instance_integration, aggregator, check,
         'replset_me:replset-arbiter-0.mongo.default.svc.cluster.local:27017',
         'hosting_type:self-hosted',
     ]
-    metrics_categories = ['serverStatus', 'replset-arbiter', 'hostinfo']
+    metrics_categories = ['serverStatus', 'replset-arbiter']
 
     assert_metrics(mongo_check, aggregator, metrics_categories, replica_tags)
 


### PR DESCRIPTION
### What does this PR do?
This PR skips host info system metrics collection on arbiter. `hostInfo` command cannot be ran on arbiter node even logged in with authentication. 

### Motivation
https://datadoghq.atlassian.net/browse/SDBM-1491

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
