### PR TITLE
streamnative: update the metrics api permission documentation

### DIFF
--- a/streamnative/README.md
+++ b/streamnative/README.md
@@ -18,7 +18,7 @@ The StreamNative integration collects the following types of [metrics][2]:
 
 1. Log into [StreamNative Cloud Console Account][3].
 2. Click the profile icon and navigate to the **Accounts & Accesses** tab.
-3. Find the Service Account with **Admin** permissions or binding with `metrics-viewer` role.
+3. Find the Service Account with **Admin** permissions or a binding to the `metrics-viewer` role.
    - If no Service Account exists, select **New -> Service Account** to create one, and make sure to enable the **Super Admin** option.
    - To bind a service account with `metrics-viewer`, your refer the [metrics-viewer rolebinding](https://docs.streamnative.io/docs/cloud-metrics-api#metrics-authorization).
 4. On the right side of the chosen Service Account, click the `...` button.

--- a/streamnative/README.md
+++ b/streamnative/README.md
@@ -18,8 +18,9 @@ The StreamNative integration collects the following types of [metrics][2]:
 
 1. Log into [StreamNative Cloud Console Account][3].
 2. Click the profile icon and navigate to the **Accounts & Accesses** tab.
-3. Find the Service Account with **Admin** permissions set to **Enabled**.
+3. Find the Service Account with **Admin** permissions or binding with `metrics-viewer` role.
    - If no Service Account exists, select **New -> Service Account** to create one, and make sure to enable the **Super Admin** option.
+   - To bind a service account with `metrics-viewer`, your refer the [metrics-viewer rolebinding](https://docs.streamnative.io/docs/cloud-metrics-api#metrics-authorization).
 4. On the right side of the chosen Service Account, click the `...` button.
 5. Select **Download OAuth2 Key** to obtain the **Client ID** and **Client Secret**.
 

--- a/streamnative/README.md
+++ b/streamnative/README.md
@@ -20,7 +20,7 @@ The StreamNative integration collects the following types of [metrics][2]:
 2. Click the profile icon and navigate to the **Accounts & Accesses** tab.
 3. Find the Service Account with **Admin** permissions or a binding to the `metrics-viewer` role.
    - If no Service Account exists, select **New -> Service Account** to create one, and make sure to enable the **Super Admin** option.
-   - To bind a service account with `metrics-viewer`, your refer the [metrics-viewer rolebinding](https://docs.streamnative.io/docs/cloud-metrics-api#metrics-authorization).
+   - To bind a service account with the `metrics-viewer` role, refer to the [metrics-viewer rolebinding][5] documentation. 
 4. On the right side of the chosen Service Account, click the `...` button.
 5. Select **Download OAuth2 Key** to obtain the **Client ID** and **Client Secret**.
 

--- a/streamnative/README.md
+++ b/streamnative/README.md
@@ -71,3 +71,4 @@ Need help? Contact [Datadog support][4].
 [2]: https://docs.streamnative.io/docs/cloud-metrics-api#metrics-endpoint
 [3]: https://console.streamnative.cloud/
 [4]: https://docs.datadoghq.com/help/
+[5]: https://docs.streamnative.io/docs/cloud-metrics-api#metrics-authorization


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR updated the description about the authorization for the StreamNative Metrics API since users can also use a a normal service account with `metrics-viewer` role. 

### Motivation
<!-- What inspired you to submit this pull request? -->
Super Admin service account works for StreamNative Metrics API authorization but it may caue the abuse of privileges since super admin can do almost everything on StreamNative Cloud. So, a normal service account with `metrics-viewer` role to limit the permission is a more acceptabled solution for users. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
