### PR TITLE
Handle RDS Postgres version

### DIFF
--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -62,12 +62,15 @@ class VersionUtils(object):
         except ValueError:
             pass
         try:
-            # Version may be missing minor eg: 10.0 and it might have an edition suffix (e.g. 12.3_TDE_1.0)
-            version = re.split('[ _]', raw_version)[0].split('.')
+            # Version may be missing minor eg: 10.0 and it might have an edition suffix
+            # (e.g. 12.3_TDE_1.0, 11.22-RDS.20241121)
+            version_parts = re.split('[ _-]', raw_version, maxsplit=1)
+            version = version_parts[0].split('.')
             version = [int(part) for part in version]
             while len(version) < 3:
                 version.append(0)
-            return VersionInfo(*version)
+            version_info = VersionInfo(*version)
+            return version_info
         except ValueError:
             # Postgres might be in development, with format \d+[beta|rc]\d+
             match = re.match(r'(\d+)([a-zA-Z]+)(\d+)', raw_version)

--- a/postgres/tests/test_version_utils.py
+++ b/postgres/tests/test_version_utils.py
@@ -41,6 +41,9 @@ def test_parse_version():
     v12_3_tde = VersionUtils.parse_version('12.3_TDE_1.0')
     assert v12_3_tde == VersionInfo(12, 3, 0)
 
+    v11_22_RDS = VersionUtils.parse_version('11.22-RDS.20241121')
+    assert v11_22_RDS == VersionInfo(11, 22, 0)
+
 
 def test_throws_exception_for_unknown_version_format():
     with pytest.raises(Exception) as e:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds handling for RDS non-semver version for Postgres.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
