### PR TITLE
[mysql] fix bug where dbms_flavor is appended to tags on every check run

### DIFF
--- a/mysql/changelog.d/19598.fixed
+++ b/mysql/changelog.d/19598.fixed
@@ -1,0 +1,1 @@
+Fix bug where `dbms_flavor` tag was repeatedly appended on each check run.

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -214,7 +214,12 @@ class MySql(AgentCheck):
             )
         )
 
-    def set_version_tags(self):
+    def set_version(self, db):
+        version = get_version(db)
+        if version == self.version:
+            return
+
+        self.version = version
         if not self.version or not self.version.flavor:
             return
 
@@ -304,8 +309,7 @@ class MySql(AgentCheck):
                     self._non_internal_tags = self._set_database_instance_tags(aurora_tags)
 
                 # version collection
-                self.version = get_version(db)
-                self.set_version_tags()
+                self.set_version(db)
                 self._send_metadata()
                 self._send_database_instance_metadata()
 

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -219,8 +219,14 @@ class MySql(AgentCheck):
         if version == self.version:
             return
 
+        if self.version and self.version.flavor != version.flavor:
+            try:
+                self.tags.remove('dbms_flavor:{}'.format(self.version.flavor.lower()))
+            except ValueError:
+                pass
+
         self.version = version
-        if not self.version or not self.version.flavor:
+        if not self.version.flavor:
             return
 
         self.tags.append('dbms_flavor:{}'.format(self.version.flavor.lower()))

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -112,6 +112,17 @@ def test_complex_config(aggregator, dd_run_check, instance_complex):
     )
 
 
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_mysql_version_set(aggregator, dd_run_check, instance_basic):
+    mysql_check = MySql(common.CHECK_NAME, {}, [instance_basic])
+    # run check twice to test the version is set once and only once
+    dd_run_check(mysql_check, cancel=False)
+    dd_run_check(mysql_check, cancel=True)
+    assert mysql_check.version is not None
+    assert mysql_check.tags.count('dbms_flavor:{}'.format(mysql_check.version.flavor.lower())) == 1
+
+
 @pytest.mark.e2e
 def test_e2e(dd_agent_check, dd_default_hostname, instance_complex):
     aggregator = dd_agent_check(instance_complex)


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug where the `dbms_flavor` tag was incorrectly appended to the tags list on every integration check run.

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-5003

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
