### PR TITLE
DubckDB: Set "display_on_public_website" to true

### DIFF
--- a/duckdb/manifest.json
+++ b/duckdb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a905fbe6-135f-4189-b027-4bdc58e51e29",
   "app_id": "duckdb",
-  "display_on_public_website": false,
+  "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
Change DuckDB `display_on_public_website` in the `manifest.json` to `true`. It's a step in the Release for [Everyone checklist](https://datadoghq.atlassian.net/browse/AI-4471).