### PR TITLE
Add role_name tag key to machine metrics

### DIFF
--- a/octopus_deploy/changelog.d/19613.fixed
+++ b/octopus_deploy/changelog.d/19613.fixed
@@ -1,0 +1,1 @@
+Add `role_name` tag key to machine metrics.

--- a/octopus_deploy/datadog_checks/octopus_deploy/check.py
+++ b/octopus_deploy/datadog_checks/octopus_deploy/check.py
@@ -474,7 +474,7 @@ class OctopusDeployCheck(AgentCheck, ConfigMixin):
                 f"health_status:{health_status}",
                 f"operating_system:{os}",
             ]
-            machine_tags += roles
+            machine_tags += [f"role_name:{role}" for role in roles]
             environment_ids = machine.get("EnvironmentIds")
             env_tags = []
             for env_id in environment_ids:

--- a/octopus_deploy/tests/test_unit.py
+++ b/octopus_deploy/tests/test_unit.py
@@ -2553,7 +2553,7 @@ def test_machines_metrics(
             "machine_slug:test-machine",
             "health_status:Healthy",
             "operating_system:Ubuntu 24.04.1 LTS",
-            "test-tag",
+            "role_name:test-tag",
         ],
     )
     aggregator.assert_metric(
@@ -2567,7 +2567,7 @@ def test_machines_metrics(
             "machine_slug:test-machine",
             "health_status:Healthy",
             "operating_system:Ubuntu 24.04.1 LTS",
-            "test-tag",
+            "role_name:test-tag",
         ],
     )
     aggregator.assert_metric(
@@ -2580,8 +2580,8 @@ def test_machines_metrics(
             "machine_slug:test-machine1",
             "health_status:Healthy with warnings",
             "operating_system:Ubuntu 24.04.1 LTS",
-            "tag",
-            "test",
+            "role_name:tag",
+            "role_name:test",
         ],
     )
     aggregator.assert_metric(
@@ -2594,8 +2594,8 @@ def test_machines_metrics(
             "machine_slug:test-machine1",
             "health_status:Healthy with warnings",
             "operating_system:Ubuntu 24.04.1 LTS",
-            "test",
-            "tag",
+            "role_name:tag",
+            "role_name:test",
         ],
     )
 
@@ -2610,7 +2610,7 @@ def test_machines_metrics(
             "machine_slug:test-machine3",
             "health_status:Unhealthy",
             "operating_system:Ubuntu 24.04.1 LTS",
-            "test",
+            "role_name:test",
         ],
     )
     aggregator.assert_metric(
@@ -2624,7 +2624,7 @@ def test_machines_metrics(
             "machine_slug:test-machine3",
             "health_status:Unhealthy",
             "operating_system:Ubuntu 24.04.1 LTS",
-            "test",
+            "role_name:test",
         ],
     )
 
@@ -2688,7 +2688,7 @@ def test_machines_pagination(
             "machine_slug:test-machine",
             "health_status:Healthy",
             "operating_system:Ubuntu 24.04.1 LTS",
-            "test-tag",
+            "role_name:test-tag",
         ],
     )
     aggregator.assert_metric(
@@ -2702,7 +2702,7 @@ def test_machines_pagination(
             "machine_slug:test-machine",
             "health_status:Healthy",
             "operating_system:Ubuntu 24.04.1 LTS",
-            "test-tag",
+            "role_name:test-tag",
         ],
     )
     aggregator.assert_metric(
@@ -2715,8 +2715,8 @@ def test_machines_pagination(
             "machine_slug:test-machine1",
             "health_status:Healthy with warnings",
             "operating_system:Ubuntu 24.04.1 LTS",
-            "tag",
-            "test",
+            "role_name:tag",
+            "role_name:test",
         ],
     )
     aggregator.assert_metric(
@@ -2729,8 +2729,8 @@ def test_machines_pagination(
             "machine_slug:test-machine1",
             "health_status:Healthy with warnings",
             "operating_system:Ubuntu 24.04.1 LTS",
-            "test",
-            "tag",
+            "role_name:tag",
+            "role_name:test",
         ],
     )
 
@@ -2745,7 +2745,7 @@ def test_machines_pagination(
             "machine_slug:test-machine3",
             "health_status:Unhealthy",
             "operating_system:Ubuntu 24.04.1 LTS",
-            "test",
+            "role_name:test",
         ],
     )
     aggregator.assert_metric(
@@ -2759,7 +2759,7 @@ def test_machines_pagination(
             "machine_slug:test-machine3",
             "health_status:Unhealthy",
             "operating_system:Ubuntu 24.04.1 LTS",
-            "test",
+            "role_name:test",
         ],
     )
 


### PR DESCRIPTION
### What does this PR do?
Adds a role_name tag key to octopus machine metrics

### Motivation
Make the metrics easier to filter by in dashboard queries
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
