### PR TITLE
Update cilium process signatures

### DIFF
--- a/cilium/manifest.json
+++ b/cilium/manifest.json
@@ -46,9 +46,14 @@
         "metadata_path": "assets/service_checks.json"
       },
       "process_signatures": [
+        "cilium-operator",
+        "cilium-operator-alibabacloud",
+        "cilium-operator-azure",
+        "cilium-operator-aws",
         "cilium-operator-generic",
         "cilium-agent",
-        "cilium-health-responder"
+        "cilium-health-responder",
+        "clustermesh-apiserver"
       ],
       "source_type_id": 10077,
       "auto_install": true


### PR DESCRIPTION
### What does this PR do?

Add missing cilium process signatures for [operator variants](https://github.com/cilium/cilium/blob/4376ee2d0333e1bf152a248175b368ef35ad75c4/operator/Makefile#L20-L24) and the [clustermesh-apiserver](https://github.com/cilium/cilium/blob/4376ee2d0333e1bf152a248175b368ef35ad75c4/clustermesh-apiserver/Makefile#L14).
### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
