### PR TITLE
Bump OpenSSL in confluent-kafka to 3.4.1 on Windows

### DIFF
--- a/.builders/images/windows-x86_64/Dockerfile
+++ b/.builders/images/windows-x86_64/Dockerfile
@@ -114,7 +114,7 @@ RUN Get-RemoteFile `
     Add-ToPath -Append "C:\perl\perl\bin" && `
     Remove-Item "strawberry-perl-$Env:PERL_VERSION-64bit.zip"
 
-ENV OPENSSL_VERSION="3.3.2"
+ENV OPENSSL_VERSION="3.4.1"
 
 ENV CURL_VERSION="8.11.1"
 

--- a/.builders/images/windows-x86_64/build_script.ps1
+++ b/.builders/images/windows-x86_64/build_script.ps1
@@ -26,7 +26,7 @@ $vcpkg_dir = "C:\vcpkg"
 $librdkafka_dir = "C:\librdkafka\librdkafka-${kafka_version}"
 # We set the desired tag to the latest release tag to ensure that we are building with the latest stable version.
 # The desired tag should be updated periodically or when critical fixes or features are released.
-$desired_tag = "2024.12.16"
+$desired_tag = "5ee5eee0d3e9c6098b24d263e9099edcdcef6631" # Commit that incudes OpenSSL 3.4.1
 
 # Clone and configure vcpkg
 if (-Not (Test-Path -Path "$vcpkg_dir\.git")) {

--- a/.builders/images/windows-x86_64/build_script.ps1
+++ b/.builders/images/windows-x86_64/build_script.ps1
@@ -24,9 +24,9 @@ Remove-Item "librdkafka-${kafka_version}.tar.gz"
 $triplet = "x64-windows"
 $vcpkg_dir = "C:\vcpkg"
 $librdkafka_dir = "C:\librdkafka\librdkafka-${kafka_version}"
-# We set the desired tag to the latest release tag to ensure that we are building with the latest stable version.
-# The desired tag should be updated periodically or when critical fixes or features are released.
-$desired_tag = "5ee5eee0d3e9c6098b24d263e9099edcdcef6631" # Commit that incudes OpenSSL 3.4.1
+# We set the desired commit to ensure that we are building with a recent version.
+# The desired commit should be updated periodically or when critical fixes or features are released.
+$desired_commit = "5ee5eee0d3e9c6098b24d263e9099edcdcef6631" # Commit that incudes OpenSSL 3.4.1
 
 # Clone and configure vcpkg
 if (-Not (Test-Path -Path "$vcpkg_dir\.git")) {
@@ -34,7 +34,7 @@ if (-Not (Test-Path -Path "$vcpkg_dir\.git")) {
 }
 
 Set-Location $vcpkg_dir
-git checkout $desired_tag
+git checkout $desired_commit
 
 Write-Host "Bootstrapping vcpkg..."
 .\bootstrap-vcpkg.bat

--- a/kafka_consumer/changelog.d/19608.added
+++ b/kafka_consumer/changelog.d/19608.added
@@ -1,0 +1,1 @@
+Bump OpenSSL in confluent-kafka to 3.4.1 on Windows.


### PR DESCRIPTION
Fixes [CVE-2024-12797.](https://nvd.nist.gov/vuln/detail/CVE-2024-12797)
3.4.1 is not on [vcpkg.io](https://vcpkg.io/en/package/openssl) yet but it's accessible in the CLI.
```
PS C:\Users\Administrator\Downloads\vcpkg> .\vcpkg.exe search openssl
...
openssl                  3.4.1            OpenSSL is an open source project that provides a robust, commercial-grade...
```
Upgrading to from 3.3.2 directly to 3.4.1 because it seems like [the vcpkg project is skipping 3.3.3 and upgrading the 3.4.X branch instead](https://github.com/microsoft/vcpkg/issues/43779). 
The CVE was already fixed on Linux and MacOS in [a previous commit](https://github.com/DataDog/integrations-core/commit/18deb23bf132f2f50afd11ca56ddec12f9926a5c).
