### PR TITLE
hotfix: pin tj-actions/changed-files by SHA

### DIFF
--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -87,7 +87,7 @@ jobs:
     # that we use the GitHub API, otherwise we would have to fetch the entire history (depth: 0)
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v42
+      uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b # v45.0.8
       with:
         files_yaml: |-
           builders:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR pins the tj-actions/changed-files GitHub action to a SHA corresponding to a version that is not compromised. For details on the compromise, see:

https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/
https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised
Compromised versions leak CI secrets, so this repo's CI secrets will need to be rotated.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
