### PR TITLE
Update Mesos Slave Ubuntu runner to 22.04

### DIFF
--- a/.ddev/config.toml
+++ b/.ddev/config.toml
@@ -37,9 +37,6 @@ exclude = true
 [overrides.ci.ibm_mq]
 platforms = ["linux", "windows"]
 
-[overrides.ci.mesos_slave]
-runners = { linux = ["ubuntu-20.04"] }
-
 [overrides.ci.network]
 platforms = ["linux", "windows"]
 

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -2534,26 +2534,6 @@ jobs:
       minimum-base-package: ${{ inputs.minimum-base-package }}
       pytest-args: ${{ inputs.pytest-args }}
     secrets: inherit
-  j76c310f:
-    uses: ./.github/workflows/test-target.yml
-    with:
-      job-name: Mesos
-      target: mesos_slave
-      platform: linux
-      runner: '["ubuntu-22.04"]'
-      repo: "${{ inputs.repo }}"
-      python-version: "${{ inputs.python-version }}"
-      standard: ${{ inputs.standard }}
-      latest: ${{ inputs.latest }}
-      agent-image: "${{ inputs.agent-image }}"
-      agent-image-py2: "${{ inputs.agent-image-py2 }}"
-      agent-image-windows: "${{ inputs.agent-image-windows }}"
-      agent-image-windows-py2: "${{ inputs.agent-image-windows-py2 }}"
-      test-py2: ${{ inputs.test-py2 }}
-      test-py3: ${{ inputs.test-py3 }}
-      minimum-base-package: ${{ inputs.minimum-base-package }}
-      pytest-args: ${{ inputs.pytest-args }}
-    secrets: inherit
   j062aeb0:
     uses: ./.github/workflows/test-target.yml
     with:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -2540,7 +2540,7 @@ jobs:
       job-name: Mesos
       target: mesos_slave
       platform: linux
-      runner: '["ubuntu-20.04"]'
+      runner: '["ubuntu-22.04"]'
       repo: "${{ inputs.repo }}"
       python-version: "${{ inputs.python-version }}"
       standard: ${{ inputs.standard }}

--- a/ddev/src/ddev/cli/validate/ci.py
+++ b/ddev/src/ddev/cli/validate/ci.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 
 import click
 
+DEPRECATED_INTEGRATIONS = set(["mesos_slave"])
+
 if TYPE_CHECKING:
     from ddev.cli.application import Application
 
@@ -65,6 +67,8 @@ def ci(app: Application, sync: bool):
 
     jobs = {}
     for data in construct_job_matrix(app.repo.path, get_all_targets(app.repo.path)):
+        if data["name"] in DEPRECATED_INTEGRATIONS:
+            continue
         python_restriction = data.get('python-support', '')
         config = {
             'job-name': data['name'],

--- a/mesos_slave/tests/common.py
+++ b/mesos_slave/tests/common.py
@@ -10,6 +10,8 @@ from datadog_checks.dev.utils import running_on_windows_ci
 
 not_windows_ci = pytest.mark.skipif(running_on_windows_ci(), reason='Test cannot be run on Windows CI')
 
+# TODO: remove
+
 HERE = get_here()
 FIXTURE_DIR = os.path.join(HERE, 'fixtures')
 CHECK_NAME = 'mesos_slave'


### PR DESCRIPTION
- **Remove ubuntu runner override for mesos_slave**
- **Sync CI**
- **Add code change to trigger CI**
- **Remove mesos_slave CI tests**

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
