### PR TITLE
[sqlserver] Remove mssql 2017 on linux from test suite

### DIFF
--- a/sqlserver/hatch.toml
+++ b/sqlserver/hatch.toml
@@ -4,7 +4,7 @@ base-package-features = ["deps", "db", "json"]
 [[envs.default.matrix]]
 python = ["3.12"]
 os = ["linux"]
-version = ["2017", "2019", "2022"]
+version = ["2019", "2022"]
 setup = ["single", "ha"]
 
 # test the compatibility of sqlserver running on non-utc timezone


### PR DESCRIPTION
### What does this PR do?
This PR removes MSSQL 2017 on Linux from the SQLServer integration test suite. The MSSQL 2017 container fails to start or crashes intermittently on Linux kernel 6.7 and 6.8.

On February 26, GitHub updated the ubuntu-22.04 runner kernel from 6.5.0 to 6.8.0, which caused SQL Server tests to start failing on MSSQL 2017. Currently, neither the MSSQL 2017 container nor the non-containerized version of MSSQL 2017 on Linux works with kernel 6.8.0.

To unblock the pipeline, this PR removes MSSQL 2017 from the test suite (for now, hopefully temporarily).

Related issue: https://github.com/microsoft/mssql-docker/issues/868

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
