### PR TITLE
Collect Cisco ACI faults as logs.

### DIFF
--- a/cisco_aci/README.md
+++ b/cisco_aci/README.md
@@ -58,6 +58,16 @@ To configure this check for an Agent running on a host:
         ## Set to `true` to enable Network Device Monitoring metadata (for devices and interfaces) to be sent.
         #
         # send_ndm_metadata: false
+
+        # send_faultinst_faults - boolean - optional - default: false
+        # Set to `true` to enable collection of Cisco ACI faultInst faults as logs.
+        #
+        # send_faultinst_faults: false
+
+        # send_faultdelegate_faults - boolean - optional - default: false
+        # Set to `true` to enable collection of Cisco ACI faultDelegate faults as logs.
+        #
+        # send_faultdelegate_faults: false
    ```
    
    *NOTE*: Be sure to specify any tenants for the integration to collect metrics on applications, EPG, etc.

--- a/cisco_aci/assets/configuration/spec.yaml
+++ b/cisco_aci/assets/configuration/spec.yaml
@@ -106,6 +106,20 @@ files:
         type: boolean
         example: False
         display_default: False
+    - name: send_faultinst_faults
+      description: |
+        Set to `true` to enable collection of Cisco ACI faultInst faults as logs.
+      value:
+        type: boolean
+        example: False
+        display_default: False
+    - name: send_faultdelegate_faults
+      description: |
+        Set to `true` to enable collection of Cisco ACI faultDelegate faults as logs.
+      value:
+        type: boolean
+        example: False
+        display_default: False
     - template: instances/http
       overrides:
         username.display_priority: 9

--- a/cisco_aci/assets/logs/cisco-aci.yaml
+++ b/cisco_aci/assets/logs/cisco-aci.yaml
@@ -1,0 +1,215 @@
+id: cisco-aci
+metric_id: cisco-aci
+backend_only: false
+facets:
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Ack
+    path: cisco_aci.ack
+    source: log
+    type: boolean
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Affected
+    path: cisco_aci.affected
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Alert
+    path: cisco_aci.alert
+    source: log
+    type: boolean
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Cause
+    path: cisco_aci.cause
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Change Set
+    path: cisco_aci.changeSet
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Child Action
+    path: cisco_aci.childAction
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Code
+    path: cisco_aci.code
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Delegated
+    path: cisco_aci.delegated
+    source: log
+    type: boolean
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Dn
+    path: cisco_aci.dn
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Domain
+    path: cisco_aci.domain
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Fault Category
+    path: cisco_aci.faultCategory
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Highest Severity
+    path: cisco_aci.highestSeverity
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Lifecycle Status
+    path: cisco_aci.lc
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Occur
+    path: cisco_aci.occur
+    source: log
+    type: integer
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Orig Severity
+    path: cisco_aci.origSeverity
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Prev Severity
+    path: cisco_aci.prevSeverity
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Rule
+    path: cisco_aci.rule
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Severity
+    path: cisco_aci.severity
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Subject
+    path: cisco_aci.subject
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Title
+    path: cisco_aci.title
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Type
+    path: cisco_aci.type
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Upgrade Status
+    path: cisco_aci.status
+    source: log
+    type: string
+pipeline:
+  type: pipeline
+  name: Cisco ACI
+  enabled: true
+  filter:
+    query: source:cisco-aci
+  processors:
+    - type: date-remapper
+      name: Define `cisco_aci.lastTransition` as the official date of the log
+      enabled: true
+      sources:
+        - cisco_aci.lastTransition
+    - type: message-remapper
+      name: Define `cisco_aci.descr` as the official message of the log
+      enabled: true
+      sources:
+        - cisco_aci.descr
+    - name: Map `cisco_aci.severity` levels into `log_status`
+      enabled: true
+      source: cisco_aci.severity
+      target: log_status
+      lookupTable: |-
+        critical,critical
+        major,error
+        minor,warning
+        warning,warning
+        info,info
+        cleared,info
+      defaultLookup: info
+      type: lookup-processor
+    - type: status-remapper
+      name: Define `log_status` as the official status of the log
+      enabled: true
+      sources:
+        - log_status

--- a/cisco_aci/assets/logs/cisco-aci_tests.yaml
+++ b/cisco_aci/assets/logs/cisco-aci_tests.yaml
@@ -1,0 +1,65 @@
+id: cisco-aci
+tests:
+  - sample: >-
+      {
+        "cisco_aci": {
+          "ack": "no",
+          "alert": "no",
+          "cause": "threshold-crossed",
+          "changeSet": "crcLast:1",
+          "childAction": "",
+          "code": "F381328",
+          "created": "2025-03-12T13:46:10.489+00:00",
+          "delegated": "no",
+          "descr": "TCA: CRC Align Errors current value(eqptIngrErrPkts5min:crcLast) value 1% raised above threshold 0% and value is recovering ",
+          "dn": "topology/pod-1/node-101/sys/aggr-[po3]/fault-F381328",
+          "domain": "infra",
+          "highestSeverity": "warning",
+          "lastTransition": "2025-03-12T15:57:27.496+00:00",
+          "lc": "raised",
+          "occur": "115",
+          "origSeverity": "warning",
+          "prevSeverity": "cleared",
+          "rule": "tca-eqpt-ingr-err-pkts5min-crc-last",
+          "severity": "warning",
+          "status": "",
+          "subject": "counter",
+          "title": "",
+          "type": "operational",
+          "faultCategory": "faultInst"
+        }
+      }
+    result: null
+  - sample: >-
+      {
+        "cisco_aci": {
+          "ack": "no",
+          "affected": "topology/pod-1/node-1/local/svc-extXMLApi-id-255/uni/userext/tacacsext/tacacsplusprovider-10.19.24.1",
+          "cause": "inoperable",
+          "changeSet": "operState (Old: unknown, New: inoperable)",
+          "childAction": "",
+          "code": "F0023",
+          "created": "2025-03-09T14:23:39.345+00:00",
+          "descr": "Fault delegate: Tacacs+ Provider 10.19.24.1 unreachable",
+          "dn": "uni/userext/tacacsext/tacacsplusprovider-10.19.24.1/fd-[topology/pod-1/node-1/local/svc-extXMLApi-id-255/uni/userext/tacacsext/tacacsplusprovider-10.19.24.1]-fault-F0023",
+          "domain": "security",
+          "highestSeverity": "minor",
+          "lastTransition": "2025-03-12T00:12:36.980+00:00",
+          "lc": "raised",
+          "occur": "1",
+          "origSeverity": "minor",
+          "prevSeverity": "minor",
+          "rule": "aaa-tacacs-plus-provider-tacacs-plus-provider-inoperable",
+          "severity": "minor",
+          "status": "",
+          "subject": "security-provider",
+          "type": "operational",
+          "faultCategory": "faultDelegate"
+        }
+      }
+    result: null
+
+# The `result` field should be left blank to start. Once you submit your log asset files with
+# your integration pull-request in a Datadog GitHub repository, Datadog's validations will
+# run your raw logs against your pipeline and return the result. If the result output in the
+# validation is accurate, take the output and add it to the `result` field in your test YAML file.

--- a/cisco_aci/assets/logs/cisco-aci_tests.yaml
+++ b/cisco_aci/assets/logs/cisco-aci_tests.yaml
@@ -29,7 +29,38 @@ tests:
           "faultCategory": "faultInst"
         }
       }
-    result: null
+    result:
+      custom:
+        cisco_aci:
+          ack: "no"
+          alert: "no"
+          cause: "threshold-crossed"
+          changeSet: "crcLast:1"
+          childAction: ""
+          code: "F381328"
+          created: "2025-03-12T13:46:10.489+00:00"
+          delegated: "no"
+          dn: "topology/pod-1/node-101/sys/aggr-[po3]/fault-F381328"
+          domain: "infra"
+          faultCategory: "faultInst"
+          highestSeverity: "warning"
+          lastTransition: "2025-03-12T15:57:27.496+00:00"
+          lc: "raised"
+          occur: "115"
+          origSeverity: "warning"
+          prevSeverity: "cleared"
+          rule: "tca-eqpt-ingr-err-pkts5min-crc-last"
+          severity: "warning"
+          status: ""
+          subject: "counter"
+          title: ""
+          type: "operational"
+        log_status: "warning"
+      message: "TCA: CRC Align Errors current value(eqptIngrErrPkts5min:crcLast) value 1% raised above threshold 0% and value is recovering "
+      status: "warn"
+      tags:
+       - "source:LOGS_SOURCE"
+      timestamp: 1741795047496
   - sample: >-
       {
         "cisco_aci": {
@@ -57,9 +88,33 @@ tests:
           "faultCategory": "faultDelegate"
         }
       }
-    result: null
-
-# The `result` field should be left blank to start. Once you submit your log asset files with
-# your integration pull-request in a Datadog GitHub repository, Datadog's validations will
-# run your raw logs against your pipeline and return the result. If the result output in the
-# validation is accurate, take the output and add it to the `result` field in your test YAML file.
+    result:
+      custom:
+        cisco_aci:
+          ack: "no"
+          affected: "topology/pod-1/node-1/local/svc-extXMLApi-id-255/uni/userext/tacacsext/tacacsplusprovider-10.19.24.1"
+          cause: "inoperable"
+          changeSet: "operState (Old: unknown, New: inoperable)"
+          childAction: ""
+          code: "F0023"
+          created: "2025-03-09T14:23:39.345+00:00"
+          dn: "uni/userext/tacacsext/tacacsplusprovider-10.19.24.1/fd-[topology/pod-1/node-1/local/svc-extXMLApi-id-255/uni/userext/tacacsext/tacacsplusprovider-10.19.24.1]-fault-F0023"
+          domain: "security"
+          faultCategory: "faultDelegate"
+          highestSeverity: "minor"
+          lastTransition: "2025-03-12T00:12:36.980+00:00"
+          lc: "raised"
+          occur: "1"
+          origSeverity: "minor"
+          prevSeverity: "minor"
+          rule: "aaa-tacacs-plus-provider-tacacs-plus-provider-inoperable"
+          severity: "minor"
+          status: ""
+          subject: "security-provider"
+          type: "operational"
+        log_status: "warning"
+      message: "Fault delegate: Tacacs+ Provider 10.19.24.1 unreachable"
+      status: "warn"
+      tags:
+       - "source:LOGS_SOURCE"
+      timestamp: 1741738356980

--- a/cisco_aci/changelog.d/19806.added
+++ b/cisco_aci/changelog.d/19806.added
@@ -1,0 +1,1 @@
+Collect Cisco ACI faults as logs.

--- a/cisco_aci/datadog_checks/cisco_aci/api.py
+++ b/cisco_aci/datadog_checks/cisco_aci/api.py
@@ -337,6 +337,20 @@ class Api:
         response = self.make_request(path)
         return self._parse_response(response)
 
+    def get_faultinst_faults(self, afterTimestamp):
+        path = "/api/node/class/faultInst.json"
+        if afterTimestamp is not None:
+            path += "?query-target-filter=and(gt(faultInst.lastTransition,\"{}\"))".format(afterTimestamp)
+        response = self.make_request(path)
+        return self._parse_response(response)
+
+    def get_faultdelegate_faults(self, afterTimestamp):
+        path = "/api/node/class/faultDelegate.json"
+        if afterTimestamp is not None:
+            path += "?query-target-filter=and(gt(faultInst.lastTransition,\"{}\"))".format(afterTimestamp)
+        response = self.make_request(path)
+        return self._parse_response(response)
+
     def _parse_response(self, response):
         try:
             return response.get('imdata')

--- a/cisco_aci/datadog_checks/cisco_aci/api.py
+++ b/cisco_aci/datadog_checks/cisco_aci/api.py
@@ -347,7 +347,7 @@ class Api:
     def get_faultdelegate_faults(self, afterTimestamp):
         path = "/api/node/class/faultDelegate.json"
         if afterTimestamp is not None:
-            path += "?query-target-filter=and(gt(faultInst.lastTransition,\"{}\"))".format(afterTimestamp)
+            path += "?query-target-filter=and(gt(faultDelegate.lastTransition,\"{}\"))".format(afterTimestamp)
         response = self.make_request(path)
         return self._parse_response(response)
 

--- a/cisco_aci/datadog_checks/cisco_aci/cisco.py
+++ b/cisco_aci/datadog_checks/cisco_aci/cisco.py
@@ -10,6 +10,7 @@ from datadog_checks.cisco_aci.aci_metrics import make_tenant_metrics
 from datadog_checks.cisco_aci.api import Api
 from datadog_checks.cisco_aci.capacity import Capacity
 from datadog_checks.cisco_aci.fabric import Fabric
+from datadog_checks.cisco_aci.faults import Faults
 from datadog_checks.cisco_aci.tags import CiscoTags
 from datadog_checks.cisco_aci.tenant import Tenant
 
@@ -132,6 +133,20 @@ class CiscoACICheck(AgentCheck):
                 SERVICE_CHECK_NAME,
                 AgentCheck.CRITICAL,
                 message="aci capacity operations failed, returning a status of {}".format(e),
+                tags=service_check_tags,
+            )
+            api.close()
+            raise
+
+        try:
+            faults = Faults(self, api, self.instance, self.instance.get('namespace', 'default'))
+            faults.collect()
+        except Exception as e:
+            self.log.error('faults collection failed: %s', e)
+            self.service_check(
+                SERVICE_CHECK_NAME,
+                AgentCheck.CRITICAL,
+                message="aci faults operations failed, returning a status of {}".format(e),
                 tags=service_check_tags,
             )
             api.close()

--- a/cisco_aci/datadog_checks/cisco_aci/config_models/defaults.py
+++ b/cisco_aci/datadog_checks/cisco_aci/config_models/defaults.py
@@ -72,6 +72,14 @@ def instance_request_size():
     return 16
 
 
+def instance_send_faultdelegate_faults():
+    return False
+
+
+def instance_send_faultinst_faults():
+    return False
+
+
 def instance_send_ndm_metadata():
     return False
 

--- a/cisco_aci/datadog_checks/cisco_aci/config_models/instance.py
+++ b/cisco_aci/datadog_checks/cisco_aci/config_models/instance.py
@@ -90,6 +90,8 @@ class InstanceConfig(BaseModel):
     pwd: Optional[str] = None
     read_timeout: Optional[float] = None
     request_size: Optional[float] = None
+    send_faultdelegate_faults: Optional[bool] = None
+    send_faultinst_faults: Optional[bool] = None
     send_ndm_metadata: Optional[bool] = None
     service: Optional[str] = None
     skip_proxy: Optional[bool] = None

--- a/cisco_aci/datadog_checks/cisco_aci/data/conf.yaml.example
+++ b/cisco_aci/datadog_checks/cisco_aci/data/conf.yaml.example
@@ -135,6 +135,16 @@ instances:
     #
     # send_ndm_metadata: false
 
+    ## @param send_faultinst_faults - boolean - optional - default: false
+    ## Set to `true` to enable collection of Cisco ACI faultInst faults as logs.
+    #
+    # send_faultinst_faults: false
+
+    ## @param send_faultdelegate_faults - boolean - optional - default: false
+    ## Set to `true` to enable collection of Cisco ACI faultDelegate faults as logs.
+    #
+    # send_faultdelegate_faults: false
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/cisco_aci/datadog_checks/cisco_aci/faults.py
+++ b/cisco_aci/datadog_checks/cisco_aci/faults.py
@@ -1,0 +1,84 @@
+# (C) Datadog, Inc. 2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import datetime
+
+from datadog_checks.base.utils.serialization import from_json, to_json
+from datadog_checks.base.utils.time import get_timestamp
+
+
+class Faults:
+    """
+    Collect faults from the APIC
+    """
+
+    # Custom facets need to be namespaced because facets must have unique paths and a path cannot
+    # be shared between different facet groups.  Most Cisco ACI fault fields are used as facets
+    # so all fields will be moved under the namespace here rather than creating a remapper in the
+    # pipeline for each field.
+    ATTR_NAMESPACE = "cisco_aci"
+
+    FAULTINST_KEY = "faultInst"
+    FAULTDELEGATE_KEY = "faultDelegate"
+
+    def __init__(self, check, api, instance, namespace):
+        self.check = check
+        self.api = api
+        self.instance = instance
+        self.namespace = namespace
+
+        self.log = check.log
+        self.read_persistent_cache = check.read_persistent_cache
+        self.send_log = check.send_log
+        self.write_persistent_cache = check.write_persistent_cache
+
+        # Config for submitting faultInst faults as logs
+        self.send_faultinst_faults = self.instance.get('send_faultinst_faults', False)
+        # Config for submitting faultDelegate faults as logs
+        self.send_faultdelegate_faults = self.instance.get('send_faultdelegate_faults', False)
+
+    def faultinst_faults_enabled(self):
+        return self.send_faultinst_faults
+
+    def faultdelegate_faults_enabled(self):
+        return self.send_faultdelegate_faults
+
+    def collect(self):
+        if self.faultinst_faults_enabled():
+            data = self.read_persistent_cache("max_timestamp_{}".format(Faults.FAULTINST_KEY))
+            max_timestamp = from_json(data) if data else None
+            faults = self.api.get_faultinst_faults(max_timestamp)
+            self.submit_faults(Faults.FAULTINST_KEY, faults)
+        if self.faultdelegate_faults_enabled():
+            data = self.read_persistent_cache("max_timestamp_{}".format(Faults.FAULTDELEGATE_KEY))
+            max_timestamp = from_json(data) if data else None
+            faults = self.api.get_faultdelegate_faults(max_timestamp)
+            self.submit_faults(Faults.FAULTDELEGATE_KEY, faults)
+
+    def submit_faults(self, faultCategory, faults):
+        if len(faults) == 0:
+            return
+
+        max_timestamp = 0.0
+        num_skipped = 0
+        for fault in faults:
+            payload = {}
+            if faultCategory in fault:
+                payload[Faults.ATTR_NAMESPACE] = fault[faultCategory]["attributes"]
+                payload[Faults.ATTR_NAMESPACE]["faultCategory"] = faultCategory
+            else:
+                num_skipped += 1
+                self.log.debug("skipping fault that does not contain %s: %s", faultCategory, fault)
+                continue
+
+            if "lastTransition" in payload[Faults.ATTR_NAMESPACE]:
+                max_timestamp = max(
+                    max_timestamp,
+                    get_timestamp(datetime.datetime.fromisoformat(payload[Faults.ATTR_NAMESPACE]["lastTransition"])),
+                )
+            self.send_log(payload)
+
+        self.write_persistent_cache("max_timestamp_{}".format(faultCategory), to_json(max_timestamp))
+
+        if num_skipped > 0:
+            self.log.warning("skipped %d faults that did not contain %s", num_skipped, faultCategory)

--- a/cisco_aci/manifest.json
+++ b/cisco_aci/manifest.json
@@ -15,6 +15,7 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
+      "Category::Log Collection",
       "Category::Network",
       "Offering::Integration"
     ]
@@ -52,6 +53,9 @@
       "CPU usage is high for Cisco ACI device": "assets/monitors/cpu_high.json",
       "Health score of device is critical": "assets/monitors/critical_health_score.json",
       "Interface for a Cisco ACI device is down": "assets/monitors/interface_down.json"
+    },
+    "logs": {
+      "source": "cisco-aci"
     }
   }
 }

--- a/cisco_aci/tests/common.py
+++ b/cisco_aci/tests/common.py
@@ -18,7 +18,8 @@ FIXTURES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'fixture
 CAPACITY_FIXTURES_DIR = os.path.join(FIXTURES_DIR, 'capacity')
 FABRIC_FIXTURES_DIR = os.path.join(FIXTURES_DIR, 'fabric')
 TENANT_FIXTURES_DIR = os.path.join(FIXTURES_DIR, 'tenant')
-ALL_FIXTURE_DIR = [FIXTURES_DIR, CAPACITY_FIXTURES_DIR, FABRIC_FIXTURES_DIR, TENANT_FIXTURES_DIR]
+FAULTS_FIXTURES_DIR = os.path.join(FIXTURES_DIR, 'faults')
+ALL_FIXTURE_DIR = [FIXTURES_DIR, CAPACITY_FIXTURES_DIR, FABRIC_FIXTURES_DIR, TENANT_FIXTURES_DIR, FAULTS_FIXTURES_DIR]
 
 USERNAME = 'datadog'
 PASSWORD = 'datadog'
@@ -33,6 +34,8 @@ CONFIG_WITH_TAGS = {
     'tenant': ['DataDog'],
     "tags": ["project:cisco_aci"],
     "send_ndm_metadata": True,
+    "send_faultinst_faults": True,
+    "send_faultdelegate_faults": True,
 }
 
 # list of fixture names
@@ -183,6 +186,14 @@ FIXTURE_LIST = [
     # 9ec9c2e1bcd513274516713bc3f68724 - Api.get_eth_list_and_stats
     '_api_node_class_topology_pod_1_node_101_l1PhysIf_json_rsp_subtree_children_rsp_subtree_include_stats_rsp_subtree_class_ethpmPhysIf_eqptEgrTotal5min_eqptIngrTotal5min_eqptEgrDropPkts5min_eqptEgrBytes5min_eqptIngrBytes5min',
     # 9bd6720132f1eef5ae8ec7d6438d9c6b - Api.get_eth_list_and_stats
+    '_api_node_class_faultInst_json',
+    # 431f5593e6349e09f0097d3f23dea75c - Api.get_faultinst_faults
+    '_api_node_class_faultDelegate_json',
+    # 5d56882ce9d312af184fedfe77bc08df - Api.get_faultdelegate_faults
+    '_api_node_class_faultInst_json_query_target_filter_and_gt_faultInst_lastTransition__1741816605_365___',
+    # 5058ab43747e6423c036a89104ec05dc - Api.get_faultinst_faults
+    '_api_node_class_faultDelegate_json_query_target_filter_and_gt_faultDelegate_lastTransition__1741791186_041___',
+    # 8bf03ccb4d494c0f8d05f7e8d9115dfd - Api.get_faultdelegate_faults
 ]
 
 # The map will contain the md5 hash to the fixture
@@ -243,3 +254,7 @@ class FakeTenantSessionWrapper(FakeSessionWrapper):
 
 class FakeFabricSessionWrapper(FakeSessionWrapper):
     fixture_dirs = [FABRIC_FIXTURES_DIR]
+
+
+class FakeFaultsSessionWrapper(FakeSessionWrapper):
+    fixture_dirs = [FAULTS_FIXTURES_DIR]

--- a/cisco_aci/tests/fixtures/faults.py
+++ b/cisco_aci/tests/fixtures/faults.py
@@ -1,0 +1,118 @@
+# (C) Datadog, Inc. 2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+EXPECTED_FAULT_LOGS = [
+    {
+        "cisco_aci": {
+            "ack": "no",
+            "alert": "no",
+            "cause": "threshold-crossed",
+            "changeSet": "crcLast:0",
+            "childAction": "",
+            "code": "F381328",
+            "created": "2025-03-12T05:00:05.650+00:00",
+            "delegated": "no",
+            "descr": "TCA: CRC Align Errors current value(eqptIngrErrPkts5min:crcLast) value 0% fell below threshold 1%",  # noqa: E501
+            "dn": "topology/pod-1/node-102/sys/phys-[eth1/1]/fault-F381328",
+            "domain": "infra",
+            "highestSeverity": "warning",
+            "lastTransition": "2025-03-12T21:56:45.365+00:00",
+            "lc": "retaining",
+            "occur": "892",
+            "origSeverity": "warning",
+            "prevSeverity": "warning",
+            "rule": "tca-eqpt-ingr-err-pkts5min-crc-last",
+            "severity": "cleared",
+            "status": "",
+            "subject": "counter",
+            "title": "",
+            "type": "operational",
+            "faultCategory": "faultInst",
+        },
+        "ddtags": "project:cisco_aci",
+    },
+    {
+        "cisco_aci": {
+            "ack": "no",
+            "affected": "resPolCont/rtdOutCont/rtdOutDef-[uni/tn-Legado/out-PANDORA_to_NELS.l3out]/node-101/stpathatt-[N5KFRE-VPC]/nwissues",  # noqa: E501
+            "cause": "configuration-failed",
+            "changeSet": "configQual:invalid-path, configSt:failed-to-apply, debugMessage:invalid-path: Interface does not exist;, temporaryError:no",  # noqa: E501
+            "childAction": "",
+            "code": "F0467",
+            "created": "2025-03-12T14:50:49.955+00:00",
+            "descr": "Fault delegate: Configuration failed for uni/tn-Legado/out-PANDORA_to_NELS.l3out node 101 N5KFRE-VPC due to Invalid Path Configuration, debug message: invalid-path: Interface does not exist;",  # noqa: E501
+            "dn": "uni/tn-Legado/out-PANDORA_to_NELS.l3out/fd-[resPolCont/rtdOutCont/rtdOutDef-[uni/tn-Legado/out-PANDORA_to_NELS.l3out]/node-101/stpathatt-[N5KFRE-VPC]/nwissues]-fault-F0467",  # noqa: E501
+            "domain": "tenant",
+            "highestSeverity": "minor",
+            "lastTransition": "2025-03-12T14:53:06.041+00:00",
+            "lc": "raised",
+            "occur": "1",
+            "origSeverity": "minor",
+            "prevSeverity": "minor",
+            "rule": "fv-nw-issues-config-failed",
+            "severity": "minor",
+            "status": "",
+            "subject": "management",
+            "type": "config",
+            "faultCategory": "faultDelegate",
+        },
+        "ddtags": "project:cisco_aci",
+    },
+    {
+        "cisco_aci": {
+            "ack": "no",
+            "alert": "no",
+            "cause": "threshold-crossed",
+            "changeSet": "errorRate:11",
+            "childAction": "",
+            "code": "F96976",
+            "created": "2025-03-12T05:01:08.717+00:00",
+            "delegated": "no",
+            "descr": "TCA: Egress Error Drop Packets rate(eqptEgrDropPkts5min:errorRate) value 11 raised above threshold 10",  # noqa: E501
+            "dn": "topology/pod-1/node-102/sys/phys-[eth1/1]/fault-F96976",
+            "domain": "infra",
+            "highestSeverity": "warning",
+            "lastTransition": "2025-03-12T21:56:45.365+00:00",
+            "lc": "raised",
+            "occur": "53",
+            "origSeverity": "warning",
+            "prevSeverity": "cleared",
+            "rule": "tca-eqpt-egr-drop-pkts5min-error-rate",
+            "severity": "warning",
+            "status": "",
+            "subject": "counter",
+            "title": "",
+            "type": "operational",
+            "faultCategory": "faultInst",
+        },
+        "ddtags": "project:cisco_aci",
+    },
+    {
+        "cisco_aci": {
+            "ack": "no",
+            "affected": "uni/epp/fv-[uni/tn-Tenant888/ap-app_demo_ap/epg-dev_epg]/node-1101/polDelSt",
+            "cause": "configuration-failed",
+            "changeSet": "deploymentState:not-registered-for-atg",
+            "childAction": "",
+            "code": "F1298",
+            "created": "2025-03-12T09:39:32.189+00:00",
+            "descr": "Fault delegate: For tenant Tenant888, application profile app_demo_ap, deployment of application EPG dev_epg failed on node 1101. Reason Node Cannot Deploy EPG",  # noqa: E501
+            "dn": "uni/tn-Tenant888/ap-app_demo_ap/epg-dev_epg/fd-[uni/epp/fv-[uni/tn-Tenant888/ap-app_demo_ap/epg-dev_epg]/node-1101/polDelSt]-fault-F1298",  # noqa: E501
+            "domain": "tenant",
+            "highestSeverity": "minor",
+            "lastTransition": "2025-03-12T14:53:06.041+00:00",
+            "lc": "raised",
+            "occur": "1",
+            "origSeverity": "minor",
+            "prevSeverity": "minor",
+            "rule": "fv-pol-delivery-status-configuration-failed",
+            "severity": "minor",
+            "status": "",
+            "subject": "epg",
+            "type": "config",
+            "faultCategory": "faultDelegate",
+        },
+        "ddtags": "project:cisco_aci",
+    },
+]

--- a/cisco_aci/tests/fixtures/faults/431f5593e6349e09f0097d3f23dea75c.txt
+++ b/cisco_aci/tests/fixtures/faults/431f5593e6349e09f0097d3f23dea75c.txt
@@ -1,0 +1,34 @@
+{
+  "totalCount": "1",
+  "imdata": [
+    {
+      "faultInst": {
+        "attributes": {
+          "ack": "no",
+          "alert": "no",
+          "cause": "threshold-crossed",
+          "changeSet": "crcLast:0",
+          "childAction": "",
+          "code": "F381328",
+          "created": "2025-03-12T05:00:05.650+00:00",
+          "delegated": "no",
+          "descr": "TCA: CRC Align Errors current value(eqptIngrErrPkts5min:crcLast) value 0% fell below threshold 1%",
+          "dn": "topology/pod-1/node-102/sys/phys-[eth1/1]/fault-F381328",
+          "domain": "infra",
+          "highestSeverity": "warning",
+          "lastTransition": "2025-03-12T21:56:45.365+00:00",
+          "lc": "retaining",
+          "occur": "892",
+          "origSeverity": "warning",
+          "prevSeverity": "warning",
+          "rule": "tca-eqpt-ingr-err-pkts5min-crc-last",
+          "severity": "cleared",
+          "status": "",
+          "subject": "counter",
+          "title": "",
+          "type": "operational"
+        }
+      }
+    }
+  ]
+}

--- a/cisco_aci/tests/fixtures/faults/5058ab43747e6423c036a89104ec05dc.txt
+++ b/cisco_aci/tests/fixtures/faults/5058ab43747e6423c036a89104ec05dc.txt
@@ -1,0 +1,34 @@
+{
+  "totalCount": "1",
+  "imdata": [
+    {
+      "faultInst": {
+        "attributes": {
+          "ack": "no",
+          "alert": "no",
+          "cause": "threshold-crossed",
+          "changeSet": "errorRate:11",
+          "childAction": "",
+          "code": "F96976",
+          "created": "2025-03-12T05:01:08.717+00:00",
+          "delegated": "no",
+          "descr": "TCA: Egress Error Drop Packets rate(eqptEgrDropPkts5min:errorRate) value 11 raised above threshold 10",
+          "dn": "topology/pod-1/node-102/sys/phys-[eth1/1]/fault-F96976",
+          "domain": "infra",
+          "highestSeverity": "warning",
+          "lastTransition": "2025-03-12T21:56:45.365+00:00",
+          "lc": "raised",
+          "occur": "53",
+          "origSeverity": "warning",
+          "prevSeverity": "cleared",
+          "rule": "tca-eqpt-egr-drop-pkts5min-error-rate",
+          "severity": "warning",
+          "status": "",
+          "subject": "counter",
+          "title": "",
+          "type": "operational"
+        }
+      }
+    }
+  ]
+}

--- a/cisco_aci/tests/fixtures/faults/5d56882ce9d312af184fedfe77bc08df.txt
+++ b/cisco_aci/tests/fixtures/faults/5d56882ce9d312af184fedfe77bc08df.txt
@@ -1,0 +1,32 @@
+{
+  "totalCount": "1",
+  "imdata": [
+    {
+      "faultDelegate": {
+        "attributes": {
+          "ack": "no",
+          "affected": "resPolCont/rtdOutCont/rtdOutDef-[uni/tn-Legado/out-PANDORA_to_NELS.l3out]/node-101/stpathatt-[N5KFRE-VPC]/nwissues",
+          "cause": "configuration-failed",
+          "changeSet": "configQual:invalid-path, configSt:failed-to-apply, debugMessage:invalid-path: Interface does not exist;, temporaryError:no",
+          "childAction": "",
+          "code": "F0467",
+          "created": "2025-03-12T14:50:49.955+00:00",
+          "descr": "Fault delegate: Configuration failed for uni/tn-Legado/out-PANDORA_to_NELS.l3out node 101 N5KFRE-VPC due to Invalid Path Configuration, debug message: invalid-path: Interface does not exist;",
+          "dn": "uni/tn-Legado/out-PANDORA_to_NELS.l3out/fd-[resPolCont/rtdOutCont/rtdOutDef-[uni/tn-Legado/out-PANDORA_to_NELS.l3out]/node-101/stpathatt-[N5KFRE-VPC]/nwissues]-fault-F0467",
+          "domain": "tenant",
+          "highestSeverity": "minor",
+          "lastTransition": "2025-03-12T14:53:06.041+00:00",
+          "lc": "raised",
+          "occur": "1",
+          "origSeverity": "minor",
+          "prevSeverity": "minor",
+          "rule": "fv-nw-issues-config-failed",
+          "severity": "minor",
+          "status": "",
+          "subject": "management",
+          "type": "config"
+        }
+      }
+    }
+  ]
+}

--- a/cisco_aci/tests/fixtures/faults/8bf03ccb4d494c0f8d05f7e8d9115dfd.txt
+++ b/cisco_aci/tests/fixtures/faults/8bf03ccb4d494c0f8d05f7e8d9115dfd.txt
@@ -1,0 +1,32 @@
+{
+  "totalCount": "1",
+  "imdata": [
+    {
+      "faultDelegate": {
+        "attributes": {
+          "ack": "no",
+          "affected": "uni/epp/fv-[uni/tn-Tenant888/ap-app_demo_ap/epg-dev_epg]/node-1101/polDelSt",
+          "cause": "configuration-failed",
+          "changeSet": "deploymentState:not-registered-for-atg",
+          "childAction": "",
+          "code": "F1298",
+          "created": "2025-03-12T09:39:32.189+00:00",
+          "descr": "Fault delegate: For tenant Tenant888, application profile app_demo_ap, deployment of application EPG dev_epg failed on node 1101. Reason Node Cannot Deploy EPG",
+          "dn": "uni/tn-Tenant888/ap-app_demo_ap/epg-dev_epg/fd-[uni/epp/fv-[uni/tn-Tenant888/ap-app_demo_ap/epg-dev_epg]/node-1101/polDelSt]-fault-F1298",
+          "domain": "tenant",
+          "highestSeverity": "minor",
+          "lastTransition": "2025-03-12T14:53:06.041+00:00",
+          "lc": "raised",
+          "occur": "1",
+          "origSeverity": "minor",
+          "prevSeverity": "minor",
+          "rule": "fv-pol-delivery-status-configuration-failed",
+          "severity": "minor",
+          "status": "",
+          "subject": "epg",
+          "type": "config"
+        }
+      }
+    }
+  ]
+}

--- a/cisco_aci/tests/test_faults.py
+++ b/cisco_aci/tests/test_faults.py
@@ -1,0 +1,21 @@
+# (C) Datadog, Inc. 2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from datadog_checks.base.utils.containers import hash_mutable
+from datadog_checks.cisco_aci import CiscoACICheck
+from datadog_checks.cisco_aci.api import Api
+
+from . import common
+from .fixtures.faults import EXPECTED_FAULT_LOGS
+
+
+def test_faults_mocked(aggregator, datadog_agent):
+    check = CiscoACICheck(common.CHECK_NAME, {}, [common.CONFIG_WITH_TAGS])
+    api = Api(common.ACI_URLS, check.http, common.USERNAME, password=common.PASSWORD, log=check.log)
+    api.wrapper_factory = common.FakeFaultsSessionWrapper
+    check._api_cache[hash_mutable(common.CONFIG_WITH_TAGS)] = api
+
+    check.check({})
+    check.check({})  # Run twice to exercise the max_timestamp logic
+    datadog_agent.assert_logs(check.check_id, EXPECTED_FAULT_LOGS)


### PR DESCRIPTION
### What does this PR do?
Adds functionality to the Cisco ACI integration to collect Cisco ACI faults and report them as logs.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
