### PR TITLE
Bump cryptography to 44.0.1

### DIFF
--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -10,7 +10,7 @@ clickhouse-cityhash==1.0.2.4
 clickhouse-driver==0.2.9
 cm-client==45.0.4
 confluent-kafka==2.8.0
-cryptography==43.0.1
+cryptography==44.0.1
 ddtrace==2.10.6
 dnspython==2.7.0
 foundationdb==6.3.24

--- a/cisco_aci/changelog.d/19751.security
+++ b/cisco_aci/changelog.d/19751.security
@@ -1,0 +1,1 @@
+Bump cryptography to 44.0.1

--- a/cisco_aci/pyproject.toml
+++ b/cisco_aci/pyproject.toml
@@ -36,7 +36,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "cryptography==43.0.1",
+    "cryptography==44.0.1",
 ]
 
 [project.urls]

--- a/datadog_checks_base/changelog.d/19751.security
+++ b/datadog_checks_base/changelog.d/19751.security
@@ -1,0 +1,1 @@
+Bump cryptography to 44.0.1

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -36,7 +36,7 @@ db = [
 deps = [
     "binary==1.0.1",
     "cachetools==5.5.1",
-    "cryptography==43.0.1",
+    "cryptography==44.0.1",
     "ddtrace==2.10.6",
     "jellyfish==1.1.3",
     "prometheus-client==0.21.1",

--- a/http_check/changelog.d/19751.security
+++ b/http_check/changelog.d/19751.security
@@ -1,0 +1,1 @@
+Bump cryptography to 44.0.1

--- a/http_check/pyproject.toml
+++ b/http_check/pyproject.toml
@@ -36,7 +36,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "cryptography==43.0.1",
+    "cryptography==44.0.1",
     "requests-ntlm==1.3.0",
 ]
 

--- a/mysql/changelog.d/19751.security
+++ b/mysql/changelog.d/19751.security
@@ -1,0 +1,1 @@
+Bump cryptography to 44.0.1

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -37,7 +37,7 @@ license = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "cachetools==5.5.1",
-    "cryptography==43.0.1",
+    "cryptography==44.0.1",
     "pymysql==1.1.1",
 ]
 

--- a/tls/changelog.d/19751.security
+++ b/tls/changelog.d/19751.security
@@ -1,0 +1,1 @@
+Bump cryptography to 44.0.1

--- a/tls/pyproject.toml
+++ b/tls/pyproject.toml
@@ -36,7 +36,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "cryptography==43.0.1",
+    "cryptography==44.0.1",
     "service-identity[idna]==24.2.0",
 ]
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR bumps the version of cryptography used for integrations.

### Motivation
<!-- What inspired you to submit this pull request? -->
This addresses https://datadoghq.atlassian.net/browse/VULN-9881
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
