### PR TITLE
[mongo] increase collection stats and collection index stats collect interval to 5 mins

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -378,14 +378,14 @@ files:
             Only applicable when `collection` is added to `additional_metrics`.
           value:
             type: integer
-            example: 15
+            example: 300
         - name: collections_indexes_stats
           description: |
             The interval in seconds at which to collect collection indexes stats metrics.
             Only applicable when `collections_indexes_stats` is set to `true`.
           value:
             type: integer
-            example: 15
+            example: 300
         - name: sharded_data_distribution
           description: |
             The interval in seconds at which to collect sharded data distribution metrics.

--- a/mongo/changelog.d/19856.added
+++ b/mongo/changelog.d/19856.added
@@ -1,0 +1,1 @@
+Increased default collection stats and collection index stats collect interval to 5 mins.

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -270,10 +270,8 @@ class MongoConfig(object):
         '''
         return {
             # $collStats and $indexStats are collected on every check run but they can get expensive on large databases
-            'collection': int(self._metrics_collection_interval.get('collection', self.min_collection_interval)),
-            'collections_indexes_stats': int(
-                self._metrics_collection_interval.get('collections_indexes_stats', self.min_collection_interval)
-            ),
+            'collection': int(self._metrics_collection_interval.get('collection', 300)),
+            'collections_indexes_stats': int(self._metrics_collection_interval.get('collections_indexes_stats', 300)),
             # $shardDataDistribution stats are collected every 5 minutes by default due to the high resource usage
             'sharded_data_distribution': int(self._metrics_collection_interval.get('sharded_data_distribution', 300)),
             'db_stats': int(self._metrics_collection_interval.get('db_stats', self.min_collection_interval)),

--- a/mongo/tests/test_unit_config.py
+++ b/mongo/tests/test_unit_config.py
@@ -208,8 +208,8 @@ def test_amazon_docdb_cloud_metadata(instance_integration_cluster, aws_cloud_met
         pytest.param(
             {},
             {
-                'collection': 15,
-                'collections_indexes_stats': 15,
+                'collection': 300,
+                'collections_indexes_stats': 300,
                 'sharded_data_distribution': 300,
                 'db_stats': 15,
                 'session_stats': 15,
@@ -240,7 +240,7 @@ def test_amazon_docdb_cloud_metadata(instance_integration_cluster, aws_cloud_met
             },
             {
                 'collection': 60,
-                'collections_indexes_stats': 15,
+                'collections_indexes_stats': 300,
                 'sharded_data_distribution': 300,
                 'db_stats': 30,
                 'session_stats': 15,


### PR DESCRIPTION
### What does this PR do?
This PR increased MongoDB the default collection stats and collection index stats to 5 mins.

### Motivation
Reduce the performance overhead from frequent `$collStats` and `$indexStats` operations on all collections. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
