### PR TITLE
Make dependency resolution workflow names more explicit

### DIFF
--- a/.github/workflows/resolve-build-deps.yaml
+++ b/.github/workflows/resolve-build-deps.yaml
@@ -1,4 +1,4 @@
-name: Build dependencies
+name: Resolve Dependencies and Build Wheels
 
 on:
   workflow_dispatch:
@@ -236,7 +236,7 @@ jobs:
         path: output
 
   publish:
-    name: Publish artifacts
+    name: Publish artifacts and Open Pull Request
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, '7.')))
     needs:
     - build

--- a/.github/workflows/resolve-build-deps.yaml
+++ b/.github/workflows/resolve-build-deps.yaml
@@ -236,7 +236,7 @@ jobs:
         path: output
 
   publish:
-    name: Publish artifacts and Open Pull Request
+    name: Publish artifacts and update lockfiles via PR
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, '7.')))
     needs:
     - build


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
I strongly associate this workflow with the word "resolve", so it's hard for me to find it without that anchor.

There are also places where this is referred to as "dependency resolution", so I'm not a unicorn.

As for the "Publish artifacts" job, I forgot that it also opened a PR until I re-read it. Adding that to the job title as a breadcrumb for later.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
