### PR TITLE
[AI-5059] Handle Mesos Slave for Ubuntu-22.04

### DIFF
--- a/mesos_slave/hatch.toml
+++ b/mesos_slave/hatch.toml
@@ -7,4 +7,5 @@ version = ["1.7"]
 [envs.default.overrides]
 matrix.version.env-vars = [
   { key = "MESOS_SLAVE_VERSION", value = "1.7.1", if = ["1.7"] },
+  { key = "ZOOKEEPER_VERSION", value = "3.8.4" },
 ]

--- a/mesos_slave/tests/common.py
+++ b/mesos_slave/tests/common.py
@@ -10,6 +10,8 @@ from datadog_checks.dev.utils import running_on_windows_ci
 
 not_windows_ci = pytest.mark.skipif(running_on_windows_ci(), reason='Test cannot be run on Windows CI')
 
+# TODO remove: trigger CI
+
 HERE = get_here()
 FIXTURE_DIR = os.path.join(HERE, 'fixtures')
 CHECK_NAME = 'mesos_slave'

--- a/mesos_slave/tests/common.py
+++ b/mesos_slave/tests/common.py
@@ -10,8 +10,6 @@ from datadog_checks.dev.utils import running_on_windows_ci
 
 not_windows_ci = pytest.mark.skipif(running_on_windows_ci(), reason='Test cannot be run on Windows CI')
 
-# TODO remove: trigger CI
-
 HERE = get_here()
 FIXTURE_DIR = os.path.join(HERE, 'fixtures')
 CHECK_NAME = 'mesos_slave'

--- a/mesos_slave/tests/compose/docker-compose.yml
+++ b/mesos_slave/tests/compose/docker-compose.yml
@@ -25,4 +25,4 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - zookeeper
-    privileged: true
+    privileged: true  # Added as a fix for Ubuntu-22.04 CI runners, we do not know why it works

--- a/mesos_slave/tests/compose/docker-compose.yml
+++ b/mesos_slave/tests/compose/docker-compose.yml
@@ -22,7 +22,8 @@ services:
     ports:
       - 5051:5051
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - zookeeper
+    privileged: true

--- a/mesos_slave/tests/compose/docker-compose.yml
+++ b/mesos_slave/tests/compose/docker-compose.yml
@@ -1,4 +1,3 @@
-
 # References:
 # - https://github.com/bobrik/mesos-compose
 # - https://github.com/mesosphere/docker-containers/tree/master/mesos
@@ -22,7 +21,7 @@ services:
     ports:
       - 5051:5051
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - zookeeper

--- a/mesos_slave/tests/compose/docker-compose.yml
+++ b/mesos_slave/tests/compose/docker-compose.yml
@@ -3,7 +3,7 @@
 # - https://github.com/mesosphere/docker-containers/tree/master/mesos
 services:
   zookeeper:
-    image: zookeeper
+    image: zookeeper:${ZOOKEEPER_VERSION}
     environment:
       ZOO_SYNC_LIMIT: 5
       ZOO_INIT_LIMIT: 10


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds `privileged: true` to the mesos slave service. 
Pins the zookeeper version.

> [!WARNING]
> We don't know why adding `privileged: true` solves the issue but it does. 🤷  

### Motivation
<!-- What inspired you to submit this pull request? -->
Tests on Ubuntu 22.04 were failing with:
```
E           mesos-slave-1  | E0319 12:51:34.982699 209223 main.cpp:483] EXIT with status 1: Failed to create a containerizer: Could not create DockerContainerizer: Failed to create docker: Failed to find a mounted cgroups hierarchy for the 'cpu' subsystem; you probably need to mount cgroups manually
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
