### PR TITLE
Fix permissions for the flaky tests workflow

### DIFF
--- a/.github/workflows/flaky-tests.yml
+++ b/.github/workflows/flaky-tests.yml
@@ -36,6 +36,11 @@ jobs:
     concurrency:
       group: test-results
 
+    permissions:
+      checks: write # Needed for test-results-master
+      contents: write # Needed for test-results-master
+      pull-requests: write # Needed for test-results-master
+      
     uses: ./.github/workflows/test-results-master.yml
     secrets: inherit
 


### PR DESCRIPTION
### What does this PR do?
Fixes permissions for the daily flaky tests GitHub Actions workflow.

### Motivation
The workflow was failing with this error: 
```
The workflow is not valid. .github/workflows/flaky-tests.yml (Line: 32, Col: 3): Error calling workflow 'DataDog/integrations-core/.github/workflows/test-results-master.yml@cdcf656538ec4f2b9d7c6cfc3552fdaf966592c4'. The nested job 'test-results' is requesting 'checks: write, contents: write, pull-requests: write', but is only allowed 'checks: none, contents: read, pull-requests: none'.
```
Example: https://github.com/DataDog/integrations-core/actions/runs/13233335605/workflow

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
