### PR TITLE
[mongo] skip explain aggregation pipeline with mergeCursors stage

### DIFF
--- a/mongo/changelog.d/19798.added
+++ b/mongo/changelog.d/19798.added
@@ -1,0 +1,1 @@
+Skip running explain on aggregation pipelines that contain $mergeCursors to prevent potential MongoDB crashes.

--- a/mongo/datadog_checks/mongo/dbm/utils.py
+++ b/mongo/datadog_checks/mongo/dbm/utils.py
@@ -68,6 +68,7 @@ UNEXPLAINABLE_PIPELINE_STAGES = frozenset(
         "$listSearchIndexes",
         "$sample",
         "$shardedDataDistribution",
+        "$mergeCursors",
     ]
 )
 


### PR DESCRIPTION
### What does this PR do?
This PR updates the mongo integration to skip running explain on aggregation pipelines that include the `$mergeCursors` stage.

### Motivation
- The $mergeCursors stage is used internally in sharded cluster aggregations to merge cursor results across shards.
- Running explain on a query that includes $mergeCursors can cause MongoDB to execute the stage in an unintended context, potentially leading to a server crash.
- Additionally, explaining this stage does not provide useful query execution insights since it references cursor IDs from a previous step that no longer exist.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
