### PR TITLE
Revert "bump pymongo to 4.11 (#19610)"

### DIFF
--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -36,7 +36,7 @@ pyasn1==0.4.8
 pycryptodomex==3.21.0
 pydantic==2.10.6
 pyjwt==2.10.1
-pymongo[srv]==4.11.1; python_version >= '3.9'
+pymongo[srv]==4.8.0; python_version >= '3.9'
 pymqi==1.12.11; sys_platform != 'darwin' or platform_machine != 'arm64'
 pymysql==1.1.1
 pyodbc==5.2.0; sys_platform != 'darwin' or platform_machine != 'arm64'

--- a/mongo/changelog.d/19814.fixed
+++ b/mongo/changelog.d/19814.fixed
@@ -1,0 +1,1 @@
+Revert "bump pymongo to 4.11 (#19610)". This brings pymongo back to v4.8.

--- a/mongo/datadog_checks/mongo/collectors/custom_queries.py
+++ b/mongo/datadog_checks/mongo/collectors/custom_queries.py
@@ -8,7 +8,6 @@ from copy import deepcopy
 
 import dateutil.parser
 import pymongo
-import pymongo.synchronous
 from dateutil.tz import tzutc
 
 from datadog_checks.mongo.api import CRITICAL_FAILURE
@@ -164,7 +163,7 @@ class CustomQueriesCollector(MongoCollector):
             submit_method(metric_prefix, result['n'], tags)
             return
 
-        cursor = pymongo.synchronous.command_cursor.CommandCursor(
+        cursor = pymongo.command_cursor.CommandCursor(
             pymongo.collection.Collection(db, collection_name), result['cursor'], None
         )
         empty_result_set = True

--- a/mongo/pyproject.toml
+++ b/mongo/pyproject.toml
@@ -39,7 +39,7 @@ license = "BSD-3-Clause"
 deps = [
     "cachetools==5.5.2",
     "psutil==6.0.0",
-    "pymongo[srv]==4.11.1; python_version >= '3.9'",
+    "pymongo[srv]==4.8.0; python_version >= '3.9'",
 ]
 
 [project.urls]

--- a/mongo/tests/conftest.py
+++ b/mongo/tests/conftest.py
@@ -177,7 +177,7 @@ def mock_pymongo(deployment):
         mock_is_localhost.return_value = False
         with mock.patch('datadog_checks.mongo.api.MongoClient', mock.MagicMock(return_value=mocked_client)), mock.patch(
             'pymongo.collection.Collection'
-        ), mock.patch('pymongo.synchronous.command_cursor') as cur:
+        ), mock.patch('pymongo.command_cursor') as cur:
             cur.CommandCursor = lambda *args, **kwargs: args[1]['firstBatch']
             yield mocked_client
 
@@ -231,7 +231,7 @@ def setup_sharding(compose_file):
 
 class InitializeDB(LazyFunction):
     def __call__(self):
-        cli = pymongo.MongoClient(
+        cli = pymongo.mongo_client.MongoClient(
             f"mongodb://{common.HOST}:{common.PORT1}",
             socketTimeoutMS=30000,
             read_preference=pymongo.ReadPreference.PRIMARY_PREFERRED,
@@ -281,7 +281,7 @@ class InitializeDB(LazyFunction):
 
 class InitializeAuthDB(LazyFunction):
     def __call__(self):
-        cli = pymongo.MongoClient(
+        cli = pymongo.mongo_client.MongoClient(
             f"mongodb://root:rootPass@{common.HOST}:{common.PORT1}",
             socketTimeoutMS=30000,
             read_preference=pymongo.ReadPreference.PRIMARY_PREFERRED,

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -56,8 +56,8 @@ def test_emits_critical_service_check_when_service_is_not_available(mock_command
         {'parsed': {}},  # getCmdLineOpts
     ],
 )
-@mock.patch('pymongo.MongoClient.server_info', return_value={'version': '5.0.0'})
-@mock.patch('pymongo.MongoClient.list_database_names', return_value=[])
+@mock.patch('pymongo.mongo_client.MongoClient.server_info', return_value={'version': '5.0.0'})
+@mock.patch('pymongo.mongo_client.MongoClient.list_database_names', return_value=[])
 def test_emits_ok_service_check_when_service_is_available(
     mock_list_database_names, mock_server_info, mock_command, dd_run_check, aggregator, datadog_agent
 ):
@@ -78,8 +78,8 @@ def test_emits_ok_service_check_when_service_is_available(
         {'parsed': {}},  # getCmdLineOpts
     ],
 )
-@mock.patch('pymongo.MongoClient.server_info', return_value={'version': '5.0.0'})
-@mock.patch('pymongo.MongoClient.list_database_names', return_value=[])
+@mock.patch('pymongo.mongo_client.MongoClient.server_info', return_value={'version': '5.0.0'})
+@mock.patch('pymongo.mongo_client.MongoClient.list_database_names', return_value=[])
 def test_emits_ok_service_check_each_run_when_service_is_available(
     mock_list_database_names, mock_server_info, mock_command, dd_run_check, aggregator, datadog_agent
 ):
@@ -101,8 +101,8 @@ def test_emits_ok_service_check_each_run_when_service_is_available(
         {'parsed': {}},  # getCmdLineOpts
     ],
 )
-@mock.patch('pymongo.MongoClient.server_info', return_value={'version': '5.0.0'})
-@mock.patch('pymongo.MongoClient.list_database_names', return_value=[])
+@mock.patch('pymongo.mongo_client.MongoClient.server_info', return_value={'version': '5.0.0'})
+@mock.patch('pymongo.mongo_client.MongoClient.list_database_names', return_value=[])
 def test_version_metadata(
     mock_list_database_names, mock_server_info, mock_command, dd_run_check, aggregator, datadog_agent
 ):
@@ -134,8 +134,8 @@ def test_version_metadata(
         {'msg': 'isdbgrid'},  # isMaster
     ],
 )
-@mock.patch('pymongo.MongoClient.server_info', return_value={'version': '5.0.0'})
-@mock.patch('pymongo.MongoClient.list_database_names', return_value=[])
+@mock.patch('pymongo.mongo_client.MongoClient.server_info', return_value={'version': '5.0.0'})
+@mock.patch('pymongo.mongo_client.MongoClient.list_database_names', return_value=[])
 def test_emits_ok_service_check_when_alibaba_mongos_deployment(
     mock_list_database_names, mock_server_info, mock_command, dd_run_check, aggregator
 ):
@@ -162,8 +162,8 @@ def test_emits_ok_service_check_when_alibaba_mongos_deployment(
         {'configsvr': True, 'set': 'replset', "myState": 1},  # replSetGetStatus
     ],
 )
-@mock.patch('pymongo.MongoClient.server_info', return_value={'version': '5.0.0'})
-@mock.patch('pymongo.MongoClient.list_database_names', return_value=[])
+@mock.patch('pymongo.mongo_client.MongoClient.server_info', return_value={'version': '5.0.0'})
+@mock.patch('pymongo.mongo_client.MongoClient.list_database_names', return_value=[])
 def test_emits_ok_service_check_when_alibaba_replicaset_role_configsvr_deployment(
     mock_list_database_names, mock_server_info, mock_command, dd_run_check, aggregator
 ):
@@ -195,8 +195,8 @@ def test_emits_ok_service_check_when_alibaba_replicaset_role_configsvr_deploymen
         {'configsvr': True, 'set': 'replset', "myState": 3},  # replSetGetStatus
     ],
 )
-@mock.patch('pymongo.MongoClient.server_info', return_value={'version': '5.0.0'})
-@mock.patch('pymongo.MongoClient.list_database_names', return_value=[])
+@mock.patch('pymongo.mongo_client.MongoClient.server_info', return_value={'version': '5.0.0'})
+@mock.patch('pymongo.mongo_client.MongoClient.list_database_names', return_value=[])
 def test_when_replicaset_state_recovering_then_database_names_not_called(
     mock_list_database_names, mock_server_info, mock_command, dd_run_check, aggregator
 ):
@@ -680,8 +680,8 @@ def test_parse_mongo_version_with_suffix(check, instance, dd_run_check, datadog_
         {},  # isMaster
     ],
 )
-@mock.patch('pymongo.MongoClient.server_info', return_value={'version': '5.0.0'})
-@mock.patch('pymongo.MongoClient.list_database_names', return_value=[])
+@mock.patch('pymongo.mongo_client.MongoClient.server_info', return_value={'version': '5.0.0'})
+@mock.patch('pymongo.mongo_client.MongoClient.list_database_names', return_value=[])
 def test_emits_ok_service_check_for_documentdb_deployment(
     mock_list_database_names, mock_server_info, mock_command, dd_run_check, aggregator
 ):
@@ -712,8 +712,8 @@ def test_emits_ok_service_check_for_documentdb_deployment(
         {'parsed': {}},  # getCmdLineOpts
     ],
 )
-@mock.patch('pymongo.MongoClient.server_info', return_value={'version': '7.0.0'})
-@mock.patch('pymongo.MongoClient.list_database_names', return_value=[])
+@mock.patch('pymongo.mongo_client.MongoClient.server_info', return_value={'version': '7.0.0'})
+@mock.patch('pymongo.mongo_client.MongoClient.list_database_names', return_value=[])
 def test_emits_ok_service_check_for_mongodb_atlas_deployment(
     mock_list_database_names, mock_server_info, mock_command, dd_run_check, aggregator
 ):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This reverts commit 772ccc5ada1e5c431802a85666d66ffe5cb75f1c.

### Motivation
<!-- What inspired you to submit this pull request? -->

Custom queries crash with the following error:
```
2025-03-12 10:57:06 UTC | CORE | INFO | (pkg/collector/python/datadog_agent.go:147 in LogMessage) | mongo:7e361d43268980ce | (mongo.py:328) | Unable to collect logs from collector <datadog_checks.mongo.collectors.custom_queries.CustomQueriesCollector object at 0x785e08260140>. Some metrics will be missing.
Traceback (most recent call last):
  File "/usr/src/dbm-integrations-core/mongo/datadog_checks/mongo/mongo.py", line 326, in _collect_metrics
    collector.collect(self.api_client)
  File "/usr/src/dbm-integrations-core/mongo/datadog_checks/mongo/collectors/custom_queries.py", line 207, in collect
    raise e  # Critical failures must bubble up to trigger a CRITICAL service check.
    ^^^^^^^
  File "/usr/src/dbm-integrations-core/mongo/datadog_checks/mongo/collectors/custom_queries.py", line 205, in collect
    self._collect_custom_metrics_for_query(api, raw_query)
  File "/usr/src/dbm-integrations-core/mongo/datadog_checks/mongo/collectors/custom_queries.py", line 144, in _collect_custom_metrics_for_query
    result = db.command(mongo_command, mongo_command_value, **mongo_query)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/datadog-agent/embedded/lib/python3.12/site-packages/pymongo/_csot.py", line 107, in csot_wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/datadog-agent/embedded/lib/python3.12/site-packages/pymongo/database.py", line 897, in command
    return self._command(
           ^^^^^^^^^^^^^^
  File "/opt/datadog-agent/embedded/lib/python3.12/site-packages/pymongo/database.py", line 737, in _command
    return conn.command(
           ^^^^^^^^^^^^^
  File "/opt/datadog-agent/embedded/lib/python3.12/site-packages/pymongo/helpers.py", line 342, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/datadog-agent/embedded/lib/python3.12/site-packages/pymongo/pool.py", line 989, in command
    return command(
           ^^^^^^^^
  File "/opt/datadog-agent/embedded/lib/python3.12/site-packages/pymongo/network.py", line 212, in command
    helpers._check_command_response(
  File "/opt/datadog-agent/embedded/lib/python3.12/site-packages/pymongo/helpers.py", line 248, in _check_command_response
    raise OperationFailure(errmsg, code, response, max_wire_version)
pymongo.errors.OperationFailure: not authorized on admin to execute command { find: "system.version", filter: { _id: "featureCompatibilityVersion" }, projection: { _id: 0, count: { $literal: 1 }, version: 1 }, lsid: { id: UUID("5331df64-8ff6-403a-a810-89127067f682") }, $clusterTime: { clusterTime: Timestamp(1741777026, 12), signature: { hash: BinData(0, "***********************************D1E62"), keyId: 7441950921099051010 } }, maxTimeMS: 29999, $db: "admin", $readPreference: { mode: "primaryPreferred" } }, full error: {'ok': 0.0, 'errmsg': 'not authorized on admin to execute command { find: "system.version", filter: { _id: "featureCompatibilityVersion" }, projection: { _id: 0, count: { $literal: 1 }, version: 1 }, lsid: { id: UUID("5331df64-8ff6-403a-a810-89127067f682") }, $clusterTime: { clusterTime: Timestamp(1741777026, 12), signature: { hash: BinData(0, "***********************************D1E62"), keyId: 7441950921099051010 } }, maxTimeMS: 29999, $db: "admin", $readPreference: { mode: "primaryPreferred" } }', 'code': 13, 'codeName': 'Unauthorized', '$clusterTime': {'clusterTime': Timestamp(1741777026, 12), 'signature': {'hash': b'\x0b\x83\x186\x11E\xec\x1d\xdd\xc4\x88\xf2\xc9\xc7\xdbu\xbe-\x1eb', 'keyId': 7441950921099051010}}, 'operationTime': Timestamp(1741777026, 12)}
```

We'd like to revert until we have time to debug this in more detail.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
