### PR TITLE
Split Postgres query metrics payload to conform to max payload size

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -11,6 +11,16 @@ files:
       value:
         example: false
         type: boolean
+    - name: metrics
+      options:
+      - name: batch_max_content_size
+        description: |
+          The maximum payload size in bytes that the check will send to the Datadog metrics intake at one time.
+          This value should match the value of `database_monitoring.metrics.batch_max_content_size` in the Datadog Agent configuration
+          and should only be set if that value has also been changed from the default.
+        value:
+          display_default: 20000000
+          type: integer
     - template: init_config/db
     - template: init_config/default
   - template: instances

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -11,16 +11,6 @@ files:
       value:
         example: false
         type: boolean
-    - name: metrics
-      options:
-      - name: batch_max_content_size
-        description: |
-          The maximum payload size in bytes that the check will send to the Datadog metrics intake at one time.
-          This value should match the value of `database_monitoring.metrics.batch_max_content_size` in the Datadog Agent configuration
-          and should only be set if that value has also been changed from the default.
-        value:
-          display_default: 20000000
-          type: integer
     - template: init_config/db
     - template: init_config/default
   - template: instances

--- a/postgres/changelog.d/19582.fixed
+++ b/postgres/changelog.d/19582.fixed
@@ -1,0 +1,1 @@
+Split Postgres query metrics payload to conform to max payload size and enable larger query metrics collection

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -29,6 +29,7 @@ class PostgresConfig:
     MONOTONIC = AgentCheck.monotonic_count
 
     def __init__(self, instance, init_config, check):
+        self.init_config = init_config
         self.host = instance.get('host', '')
         if not self.host:
             raise ConfigurationError('Specify a Postgres host to connect to.')

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -176,7 +176,9 @@ class PostgresStatementMetrics(DBMAsyncJob):
         # (database_monitoring.metrics.batch_max_content_size) cannot be decreased, and increasing it
         # will typically cause the backend to reject the payload
         # It's set here as an option for potential debugging issues but should not be used otherwise
-        # NB: This value should always match the datadog.yaml value, and if that default changes, this should be updated
+        # NB: This value should always match the datadog.yaml value, whose default is set
+        # https://github.com/DataDog/datadog-agent/blob/96d253e8b91326c2418302b13a73b420ad5a6d92/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go#L79
+        # If that default changes, this should be updated
         self.batch_max_content_size = config.init_config.get('metrics', {}).get('batch_max_content_size', 20_000_000)
         self._tags_no_db = None
         self.tags = None

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -263,7 +263,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 return
             for event in self._rows_to_fqt_events(rows):
                 self._check.database_monitoring_query_sample(json.dumps(event, default=default_json_event_encoding))
-            
+
             payload_wrapper = {
                 'host': self._check.resolved_hostname,
                 'timestamp': time.time() * 1000,
@@ -283,7 +283,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
         except Exception:
             self._log.exception('Unable to collect statement metrics due to an error')
             return []
-    
+
     def _get_query_metrics_payloads(self, payload_wrapper, rows):
         payloads = []
 
@@ -293,7 +293,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
             current = queue.pop()
             if len(current) == 0:
                 continue
-            
+
             payload = copy.deepcopy(payload_wrapper)
             payload["postgres_rows"] = current
             serialized_payload = json.dumps(payload, default=default_json_event_encoding)
@@ -303,8 +303,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
             else:
                 if len(current) == 1:
                     self._log.warning(
-                        "A single query is too large to send to Datadog. This query will be dropped. "
-                        "size=%d",
+                        "A single query is too large to send to Datadog. This query will be dropped. " "size=%d",
                         size,
                     )
                     continue

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -172,6 +172,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
             'pg_stat_statements_max_warning_threshold', 10000
         )
         self._config = config
+        self.batch_max_content_size = config.init_config.get('metrics', {}).get('batch_max_content_size', 20_000_000)
         self._tags_no_db = None
         self.tags = None
         self._state = StatementMetrics()
@@ -262,22 +263,55 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 return
             for event in self._rows_to_fqt_events(rows):
                 self._check.database_monitoring_query_sample(json.dumps(event, default=default_json_event_encoding))
-            payload = {
+            
+            payload_wrapper = {
                 'host': self._check.resolved_hostname,
                 'timestamp': time.time() * 1000,
                 'min_collection_interval': self._metrics_collection_interval,
                 'tags': self._tags_no_db,
                 'cloud_metadata': self._config.cloud_metadata,
-                'postgres_rows': rows,
                 'postgres_version': payload_pg_version(self._check.version),
                 'ddagentversion': datadog_agent.get_version(),
                 'ddagenthostname': self._check.agent_hostname,
                 'service': self._config.service,
             }
-            self._check.database_monitoring_query_metrics(json.dumps(payload, default=default_json_event_encoding))
+
+            payloads = self._get_query_metrics_payloads(payload_wrapper, rows)
+
+            for payload in payloads:
+                self._check.database_monitoring_query_metrics(payload)
         except Exception:
             self._log.exception('Unable to collect statement metrics due to an error')
             return []
+    
+    def _get_query_metrics_payloads(self, payload_wrapper, rows):
+        payloads = []
+
+        max_size = self.batch_max_content_size
+        queue = [rows]
+        while queue:
+            current = queue.pop()
+            if len(current) == 0:
+                continue
+            
+            payload = copy.deepcopy(payload_wrapper)
+            payload["postgres_rows"] = current
+            serialized_payload = json.dumps(payload, default=default_json_event_encoding)
+            size = len(serialized_payload)
+            if size < max_size:
+                payloads.append(serialized_payload)
+            else:
+                if len(current) == 1:
+                    self._log.warning(
+                        "A single query is too large to send to Datadog. This query will be dropped. "
+                        "size=%d",
+                        size,
+                    )
+                    continue
+                mid = len(current) // 2
+                queue.append(current[:mid])
+                queue.append(current[mid:])
+        return payloads
 
     @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
     def _load_pg_stat_statements(self):

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -172,6 +172,11 @@ class PostgresStatementMetrics(DBMAsyncJob):
             'pg_stat_statements_max_warning_threshold', 10000
         )
         self._config = config
+        # This config option isn't publicized because the related option in datadog.yaml
+        # (database_monitoring.metrics.batch_max_content_size) cannot be decreased, and increasing it
+        # will typically cause the backend to reject the payload
+        # It's set here as an option for potential debugging issues but should not be used otherwise
+        # NB: This value should always match the datadog.yaml value, and if that default changes, this should be updated
         self.batch_max_content_size = config.init_config.get('metrics', {}).get('batch_max_content_size', 20_000_000)
         self._tags_no_db = None
         self.tags = None

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -5,11 +5,12 @@ import datetime
 import re
 import select
 import time
-from collections import Counter
+from collections import Counter, namedtuple
 from concurrent.futures.thread import ThreadPoolExecutor
 
 import mock
 import psycopg2
+from datadog_checks.postgres.config import PostgresConfig
 import pytest
 from dateutil import parser
 from semver import VersionInfo
@@ -22,7 +23,7 @@ from datadog_checks.postgres.statement_samples import (
     DBExplainError,
     StatementTruncationState,
 )
-from datadog_checks.postgres.statements import PG_STAT_STATEMENTS_METRICS_COLUMNS, PG_STAT_STATEMENTS_TIMING_COLUMNS
+from datadog_checks.postgres.statements import PG_STAT_STATEMENTS_METRICS_COLUMNS, PG_STAT_STATEMENTS_TIMING_COLUMNS, PostgresStatementMetrics
 from datadog_checks.postgres.util import payload_pg_version
 from datadog_checks.postgres.version_utils import V12
 
@@ -2086,3 +2087,40 @@ def test_plan_time_metrics(aggregator, integration_check, dbm_instance):
 
     for conn in connections.values():
         conn.close()
+
+@pytest.mark.unit
+def test_get_query_metrics_payload_rows():
+    config = PostgresConfig({"host":"host", "username":"user"}, {}, None)
+    statement_metrics = PostgresStatementMetrics({}, config, None)
+    wrapper = {}
+
+    TestCase = namedtuple('TestCase', 'rows max_size expected')
+
+    test_cases = [
+        # Empty
+        TestCase(rows=[], max_size= 1000, expected= 0),
+        # Single row too large
+        TestCase(rows=[{'query': 'a' * 1000}], max_size= 10, expected= 0),
+        # Both rows fit
+        TestCase(rows=[{'query': 'a' * 20},{'query': 'b' * 20}], max_size= 100, expected= 1),
+        # Split rows once
+        TestCase(rows=[{'query': 'a' * 20},{'query': 'b' * 20},{'query': 'a' * 20},{'query': 'b' * 20}], max_size= 100, expected= 2),
+        # Split rows twice
+        TestCase(rows=[{'query': 'a' * 40},{'query': 'b' * 40},{'query': 'b' * 40},{'query': 'b' * 40}], max_size= 100, expected= 4),
+        # Split rows once, last row too large
+        TestCase(rows=[{'query': 'a' * 40},{'query': 'b' * 40},{'query': 'b' * 40},{'query': 'b' * 400}], max_size= 100, expected= 3),
+        # Split rows once, first row too large
+        TestCase(rows=[{'query': 'a' * 400},{'query': 'b' * 40},{'query': 'b' * 40},{'query': 'b' * 40}], max_size= 100, expected= 3),
+    ]
+
+    for tc in test_cases:
+        statement_metrics.batch_max_content_size = tc.max_size
+        rows = statement_metrics._get_query_metrics_payloads(wrapper,tc.rows)
+        assert len(rows) == tc.expected
+
+
+
+
+
+
+

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -10,7 +10,6 @@ from concurrent.futures.thread import ThreadPoolExecutor
 
 import mock
 import psycopg2
-from datadog_checks.postgres.config import PostgresConfig
 import pytest
 from dateutil import parser
 from semver import VersionInfo
@@ -19,11 +18,16 @@ from datadog_checks.base.utils.db.sql import compute_sql_signature
 from datadog_checks.base.utils.db.utils import DBMAsyncJob
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.time import UTC
+from datadog_checks.postgres.config import PostgresConfig
 from datadog_checks.postgres.statement_samples import (
     DBExplainError,
     StatementTruncationState,
 )
-from datadog_checks.postgres.statements import PG_STAT_STATEMENTS_METRICS_COLUMNS, PG_STAT_STATEMENTS_TIMING_COLUMNS, PostgresStatementMetrics
+from datadog_checks.postgres.statements import (
+    PG_STAT_STATEMENTS_METRICS_COLUMNS,
+    PG_STAT_STATEMENTS_TIMING_COLUMNS,
+    PostgresStatementMetrics,
+)
 from datadog_checks.postgres.util import payload_pg_version
 from datadog_checks.postgres.version_utils import V12
 
@@ -2088,9 +2092,10 @@ def test_plan_time_metrics(aggregator, integration_check, dbm_instance):
     for conn in connections.values():
         conn.close()
 
+
 @pytest.mark.unit
 def test_get_query_metrics_payload_rows():
-    config = PostgresConfig({"host":"host", "username":"user"}, {}, None)
+    config = PostgresConfig({"host": "host", "username": "user"}, {}, None)
     statement_metrics = PostgresStatementMetrics({}, config, None)
     wrapper = {}
 
@@ -2098,29 +2103,38 @@ def test_get_query_metrics_payload_rows():
 
     test_cases = [
         # Empty
-        TestCase(rows=[], max_size= 1000, expected= 0),
+        TestCase(rows=[], max_size=1000, expected=0),
         # Single row too large
-        TestCase(rows=[{'query': 'a' * 1000}], max_size= 10, expected= 0),
+        TestCase(rows=[{'query': 'a' * 1000}], max_size=10, expected=0),
         # Both rows fit
-        TestCase(rows=[{'query': 'a' * 20},{'query': 'b' * 20}], max_size= 100, expected= 1),
+        TestCase(rows=[{'query': 'a' * 20}, {'query': 'b' * 20}], max_size=100, expected=1),
         # Split rows once
-        TestCase(rows=[{'query': 'a' * 20},{'query': 'b' * 20},{'query': 'a' * 20},{'query': 'b' * 20}], max_size= 100, expected= 2),
+        TestCase(
+            rows=[{'query': 'a' * 20}, {'query': 'b' * 20}, {'query': 'a' * 20}, {'query': 'b' * 20}],
+            max_size=100,
+            expected=2,
+        ),
         # Split rows twice
-        TestCase(rows=[{'query': 'a' * 40},{'query': 'b' * 40},{'query': 'b' * 40},{'query': 'b' * 40}], max_size= 100, expected= 4),
+        TestCase(
+            rows=[{'query': 'a' * 40}, {'query': 'b' * 40}, {'query': 'b' * 40}, {'query': 'b' * 40}],
+            max_size=100,
+            expected=4,
+        ),
         # Split rows once, last row too large
-        TestCase(rows=[{'query': 'a' * 40},{'query': 'b' * 40},{'query': 'b' * 40},{'query': 'b' * 400}], max_size= 100, expected= 3),
+        TestCase(
+            rows=[{'query': 'a' * 40}, {'query': 'b' * 40}, {'query': 'b' * 40}, {'query': 'b' * 400}],
+            max_size=100,
+            expected=3,
+        ),
         # Split rows once, first row too large
-        TestCase(rows=[{'query': 'a' * 400},{'query': 'b' * 40},{'query': 'b' * 40},{'query': 'b' * 40}], max_size= 100, expected= 3),
+        TestCase(
+            rows=[{'query': 'a' * 400}, {'query': 'b' * 40}, {'query': 'b' * 40}, {'query': 'b' * 40}],
+            max_size=100,
+            expected=3,
+        ),
     ]
 
     for tc in test_cases:
         statement_metrics.batch_max_content_size = tc.max_size
-        rows = statement_metrics._get_query_metrics_payloads(wrapper,tc.rows)
+        rows = statement_metrics._get_query_metrics_payloads(wrapper, tc.rows)
         assert len(rows) == tc.expected
-
-
-
-
-
-
-


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR splits query metrics payload into separate submissions to keep each below the max content size limit for the `dbm-metrics` pipeline.

### Motivation
<!-- What inspired you to submit this pull request? -->
This change will allow customers with unusually large query metrics payloads to still submit metrics.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
