### PR TITLE
Add more optional metrics in tests

### DIFF
--- a/tekton/tests/common.py
+++ b/tekton/tests/common.py
@@ -56,7 +56,6 @@ PIPELINES_METRICS = [
     "taskrun_duration.bucket",
     "taskrun_duration.count",
     "taskrun_duration.sum",
-    "taskruns_pod_latency",
     "workqueue.longest_running_processor.bucket",
     "workqueue.longest_running_processor.count",
     "workqueue.longest_running_processor.sum",
@@ -67,6 +66,7 @@ PIPELINES_METRICS = [
 assert PIPELINES_METRICS == sorted(PIPELINES_METRICS)
 
 PIPELINES_OPTIONAL_METRICS = [
+    "pipelines_controller.taskruns_pod_latency",
     "pipelinerun.taskrun.duration.bucket",
     "pipelinerun.taskrun.duration.count",
     "pipelinerun.taskrun.duration.sum",

--- a/tekton/tests/common.py
+++ b/tekton/tests/common.py
@@ -56,6 +56,7 @@ PIPELINES_METRICS = [
     "taskrun_duration.bucket",
     "taskrun_duration.count",
     "taskrun_duration.sum",
+    "taskruns_pod_latency",
     "workqueue.longest_running_processor.bucket",
     "workqueue.longest_running_processor.count",
     "workqueue.longest_running_processor.sum",
@@ -66,12 +67,14 @@ PIPELINES_METRICS = [
 assert PIPELINES_METRICS == sorted(PIPELINES_METRICS)
 
 PIPELINES_OPTIONAL_METRICS = [
-    "pipelines_controller.taskruns_pod_latency",
     "pipelinerun.taskrun.duration.bucket",
     "pipelinerun.taskrun.duration.count",
     "pipelinerun.taskrun.duration.sum",
+    "taskruns_pod_latency",
 ]
 assert PIPELINES_OPTIONAL_METRICS == sorted(PIPELINES_OPTIONAL_METRICS)
+
+PIPELINES_E2E_METRICS = set(PIPELINES_METRICS) - set(PIPELINES_OPTIONAL_METRICS)
 
 TRIGGERS_METRICS = [
     "client.latency.bucket",

--- a/tekton/tests/test_e2e.py
+++ b/tekton/tests/test_e2e.py
@@ -4,13 +4,13 @@
 from datadog_checks.base import AgentCheck
 from datadog_checks.dev.utils import get_metadata_metrics
 
-from .common import PIPELINES_METRICS, PIPELINES_OPTIONAL_METRICS, TRIGGERS_METRICS
+from .common import PIPELINES_E2E_METRICS, PIPELINES_OPTIONAL_METRICS, TRIGGERS_METRICS
 
 
 def test_check(dd_agent_check):
     aggregator = dd_agent_check(rate=True)
 
-    for expected_metric in PIPELINES_METRICS:
+    for expected_metric in PIPELINES_E2E_METRICS:
         aggregator.assert_metric(f"tekton.pipelines_controller.{expected_metric}")
 
     for optional_metrics in PIPELINES_OPTIONAL_METRICS:


### PR DESCRIPTION
### What does this PR do?
Adds more optional metrics in tests 

### Motivation
tekton integration e2e tests started flaking https://github.com/DataDog/integrations-core/actions/runs/13951715127/job/39053051152
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
