### PR TITLE
Rename `describe_consumer_groups` and don't return `group_id`

### DIFF
--- a/kafka_consumer/changelog.d/19819.fixed
+++ b/kafka_consumer/changelog.d/19819.fixed
@@ -1,1 +1,0 @@
-Refactor `describe_consumer_groups` function.

--- a/kafka_consumer/changelog.d/19819.fixed
+++ b/kafka_consumer/changelog.d/19819.fixed
@@ -1,0 +1,1 @@
+Refactor `describe_consumer_groups` function.

--- a/kafka_consumer/datadog_checks/kafka_consumer/client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client.py
@@ -172,15 +172,9 @@ class KafkaClient:
             offsets.append((response_offset_info.group_id, tpo))
         return offsets
 
-    def describe_consumer_groups(self, consumer_group):
-        """
-        :returns: A dict of futures for each group, keyed by the group_id.
-                  The future result() method returns :class:`ConsumerGroupDescription`.
-
-        :rtype: dict[str, future]
-        """
+    def describe_consumer_group(self, consumer_group):
         desc = self.kafka_client.describe_consumer_groups([consumer_group])[consumer_group].result()
-        return (desc.group_id, desc.state.name)
+        return desc.state.name
 
     def close_admin_client(self):
         self._kafka_client = None

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -293,12 +293,10 @@ class KafkaCheck(AgentCheck):
         self.log.debug('%s consumer offsets reported', reported_contexts)
 
     def get_consumer_group_state(self, consumer_group):
-        consumer_group_state = ""
-        # Get the consumer group state if present
-        group_id, consumer_group_state = self.client.describe_consumer_groups(consumer_group)
+        consumer_group_state = self.client.describe_consumer_group(consumer_group)
         self.log.debug(
-            "Consumer group: %s in state %s",
-            group_id,
+            "Consumer group: %s is in state %s",
+            consumer_group,
             consumer_group_state,
         )
         return consumer_group_state

--- a/kafka_consumer/tests/test_client.py
+++ b/kafka_consumer/tests/test_client.py
@@ -10,6 +10,5 @@ pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')
 
 def test_client_returns_expected_consumer_group_state(aggregator, check, kafka_instance, dd_run_check):
     check = check(kafka_instance)
-    group_id, state = check.client.describe_consumer_groups('my_consumer')
-    assert group_id == 'my_consumer'
+    state = check.client.describe_consumer_group('my_consumer')
     assert state in POSSIBLE_CONSUMER_GROUP_STATES

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -26,7 +26,7 @@ def seed_mock_client():
     client.list_consumer_groups.return_value = ["consumer_group1"]
     client.get_partitions_for_topic.return_value = ['partition1']
     client.list_consumer_group_offsets.return_value = [("consumer_group1", [("topic1", "partition1", 2)])]
-    client.describe_consumer_group.return_value = ('STABLE')
+    client.describe_consumer_group.return_value = 'STABLE'
     client.consumer_get_cluster_id_and_list_topics.return_value = (
         "cluster_id",
         # topics

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -26,7 +26,7 @@ def seed_mock_client():
     client.list_consumer_groups.return_value = ["consumer_group1"]
     client.get_partitions_for_topic.return_value = ['partition1']
     client.list_consumer_group_offsets.return_value = [("consumer_group1", [("topic1", "partition1", 2)])]
-    client.describe_consumer_groups.return_value = ('consumer_group', 'STABLE')
+    client.describe_consumer_group.return_value = ('STABLE')
     client.consumer_get_cluster_id_and_list_topics.return_value = (
         "cluster_id",
         # topics


### PR DESCRIPTION
### What does this PR do?
Renames `describe_consumer_groups` to `describe_consumer_group` and stops returning `group_id`. 

### Motivation
This function only describes one consumer group at a time, the `consumer_group` argument. Furthermore, since it's passed in as an argument, there's no need to return the `group_id`. 

follow-up to https://github.com/DataDog/integrations-core/pull/19744

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
