### PR TITLE
Agent integrations team can approve snowflake version bumps.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -339,6 +339,7 @@ datadog_checks_base/datadog_checks/base/checks/windows/              @DataDog/wi
 /snowflake/                                                          @DataDog/saas-integrations
 /snowflake/*.md                                                      @DataDog/saas-integrations @DataDog/documentation @DataDog/agent-integrations
 /snowflake/changelog.d/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/agent-integrations
+/snowflake/datadog_checks/snowflake/__about__.py                     @DataDog/saas-integrations @DataDog/documentation @DataDog/agent-integrations
 /snowflake/pyproject.toml                                            @DataDog/saas-integrations @DataDog/documentation @DataDog/agent-integrations
 /snowflake/manifest.json                                             @DataDog/saas-integrations @DataDog/documentation
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
### Before
PRs with new releases of the snowflake integration **require** approval from SAAS ints.

### After
PRs with new releases of the snowflake integration can be merged after Agent Ints team approves them. No need to ping SAAS ints or admin-merge.

### Motivation
<!-- What inspired you to submit this pull request? -->
No need to bother SAAS ints if we're releasing a new snowflake integration version due to dependency or Python version updates.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
