### PR TITLE
Probable Typo in Kubernetes Annotations Config for NGINX

### DIFF
--- a/nginx/README.md
+++ b/nginx/README.md
@@ -268,7 +268,7 @@ To collect metrics, set the following parameters and values in an [Autodiscovery
 | -------------------- | -------------------------------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `["nginx"]`                                                                |
 | `<INIT_CONFIG>`      | `[{}]`                                                                     |
-| `<INSTANCE_CONFIG>`  | `[{"nginx_status_url": "http://%%host%%:18080/nginx_status"}]`             |
+| `<INSTANCE_CONFIG>`  | `[{"nginx_status_url": "http://%%host%%:81/nginx_status"}]`             |
 
 **Annotations v1** (for Datadog Agent < v7.36)
 


### PR DESCRIPTION
In the configuration table in the documentation, the Annotation Value for the INSTANCE_CONFIG uses a different port than what the config for the NGINX server use, which is 81. It is 81 in all other Environments except Kubernetes, making me believe this was an oversight

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
