### PR TITLE
Fix content permissions error for GitHub Actions labeler.

### DIFF
--- a/.github/workflows/labeler-community.yml
+++ b/.github/workflows/labeler-community.yml
@@ -16,6 +16,7 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.full_name != github.repository }} # only PRs from other repos
     permissions:
       pull-requests: write # Needed for labeler-reusable.yml
+      contents: read # Needed for labeler-reusable.yml
     uses: ./.github/workflows/labeler-reusable.yml
     secrets:
       app-id: "${{ secrets.DD_AGENT_INTEGRATIONS_BOT_APP_ID }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,7 +13,8 @@ jobs:
   labeler:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }} # only PRs from this repo
     permissions:
-      pull-requests: write # Need for labeler-reusable.yml
+      pull-requests: write # Needed for labeler-reusable.yml
+      contents: read # Needed for labeler-reusable.yml
     uses: ./.github/workflows/labeler-reusable.yml
     secrets:
       app-id: "${{ secrets.DD_AGENT_INTEGRATIONS_BOT_APP_ID }}"


### PR DESCRIPTION
This PR fixes the error here:
> [Invalid workflow file: .github/workflows/labeler-community.yml#L15](https://github.com/DataDog/integrations-core/actions/runs/13326543000/workflow)
The workflow is not valid. .github/workflows/labeler-community.yml (Line: 15, Col: 3): Error calling workflow 'DataDog/integrations-core/.github/workflows/labeler-reusable.yml@c6823fe5f828c2506b828d8dd68a622447945705'. 

My [recent fix](https://github.com/DataDog/integrations-core/pull/19585) added pull_request: write permissions, however setting permissions explicitly removed the implicit `contents: read` permission, so I'm reintroducing it here.