### PR TITLE
Update agent build in GitLab CI to point to the proper branch

### DIFF
--- a/.gitlab/build_agent.yaml
+++ b/.gitlab/build_agent.yaml
@@ -30,15 +30,26 @@ build-agent-auto:
           - .deps/*
           - .gitlab/build_agent.yaml
 
-build-agent-manual:
+build-agent-manual-release:
   extends: .build-agent-tpl
   # We don't want to require the manual build job for regular pipelines.
   allow_failure: true
   rules:
     # By default we test with Agent's main branch.
     # From a release branch we want to use the same release branch in the agent repo.
-    - if: $CI_COMMIT_BRANCH =~ "/^7.\d+.x$/"
+    - if: $CI_COMMIT_BRANCH =~ /^7\.\d+\.x$/
       when: manual
       variables:
         _AGENT_BRANCH: ${CI_COMMIT_BRANCH}
+    - when: manual
+
+# Split both manual build to give visibility over which one was triggered on the pipeline
+# We can remove this once the behavior in AI-5006 is understood.
+build-agent-manual:
+  extends: .build-agent-tpl
+  # We don't want to require the manual build job for regular pipelines.
+  allow_failure: true
+  rules:
+    - if: $CI_COMMIT_BRANCH =~ /^7\.\d+\.x$/
+      when: never
     - when: manual

--- a/.gitlab/build_agent.yaml
+++ b/.gitlab/build_agent.yaml
@@ -41,7 +41,6 @@ build-agent-manual-release:
       when: manual
       variables:
         _AGENT_BRANCH: ${CI_COMMIT_BRANCH}
-    - when: manual
 
 # Split both manual build to give visibility over which one was triggered on the pipeline
 # We can remove this once the behavior in AI-5006 is understood.


### PR DESCRIPTION
### What does this PR do?
Small update on the agent build CI config file to define separate jobs and understand if the corresponding one is the one being run.

- Update the regex to ensure we are using a dot (`.`) instead of any character.
- Define 2 downstream trigger jobs to understand if the proper one is triggered form a release branch

### Motivation
Already validated that the override is working properly. This change is meant to be tested on a release branch.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
