### PR TITLE
dont run compute_matrix on merge_group

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -24,6 +24,9 @@ on:
 jobs:
   compute-matrix:
     uses: ./.github/workflows/compute-matrix.yml
+    # this job always fails in the merge queue due to lack of
+    # github.event.pull_request.head.sha and github.event.pull_request.base.sha,
+    # and we don't run tests in the merge queue now so it's not needed
     if: github.event_name != 'merge_group'
     with:
       repo: "${{ inputs.repo }}"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -24,6 +24,7 @@ on:
 jobs:
   compute-matrix:
     uses: ./.github/workflows/compute-matrix.yml
+    if: github.event_name != 'merge_group'
     with:
       repo: "${{ inputs.repo }}"
 


### PR DESCRIPTION
### What does this PR do?
Stop running compute_matrix on merge_group
### Motivation
it always fails due to lack of `github.event.pull_request.head.sha` and `github.event.pull_request.base.sha`, and we don't run tests in merge_group so it's not needed 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
