### PR TITLE
[AI-5168] Add debug logging in compute-matrix step

### DIFF
--- a/.github/workflows/compute-matrix.yml
+++ b/.github/workflows/compute-matrix.yml
@@ -41,6 +41,7 @@ jobs:
       # Generic version of the following:
       # https://gist.github.com/bnb/9de89a07278e9f57cd058a535ab89a9b?permalink_comment_id=4417593#gistcomment-4417593
       run: |-
+        echo "TEST"
         # Fetch commits to a depth so that head and base reach their merge base.
         comparison=$(gh api\
           repos/${{ github.repository }}/compare/${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }})

--- a/.github/workflows/compute-matrix.yml
+++ b/.github/workflows/compute-matrix.yml
@@ -41,7 +41,9 @@ jobs:
       # Generic version of the following:
       # https://gist.github.com/bnb/9de89a07278e9f57cd058a535ab89a9b?permalink_comment_id=4417593#gistcomment-4417593
       run: |-
-        echo "TEST"
+        base_sha=${{ github.event.pull_request.base.sha }}
+        head_sha=${{ github.event.pull_request.head.sha }}
+        echo "base is $base_sha, head is $head_sha"
         # Fetch commits to a depth so that head and base reach their merge base.
         comparison=$(gh api\
           repos/${{ github.repository }}/compare/${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }})


### PR DESCRIPTION
### What does this PR do?
The compute-matrix step has been failing in master pipelines and some merge queue pipelines with the error: `gh: Not Found (HTTP 404)`. This will help confirm the issue. 

from this comment: https://gist.github.com/bnb/9de89a07278e9f57cd058a535ab89a9b?permalink_comment_id=4417593 it seems like `github.event.pull_request.head.sha` could be missing on the merge queues, so extra logging can confirm this. 

note: we already log these values later on in the script, this is is just allowing us to see the values before the github api fails. we can revert this once the issue is fixed


### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
