### PR TITLE
[mysql] collect foreign key delete and update rule

### DIFF
--- a/mysql/datadog_checks/mysql/databases_data.py
+++ b/mysql/datadog_checks/mysql/databases_data.py
@@ -225,6 +225,8 @@ class DatabasesData:
                             - referenced_table_schema (str): The schema of the referenced table.
                             - referenced_table_name (str): The name of the referenced table.
                             - referenced_column_names (str): The column names in the referenced table.
+                            - update_action (str): The update rule for the foreign key.
+                            - delete_action (str): The delete rule for the foreign key.
                     - partitions (list): A list of partition dictionaries.
                         - partition (dict): A dictionary representing a partition.
                             - name (str): The name of the partition.

--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -161,19 +161,32 @@ WHERE table_schema = %s AND table_name IN ({});
 
 SQL_FOREIGN_KEYS = """\
 SELECT
-    constraint_schema as `constraint_schema`,
-    constraint_name as `name`,
-    table_name as `table_name`,
-    group_concat(column_name order by ordinal_position asc) as column_names,
-    referenced_table_schema as `referenced_table_schema`,
-    referenced_table_name as `referenced_table_name`,
-    group_concat(referenced_column_name) as referenced_column_names
+    kcu.constraint_schema as constraint_schema,
+    kcu.constraint_name as name,
+    kcu.table_name as table_name,
+    group_concat(kcu.column_name order by kcu.ordinal_position asc) as column_names,
+    kcu.referenced_table_schema as referenced_table_schema,
+    kcu.referenced_table_name as referenced_table_name,
+    group_concat(kcu.referenced_column_name) as referenced_column_names,
+    rc.update_rule as update_action,
+    rc.delete_rule as delete_action
 FROM
-    INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+    INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
+LEFT JOIN
+    INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
+    ON kcu.CONSTRAINT_SCHEMA = rc.CONSTRAINT_SCHEMA
+    AND kcu.CONSTRAINT_NAME = rc.CONSTRAINT_NAME
 WHERE
-    table_schema = %s AND table_name in ({})
-    AND referenced_table_name is not null
-GROUP BY constraint_schema, constraint_name, table_name, referenced_table_schema, referenced_table_name;
+    kcu.table_schema = %s AND kcu.table_name in ({})
+    AND kcu.referenced_table_name is not null
+GROUP BY
+    kcu.constraint_schema,
+    kcu.constraint_name,
+    kcu.table_name,
+    kcu.referenced_table_schema,
+    kcu.referenced_table_name,
+    rc.update_rule,
+    rc.delete_rule
 """
 
 SQL_PARTITION = """\

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -508,7 +508,8 @@ def add_schema_test_databases(cursor):
         """CREATE TABLE landmarks (
            name VARCHAR(255),
            city_id INT DEFAULT 0,
-           CONSTRAINT FK_CityId FOREIGN KEY (city_id) REFERENCES cities(id));
+           CONSTRAINT FK_CityId FOREIGN KEY (city_id)
+           REFERENCES cities(id) ON DELETE SET NULL ON UPDATE RESTRICT);
         """
     )
 
@@ -527,7 +528,7 @@ def add_schema_test_databases(cursor):
             District VARCHAR(255),
             Review TEXT,
             CONSTRAINT FK_RestaurantNameDistrict FOREIGN KEY (RestaurantName, District)
-            REFERENCES Restaurants(RestaurantName, District));
+            REFERENCES Restaurants(RestaurantName, District) ON DELETE CASCADE ON UPDATE NO ACTION);
         """
     )
     # Second DB

--- a/mysql/tests/test_metadata.py
+++ b/mysql/tests/test_metadata.py
@@ -156,6 +156,8 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                         "referenced_table_schema": "datadog_test_schemas",
                         "referenced_table_name": "Restaurants",
                         "referenced_column_names": "District,RestaurantName",
+                        "update_action": "NO ACTION",
+                        "delete_action": "CASCADE",
                     }
                 ],
                 "indexes": [
@@ -458,6 +460,8 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                         "referenced_table_schema": "datadog_test_schemas",
                         "referenced_table_name": "cities",
                         "referenced_column_names": "id",
+                        "update_action": "RESTRICT",
+                        "delete_action": "SET NULL",
                     }
                 ],
                 "indexes": [


### PR DESCRIPTION
### What does this PR do?
This PR enhances MySQL foreign key metadata collection by including delete and update rules from `INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS`. These rules define the referential behavior enforced when a referenced row is deleted or updated. Capturing this information is essential for understanding the impact of foreign key constraints on cascading operations. The possible values for delete and update actions are: `CASCADE`, `SET NULL`, `SET DEFAULT`, `RESTRICT`, `NO ACTION`.

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-5083
The delete and update rules dictate how changes propagate when modifications occurs for a foreign key. Without this information, users reviewing foreign key definitions lack critical context on cascading behaviors. This PR ensures that these actions are captured.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
