### PR TITLE
[LOGSC-2211] Set up new github team to review logs integrations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -497,4 +497,4 @@ docs/developer/process/integration-release.md                         @DataDog/a
 
 # LEAVE THE FOLLOWING LOG OWNERSHIP LAST IN THE FILE
 # Make sure logs team is the full owner for all logs related files
-**/assets/logs/                          @DataDog/logs-backend @DataDog/logs-core @DataDog/siem-logs-reviewers
+**/assets/logs/                                                       @DataDog/logs-integrations-reviewers @DataDog/logs-backend @DataDog/logs-core @DataDog/siem-logs-reviewers


### PR DESCRIPTION
Some engineers from not the logs-backend team will now help to review integrations. So we create this new reviewer team for all people with the ownership to review logs integrations files.