### PR TITLE
[sqlserver] fix bug where tempdb is wrongly excluded in database files metrics

### DIFF
--- a/sqlserver/changelog.d/19803.fixed
+++ b/sqlserver/changelog.d/19803.fixed
@@ -1,0 +1,1 @@
+Fix a bug where `tempdb` is wrongly excluded from database files metrics due to all instances inherited from `SqlserverDatabaseMetricsBase` share the same reference of auto-discovered databases.

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/base.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/base.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 
+import copy
 from typing import Callable, List, Optional
 
 from datadog_checks.base.log import get_check_logger
@@ -28,7 +29,7 @@ class SqlserverDatabaseMetricsBase:
         ] = new_query_executor
         self.execute_query_handler: Callable[[str, Optional[str]], List[tuple]] = execute_query_handler
         self.track_operation_time: bool = track_operation_time
-        self._databases: Optional[List[str]] = databases
+        self._databases: Optional[List[str]] = copy.copy(databases)
         self._query_executors: List[QueryExecutor] = []
         self.log = get_check_logger()
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug where `tempdb` is wrongly excluded in database files metrics due to all instances inherited from `SqlserverDatabaseMetricsBase` share the same reference of auto-discovered databases.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
