### PR TITLE
Parse RDS end-of-life versions.

### DIFF
--- a/postgres/changelog.d/19773.added
+++ b/postgres/changelog.d/19773.added
@@ -1,0 +1,1 @@
+When Amazon adds Extended Support to older Postgres versions, they update the version string to a format we are currently unable to parse. This adds the ability to parse those versions. Here is an example announcement where they communicate such a version string: https://aws.amazon.com/about-aws/whats-new/2024/12/amazon-rds-postgresql-minor-11-22-rds-20241121/

--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -69,11 +69,22 @@ class VersionUtils(object):
                 version.append(0)
             return VersionInfo(*version)
         except ValueError:
+            pass
+        try:
             # Postgres might be in development, with format \d+[beta|rc]\d+
             match = re.match(r'(\d+)([a-zA-Z]+)(\d+)', raw_version)
             if match:
                 version = list(match.groups())
                 return VersionInfo.parse('{}.0.0-{}.{}'.format(*version))
+            else:
+                raise ValueError('Unable to match development version')
+        except ValueError:
+            # RDS changes the version format when the version switches to EOL.
+            # Example: 11.22-rds.20241121.
+            match = re.match(r'(\d+\.\d+)-rds\.(\d+)', raw_version)
+            if match:
+                version = list(match.groups())
+                return VersionInfo.parse('{}.{}'.format(*version))
         raise Exception("Cannot determine which version is {}".format(raw_version))
 
     @staticmethod

--- a/postgres/tests/test_version_utils.py
+++ b/postgres/tests/test_version_utils.py
@@ -79,3 +79,9 @@ def test_transform_version():
         'version.scheme': 'semver',
     }
     assert expected == version
+
+def test_parse_rds_eol_version():
+    version = '11.22-rds.20241121'
+    v11_22_rds = VersionUtils.parse_version(version)
+
+    assert v11_22_rds == VersionInfo(11, 22, 20241121)

--- a/postgres/tests/test_version_utils.py
+++ b/postgres/tests/test_version_utils.py
@@ -80,6 +80,7 @@ def test_transform_version():
     }
     assert expected == version
 
+
 def test_parse_rds_eol_version():
     version = '11.22-rds.20241121'
     v11_22_rds = VersionUtils.parse_version(version)


### PR DESCRIPTION
### What does this PR do?

When Amazon adds Extended Support to older Postgres versions, they update the version string to a format we are currently unable to parse. This adds the ability to parse those versions. Here is an example announcement where they communicate such a version string: https://aws.amazon.com/about-aws/whats-new/2024/12/amazon-rds-postgresql-minor-11-22-rds-20241121/
### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
