### PR TITLE
Refactor imports

### DIFF
--- a/datadog_checks_base/README.md
+++ b/datadog_checks_base/README.md
@@ -29,19 +29,6 @@ install the toolkit locally and play with it:
 pip install datadog-checks-base
 ```
 
-## Performance Optimizations
-
-We strive to balance lean resource usage with a "batteries included" user experience.
-This is why we import some of our dependencies inside functions that use them instead of the more conventional import section at the top of the file.
-
-Below are some examples for how much we shave off the Python heap for a given dependency:
-
-- `requests==2.32.3`: 3.6MB
-- `RequestWrapper` class (`datadog_checks_base==37.7.0`): 2.9MB
-- `prometheus-client==0.21.1`: around 1MB
-
-This translates into even bigger savings when we run in the Agent, something close to 50MB.
-
 ## Troubleshooting
 
 Need help? Contact [Datadog support][8].

--- a/datadog_checks_base/changelog.d/19845.added
+++ b/datadog_checks_base/changelog.d/19845.added
@@ -1,0 +1,1 @@
+Add more lazy imports to reduce overhead

--- a/datadog_checks_base/changelog.d/19845.added.1
+++ b/datadog_checks_base/changelog.d/19845.added.1
@@ -1,0 +1,1 @@
+Add `datadog_checks.base.utils.format.json` module for JSON serialization

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -1,15 +1,14 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
 import copy
 import functools
 import importlib
-import inspect
 import logging
 import os
 import re
-import traceback
-import unicodedata
 from collections import deque
 from os.path import basename
 from typing import (  # noqa: F401
@@ -27,10 +26,10 @@ from typing import (  # noqa: F401
     Union,
 )
 
-import yaml
-from pydantic import BaseModel, ValidationError
+import lazy_loader
 
 from datadog_checks.base.agent import AGENT_RUNNING, aggregator, datadog_agent
+from datadog_checks.base.utils.format import json
 
 from ..config import is_affirmative
 from ..constants import ServiceCheck
@@ -46,14 +45,8 @@ from ..types import (
 )
 from ..utils.agent.utils import should_profile_memory
 from ..utils.common import ensure_bytes, to_native_string
-from ..utils.diagnose import Diagnosis
 from ..utils.fips import enable_fips
-from ..utils.limiter import Limiter
-from ..utils.metadata import MetadataManager
-from ..utils.secrets import SecretsSanitizer
-from ..utils.serialization import from_json, to_json
 from ..utils.tagging import GENERIC_TAGS
-from ..utils.tls import TlsContextWrapper
 from ..utils.tracing import traced_class
 
 if AGENT_RUNNING:
@@ -86,7 +79,18 @@ if is_affirmative(datadog_agent.get_config('integration_profiling')):
     prof.start()
 
 if TYPE_CHECKING:
+    import inspect as _module_inspect
     import ssl  # noqa: F401
+    import traceback as _module_traceback
+    import unicodedata as _module_unicodedata
+
+    from datadog_checks.base.utils.diagnose import Diagnosis
+    from datadog_checks.base.utils.http import RequestsWrapper
+    from datadog_checks.base.utils.metadata import MetadataManager
+
+inspect: _module_inspect = lazy_loader.load('inspect')
+traceback: _module_traceback = lazy_loader.load('traceback')
+unicodedata: _module_unicodedata = lazy_loader.load('unicodedata')
 
 # Metric types for which it's only useful to submit once per set of tags
 ONE_PER_CONTEXT_METRIC_TYPES = [aggregator.GAUGE, aggregator.RATE, aggregator.MONOTONIC_COUNT]
@@ -341,6 +345,8 @@ class AgentCheck(object):
         limit = self._get_metric_limit(instance=instance)
 
         if limit > 0:
+            from datadog_checks.base.utils.limiter import Limiter
+
             return Limiter(name, 'metrics', limit, self.warning)
 
         return None
@@ -385,20 +391,20 @@ class AgentCheck(object):
         """
         Convenience wrapper to ease programmatic use of this class from the C API.
         """
+        import yaml
+
         return yaml.safe_load(yaml_str)
 
     @property
-    def http(self):
-        # type: () -> RequestsWrapper
+    def http(self) -> RequestsWrapper:
         """
         Provides logic to yield consistent network behavior based on user configuration.
 
         Only new checks or checks on Agent 6.13+ can and should use this for HTTP requests.
         """
-        # See Performance Optimizations in this package's README.md.
-        from ..utils.http import RequestsWrapper
-
         if not hasattr(self, '_http'):
+            from datadog_checks.base.utils.http import RequestsWrapper
+
             self._http = RequestsWrapper(self.instance or {}, self.init_config, self.HTTP_CONFIG_REMAPPER, self.log)
 
         return self._http
@@ -434,12 +440,13 @@ class AgentCheck(object):
         return self.__formatted_tags
 
     @property
-    def diagnosis(self):
-        # type: () -> Diagnosis
+    def diagnosis(self) -> Diagnosis:
         """
         A Diagnosis object to register explicit diagnostics and record diagnoses.
         """
         if not hasattr(self, '_diagnosis'):
+            from datadog_checks.base.utils.diagnose import Diagnosis
+
             self._diagnosis = Diagnosis(sanitize=self.sanitize)
         return self._diagnosis
 
@@ -453,6 +460,8 @@ class AgentCheck(object):
         Since: Agent 7.24
         """
         if not hasattr(self, '_tls_context_wrapper'):
+            from datadog_checks.base.utils.tls import TlsContextWrapper
+
             self._tls_context_wrapper = TlsContextWrapper(
                 self.instance or {}, self.TLS_CONFIG_REMAPPER, overrides=overrides
             )
@@ -463,14 +472,15 @@ class AgentCheck(object):
         return self._tls_context_wrapper.tls_context
 
     @property
-    def metadata_manager(self):
-        # type: () -> MetadataManager
+    def metadata_manager(self) -> MetadataManager:
         """
         Used for sending metadata via Go bindings.
         """
         if not hasattr(self, '_metadata_manager'):
             if not self.check_id and AGENT_RUNNING:
                 raise RuntimeError('Attribute `check_id` must be set')
+
+            from datadog_checks.base.utils.metadata import MetadataManager
 
             self._metadata_manager = MetadataManager(self.name, self.check_id, self.log, self.METADATA_TRANSFORMERS)
 
@@ -500,8 +510,8 @@ class AgentCheck(object):
         return False
 
     def log_typos_in_options(self, user_config, models_config, level):
-        # only import it when running in python 3
         from jellyfish import jaro_winkler_similarity
+        from pydantic import BaseModel
 
         user_configs = user_config or {}  # type: Dict[str, Any]
         models_config = models_config or {}
@@ -572,6 +582,8 @@ class AgentCheck(object):
 
         model = getattr(package, model_name, None)
         if model is not None:
+            from pydantic import ValidationError
+
             try:
                 config_model = model.model_validate(config, context=context)
             except ValidationError as e:
@@ -600,12 +612,13 @@ class AgentCheck(object):
     def _get_config_model_context(self, config):
         return {'logger': self.log, 'warning': self.warning, 'configured_fields': frozenset(config)}
 
-    def register_secret(self, secret):
-        # type: (str) -> None
+    def register_secret(self, secret: str) -> None:
         """
         Register a secret to be scrubbed by `.sanitize()`.
         """
         if not hasattr(self, '_sanitizer'):
+            from datadog_checks.base.utils.secrets import SecretsSanitizer
+
             # Configure lazily so that checks that don't use sanitization aren't affected.
             self._sanitizer = SecretsSanitizer()
             self.log.setup_sanitization(sanitize=self.sanitize)
@@ -1011,15 +1024,15 @@ class AgentCheck(object):
             # convert seconds to milliseconds
             attributes['timestamp'] = int(timestamp * 1000)
 
-        datadog_agent.send_log(to_json(attributes), self.check_id)
+        datadog_agent.send_log(json.encode(attributes), self.check_id)
         if cursor is not None:
-            self.write_persistent_cache('log_cursor_{}'.format(stream), to_json(cursor))
+            self.write_persistent_cache('log_cursor_{}'.format(stream), json.encode(cursor))
 
     def get_log_cursor(self, stream='default'):
         # type: (str) -> dict[str, Any] | None
         """Returns the most recent log cursor from disk."""
         data = self.read_persistent_cache('log_cursor_{}'.format(stream))
-        return from_json(data) if data else None
+        return json.decode(data) if data else None
 
     def _log_deprecation(self, deprecation_key, *args):
         # type: (str, *str) -> None
@@ -1190,7 +1203,11 @@ class AgentCheck(object):
         The agent calls this method to retrieve diagnostics from integrations. This method
         runs explicit diagnostics if available.
         """
-        return to_json([d._asdict() for d in (self.diagnosis.diagnoses + self.diagnosis.run_explicit())])
+        return json.encode([d._asdict() for d in (self.diagnosis.diagnoses + self.diagnosis.run_explicit())])
+
+    def _clear_diagnosis(self) -> None:
+        if hasattr(self, '_diagnosis'):
+            self._diagnosis.clear()
 
     def _get_requests_proxy(self):
         # type: () -> ProxySettings
@@ -1274,7 +1291,7 @@ class AgentCheck(object):
     def run(self):
         # type: () -> str
         try:
-            self.diagnosis.clear()
+            self._clear_diagnosis()
             # Ignore check initializations if running in a separate process
             if is_affirmative(self.instance.get('process_isolation', self.init_config.get('process_isolation', False))):
                 from ..utils.replay.execute import run_with_isolation
@@ -1310,7 +1327,7 @@ class AgentCheck(object):
         except Exception as e:
             message = self.sanitize(str(e))
             tb = self.sanitize(traceback.format_exc())
-            error_report = to_json([{'message': message, 'traceback': tb}])
+            error_report = json.encode([{'message': message, 'traceback': tb}])
         finally:
             if self.metric_limiter:
                 if is_affirmative(self.debug_metrics.get('metric_contexts', False)):

--- a/datadog_checks_base/datadog_checks/base/checks/libs/prometheus.py
+++ b/datadog_checks_base/datadog_checks/base/checks/libs/prometheus.py
@@ -4,6 +4,9 @@
 
 from itertools import tee
 
+from prometheus_client.metrics_core import Metric
+from prometheus_client.parser import _parse_sample, _replace_help_escaping
+
 
 def text_fd_to_metric_families(fd):
     raw_lines, input_lines = tee(fd, 2)
@@ -29,10 +32,6 @@ def _parse_payload(fd):
 
     Yields Metric's.
     """
-    # See Performance Optimizations in this package's README.md.
-    from prometheus_client.metrics_core import Metric
-    from prometheus_client.parser import _parse_sample, _replace_help_escaping
-
     name = ''
     documentation = ''
     typ = 'untyped'

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -3,6 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from copy import deepcopy
 
+import requests
+
 from ...errors import CheckException
 from ...utils.tracing import traced_class
 from .. import AgentCheck
@@ -72,9 +74,6 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
         """
         The base class for any Prometheus-based integration.
         """
-        # See Performance Optimizations in this package's README.md.
-        import requests
-
         args = list(args)
         default_instances = kwargs.pop('default_instances', None) or {}
         default_namespace = kwargs.pop('default_namespace', None)

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -10,11 +10,15 @@ from math import isinf, isnan
 from os.path import isfile
 from re import compile
 
+import requests
+from prometheus_client.samples import Sample
+
 from datadog_checks.base.agent import datadog_agent
 
 from ...config import is_affirmative
 from ...errors import CheckException
 from ...utils.common import to_native_string
+from ...utils.http import RequestsWrapper
 from .. import AgentCheck
 from ..libs.prometheus import text_fd_to_metric_families
 
@@ -376,10 +380,6 @@ class OpenMetricsScraperMixin(object):
         The http handler is cached using `prometheus_url` as key.
         The http handler doesn't use the cache if a bearer token is used to allow refreshing it.
         """
-
-        # See Performance Optimizations in this package's README.md.
-        from ...utils.http import RequestsWrapper
-
         prometheus_url = scraper_config['prometheus_url']
         bearer_token = scraper_config['_bearer_token']
         if prometheus_url in self._http_handlers and bearer_token is None:
@@ -826,9 +826,6 @@ class OpenMetricsScraperMixin(object):
 
         Custom headers can be added to the default headers.
         """
-        # See Performance Optimizations in this package's README.md.
-        import requests
-
         endpoint = scraper_config.get('prometheus_url')
 
         # Should we send a service check for when we make a request
@@ -1063,9 +1060,6 @@ class OpenMetricsScraperMixin(object):
         """
         Decumulate buckets in a given histogram metric and adds the lower_bound label (le being upper_bound)
         """
-        # See Performance Optimizations in this package's README.md.
-        from prometheus_client.samples import Sample
-
         bucket_values_by_context_upper_bound = {}
         for sample in metric.samples:
             if sample[self.SAMPLE_NAME].endswith("_bucket"):

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
@@ -4,6 +4,8 @@
 from collections import ChainMap
 from contextlib import contextmanager
 
+from requests.exceptions import RequestException
+
 from ....errors import ConfigurationError
 from ....utils.tracing import traced_class
 from ... import AgentCheck
@@ -60,9 +62,6 @@ class OpenMetricsBaseCheckV2(AgentCheck):
         Another thing to note is that this check ignores its instance argument completely.
         We take care of instance-level customization at initialization time.
         """
-        # See Performance Optimizations in this package's README.md.
-        from requests.exceptions import RequestException
-
         self.refresh_scrapers()
 
         for endpoint, scraper in self.scrapers.items():

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
@@ -9,12 +9,17 @@ from itertools import chain
 from math import isinf, isnan
 from typing import List  # noqa: F401
 
+from prometheus_client.openmetrics.parser import text_fd_to_metric_families as parse_openmetrics
+from prometheus_client.parser import text_fd_to_metric_families as parse_prometheus
+from requests.exceptions import ConnectionError
+
 from datadog_checks.base.agent import datadog_agent
 
 from ....config import is_affirmative
 from ....constants import ServiceCheck
 from ....errors import ConfigurationError
 from ....utils.functions import no_op, return_true
+from ....utils.http import RequestsWrapper
 from .first_scrape_handler import first_scrape_handler
 from .labels import LabelAggregator, get_label_normalizer
 from .transform import MetricTransformer
@@ -45,9 +50,6 @@ class OpenMetricsScraper:
         """
         The base class for any scraper overrides.
         """
-        # See Performance Optimizations in this package's README.md.
-        from ....utils.http import RequestsWrapper
-
         self.config = config
 
         # Save a reference to the check instance
@@ -330,10 +332,6 @@ class OpenMetricsScraper:
 
     @property
     def parse_metric_families(self):
-        # See Performance Optimizations in this package's README.md.
-        from prometheus_client.openmetrics.parser import text_fd_to_metric_families as parse_openmetrics
-        from prometheus_client.parser import text_fd_to_metric_families as parse_prometheus
-
         media_type = self._content_type.split(';')[0]
         # Setting `use_latest_spec` forces the use of the OpenMetrics format, otherwise
         # the format will be chosen based on the media type specified in the response's content-header.
@@ -394,9 +392,6 @@ class OpenMetricsScraper:
         """
         Yield the connection line.
         """
-        # See Performance Optimizations in this package's README.md.
-        from requests.exceptions import ConnectionError
-
         try:
             with self.get_connection() as connection:
                 # Media type will be used to select parser dynamically

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/utils.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/utils.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from prometheus_client.samples import Sample
 
 NEGATIVE_INFINITY = float('-inf')
 
@@ -9,9 +10,6 @@ def decumulate_histogram_buckets(sample_data):
     """
     Decumulate buckets in a given histogram metric and adds the lower_bound label (le being upper_bound)
     """
-    # See Performance Optimizations in this package's README.md.
-    from prometheus_client.samples import Sample
-
     # TODO: investigate performance optimizations
     new_sample_data = []
     bucket_values_by_context_upper_bound = {}

--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -1,11 +1,10 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import json
 import re
 from collections import defaultdict
 
-from datadog_checks.base.utils.serialization import from_json, to_json
+from datadog_checks.base.utils.format import json
 
 
 class DatadogAgentStub(object):
@@ -102,7 +101,7 @@ class DatadogAgentStub(object):
         return self._host_tags
 
     def _set_host_tags(self, tags_dict):
-        self._host_tags = json.dumps(tags_dict)
+        self._host_tags = json.encode(tags_dict)
 
     def _reset_host_tags(self):
         self._host_tags = "{}"
@@ -120,7 +119,7 @@ class DatadogAgentStub(object):
         self._metadata[(check_id, name)] = value
 
     def send_log(self, log_line, check_id):
-        self._sent_logs[check_id].append(from_json(log_line))
+        self._sent_logs[check_id].append(json.decode(log_line))
 
     def set_external_tags(self, external_tags):
         self._external_tags = external_tags
@@ -139,8 +138,8 @@ class DatadogAgentStub(object):
         if options:
             # Options provided is a JSON string because the Go stub requires it, whereas
             # the python stub does not for things such as testing.
-            if from_json(options).get('return_json_metadata', False):
-                return to_json({'query': re.sub(r'\s+', ' ', query or '').strip(), 'metadata': {}})
+            if json.decode(options).get('return_json_metadata', False):
+                return json.encode({'query': re.sub(r'\s+', ' ', query or '').strip(), 'metadata': {}})
         return re.sub(r'\s+', ' ', query or '').strip()
 
     def obfuscate_sql_exec_plan(self, plan, normalize=False):

--- a/datadog_checks_base/datadog_checks/base/utils/_http_utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/_http_utils.py
@@ -1,0 +1,51 @@
+# (C) Datadog, Inc. 2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+from typing import Any
+
+
+def __getattr__(name: str) -> Any:
+    # This is used to lazily load imports when the path contains subpackages
+    if name == 'HostHeaderSSLAdapter':
+        from requests_toolbelt.adapters.host_header_ssl import HostHeaderSSLAdapter
+
+        return HostHeaderSSLAdapter
+
+    if name == 'BotoAWSRequestsAuth':
+        from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
+
+        return BotoAWSRequestsAuth
+
+    if name == 'oauth2':
+        from oauthlib import oauth2
+
+        return oauth2
+
+    if name == 'cryptography_serialization':
+        from cryptography.hazmat.primitives import serialization
+
+        return serialization
+
+    if name == 'cryptography_x509_load_certificate':
+        from cryptography.x509 import load_der_x509_certificate
+
+        return load_der_x509_certificate
+
+    if name == 'cryptography_x509_ExtensionNotFound':
+        from cryptography.x509.extensions import ExtensionNotFound
+
+        return ExtensionNotFound
+
+    if name == 'cryptography_x509_AuthorityInformationAccessOID':
+        from cryptography.x509.oid import AuthorityInformationAccessOID
+
+        return AuthorityInformationAccessOID
+
+    if name == 'cryptography_x509_ExtensionOID':
+        from cryptography.x509.oid import ExtensionOID
+
+        return ExtensionOID
+
+    raise AttributeError(f'`{__name__}` object has no attribute `{name}`')

--- a/datadog_checks_base/datadog_checks/base/utils/db/sql.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/sql.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 import mmh3
 
 from datadog_checks.base import ensure_bytes
-from datadog_checks.base.utils.serialization import json, sort_keys_kwargs
+from datadog_checks.base.utils.format import json
 
 # Unicode character "Arabic Decimal Separator" (U+066B) is a character which looks like an ascii
 # comma, but is not treated like a comma when parsing metrics tags. This is used to replace
@@ -52,5 +52,5 @@ def compute_exec_plan_signature(normalized_json_plan):
     """
     if not normalized_json_plan:
         return None
-    with_sorted_keys = json.dumps(json.loads(normalized_json_plan), **sort_keys_kwargs)
+    with_sorted_keys = json.encode(json.decode(normalized_json_plan), sort_keys=True)
     return format(mmh3.hash64(with_sorted_keys, signed=False)[0], 'x')

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -20,7 +20,7 @@ from datadog_checks.base import is_affirmative
 from datadog_checks.base.agent import datadog_agent
 from datadog_checks.base.log import get_check_logger
 from datadog_checks.base.utils.db.types import Transformer  # noqa: F401
-from datadog_checks.base.utils.serialization import json
+from datadog_checks.base.utils.format import json
 from datadog_checks.base.utils.tracing import INTEGRATION_TRACING_SERVICE_NAME, tracing_enabled
 
 from ..common import to_native_string
@@ -193,7 +193,7 @@ def get_agent_host_tags():
     if not host_tags:
         return result
     try:
-        tags_dict = json.loads(host_tags) or {}
+        tags_dict = json.decode(host_tags) or {}
         for key, value in tags_dict.items():
             if isinstance(value, list):
                 result.extend(value)
@@ -250,7 +250,7 @@ def obfuscate_sql_with_metadata(query, options=None, replace_null_character=Fals
     if not statement.startswith('{'):
         return {'query': statement, 'metadata': {}}
 
-    statement_with_metadata = json.loads(statement)
+    statement_with_metadata = json.decode(statement)
     metadata = statement_with_metadata.get('metadata', {})
     tables = metadata.pop('tables_csv', None)
     tables = [table.strip() for table in tables.split(',') if table != ''] if tables else None

--- a/datadog_checks_base/datadog_checks/base/utils/format/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/utils/format/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/datadog_checks_base/datadog_checks/base/utils/format/_json.py
+++ b/datadog_checks_base/datadog_checks/base/utils/format/_json.py
@@ -1,0 +1,43 @@
+# (C) Datadog, Inc. 2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+try:
+    import orjson
+
+    logger.debug('Using JSON implementation from orjson')
+
+    def decode(s: str | bytes) -> Any:
+        return orjson.loads(s)
+
+    def encode(obj: Any, *, sort_keys: bool = False, default: Callable[[Any], Any] | None = None) -> str:
+        return encode_bytes(obj, sort_keys=sort_keys, default=default).decode()
+
+    def encode_bytes(obj: Any, *, sort_keys: bool = False, default: Callable[[Any], Any] | None = None) -> bytes:
+        if sort_keys:
+            return orjson.dumps(obj, option=orjson.OPT_SORT_KEYS, default=default)
+
+        return orjson.dumps(obj, default=default)
+
+except ImportError:
+    import json
+
+    logger.debug('Using JSON implementation from stdlib')
+
+    def decode(s: str | bytes) -> Any:
+        return json.loads(s)
+
+    def encode(obj: Any, *, sort_keys: bool = False, default: Callable[[Any], Any] | None = None) -> str:
+        return json.dumps(obj, sort_keys=sort_keys, separators=(',', ':'), default=default)
+
+    def encode_bytes(obj: Any, *, sort_keys: bool = False, default: Callable[[Any], Any] | None = None) -> bytes:
+        return encode(obj, sort_keys=sort_keys, default=default).encode()

--- a/datadog_checks_base/datadog_checks/base/utils/format/json.py
+++ b/datadog_checks_base/datadog_checks/base/utils/format/json.py
@@ -1,0 +1,30 @@
+# (C) Datadog, Inc. 2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING, Any
+
+import lazy_loader
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from datadog_checks.base.utils.format import _json
+
+with warnings.catch_warnings():
+    warnings.filterwarnings('ignore', category=RuntimeWarning, module='lazy_loader')
+    json: _json = lazy_loader.load('datadog_checks.base.utils.format._json')
+
+
+def decode(s: str | bytes) -> Any:
+    return json.decode(s)
+
+
+def encode(obj: Any, *, sort_keys: bool = False, default: Callable[[Any], Any] | None = None) -> str:
+    return json.encode(obj, sort_keys=sort_keys, default=default)
+
+
+def encode_bytes(obj: Any, *, sort_keys: bool = False, default: Callable[[Any], Any] | None = None) -> bytes:
+    return json.encode_bytes(obj, sort_keys=sort_keys, default=default)

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -1,28 +1,27 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
 import logging
 import os
 import re
 import ssl
-from contextlib import contextmanager
+import warnings
+from contextlib import ExitStack, contextmanager
 from copy import deepcopy
-from io import open
-from ipaddress import ip_address, ip_network
 from urllib.parse import quote, urlparse, urlunparse
 
+import lazy_loader
 import requests
-import requests_unixsocket
 from binary import KIBIBYTE
-from cryptography.x509 import load_der_x509_certificate
-from cryptography.x509.extensions import ExtensionNotFound
-from cryptography.x509.oid import AuthorityInformationAccessOID, ExtensionOID
 from requests import auth as requests_auth
 from requests.exceptions import SSLError
-from requests_toolbelt.adapters import host_header_ssl
+from urllib3.exceptions import InsecureRequestWarning
 from wrapt import ObjectProxy
 
 from datadog_checks.base.agent import datadog_agent
+from datadog_checks.base.utils import _http_utils
 
 from ..config import is_affirmative
 from ..errors import ConfigurationError
@@ -31,19 +30,16 @@ from .headers import get_default_headers, update_headers
 from .network import CertAdapter, create_socket_connection
 from .time import get_timestamp
 
-try:
-    from contextlib import ExitStack
-except ImportError:
-    from contextlib2 import ExitStack
+# Import lazily to reduce memory footprint, and ease installation of optional dependencies for development
+requests_kerberos = lazy_loader.load('requests_kerberos')
+requests_ntlm = lazy_loader.load('requests_ntlm')
+requests_oauthlib = lazy_loader.load('requests_oauthlib')
+requests_unixsocket = lazy_loader.load('requests_unixsocket')
+jwt = lazy_loader.load('jwt')
+ipaddress = lazy_loader.load('ipaddress')
 
-# Import lazily to reduce memory footprint and ease installation for development
-requests_aws = None
-requests_kerberos = None
-requests_ntlm = None
-requests_oauthlib = None
-oauth2 = None
-jwt = None
-serialization = None
+# We log instead of emit warnings for unintentionally insecure HTTPS requests
+warnings.simplefilter('ignore', InsecureRequestWarning)
 
 LOGGER = logging.getLogger(__file__)
 
@@ -499,23 +495,26 @@ class RequestsWrapper(object):
         # https://tools.ietf.org/html/rfc3280#section-4.2.2.1
         # https://tools.ietf.org/html/rfc5280#section-5.2.7
         try:
-            cert = load_der_x509_certificate(der_cert)
+            cert = _http_utils.cryptography_x509_load_certificate(der_cert)
         except Exception as e:
             self.logger.error('Error while deserializing peer certificate to discover intermediate certificates: %s', e)
             return
 
         try:
             authority_information_access = cert.extensions.get_extension_for_oid(
-                ExtensionOID.AUTHORITY_INFORMATION_ACCESS
+                _http_utils.cryptography_x509_ExtensionOID.AUTHORITY_INFORMATION_ACCESS
             )
-        except ExtensionNotFound:
+        except _http_utils.cryptography_x509_ExtensionNotFound:
             self.logger.debug(
                 'No Authority Information Access extension found, skipping discovery of intermediate certificates'
             )
             return
 
         for access_description in authority_information_access.value:
-            if access_description.access_method != AuthorityInformationAccessOID.CA_ISSUERS:
+            if (
+                access_description.access_method
+                != _http_utils.cryptography_x509_AuthorityInformationAccessOID.CA_ISSUERS
+            ):
                 continue
 
             uri = access_description.access_location.value
@@ -541,7 +540,7 @@ class RequestsWrapper(object):
             # Enables HostHeaderSSLAdapter
             # https://toolbelt.readthedocs.io/en/latest/adapters.html#hostheaderssladapter
             if self.tls_use_host_header:
-                self._session.mount('https://', host_header_ssl.HostHeaderSSLAdapter())
+                self._session.mount('https://', _http_utils.HostHeaderSSLAdapter())
             # Enable Unix Domain Socket (UDS) support.
             # See: https://github.com/msabramo/requests-unixsocket
             self._session.mount('{}://'.format(UDS_SCHEME), requests_unixsocket.UnixAdapter())
@@ -619,9 +618,9 @@ def should_bypass_proxy(url, no_proxy_uris):
         try:
             # If no_proxy_uri is an IP or IP CIDR.
             # A ValueError is raised if address does not represent a valid IPv4 or IPv6 address.
-            ipnetwork = ip_network(ensure_unicode(no_proxy_uri))
-            ipaddress = ip_address(ensure_unicode(parsed_uri))
-            if ipaddress in ipnetwork:
+            ip_network = ipaddress.ip_network(ensure_unicode(no_proxy_uri))
+            ip_address = ipaddress.ip_address(ensure_unicode(parsed_uri))
+            if ip_address in ip_network:
                 return True
         except ValueError:
             # Treat no_proxy_uri as a domain name
@@ -655,21 +654,13 @@ def create_digest_auth(config):
 
 
 def create_ntlm_auth(config):
-    global requests_ntlm
-    if requests_ntlm is None:
-        import requests_ntlm
-
     return requests_ntlm.HttpNtlmAuth(config['ntlm_domain'], config['password'])
 
 
 def create_kerberos_auth(config):
-    global requests_kerberos
-    if requests_kerberos is None:
-        import requests_kerberos
-
-        KERBEROS_STRATEGIES['required'] = requests_kerberos.REQUIRED
-        KERBEROS_STRATEGIES['optional'] = requests_kerberos.OPTIONAL
-        KERBEROS_STRATEGIES['disabled'] = requests_kerberos.DISABLED
+    KERBEROS_STRATEGIES['required'] = requests_kerberos.REQUIRED
+    KERBEROS_STRATEGIES['optional'] = requests_kerberos.OPTIONAL
+    KERBEROS_STRATEGIES['disabled'] = requests_kerberos.DISABLED
 
     # For convenience
     if config['kerberos_auth'] is None or is_affirmative(config['kerberos_auth']):
@@ -692,15 +683,11 @@ def create_kerberos_auth(config):
 
 
 def create_aws_auth(config):
-    global requests_aws
-    if requests_aws is None:
-        from aws_requests_auth import boto_utils as requests_aws
-
     for setting in ('aws_host', 'aws_region', 'aws_service'):
         if not config[setting]:
             raise ConfigurationError('AWS auth requires the setting `{}`'.format(setting))
 
-    return requests_aws.BotoAWSRequestsAuth(
+    return _http_utils.BotoAWSRequestsAuth(
         aws_host=config['aws_host'], aws_region=config['aws_region'], aws_service=config['aws_service']
     )
 
@@ -851,15 +838,7 @@ class AuthTokenOAuthReader(object):
 
     def read(self, **request):
         if self._token is None or get_timestamp() >= self._expiration or 'error' in request:
-            global oauth2
-            if oauth2 is None:
-                from oauthlib import oauth2
-
-            global requests_oauthlib
-            if requests_oauthlib is None:
-                import requests_oauthlib
-
-            client = oauth2.BackendApplicationClient(client_id=self._client_id)
+            client = _http_utils.oauth2.BackendApplicationClient(client_id=self._client_id)
             oauth = requests_oauthlib.OAuth2Session(client=client)
             response = oauth.fetch_token(**self._fetch_options)
 
@@ -911,20 +890,12 @@ class DCOSAuthTokenReader(object):
     def read(self, **request):
         if self._token is None or 'error' in request:
             with open(self._private_key_path, 'rb') as f:
-                global serialization
-                if serialization is None:
-                    from cryptography.hazmat.primitives import serialization
-
-                global jwt
-                if jwt is None:
-                    import jwt
-
-                private_key = serialization.load_pem_private_key(f.read(), password=None)
+                private_key = _http_utils.cryptography_serialization.load_pem_private_key(f.read(), password=None)
 
                 serialized_private = private_key.private_bytes(
-                    encoding=serialization.Encoding.PEM,
-                    format=serialization.PrivateFormat.PKCS8,
-                    encryption_algorithm=serialization.NoEncryption(),
+                    encoding=_http_utils.cryptography_serialization.Encoding.PEM,
+                    format=_http_utils.cryptography_serialization.PrivateFormat.PKCS8,
+                    encryption_algorithm=_http_utils.cryptography_serialization.NoEncryption(),
                 )
 
                 exp = int(get_timestamp() + self._expiration)

--- a/datadog_checks_base/datadog_checks/base/utils/replay/execute.py
+++ b/datadog_checks_base/datadog_checks/base/utils/replay/execute.py
@@ -5,9 +5,10 @@ import os
 import subprocess
 import sys
 
+from datadog_checks.base.utils.format import json
+
 from ..common import ensure_bytes, to_native_string
 from ..platform import Platform
-from ..serialization import json
 from .constants import KNOWN_DATADOG_AGENT_SETTER_METHODS, EnvVars
 
 
@@ -24,8 +25,8 @@ def run_with_isolation(check, aggregator, datadog_agent):
     env_vars[EnvVars.MESSAGE_INDICATOR] = message_indicator
     env_vars[EnvVars.CHECK_NAME] = check.name
     env_vars[EnvVars.CHECK_ID] = check.check_id
-    env_vars[EnvVars.INIT_CONFIG] = to_native_string(json.dumps(init_config))
-    env_vars[EnvVars.INSTANCE] = to_native_string(json.dumps(instance))
+    env_vars[EnvVars.INIT_CONFIG] = to_native_string(json.encode(init_config))
+    env_vars[EnvVars.INSTANCE] = to_native_string(json.encode(instance))
 
     if Platform.is_windows():
         env_vars[EnvVars.DDTRACE] = "false"
@@ -60,7 +61,7 @@ def run_with_isolation(check, aggregator, datadog_agent):
             check.log.trace(line)
 
             message_type, _, message = procedure.partition(':')
-            message = json.loads(message)
+            message = json.decode(message)
             if message_type == 'aggregator':
                 getattr(aggregator, message['method'])(check, *message['args'], **message['kwargs'])
             elif message_type == 'log':
@@ -69,7 +70,7 @@ def run_with_isolation(check, aggregator, datadog_agent):
                 method = message['method']
                 value = getattr(datadog_agent, method)(*message['args'], **message['kwargs'])
                 if method not in KNOWN_DATADOG_AGENT_SETTER_METHODS:
-                    process.stdin.write(b'%s\n' % ensure_bytes(json.dumps({'value': value})))
+                    process.stdin.write(b'%s\n' % ensure_bytes(json.encode({'value': value})))
                     process.stdin.flush()
             elif message_type == 'error':
                 check.log.error(message[0]['traceback'])

--- a/datadog_checks_base/datadog_checks/base/utils/replay/redirect.py
+++ b/datadog_checks_base/datadog_checks/base/utils/replay/redirect.py
@@ -5,12 +5,13 @@ import logging
 import os
 import sys
 
+from datadog_checks.base.utils.format import json
+
 from ...checks import base
 from ...log import LOG_LEVEL_MAP, TRACE_LEVEL, _get_py_loglevel
 from ...utils.common import to_native_string
 from ...utils.metadata import core
 from ...utils.replay.constants import KNOWN_DATADOG_AGENT_SETTER_METHODS, EnvVars
-from ...utils.serialization import json
 
 MESSAGE_INDICATOR = os.environ[EnvVars.MESSAGE_INDICATOR]
 LOG_METHODS = {log_level: log_method.lower() for log_method, log_level in LOG_LEVEL_MAP.items()}
@@ -30,7 +31,7 @@ class ReplayAggregator(object):
             print(
                 '{}:aggregator:{}'.format(
                     MESSAGE_INDICATOR,
-                    to_native_string(json.dumps({'method': method_name, 'args': list(args)[1:], 'kwargs': kwargs})),
+                    to_native_string(json.encode({'method': method_name, 'args': list(args)[1:], 'kwargs': kwargs})),
                 )
             )
 
@@ -49,11 +50,11 @@ class ReplayDatadogAgent(object):
             print(
                 '{}:datadog_agent:{}'.format(
                     MESSAGE_INDICATOR,
-                    to_native_string(json.dumps({'method': method_name, 'args': list(args), 'kwargs': kwargs})),
+                    to_native_string(json.encode({'method': method_name, 'args': list(args), 'kwargs': kwargs})),
                 )
             )
             if read:
-                return json.loads(sys.stdin.readline())['value']
+                return json.decode(sys.stdin.readline())['value']
 
         return method
 
@@ -63,7 +64,7 @@ class ReplayLogger(logging.Logger):
         print(
             '{}:log:{}'.format(
                 MESSAGE_INDICATOR,
-                to_native_string(json.dumps({'method': LOG_METHODS[level], 'args': [str(a) for a in args]})),
+                to_native_string(json.encode({'method': LOG_METHODS[level], 'args': [str(a) for a in args]})),
             )
         )
 
@@ -80,8 +81,8 @@ logging.getLogger().setLevel(_get_py_loglevel(base.datadog_agent.get_config('log
 def run_check(check_class):
     check = check_class(
         os.environ[EnvVars.CHECK_NAME],
-        json.loads(os.environ[EnvVars.INIT_CONFIG]),
-        [json.loads(os.environ[EnvVars.INSTANCE])],
+        json.decode(os.environ[EnvVars.INIT_CONFIG]),
+        [json.decode(os.environ[EnvVars.INSTANCE])],
     )
     check.check_id = os.environ[EnvVars.CHECK_ID]
 

--- a/datadog_checks_base/datadog_checks/base/utils/serialization.py
+++ b/datadog_checks_base/datadog_checks/base/utils/serialization.py
@@ -1,3 +1,8 @@
+"""
+This module is deprecated and will begin emitting deprecation warnings after all official
+integrations have migrated to the new `datadog_checks.base.utils.format.json` module.
+"""
+
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)

--- a/datadog_checks_base/datadog_checks/base/utils/tracing.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tracing.py
@@ -1,14 +1,23 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+from __future__ import annotations
+
 import functools
-import inspect
 import os
+from typing import TYPE_CHECKING
+
+import lazy_loader
 
 from datadog_checks.base.agent import datadog_agent
 
 from ..config import is_affirmative
 from ..utils.common import to_native_string
+
+if TYPE_CHECKING:
+    import inspect as _module_inspect
+
+inspect: _module_inspect = lazy_loader.load('inspect')
 
 EXCLUDED_MODULES = ['threading']
 

--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -23,7 +23,7 @@ from datadog_checks.base.utils.db.utils import (
     resolve_db_host,
     tracked_query,
 )
-from datadog_checks.base.utils.serialization import json
+from datadog_checks.base.utils.format import json
 
 
 @pytest.mark.parametrize(
@@ -129,7 +129,7 @@ class DBExceptionForTests(BaseException):
     "obfuscator_return_value,expected_value",
     [
         (
-            json.dumps(
+            json.encode(
                 {
                     'query': 'SELECT * FROM datadog',
                     'metadata': {'tables_csv': 'datadog,', 'commands': ['SELECT'], 'comments': None},
@@ -150,7 +150,7 @@ class DBExceptionForTests(BaseException):
             },
         ),
         (
-            json.dumps(
+            json.encode(
                 {
                     'query': 'SELECT * FROM datadog WHERE age = (SELECT AVG(age) FROM datadog2)',
                     'metadata': {
@@ -170,7 +170,7 @@ class DBExceptionForTests(BaseException):
             },
         ),
         (
-            json.dumps(
+            json.encode(
                 {
                     'query': 'COMMIT',
                     'metadata': {'tables_csv': '', 'commands': ['COMMIT'], 'comments': None},
@@ -229,7 +229,7 @@ def test_obfuscate_sql_with_metadata(obfuscator_return_value, expected_value):
 )
 def test_obfuscate_sql_with_metadata_replace_null_character(input_query, expected_query, replace_null_character):
     def _mock_obfuscate_sql(query, options=None):
-        return json.dumps({'query': query, 'metadata': {}})
+        return json.encode({'query': query, 'metadata': {}})
 
     # Check that it can handle null characters
     with mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent:
@@ -374,7 +374,7 @@ def test_dbm_async_job_inactive_stop(aggregator):
 )
 def test_default_json_event_encoding(input):
     # assert that the default json event encoding can handle all defined types without raising TypeError
-    assert json.dumps(input, default=default_json_event_encoding)
+    assert json.encode(input, default=default_json_event_encoding)
 
 
 def test_tracked_query(aggregator):

--- a/datadog_checks_base/tests/base/utils/format/__init__.py
+++ b/datadog_checks_base/tests/base/utils/format/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/datadog_checks_base/tests/base/utils/format/test_json.py
+++ b/datadog_checks_base/tests/base/utils/format/test_json.py
@@ -1,0 +1,26 @@
+# (C) Datadog, Inc. 2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from datadog_checks.base.utils.format import json
+
+
+def test_encode_str():
+    obj = {'b': 2, 'a': 1}
+    encoded = json.encode(obj)
+    assert encoded == '{"b":2,"a":1}'
+    decoded = json.decode(encoded)
+    assert obj == decoded
+
+
+def test_encode_bytes():
+    obj = {'b': 2, 'a': 1}
+    encoded = json.encode_bytes(obj)
+    assert encoded == b'{"b":2,"a":1}'
+    decoded = json.decode(encoded)
+    assert obj == decoded
+
+
+def test_sort_keys():
+    obj = {'b': 2, 'a': 1}
+    encoded = json.encode(obj, sort_keys=True)
+    assert encoded == '{"a":1,"b":2}'

--- a/datadog_checks_base/tests/base/utils/http/test_auth.py
+++ b/datadog_checks_base/tests/base/utils/http/test_auth.py
@@ -123,7 +123,7 @@ def test_config_aws():
     http = RequestsWrapper(instance, init_config)
     assert isinstance(http.options['auth'], requests_aws.BotoAWSRequestsAuth)
 
-    with mock.patch('datadog_checks.base.utils.http.requests_aws.BotoAWSRequestsAuth') as m:
+    with mock.patch('datadog_checks.base.utils.http._http_utils.BotoAWSRequestsAuth') as m:
         RequestsWrapper(instance, init_config)
 
         m.assert_called_once_with(aws_host='uri', aws_region='earth', aws_service='saas')
@@ -137,7 +137,7 @@ def test_config_aws_service_remapper():
         'aws_host': {'name': 'aws_host', 'default': 'uri'},
     }
 
-    with mock.patch('datadog_checks.base.utils.http.requests_aws.BotoAWSRequestsAuth') as m:
+    with mock.patch('datadog_checks.base.utils.http._http_utils.BotoAWSRequestsAuth') as m:
         RequestsWrapper(instance, init_config, remapper)
 
         m.assert_called_once_with(aws_host='uri', aws_region='us-east-1', aws_service='es')


### PR DESCRIPTION
### What does this PR do?

- Reverts this PR minus the changelog entry: https://github.com/DataDog/integrations-core/pull/19781
- Makes a new `datadog_checks.base.utils.format.json` module that everything should switch to instead of `datadog_checks.base.utils.serialization` to avoid always importing `orjson` (and for a nicer API)
- Adds lazy loading to other parts of the base package, especially the HTTP utilities. Checks that use them will now have a much lower memory overhead most of the time (depending on the configuration)

### Motivation

This PR provides a long-term lazy import solution: https://github.com/DataDog/integrations-core/pull/19838

### Notes

- We should switch to using absolute imports everywhere for better readability and the possibility of compiling with Mypyc
- We should also switch all comment-based type hints to standard ones (perhaps there is a tool that can do this semi-automatically)