### PR TITLE
Fix exception handling for auto discovered databases

### DIFF
--- a/postgres/changelog.d/19586.fixed
+++ b/postgres/changelog.d/19586.fixed
@@ -1,0 +1,1 @@
+Fix exception handling for auto discovered databases

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -644,10 +644,13 @@ class PostgreSql(AgentCheck):
         start_time = time()
         databases = self.autodiscovery.get_items()
         for db in databases:
-            with self.db_pool.get_connection(db, self._config.idle_connection_timeout) as conn:
-                with conn.cursor(cursor_factory=CommenterCursor) as cursor:
-                    for scope in scopes:
-                        self._query_scope(cursor, scope, instance_tags, False, db)
+            try:
+                with self.db_pool.get_connection(db, self._config.idle_connection_timeout) as conn:
+                    with conn.cursor(cursor_factory=CommenterCursor) as cursor:
+                        for scope in scopes:
+                            self._query_scope(cursor, scope, instance_tags, False, db)
+            except Exception as e:
+                self.log.error(f"Error collecting metrics for database %s {e}", db)
         elapsed_ms = (time() - start_time) * 1000
         self.histogram(
             f"dd.postgres.{scope_type}.time",

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -650,7 +650,7 @@ class PostgreSql(AgentCheck):
                         for scope in scopes:
                             self._query_scope(cursor, scope, instance_tags, False, db)
             except Exception as e:
-                self.log.error(f"Error collecting metrics for database %s {e}", db)
+                self.log.error("Error collecting metrics for database %s %s", db, str(e))
         elapsed_ms = (time() - start_time) * 1000
         self.histogram(
             f"dd.postgres.{scope_type}.time",

--- a/postgres/tests/test_discovery.py
+++ b/postgres/tests/test_discovery.py
@@ -14,7 +14,7 @@ import pytest
 
 from datadog_checks.base import ConfigurationError
 
-from .common import DB_NAME, HOST, PASSWORD_ADMIN, USER_ADMIN, PASSWORD_ADMIN, check_common_metrics, _get_expected_tags
+from .common import HOST, PASSWORD_ADMIN, USER_ADMIN, _get_expected_tags, check_common_metrics
 from .utils import requires_over_13, run_one_check
 
 DISCOVERY_CONFIG = {
@@ -299,6 +299,7 @@ def test_autodiscovery_dbname_specified(integration_check, pg_instance):
     with pytest.raises(ConfigurationError):
         integration_check(pg_instance)
 
+
 def _set_allow_connection(dbname: str, allow: bool):
     with get_postgres_connection() as conn:
         cursor = conn.cursor()
@@ -307,6 +308,7 @@ def _set_allow_connection(dbname: str, allow: bool):
             (allow, dbname),
         )
         conn.commit()
+
 
 @pytest.mark.integration
 def test_handle_cannot_connect(aggregator, integration_check, pg_instance):
@@ -322,4 +324,3 @@ def test_handle_cannot_connect(aggregator, integration_check, pg_instance):
     expected_tags = _get_expected_tags(check, pg_instance)
     check_common_metrics(aggregator, expected_tags=expected_tags)
     _set_allow_connection(db_to_disable, True)
-


### PR DESCRIPTION
### What does this PR do?

Previously, if the agent failed to connect to one database, it stopped collecting metrics for all. Now, an exception logs the error but allows processing to continue.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
