### PR TITLE
Warning for missing explain_plan function

### DIFF
--- a/mysql/changelog.d/19908.changed
+++ b/mysql/changelog.d/19908.changed
@@ -1,0 +1,1 @@
+Warning for missing explain_plan function

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -659,7 +659,9 @@ class MySQLStatementSamples(DBMAsyncJob):
         error_state = self._use_schema(cursor, schema, explain_state_cache_key)
         if error_state:
             self._log.warning(
-                'Failed to collect execution plan. Check that the `explain_statement` function exists in the schema `%s`. See https://docs.datadoghq.com/database_monitoring/setup_mysql/troubleshooting/#explain-plan-fq-procedure-missing. error=%s: %s',
+                'Failed to collect execution plan. Check that the `explain_statement` function exists in the schema `%s`. '
+                'See https://docs.datadoghq.com/database_monitoring/setup_mysql/troubleshooting/#explain-plan-fq-procedure-missing. '
+                'error=%s: %s',
                 schema,
                 error_state,
                 obfuscated_statement,

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -659,8 +659,11 @@ class MySQLStatementSamples(DBMAsyncJob):
         error_state = self._use_schema(cursor, schema, explain_state_cache_key)
         if error_state:
             self._log.warning(
-                'Failed to collect execution plan. Check that the `explain_statement` function exists in the schema `%s`. '
-                'See https://docs.datadoghq.com/database_monitoring/setup_mysql/troubleshooting/#explain-plan-fq-procedure-missing. '
+                'Failed to collect execution plan. '
+                'Check that the `explain_statement` function exists in the schema `%s`. '
+                'See '
+                'https://docs.datadoghq.com/database_monitoring/setup_mysql/troubleshooting/'
+                '#explain-plan-fq-procedure-missing. '
                 'error=%s: %s',
                 schema,
                 error_state,

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -658,8 +658,8 @@ class MySQLStatementSamples(DBMAsyncJob):
         self._log.debug('explaining statement. schema=%s, statement="%s"', schema, obfuscated_statement)
         error_state = self._use_schema(cursor, schema, explain_state_cache_key)
         if error_state:
-            self._log.debug(
-                'Failed to collect execution plan because schema could not be accessed. schema=%s error=%s: %s',
+            self._log.warning(
+                'Failed to collect execution plan. Check that the `explain_statement` function exists in the schema `%s`. See https://docs.datadoghq.com/database_monitoring/setup_mysql/troubleshooting/#explain-plan-fq-procedure-missing. error=%s: %s',
                 schema,
                 error_state,
                 obfuscated_statement,


### PR DESCRIPTION
### What does this PR do?
Show a warning if the `explain_plan` statement is missing in the schema.

### Motivation
Alert customers about a problem in the execution plan collection. For example, Believe (1000143129), a heavy APM/DBM user, never gets execution plan in APM traces due to the missing function.

![image](https://github.com/user-attachments/assets/04824a20-c0e9-4e74-b80a-57cab70e4a56)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
