### PR TITLE
update postgres ECS docs to include Autodiscovery v2 Annotations

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -384,6 +384,8 @@ To configure this check for an Agent running on ECS:
 
 Set [Autodiscovery Integrations Templates][9] as Docker labels on your application container:
 
+**Annotations v1** (for Datadog Agent < v7.36)
+
 ```json
 {
   "containerDefinitions": [{
@@ -393,6 +395,20 @@ Set [Autodiscovery Integrations Templates][9] as Docker labels on your applicati
       "com.datadoghq.ad.check_names": "[\"postgres\"]",
       "com.datadoghq.ad.init_configs": "[{}]",
       "com.datadoghq.ad.instances": "[{\"host\":\"%%host%%\", \"port\":5432,\"username\":\"datadog\",\"password\":\"<PASSWORD>\"}]"
+    }
+  }]
+}
+```
+
+**Annotations v2** (for Datadog Agent v7.36+)
+
+```json
+{
+  "containerDefinitions": [{
+    "name": "postgres",
+    "image": "postgres:latest",
+    "dockerLabels": {
+      "com.datadoghq.ad.checks": "{\"postgres\": {\"instances\": [{\"host\":\"%%host%%\", \"port\":5432, \"username\":\"postgres\", \"password\":\"<PASSWORD>\"}]}}"
     }
   }]
 }


### PR DESCRIPTION
### What does this PR do?

This PR includes Autodiscovery v2 Annotations for collecting metrics from a postgres database.

### Motivation

Documentation should always support the latest versions of software. Future configurations would, hopefully use the Autodiscovery Annotations v2 configuration instead which would make deprecating Autodiscovery Annotations v1 easier in the future.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
