### PR TITLE
[SEMCON-748] fix DD exporter and connector metrics on OTel collector dashboard

### DIFF
--- a/otel/assets/dashboards/otel_collector_metrics_dashboard.json
+++ b/otel/assets/dashboards/otel_collector_metrics_dashboard.json
@@ -2592,7 +2592,7 @@
                         "id": 3312471392848186,
                         "definition": {
                             "type": "note",
-                            "content": "**Deprecated**: When feature gate `connector.datadogconnector.NativeIngest` is enabled (default is enabled since OTel collector v0.107.0), the Datadog connector uses a different code path that does not emit these metrics. Traces and spans ingested/s represents the rate of OTLP traces received and processed by the legecy trace API. The trace API receives data from both the Datadog Exporter and the Datadog Connector, which can be grouped by the `source` tag.",
+                            "content": "**Deprecated**: When feature gate `connector.datadogconnector.NativeIngest` is enabled (default is enabled since OTel collector v0.107.0), the Datadog connector uses a different code path that does not emit these metrics. Traces and spans ingested/s represents the rate of OTLP traces received and processed by the legacy trace API. The trace API receives data from both the Datadog Exporter and the Datadog Connector, which can be grouped by the `source` tag.",
                             "background_color": "white",
                             "font_size": "12",
                             "text_align": "left",

--- a/otel/assets/dashboards/otel_collector_metrics_dashboard.json
+++ b/otel/assets/dashboards/otel_collector_metrics_dashboard.json
@@ -1999,7 +1999,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_traces{$host,$service}.as_rate()",
+                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_traces{$host,source:datadogexporter,$service}.as_rate()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2044,7 +2044,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_spans{$host,$service}.as_rate()",
+                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_spans{$host,source:datadogexporter,$service}.as_rate()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2115,12 +2115,12 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "max:otelcol_datadog_trace_agent_trace_writer_flush_duration_max{$host,$service}",
+                                            "query": "max:otelcol_datadog_trace_agent_trace_writer_flush_duration_max{$host,source:datadogexporter,$service}",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         },
                                         {
-                                            "query": "avg:otelcol_datadog_trace_agent_trace_writer_flush_duration_avg{$host,$service}",
+                                            "query": "avg:otelcol_datadog_trace_agent_trace_writer_flush_duration_avg{$host,source:datadogexporter,$service}",
                                             "data_source": "metrics",
                                             "name": "query2"
                                         }
@@ -2172,7 +2172,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_bytes{$host,$service}.as_rate()",
+                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_bytes{$host,source:datadogexporter,$service}.as_rate()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2224,7 +2224,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_payloads{$host,$service}.as_rate()",
+                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_payloads{$host,source:datadogexporter,$service}.as_rate()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2297,7 +2297,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_errors{$host,$service}.as_count()",
+                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_errors{$host,source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2488,7 +2488,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_retries{$host,$service}.as_count()",
+                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_retries{$host,source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2538,7 +2538,7 @@
                                     "response_format": "scalar",
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_stats_entries{$host,$service}.as_count()",
+                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_stats_entries{$host,source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1",
                                             "aggregator": "avg"
@@ -2592,7 +2592,7 @@
                         "id": 3312471392848186,
                         "definition": {
                             "type": "note",
-                            "content": "Traces and spans ingested/s represents the rate of OTLP traces received and processed by the trace API. The trace API receives data from both the Datadog Exporter and the Datadog Connector, which can be grouped by the `source` tag.",
+                            "content": "**Deprecated**: When feature gate `connector.datadogconnector.NativeIngest` is enabled (default is enabled since OTel collector v0.107.0), the Datadog connector uses a different code path that does not emit these metrics. Traces and spans ingested/s represents the rate of OTLP traces received and processed by the legecy trace API. The trace API receives data from both the Datadog Exporter and the Datadog Connector, which can be grouped by the `source` tag.",
                             "background_color": "white",
                             "font_size": "12",
                             "text_align": "left",
@@ -2736,7 +2736,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_payloads{$host,$service}.as_rate()",
+                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_payloads{$host,source:datadogexporter,$service}.as_rate()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2781,7 +2781,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_bytes{$host,$service}.as_rate()",
+                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_bytes{$host,source:datadogexporter,$service}.as_rate()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2847,7 +2847,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_retries{$host,$service}.as_count()",
+                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_retries{$host,source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2892,7 +2892,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_stats_entries{$host,$service}.as_rate()",
+                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_stats_entries{$host,source:datadogexporter,$service}.as_rate()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2937,7 +2937,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_stats_buckets{$host,$service}.as_count()",
+                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_stats_buckets{$host,source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -3003,7 +3003,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_errors{$host,$service}.as_count()",
+                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_errors{$host,source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }


### PR DESCRIPTION
### What does this PR do?
Fix DD exporter and connector APM related metrics on OTel collector dashboard

### Motivation

- https://datadoghq.atlassian.net/browse/SEMCON-748 Filter internal APM health metrics (`otelcol_datadog_trace_agent_*` metrics) by `source:datadogexporter`, only metrics with this tag are indeed from DD exporter or connector. 
  - **Note** most metrics from DD connector also have `source:datadogexporter` rather than `source:datadogconnector` because metrics are sent with DD exporter.
- https://datadoghq.atlassian.net/browse/OTAGENT-44 Add deprecation notice to traces/s and spans/s metrics on the DD connector section. Those 2 metrics no longer apply when native ingest in DD connector is enabled, in that case traces go through the new OTel stats API rather than the OTLP receiver in trace agent.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
