### PR TITLE
[SDBM-1534] Modify sqlserver index usage stats query

### DIFF
--- a/sqlserver/changelog.d/19807.changed
+++ b/sqlserver/changelog.d/19807.changed
@@ -1,0 +1,1 @@
+Optimize sqlserver index usage stats query

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/index_usage_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/index_usage_metrics.py
@@ -100,6 +100,7 @@ class SqlserverIndexUsageMetrics(SqlserverDatabaseMetricsBase):
 
     def _build_query_executors(self):
         executors = []
+        self.log.debug("Hello Austin!")
         for database in self.databases:
             executor = self.new_query_executor(
                 self.queries,

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/index_usage_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/index_usage_metrics.py
@@ -11,8 +11,8 @@ from .base import SqlserverDatabaseMetricsBase
 INDEX_USAGE_STATS_QUERY = {
     "name": "sys.dm_db_index_usage_stats",
     "query": """
-    SELECT 
-        DB_NAME(ixus.database_id) AS db, 
+    SELECT
+        DB_NAME(ixus.database_id) AS db,
         COALESCE(ind.name, 'HeapIndex_' + OBJECT_NAME(ind.object_id)) AS index_name,
         OBJECT_SCHEMA_NAME(ind.object_id, ixus.database_id) AS "schema",
         OBJECT_NAME(ind.object_id) AS table_name,
@@ -22,11 +22,11 @@ INDEX_USAGE_STATS_QUERY = {
         ixus.user_updates as user_updates
     FROM sys.indexes ind
     JOIN sys.dm_db_index_usage_stats ixus
-        ON ixus.index_id = ind.index_id 
+        ON ixus.index_id = ind.index_id
         AND ixus.object_id = ind.object_id
         AND ixus.database_id = DB_ID()
-    JOIN sys.objects o 
-        ON ind.object_id = o.object_id 
+    JOIN sys.objects o
+        ON ind.object_id = o.object_id
         AND o.type = 'U'
 """,
     "columns": [

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -790,7 +790,6 @@ class SQLServer(AgentCheck):
             server_static_info=self.static_info_cache,
             execute_query_handler=self.execute_query_raw,
             databases=db_names,
-            track_operation_time=True,
         )
 
     @property

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -790,6 +790,7 @@ class SQLServer(AgentCheck):
             server_static_info=self.static_info_cache,
             execute_query_handler=self.execute_query_raw,
             databases=db_names,
+            track_operation_time=True,
         )
 
     @property


### PR DESCRIPTION
### What does this PR do?
Optimize the index usage stats query for sqlserver

- Remove function in filter (OBJECTPROPERTY), replace with a join on sys.objects
- Remove function in filter (DB_NAME), replace with database_id comparison
- Remove group by, not needed
- Replace CASE with COALESCE

### Motivation
This query can take ~minutes, for example https://datadoghq.atlassian.net/browse/SDBM-1534

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
