### PR TITLE
Remove unnecessary 'like'

### DIFF
--- a/sqlserver/changelog.d/19921.fixed
+++ b/sqlserver/changelog.d/19921.fixed
@@ -1,0 +1,1 @@
+Remove unnecessary `like` from SQL Server deadlock query

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -201,6 +201,6 @@ CONVERT(xml, event_data).value('(event[@name="xml_deadlock_report"]/@timestamp)[
 FROM
 sys.fn_xe_file_target_read_file
 ('system_health*.xel', null, null, null)
-WHERE object_name like 'xml_deadlock_report'
+WHERE object_name = 'xml_deadlock_report'
   and CONVERT(xml, event_data).value('(event[@name="xml_deadlock_report"]/@timestamp)[1]','datetime')
     >= DATEADD(SECOND, ?, TODATETIMEOFFSET(GETDATE(), DATEPART(TZOFFSET, SYSDATETIMEOFFSET())) AT TIME ZONE 'UTC');"""


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Replaces a `like` in the SQL Server deadlock query with an `=` since there is no wildcard in the target string.

### Motivation
<!-- What inspired you to submit this pull request? -->
This will improve performance on the query.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
