### PR TITLE
Pgbouncer connection lifecycle fixes

### DIFF
--- a/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
+++ b/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
@@ -231,7 +231,7 @@ class PgBouncer(AgentCheck):
         if not self.connection:
             self.log.warning("Cannot get version: no active connection")
             return None
-            
+
         regex = r'\d+\.\d+\.\d+'
         with self.connection.cursor(cursor_factory=pgextras.DictCursor) as cursor:
             cursor.execute('SHOW VERSION;')

--- a/pgbouncer/tests/test_pgbouncer_unit.py
+++ b/pgbouncer/tests/test_pgbouncer_unit.py
@@ -3,6 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 import pytest
+from unittest.mock import patch, MagicMock
 
 from datadog_checks.base import ConfigurationError
 from datadog_checks.pgbouncer import PgBouncer
@@ -20,3 +21,70 @@ def test_config_missing_user(instance):
     with pytest.raises(ConfigurationError):
         del instance['username']
         PgBouncer('pgbouncer', {}, [instance])
+
+
+@pytest.mark.unit
+def test_connection_cleanup_on_error(instance):
+    """
+    This test ensures that connection resources are properly cleaned up when a connection fails to establish.
+    """
+    mock_connection = MagicMock()
+    mock_connection.close = MagicMock()
+    
+    with patch('psycopg2.connect', side_effect=Exception("Connection failed")):
+        check = PgBouncer('pgbouncer', {}, [instance])
+        with pytest.raises(Exception):
+            check._get_connection(use_cached=False)
+        
+        # Verify no connection was stored
+        assert check.connection is None
+
+
+@pytest.mark.unit
+def test_connection_lifecycle_without_caching(instance):
+    """
+    This test verifies the complete lifecycle of a connection when caching is disabled (use_cached=False).
+    The test confirms that connections are properly initialized for metrics collection and fully cleaned up,
+    preventing connection leaks.
+    """
+    mock_connection = MagicMock()
+    mock_connection.close = MagicMock()
+    mock_connection.notices = []
+    mock_connection.cursor.return_value.__enter__.return_value.fetchone.return_value = ['1.2.3']
+    
+    with patch('psycopg2.connect', return_value=mock_connection) as mock_connect:
+        instance['use_cached'] = False
+        check = PgBouncer('pgbouncer', {}, [instance])
+        
+        # Run the check
+        check.check(instance)
+        
+        # Verify exactly one connection was created and closed
+        assert mock_connect.call_count == 1
+        assert mock_connection.close.call_count == 1
+        assert check.connection is None
+
+
+@pytest.mark.unit
+def test_connection_lifecycle_with_caching(instance):
+    """
+    This test verifies connection handling when caching is enabled (use_cached=True).
+    This test ensures that cached connections persist correctly between checks while still being
+    properly managed.
+    """
+    mock_connection = MagicMock()
+    mock_connection.close = MagicMock()
+    mock_connection.notices = []
+    mock_connection.cursor.return_value.__enter__.return_value.fetchone.return_value = ['1.2.3']
+    
+    with patch('psycopg2.connect', return_value=mock_connection) as mock_connect:
+        instance['use_cached'] = True
+        check = PgBouncer('pgbouncer', {}, [instance])
+        
+        # Run the check
+        check.check(instance)
+        
+        # Verify exactly one connection was created and kept open
+        assert mock_connect.call_count == 1
+        assert mock_connection.close.call_count == 0
+        assert check.connection is not None

--- a/pgbouncer/tests/test_pgbouncer_unit.py
+++ b/pgbouncer/tests/test_pgbouncer_unit.py
@@ -2,8 +2,9 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 
 from datadog_checks.base import ConfigurationError
 from datadog_checks.pgbouncer import PgBouncer
@@ -31,12 +32,12 @@ def test_connection_cleanup_on_error(instance, use_cached):
     """
     mock_connection = MagicMock()
     mock_connection.close = MagicMock()
-    
+
     with patch('psycopg2.connect', side_effect=Exception("Connection failed")):
         check = PgBouncer('pgbouncer', {}, [instance])
         with pytest.raises(Exception):
             check._get_connection(use_cached=use_cached)
-        
+
         # Verify no connection was stored
         assert check.connection is None
 
@@ -52,14 +53,14 @@ def test_connection_lifecycle_without_caching(instance):
     mock_connection.close = MagicMock()
     mock_connection.notices = []
     mock_connection.cursor.return_value.__enter__.return_value.fetchone.return_value = ['1.2.3']
-    
+
     with patch('psycopg2.connect', return_value=mock_connection) as mock_connect:
         instance['use_cached'] = False
         check = PgBouncer('pgbouncer', {}, [instance])
-        
+
         # Run the check
         check.check(instance)
-        
+
         # Verify exactly one connection was created and closed
         assert mock_connect.call_count == 1
         assert mock_connection.close.call_count == 1
@@ -77,14 +78,14 @@ def test_connection_lifecycle_with_caching(instance):
     mock_connection.close = MagicMock()
     mock_connection.notices = []
     mock_connection.cursor.return_value.__enter__.return_value.fetchone.return_value = ['1.2.3']
-    
+
     with patch('psycopg2.connect', return_value=mock_connection) as mock_connect:
         instance['use_cached'] = True
         check = PgBouncer('pgbouncer', {}, [instance])
-        
+
         # Run the check
         check.check(instance)
-        
+
         # Verify exactly one connection was created and kept open
         assert mock_connect.call_count == 1
         assert mock_connection.close.call_count == 0
@@ -100,12 +101,12 @@ def test_connection_cleanup_on_isolation_level_error(instance, use_cached):
     mock_connection = MagicMock()
     mock_connection.close = MagicMock()
     mock_connection.set_isolation_level.side_effect = Exception("Failed to set isolation level")
-    
+
     with patch('psycopg2.connect', return_value=mock_connection):
         check = PgBouncer('pgbouncer', {}, [instance])
         with pytest.raises(Exception):
             check._get_connection(use_cached=use_cached)
-        
+
         # Verify connection was closed and not stored
         assert mock_connection.close.call_count == 1
         assert check.connection is None

--- a/pgbouncer/tests/test_pgbouncer_unit.py
+++ b/pgbouncer/tests/test_pgbouncer_unit.py
@@ -24,7 +24,8 @@ def test_config_missing_user(instance):
 
 
 @pytest.mark.unit
-def test_connection_cleanup_on_error(instance):
+@pytest.mark.parametrize('use_cached', [True, False])
+def test_connection_cleanup_on_error(instance, use_cached):
     """
     This test ensures that connection resources are properly cleaned up when a connection fails to establish.
     """
@@ -34,7 +35,7 @@ def test_connection_cleanup_on_error(instance):
     with patch('psycopg2.connect', side_effect=Exception("Connection failed")):
         check = PgBouncer('pgbouncer', {}, [instance])
         with pytest.raises(Exception):
-            check._get_connection(use_cached=False)
+            check._get_connection(use_cached=use_cached)
         
         # Verify no connection was stored
         assert check.connection is None
@@ -91,7 +92,8 @@ def test_connection_lifecycle_with_caching(instance):
 
 
 @pytest.mark.unit
-def test_connection_cleanup_on_isolation_level_error(instance):
+@pytest.mark.parametrize('use_cached', [True, False])
+def test_connection_cleanup_on_isolation_level_error(instance, use_cached):
     """
     This test ensures that connection resources are properly cleaned up when setting the isolation level fails.
     """
@@ -102,7 +104,7 @@ def test_connection_cleanup_on_isolation_level_error(instance):
     with patch('psycopg2.connect', return_value=mock_connection):
         check = PgBouncer('pgbouncer', {}, [instance])
         with pytest.raises(Exception):
-            check._get_connection(use_cached=False)
+            check._get_connection(use_cached=use_cached)
         
         # Verify connection was closed and not stored
         assert mock_connection.close.call_count == 1


### PR DESCRIPTION
### What does this PR do?
This PR fixes:
1) Leaving connections open if an exception occurs right after opening a connection.
2) Leaving connections open after a check iteration when use_cached is set to false.
3) Opening two connections per check iteration when use_cached is set to false.

Use_cached controls connection caching between iterations.


### Motivation

This PR is a possible fix for AGENT-13032 (pgbouncer integration opens two persistent connections).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
…nnection caching is disabled.