### PR TITLE
Honor `tags` instance configuration in FoundationDB integration

### DIFF
--- a/foundationdb/changelog.d/19771.fixed
+++ b/foundationdb/changelog.d/19771.fixed
@@ -1,0 +1,1 @@
+Honor `tags` instance configuration in FoundationDB integration

--- a/foundationdb/tests/test_foundationdb.py
+++ b/foundationdb/tests/test_foundationdb.py
@@ -27,12 +27,15 @@ def test_partial(aggregator, instance):
 
 def test_full(aggregator, instance):
     with open(current_dir + 'full.json', 'r') as f:
+        instance['tags'] = ['fdb_test:true']
         data = json.loads(f.read())
         check = FoundationdbCheck('foundationdb', {}, [instance])
         check.check_metrics(data)
 
         for metric in METRICS:
             aggregator.assert_metric(metric)
+            aggregator.assert_metric_has_tag(metric, 'fdb_test:true')
+
         aggregator.assert_all_metrics_covered()
         aggregator.assert_metrics_using_metadata(get_metadata_metrics())
         aggregator.assert_service_check("foundationdb.can_connect", AgentCheck.OK)


### PR DESCRIPTION
### What does this PR do?
This change fixes an issue where the FoundationDB integration appears to accept user-provided tags, but then does not actually apply them to metrics/service checks/events. This fixes #19769.

### Motivation
In a use case where an operator has several FoundationDB clusters, it can be helpful to apply different sets of tags to different clusters.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
