### PR TITLE
Port changelogs and version bumps from 7.63 RC7

### DIFF
--- a/kafka_consumer/CHANGELOG.md
+++ b/kafka_consumer/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 6.4.0 / 2025-02-12
+
+***Added***:
+
+* Bump the OpenSSL version in confluent-kakfa to 3.3.3 on Linux and MacOS. ([#19591](https://github.com/DataDog/integrations-core/pull/19591))
+
 ## 6.3.0 / 2025-01-25
 
 ***Added***:

--- a/kafka_consumer/datadog_checks/kafka_consumer/__about__.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "6.3.0"
+__version__ = "6.4.0"

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -92,7 +92,7 @@ datadog-impala==3.2.0
 datadog-istio==8.1.0
 datadog-jboss-wildfly==3.1.0
 datadog-journald==3.0.0
-datadog-kafka-consumer==6.3.0
+datadog-kafka-consumer==6.4.0
 datadog-kafka==4.0.0
 datadog-karpenter==2.2.0
 datadog-keda==1.0.0


### PR DESCRIPTION
This PR ports the changelogs and version bumps from 7.63 RC7 back to master.