### PR TITLE
Update kubernetes dependency and move to correct place

### DIFF
--- a/kubevirt_api/changelog.d/19655.fixed
+++ b/kubevirt_api/changelog.d/19655.fixed
@@ -1,0 +1,1 @@
+Fix `kubernetes` dependency packaging.

--- a/kubevirt_api/pyproject.toml
+++ b/kubevirt_api/pyproject.toml
@@ -30,7 +30,6 @@ classifiers = [
 ]
 dependencies = [
     "datadog-checks-base>=37.4.0",
-    "kubernetes>=30.1.0",
 ]
 dynamic = [
     "version",
@@ -38,6 +37,7 @@ dynamic = [
 
 [project.optional-dependencies]
 deps = [
+    "kubernetes==32.0.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?
Makes kubernetes an official dependency of kubevirt_api and updates version
### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
