### PR TITLE
Add option to disable missing mountpoints warning in nfsstat

### DIFF
--- a/nfsstat/assets/configuration/spec.yaml
+++ b/nfsstat/assets/configuration/spec.yaml
@@ -23,6 +23,14 @@ files:
     - template: init_config/default
   - template: instances
     options:
+    - name: disable_missing_mountpoints_warning
+      required: false
+      description: |
+        If false, no warning is logged if host has check enabled but no NFS mount point is found.
+      value:
+        type: boolean
+        default: false
+        example: false
     - template: instances/default
   - template: logs
     example:

--- a/nfsstat/datadog_checks/nfsstat/config_models/defaults.py
+++ b/nfsstat/datadog_checks/nfsstat/config_models/defaults.py
@@ -22,3 +22,7 @@ def instance_empty_default_hostname():
 
 def instance_min_collection_interval():
     return 15
+
+
+def instance_disable_missing_mountpoints_warning():
+    return False

--- a/nfsstat/datadog_checks/nfsstat/config_models/instance.py
+++ b/nfsstat/datadog_checks/nfsstat/config_models/instance.py
@@ -36,6 +36,7 @@ class InstanceConfig(BaseModel):
     )
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
+    disable_missing_mountpoints_warning: Optional[bool] = None
     metric_patterns: Optional[MetricPatterns] = None
     min_collection_interval: Optional[float] = None
     service: Optional[str] = None

--- a/nfsstat/datadog_checks/nfsstat/data/conf.yaml.example
+++ b/nfsstat/datadog_checks/nfsstat/data/conf.yaml.example
@@ -56,6 +56,11 @@ instances:
     #
     # empty_default_hostname: false
 
+    ## @param disable_missing_mountpoints_warning - boolean - optional - default: false
+    ## If false, no warning is logged if host has check enabled but no NFS mount point is found.
+    #
+    # disable_missing_mountpoints_warning: false
+
     ## @param metric_patterns - mapping - optional
     ## A mapping of metrics to include or exclude, with each entry being a regular expression.
     ##

--- a/nfsstat/datadog_checks/nfsstat/nfsstat.py
+++ b/nfsstat/datadog_checks/nfsstat/nfsstat.py
@@ -38,10 +38,12 @@ class NfsStatCheck(AgentCheck):
         this_device = []
         custom_tags = instance.get("tags", [])
         stats = stat_out.splitlines()
+        disable_missing_mountpoints_warning = is_affirmative(instance.get('disable_missing_mountpoints_warning', False))
 
         if 'No NFS mount point' in stats[0]:
             if not self.autofs_enabled:
-                self.warning("No NFS mount points were found.")
+                if not disable_missing_mountpoints_warning:
+                    self.warning("No NFS mount points were found.")
             else:
                 self.log.debug("AutoFS enabled: no mount points currently.")
             return


### PR DESCRIPTION
### What does this PR do?

This PR adds and optional instance config option do disable the repeating warning occuring if an instance is configured but no NFS mount point is actually found.
This is the follow up to #19695 .
### Motivation

We're actually deploying the configuration to hosts without NFS mounts and so getting a lot of useless log warnings - where the check itself is perfectly working (just with no metrics obviously).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
