### PR TITLE
Add target_info_enabled param

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/labels.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/labels.py
@@ -9,13 +9,13 @@ from ....utils.functions import no_op
 class LabelAggregator:
     def __init__(self, check, config):
         share_labels = config.get('share_labels', {})
-        self.target_info = config.get('target_info', False)
+        self.target_info_enabled = config.get('target_info_enabled', False)
         self.target_info_labels = {}
 
         self._validate_type(share_labels, dict, "Setting `share_labels` must be a mapping")
-        self._validate_type(self.target_info, bool, "Setting `target_info` must be a boolean")
+        self._validate_type(self.target_info_enabled, bool, "Setting `target_info_enabled` must be a boolean")
 
-        if not share_labels and not self.target_info:
+        if not share_labels and not self.target_info_enabled:
             self.populate = no_op
             return
 

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
@@ -239,7 +239,7 @@ class OpenMetricsScraper:
         runtime_data = {'flush_first_value': self.flush_first_value, 'static_tags': self.static_tags}
 
         # Determine which consume method to use based on target_info config
-        if self.target_info:
+        if self.label_aggregator.target_info_enabled:
             consume_method = self.consume_metrics_w_target_info
         else:
             consume_method = self.consume_metrics

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_options.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_options.py
@@ -683,7 +683,7 @@ class TestShareLabels:
 
     def test_target_info_tags_propagation(self, aggregator, dd_run_check, mock_http_response):
 
-        check = get_check({'metrics': ['.+'], 'target_info': True})
+        check = get_check({'metrics': ['.+'], 'target_info_enabled': True})
 
         mock_http_response(
             """
@@ -709,7 +709,7 @@ class TestShareLabels:
 
     def test_target_info_tags_propagation_unordered(self, aggregator, dd_run_check, mock_http_response):
 
-        check = get_check({'metrics': ['.+'], 'target_info': True, 'cache_shared_labels': False})
+        check = get_check({'metrics': ['.+'], 'target_info_enabled': True, 'cache_shared_labels': False})
 
         mock_http_response(
             """
@@ -735,7 +735,7 @@ class TestShareLabels:
 
     def test_target_info_tags_propagation_unordered_w_cache(self, aggregator, dd_run_check, mock_http_response):
 
-        check = get_check({'metrics': ['.+'], 'target_info': True})
+        check = get_check({'metrics': ['.+'], 'target_info_enabled': True})
 
         mock_http_response(
             """
@@ -770,7 +770,7 @@ class TestShareLabels:
 
     def test_target_info_update_cache(self, aggregator, dd_run_check, mock_http_response):
 
-        check = get_check({'metrics': ['.+'], 'target_info': True})
+        check = get_check({'metrics': ['.+'], 'target_info_enabled': True})
         check_var = check
 
         mock_http_response(
@@ -817,7 +817,7 @@ class TestShareLabels:
 
     def test_target_info_w_shared_labels_cache(self, aggregator, dd_run_check, mock_http_response):
 
-        check = get_check({'metrics': ['.+'], 'share_labels': {'go_memstats_free_bytes': True}, 'target_info': True})
+        check = get_check({'metrics': ['.+'], 'share_labels': {'go_memstats_free_bytes': True}, 'target_info_enabled': True})
         check_var = check
 
         mock_http_response(

--- a/openmetrics/assets/configuration/spec.yaml
+++ b/openmetrics/assets/configuration/spec.yaml
@@ -17,6 +17,13 @@ files:
             tag_by_endpoint.example: false
             tag_by_endpoint.hidden: false
             tag_by_endpoint.enabled: true
+        - name: target_info_enabled
+          description: |
+            Whether to enable scraping for the OpenMetrics target_info metric type.When enabled,
+            this collects metadata about the target being scraped, such as instancelabels and other identifying details.
+          value:
+            example: false
+            type: boolean
         - template: instances/openmetrics_legacy_base
           hidden: true
           overrides:

--- a/openmetrics/datadog_checks/openmetrics/config_models/defaults.py
+++ b/openmetrics/datadog_checks/openmetrics/config_models/defaults.py
@@ -132,6 +132,10 @@ def instance_tag_by_endpoint():
     return True
 
 
+def instance_target_info_enabled():
+    return False
+
+
 def instance_telemetry():
     return False
 

--- a/openmetrics/datadog_checks/openmetrics/config_models/instance.py
+++ b/openmetrics/datadog_checks/openmetrics/config_models/instance.py
@@ -180,6 +180,7 @@ class InstanceConfig(BaseModel):
     skip_proxy: Optional[bool] = None
     tag_by_endpoint: Optional[bool] = None
     tags: Optional[tuple[str, ...]] = None
+    target_info_enabled: Optional[bool] = None
     telemetry: Optional[bool] = None
     timeout: Optional[float] = None
     tls_ca_cert: Optional[str] = None

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -548,7 +548,7 @@ instances:
     #   - TLS_AES_256_GCM_SHA384
     #   - TLS_CHACHA20_POLY1305_SHA256
     #   - TLS_AES_128_GCM_SHA256
-
+    
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for
@@ -643,3 +643,9 @@ instances:
     #   - <INCLUDE_REGEX>
     #   exclude:
     #   - <EXCLUDE_REGEX>
+
+    ## @param target_info_enabled - boolean - optional - default: false
+    ## Whether to enable scraping for the OpenMetrics target_info metric type.When enabled,
+    ## this collects metadata about the target being scraped, such as instancelabels and other identifying details.
+    #
+    # target_info_enabled: false


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
* Update `target_info` parameter to `target_info_enabled` for clarity
* Update unit tests to use new parameter name
* Removes redundant `taget_info` attribute from `OpenMetricsScraper` class

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
