### PR TITLE
Logs integrations assets for Cisco ACI integration faults sent as logs.

### DIFF
--- a/cisco_aci/assets/logs/cisco-aci.yaml
+++ b/cisco_aci/assets/logs/cisco-aci.yaml
@@ -1,0 +1,215 @@
+id: cisco-aci
+metric_id: cisco-aci
+backend_only: false
+facets:
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Ack
+    path: cisco_aci.ack
+    source: log
+    type: boolean
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Affected
+    path: cisco_aci.affected
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Alert
+    path: cisco_aci.alert
+    source: log
+    type: boolean
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Cause
+    path: cisco_aci.cause
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Change Set
+    path: cisco_aci.changeSet
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Child Action
+    path: cisco_aci.childAction
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Code
+    path: cisco_aci.code
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Delegated
+    path: cisco_aci.delegated
+    source: log
+    type: boolean
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Dn
+    path: cisco_aci.dn
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Domain
+    path: cisco_aci.domain
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Fault Category
+    path: cisco_aci.faultCategory
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Highest Severity
+    path: cisco_aci.highestSeverity
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Lifecycle Status
+    path: cisco_aci.lc
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Occur
+    path: cisco_aci.occur
+    source: log
+    type: integer
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Orig Severity
+    path: cisco_aci.origSeverity
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Prev Severity
+    path: cisco_aci.prevSeverity
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Rule
+    path: cisco_aci.rule
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Severity
+    path: cisco_aci.severity
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Subject
+    path: cisco_aci.subject
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Title
+    path: cisco_aci.title
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Type
+    path: cisco_aci.type
+    source: log
+    type: string
+  - description: ""
+    facetType: list
+    groups:
+      - Cisco ACI
+    name: Upgrade Status
+    path: cisco_aci.status
+    source: log
+    type: string
+pipeline:
+  type: pipeline
+  name: Cisco ACI
+  enabled: true
+  filter:
+    query: source:cisco-aci
+  processors:
+    - type: date-remapper
+      name: Define `cisco_aci.lastTransition` as the official date of the log
+      enabled: true
+      sources:
+        - cisco_aci.lastTransition
+    - type: message-remapper
+      name: Define `cisco_aci.descr` as the official message of the log
+      enabled: true
+      sources:
+        - cisco_aci.descr
+    - name: Map `cisco_aci.severity` levels into `log_status`
+      enabled: true
+      source: cisco_aci.severity
+      target: log_status
+      lookupTable: |-
+        critical,critical
+        major,error
+        minor,warning
+        warning,warning
+        info,info
+        cleared,info
+      defaultLookup: info
+      type: lookup-processor
+    - type: status-remapper
+      name: Define `log_status` as the official status of the log
+      enabled: true
+      sources:
+        - log_status

--- a/cisco_aci/assets/logs/cisco-aci_tests.yaml
+++ b/cisco_aci/assets/logs/cisco-aci_tests.yaml
@@ -1,0 +1,65 @@
+id: cisco-aci
+tests:
+  - sample: >-
+      {
+        "cisco_aci": {
+          "ack": "no",
+          "alert": "no",
+          "cause": "threshold-crossed",
+          "changeSet": "crcLast:1",
+          "childAction": "",
+          "code": "F381328",
+          "created": "2025-03-12T13:46:10.489+00:00",
+          "delegated": "no",
+          "descr": "TCA: CRC Align Errors current value(eqptIngrErrPkts5min:crcLast) value 1% raised above threshold 0% and value is recovering ",
+          "dn": "topology/pod-1/node-101/sys/aggr-[po3]/fault-F381328",
+          "domain": "infra",
+          "highestSeverity": "warning",
+          "lastTransition": "2025-03-12T15:57:27.496+00:00",
+          "lc": "raised",
+          "occur": "115",
+          "origSeverity": "warning",
+          "prevSeverity": "cleared",
+          "rule": "tca-eqpt-ingr-err-pkts5min-crc-last",
+          "severity": "warning",
+          "status": "",
+          "subject": "counter",
+          "title": "",
+          "type": "operational",
+          "faultCategory": "faultInst"
+        }
+      }
+    result: null
+  - sample: >-
+      {
+        "cisco_aci": {
+          "ack": "no",
+          "affected": "topology/pod-1/node-1/local/svc-extXMLApi-id-255/uni/userext/tacacsext/tacacsplusprovider-10.19.24.1",
+          "cause": "inoperable",
+          "changeSet": "operState (Old: unknown, New: inoperable)",
+          "childAction": "",
+          "code": "F0023",
+          "created": "2025-03-09T14:23:39.345+00:00",
+          "descr": "Fault delegate: Tacacs+ Provider 10.19.24.1 unreachable",
+          "dn": "uni/userext/tacacsext/tacacsplusprovider-10.19.24.1/fd-[topology/pod-1/node-1/local/svc-extXMLApi-id-255/uni/userext/tacacsext/tacacsplusprovider-10.19.24.1]-fault-F0023",
+          "domain": "security",
+          "highestSeverity": "minor",
+          "lastTransition": "2025-03-12T00:12:36.980+00:00",
+          "lc": "raised",
+          "occur": "1",
+          "origSeverity": "minor",
+          "prevSeverity": "minor",
+          "rule": "aaa-tacacs-plus-provider-tacacs-plus-provider-inoperable",
+          "severity": "minor",
+          "status": "",
+          "subject": "security-provider",
+          "type": "operational",
+          "faultCategory": "faultDelegate"
+        }
+      }
+    result: null
+
+# The `result` field should be left blank to start. Once you submit your log asset files with
+# your integration pull-request in a Datadog GitHub repository, Datadog's validations will
+# run your raw logs against your pipeline and return the result. If the result output in the
+# validation is accurate, take the output and add it to the `result` field in your test YAML file.

--- a/cisco_aci/assets/logs/cisco-aci_tests.yaml
+++ b/cisco_aci/assets/logs/cisco-aci_tests.yaml
@@ -29,7 +29,38 @@ tests:
           "faultCategory": "faultInst"
         }
       }
-    result: null
+    result:
+      custom:
+        cisco_aci:
+          ack: "no"
+          alert: "no"
+          cause: "threshold-crossed"
+          changeSet: "crcLast:1"
+          childAction: ""
+          code: "F381328"
+          created: "2025-03-12T13:46:10.489+00:00"
+          delegated: "no"
+          dn: "topology/pod-1/node-101/sys/aggr-[po3]/fault-F381328"
+          domain: "infra"
+          faultCategory: "faultInst"
+          highestSeverity: "warning"
+          lastTransition: "2025-03-12T15:57:27.496+00:00"
+          lc: "raised"
+          occur: "115"
+          origSeverity: "warning"
+          prevSeverity: "cleared"
+          rule: "tca-eqpt-ingr-err-pkts5min-crc-last"
+          severity: "warning"
+          status: ""
+          subject: "counter"
+          title: ""
+          type: "operational"
+        log_status: "warning"
+      message: "TCA: CRC Align Errors current value(eqptIngrErrPkts5min:crcLast) value 1% raised above threshold 0% and value is recovering "
+      status: "warn"
+      tags:
+       - "source:LOGS_SOURCE"
+      timestamp: 1741795047496
   - sample: >-
       {
         "cisco_aci": {
@@ -57,9 +88,33 @@ tests:
           "faultCategory": "faultDelegate"
         }
       }
-    result: null
-
-# The `result` field should be left blank to start. Once you submit your log asset files with
-# your integration pull-request in a Datadog GitHub repository, Datadog's validations will
-# run your raw logs against your pipeline and return the result. If the result output in the
-# validation is accurate, take the output and add it to the `result` field in your test YAML file.
+    result:
+      custom:
+        cisco_aci:
+          ack: "no"
+          affected: "topology/pod-1/node-1/local/svc-extXMLApi-id-255/uni/userext/tacacsext/tacacsplusprovider-10.19.24.1"
+          cause: "inoperable"
+          changeSet: "operState (Old: unknown, New: inoperable)"
+          childAction: ""
+          code: "F0023"
+          created: "2025-03-09T14:23:39.345+00:00"
+          dn: "uni/userext/tacacsext/tacacsplusprovider-10.19.24.1/fd-[topology/pod-1/node-1/local/svc-extXMLApi-id-255/uni/userext/tacacsext/tacacsplusprovider-10.19.24.1]-fault-F0023"
+          domain: "security"
+          faultCategory: "faultDelegate"
+          highestSeverity: "minor"
+          lastTransition: "2025-03-12T00:12:36.980+00:00"
+          lc: "raised"
+          occur: "1"
+          origSeverity: "minor"
+          prevSeverity: "minor"
+          rule: "aaa-tacacs-plus-provider-tacacs-plus-provider-inoperable"
+          severity: "minor"
+          status: ""
+          subject: "security-provider"
+          type: "operational"
+        log_status: "warning"
+      message: "Fault delegate: Tacacs+ Provider 10.19.24.1 unreachable"
+      status: "warn"
+      tags:
+       - "source:LOGS_SOURCE"
+      timestamp: 1741738356980


### PR DESCRIPTION
### What does this PR do?
Add assets for new logs being sent by Cisco ACI integration in https://github.com/DataDog/integrations-core/pull/19836.
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
