### PR TITLE
Move import of prometheus_client inside the functions using it

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/libs/prometheus.py
+++ b/datadog_checks_base/datadog_checks/base/checks/libs/prometheus.py
@@ -31,6 +31,7 @@ def _parse_payload(fd):
     """
     from prometheus_client.metrics_core import Metric
     from prometheus_client.parser import _parse_sample, _replace_help_escaping
+
     name = ''
     documentation = ''
     typ = 'untyped'

--- a/datadog_checks_base/datadog_checks/base/checks/libs/prometheus.py
+++ b/datadog_checks_base/datadog_checks/base/checks/libs/prometheus.py
@@ -4,9 +4,6 @@
 
 from itertools import tee
 
-from prometheus_client.metrics_core import Metric
-from prometheus_client.parser import _parse_sample, _replace_help_escaping
-
 
 def text_fd_to_metric_families(fd):
     raw_lines, input_lines = tee(fd, 2)
@@ -32,6 +29,8 @@ def _parse_payload(fd):
 
     Yields Metric's.
     """
+    from prometheus_client.metrics_core import Metric
+    from prometheus_client.parser import _parse_sample, _replace_help_escaping
     name = ''
     documentation = ''
     typ = 'untyped'

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -11,7 +11,6 @@ from os.path import isfile
 from re import compile
 
 import requests
-from prometheus_client.samples import Sample
 
 from datadog_checks.base.agent import datadog_agent
 
@@ -1060,6 +1059,8 @@ class OpenMetricsScraperMixin(object):
         """
         Decumulate buckets in a given histogram metric and adds the lower_bound label (le being upper_bound)
         """
+        from prometheus_client.samples import Sample
+
         bucket_values_by_context_upper_bound = {}
         for sample in metric.samples:
             if sample[self.SAMPLE_NAME].endswith("_bucket"):

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
@@ -9,8 +9,6 @@ from itertools import chain
 from math import isinf, isnan
 from typing import List  # noqa: F401
 
-from prometheus_client.openmetrics.parser import text_fd_to_metric_families as parse_openmetrics
-from prometheus_client.parser import text_fd_to_metric_families as parse_prometheus
 from requests.exceptions import ConnectionError
 
 from datadog_checks.base.agent import datadog_agent
@@ -297,6 +295,8 @@ class OpenMetricsScraper:
 
     @property
     def parse_metric_families(self):
+        from prometheus_client.parser import text_fd_to_metric_families as parse_prometheus
+        from prometheus_client.openmetrics.parser import text_fd_to_metric_families as parse_openmetrics
         media_type = self._content_type.split(';')[0]
         # Setting `use_latest_spec` forces the use of the OpenMetrics format, otherwise
         # the format will be chosen based on the media type specified in the response's content-header.

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
@@ -297,6 +297,7 @@ class OpenMetricsScraper:
     def parse_metric_families(self):
         from prometheus_client.parser import text_fd_to_metric_families as parse_prometheus
         from prometheus_client.openmetrics.parser import text_fd_to_metric_families as parse_openmetrics
+
         media_type = self._content_type.split(';')[0]
         # Setting `use_latest_spec` forces the use of the OpenMetrics format, otherwise
         # the format will be chosen based on the media type specified in the response's content-header.

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
@@ -295,8 +295,8 @@ class OpenMetricsScraper:
 
     @property
     def parse_metric_families(self):
-        from prometheus_client.parser import text_fd_to_metric_families as parse_prometheus
         from prometheus_client.openmetrics.parser import text_fd_to_metric_families as parse_openmetrics
+        from prometheus_client.parser import text_fd_to_metric_families as parse_prometheus
 
         media_type = self._content_type.split(';')[0]
         # Setting `use_latest_spec` forces the use of the OpenMetrics format, otherwise

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/utils.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/utils.py
@@ -10,6 +10,7 @@ def decumulate_histogram_buckets(sample_data):
     Decumulate buckets in a given histogram metric and adds the lower_bound label (le being upper_bound)
     """
     from prometheus_client.samples import Sample
+
     # TODO: investigate performance optimizations
     new_sample_data = []
     bucket_values_by_context_upper_bound = {}

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/utils.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/utils.py
@@ -1,7 +1,6 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from prometheus_client.samples import Sample
 
 NEGATIVE_INFINITY = float('-inf')
 
@@ -10,6 +9,7 @@ def decumulate_histogram_buckets(sample_data):
     """
     Decumulate buckets in a given histogram metric and adds the lower_bound label (le being upper_bound)
     """
+    from prometheus_client.samples import Sample
     # TODO: investigate performance optimizations
     new_sample_data = []
     bucket_values_by_context_upper_bound = {}


### PR DESCRIPTION
### What does this PR do?
Move the various imports of prometheus inside the functions using it.

### Motivation
Reduce the default memory usage of BaseChecks by avoiding importing prometheus.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
