### PR TITLE
Allow timezone config option to be used in metric collection

### DIFF
--- a/ibm_mq/assets/configuration/spec.yaml
+++ b/ibm_mq/assets/configuration/spec.yaml
@@ -215,6 +215,14 @@ files:
           example: Etc/UTC
           type: string
           minLength: 1
+      - name: use_qm_tz_for_metrics
+        description: |
+          Use the `queue_manager_timezone` parameter to collect metrics. Metrics can be skipped sometimes if the 
+          timezone is not in UTC. The queried data that the agent retrieves is timezone naive and is expected to 
+          be in UTC. Use this setting if the queue manager has a different timezone setting.
+        value:
+          example: false
+          type: boolean
       - name: timeout
         description: |
           The number of seconds to wait for IBM MQ to respond.

--- a/ibm_mq/changelog.d/19912.added
+++ b/ibm_mq/changelog.d/19912.added
@@ -1,0 +1,1 @@
+Allow timezone config option to be used in metric collection

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/stats_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/stats_collector.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+from dateutil.tz import UTC
 from pymqi.CMQCFC import MQCMD_STATISTICS_CHANNEL, MQCMD_STATISTICS_Q
 
 from datadog_checks.ibm_mq.stats.base_stats import BaseStats
@@ -47,14 +48,14 @@ class StatsCollector(object):
                 message, header = pymqi.PCFExecute.unpack(bin_message)
                 self.log.trace('Stats unpacked message: %s, Stats unpacked header: %s', message, header)
 
-                stats = self._get_stats(message, header)
+                stats = self._get_stats(message, header, self.config.qm_stats_tz)
 
                 # We only collect metrics generated after the check instance creation.
                 if stats.start_datetime < self.config.instance_creation_datetime:
                     self.log.debug(
                         "Skipping messages created before agent startup. "
                         "Message time: %s / Check instance creation time: %s",
-                        stats.start_datetime,
+                        stats.start_datetime.astimezone(UTC),
                         self.config.instance_creation_datetime,
                     )
                     continue
@@ -106,11 +107,11 @@ class StatsCollector(object):
             )
 
     @staticmethod
-    def _get_stats(message, header):
+    def _get_stats(message, header, timezone=None):
         if header.Command == MQCMD_STATISTICS_CHANNEL:
-            stats = ChannelStats(message)
+            stats = ChannelStats(message, timezone)
         elif header.Command == MQCMD_STATISTICS_Q:
-            stats = QueueStats(message)
+            stats = QueueStats(message, timezone)
         else:
-            stats = BaseStats(message)
+            stats = BaseStats(message, timezone)
         return stats

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -101,6 +101,7 @@ class IBMMQConfig:
         self.qm_timezone = instance.get('queue_manager_timezone', 'UTC')  # type: str
         self.auto_discover_channels = instance.get('auto_discover_channels', True)  # type: bool
 
+        # Initialize timezone handling
         try:
             if self.qm_timezone != 'UTC':
                 self.qm_stats_tz = tz.gettz(self.qm_timezone)
@@ -115,6 +116,7 @@ class IBMMQConfig:
                 e,
             )
             self.qm_stats_tz = tz.UTC
+            self.qm_timezone = 'UTC'  # Ensure string version matches object version
 
         custom_tags = instance.get('tags', [])  # type: List[str]
         tags = [

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -109,8 +109,9 @@ class IBMMQConfig:
                 if self.qm_stats_tz is None:
                     raise ValueError(f"'{self.qm_timezone}' is not a recognized timezone.")
             else:
+                #  Default to UTC if the timezone is not set or if use_qm_tz_for_metrics is False
                 self.qm_stats_tz = tz.UTC
-                self.qm_timezone = 'UTC'  # Ensure string representation is also UTC
+                self.qm_timezone = 'UTC'
         except ValueError as e:
             self.log.error(
                 "Invalid timezone: %s. Defaulting to UTC. Please specify a valid time zone in IANA/Olson format. %s",

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -110,6 +110,7 @@ class IBMMQConfig:
                     raise ValueError(f"'{self.qm_timezone}' is not a recognized timezone.")
             else:
                 self.qm_stats_tz = tz.UTC
+                self.qm_timezone = 'UTC'  # Ensure string representation is also UTC
         except ValueError as e:
             self.log.error(
                 "Invalid timezone: %s. Defaulting to UTC. Please specify a valid time zone in IANA/Olson format. %s",

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -109,9 +109,8 @@ class IBMMQConfig:
                 if self.qm_stats_tz is None:
                     raise ValueError(f"'{self.qm_timezone}' is not a recognized timezone.")
             else:
-                #  Default to UTC if the timezone is not set or if use_qm_tz_for_metrics is False
+                # Default to UTC for the timezone object if not using custom timezone
                 self.qm_stats_tz = tz.UTC
-                self.qm_timezone = 'UTC'
         except ValueError as e:
             self.log.error(
                 "Invalid timezone: %s. Defaulting to UTC. Please specify a valid time zone in IANA/Olson format. %s",
@@ -119,7 +118,7 @@ class IBMMQConfig:
                 e,
             )
             self.qm_stats_tz = tz.UTC
-            self.qm_timezone = 'UTC'
+            self.qm_timezone = 'UTC'  # Only set string representation to UTC on error
 
         custom_tags = instance.get('tags', [])  # type: List[str]
         tags = [

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -100,10 +100,13 @@ class IBMMQConfig:
         self.convert_endianness = instance.get('convert_endianness', False)  # type: bool
         self.qm_timezone = instance.get('queue_manager_timezone', 'UTC')  # type: str
         self.auto_discover_channels = instance.get('auto_discover_channels', True)  # type: bool
+        self.use_qm_tz_for_metrics = is_affirmative(instance.get('use_qm_tz_for_metrics', False))  # type: bool
 
         # Initialize timezone handling
+        # - If use_qm_tz_for_metrics is True and a non-UTC timezone is provided, use that timezone object
+        # - Otherwise, use UTC (either string or object) to maintain backward compatibility
         try:
-            if self.qm_timezone != 'UTC':
+            if self.qm_timezone != 'UTC' and self.use_qm_tz_for_metrics:
                 self.qm_stats_tz = tz.gettz(self.qm_timezone)
                 if self.qm_stats_tz is None:
                     raise ValueError(f"'{self.qm_timezone}' is not a recognized timezone.")
@@ -116,7 +119,7 @@ class IBMMQConfig:
                 e,
             )
             self.qm_stats_tz = tz.UTC
-            self.qm_timezone = 'UTC'  # Ensure string version matches object version
+            self.qm_timezone = 'UTC'
 
         custom_tags = instance.get('tags', [])  # type: List[str]
         tags = [

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -103,8 +103,6 @@ class IBMMQConfig:
         self.use_qm_tz_for_metrics = is_affirmative(instance.get('use_qm_tz_for_metrics', False))  # type: bool
 
         # Initialize timezone handling
-        # - If use_qm_tz_for_metrics is True and a non-UTC timezone is provided, use that timezone object
-        # - Otherwise, use UTC (either string or object) to maintain backward compatibility
         try:
             if self.qm_timezone != 'UTC' and self.use_qm_tz_for_metrics:
                 self.qm_stats_tz = tz.gettz(self.qm_timezone)

--- a/ibm_mq/datadog_checks/ibm_mq/config_models/defaults.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config_models/defaults.py
@@ -78,3 +78,7 @@ def instance_timeout():
 
 def instance_try_basic_auth():
     return True
+
+
+def instance_use_qm_tz_for_metrics():
+    return False

--- a/ibm_mq/datadog_checks/ibm_mq/config_models/instance.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config_models/instance.py
@@ -68,6 +68,7 @@ class InstanceConfig(BaseModel):
     tags: Optional[tuple[str, ...]] = None
     timeout: Optional[int] = None
     try_basic_auth: Optional[bool] = None
+    use_qm_tz_for_metrics: Optional[bool] = None
     username: Optional[str] = Field(None, min_length=1)
 
     @model_validator(mode='before')

--- a/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+++ b/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
@@ -190,6 +190,13 @@ instances:
     #
     # queue_manager_timezone: Etc/UTC
 
+    ## @param use_qm_tz_for_metrics - boolean - optional - default: false
+    ## Use the `queue_manager_timezone` parameter to collect metrics. Metrics can be skipped sometimes if the 
+    ## timezone is not in UTC. The queried data that the agent retrieves is timezone naive and is expected to 
+    ## be in UTC. Use this setting if the queue manager has a different timezone setting.
+    #
+    # use_qm_tz_for_metrics: false
+
     ## @param timeout - integer - optional - default: 5
     ## The number of seconds to wait for IBM MQ to respond.
     #

--- a/ibm_mq/datadog_checks/ibm_mq/stats/base_stats.py
+++ b/ibm_mq/datadog_checks/ibm_mq/stats/base_stats.py
@@ -16,11 +16,13 @@ except ImportError as e:
 
 
 class BaseStats(object):
-    def __init__(self, raw_message):
-        self.start_datetime = self._parse_datetime(raw_message[MQCAMO_START_DATE], raw_message[MQCAMO_START_TIME])
+    def __init__(self, raw_message, timezone=None):
+        self.start_datetime = self._parse_datetime(
+            raw_message[MQCAMO_START_DATE], raw_message[MQCAMO_START_TIME], timezone=timezone
+        )
 
     @staticmethod
-    def _parse_datetime(raw_date, raw_time):
+    def _parse_datetime(raw_date, raw_time, timezone=None):
         # date might contain extra chars, we only keep 10 first that match the format YYYY-MM-DD
         date = sanitize_strings(raw_date[:10])
         time = sanitize_strings(raw_time)  # date format YYYY-MM-DD
@@ -31,4 +33,5 @@ class BaseStats(object):
         #       when the integration doesn't need to be backward compatible anymore
         #       with agent versions without ensure_aware_datetime.
         #       When doing that, bump the base package in setup.py
-        return naive_start_datetime.replace(tzinfo=UTC)
+        timezone = timezone if timezone is not None else UTC
+        return naive_start_datetime.replace(tzinfo=timezone)

--- a/ibm_mq/datadog_checks/ibm_mq/stats/channel_stats.py
+++ b/ibm_mq/datadog_checks/ibm_mq/stats/channel_stats.py
@@ -38,6 +38,6 @@ class ChannelInfo(object):
 
 
 class ChannelStats(BaseStats):
-    def __init__(self, raw_message):
-        super(ChannelStats, self).__init__(raw_message)
+    def __init__(self, raw_message, timezone=None):
+        super(ChannelStats, self).__init__(raw_message, timezone=timezone)
         self.channels = [ChannelInfo(channel) for channel in raw_message[MQGACF_CHL_STATISTICS_DATA]]

--- a/ibm_mq/datadog_checks/ibm_mq/stats/queue_stats.py
+++ b/ibm_mq/datadog_checks/ibm_mq/stats/queue_stats.py
@@ -48,6 +48,6 @@ class QueueInfo(object):
 
 
 class QueueStats(BaseStats):
-    def __init__(self, raw_message):
-        super(QueueStats, self).__init__(raw_message)
+    def __init__(self, raw_message, timezone=None):
+        super(QueueStats, self).__init__(raw_message, timezone=timezone)
         self.queues = [QueueInfo(channel) for channel in raw_message[MQGACF_Q_STATISTICS_DATA]]

--- a/ibm_mq/tests/test_ibm_mq_unit.py
+++ b/ibm_mq/tests/test_ibm_mq_unit.py
@@ -281,7 +281,7 @@ def test_queue_manager_process_direct_ssl(instance):
         pytest.param(
             'America/New_York',
             'America/New_York',
-            tz.UTC,
+            tz.UTC,  # When use_qm_tz_for_metrics is False, always use UTC
             None,
             False,
             id='valid-timezone-string',

--- a/ibm_mq/tests/test_ibm_mq_unit.py
+++ b/ibm_mq/tests/test_ibm_mq_unit.py
@@ -281,7 +281,7 @@ def test_queue_manager_process_direct_ssl(instance):
         pytest.param(
             'America/New_York',
             'America/New_York',
-            tz.UTC,  # When use_qm_tz_for_metrics is False, always use UTC
+            tz.UTC,
             None,
             False,
             id='valid-timezone-string',

--- a/ibm_mq/tests/test_ibm_mq_unit.py
+++ b/ibm_mq/tests/test_ibm_mq_unit.py
@@ -274,26 +274,54 @@ def test_queue_manager_process_direct_ssl(instance):
 
 
 @pytest.mark.parametrize(
-    'timezone_config, expected_timezone, expected_stats_tz, expected_error',
+    'timezone_config, expected_timezone, expected_stats_tz, expected_error, use_qm_tz_for_metrics',
     [
-        pytest.param('UTC', 'UTC', tz.UTC, None, id='default-utc'),
-        pytest.param('America/New_York', 'America/New_York', tz.gettz('America/New_York'), None, id='valid-timezone'),
-        pytest.param('Europe/London', 'Europe/London', tz.gettz('Europe/London'), None, id='another-valid-timezone'),
-        pytest.param('Invalid/Timezone', 'UTC', tz.UTC, 'Invalid timezone', id='invalid-timezone'),
+        pytest.param('UTC', 'UTC', tz.UTC, None, False, id='default-utc-string'),
+        pytest.param('UTC', 'UTC', tz.UTC, None, True, id='default-utc-object'),
+        pytest.param(
+            'America/New_York',
+            'America/New_York',
+            tz.gettz('America/New_York'),
+            None,
+            False,
+            id='valid-timezone-string',
+        ),
+        pytest.param(
+            'America/New_York', 'America/New_York', tz.gettz('America/New_York'), None, True, id='valid-timezone-object'
+        ),
+        pytest.param(
+            'Europe/London', 'Europe/London', tz.gettz('Europe/London'), None, False, id='another-valid-timezone-string'
+        ),
+        pytest.param(
+            'Europe/London', 'Europe/London', tz.gettz('Europe/London'), None, True, id='another-valid-timezone-object'
+        ),
+        pytest.param('Invalid/Timezone', 'UTC', tz.UTC, 'Invalid timezone', False, id='invalid-timezone-string'),
+        pytest.param('Invalid/Timezone', 'UTC', tz.UTC, 'Invalid timezone', True, id='invalid-timezone-object'),
     ],
 )
-def test_timezone_configuration(instance, timezone_config, expected_timezone, expected_stats_tz, expected_error):
+def test_timezone_configuration(
+    instance, timezone_config, expected_timezone, expected_stats_tz, expected_error, use_qm_tz_for_metrics
+):
     from datadog_checks.ibm_mq.config import IBMMQConfig
 
     instance['queue_manager_timezone'] = timezone_config
+    instance['use_qm_tz_for_metrics'] = use_qm_tz_for_metrics
     config = IBMMQConfig(instance, {})
 
+    # Test string representation (used for PCF metrics)
     assert config.qm_timezone == expected_timezone
 
+    # Test timezone object (used for statistics messages)
     assert config.qm_stats_tz == expected_stats_tz
 
+    # Test that both representations are consistent
     if expected_error:
+        # When there's an error, both should default to UTC
         assert config.qm_timezone == 'UTC'
         assert config.qm_stats_tz == tz.UTC
     else:
+        # For valid timezones, string should match the input timezone
         assert config.qm_timezone == timezone_config
+
+    # Test the new option
+    assert config.use_qm_tz_for_metrics == use_qm_tz_for_metrics

--- a/ibm_mq/tests/test_ibm_mq_unit.py
+++ b/ibm_mq/tests/test_ibm_mq_unit.py
@@ -289,9 +289,11 @@ def test_timezone_configuration(instance, timezone_config, expected_timezone, ex
     config = IBMMQConfig(instance, {})
 
     assert config.qm_timezone == expected_timezone
+
     assert config.qm_stats_tz == expected_stats_tz
+
     if expected_error:
         assert config.qm_timezone == 'UTC'
         assert config.qm_stats_tz == tz.UTC
     else:
-        assert config.qm_timezone == config.qm_stats_tz.zone
+        assert config.qm_timezone == timezone_config

--- a/ibm_mq/tests/test_ibm_mq_unit.py
+++ b/ibm_mq/tests/test_ibm_mq_unit.py
@@ -289,9 +289,7 @@ def test_queue_manager_process_direct_ssl(instance):
         pytest.param(
             'America/New_York', 'America/New_York', tz.gettz('America/New_York'), None, True, id='valid-timezone-object'
         ),
-        pytest.param(
-            'Europe/London', 'Europe/London', tz.UTC, None, False, id='another-valid-timezone-string'
-        ),
+        pytest.param('Europe/London', 'Europe/London', tz.UTC, None, False, id='another-valid-timezone-string'),
         pytest.param(
             'Europe/London', 'Europe/London', tz.gettz('Europe/London'), None, True, id='another-valid-timezone-object'
         ),

--- a/ibm_mq/tests/test_ibm_mq_unit.py
+++ b/ibm_mq/tests/test_ibm_mq_unit.py
@@ -281,7 +281,7 @@ def test_queue_manager_process_direct_ssl(instance):
         pytest.param(
             'America/New_York',
             'America/New_York',
-            tz.gettz('America/New_York'),
+            tz.UTC,
             None,
             False,
             id='valid-timezone-string',
@@ -290,7 +290,7 @@ def test_queue_manager_process_direct_ssl(instance):
             'America/New_York', 'America/New_York', tz.gettz('America/New_York'), None, True, id='valid-timezone-object'
         ),
         pytest.param(
-            'Europe/London', 'Europe/London', tz.gettz('Europe/London'), None, False, id='another-valid-timezone-string'
+            'Europe/London', 'Europe/London', tz.UTC, None, False, id='another-valid-timezone-string'
         ),
         pytest.param(
             'Europe/London', 'Europe/London', tz.gettz('Europe/London'), None, True, id='another-valid-timezone-object'


### PR DESCRIPTION
### What does this PR do?
Old change that I had laying around that solved an escalation. https://datadoghq.atlassian.net/browse/AGENT-12517

The customer had a timezone set in their ibm mq instance that wasn't UTC, as a result a lot of their metrics were not getting collected as the check would think they were too old.

Not sure how to test it, but it was confirmed working here:
https://datadoghq.atlassian.net/browse/AGENT-12794

