### PR TITLE
Modify auto agent build behavior and manual build agent branch

### DIFF
--- a/.gitlab/build_agent.yaml
+++ b/.gitlab/build_agent.yaml
@@ -20,8 +20,11 @@
 build-agent-auto:
   extends: .build-agent-tpl
   rules:
-    # Only trigger this job on a PR that modifies agent related files
-    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event"
+    # Do not run on release branches
+    - if: $CI_COMMIT_BRANCH =~ /^7\.\d+\.x$/
+      when: never
+    # Only run if the branch is not a merge train one from GitHub
+    - if: $CI_COMMIT_BRANCH !~ /^gh-readonly-queue.*/
       changes:
         # We don't yet support variable expansion in `compare_to`. It was added in gitlab 17.2:
         # https://gitlab.com/gitlab-org/gitlab/-/issues/369916#note_1972773223

--- a/.gitlab/build_agent.yaml
+++ b/.gitlab/build_agent.yaml
@@ -1,7 +1,6 @@
 ---
 .build-agent-tpl:
   variables:
-    _AGENT_BRANCH: main # Used only by this job
     # Pass these to triggered agent build job.
     RELEASE_VERSION_6: "nightly"
     RELEASE_VERSION_7: "nightly-a7"
@@ -14,14 +13,15 @@
   stage: build
   trigger:
     project: DataDog/datadog-agent
-    branch: ${_AGENT_BRANCH}
+    branch: main
     # It's more convenient to directly show if downstream pipeline succeeded.
     strategy: depend
 
 build-agent-auto:
   extends: .build-agent-tpl
   rules:
-    - if: $CI_COMMIT_BRANCH !~ "/gh-readonly-queue/"
+    # Only trigger this job on a PR that modifies agent related files
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event"
       changes:
         # We don't yet support variable expansion in `compare_to`. It was added in gitlab 17.2:
         # https://gitlab.com/gitlab-org/gitlab/-/issues/369916#note_1972773223
@@ -32,21 +32,16 @@ build-agent-auto:
 
 build-agent-manual-release:
   extends: .build-agent-tpl
-  # We don't want to require the manual build job for regular pipelines.
   allow_failure: true
+  trigger:
+    branch: $CI_COMMIT_BRANCH
   rules:
-    # By default we test with Agent's main branch.
-    # From a release branch we want to use the same release branch in the agent repo.
     - if: $CI_COMMIT_BRANCH =~ /^7\.\d+\.x$/
       when: manual
-      variables:
-        _AGENT_BRANCH: ${CI_COMMIT_BRANCH}
 
-# Split both manual build to give visibility over which one was triggered on the pipeline
-# We can remove this once the behavior in AI-5006 is understood.
+# Always have the option to run manually the agent build manually against the agent's main
 build-agent-manual:
   extends: .build-agent-tpl
-  # We don't want to require the manual build job for regular pipelines.
   allow_failure: true
   rules:
     - if: $CI_COMMIT_BRANCH =~ /^7\.\d+\.x$/

--- a/.gitlab/build_agent.yaml
+++ b/.gitlab/build_agent.yaml
@@ -23,7 +23,7 @@ build-agent-auto:
     # Do not run on release branches
     - if: $CI_COMMIT_BRANCH =~ /^7\.\d+\.x$/
       when: never
-    # Only run if the branch is not a merge train one from GitHub
+    # Only run if the branch is not a Github Merge Queue one.
     - if: $CI_COMMIT_BRANCH !~ /^gh-readonly-queue.*/
       changes:
         # We don't yet support variable expansion in `compare_to`. It was added in gitlab 17.2:


### PR DESCRIPTION
### What does this PR do?
We noticed that the pipeline kicks in on any branch after being merged. Ideally we want the agent build to happen whenever a relevant file is changed before merging it. The change on `build-agent-auto` modifies its behavior so it only triggers on Github PRs that modify those files.

EDIT: after the PR was created we noticed that the [external pull requests](https://docs.gitlab.com/ci/ci_cd_for_external_repos/#pipelines-for-external-pull-requests) does not work with our sync to GitLab. The latest commit removes the use of external pull requests and instead avoid running it after having merged it to a release branch.

Once the PR is merged we should have the option to trigger a manual build either on the corresponding agent  branch:
- If we merged the PR to a release branch, the manual build will be triggered on the agent release branch.
- If we merged to a non release branch, the manual build will be triggered on the agent main branch.

We noticed that using the variable override, after fixing the regexp, the downstream pipeline cannot be created because the reference is not found. This is likely due to when the variables are defined yielding an invalid reference on the `_AGENT_BRANCH` variable.

In order to fix this we are dropping this variable and relying on the reverse merge applied to the `extends` keyword overriding the `branch` on `trigger` with the default variable of the branch name.

### Motivation
We want to understand whether the agent builds for any change on relevant files.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
