### PR TITLE
Fix GitHub Actions permissions for Labeler

### DIFF
--- a/.github/workflows/labeler-community.yml
+++ b/.github/workflows/labeler-community.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   labeler:
     if: ${{ github.event.pull_request.head.repo.full_name != github.repository }} # only PRs from other repos
+    permissions:
+      pull-requests: write # Needed for labeler-reusable.yml
     uses: ./.github/workflows/labeler-reusable.yml
     secrets:
       app-id: "${{ secrets.DD_AGENT_INTEGRATIONS_BOT_APP_ID }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   labeler:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }} # only PRs from this repo
+    permissions:
+      pull-requests: write # Need for labeler-reusable.yml
     uses: ./.github/workflows/labeler-reusable.yml
     secrets:
       app-id: "${{ secrets.DD_AGENT_INTEGRATIONS_BOT_APP_ID }}"


### PR DESCRIPTION
### What does this PR do?
Adds `pull-requests: write` permissions to labeler-community.yml and labeler.yml.

We're the [only ones using labeler-reusable.yml](https://github.com/search?q=org%3ADataDog+labeler-reusable.yml&type=code)  so no fixes needed in other repos.

### Motivation
Fixes this error in the `Community PR Labels` workflow in CI:
```
Invalid workflow file

The workflow is not valid. .github/workflows/labeler-community.yml (Line: 15, Col: 3): Error calling workflow 'DataDog/integrations-core/.github/workflows/labeler-reusable.yml@b33cd00ba0f9619b587a209b628df1ce2e55a814'. The nested job 'apply' is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'.
```