### PR TITLE
Cleanup for GKE recommendations

### DIFF
--- a/gke/README.md
+++ b/gke/README.md
@@ -45,7 +45,7 @@ Deploy a [containerized version of the Datadog Agent][7] on your Kubernetes clus
 
 Autopilot requires a more distinct setup for the Kubernetes installation compared to the standard installation. This type of cluster requires using the Datadog Helm chart.
 
-Deploy a [containerized version of the Datadog Agent][7] on your Kubernetes cluster with the Helm [installation of the Datadog Agent on Kubernetes][16]. When setting your Helm `datadog-values.yaml` configuration, see the [GKE Autopilot section on the Kubernetes Distributions][14] for the necessary configuration changes. Most notably setting `providers.gke.autopilot` to `true`.
+Deploy a [containerized version of the Datadog Agent][7] on your Kubernetes cluster with the Helm [installation of the Datadog Agent on Kubernetes][16]. When setting your Helm `datadog-values.yaml` configuration, see the [GKE Autopilot section on the Kubernetes Distributions][14] for the necessary configuration changes. Most notably, set `providers.gke.autopilot` to `true`.
 
 #### Admission Controller
  

--- a/gke/README.md
+++ b/gke/README.md
@@ -22,7 +22,7 @@ You can then access an out-of-the-box [Google Compute Engine dashboard][6] that 
 
 ### Set up the Kubernetes integration
 
-To further monitor you GKE cluster install the Datadog Agent utilizing the Datadog Helm Chart or Datadog Operator. Once deployed the Datadog Agent and Datadog Cluster Agent will monitor your cluster and the workloads on it.
+To further monitor your GKE cluster, install the Datadog Agent using the Datadog Helm Chart or Datadog Operator. Once deployed, the Datadog Agent and Datadog Cluster Agent monitor your cluster and the workloads on it.
 
 GKE supports two [main modes of operation][15] that can change the level of flexibility, responsibility, and control that you have over your cluster. These different modes change how you deploy the Datadog components.
 
@@ -43,7 +43,7 @@ Deploy a [containerized version of the Datadog Agent][7] on your Kubernetes clus
 
 #### Autopilot
 
-Autopilot requires a more distinct setup for the Kubernetes installation compared to the standard installation. This type of cluster requires using the Datadog Helm Chart. See the configuration in the GKE [Autopilot section][14] of the Kubernetes distributions page for the required changes to your Helm configuration.
+Autopilot requires a more distinct setup for the Kubernetes installation compared to the standard installation. This type of cluster requires using the Datadog Helm chart. See the configuration in the GKE [Autopilot section][14] of the Kubernetes distributions page for the required changes to your Helm configuration.
 
 After that you will deploy a [containerized version of the Datadog Agent][7] on your Kubernetes cluster with the Helm [installation of the Datadog Agent on Kubernetes][16] with this Autopilot based configuration.
 

--- a/gke/README.md
+++ b/gke/README.md
@@ -43,9 +43,9 @@ Deploy a [containerized version of the Datadog Agent][7] on your Kubernetes clus
 
 #### Autopilot
 
-Autopilot requires a more distinct setup for the Kubernetes installation compared to the standard installation. This type of cluster requires using the Datadog Helm chart. See the configuration in the GKE [Autopilot section][14] of the Kubernetes distributions page for the required changes to your Helm configuration.
+Autopilot requires a more distinct setup for the Kubernetes installation compared to the standard installation. This type of cluster requires using the Datadog Helm chart.
 
-After that you will deploy a [containerized version of the Datadog Agent][7] on your Kubernetes cluster with the Helm [installation of the Datadog Agent on Kubernetes][16] with this Autopilot based configuration.
+Deploy a [containerized version of the Datadog Agent][7] on your Kubernetes cluster with the Helm [installation of the Datadog Agent on Kubernetes][16]. When setting your Helm `datadog-values.yaml` configuration, see the [GKE Autopilot section on the Kubernetes Distributions][14] for the necessary configuration changes. Most notably setting `providers.gke.autopilot` to `true`.
 
 #### Admission Controller
  

--- a/gke/README.md
+++ b/gke/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Google Kubernetes Engine (GKE), a service on the Google Cloud Platform (GCP), is a hosted platform for running and orchestrating containerized applications. Similar to Amazon's Elastic Container Service (ECS), GKE manages Docker containers deployed on a cluster of machines. However, unlike ECS, GKE uses Kubernetes.
+Google Kubernetes Engine (GKE), a service on the Google Cloud Platform (GCP), is a hosted platform for running and orchestrating containerized applications backed by Kubernetes. GKE clusters can be monitored by the [Google Cloud Platform][5] integration as well as by the Datadog Agent running as workloads within the cluster.
 
 ## Setup
 
@@ -14,21 +14,17 @@ Google Kubernetes Engine (GKE), a service on the Google Cloud Platform (GCP), is
 
 3. Install the [Google Cloud SDK][3] and the `kubectl` command line tool on your local machine. Once you [pair the Cloud SDK with your GCP account][4], you can control your clusters directly from your local machine using `kubectl`.
 
-4. Create a small GKE cluster named `doglib` with the ability to access the Cloud Datastore by running the following command:
-
-```
-$  gcloud container clusters create doglib --num-nodes 3 --zone "us-central1-b" --scopes "cloud-platform"
-```
-
 ### Set up the GCE integration 
 
 Install the [Google Cloud Platform][5] integration.
 
 You can then access an out-of-the-box [Google Compute Engine dashboard][6] that displays metrics like disk I/O, CPU utilization, and network traffic.
 
-### Set up the GKE integration
+### Set up the Kubernetes integration
 
-Choose a mode of operation. A *mode of operation* refers to the level of flexibility, responsibility, and control that you have over your cluster. GKE offers two modes of operation:
+To further monitor you GKE cluster install the Datadog Agent utilizing the Datadog Helm Chart or Datadog Operator. Once deployed the Datadog Agent and Datadog Cluster Agent will monitor your cluster and the workloads on it.
+
+GKE supports two [main modes of operation][15] that can change the level of flexibility, responsibility, and control that you have over your cluster. These different modes change how you deploy the Datadog components.
 
 - **Standard**: You manage the cluster's underlying infrastructure, giving you node configuration flexibility.
 
@@ -47,7 +43,9 @@ Deploy a [containerized version of the Datadog Agent][7] on your Kubernetes clus
 
 #### Autopilot
 
-Follow the instructions in the GKE [Autopilot section][14] of the Kubernetes distributions page.
+Autopilot requires a more distinct setup for the Kubernetes installation compared to the standard installation. This type of cluster requires using the Datadog Helm Chart. See the configuration in the GKE [Autopilot section][14] of the Kubernetes distributions page for the required changes to your Helm configuration.
+
+After that you will deploy a [containerized version of the Datadog Agent][7] on your Kubernetes cluster with the Helm [installation of the Datadog Agent on Kubernetes][16] with this Autopilot based configuration.
 
 #### Admission Controller
  
@@ -57,7 +55,7 @@ Because Autopilot does not allow `socket` mode, Datadog recommends using `servic
 
 [101]: https://github.com/DataDog/helm-charts/tree/master/charts/datadog#values
 [102]: https://docs.datadoghq.com/containers/cluster_agent/admission_controller/?tab=operator
-[103]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L1046
+[103]: https://github.com/DataDog/helm-charts/blob/datadog-3.110.0/charts/datadog/values.yaml#L1284-L1293
 
 
 <!-- xxz tab xxx -->
@@ -84,3 +82,5 @@ Because Autopilot does not allow `socket` mode, Datadog recommends using `servic
 [12]: https://www.datadoghq.com/blog/monitor-tau-t2a-gke-workloads-with-datadog-arm-support/
 [13]: https://www.datadoghq.com/blog/gke-dashboards-integration-improvements/
 [14]: https://docs.datadoghq.com/containers/kubernetes/distributions/?tab=helm#autopilot
+[15]: https://cloud.google.com/kubernetes-engine/docs/concepts/choose-cluster-mode
+[16]: https://docs.datadoghq.com/containers/kubernetes/installation?tab=helm


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
A bit of cleanup on the GKE install page:
- Cleans up description for what GKE is and what Datadog does. Don't really need to compare it to AWS.
- Gets rid of section for creating a new `doglib` cluster. This is not necessary and was a point of confusion for a few users.
- Modified to "Kubernetes integration" instead of "GKE integration" and provided a bit more context towards the K8s setup in general and Autopilot.

### Motivation
<!-- What inspired you to submit this pull request? -->

Internally tracking: [TEEP-384](https://datadoghq.atlassian.net/browse/TEEP-384)

Started with removing the `doglib` cluster instructions but became just a general touch up for this doc.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[TEEP-384]: https://datadoghq.atlassian.net/browse/TEEP-384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ