### PR TITLE
Improve message assert for service checks

### DIFF
--- a/datadog_checks_base/changelog.d/19690.fixed
+++ b/datadog_checks_base/changelog.d/19690.fixed
@@ -1,1 +1,1 @@
-Modify the TLS FIPS E2E test condition to include more causes for SSL handshake failure
+Include substrings in service check message assertion

--- a/datadog_checks_base/changelog.d/19690.fixed
+++ b/datadog_checks_base/changelog.d/19690.fixed
@@ -1,0 +1,1 @@
+Modify the TLS FIPS E2E test condition to include more causes for SSL handshake failure

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -385,7 +385,7 @@ class AggregatorStub(object):
             if hostname is not None and hostname != sc.hostname:
                 continue
 
-            if message is not None and message != sc.message:
+            if message is not None and message not in sc.message:
                 continue
 
             candidates.append(sc)

--- a/datadog_checks_base/tests/stubs/test_aggregator_service_checks.py
+++ b/datadog_checks_base/tests/stubs/test_aggregator_service_checks.py
@@ -87,3 +87,9 @@ class TestServiceChecks(object):
             AssertionError, match="Expect `ok` value to be in service_check.json for service check test.service_check."
         ):
             aggregator.assert_service_checks(service_check_definition)
+
+    def test_assert_service_check_message_substring(self, aggregator):
+        check = AgentCheck()
+
+        check.service_check('test.service_check', AgentCheck.CRITICAL, message="Some service check message")
+        aggregator.assert_service_check('test.service_check', message="check")


### PR DESCRIPTION
- **Make assert message parameter pass on substrings**
- **Fix changelog message**

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
