### PR TITLE
Stop using the uptime library

### DIFF
--- a/.ddev/config.toml
+++ b/.ddev/config.toml
@@ -94,8 +94,6 @@ semver = ['BSD-3-Clause']
 simplejson = ['MIT']
 # https://github.com/Supervisor/supervisor/blob/master/LICENSES.txt
 supervisor = ['BSD-3-Clause-Modification']
-# https://github.com/Cairnarvon/uptime/blob/master/COPYING.txt
-uptime = ['BSD-2-Clause']
 
 [overrides.dependencies.repo]
 PyYAML = 'https://github.com/yaml/pyyaml'

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -83,6 +83,5 @@ snowflake-connector-python,PyPI,Apache-2.0,"Copyright (c) 2013-2023 Snowflake Co
 supervisor,PyPI,BSD-3-Clause-Modification,"Copyright (c) 2002-2005, Daniel Krech, http://eikeon.com/"
 tuf,PyPI,Apache-2.0,Copyright (c) 2010 New York University
 tuf,PyPI,MIT,Copyright (c) 2010 New York University
-uptime,PyPI,BSD-2-Clause,"Copyright (c) 2012, Koen Crolla"
 vertica-python,PyPI,Apache-2.0,"Copyright 2013 Justin Berka, Alex Kim, Siting Ren"
 wrapt,PyPI,BSD-3-Clause,"Copyright (c) 2013-2023, Graham Dumpleton"

--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -66,6 +66,5 @@ simplejson==3.20.1
 snowflake-connector-python==3.13.2
 supervisor==4.2.5
 tuf==4.0.0
-uptime==3.0.1
 vertica-python==1.4.0
 wrapt==1.17.2

--- a/datadog_checks_base/changelog.d/19842.fixed
+++ b/datadog_checks_base/changelog.d/19842.fixed
@@ -1,0 +1,1 @@
+Stop using the `uptime` library.

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -49,7 +49,6 @@ deps = [
     "requests-unixsocket2==0.4.2",
     "requests==2.32.3",
     "simplejson==3.20.1",
-    "uptime==3.0.1",
     "wrapt==1.17.2",
 ]
 http = [

--- a/datadog_checks_dev/changelog.d/19842.fixed
+++ b/datadog_checks_dev/changelog.d/19842.fixed
@@ -1,0 +1,1 @@
+Stop using the uptime library

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
@@ -68,8 +68,6 @@ EXPLICIT_LICENSES = {
     'simplejson': ['MIT'],
     # https://github.com/Supervisor/supervisor/blob/master/LICENSES.txt
     'supervisor': ['BSD-3-Clause-Modification'],
-    # https://github.com/Cairnarvon/uptime/blob/master/COPYING.txt
-    'uptime': ['BSD-2-Clause'],
     # https://github.com/hickeroar/win_inet_pton/blob/master/LICENSE
     'win-inet-pton': ['Unlicense'],
 }

--- a/win32_event_log/changelog.d/19842.fixed
+++ b/win32_event_log/changelog.d/19842.fixed
@@ -1,0 +1,1 @@
+Stop using the `uptime` library.

--- a/win32_event_log/datadog_checks/win32_event_log/legacy/win32_event_log.py
+++ b/win32_event_log/datadog_checks/win32_event_log/legacy/win32_event_log.py
@@ -2,9 +2,9 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import calendar
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
-from uptime import uptime
+import psutil
 
 from datadog_checks.base import ConfigurationError, is_affirmative
 from datadog_checks.base.checks.win.wmi import WinWMICheck, from_time, to_time
@@ -92,8 +92,9 @@ class Win32EventLogWMI(WinWMICheck):
         # Store the last timestamp by instance
         if instance_key not in self.last_ts:
             # If system boot was within 600s of dd agent start then use boottime as last_ts
-            if uptime() <= 600:
-                self.last_ts[instance_key] = datetime.utcnow() - timedelta(seconds=uptime())
+            uptime = datetime.now(timezone.utc) - datetime.fromtimestamp(psutil.boot_time(), timezone.utc)
+            if uptime.total_seconds() <= 600:
+                self.last_ts[instance_key] = datetime.utcnow() - uptime
             else:
                 self.last_ts[instance_key] = datetime.utcnow()
             return

--- a/win32_event_log/pyproject.toml
+++ b/win32_event_log/pyproject.toml
@@ -37,7 +37,7 @@ dynamic = [
 [project.optional-dependencies]
 deps = [
     "pywin32==308; sys_platform == 'win32'",
-    "uptime==3.0.1",
+    "psutil==6.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Stop using the uptime library. 

### Motivation
<!-- What inspired you to submit this pull request? -->

- `uptime` is no longer maintained (last release: 2013)
- We already have psutil, which is maintained, and can be used to achieve the same thing
- We use it in only one check and for its legacy version it seems
- It's not used in extras, marketplace nor internal
- Even if `uptime` is lightweight, that's still one less deps to ship with the agent

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
