### PR TITLE
Use modern namespace packaging

### DIFF
--- a/active_directory/datadog_checks/__init__.py
+++ b/active_directory/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/activemq/datadog_checks/__init__.py
+++ b/activemq/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/activemq_xml/datadog_checks/__init__.py
+++ b/activemq_xml/datadog_checks/__init__.py
@@ -1,5 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/aerospike/datadog_checks/__init__.py
+++ b/aerospike/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/airflow/datadog_checks/__init__.py
+++ b/airflow/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/amazon_msk/datadog_checks/__init__.py
+++ b/amazon_msk/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/ambari/datadog_checks/__init__.py
+++ b/ambari/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/apache/datadog_checks/__init__.py
+++ b/apache/datadog_checks/__init__.py
@@ -1,5 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/appgate_sdp/datadog_checks/__init__.py
+++ b/appgate_sdp/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/arangodb/datadog_checks/__init__.py
+++ b/arangodb/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2022-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/argo_rollouts/datadog_checks/__init__.py
+++ b/argo_rollouts/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/argo_workflows/datadog_checks/__init__.py
+++ b/argo_workflows/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/argocd/datadog_checks/__init__.py
+++ b/argocd/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2022-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/aspdotnet/datadog_checks/__init__.py
+++ b/aspdotnet/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/avi_vantage/datadog_checks/__init__.py
+++ b/avi_vantage/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2021-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/aws_neuron/datadog_checks/__init__.py
+++ b/aws_neuron/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/azure_iot_edge/datadog_checks/__init__.py
+++ b/azure_iot_edge/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2020-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/boundary/datadog_checks/__init__.py
+++ b/boundary/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2022-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/btrfs/datadog_checks/__init__.py
+++ b/btrfs/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/cacti/datadog_checks/__init__.py
+++ b/cacti/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/calico/datadog_checks/__init__.py
+++ b/calico/datadog_checks/__init__.py
@@ -1,5 +1,0 @@
-# (C) Datadog, Inc. 2022-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/cassandra/datadog_checks/__init__.py
+++ b/cassandra/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/cassandra_nodetool/datadog_checks/__init__.py
+++ b/cassandra_nodetool/datadog_checks/__init__.py
@@ -1,5 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/ceph/datadog_checks/__init__.py
+++ b/ceph/datadog_checks/__init__.py
@@ -1,5 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/cert_manager/datadog_checks/__init__.py
+++ b/cert_manager/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/checkpoint_quantum_firewall/datadog_checks/__init__.py
+++ b/checkpoint_quantum_firewall/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/cilium/datadog_checks/__init__.py
+++ b/cilium/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/cisco_aci/datadog_checks/__init__.py
+++ b/cisco_aci/datadog_checks/__init__.py
@@ -1,5 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/cisco_secure_firewall/datadog_checks/__init__.py
+++ b/cisco_secure_firewall/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/cisco_secure_web_appliance/datadog_checks/__init__.py
+++ b/cisco_secure_web_appliance/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2025-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/citrix_hypervisor/datadog_checks/__init__.py
+++ b/citrix_hypervisor/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2021-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/clickhouse/datadog_checks/__init__.py
+++ b/clickhouse/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/cloud_foundry_api/datadog_checks/__init__.py
+++ b/cloud_foundry_api/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2020-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/cloudera/datadog_checks/__init__.py
+++ b/cloudera/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2022-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/cockroachdb/datadog_checks/__init__.py
+++ b/cockroachdb/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/confluent_platform/datadog_checks/__init__.py
+++ b/confluent_platform/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2020-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/consul/datadog_checks/__init__.py
+++ b/consul/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/coredns/datadog_checks/__init__.py
+++ b/coredns/datadog_checks/__init__.py
@@ -1,5 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/couch/datadog_checks/__init__.py
+++ b/couch/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/couchbase/datadog_checks/__init__.py
+++ b/couchbase/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/crio/datadog_checks/__init__.py
+++ b/crio/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/datadog_checks_dependency_provider/datadog_checks/__init__.py
+++ b/datadog_checks_dependency_provider/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2021-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/datadog_checks_dev/datadog_checks/__init__.py
+++ b/datadog_checks_dev/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/__init__.py
@@ -1,2 +1,0 @@
-{license_header}
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check_only/{check_name}/datadog_checks/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check_only/{check_name}/datadog_checks/__init__.py
@@ -1,2 +1,0 @@
-{license_header}
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/datadog_checks/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/datadog_checks/__init__.py
@@ -1,2 +1,0 @@
-{license_header}
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/datadog_checks/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/datadog_checks/__init__.py
@@ -1,2 +1,0 @@
-{license_header}
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/datadog_checks_downloader/datadog_checks/__init__.py
+++ b/datadog_checks_downloader/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/datadog_cluster_agent/datadog_checks/__init__.py
+++ b/datadog_cluster_agent/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2021-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/dcgm/datadog_checks/__init__.py
+++ b/dcgm/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2023-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/delinea_privilege_manager/datadog_checks/__init__.py
+++ b/delinea_privilege_manager/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2025-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/directory/datadog_checks/__init__.py
+++ b/directory/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/disk/datadog_checks/__init__.py
+++ b/disk/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/dns_check/datadog_checks/__init__.py
+++ b/dns_check/datadog_checks/__init__.py
@@ -1,5 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/dotnetclr/datadog_checks/__init__.py
+++ b/dotnetclr/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/druid/datadog_checks/__init__.py
+++ b/druid/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/duckdb/datadog_checks/__init__.py
+++ b/duckdb/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/ecs_fargate/datadog_checks/__init__.py
+++ b/ecs_fargate/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/eks_fargate/datadog_checks/__init__.py
+++ b/eks_fargate/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2020
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/elastic/datadog_checks/__init__.py
+++ b/elastic/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/envoy/datadog_checks/__init__.py
+++ b/envoy/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/esxi/datadog_checks/__init__.py
+++ b/esxi/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/etcd/datadog_checks/__init__.py
+++ b/etcd/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/exchange_server/datadog_checks/__init__.py
+++ b/exchange_server/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/external_dns/datadog_checks/__init__.py
+++ b/external_dns/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/flink/datadog_checks/__init__.py
+++ b/flink/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2020-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/fluentd/datadog_checks/__init__.py
+++ b/fluentd/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/fluxcd/datadog_checks/__init__.py
+++ b/fluxcd/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/fly_io/datadog_checks/__init__.py
+++ b/fly_io/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/foundationdb/datadog_checks/__init__.py
+++ b/foundationdb/datadog_checks/__init__.py
@@ -1,5 +1,0 @@
-# (C) Datadog, Inc. 2022-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/gearmand/datadog_checks/__init__.py
+++ b/gearmand/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/gitlab/datadog_checks/__init__.py
+++ b/gitlab/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/gitlab_runner/datadog_checks/__init__.py
+++ b/gitlab_runner/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/glusterfs/datadog_checks/__init__.py
+++ b/glusterfs/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2020-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/go_expvar/datadog_checks/__init__.py
+++ b/go_expvar/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/gunicorn/datadog_checks/__init__.py
+++ b/gunicorn/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/haproxy/datadog_checks/__init__.py
+++ b/haproxy/datadog_checks/__init__.py
@@ -1,5 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/harbor/datadog_checks/__init__.py
+++ b/harbor/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/hazelcast/datadog_checks/__init__.py
+++ b/hazelcast/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2020-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/hdfs_datanode/datadog_checks/__init__.py
+++ b/hdfs_datanode/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/hdfs_namenode/datadog_checks/__init__.py
+++ b/hdfs_namenode/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/hive/datadog_checks/__init__.py
+++ b/hive/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/hivemq/datadog_checks/__init__.py
+++ b/hivemq/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2020-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/http_check/datadog_checks/__init__.py
+++ b/http_check/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/hudi/datadog_checks/__init__.py
+++ b/hudi/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2021-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/hyperv/datadog_checks/__init__.py
+++ b/hyperv/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/ibm_ace/datadog_checks/__init__.py
+++ b/ibm_ace/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2022-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/ibm_db2/datadog_checks/__init__.py
+++ b/ibm_db2/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/ibm_i/datadog_checks/__init__.py
+++ b/ibm_i/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2021-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/ibm_mq/datadog_checks/__init__.py
+++ b/ibm_mq/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/ibm_was/datadog_checks/__init__.py
+++ b/ibm_was/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/ignite/datadog_checks/__init__.py
+++ b/ignite/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2020-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/iis/datadog_checks/__init__.py
+++ b/iis/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/impala/datadog_checks/__init__.py
+++ b/impala/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2022-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/istio/datadog_checks/__init__.py
+++ b/istio/datadog_checks/__init__.py
@@ -1,5 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/ivanti_connect_secure/datadog_checks/__init__.py
+++ b/ivanti_connect_secure/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2025-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/jboss_wildfly/datadog_checks/__init__.py
+++ b/jboss_wildfly/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/journald/datadog_checks/__init__.py
+++ b/journald/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2021-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/kafka/datadog_checks/__init__.py
+++ b/kafka/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/kafka_consumer/datadog_checks/__init__.py
+++ b/kafka_consumer/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/karpenter/datadog_checks/__init__.py
+++ b/karpenter/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2023-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/keda/datadog_checks/__init__.py
+++ b/keda/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/keycloak/datadog_checks/__init__.py
+++ b/keycloak/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2025-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/kong/datadog_checks/__init__.py
+++ b/kong/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/kube_apiserver_metrics/datadog_checks/__init__.py
+++ b/kube_apiserver_metrics/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/kube_controller_manager/datadog_checks/__init__.py
+++ b/kube_controller_manager/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/kube_dns/datadog_checks/__init__.py
+++ b/kube_dns/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/kube_metrics_server/datadog_checks/__init__.py
+++ b/kube_metrics_server/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/kube_proxy/datadog_checks/__init__.py
+++ b/kube_proxy/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/kube_scheduler/datadog_checks/__init__.py
+++ b/kube_scheduler/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/kubeflow/datadog_checks/__init__.py
+++ b/kubeflow/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/kubelet/datadog_checks/__init__.py
+++ b/kubelet/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/kubernetes_cluster_autoscaler/datadog_checks/__init__.py
+++ b/kubernetes_cluster_autoscaler/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/kubernetes_state/datadog_checks/__init__.py
+++ b/kubernetes_state/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/kubevirt_api/datadog_checks/__init__.py
+++ b/kubevirt_api/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/kubevirt_controller/datadog_checks/__init__.py
+++ b/kubevirt_controller/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/kubevirt_handler/datadog_checks/__init__.py
+++ b/kubevirt_handler/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/kyototycoon/datadog_checks/__init__.py
+++ b/kyototycoon/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/kyverno/datadog_checks/__init__.py
+++ b/kyverno/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/lighttpd/datadog_checks/__init__.py
+++ b/lighttpd/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/linkerd/datadog_checks/__init__.py
+++ b/linkerd/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/linux_proc_extras/datadog_checks/__init__.py
+++ b/linux_proc_extras/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/mapr/datadog_checks/__init__.py
+++ b/mapr/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/mapreduce/datadog_checks/__init__.py
+++ b/mapreduce/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/marathon/datadog_checks/__init__.py
+++ b/marathon/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/marklogic/datadog_checks/__init__.py
+++ b/marklogic/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2020-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/mcache/datadog_checks/__init__.py
+++ b/mcache/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/mesos_master/datadog_checks/__init__.py
+++ b/mesos_master/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/mesos_slave/datadog_checks/__init__.py
+++ b/mesos_slave/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/milvus/datadog_checks/__init__.py
+++ b/milvus/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/mongo/datadog_checks/__init__.py
+++ b/mongo/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/mysql/datadog_checks/__init__.py
+++ b/mysql/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/nagios/datadog_checks/__init__.py
+++ b/nagios/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/network/datadog_checks/__init__.py
+++ b/network/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/nfsstat/datadog_checks/__init__.py
+++ b/nfsstat/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/nginx/datadog_checks/__init__.py
+++ b/nginx/datadog_checks/__init__.py
@@ -1,5 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/nginx_ingress_controller/datadog_checks/__init__.py
+++ b/nginx_ingress_controller/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/nvidia_nim/datadog_checks/__init__.py
+++ b/nvidia_nim/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/nvidia_triton/datadog_checks/__init__.py
+++ b/nvidia_triton/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2023-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/octopus_deploy/datadog_checks/__init__.py
+++ b/octopus_deploy/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2025-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/openldap/datadog_checks/__init__.py
+++ b/openldap/datadog_checks/__init__.py
@@ -1,5 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/openmetrics/datadog_checks/__init__.py
+++ b/openmetrics/datadog_checks/__init__.py
@@ -1,5 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/openstack/datadog_checks/__init__.py
+++ b/openstack/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/openstack_controller/datadog_checks/__init__.py
+++ b/openstack_controller/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/oracle/datadog_checks/__init__.py
+++ b/oracle/datadog_checks/__init__.py
@@ -1,5 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/ossec_security/datadog_checks/__init__.py
+++ b/ossec_security/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/palo_alto_panorama/datadog_checks/__init__.py
+++ b/palo_alto_panorama/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/pan_firewall/datadog_checks/__init__.py
+++ b/pan_firewall/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2021-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/pdh_check/datadog_checks/__init__.py
+++ b/pdh_check/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/pgbouncer/datadog_checks/__init__.py
+++ b/pgbouncer/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/php_fpm/datadog_checks/__init__.py
+++ b/php_fpm/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/ping_federate/datadog_checks/__init__.py
+++ b/ping_federate/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/postfix/datadog_checks/__init__.py
+++ b/postfix/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/postgres/datadog_checks/__init__.py
+++ b/postgres/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/powerdns_recursor/datadog_checks/__init__.py
+++ b/powerdns_recursor/datadog_checks/__init__.py
@@ -1,5 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/presto/datadog_checks/__init__.py
+++ b/presto/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/process/datadog_checks/__init__.py
+++ b/process/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/prometheus/datadog_checks/__init__.py
+++ b/prometheus/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/proxysql/datadog_checks/__init__.py
+++ b/proxysql/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2020-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/pulsar/datadog_checks/__init__.py
+++ b/pulsar/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2022-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ exclude = [
 ]
 target-version = "py311"
 line-length = 120
+namespace-packages = ["datadog_checks"]
 
 [tool.ruff.lint]
 # Rules were ported over from the legacy flake8 settings for parity

--- a/quarkus/datadog_checks/__init__.py
+++ b/quarkus/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/rabbitmq/datadog_checks/__init__.py
+++ b/rabbitmq/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/ray/datadog_checks/__init__.py
+++ b/ray/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2023-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/redisdb/datadog_checks/__init__.py
+++ b/redisdb/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/rethinkdb/datadog_checks/__init__.py
+++ b/rethinkdb/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2020-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/rethinkdb/pyproject.toml
+++ b/rethinkdb/pyproject.toml
@@ -54,7 +54,7 @@ include = [
 
 [tool.hatch.build.targets.wheel]
 include = [
-    "/datadog_checks/rethinkdb",
+    "/datadog_checks",
 ]
 dev-mode-dirs = [
     ".",

--- a/riak/datadog_checks/__init__.py
+++ b/riak/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/riakcs/datadog_checks/__init__.py
+++ b/riakcs/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/sap_hana/datadog_checks/__init__.py
+++ b/sap_hana/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/scylla/datadog_checks/__init__.py
+++ b/scylla/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2020-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/sidekiq/datadog_checks/__init__.py
+++ b/sidekiq/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2020-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/silk/datadog_checks/__init__.py
+++ b/silk/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2021-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/singlestore/datadog_checks/__init__.py
+++ b/singlestore/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2021-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/slurm/datadog_checks/__init__.py
+++ b/slurm/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/snmp/datadog_checks/__init__.py
+++ b/snmp/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/snowflake/datadog_checks/__init__.py
+++ b/snowflake/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2020-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/snowflake/pyproject.toml
+++ b/snowflake/pyproject.toml
@@ -55,7 +55,7 @@ include = [
 
 [tool.hatch.build.targets.wheel]
 include = [
-    "/datadog_checks/snowflake",
+    "/datadog_checks",
 ]
 dev-mode-dirs = [
     ".",

--- a/solr/datadog_checks/__init__.py
+++ b/solr/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/sonarqube/datadog_checks/__init__.py
+++ b/sonarqube/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2020-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/sonicwall_firewall/datadog_checks/__init__.py
+++ b/sonicwall_firewall/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/spark/datadog_checks/__init__.py
+++ b/spark/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/sqlserver/datadog_checks/__init__.py
+++ b/sqlserver/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/squid/datadog_checks/__init__.py
+++ b/squid/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/ssh_check/datadog_checks/__init__.py
+++ b/ssh_check/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/statsd/datadog_checks/__init__.py
+++ b/statsd/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/strimzi/datadog_checks/__init__.py
+++ b/strimzi/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2023-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/supabase/datadog_checks/__init__.py
+++ b/supabase/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/supervisord/datadog_checks/__init__.py
+++ b/supervisord/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/suricata/datadog_checks/__init__.py
+++ b/suricata/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/symantec_endpoint_protection/datadog_checks/__init__.py
+++ b/symantec_endpoint_protection/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/system_core/datadog_checks/__init__.py
+++ b/system_core/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/system_swap/datadog_checks/__init__.py
+++ b/system_swap/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/tcp_check/datadog_checks/__init__.py
+++ b/tcp_check/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/teamcity/datadog_checks/__init__.py
+++ b/teamcity/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/tekton/datadog_checks/__init__.py
+++ b/tekton/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/teleport/datadog_checks/__init__.py
+++ b/teleport/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/temporal/datadog_checks/__init__.py
+++ b/temporal/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2023-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/teradata/datadog_checks/__init__.py
+++ b/teradata/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2022-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/tibco_ems/datadog_checks/__init__.py
+++ b/tibco_ems/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/tls/datadog_checks/__init__.py
+++ b/tls/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/tokumx/datadog_checks/__init__.py
+++ b/tokumx/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/tomcat/datadog_checks/__init__.py
+++ b/tomcat/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/torchserve/datadog_checks/__init__.py
+++ b/torchserve/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2023-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/traefik_mesh/datadog_checks/__init__.py
+++ b/traefik_mesh/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/traffic_server/datadog_checks/__init__.py
+++ b/traffic_server/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2022-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/twemproxy/datadog_checks/__init__.py
+++ b/twemproxy/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/twistlock/datadog_checks/__init__.py
+++ b/twistlock/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/varnish/datadog_checks/__init__.py
+++ b/varnish/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/vault/datadog_checks/__init__.py
+++ b/vault/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/vertica/datadog_checks/__init__.py
+++ b/vertica/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2019-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/vllm/datadog_checks/__init__.py
+++ b/vllm/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/voltdb/datadog_checks/__init__.py
+++ b/voltdb/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2020-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/vsphere/datadog_checks/__init__.py
+++ b/vsphere/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/wazuh/datadog_checks/__init__.py
+++ b/wazuh/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/weaviate/datadog_checks/__init__.py
+++ b/weaviate/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2023-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/weblogic/datadog_checks/__init__.py
+++ b/weblogic/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2021-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/win32_event_log/datadog_checks/__init__.py
+++ b/win32_event_log/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/windows_performance_counters/datadog_checks/__init__.py
+++ b/windows_performance_counters/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2021-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/windows_service/datadog_checks/__init__.py
+++ b/windows_service/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/wmi_check/datadog_checks/__init__.py
+++ b/wmi_check/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/yarn/datadog_checks/__init__.py
+++ b/yarn/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/zeek/datadog_checks/__init__.py
+++ b/zeek/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2024-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/zk/datadog_checks/__init__.py
+++ b/zk/datadog_checks/__init__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore


### PR DESCRIPTION
### Motivation

Now that we've dropped Python 2 we can use the modern approach: https://packaging.python.org/en/latest/guides/packaging-namespace-packages/#native-namespace-packages

### Notes

I kept the `__init__.py` file for `datadog_checks_base` package because a very old version of our integrations had imports right under `datadog_checks` and they live there so we must support that, for now...