### PR TITLE
Adds a more accurate description of container rss metric

### DIFF
--- a/container/metadata.csv
+++ b/container/metadata.csv
@@ -17,7 +17,7 @@ container.memory.limit,gauge,,byte,,The container memory limit,0,container,mem_l
 container.memory.major_page_faults,count,,,,Number of major page faults incurred,0,container,pgmajfault,
 container.memory.oom_events,gauge,,,,The number of OOM events triggered by the container,0,container,mem_oom_events,
 container.memory.page_faults,count,,,,Total number of page faults incurred,0,container,pgfault,
-container.memory.rss,gauge,,byte,,The container RSS usage,0,container,mem_rss,
+container.memory.rss,gauge,,byte,,The 'anon' memory used by the container,0,container,mem_rss,
 container.memory.soft_limit,gauge,,byte,,The container memory soft limit,0,container,mem_soft_limit,
 container.memory.swap,gauge,,byte,,The container swap usage,0,container,mem_swap,
 container.memory.usage,gauge,,byte,,The container total memory usage,0,container,mem_usage,


### PR DESCRIPTION
### What does this PR do?
Updates the `container.memory.rss` description to be more accurate.

### Motivation
The `container.memory.rss` metric reports only the 'anonymous' portion of the container memory.
This is potentially confusing as the term RSS is typically used to describe the combination of `RssAnon, RssFile, and RssShmem` when looking at a process-view. 

However, a container-view will use `rss` to refer to _only_ the `anon` portion of the memory.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [x] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
