### PR TITLE
Consolidate process count metrics

### DIFF
--- a/foundationdb/changelog.d/19706.added
+++ b/foundationdb/changelog.d/19706.added
@@ -1,0 +1,1 @@
+Introduce a `foundationdb.processes_per_role` gauge tagged by process role/class

--- a/foundationdb/metadata.csv
+++ b/foundationdb/metadata.csv
@@ -94,6 +94,7 @@ foundationdb.process.role.stored_bytes,gauge,,byte,,,0,foundationdb,stored bytes
 foundationdb.process.role.total_queries.counter,count,,query,,,0,foundationdb,total queries,
 foundationdb.process.role.total_queries.hz,gauge,,query,,,0,foundationdb,total queries,
 foundationdb.processes,gauge,,process,,,0,foundationdb,processes,
+foundationdb.processes_per_role,gauge,,process,,,0,foundationdb,processes per role/process class,
 foundationdb.processes_per_role.cluster_controller,gauge,,process,,,0,foundationdb,processes per cluster controller,
 foundationdb.processes_per_role.coordinator,gauge,,process,,,0,foundationdb,processes per coordinator,
 foundationdb.processes_per_role.data_distributor,gauge,,process,,,0,foundationdb,processes per data distributor,

--- a/foundationdb/tests/common.py
+++ b/foundationdb/tests/common.py
@@ -189,6 +189,7 @@ METRICS = [
     "foundationdb.process.role.read_latency_statistics.p90",
     "foundationdb.process.role.read_latency_statistics.p99",
     "foundationdb.process.role.queue_length",
+    "foundationdb.processes_per_role",
     "foundationdb.processes_per_role.cluster_controller",
     "foundationdb.processes_per_role.coordinator",
     "foundationdb.processes_per_role.data_distributor",

--- a/foundationdb/tests/test_foundationdb.py
+++ b/foundationdb/tests/test_foundationdb.py
@@ -63,6 +63,18 @@ def test_full(aggregator, instance):
         aggregator.assert_metrics_using_metadata(get_metadata_metrics())
         aggregator.assert_service_check("foundationdb.can_connect", AgentCheck.OK)
 
+        aggregator.assert_metric_has_tag("foundationdb.processes_per_role", "fdb_process_class:unset")
+
+        aggregator.assert_metric_has_tag("foundationdb.processes_per_role", "fdb_role:master")
+        aggregator.assert_metric_has_tag("foundationdb.processes_per_role", "fdb_role:cluster_controller")
+        aggregator.assert_metric_has_tag("foundationdb.processes_per_role", "fdb_role:data_distributor")
+        aggregator.assert_metric_has_tag("foundationdb.processes_per_role", "fdb_role:ratekeeper")
+        aggregator.assert_metric_has_tag("foundationdb.processes_per_role", "fdb_role:coordinator")
+        aggregator.assert_metric_has_tag("foundationdb.processes_per_role", "fdb_role:proxy")
+        aggregator.assert_metric_has_tag("foundationdb.processes_per_role", "fdb_role:log")
+        aggregator.assert_metric_has_tag("foundationdb.processes_per_role", "fdb_role:storage")
+        aggregator.assert_metric_has_tag("foundationdb.processes_per_role", "fdb_role:resolver")
+
 
 @pytest.mark.skipif(PROTOCOL == 'tls', reason="Non-TLS FoundationDB cluster only.")
 @pytest.mark.usefixtures("dd_environment")


### PR DESCRIPTION
### What does this PR do?
This introduces a new, single `foundationdb.processes_per_role` gauge that is tagged by `fdb_role` and `fdb_process_class`. It makes no changes to existing metrics.

### Motivation
There are two main motivations for this new gauge:

1. The set of role types in a FoundationDB cluster can change from version to version. For example, FoundationDB 6.x had a notion of a `proxy` role, but in FoundationDB 7.x, that role is gone and has been replaced by `grv_proxy` and `commit_proxy`. Using tags (instead of individual gauges) to count processes by role gives this integration more flexibility to work with different versions of FoundationDB.
2. Having processes tagged by role gives operators a mechanism by which they can detect if a single process is performing multiple roles. For example, in a heavily-loaded cluster, having a single process act in both the `storage` and `log` roles would be bad news, and operators might want to add a monitor for problematic duplicate role assignments.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
