### PR TITLE
Add support to `ddev validate dep` command to support git urls

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
+from urllib.parse import urlparse
 
 import click
 from packaging.requirements import Requirement
@@ -114,6 +115,26 @@ def verify_dependency(source, name, python_versions, file):
         for dependency_definition, checks in dependency_definitions.items():
             requirement = Requirement(dependency_definition)
             specifier_set = requirement.specifier
+
+            # git support: https://pip.pypa.io/en/stable/topics/vcs-support/
+            valid_schemes = ["git+file", "git+https", "git+ssh", "git+http", "git+git",  "git"]
+            
+            if requirement.url:
+                u = urlparse(requirement.url)
+                if u.scheme not in valid_schemes:
+                    message = f'Invalid URL scheme found for dependency `{name}`: {format_check_usage(checks, source)}'
+                    echo_failure(message)
+                    annotate_error(file, message)
+                    return False
+                
+                fields = requirement.url.split("@")
+                if len(fields) < 2:
+                    message = f'Missing git ref for dependency `{name}`: {format_check_usage(checks, source)}'
+                    echo_failure(message)
+                    annotate_error(file, message)
+                    return False
+                
+                return True
 
             if not specifier_set:
                 message = f'Unpinned version found for dependency `{name}`: {format_check_usage(checks, source)}'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add support to `ddev validate dep` for dependencies with git urls such as:
```
gstatus@ git+https://github.com/DataDog/gstatus.git@591f657a048ccc9f11c8940f750adbcd1d7dc8a0
```

The command will check for requirements that are using a url, and then will validate the following:
- Valid scheme as documented in: https://pip.pypa.io/en/stable/topics/vcs-support/
- Existing git ref (commit hash, branch name, ...)

### Motivation
<!-- What inspired you to submit this pull request? -->

Add support for this uses case since we really need it in https://github.com/DataDog/integrations-core/pull/19742

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
