### PR TITLE
Reduce log verbosity level for unverified HTTP requests.

### DIFF
--- a/datadog_checks_base/changelog.d/19791.fixed
+++ b/datadog_checks_base/changelog.d/19791.fixed
@@ -1,0 +1,1 @@
+Reduce log verbosity level for unverified HTTP requests. WARNING level spams a lot with no evidence that users pay attention. DEBUG will be useful for support cases.

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
@@ -569,7 +569,7 @@ class PrometheusScraperMixin(object):
             and not handler.ignore_tls_warning
             and not is_affirmative(handler.options.get('ssl_verify', True))
         ):
-            self.log.warning(u'An unverified HTTPS request is being made to %s', endpoint)
+            self.log.debug(u'An unverified HTTPS request is being made to %s', endpoint)
 
         try:
             response = handler.get(endpoint, extra_headers=headers, stream=False)

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -394,7 +394,7 @@ class RequestsWrapper(object):
         new_options = self.populate_options(options)
 
         if url.startswith('https') and not self.ignore_tls_warning and not new_options['verify']:
-            self.logger.warning(u'An unverified HTTPS request is being made to %s', url)
+            self.logger.debug(u'An unverified HTTPS request is being made to %s', url)
 
         extra_headers = options.pop('extra_headers', None)
         if extra_headers is not None:

--- a/datadog_checks_base/tests/base/utils/http/test_tls_and_certs.py
+++ b/datadog_checks_base/tests/base/utils/http/test_tls_and_certs.py
@@ -76,10 +76,10 @@ class TestIgnoreTLSWarning:
 
         expected_message = 'An unverified HTTPS request is being made to https://www.google.com'
         for _, level, message in caplog.record_tuples:
-            if level == logging.WARNING and message == expected_message:
+            if level == logging.DEBUG and message == expected_message:
                 break
         else:
-            raise AssertionError('Expected WARNING log with message `{}`'.format(expected_message))
+            raise AssertionError('Expected DEBUG log with message `{}`'.format(expected_message))
 
     def test_default_no_ignore_http(self, caplog):
         instance = {}
@@ -113,10 +113,10 @@ class TestIgnoreTLSWarning:
 
         expected_message = 'An unverified HTTPS request is being made to https://www.google.com'
         for _, level, message in caplog.record_tuples:
-            if level == logging.WARNING and message == expected_message:
+            if level == logging.DEBUG and message == expected_message:
                 break
         else:
-            raise AssertionError('Expected WARNING log with message `{}`'.format(expected_message))
+            raise AssertionError('Expected DEBUG log with message `{}`'.format(expected_message))
 
     def test_ignore_session(self, caplog):
         instance = {'tls_ignore_warning': True, 'persist_connections': True}
@@ -152,10 +152,10 @@ class TestIgnoreTLSWarning:
 
         expected_message = 'An unverified HTTPS request is being made to https://www.google.com'
         for _, level, message in caplog.record_tuples:
-            if level == logging.WARNING and message == expected_message:
+            if level == logging.DEBUG and message == expected_message:
                 break
         else:
-            raise AssertionError('Expected WARNING log with message `{}`'.format(expected_message))
+            raise AssertionError('Expected DEBUG log with message `{}`'.format(expected_message))
 
     def test_instance_ignore(self, caplog):
         instance = {'tls_ignore_warning': True}
@@ -179,10 +179,10 @@ class TestIgnoreTLSWarning:
 
         expected_message = 'An unverified HTTPS request is being made to https://www.google.com'
         for _, level, message in caplog.record_tuples:
-            if level == logging.WARNING and message == expected_message:
+            if level == logging.DEBUG and message == expected_message:
                 break
         else:
-            raise AssertionError('Expected WARNING log with message `{}`'.format(expected_message))
+            raise AssertionError('Expected DEBUG log with message `{}`'.format(expected_message))
 
 
 class TestAIAChasing:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We log if we make an unverified HTTP request. This PR changes the level from WARNING to DEBUG.

### Motivation
<!-- What inspired you to submit this pull request? -->
WARNING level is spamming our internal logs and users aren't responding to it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
