### PR TITLE
[CONTP-672]Add widget for local failover metric store in cluster-agent

### DIFF
--- a/datadog_cluster_agent/assets/dashboards/datadog_cluster_agent_overview.json
+++ b/datadog_cluster_agent/assets/dashboards/datadog_cluster_agent_overview.json
@@ -1852,6 +1852,56 @@
                 "width": 8,
                 "height": 13
             }
+        },
+        {
+            "id": 1439774421918952,
+            "definition": {
+                "title": "Number of workload metrics for local autoscaling recommendations",
+                "title_size": "16",
+                "title_align": "left",
+                "type": "query_table",
+                "requests": [
+                    {
+                        "queries": [
+                            {
+                                "data_source": "metrics",
+                                "name": "query1",
+                                "query": "avg:datadog.cluster_agent.autoscaling.workload.store_load_entities{$cluster, $namespace} by {deployment,loadname}",
+                                "aggregator": "max"
+                            }
+                        ],
+                        "response_format": "scalar",
+                        "sort": {
+                            "count": 25,
+                            "order_by": [
+                                {
+                                    "type": "formula",
+                                    "index": 0,
+                                    "order": "desc"
+                                }
+                            ]
+                        },
+                        "formulas": [
+                            {
+                                "cell_display_mode": "trend",
+                                "cell_display_mode_options": {
+                                    "trend_type": "area",
+                                    "y_scale": "shared"
+                                },
+                                "alias": "Number of Entities",
+                                "formula": "query1"
+                            }
+                        ]
+                    }
+                ],
+                "has_search_bar": "auto"
+            },
+            "layout": {
+                "x": 0,
+                "y": 9,
+                "width": 4,
+                "height": 3
+            }
         }
     ],
     "template_variables": [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates the Datadog Cluster Agent - Overview dashboard.
[CONTP-672]Add widget for local failover metric store in cluster-agent
The widget will provide entities number in dca's local failover metric store. These entities and metric values will be used for local autoscaling recommendation. 

The data is selected by cluster->namespace. The columns of the table include deployment name, workload metrics name, and number of entities stored in dca (for example, it could populated from number of container if metric is container metric, or number of pods if the metric is pod metric )
<img width="1771" alt="Screenshot 2025-03-12 at 10 56 33 AM" src="https://github.com/user-attachments/assets/19c7826f-ab2c-4bc1-83bc-3f1b49ab7ccf" />

**Query**
<img width="1243" alt="Screenshot 2025-03-12 at 11 02 19 AM" src="https://github.com/user-attachments/assets/f2d7183b-728f-4ff8-af30-64aa54045abe" />


### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[CONTP-672]: https://datadoghq.atlassian.net/browse/CONTP-672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ