### PR TITLE
Create new kafka consumer client only if needed

### DIFF
--- a/kafka_consumer/changelog.d/19658.fixed
+++ b/kafka_consumer/changelog.d/19658.fixed
@@ -1,0 +1,1 @@
+Create new kafka consumer client only if needed when fetching highwater offsets


### PR DESCRIPTION
### What does this PR do?
Only create new consumer client when needed otherwise reuses the existing client. 

### Motivation
Currently the check spends a lot of time opening and closing consumer. Issue is explained in more detail https://github.com/DataDog/integrations-core/issues/19564

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
