### PR TITLE
FoundationDB: Respect 'tls_ca_file' and 'tls_password' config options

### DIFF
--- a/foundationdb/changelog.d/19865.fixed
+++ b/foundationdb/changelog.d/19865.fixed
@@ -1,0 +1,1 @@
+Respect `tls_ca_file` and `tls_password` config options

--- a/foundationdb/datadog_checks/foundationdb/check.py
+++ b/foundationdb/datadog_checks/foundationdb/check.py
@@ -30,6 +30,8 @@ class FoundationdbCheck(AgentCheck):
             fdb.options.set_tls_cert_path(self.instance.get('tls_certificate_file'))
         if 'tls_key_file' in self.instance:
             fdb.options.set_tls_key_path(self.instance.get('tls_key_file'))
+        if 'tls_password' in self.instance:
+            fdb.options.set_tls_password(self.instance.get('tls_password'))
         if 'tls_verify_peers' in self.instance:
             fdb.options.set_tls_verify_peers(self.instance.get('tls_verify_peers').encode('latin-1'))
 

--- a/foundationdb/datadog_checks/foundationdb/check.py
+++ b/foundationdb/datadog_checks/foundationdb/check.py
@@ -28,10 +28,10 @@ class FoundationdbCheck(AgentCheck):
             fdb.options.set_tls_ca_path(self.instance.get('tls_ca_file'))
         if 'tls_certificate_file' in self.instance:
             fdb.options.set_tls_cert_path(self.instance.get('tls_certificate_file'))
-        if 'tls_key_file' in self.instance:
-            fdb.options.set_tls_key_path(self.instance.get('tls_key_file'))
         if 'tls_password' in self.instance:
             fdb.options.set_tls_password(self.instance.get('tls_password'))
+        if 'tls_key_file' in self.instance:
+            fdb.options.set_tls_key_path(self.instance.get('tls_key_file'))
         if 'tls_verify_peers' in self.instance:
             fdb.options.set_tls_verify_peers(self.instance.get('tls_verify_peers').encode('latin-1'))
 

--- a/foundationdb/datadog_checks/foundationdb/check.py
+++ b/foundationdb/datadog_checks/foundationdb/check.py
@@ -24,6 +24,8 @@ class FoundationdbCheck(AgentCheck):
             return self._db
 
         # TLS options. Each option has a different function name, so we cannot be smart with it without ugly code
+        if 'tls_ca_file' in self.instance:
+            fdb.options.set_tls_ca_path(self.instance.get('tls_ca_file'))
         if 'tls_certificate_file' in self.instance:
             fdb.options.set_tls_cert_path(self.instance.get('tls_certificate_file'))
         if 'tls_key_file' in self.instance:


### PR DESCRIPTION
### What does this PR do?
[Fix the FoundationDB check so that the 'tls_ca_file' and 'tls_password' options are respected.](https://github.com/DataDog/integrations-core/blob/master/foundationdb/datadog_checks/foundationdb/data/conf.yaml.example#L48)

### Motivation
They weren't being respected.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
