### PR TITLE
Use`.gitignore` to allow ruff to skip over linting autogenerated file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,3 @@ benchmark_*.svg
 
 ## Direnv
 .envrc
-
-# Auto-generated during builds
-/ddev/src/ddev/_version.py

--- a/ddev/.gitignore
+++ b/ddev/.gitignore
@@ -1,0 +1,2 @@
+# Auto-generated during builds
+/src/ddev/_version.py

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -106,7 +106,6 @@ ignore = [
   "B027",
   # Ignore McCabe complexity
   "C901",
-  "I001",
 ]
 unfixable = [
   # Don't touch unused imports

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -122,3 +122,5 @@ ban-relative-imports = "all"
 [tool.ruff.lint.per-file-ignores]
 #Tests can use assertions and relative imports
 "**/tests/**/*" = ["I252"]
+# Transient dep setuptools-scm 8.2.0+ generated files conflicts with I001 when generating the _version.py file
+"src/ddev/_version.py" = ["I001"]

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -83,7 +83,6 @@ extend-exclude = "src/ddev/_version.py"
 exclude = []
 target-version = "py312"
 line-length = 120
-respect-gitignore = true
 
 [tool.ruff.lint]
 # Rules were ported over from the legacy flake8 settings for parity

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -83,6 +83,7 @@ extend-exclude = "src/ddev/_version.py"
 exclude = []
 target-version = "py312"
 line-length = 120
+respect-gitignore = true
 
 [tool.ruff.lint]
 # Rules were ported over from the legacy flake8 settings for parity
@@ -122,5 +123,3 @@ ban-relative-imports = "all"
 [tool.ruff.lint.per-file-ignores]
 #Tests can use assertions and relative imports
 "**/tests/**/*" = ["I252"]
-# Transient dep setuptools-scm 8.2.0+ generated files conflicts with I001 when generating the _version.py file
-"src/ddev/_version.py" = ["I001"]


### PR DESCRIPTION
### What does this PR do?
ruff will automatically ignore linting for files in the .gitignore. This might be better since we don't want to really lint for files that are automatically generated and we have little control over.