### PR TITLE
Stop validating assets since APW now handles that

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,7 +21,6 @@ jobs:
       ci: true
       codeowners: true
       config: true
-      dashboards: true
       dep: true
       http: true
       imports: true
@@ -37,6 +36,5 @@ jobs:
       package: true
       readmes: true
       saved-views: true
-      service-checks: true
       version: true
     secrets: inherit


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
All in the title. We now have a more up-to-date validation coming from the Asset Publishing Workflow.
I've even seen our validations diverge with it already.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
