### PR TITLE
[NDMII-3310] add support for HA for integrations

### DIFF
--- a/cisco_aci/datadog_checks/cisco_aci/cisco.py
+++ b/cisco_aci/datadog_checks/cisco_aci/cisco.py
@@ -22,8 +22,6 @@ class CiscoACICheck(AgentCheck):
 
     HTTP_CONFIG_REMAPPER = {'ssl_verify': {'name': 'tls_verify'}, 'pwd': {'name': 'password'}}
 
-    HA_SUPPORTED = True
-
     def __init__(self, name, init_config, instances):
         super(CiscoACICheck, self).__init__(name, init_config, instances)
         self.tenant_metrics = make_tenant_metrics()

--- a/cisco_aci/datadog_checks/cisco_aci/cisco.py
+++ b/cisco_aci/datadog_checks/cisco_aci/cisco.py
@@ -22,6 +22,8 @@ class CiscoACICheck(AgentCheck):
 
     HTTP_CONFIG_REMAPPER = {'ssl_verify': {'name': 'tls_verify'}, 'pwd': {'name': 'password'}}
 
+    HA_SUPPORTED = True
+
     def __init__(self, name, init_config, instances):
         super(CiscoACICheck, self).__init__(name, init_config, instances)
         self.tenant_metrics = make_tenant_metrics()

--- a/datadog_checks_base/changelog.d/19580.added
+++ b/datadog_checks_base/changelog.d/19580.added
@@ -1,0 +1,1 @@
+Adds HA_SUPPORTED as a class attribute to the AgentCheck to let integrations self declare that they support HA.

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -318,7 +318,9 @@ class AgentCheck(object):
         ha_enabled_instance = self.instance.get('ha_enabled', False) if self.instance else False
 
         if not self.HA_SUPPORTED and (ha_enabled_init or ha_enabled_instance):
-            raise ConfigurationError("High availability is not supported for this check")
+            raise ConfigurationError(
+                f"High Availability is enabled for check {self.name} but this integration does not support it"
+            )
 
     def _create_metrics_pattern(self, metric_patterns, option_name):
         all_patterns = metric_patterns.get(option_name, [])

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -164,6 +164,8 @@ class AgentCheck(object):
     # See https://github.com/DataDog/integrations-core/pull/2093 for more information.
     DEFAULT_METRIC_LIMIT = 0
 
+    HA_SUPPORTED = False
+
     # Allow tracing for classic integrations
     def __init_subclass__(cls, *args, **kwargs):
         try:
@@ -311,6 +313,12 @@ class AgentCheck(object):
 
         if os.environ.get("GOFIPS", "0") == "1":
             enable_fips()
+
+        ha_enabled_init = self.init_config.get('ha_enabled', False) if self.init_config else False
+        ha_enabled_instance = self.instance.get('ha_enabled', False) if self.instance else False
+
+        if not self.HA_SUPPORTED and (ha_enabled_init or ha_enabled_instance):
+            raise ConfigurationError("High availability is not supported for this check")
 
     def _create_metrics_pattern(self, metric_patterns, option_name):
         all_patterns = metric_patterns.get(option_name, [])

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -1314,7 +1314,20 @@ def test_env_var_logic_preset():
 
 
 def test_ha_enabled_and_unsupported():
+    class TestNonHACheck(AgentCheck):
+        HA_SUPPORTED = False
+
+    TestNonHACheck('test', {}, [{}])
     with pytest.raises(ConfigurationError):
-        AgentCheck('test', {'ha_enabled': True}, [{}])
+        TestNonHACheck('test', {'ha_enabled': True}, [{}])
     with pytest.raises(ConfigurationError):
-        AgentCheck('test', {}, [{'ha_enabled': True}])
+        TestNonHACheck('test', {}, [{'ha_enabled': True}])
+
+
+def test_ha_enabled_and_supported():
+    class TestHACheck(AgentCheck):
+        HA_SUPPORTED = True
+
+    TestHACheck('test', {}, [{}])
+    TestHACheck('test', {'ha_enabled': True}, [{}])
+    TestHACheck('test', {}, [{'ha_enabled': True}])

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -13,6 +13,7 @@ import pytest
 
 from datadog_checks.base import AgentCheck, to_native_string
 from datadog_checks.base import __version__ as base_package_version
+from datadog_checks.errors import ConfigurationError
 
 from .utils import BaseModelTest
 
@@ -1310,3 +1311,10 @@ def test_env_var_logic_preset():
         AgentCheck()
         assert os.getenv('OPENSSL_CONF', None) == preset_conf
         assert os.getenv('OPENSSL_MODULES', None) == preset_modules
+
+
+def test_ha_enabled_and_unsupported():
+    with pytest.raises(ConfigurationError):
+        AgentCheck('test', {'ha_enabled': True}, [{}])
+    with pytest.raises(ConfigurationError):
+        AgentCheck('test', {}, [{'ha_enabled': True}])

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -11,9 +11,8 @@ from typing import Any  # noqa: F401
 import mock
 import pytest
 
-from datadog_checks.base import AgentCheck, to_native_string
+from datadog_checks.base import AgentCheck, ConfigurationError, to_native_string
 from datadog_checks.base import __version__ as base_package_version
-from datadog_checks.base import ConfigurationError
 
 from .utils import BaseModelTest
 

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -13,7 +13,7 @@ import pytest
 
 from datadog_checks.base import AgentCheck, to_native_string
 from datadog_checks.base import __version__ as base_package_version
-from datadog_checks.errors import ConfigurationError
+from datadog_checks.base import ConfigurationError
 
 from .utils import BaseModelTest
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a class attribute `HA_SUPPORTED` to the `Check` class which is false by default.
Overriding it to true means that the integration does support HA.
If a user configures an integration with `ha_enabled:` true on a non supported integration the`__init__` will fail and the check not schedule


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
