### PR TITLE
Add config option to skip db, collection and index stats for system databases

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -377,6 +377,18 @@ files:
           value:
             type: integer
             example: 300
+        - name: db_stats
+          description: |
+            The interval in seconds at which to collect db stats metrics.
+          value:
+            type: integer
+            example: 15
+        - name: session_stats
+          description: |
+            The interval in seconds at which to collect session stats metrics.
+          value:
+            type: integer
+            example: 15
     - name: collections
       description: |
         Collect metrics on specific collections from the database specified
@@ -401,6 +413,15 @@ files:
       value:
         type: boolean
         example: false
+    - name: system_database_stats
+      description: |
+        Enable or disable the collection of database stats, collection stats, and index stats for system databases 
+        (`admin`, `local`, and `config`).
+        By default, this option is enabled (`true`), meaning stats for system databases are collected. 
+        Set to `false` to disable collection of stats for all system databases.
+      value:
+        type: boolean
+        example: true
     - name: add_node_tag_to_events
       description: |
         Adds the Mongo node to events as a tag rather than creating a seperate host for the event.

--- a/mongo/changelog.d/19756.added
+++ b/mongo/changelog.d/19756.added
@@ -1,0 +1,1 @@
+Added `system_database_stats` to control system database stats collection and `metrics_collection_interval.db_stats`, `metrics_collection_interval.session_stats` for customizable collection intervals.

--- a/mongo/datadog_checks/mongo/collectors/coll_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/coll_stats.py
@@ -18,7 +18,7 @@ class CollStatsCollector(MongoCollector):
         super(CollStatsCollector, self).__init__(check, tags)
         self.coll_names = coll_names
         self.db_name = db_name
-        self.max_collections_per_database = check._config.database_autodiscovery_config['max_collections_per_database']
+        self._max_collections_per_database = check._config.database_autodiscovery_config['max_collections_per_database']
         self._collection_interval = check._config.metrics_collection_interval['collection']
         self._collector_key = (self.__class__.__name__, db_name)  # db_name is part of collector key
 
@@ -29,7 +29,7 @@ class CollStatsCollector(MongoCollector):
     def _get_collections(self, api):
         if self.coll_names:
             return self.coll_names
-        return api.list_authorized_collections(self.db_name, limit=self.max_collections_per_database)
+        return api.list_authorized_collections(self.db_name, limit=self._max_collections_per_database)
 
     def __calculate_oplatency_avg(self, latency_stats):
         """Calculate the average operation latency."""

--- a/mongo/datadog_checks/mongo/collectors/db_stat.py
+++ b/mongo/datadog_checks/mongo/collectors/db_stat.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from datadog_checks.mongo.collectors.base import MongoCollector
+from datadog_checks.mongo.collectors.base import MongoCollector, collection_interval_checker
 from datadog_checks.mongo.common import MongosDeployment, ReplicaSetDeployment, StandaloneDeployment
 
 
@@ -17,6 +17,8 @@ class DbStatCollector(MongoCollector):
         super(DbStatCollector, self).__init__(check, tags)
         self.db_name = db_name
         self.dbstats_tag_dbname = dbstats_tag_dbname
+        self._collection_interval = check._config.metrics_collection_interval['db_stats']
+        self._collector_key = (self.__class__.__name__, db_name)  # db_name is part of collector key
 
     def compatible_with(self, deployment):
         # Can theoretically be run on any node as long as it contains data.
@@ -32,6 +34,7 @@ class DbStatCollector(MongoCollector):
         else:
             return isinstance(deployment, (StandaloneDeployment, MongosDeployment)) or deployment.is_primary
 
+    @collection_interval_checker
     def collect(self, api):
         db = api[self.db_name]
         # Submit the metric

--- a/mongo/datadog_checks/mongo/collectors/session_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/session_stats.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 from datadog_checks.base import AgentCheck
-from datadog_checks.mongo.collectors.base import MongoCollector
+from datadog_checks.mongo.collectors.base import MongoCollector, collection_interval_checker
 from datadog_checks.mongo.common import MongosDeployment
 
 
@@ -11,10 +11,15 @@ class SessionStatsCollector(MongoCollector):
     """Gets the count of current sessions stored in the system.sessions config database.
     The system.sessions collection is sharded so it's only collected from mongos."""
 
+    def __init__(self, check, tags):
+        super(SessionStatsCollector, self).__init__(check, tags)
+        self._collection_interval = check._config.metrics_collection_interval['session_stats']
+
     def compatible_with(self, deployment):
         # Can only be run on mongos nodes.
         return isinstance(deployment, MongosDeployment)
 
+    @collection_interval_checker
     def collect(self, api):
         config_db = api["config"]
         try:

--- a/mongo/datadog_checks/mongo/common.py
+++ b/mongo/datadog_checks/mongo/common.py
@@ -35,6 +35,8 @@ DEFAULT_TIMEOUT = 30
 ALLOWED_CUSTOM_METRICS_TYPES = ['gauge', 'rate', 'count', 'monotonic_count']
 ALLOWED_CUSTOM_QUERIES_COMMANDS = ['aggregate', 'count', 'find']
 
+MONGODB_SYSTEM_DATABASES = frozenset(["admin", "config", "local"])
+
 
 class HostingType:
     ATLAS = "mongodb-atlas"

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -96,6 +96,7 @@ class MongoConfig(object):
         self.coll_names = instance.get('collections', [])
         self.custom_queries = instance.get("custom_queries", [])
         self._metrics_collection_interval = instance.get("metrics_collection_interval", {})
+        self.system_database_stats = is_affirmative(instance.get('system_database_stats', True))
 
         self._base_tags = list(set(instance.get('tags', [])))
 
@@ -273,4 +274,6 @@ class MongoConfig(object):
             ),
             # $shardDataDistribution stats are collected every 5 minutes by default due to the high resource usage
             'sharded_data_distribution': int(self._metrics_collection_interval.get('sharded_data_distribution', 300)),
+            'db_stats': int(self._metrics_collection_interval.get('db_stats', self.min_collection_interval)),
+            'session_stats': int(self._metrics_collection_interval.get('session_stats', self.min_collection_interval)),
         }

--- a/mongo/datadog_checks/mongo/config_models/defaults.py
+++ b/mongo/datadog_checks/mongo/config_models/defaults.py
@@ -48,6 +48,10 @@ def instance_replica_check():
     return True
 
 
+def instance_system_database_stats():
+    return True
+
+
 def instance_timeout():
     return 30
 

--- a/mongo/datadog_checks/mongo/config_models/instance.py
+++ b/mongo/datadog_checks/mongo/config_models/instance.py
@@ -80,6 +80,8 @@ class MetricsCollectionInterval(BaseModel):
     )
     collection: Optional[int] = None
     collections_indexes_stats: Optional[int] = None
+    db_stats: Optional[int] = None
+    session_stats: Optional[int] = None
     sharded_data_distribution: Optional[int] = None
 
 
@@ -150,6 +152,7 @@ class InstanceConfig(BaseModel):
     server: Optional[str] = None
     service: Optional[str] = None
     slow_operations: Optional[SlowOperations] = None
+    system_database_stats: Optional[bool] = None
     tags: Optional[tuple[str, ...]] = None
     timeout: Optional[int] = None
     tls: Optional[bool] = None

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -327,6 +327,14 @@ instances:
     #
     # collections_indexes_stats: false
 
+    ## @param system_database_stats - boolean - optional - default: true
+    ## Enable or disable the collection of database stats, collection stats, and index stats for system databases 
+    ## (`admin`, `local`, and `config`).
+    ## By default, this option is enabled (`true`), meaning stats for system databases are collected. 
+    ## Set to `false` to disable collection of stats for all system databases.
+    #
+    # system_database_stats: true
+
     ## @param custom_queries - list of mappings - optional
     ## Define custom queries to collect custom metrics on your Mongo
     ## Note: Custom queries are ignored by default when the mongo node is a secondary of a replica set.

--- a/mongo/datadog_checks/mongo/dbm/utils.py
+++ b/mongo/datadog_checks/mongo/dbm/utils.py
@@ -10,14 +10,13 @@ from bson import json_util, regex
 from datadog_checks.base.utils.common import to_native_string
 from datadog_checks.base.utils.db.sql import compute_exec_plan_signature
 from datadog_checks.base.utils.db.utils import RateLimitingTTLCache
+from datadog_checks.mongo.common import MONGODB_SYSTEM_DATABASES
 
 try:
     import datadog_agent
 except ImportError:
     from datadog_checks.base.stubs import datadog_agent
 
-
-MONGODB_SYSTEM_DATABASES = frozenset(["admin", "config", "local"])
 
 # exclude keys in sampled operation that cause issues with the explain command
 EXPLAIN_COMMAND_EXCLUDE_KEYS = frozenset(
@@ -54,6 +53,8 @@ UNEXPLAINABLE_COMMANDS = frozenset(
         "explain",
         "profile",  # command to get profile level
         "listCollections",
+        "listDatabases",
+        'dbStats',
     ]
 )
 

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -32,6 +32,7 @@ from datadog_checks.mongo.collectors.conn_pool_stats import ConnPoolStatsCollect
 from datadog_checks.mongo.collectors.jumbo_stats import JumboStatsCollector
 from datadog_checks.mongo.collectors.session_stats import SessionStatsCollector
 from datadog_checks.mongo.common import (
+    MONGODB_SYSTEM_DATABASES,
     SERVICE_CHECK_NAME,
     HostingType,
     MongosDeployment,
@@ -155,6 +156,8 @@ class MongoDb(AgentCheck):
             # DbStatCollector is always collected on all monitored databases (filtered by db_names config option)
             # For backward compatibility, we keep collecting from all monitored databases
             # regardless of the auto-discovery settings.
+            if db_name in MONGODB_SYSTEM_DATABASES and not self._config.system_database_stats:
+                continue
             potential_collectors.append(DbStatCollector(self, db_name, dbstats_tag_dbname, tags))
 
         # When autodiscovery is enabled, we collect collstats and indexstats for all auto-discovered databases
@@ -162,6 +165,8 @@ class MongoDb(AgentCheck):
         for db_name in self.databases_monitored:
             # For backward compatibility, coll_names is ONLY applied when autodiscovery is not enabled
             # Otherwise, we collect collstats & indexstats for all auto-discovered databases and authorized collections
+            if db_name in MONGODB_SYSTEM_DATABASES and not self._config.system_database_stats:
+                continue
             coll_names = None if self._database_autodiscovery.autodiscovery_enabled else self._config.coll_names
             if 'collection' in self._config.additional_metrics:
                 potential_collectors.append(CollStatsCollector(self, db_name, tags, coll_names=coll_names))

--- a/mongo/tests/results/metrics-collection-non-system.json
+++ b/mongo/tests/results/metrics-collection-non-system.json
@@ -1,0 +1,926 @@
+[
+    {
+        "name": "mongodb.collection.size",
+        "type": 0,
+        "value": 5670.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.size",
+        "type": 0,
+        "value": 2600.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.avgobjsize",
+        "type": 0,
+        "value": 27.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.avgobjsize",
+        "type": 0,
+        "value": 26.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.count",
+        "type": 0,
+        "value": 210.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.count",
+        "type": 0,
+        "value": 100.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.capped",
+        "type": 0,
+        "value": 1.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.capped",
+        "type": 0,
+        "value": 1.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.max",
+        "type": 0,
+        "value": 10.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.max",
+        "type": 0,
+        "value": 10.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.maxsize",
+        "type": 0,
+        "value": 10.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.maxsize",
+        "type": 0,
+        "value": 10.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.storagesize",
+        "type": 0,
+        "value": 16384.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.storagesize",
+        "type": 0,
+        "value": 16384.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.nindexes",
+        "type": 0,
+        "value": 1.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.nindexes",
+        "type": 0,
+        "value": 1.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.indexsizes",
+        "type": 0,
+        "value": 16384.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo",
+            "index:_id_"
+        ]
+    },
+    {
+        "name": "mongodb.collection.indexsizes",
+        "type": 0,
+        "value": 16384.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar",
+            "index:_id_"
+        ]
+    },
+    {
+        "name": "mongodb.collection.totalindexsize",
+        "type": 0,
+        "value": 16384.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.totalindexsize",
+        "type": 0,
+        "value": 16384.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.reads.latency",
+        "type": 0,
+        "value": 13165.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.reads.latency.avg",
+        "type": 0,
+        "value": 1316.5,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.reads.latency",
+        "type": 0,
+        "value": 13165.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.reads.latency.avg",
+        "type": 0,
+        "value": 1316.5,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.reads.opsps",
+        "type": 1,
+        "value": 10.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.reads.opsps",
+        "type": 1,
+        "value": 10.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.writes.latency",
+        "type": 0,
+        "value": 8542.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.writes.latency.avg",
+        "type": 0,
+        "value": 8542.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.writes.latency",
+        "type": 0,
+        "value": 8542.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.writes.latency.avg",
+        "type": 0,
+        "value": 8542.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.writes.opsps",
+        "type": 1,
+        "value": 1.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.writes.opsps",
+        "type": 1,
+        "value": 1.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.commands.latency",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.commands.latency",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.commands.opsps",
+        "type": 1,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.commands.opsps",
+        "type": 1,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.transactions.latency",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.transactions.latency",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.transactions.opsps",
+        "type": 1,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.transactions.opsps",
+        "type": 1,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.collectionscans.nontailable",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.collectionscans.nontailable",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.collectionscans.total",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.collectionscans.total",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.collectionscans.nontailableps",
+        "type": 1,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.collectionscans.nontailableps",
+        "type": 1,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.collectionscans.totalps",
+        "type": 1,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.collectionscans.totalps",
+        "type": 1,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:test",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.size",
+        "type": 0,
+        "value": 5670.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.size",
+        "type": 0,
+        "value": 2600.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.avgobjsize",
+        "type": 0,
+        "value": 27.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.avgobjsize",
+        "type": 0,
+        "value": 26.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.count",
+        "type": 0,
+        "value": 210.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.count",
+        "type": 0,
+        "value": 100.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.capped",
+        "type": 0,
+        "value": 1.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.capped",
+        "type": 0,
+        "value": 1.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.max",
+        "type": 0,
+        "value": 10.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.max",
+        "type": 0,
+        "value": 10.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.maxsize",
+        "type": 0,
+        "value": 10.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.maxsize",
+        "type": 0,
+        "value": 10.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.storagesize",
+        "type": 0,
+        "value": 16384.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.storagesize",
+        "type": 0,
+        "value": 16384.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.nindexes",
+        "type": 0,
+        "value": 1.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.nindexes",
+        "type": 0,
+        "value": 1.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.indexsizes",
+        "type": 0,
+        "value": 16384.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo",
+            "index:_id_"
+        ]
+    },
+    {
+        "name": "mongodb.collection.indexsizes",
+        "type": 0,
+        "value": 16384.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar",
+            "index:_id_"
+        ]
+    },
+    {
+        "name": "mongodb.collection.totalindexsize",
+        "type": 0,
+        "value": 16384.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.totalindexsize",
+        "type": 0,
+        "value": 16384.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.reads.latency",
+        "type": 0,
+        "value": 13165.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.reads.latency",
+        "type": 0,
+        "value": 13165.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.reads.opsps",
+        "type": 1,
+        "value": 10.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.reads.opsps",
+        "type": 1,
+        "value": 10.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.writes.latency",
+        "type": 0,
+        "value": 8542.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.writes.latency",
+        "type": 0,
+        "value": 8542.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.writes.opsps",
+        "type": 1,
+        "value": 1.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.writes.opsps",
+        "type": 1,
+        "value": 1.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.commands.latency",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.commands.latency",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.commands.opsps",
+        "type": 1,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.commands.opsps",
+        "type": 1,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.transactions.latency",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.transactions.latency",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.transactions.opsps",
+        "type": 1,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.transactions.opsps",
+        "type": 1,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.collectionscans.nontailable",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.collectionscans.nontailable",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.collectionscans.total",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.collectionscans.total",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.collectionscans.nontailableps",
+        "type": 1,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.collectionscans.nontailableps",
+        "type": 1,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar"
+        ]
+    },
+    {
+        "name": "mongodb.collection.collectionscans.totalps",
+        "type": 1,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:foo"
+        ]
+    },
+    {
+        "name": "mongodb.collection.collectionscans.totalps",
+        "type": 1,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "db:integration",
+            "collection:bar"
+        ]
+    }
+]

--- a/mongo/tests/results/metrics-dbstats-non-system.json
+++ b/mongo/tests/results/metrics-dbstats-non-system.json
@@ -1,0 +1,142 @@
+[
+  {
+        "name": "mongodb.stats.avgobjsize",
+        "type": 0,
+        "value": 27.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.stats.datasize",
+        "type": 0,
+        "value": 8708.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.stats.filesize",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.stats.indexes",
+        "type": 0,
+        "value": 3.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.stats.indexsize",
+        "type": 0,
+        "value": 49152.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.stats.numextents",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.stats.objects",
+        "type": 0,
+        "value": 316.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.stats.storagesize",
+        "type": 0,
+        "value": 49152.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.stats.totalsize",
+        "type": 0,
+        "value": 35102720.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.stats.freestoragesize",
+        "type": 0,
+        "value": 8097792.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.stats.indexfreestoragesize",
+        "type": 0,
+        "value": 8556544.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.stats.totalfreestoragesize",
+        "type": 0,
+        "value": 16654336.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.stats.fsusedsize",
+        "type": 0,
+        "value": 45563666432.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.stats.fstotalsize",
+        "type": 0,
+        "value": 62725623808.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    }
+]

--- a/mongo/tests/results/metrics-indexes-stats-non-system.json
+++ b/mongo/tests/results/metrics-indexes-stats-non-system.json
@@ -1,0 +1,98 @@
+[
+    {
+        "name": "mongodb.collection.indexes.accesses.ops",
+        "type": 0,
+        "value": 1243.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "name:_id_",
+            "index:_id_",
+            "collection:foo",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.collection.indexes.accesses.ops",
+        "type": 0,
+        "value": 12.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "name:_id_",
+            "index:_id_",
+            "collection:bar",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.collection.indexes.accesses.ops",
+        "type": 0,
+        "value": 1243.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "name:_id_",
+            "index:_id_",
+            "collection:foo",
+            "db:integration"
+        ]
+    },
+    {
+        "name": "mongodb.collection.indexes.accesses.ops",
+        "type": 0,
+        "value": 12.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "name:_id_",
+            "index:_id_",
+            "collection:bar",
+            "db:integration"
+        ]
+    },
+    {
+        "name": "mongodb.collection.indexes.accesses.opsps",
+        "type": 1,
+        "value": 1243.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "name:_id_",
+            "index:_id_",
+            "collection:foo",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.collection.indexes.accesses.opsps",
+        "type": 1,
+        "value": 12.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "name:_id_",
+            "index:_id_",
+            "collection:bar",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.collection.indexes.accesses.opsps",
+        "type": 1,
+        "value": 1243.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "name:_id_",
+            "index:_id_",
+            "collection:foo",
+            "db:integration"
+        ]
+    },
+    {
+        "name": "mongodb.collection.indexes.accesses.opsps",
+        "type": 1,
+        "value": 12.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "name:_id_",
+            "index:_id_",
+            "collection:bar",
+            "db:integration"
+        ]
+    }
+]

--- a/mongo/tests/test_unit_config.py
+++ b/mongo/tests/test_unit_config.py
@@ -206,22 +206,45 @@ def test_amazon_docdb_cloud_metadata(instance_integration_cluster, aws_cloud_met
     'metrics_collection_interval, expected_metrics_collection_interval',
     [
         pytest.param(
-            {}, {'collection': 15, 'collections_indexes_stats': 15, 'sharded_data_distribution': 300}, id='default'
+            {},
+            {
+                'collection': 15,
+                'collections_indexes_stats': 15,
+                'sharded_data_distribution': 300,
+                'db_stats': 15,
+                'session_stats': 15,
+            },
+            id='default',
         ),
         pytest.param(
             {
                 'collection': '60',
                 'collections_indexes_stats': '30',
                 'sharded_data_distribution': '600',
+                'db_stats': '30',
+                'session_stats': '30',
             },
-            {'collection': 60, 'collections_indexes_stats': 30, 'sharded_data_distribution': 600},
+            {
+                'collection': 60,
+                'collections_indexes_stats': 30,
+                'sharded_data_distribution': 600,
+                'db_stats': 30,
+                'session_stats': 30,
+            },
             id='custom',
         ),
         pytest.param(
             {
                 'collection': 60,
+                'db_stats': 30,
             },
-            {'collection': 60, 'collections_indexes_stats': 15, 'sharded_data_distribution': 300},
+            {
+                'collection': 60,
+                'collections_indexes_stats': 15,
+                'sharded_data_distribution': 300,
+                'db_stats': 30,
+                'session_stats': 15,
+            },
             id='partial',
         ),
     ],


### PR DESCRIPTION
### What does this PR do?
This PR introduces new configuration options to improve control over MongoDB system database statistics collection and metric collection intervals:
- system_database_stats (default: true) – Allows users to optionally skip collecting database stats, collection stats, and index stats for system databases (admin, local, and config). By default, stats metrics are still collected from system databases.
- metrics_collection_interval.db_stats and metrics_collection_interval.session_stats – Enable customizable collection intervals for database stats and session stats (applicable to mongos instances only).

These changes provide greater flexibility in monitoring configurations, reducing mongo integration overhead where needed.

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-5056

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
