### PR TITLE
Add nginx version 1.27

### DIFF
--- a/nginx/hatch.toml
+++ b/nginx/hatch.toml
@@ -2,7 +2,7 @@
 
 [[envs.default.matrix]]
 python = ["3.12"]
-version = ["1.12", "1.13", "vts"]
+version = ["1.12", "1.13","1.27", "vts"]
 
 [envs.default.env-vars]
 # We need this for tests that check the "host" tag being submitted with the service check.
@@ -12,6 +12,7 @@ DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
 matrix.version.env-vars = [
   { key = "NGINX_IMAGE", value = "nginx:1.12", if = ["1.12"] },
   { key = "NGINX_IMAGE", value = "nginx:1.13", if = ["1.13"] },
+  { key = "NGINX_IMAGE", value = "nginx:1.27", if = ["1.27"] },
   { key = "NGINX_IMAGE", value = "datadog/docker-library:nginx-vts", if = ["vts"] },
 ]
 


### PR DESCRIPTION
### What does this PR do?
Adds the 1.27 version to nginx test.

### Motivation
Cover newer versions of nginx by test. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
