### PR TITLE
Backport: [mongo] skip explain aggregation pipeline with mergeCursors stage (#19798)

### DIFF
--- a/mongo/changelog.d/19798.added
+++ b/mongo/changelog.d/19798.added
@@ -1,0 +1,1 @@
+Skip running explain on aggregation pipelines that contain $mergeCursors to prevent potential MongoDB crashes.

--- a/mongo/datadog_checks/mongo/dbm/utils.py
+++ b/mongo/datadog_checks/mongo/dbm/utils.py
@@ -65,6 +65,7 @@ UNEXPLAINABLE_PIPELINE_STAGES = frozenset(
         "$listSearchIndexes",
         "$sample",
         "$shardedDataDistribution",
+        "$mergeCursors",
     ]
 )
 


### PR DESCRIPTION
Backport https://github.com/DataDog/integrations-core/commit/0c8fdf35338c1ae20789e90a513e1f500c699c4e to fix a high severity issue that causes MongoDB to crash due to explaining queries with `$mergeCursors` stage

* skip explain aggregation pipeline with  stage

* add changelog

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
Backport to `7.64.x` to fix a high severity issue reported by customer. The mongo integration samples running operations and explains the operation to gather execution plan. When it tries to explain an aggregation pipeline with `$mergeCursors` stage, it potentially caused MongoDB database engine to crash. The issue is escalated from the customer to MongoDB support with below explanation
```
For aggregations which target at least two shards for a sharded collection, the original aggregation is run in the following manner:
1. Mongos forwards the aggregate command to the relevant shards with the cursor batch size set to 0. This fetches no data but establishes the placement version (aka shard version) to return consistent results even in the presence of data balancing.
2.  For aggregations which can spill to disk or have other constraints to require running on mongod, mongos will run another aggregate command against a shard which accepts the individual shard's cursor IDs returned by the earlier step. This is the purpose of the $mergeCursors aggregation stage.
3. The merging shard accumulates the cursor results from the other shards and executes the remainder of the aggregation pipeline (aka merging pipeline).
4. The mongos receives the final cursor results from the merging shard.
```
Skip explaining queries with `$mergeCursors` stage resolves this issue. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
