### PR TITLE
Only trigger extensions in default namespaces

### DIFF
--- a/postgres/changelog.d/19694.fixed
+++ b/postgres/changelog.d/19694.fixed
@@ -1,0 +1,1 @@
+When collecting Postgres setttings, only trigger the activations extensions that are installed in default namespaces.

--- a/postgres/tests/compose/resources/03_load_data.sh
+++ b/postgres/tests/compose/resources/03_load_data.sh
@@ -4,7 +4,9 @@ set -e
 # Create extensions for settings testing
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" datadog_test <<-EOSQL
     CREATE EXTENSION IF NOT EXISTS pg_trgm;
-    CREATE EXTENSION IF NOT EXISTS hstore;
+    -- Create an extension in a non-standard schema to test that behavior
+    CREATE SCHEMA hstore;
+    CREATE EXTENSION IF NOT EXISTS hstore WITH SCHEMA hstore;
     CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 EOSQL


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds a check to only trigger the activation of extensions that are installed in `public` or `pg_catalog`.

### Motivation
<!-- What inspired you to submit this pull request? -->
If an extension is installed into a schema that the agent does not have access to, it causes the settings collection to fail.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
