### PR TITLE
Ignore I001 linting rule for autogenerated `_version.py` file in ddev

### DIFF
--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -121,3 +121,5 @@ ban-relative-imports = "all"
 [tool.ruff.lint.per-file-ignores]
 #Tests can use assertions and relative imports
 "**/tests/**/*" = ["I252"]
+# Transient dep setuptools-scm 8.2.0+ generated files conflicts with I001 when generating the _version.py file
+"src/ddev/_version.py" = ["I001"]


### PR DESCRIPTION
### What does this PR do?
We use hatch to build our packages. Hatch I think uses setuptools-scm to generate the `_version.py` file. In version 8.2.0, the file changed to:

```
...
TYPE_CHECKING = False
if TYPE_CHECKING:
    from typing import Tuple
    from typing import Union

....
```

Which triggers a linting error. The best approach I believe is to simply ignore it since we know what the root cause is.