### PR TITLE
Add deadlock support for Azure DB

### DIFF
--- a/sqlserver/changelog.d/19577.added
+++ b/sqlserver/changelog.d/19577.added
@@ -1,0 +1,1 @@
+Add deadlock support for Azure DB

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/xe_session_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/xe_session_metrics.py
@@ -3,6 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 from datadog_checks.base.config import is_affirmative
+from datadog_checks.sqlserver.const import STATIC_INFO_ENGINE_EDITION
+from datadog_checks.sqlserver.utils import is_azure_sql_database
 
 from .base import SqlserverDatabaseMetricsBase
 
@@ -47,6 +49,8 @@ XE_EVENTS_NOT_IN_XML = {
 class SQLServerXESessionMetrics(SqlserverDatabaseMetricsBase):
     @property
     def enabled(self):
+        if is_azure_sql_database(self.engine_edition):
+            return False
         self.deadlocks_config: dict = self.config.deadlocks_config
         return self.config.database_metrics_config["xe_metrics"]["enabled"] or is_affirmative(
             self.deadlocks_config.get('enabled', False)

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/xe_session_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/xe_session_metrics.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 from datadog_checks.base.config import is_affirmative
-from datadog_checks.sqlserver.const import STATIC_INFO_ENGINE_EDITION
 from datadog_checks.sqlserver.utils import is_azure_sql_database
 
 from .base import SqlserverDatabaseMetricsBase

--- a/sqlserver/datadog_checks/sqlserver/deadlocks.py
+++ b/sqlserver/datadog_checks/sqlserver/deadlocks.py
@@ -15,8 +15,8 @@ from datadog_checks.sqlserver.database_metrics.xe_session_metrics import XE_EVEN
 from datadog_checks.sqlserver.queries import (
     DEADLOCK_TIMESTAMP_ALIAS,
     DEADLOCK_XML_ALIAS,
-    DEFAULT_DM_XE_TARGETS,
     DEFAULT_DM_XE_SESSIONS,
+    DEFAULT_DM_XE_TARGETS,
     XE_SESSION_DATADOG,
     XE_SESSION_SYSTEM,
     get_deadlocks_query,
@@ -136,7 +136,9 @@ class Deadlocks(DBMAsyncJob):
         with self._check.connection.open_managed_default_connection(key_prefix=self._conn_key_prefix):
             with self._check.connection.get_managed_cursor(key_prefix=self._conn_key_prefix) as cursor:
                 if self._xe_session_name is None:
-                    cursor.execute(get_xe_sessions_query(dm_xe_targets=self._dm_xe_targets, dm_xe_sessions=self._dm_xe_sessions))
+                    cursor.execute(
+                        get_xe_sessions_query(dm_xe_targets=self._dm_xe_targets, dm_xe_sessions=self._dm_xe_sessions)
+                    )
                     rows = cursor.fetchall()
                     if not rows:
                         raise NoXESessionError(NO_XE_SESSION_ERROR)

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -155,7 +155,7 @@ DEADLOCK_TIMESTAMP_ALIAS = "timestamp"
 DEADLOCK_XML_ALIAS = "event_xml"
 
 
-def get_deadlocks_query(convert_xml_to_str=False, xe_session_name=XE_SESSION_DATADOG, xe_target_name=XE_RING_BUFFER, dm_xe_targets=DEFAULT_DM_XE_TARGETS, dm_xe_sessions=DEFAULT_DM_XE_SESSIONS):
+def get_deadlocks_query(convert_xml_to_str=False, xe_session_name=XE_SESSION_DATADOG, xe_target_name=XE_RING_BUFFER, dm_xe_targets=DEFAULT_DM_XE_TARGETS, dm_xe_sessions=DEFAULT_DM_XE_SESSIONS, level=""):
     """
     Construct the query to fetch deadlocks from the system_health extended event session
     :params:
@@ -165,6 +165,7 @@ def get_deadlocks_query(convert_xml_to_str=False, xe_session_name=XE_SESSION_DAT
         xe_target_name: The name of the extended event target to query
         dm_xe_targets: The name of the DMV to query for extended event targets
         dm_xe_sessions: The name of the DMV to query for extended event sessions
+        level: 'database_' for Azure database, '' for all other versions
     :return: The query to fetch deadlocks
     """
     xml_expression = "xdr.query('.')"
@@ -180,7 +181,7 @@ def get_deadlocks_query(convert_xml_to_str=False, xe_session_name=XE_SESSION_DAT
                 WHERE xs.name = N'{xe_session_name}'
                 AND xt.target_name = N'{XE_RING_BUFFER}'
         ) AS XML_Data
-    CROSS APPLY Target_Data.nodes('RingBufferTarget/event[@name="xml_deadlock_report"]') AS XEventData(xdr)
+    CROSS APPLY Target_Data.nodes('RingBufferTarget/event[@name="{level}xml_deadlock_report"]') AS XEventData(xdr)
     WHERE xdr.value('@timestamp', 'datetime')
         >= DATEADD(SECOND, ?, TODATETIMEOFFSET(GETDATE(), DATEPART(TZOFFSET, SYSDATETIMEOFFSET())) AT TIME ZONE 'UTC')
     ;"""

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -151,11 +151,19 @@ WHERE
     s.name IN ('{XE_SESSION_DATADOG}', '{XE_SESSION_SYSTEM}');
 """
 
+
 DEADLOCK_TIMESTAMP_ALIAS = "timestamp"
 DEADLOCK_XML_ALIAS = "event_xml"
 
 
-def get_deadlocks_query(convert_xml_to_str=False, xe_session_name=XE_SESSION_DATADOG, xe_target_name=XE_RING_BUFFER, dm_xe_targets=DEFAULT_DM_XE_TARGETS, dm_xe_sessions=DEFAULT_DM_XE_SESSIONS, level=""):
+def get_deadlocks_query(
+    convert_xml_to_str=False,
+    xe_session_name=XE_SESSION_DATADOG,
+    xe_target_name=XE_RING_BUFFER,
+    dm_xe_targets=DEFAULT_DM_XE_TARGETS,
+    dm_xe_sessions=DEFAULT_DM_XE_SESSIONS,
+    level="",
+):
     """
     Construct the query to fetch deadlocks from the system_health extended event session
     :params:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add deadlocks monitoring for Azure database.

![image](https://github.com/user-attachments/assets/7f3fc4ae-5ae0-4c87-b41b-5031e29dc01b)

Azure DB can't access the instance views, so I modified the query to get deadlocks from the local views.

### Setup

```
CREATE EVENT SESSION datadog
ON database
ADD EVENT sqlserver.database_xml_deadlock_report
ADD TARGET package0.ring_buffer
WITH (
    MAX_MEMORY = 1024 KB,
    EVENT_RETENTION_MODE = ALLOW_SINGLE_EVENT_LOSS,
    MAX_DISPATCH_LATENCY = 30 SECONDS,
    STARTUP_STATE = ON
);
GO

ALTER EVENT SESSION datadog ON DATABASE STATE = START;
GO
```

### Motivation
<!-- What inspired you to submit this pull request? -->

Requested by customers, e.g. by Thomson Reuters. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
