### PR TITLE
Port changelog and versions from 7.65 RC2

### DIFF
--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -208,7 +208,7 @@ datadog-twemproxy==3.0.0
 datadog-twistlock==5.1.0
 datadog-varnish==4.0.0
 datadog-vault==6.1.0
-datadog-velero==1.0.0
+datadog-velero==2.0.0
 datadog-vertica==6.1.0
 datadog-vllm==2.3.0
 datadog-voltdb==5.1.0

--- a/velero/CHANGELOG.md
+++ b/velero/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 2.0.0 / 2025-03-21
+
+***Changed***:
+
+* Rename `velero.backup` and `velero.restore` metrics ([#19904](https://github.com/DataDog/integrations-core/pull/19904))
+
 ## 1.0.0 / 2025-03-19
 
 ***Added***:

--- a/velero/changelog.d/19904.changed
+++ b/velero/changelog.d/19904.changed
@@ -1,1 +1,0 @@
-Rename `velero.backup` and `velero.restore` metrics

--- a/velero/datadog_checks/velero/__about__.py
+++ b/velero/datadog_checks/velero/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2025-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '1.0.0'
+__version__ = '2.0.0'


### PR DESCRIPTION
This PR ports changelogs and versions from https://github.com/DataDog/integrations-core/commit/2f519bf44eef44bfddea74119b26365a59d0b756.