### PR TITLE
Fix not fips keyword on target tests

### DIFF
--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -225,7 +225,7 @@ jobs:
       run: |
         if [ '${{ inputs.pytest-args }}' = '-m flaky' ]; then
           set +e # Disable immediate exit
-          ddev test --cov --junit ${{ inputs.target }} -- ${{ inputs.pytest-args }} -- '-k "not fips"'
+          ddev test --cov --junit ${{ inputs.target }} -- ${{ inputs.pytest-args }} -k "not fips"
           exit_code=$?
           if [ $exit_code -eq 5 ]; then
             # Flaky test count can be zero, this is done to avoid pipeline failure


### PR DESCRIPTION
### What does this PR do?
Looking at CI health I noticed that there were failures related with a typo on the tests we are running in which `--` were passed twice and `-k "no fips"` was understood to be a folder to discovery tests. The error showed the folder does not exist.

- [Example error](https://github.com/DataDog/integrations-core/actions/runs/13756610984/job/38465071863#step:14:289)
- [Example wrong command](https://github.com/DataDog/integrations-core/actions/runs/13756610984/job/38465071863#step:14:270)
#### Validation
Run tests:
```
ddev test azure_iot_edge -- -m unit -k "not fips"
```

Output:
```
────────────────────────────────────────────────────────────────────────────────────────────────────── Azure IoT Edge ──────────────────────────────────────────────────────────────────────────────────────────────────────
──────────────────────────────────────────────────────────────────────────────────────────────────────── py3.12-tls ────────────────────────────────────────────────────────────────────────────────────────────────────────
cmd [1] | pytest -vv --benchmark-skip --tb short -m unit -k 'not fips'
=================================================================================================== test session starts ====================================================================================================
platform darwin -- Python 3.12.2, pytest-8.1.1, pluggy-1.5.0 -- /Users/juanpedro.araque/Library/Application Support/hatch/env/virtual/datadog-azure-iot-edge/8xOm3K7P/py3.12-tls/bin/python
cachedir: .pytest_cache
benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/juanpedro.araque/go/src/github.com/DataDog/integrations-core/azure_iot_edge
configfile: pyproject.toml
plugins: asyncio-0.23.8, cov-6.0.0, ddtrace-2.10.6, flaky-3.8.1, memray-1.7.0, benchmark-5.1.0, datadog-checks-dev-35.0.0, mock-3.14.0
asyncio: mode=Mode.STRICT
collected 11 items / 6 deselected / 5 selected                                                                                                                                                                             

tests/test_config.py::test_config PASSED                                                                                                                                                                             [ 20%]
tests/test_config.py::test_config_custom_tags PASSED                                                                                                                                                                 [ 40%]
tests/test_config.py::test_config_required_options[edge_hub_prometheus_url] PASSED                                                                                                                                   [ 60%]
tests/test_config.py::test_config_required_options[edge_agent_prometheus_url] PASSED                                                                                                                                 [ 80%]
tests/test_config.py::test_config_tags_must_be_list PASSED                                                                                                                                                           [100%]

============================================================================================= 5 passed, 6 deselected in 0.01s ==============================================================================================
```

### Motivation
Try improving CI health

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
