### PR TITLE
Add `lazy-loader` dependency

### DIFF
--- a/.ddev/config.toml
+++ b/.ddev/config.toml
@@ -61,6 +61,8 @@ cryptography = ['Apache-2.0', 'BSD-3-Clause', 'PSF']
 # https://github.com/confluentinc/confluent-kafka-python/blob/master/LICENSE
 # https://github.com/rthalley/dnspython/blob/master/LICENSE
 dnspython = ['ISC']
+# https://github.com/scientific-python/lazy-loader/blob/main/LICENSE.md
+lazy-loader = ['BSD-3-Clause']
 # https://github.com/cannatag/ldap3/blob/dev/COPYING.txt
 ldap3 = ['LGPL-3.0-only']
 # https://cloudera.github.io/cm_api/

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -30,6 +30,7 @@ in-toto,PyPI,Apache-2.0,Copyright 2018 New York University
 jellyfish,PyPI,MIT,Copyright (c) 2015 James Turk
 kentik-snmp-profiles,"https://github.com/kentik/snmp-profiles",Apache-2.0,
 kubernetes,PyPI,Apache-2.0,Copyright 2014 The Kubernetes Authors.
+lazy-loader,PyPI,BSD-3-Clause,"Copyright (c) 2022--2023, Scientific Python project"
 ldap3,PyPI,LGPL-3.0-only,Copyright 2013 - 2020 Giovanni Cannata
 lxml,PyPI,BSD-3-Clause,Copyright (c) 2004 Infrae. All rights reserved.
 lz4,PyPI,BSD-3-Clause,"Copyright (c) 2012-2013, Steeve Morin"

--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -18,6 +18,7 @@ hazelcast-python-client==5.5.0
 in-toto==2.0.0
 jellyfish==1.1.3
 kubernetes==32.0.1
+lazy-loader==0.4
 ldap3==2.9.1
 lxml==5.1.1
 lz4==4.4.3

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -39,6 +39,7 @@ deps = [
     "cryptography==44.0.1",
     "ddtrace==2.10.6",
     "jellyfish==1.1.3",
+    "lazy-loader==0.4",
     "prometheus-client==0.21.1",
     "protobuf==5.29.3",
     "pydantic==2.10.6",


### PR DESCRIPTION
### Motivation

Extracted from https://github.com/DataDog/integrations-core/pull/19838, we want the dependencies built already in order to test on a live Agent