### PR TITLE
Revert "[mongo] add service tag to agent operations (#19456)"

### DIFF
--- a/mongo/changelog.d/19768.fixed
+++ b/mongo/changelog.d/19768.fixed
@@ -1,0 +1,1 @@
+Revert "[mongo] add service tag to agent operations (#19456)"

--- a/mongo/datadog_checks/mongo/api.py
+++ b/mongo/datadog_checks/mongo/api.py
@@ -28,10 +28,6 @@ CRITICAL_FAILURE = (
     ProtocolError,
 )
 
-DD_OPERATION_ATTRIBUTES = {
-    'service': DD_APP_NAME,
-}
-
 
 class MongoApi(object):
     """Mongodb connection through pymongo.MongoClient
@@ -74,7 +70,6 @@ class MongoApi(object):
 
         # Check if the server supports the $collStats aggregation pipeline stage.
         self.coll_stats_pipeline_supported = True
-        self.__comment = ",".join([f"{k}='{v}'" for k, v in DD_OPERATION_ATTRIBUTES.items()])
 
     def __getitem__(self, item):
         return self._cli[item]
@@ -88,13 +83,13 @@ class MongoApi(object):
             raise
 
     def ping(self):
-        return self['admin'].command('ping', comment=self.__comment)
+        return self['admin'].command('ping')
 
     def server_info(self, session=None):
         return self._cli.server_info(session)
 
     def list_database_names(self, session=None):
-        return self._cli.list_database_names(session, comment=self.__comment)
+        return self._cli.list_database_names(session)
 
     def current_op(self, session=None):
         # Use $currentOp stage to get all users and idle sessions.
@@ -102,7 +97,7 @@ class MongoApi(object):
         # Because the currentOp command and db.currentOp() helper method return the results in a single document,
         # the total size of the currentOp result set is subject to the maximum 16MB BSON size limit for documents.
         # The $currentOp stage returns a cursor over a stream of documents, each of which reports a single operation.
-        return self["admin"].aggregate([{'$currentOp': {'allUsers': True}}], session=session, comment=self.__comment)
+        return self["admin"].aggregate([{'$currentOp': {'allUsers': True}}], session=session)
 
     def get_collection_stats(self, db_name, coll_name, stats=None, session=None):
         if not self.coll_stats_pipeline_supported:
@@ -134,24 +129,23 @@ class MongoApi(object):
                 },
             ],
             session=session,
-            comment=self.__comment,
         )
 
     def coll_stats_compatible(self, db_name, coll_name, session=None):
         # collStats is deprecated in MongoDB 6.2. Use the $collStats aggregation stage instead.
-        return self[db_name].command({'collStats': coll_name}, session=session, comment=self.__comment)
+        return self[db_name].command({'collStats': coll_name}, session=session)
 
     def index_stats(self, db_name, coll_name, session=None):
-        return self[db_name][coll_name].aggregate([{"$indexStats": {}}], session=session, comment=self.__comment)
+        return self[db_name][coll_name].aggregate([{"$indexStats": {}}], session=session)
 
     def index_information(self, db_name, coll_name, session=None):
-        return self[db_name][coll_name].index_information(session=session, comment=self.__comment)
+        return self[db_name][coll_name].index_information(session=session)
 
     def list_search_indexes(self, db_name, coll_name, session=None):
-        return self[db_name][coll_name].list_search_indexes(session=session, comment=self.__comment)
+        return self[db_name][coll_name].list_search_indexes(session=session)
 
     def sharded_data_distribution_stats(self, session=None):
-        return self["admin"].aggregate([{"$shardedDataDistribution": {}}], session=session, comment=self.__comment)
+        return self["admin"].aggregate([{"$shardedDataDistribution": {}}], session=session)
 
     def _is_auth_required(self, options):
         # Check if the node is an arbiter. If it is, usually it does not require authentication.
@@ -159,7 +153,7 @@ class MongoApi(object):
         try:
             # Try connect to the admin database to run the isMaster command without authentication.
             cli = MongoClient(**options)
-            is_master_payload = cli['admin'].command('isMaster', comment=self.__comment)
+            is_master_payload = cli['admin'].command('isMaster')
             is_arbiter = is_master_payload.get('arbiterOnly', False)
             # If the node is an arbiter and we are able to connect without authentication
             # we can assume that the node does not require authentication.
@@ -168,37 +162,35 @@ class MongoApi(object):
             return True
 
     def get_profiling_level(self, db_name, session=None):
-        return self[db_name].command('profile', -1, session=session, comment=self.__comment)
+        return self[db_name].command('profile', -1, session=session)
 
     def get_profiling_data(self, db_name, ts, session=None):
         filter = {'ts': {'$gt': ts}}
-        return self[db_name]['system.profile'].find(filter, session=session, comment=self.__comment).sort('ts', 1)
+        return self[db_name]['system.profile'].find(filter, session=session).sort('ts', 1)
 
     def get_log_data(self, session=None):
-        return self['admin'].command("getLog", "global", session=session, comment=self.__comment)
+        return self['admin'].command("getLog", "global", session=session)
 
     def sample(self, db_name, coll_name, sample_size, session=None):
-        return self[db_name][coll_name].aggregate(
-            [{"$sample": {"size": sample_size}}], session=session, comment=self.__comment
-        )
+        return self[db_name][coll_name].aggregate([{"$sample": {"size": sample_size}}], session=session)
 
     def get_cmdline_opts(self):
-        return self["admin"].command("getCmdLineOpts", comment=self.__comment)["parsed"]
+        return self["admin"].command("getCmdLineOpts")["parsed"]
 
     def replset_get_status(self):
-        return self["admin"].command("replSetGetStatus", comment=self.__comment)
+        return self["admin"].command("replSetGetStatus")
 
     def is_master(self):
-        return self["admin"].command("isMaster", comment=self.__comment)
+        return self["admin"].command("isMaster")
 
     def sharding_state_is_enabled(self):
-        return self["admin"].command("shardingState", comment=self.__comment).get("enabled", False)
+        return self["admin"].command("shardingState").get("enabled", False)
 
     def get_shard_map(self):
-        return self['admin'].command('getShardMap', comment=self.__comment)
+        return self['admin'].command('getShardMap')
 
     def server_status(self):
-        return self['admin'].command('serverStatus', comment=self.__comment)
+        return self['admin'].command('serverStatus')
 
     def list_authorized_collections(
         self,
@@ -210,12 +202,11 @@ class MongoApi(object):
             coll_names = self[db_name].list_collection_names(
                 filter={"type": "collection"},  # Only return collections, not views
                 authorizedCollections=True,
-                comment=self.__comment,
             )
         except OperationFailure as e:
             if e.code == 303 and e.details.get("errmsg") == "Field 'type' is currently not supported":
                 # Filter by type is not supported on AWS DocumentDB
-                coll_names = self[db_name].list_collection_names(authorizedCollections=True, comment=self.__comment)
+                coll_names = self[db_name].list_collection_names(authorizedCollections=True)
             else:
                 # The user is not authorized to run listCollections on this database.
                 # This is NOT a critical error, so we log it as a warning.
@@ -233,9 +224,7 @@ class MongoApi(object):
         try:
             # Check if the collection is sharded by looking for the collection config
             # in the config.collections collection.
-            collection_config = self["config"]["collections"].find_one(
-                {"_id": f"{db_name}.{coll_name}"}, comment=self.__comment
-            )
+            collection_config = self["config"]["collections"].find_one({"_id": f"{db_name}.{coll_name}"})
             return collection_config is not None
         except OperationFailure as e:
             self._log.warning("Could not determine if collection %s.%s is sharded: %s", db_name, coll_name, e)

--- a/mongo/tests/mocked_api.py
+++ b/mongo/tests/mocked_api.py
@@ -76,7 +76,7 @@ class MockedDB(object):
     def __getitem__(self, coll_name):
         return MockedCollection(self._db_name, coll_name, self.deployment)
 
-    def command(self, command, *args, **kwargs):
+    def command(self, command, *args, **_):
         filename = command
         if "dbStats" in command:
             filename = f"dbstats-{self._db_name}"

--- a/mongo/tests/mocked_api.py
+++ b/mongo/tests/mocked_api.py
@@ -76,7 +76,7 @@ class MockedDB(object):
     def __getitem__(self, coll_name):
         return MockedCollection(self._db_name, coll_name, self.deployment)
 
-    def command(self, command, *args, **_):
+    def command(self, command, *args, **kwargs):
         filename = command
         if "dbStats" in command:
             filename = f"dbstats-{self._db_name}"

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -37,8 +37,6 @@ DEFAULT_METRICS_LEN = len(
     }
 )
 
-DD_OPERATION_COMMENT = "service='datadog-agent'"
-
 
 @mock.patch('pymongo.database.Database.command', side_effect=ConnectionFailure('Service not available'))
 def test_emits_critical_service_check_when_service_is_not_available(mock_command, dd_run_check, aggregator):
@@ -148,13 +146,7 @@ def test_emits_ok_service_check_when_alibaba_mongos_deployment(
     dd_run_check(check)
     # Then
     aggregator.assert_service_check('mongodb.can_connect', MongoDb.OK)
-    mock_command.assert_has_calls(
-        [
-            mock.call('serverStatus', comment=DD_OPERATION_COMMENT),
-            mock.call('getCmdLineOpts', comment=DD_OPERATION_COMMENT),
-            mock.call('isMaster', comment=DD_OPERATION_COMMENT),
-        ]
-    )
+    mock_command.assert_has_calls([mock.call('serverStatus'), mock.call('getCmdLineOpts'), mock.call('isMaster')])
     mock_server_info.assert_called_once()
     mock_list_database_names.assert_called_once()
     assert check._resolved_hostname == 'test-hostname:27017'
@@ -184,10 +176,10 @@ def test_emits_ok_service_check_when_alibaba_replicaset_role_configsvr_deploymen
     aggregator.assert_service_check('mongodb.can_connect', MongoDb.OK)
     mock_command.assert_has_calls(
         [
-            mock.call('serverStatus', comment=DD_OPERATION_COMMENT),
-            mock.call('getCmdLineOpts', comment=DD_OPERATION_COMMENT),
-            mock.call('isMaster', comment=DD_OPERATION_COMMENT),
-            mock.call('replSetGetStatus', comment=DD_OPERATION_COMMENT),
+            mock.call('serverStatus'),
+            mock.call('getCmdLineOpts'),
+            mock.call('isMaster'),
+            mock.call('replSetGetStatus'),
         ]
     )
     mock_server_info.assert_called_once()
@@ -217,10 +209,10 @@ def test_when_replicaset_state_recovering_then_database_names_not_called(
     aggregator.assert_service_check('mongodb.can_connect', MongoDb.OK)
     mock_command.assert_has_calls(
         [
-            mock.call('serverStatus', comment=DD_OPERATION_COMMENT),
-            mock.call('getCmdLineOpts', comment=DD_OPERATION_COMMENT),
-            mock.call('isMaster', comment=DD_OPERATION_COMMENT),
-            mock.call('replSetGetStatus', comment=DD_OPERATION_COMMENT),
+            mock.call('serverStatus'),
+            mock.call('getCmdLineOpts'),
+            mock.call('isMaster'),
+            mock.call('replSetGetStatus'),
         ]
     )
     mock_server_info.assert_called_once()
@@ -507,12 +499,8 @@ def test_collector_submit_payload(check, aggregator):
 
 def test_api_alibaba_mongos(check, aggregator):
     payload = {'isMaster': {'msg': 'isdbgrid'}}
-
-    def mocked_command(command, *args, **kwargs):
-        return payload[command]
-
     mocked_client = mock.MagicMock()
-    mocked_client.__getitem__ = mock.MagicMock(return_value=mock.MagicMock(command=mocked_command))
+    mocked_client.__getitem__ = mock.MagicMock(return_value=mock.MagicMock(command=payload.__getitem__))
     mocked_client.get_cmdline_opts.side_effect = OperationFailure('getCmdLineOpts is not supported')
 
     with mock.patch('datadog_checks.mongo.api.MongoClient', mock.MagicMock(return_value=mocked_client)):
@@ -529,12 +517,8 @@ def test_api_alibaba_mongod_shard(check, aggregator):
         'replSetGetStatus': {'myState': 1, 'set': 'foo', 'configsvr': False},
         'shardingState': {'enabled': True},
     }
-
-    def mocked_command(command, *args, **kwargs):
-        return payload[command]
-
     mocked_client = mock.MagicMock()
-    mocked_client.__getitem__ = mock.MagicMock(return_value=mock.MagicMock(command=mocked_command))
+    mocked_client.__getitem__ = mock.MagicMock(return_value=mock.MagicMock(command=payload.__getitem__))
     mocked_client.get_cmdline_opts.side_effect = OperationFailure('getCmdLineOpts is not supported')
 
     with mock.patch('datadog_checks.mongo.api.MongoClient', mock.MagicMock(return_value=mocked_client)):
@@ -555,12 +539,8 @@ def test_api_alibaba_mongod_shard(check, aggregator):
 
 def test_api_alibaba_configsvr(check, aggregator):
     payload = {'isMaster': {}, 'replSetGetStatus': {'myState': 2, 'set': 'config', 'configsvr': True}}
-
-    def mocked_command(command, *args, **kwargs):
-        return payload[command]
-
     mocked_client = mock.MagicMock()
-    mocked_client.__getitem__ = mock.MagicMock(return_value=mock.MagicMock(command=mocked_command))
+    mocked_client.__getitem__ = mock.MagicMock(return_value=mock.MagicMock(command=payload.__getitem__))
     mocked_client.get_cmdline_opts.side_effect = OperationFailure('getCmdLineOpts is not supported')
 
     with mock.patch('datadog_checks.mongo.api.MongoClient', mock.MagicMock(return_value=mocked_client)):
@@ -585,12 +565,8 @@ def test_api_alibaba_mongod(check, aggregator):
         'replSetGetStatus': {'myState': 1, 'set': 'foo', 'configsvr': False},
         'shardingState': {'enabled': False},
     }
-
-    def mocked_command(command, *args, **kwargs):
-        return payload[command]
-
     mocked_client = mock.MagicMock()
-    mocked_client.__getitem__ = mock.MagicMock(return_value=mock.MagicMock(command=mocked_command))
+    mocked_client.__getitem__ = mock.MagicMock(return_value=mock.MagicMock(command=payload.__getitem__))
 
     with mock.patch('datadog_checks.mongo.api.MongoClient', mock.MagicMock(return_value=mocked_client)):
         check = check(common.INSTANCE_BASIC)
@@ -718,10 +694,10 @@ def test_emits_ok_service_check_for_documentdb_deployment(
     aggregator.assert_service_check('mongodb.can_connect', MongoDb.OK)
     mock_command.assert_has_calls(
         [
-            mock.call('serverStatus', comment=DD_OPERATION_COMMENT),
-            mock.call('getCmdLineOpts', comment=DD_OPERATION_COMMENT),
-            mock.call('isMaster', comment=DD_OPERATION_COMMENT),
-            mock.call('replSetGetStatus', comment=DD_OPERATION_COMMENT),
+            mock.call('serverStatus'),
+            mock.call('getCmdLineOpts'),
+            mock.call('isMaster'),
+            mock.call('replSetGetStatus'),
         ]
     )
     mock_server_info.assert_called_once()
@@ -750,8 +726,8 @@ def test_emits_ok_service_check_for_mongodb_atlas_deployment(
     aggregator.assert_service_check('mongodb.can_connect', MongoDb.OK)
     mock_command.assert_has_calls(
         [
-            mock.call('serverStatus', comment=DD_OPERATION_COMMENT),
-            mock.call('getCmdLineOpts', comment=DD_OPERATION_COMMENT),
+            mock.call('serverStatus'),
+            mock.call('getCmdLineOpts'),
         ]
     )
     mock_server_info.assert_called_once()


### PR DESCRIPTION
This reverts commit 6c5362ed47c57f1fb1119b8015c5ab59c9e1d01a.

### What does this PR do?
`comment` breaks mongodb prior to v4.4 and documentdb v4 and v5. we can rely on `application_name:datadog-agent` to identify queries from the agent 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
