### PR TITLE
Add metrics to Go defaults

### DIFF
--- a/datadog_checks_base/changelog.d/19802.added
+++ b/datadog_checks_base/changelog.d/19802.added
@@ -1,0 +1,1 @@
+Add two additional Go metrics to list of defaults

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/metrics.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/metrics.py
@@ -1,6 +1,8 @@
 DEFAULT_GO_METRICS = {
     'go_gc_duration_seconds': 'go.gc.duration.seconds',
+    'go_gc_duration_seconds_quantile': 'go.gc.duration.seconds.quantile',
     'go_goroutines': 'go.goroutines',
+    'go_info': 'go.info',
     'go_memstats_alloc_bytes': {'name': 'go.memstats.alloc_bytes', 'type': 'native_dynamic'},
     'go_memstats_buck_hash_sys_bytes': 'go.memstats.buck_hash.sys_bytes',
     'go_memstats_frees': 'go.memstats.frees',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds two metrics to the default list of Go metrics

### Motivation
<!-- What inspired you to submit this pull request? -->
When using the defaults for [this PR](https://github.com/DataDog/integrations-core/pull/19539), I noticed that two entries in my payload were not covered
Go version: 1.22.10

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
