### PR TITLE
update mariadb test suite to include 11.4 LTS and remove eol versions

### DIFF
--- a/mysql/hatch.toml
+++ b/mysql/hatch.toml
@@ -30,11 +30,8 @@ replication = ["group"]
 python = ["3.12"]
 flavor = ["mariadb"]
 version = [
-  "10.2",  # EOL 23 May 2022 (ended)
   "10.5",  # EOL 24 June 2025 (LTS version)
   "10.6",  # EOL 06 July 2026 (LTS version)
-  "10.8",  # EOL 20 May 2023 (ended)
-  "10.9",  # EOL 22 Aug 2023 (ended)
   "10.11", # EOL 16 Feb 2028 (LTS version)
   "11.4",  # EOL 29 May 2029 (LTS version)
 ]

--- a/mysql/hatch.toml
+++ b/mysql/hatch.toml
@@ -36,6 +36,7 @@ version = [
   "10.8",  # EOL 20 May 2023 (ended)
   "10.9",  # EOL 22 Aug 2023 (ended)
   "10.11", # EOL 16 Feb 2028 (LTS version)
+  "11.4",  # EOL 29 May 2029 (LTS version)
 ]
 
 [envs.default.overrides]


### PR DESCRIPTION
### What does this PR do?
Add MariaDB 11.4 LTS to test suite. Removed 10.2, 10.8 and 10.9 from the test suite.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
