### PR TITLE
Tag FoundationDB process metrics with process class, assigned roles

### DIFF
--- a/foundationdb/changelog.d/19682.added
+++ b/foundationdb/changelog.d/19682.added
@@ -1,0 +1,1 @@
+Tag FoundationDB process metrics with process class, assigned roles

--- a/foundationdb/tests/test_foundationdb.py
+++ b/foundationdb/tests/test_foundationdb.py
@@ -36,6 +36,29 @@ def test_full(aggregator, instance):
             aggregator.assert_metric(metric)
             aggregator.assert_metric_has_tag(metric, 'fdb_test:true')
 
+            if metric.startswith('foundationdb.process.'):
+                aggregator.assert_metric_has_tag_prefix(metric, 'fdb_process_class')
+                aggregator.assert_metric_has_tag_prefix(metric, 'fdb_role')
+
+        aggregator.assert_metric(
+            'foundationdb.process.cpu.usage_cores',
+            tags=[
+                'fdb_test:true',
+                'fdb_process:127.0.0.1:4000',
+                'fdb_process_class:unset',
+                'fdb_role:master',
+                'fdb_role:cluster_controller',
+                'fdb_role:data_distributor',
+                'fdb_role:ratekeeper',
+                'fdb_role:coordinator',
+                'fdb_role:proxy',
+                'fdb_role:log',
+                'fdb_role:storage',
+                'fdb_role:resolver',
+            ],
+            value=0.015280199999999999,
+        )
+
         aggregator.assert_all_metrics_covered()
         aggregator.assert_metrics_using_metadata(get_metadata_metrics())
         aggregator.assert_service_check("foundationdb.can_connect", AgentCheck.OK)


### PR DESCRIPTION
### What does this PR do?
This pull request adds additional tags to existing FoundationDB process metrics to help operators identify which roles the associated processes are performing.

### Motivation
FoundationDB processes can take on one or more roles within a cluster. When scaling a cluster, operators generally add new processes for overloaded roles. The heuristics for "overloaded" vary by process, but basic indicators like CPU utilization often give helpful first-order clues for where to begin.

Before this change, each process would report metrics (like CPU utilization) such that each metric was tagged with the process ID. We _can_ use the process ID in conjunction with additional external tools to identify the roles a process is performing, but it would be much more convenient if the process metrics were already tagged by role. After this change, process metrics will be tagged with all of the roles performed by the associated process.

This change should not affect any existing queries, but will allow operators to write new queries to show things like "average CPU load for GRV proxies" or "network throughput for log processes."

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
