### PR TITLE
Update kubernetes_pods.json

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_pods.json
+++ b/kubernetes/assets/dashboards/kubernetes_pods.json
@@ -95,7 +95,7 @@
                 "custom_links": [],
                 "requests": [
                   {
-                    "q": "sum:kubernetes.pods.running{$scope,$namespace,$cluster,$deployment,$statefulset,$daemonset,$job} by {kube_namespace,kube_deployment}",
+                    "q": "sum:kubernetes.pods.running{$scope,$namespace,$cluster,$deployment,$statefulset,$daemonset,$job,$cronjob} by {kube_namespace,kube_deployment}",
                     "order_by": "change",
                     "order_dir": "desc",
                     "compare_to": "week_before",
@@ -160,7 +160,7 @@
                     "response_format": "timeseries",
                     "queries": [
                       {
-                        "query": "sum:kubernetes.pods.running{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job} by {kube_cluster_name,kube_namespace}",
+                        "query": "sum:kubernetes.pods.running{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job,$cronjob} by {kube_cluster_name,kube_namespace}",
                         "data_source": "metrics",
                         "name": "query1"
                       }
@@ -215,7 +215,7 @@
                     "response_format": "scalar",
                     "queries": [
                       {
-                        "query": "sum:kubernetes.cpu.usage.total{$scope,$namespace,$deployment,!pod_name:no_pod,$cluster,$statefulset,$daemonset,$job} by {pod_name}",
+                        "query": "sum:kubernetes.cpu.usage.total{$scope,$namespace,$deployment,!pod_name:no_pod,$cluster,$statefulset,$daemonset,$job,$cronjob} by {pod_name}",
                         "data_source": "metrics",
                         "name": "query1",
                         "aggregator": "avg"
@@ -243,7 +243,7 @@
                     "on_right_yaxis": false,
                     "queries": [
                       {
-                        "query": "sum:kubernetes.cpu.usage.total{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {pod_name}",
+                        "query": "sum:kubernetes.cpu.usage.total{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job,$cronjob} by {pod_name}",
                         "data_source": "metrics",
                         "name": "query1"
                       }
@@ -285,7 +285,7 @@
                     "response_format": "scalar",
                     "queries": [
                       {
-                        "query": "sum:kubernetes.memory.usage{$scope,$namespace,$deployment,!pod_name:no_pod,$cluster,$statefulset,$daemonset,$job} by {pod_name}",
+                        "query": "sum:kubernetes.memory.usage{$scope,$namespace,$deployment,!pod_name:no_pod,$cluster,$statefulset,$daemonset,$job,$cronjob} by {pod_name}",
                         "data_source": "metrics",
                         "name": "query1",
                         "aggregator": "avg"
@@ -315,7 +315,7 @@
                     "on_right_yaxis": false,
                     "queries": [
                       {
-                        "query": "sum:kubernetes.memory.usage{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {pod_name}",
+                        "query": "sum:kubernetes.memory.usage{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job,$cronjob} by {pod_name}",
                         "data_source": "metrics",
                         "name": "query1"
                       }
@@ -348,7 +348,7 @@
                 "type": "toplist",
                 "requests": [
                   {
-                    "q": "top(sum:kubernetes.pods.running{$scope,$namespace,$deployment,$cluster,$statefulset,$daemonset,$job} by {kube_cluster_name,kube_namespace}, 100, 'max', 'desc')",
+                    "q": "top(sum:kubernetes.pods.running{$scope,$namespace,$deployment,$cluster,$statefulset,$daemonset,$job,$cronjob} by {kube_cluster_name,kube_namespace}, 100, 'max', 'desc')",
                     "conditional_formats": [
                       {
                         "comparator": ">",
@@ -381,7 +381,7 @@
                 "type": "toplist",
                 "requests": [
                   {
-                    "q": "top(sum:kubernetes_state.pod.ready{$scope,$cluster,$namespace,$deployment,condition:true,$statefulset,$daemonset,$job} by {kube_cluster_name,host,nodepool}, 10, 'last', 'desc')",
+                    "q": "top(sum:kubernetes_state.pod.ready{$scope,$cluster,$namespace,$deployment,condition:true,$statefulset,$daemonset,$job,$cronjob} by {kube_cluster_name,host,nodepool}, 10, 'last', 'desc')",
                     "conditional_formats": [
                       {
                         "comparator": "<=",
@@ -414,7 +414,7 @@
                 "type": "toplist",
                 "requests": [
                   {
-                    "q": "top(exclude_null(sum:kubernetes_state.pod.ready{condition:false,$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job,!pod_phase:succeeded} by {kube_namespace}), 25, 'last', 'desc')",
+                    "q": "top(exclude_null(sum:kubernetes_state.pod.ready{condition:false,$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job,$cronjob,!pod_phase:succeeded} by {kube_namespace}), 25, 'last', 'desc')",
                     "conditional_formats": [
                       {
                         "comparator": ">",
@@ -442,7 +442,7 @@
                 "type": "toplist",
                 "requests": [
                   {
-                    "q": "top(sum:kubernetes.pods.running{$scope,$namespace,$deployment,$cluster,$statefulset,$daemonset,$job} by {kube_runtime_class}, 100, 'max', 'desc')",
+                    "q": "top(sum:kubernetes.pods.running{$scope,$namespace,$deployment,$cluster,$statefulset,$daemonset,$job,$cronjob} by {kube_runtime_class}, 100, 'max', 'desc')",
                     "conditional_formats": [
                       {
                         "comparator": ">",
@@ -487,22 +487,22 @@
                     "response_format": "timeseries",
                     "queries": [
                       {
-                        "query": "sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:failed,$scope,$statefulset,$daemonset,$job}",
+                        "query": "sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:failed,$scope,$statefulset,$daemonset,$job,$cronjob}",
                         "data_source": "metrics",
                         "name": "query1"
                       },
                       {
-                        "query": "sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:pending,$scope,$statefulset,$daemonset,$job}",
+                        "query": "sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:pending,$scope,$statefulset,$daemonset,$job,$cronjob}",
                         "data_source": "metrics",
                         "name": "query2"
                       },
                       {
-                        "query": "sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:running,$scope,$statefulset,$daemonset,$job}",
+                        "query": "sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:running,$scope,$statefulset,$daemonset,$job,$cronjob}",
                         "data_source": "metrics",
                         "name": "query3"
                       },
                       {
-                        "query": "sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:succeeded,$scope,$statefulset,$daemonset,$job}",
+                        "query": "sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:succeeded,$scope,$statefulset,$daemonset,$job,$cronjob}",
                         "data_source": "metrics",
                         "name": "query4"
                       }
@@ -560,22 +560,22 @@
                     "on_right_yaxis": false,
                     "queries": [
                       {
-                        "query": "sum:kubernetes_state.container.ready{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job}",
+                        "query": "sum:kubernetes_state.container.ready{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job,$cronjob}",
                         "data_source": "metrics",
                         "name": "query1"
                       },
                       {
-                        "query": "sum:kubernetes_state.container.running{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job}",
+                        "query": "sum:kubernetes_state.container.running{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job,$cronjob}",
                         "data_source": "metrics",
                         "name": "query2"
                       },
                       {
-                        "query": "sum:kubernetes_state.container.terminated{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job}",
+                        "query": "sum:kubernetes_state.container.terminated{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job,$cronjob}",
                         "data_source": "metrics",
                         "name": "query3"
                       },
                       {
-                        "query": "sum:kubernetes_state.container.status_report.count.waiting{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job}",
+                        "query": "sum:kubernetes_state.container.status_report.count.waiting{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job,$cronjob}",
                         "data_source": "metrics",
                         "name": "query4"
                       }
@@ -615,7 +615,7 @@
                     "response_format": "timeseries",
                     "queries": [
                       {
-                        "query": "sum:kubernetes.containers.state.terminated{$cluster,$namespace,$deployment,reason:oomkilled,$scope,$statefulset,$daemonset,$job} by {pod_name}",
+                        "query": "sum:kubernetes.containers.state.terminated{$cluster,$namespace,$deployment,reason:oomkilled,$scope,$statefulset,$daemonset,$job,$cronjob} by {pod_name}",
                         "data_source": "metrics",
                         "name": "query1"
                       }
@@ -658,7 +658,7 @@
                     "on_right_yaxis": false,
                     "queries": [
                       {
-                        "query": "sum:kubernetes_state.container.status_report.count.waiting{$cluster,$namespace,$deployment,reason:crashloopbackoff,$scope,$statefulset,$daemonset,$job} by {pod_name}",
+                        "query": "sum:kubernetes_state.container.status_report.count.waiting{$cluster,$namespace,$deployment,reason:crashloopbackoff,$scope,$statefulset,$daemonset,$job,$cronjob} by {pod_name}",
                         "data_source": "metrics",
                         "name": "query1"
                       }
@@ -699,7 +699,7 @@
                     "on_right_yaxis": false,
                     "queries": [
                       {
-                        "query": "sum:kubernetes_state.container.restarts{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job} by {pod_name}",
+                        "query": "sum:kubernetes_state.container.restarts{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job,$cronjob} by {pod_name}",
                         "data_source": "metrics",
                         "name": "query1"
                       }
@@ -740,7 +740,7 @@
                     "on_right_yaxis": false,
                     "queries": [
                       {
-                        "query": "sum:kubernetes.cpu.usage.total{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {kube_container_name,container_id}",
+                        "query": "sum:kubernetes.cpu.usage.total{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job,$cronjob} by {kube_container_name,container_id}",
                         "data_source": "metrics",
                         "name": "query1"
                       }
@@ -783,7 +783,7 @@
                     "on_right_yaxis": false,
                     "queries": [
                       {
-                        "query": "sum:kubernetes.memory.usage{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {kube_container_name,container_id}",
+                        "query": "sum:kubernetes.memory.usage{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job,$cronjob} by {kube_container_name,container_id}",
                         "data_source": "metrics",
                         "name": "query1"
                       }
@@ -827,12 +827,12 @@
                     "on_right_yaxis": false,
                     "queries": [
                       {
-                        "query": "sum:kubernetes.network.rx_bytes{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {pod_name}",
+                        "query": "sum:kubernetes.network.rx_bytes{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job,$cronjob} by {pod_name}",
                         "data_source": "metrics",
                         "name": "query1"
                       },
                       {
-                        "query": "sum:kubernetes.network.tx_bytes{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {pod_name}",
+                        "query": "sum:kubernetes.network.tx_bytes{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job,$cronjob} by {pod_name}",
                         "data_source": "metrics",
                         "name": "query2"
                       }
@@ -876,12 +876,12 @@
                     "on_right_yaxis": false,
                     "queries": [
                       {
-                        "query": "sum:kubernetes.network.rx_errors{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {pod_name}",
+                        "query": "sum:kubernetes.network.rx_errors{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job,$cronjob} by {pod_name}",
                         "data_source": "metrics",
                         "name": "query1"
                       },
                       {
-                        "query": "sum:kubernetes.network.tx_errors{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {pod_name}",
+                        "query": "sum:kubernetes.network.tx_errors{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job,$cronjob} by {pod_name}",
                         "data_source": "metrics",
                         "name": "query2"
                       }


### PR DESCRIPTION
### What does this PR do?
Add template variable `$cronjob` to all widgets in OOTB Kubernetes Pod Overview Dashboard. Currently, it is only filtering a few widgets based on dashboard template variable `$cronjob`

### Motivation
https://datadog.zendesk.com/agent/tickets/2037802 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
