### PR TITLE
Update http.yaml with <TOKEN> information for auth_token

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
@@ -198,7 +198,7 @@
 
       - type: header
         name (required): The name of the field, for example: Authorization
-        value: The template value, for example `Bearer <TOKEN>`. The default is: <TOKEN>
+        value: The template value, for example `"Bearer <TOKEN>"`. Note that <TOKEN> is not something that you are supposed to replace. The default is: <TOKEN>
         placeholder: The substring in `value` to replace with the token, defaults to: <TOKEN>
 - name: aws_region
   value:


### PR DESCRIPTION
### What does this PR do?
Add a comment about auth_token configuration and `<TOKEN>`.

### Motivation
Some customer get confused with `<TOKEN>` that seems to be a placeholder to replace in the auth_token configuration, resulting this error:
```
Error: The `value` setting of `auth_token` writer does not contain the placeholder string `<TOKEN>`
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged