### PR TITLE
Port changelog from 7.62.3 rc1

### DIFF
--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -1,17 +1,20 @@
 # CHANGELOG - mysql
 
 <!-- towncrier release notes start -->
-
 ## 14.5.0 / 2025-01-25
 
 ***Added***:
 
 * Added an optional optimization to MySQL statement metrics collection to only query for queries that have run since the last check collection. ([#19321](https://github.com/DataDog/integrations-core/pull/19321))
 * Emit index usage and index metrics from mysql integration ([#19383](https://github.com/DataDog/integrations-core/pull/19383))
+  (Note: does not contain the`dmbs_flavor` fix from 14.4.1)
+
+## 14.4.1 / 2025-02-13 / Agent 7.62.3
 
 ***Fixed***:
 
-* Bump datadog-checks-base version ([#19478](https://github.com/DataDog/integrations-core/pull/19478))
+* Fix bug where `dbms_flavor` tag was repeatedly appended on each check run. ([#19598](https://github.com/DataDog/integrations-core/pull/19598))
+  (Note: not included in 14.5.0)
 
 ## 14.4.0 / 2024-12-26 / Agent 7.62.0
 


### PR DESCRIPTION
This PR ports the changelog for the dmb_flavor fix from 7.62.3 rc1. I added notes to clarify that 14.5.0 doesn't have the fix.