### PR TITLE
Add support for case sensitive collations in SQL Server

### DIFF
--- a/sqlserver/changelog.d/19930.fixed
+++ b/sqlserver/changelog.d/19930.fixed
@@ -1,0 +1,1 @@
+Fix SQL Server integration when database is using case sensitive collation

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -32,7 +32,7 @@ COLUMN_QUERY = """
 SELECT
     column_name AS name, data_type, column_default, is_nullable AS nullable , table_name, ordinal_position
 FROM
-    information_schema.columns
+    INFORMATION_SCHEMA.COLUMNS
 WHERE
     table_name IN ({}) and table_schema='{}';
 """

--- a/sqlserver/tests/compose-ha/sql/aoag_primary.sql
+++ b/sqlserver/tests/compose-ha/sql/aoag_primary.sql
@@ -121,13 +121,6 @@ CREATE DATABASE datadog_test_collation
     COLLATE Latin1_General_100_BIN2;
 GO
 USE datadog_test_collation;
-CREATE TABLE datadog_test_collation.dbo.ϑings (id int DEFAULT 0, name varchar(255));
-INSERT INTO datadog_test_collation.dbo.ϑings VALUES (1, 'foo'), (2, 'bar');
-CREATE USER bob FOR LOGIN bob;
-CREATE USER fred FOR LOGIN fred;
-CREATE CLUSTERED INDEX thingsindex ON datadog_test_collation.dbo.ϑings (name);
-GO
-
 
 CREATE SCHEMA test_schema;
 GO

--- a/sqlserver/tests/compose-ha/sql/aoag_primary.sql
+++ b/sqlserver/tests/compose-ha/sql/aoag_primary.sql
@@ -116,6 +116,11 @@ CREATE USER fred FOR LOGIN fred;
 CREATE CLUSTERED INDEX thingsindex ON datadog_test_schemas_second.dbo.ϑings (name);
 GO
 
+-- Create an alternate collation database to test handling of case sensitivity
+CREATE DATABASE datadog_test_collation
+    COLLATE Latin1_General_100_BIN2;
+GO
+
 -- Create test database for integration tests
 -- only bob and fred have read/write access to this database
 USE [datadog_test-1];

--- a/sqlserver/tests/compose-ha/sql/aoag_primary.sql
+++ b/sqlserver/tests/compose-ha/sql/aoag_primary.sql
@@ -120,6 +120,13 @@ GO
 CREATE DATABASE datadog_test_collation
     COLLATE Latin1_General_100_BIN2;
 GO
+USE datadog_test_collation;
+CREATE TABLE datadog_test_collation.dbo.ϑings (id int DEFAULT 0, name varchar(255));
+INSERT INTO datadog_test_collation.dbo.ϑings VALUES (1, 'foo'), (2, 'bar');
+CREATE USER bob FOR LOGIN bob;
+CREATE USER fred FOR LOGIN fred;
+CREATE CLUSTERED INDEX thingsindex ON datadog_test_collation.dbo.ϑings (name);
+GO
 
 -- Create test database for integration tests
 -- only bob and fred have read/write access to this database

--- a/sqlserver/tests/compose-ha/sql/aoag_primary.sql
+++ b/sqlserver/tests/compose-ha/sql/aoag_primary.sql
@@ -121,6 +121,7 @@ CREATE DATABASE datadog_test_collation
     COLLATE Latin1_General_100_BIN2;
 GO
 USE datadog_test_collation;
+GO
 
 CREATE SCHEMA test_schema;
 GO

--- a/sqlserver/tests/compose-high-cardinality-windows/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality-windows/setup.sql
@@ -104,6 +104,12 @@ CREATE USER fred FOR LOGIN fred;
 CREATE CLUSTERED INDEX thingsindex ON datadog_test_schemas_second.dbo.ϑings (name);
 GO
 
+-- Create an alternate collation database to test handling of case sensitivity
+CREATE DATABASE datadog_test_collation
+    COLLATE Latin1_General_100_BIN2;
+GO
+
+
 -- Create test database for integration tests
 -- only bob and fred have read/write access to this database
 -- the datadog user has only connect access but can't read any objects

--- a/sqlserver/tests/compose-high-cardinality/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality/setup.sql
@@ -197,6 +197,11 @@ CREATE USER fred FOR LOGIN fred;
 CREATE CLUSTERED INDEX thingsindex ON datadog_test_schemas_second.dbo.ϑings (name);
 GO
 
+-- Create an alternate collation database to test handling of case sensitivity
+CREATE DATABASE datadog_test_collation
+    COLLATE Latin1_General_100_BIN2;
+GO
+
 -- Create test database for integration tests.
 -- Only bob and fred have read/write access to this database.
 CREATE DATABASE [datadog_test-1];

--- a/sqlserver/tests/compose-windows/setup.sql
+++ b/sqlserver/tests/compose-windows/setup.sql
@@ -106,6 +106,11 @@ CREATE USER fred FOR LOGIN fred;
 CREATE CLUSTERED INDEX thingsindex ON datadog_test_schemas_second.dbo.ϑings (name);
 GO
 
+-- Create an alternate collation database to test handling of case sensitivity
+CREATE DATABASE datadog_test_collation
+    COLLATE Latin1_General_100_BIN2;
+GO
+
 -- Create test database for integration tests
 -- only bob and fred have read/write access to this database
 -- the datadog user has only connect access but can't read any objects

--- a/sqlserver/tests/compose-windows/setup.sql
+++ b/sqlserver/tests/compose-windows/setup.sql
@@ -110,6 +110,13 @@ GO
 CREATE DATABASE datadog_test_collation
     COLLATE Latin1_General_100_BIN2;
 GO
+USE datadog_test_collation;
+CREATE TABLE datadog_test_collation.dbo.ϑings (id int DEFAULT 0, name varchar(255));
+INSERT INTO datadog_test_collation.dbo.ϑings VALUES (1, 'foo'), (2, 'bar');
+CREATE USER bob FOR LOGIN bob;
+CREATE USER fred FOR LOGIN fred;
+CREATE CLUSTERED INDEX thingsindex ON datadog_test_collation.dbo.ϑings (name);
+GO
 
 -- Create test database for integration tests
 -- only bob and fred have read/write access to this database

--- a/sqlserver/tests/compose-windows/setup.sql
+++ b/sqlserver/tests/compose-windows/setup.sql
@@ -118,6 +118,62 @@ CREATE USER fred FOR LOGIN fred;
 CREATE CLUSTERED INDEX thingsindex ON datadog_test_collation.dbo.ϑings (name);
 GO
 
+CREATE SCHEMA test_schema;
+GO
+
+-- Create the partition function
+CREATE PARTITION FUNCTION CityPartitionFunction (INT)
+AS RANGE LEFT FOR VALUES (100, 200, 300); -- Define your partition boundaries here
+
+-- Create the partition scheme
+CREATE PARTITION SCHEME CityPartitionScheme
+AS PARTITION CityPartitionFunction ALL TO ([PRIMARY]); -- Assign partitions to filegroups
+
+-- Create the partitioned table
+CREATE TABLE datadog_test_collation.test_schema.cities (
+    id INT NOT NULL DEFAULT 0,
+    name VARCHAR(255),
+    population INT NOT NULL DEFAULT 0,
+    CONSTRAINT PK_Cities PRIMARY KEY (id)
+) ON CityPartitionScheme(id); -- Assign the partition scheme to the table
+
+-- Create indexes
+CREATE INDEX two_columns_index ON datadog_test_collation.test_schema.cities (id, name);
+CREATE INDEX single_column_index ON datadog_test_collation.test_schema.cities (population);
+
+INSERT INTO datadog_test_collation.test_schema.cities  VALUES (1, 'yey', 100), (2, 'bar', 200);
+GO
+
+-- Create table with a foreign key
+CREATE TABLE datadog_test_collation.test_schema.landmarks (name varchar(255), city_id int DEFAULT 0);
+GO
+ALTER TABLE datadog_test_collation.test_schema.landmarks ADD CONSTRAINT FK_CityId FOREIGN KEY (city_id)
+REFERENCES datadog_test_collation.test_schema.cities(id)
+ON DELETE SET NULL;
+GO
+
+-- Create table with unique constraint
+CREATE TABLE datadog_test_collation.test_schema.Restaurants (
+    RestaurantName VARCHAR(255),
+    District VARCHAR(100),
+    Cuisine VARCHAR(100),
+    CONSTRAINT UC_RestaurantNameDistrict UNIQUE (RestaurantName, District)
+);
+GO
+
+-- Create table with a foreign key on two columns
+CREATE TABLE datadog_test_collation.test_schema.RestaurantReviews (
+    RestaurantName VARCHAR(255),
+    District VARCHAR(100),
+    Review VARCHAR(MAX),
+    CONSTRAINT FK_RestaurantNameDistrict FOREIGN KEY (RestaurantName, District)
+        REFERENCES datadog_test_collation.test_schema.Restaurants(RestaurantName, District)
+        ON DELETE CASCADE
+        ON UPDATE SET NULL
+);
+GO
+
+
 -- Create test database for integration tests
 -- only bob and fred have read/write access to this database
 -- the datadog user has only connect access but can't read any objects

--- a/sqlserver/tests/compose-windows/setup.sql
+++ b/sqlserver/tests/compose-windows/setup.sql
@@ -111,6 +111,7 @@ CREATE DATABASE datadog_test_collation
     COLLATE Latin1_General_100_BIN2;
 GO
 USE datadog_test_collation;
+GO
 
 CREATE SCHEMA test_schema;
 GO

--- a/sqlserver/tests/compose-windows/setup.sql
+++ b/sqlserver/tests/compose-windows/setup.sql
@@ -111,12 +111,6 @@ CREATE DATABASE datadog_test_collation
     COLLATE Latin1_General_100_BIN2;
 GO
 USE datadog_test_collation;
-CREATE TABLE datadog_test_collation.dbo.ϑings (id int DEFAULT 0, name varchar(255));
-INSERT INTO datadog_test_collation.dbo.ϑings VALUES (1, 'foo'), (2, 'bar');
-CREATE USER bob FOR LOGIN bob;
-CREATE USER fred FOR LOGIN fred;
-CREATE CLUSTERED INDEX thingsindex ON datadog_test_collation.dbo.ϑings (name);
-GO
 
 CREATE SCHEMA test_schema;
 GO

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -99,6 +99,13 @@ GO
 CREATE DATABASE datadog_test_collation
     COLLATE Latin1_General_100_BIN2;
 GO
+CREATE TABLE datadog_test_collation.dbo.ϑings (id int DEFAULT 0, name varchar(255));
+INSERT INTO datadog_test_collation.dbo.ϑings VALUES (1, 'foo'), (2, 'bar');
+CREATE USER bob FOR LOGIN bob;
+CREATE USER fred FOR LOGIN fred;
+CREATE CLUSTERED INDEX thingsindex ON datadog_test_collation.dbo.ϑings (name);
+GO
+
 
 -- Create test database for integration tests
 -- only bob and fred have read/write access to this database

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -86,6 +86,13 @@ GO
 CREATE DATABASE datadog_test_schemas_second;
 GO
 USE datadog_test_schemas_second;
+-- This table is pronounced "things" except we've replaced "th" with the greek lower case "theta" to ensure we
+-- correctly support unicode throughout the integration.
+CREATE TABLE datadog_test_schemas_second.dbo.ϑings (id int DEFAULT 0, name varchar(255));
+INSERT INTO datadog_test_schemas_second.dbo.ϑings VALUES (1, 'foo'), (2, 'bar');
+CREATE USER bob FOR LOGIN bob;
+CREATE USER fred FOR LOGIN fred;
+CREATE CLUSTERED INDEX thingsindex ON datadog_test_schemas_second.dbo.ϑings (name);
 GO
 
 -- Create an alternate collation database to test handling of case sensitivity

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -99,6 +99,7 @@ GO
 CREATE DATABASE datadog_test_collation
     COLLATE Latin1_General_100_BIN2;
 GO
+USE datadog_test_collation;
 CREATE TABLE datadog_test_collation.dbo.ϑings (id int DEFAULT 0, name varchar(255));
 INSERT INTO datadog_test_collation.dbo.ϑings VALUES (1, 'foo'), (2, 'bar');
 CREATE USER bob FOR LOGIN bob;

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -95,6 +95,11 @@ CREATE USER fred FOR LOGIN fred;
 CREATE CLUSTERED INDEX thingsindex ON datadog_test_schemas_second.dbo.ϑings (name);
 GO
 
+-- Create an alternate collation database to test handling of case sensitivity
+CREATE DATABASE datadog_test_collation
+    COLLATE Latin1_General_100_BIN2;
+GO
+
 -- Create test database for integration tests
 -- only bob and fred have read/write access to this database
 CREATE DATABASE [datadog_test-1];

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -107,6 +107,61 @@ CREATE USER fred FOR LOGIN fred;
 CREATE CLUSTERED INDEX thingsindex ON datadog_test_collation.dbo.ϑings (name);
 GO
 
+CREATE SCHEMA test_schema;
+GO
+
+-- Create the partition function
+CREATE PARTITION FUNCTION CityPartitionFunction (INT)
+AS RANGE LEFT FOR VALUES (100, 200, 300); -- Define your partition boundaries here
+
+-- Create the partition scheme
+CREATE PARTITION SCHEME CityPartitionScheme
+AS PARTITION CityPartitionFunction ALL TO ([PRIMARY]); -- Assign partitions to filegroups
+
+-- Create the partitioned table
+CREATE TABLE datadog_test_collation.test_schema.cities (
+    id INT NOT NULL DEFAULT 0,
+    name VARCHAR(255),
+    population INT NOT NULL DEFAULT 0,
+    CONSTRAINT PK_Cities PRIMARY KEY (id)
+) ON CityPartitionScheme(id); -- Assign the partition scheme to the table
+
+-- Create indexes
+CREATE INDEX two_columns_index ON datadog_test_collation.test_schema.cities (id, name);
+CREATE INDEX single_column_index ON datadog_test_collation.test_schema.cities (population);
+
+INSERT INTO datadog_test_collation.test_schema.cities  VALUES (1, 'yey', 100), (2, 'bar', 200);
+GO
+
+-- Create table with a foreign key
+CREATE TABLE datadog_test_collation.test_schema.landmarks (name varchar(255), city_id int DEFAULT 0);
+GO
+ALTER TABLE datadog_test_collation.test_schema.landmarks ADD CONSTRAINT FK_CityId FOREIGN KEY (city_id)
+REFERENCES datadog_test_collation.test_schema.cities(id)
+ON DELETE SET NULL;
+GO
+
+-- Create table with unique constraint
+CREATE TABLE datadog_test_collation.test_schema.Restaurants (
+    RestaurantName VARCHAR(255),
+    District VARCHAR(100),
+    Cuisine VARCHAR(100),
+    CONSTRAINT UC_RestaurantNameDistrict UNIQUE (RestaurantName, District)
+);
+GO
+
+-- Create table with a foreign key on two columns
+CREATE TABLE datadog_test_collation.test_schema.RestaurantReviews (
+    RestaurantName VARCHAR(255),
+    District VARCHAR(100),
+    Review VARCHAR(MAX),
+    CONSTRAINT FK_RestaurantNameDistrict FOREIGN KEY (RestaurantName, District)
+        REFERENCES datadog_test_collation.test_schema.Restaurants(RestaurantName, District)
+        ON DELETE CASCADE
+        ON UPDATE SET NULL
+);
+GO
+
 
 -- Create test database for integration tests
 -- only bob and fred have read/write access to this database

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -86,26 +86,12 @@ GO
 CREATE DATABASE datadog_test_schemas_second;
 GO
 USE datadog_test_schemas_second;
--- This table is pronounced "things" except we've replaced "th" with the greek lower case "theta" to ensure we
--- correctly support unicode throughout the integration.
-CREATE TABLE datadog_test_schemas_second.dbo.ϑings (id int DEFAULT 0, name varchar(255));
-INSERT INTO datadog_test_schemas_second.dbo.ϑings VALUES (1, 'foo'), (2, 'bar');
-CREATE USER bob FOR LOGIN bob;
-CREATE USER fred FOR LOGIN fred;
-CREATE CLUSTERED INDEX thingsindex ON datadog_test_schemas_second.dbo.ϑings (name);
-GO
 
 -- Create an alternate collation database to test handling of case sensitivity
 CREATE DATABASE datadog_test_collation
     COLLATE Latin1_General_100_BIN2;
 GO
 USE datadog_test_collation;
-CREATE TABLE datadog_test_collation.dbo.ϑings (id int DEFAULT 0, name varchar(255));
-INSERT INTO datadog_test_collation.dbo.ϑings VALUES (1, 'foo'), (2, 'bar');
-CREATE USER bob FOR LOGIN bob;
-CREATE USER fred FOR LOGIN fred;
-CREATE CLUSTERED INDEX thingsindex ON datadog_test_collation.dbo.ϑings (name);
-GO
 
 CREATE SCHEMA test_schema;
 GO

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -86,12 +86,14 @@ GO
 CREATE DATABASE datadog_test_schemas_second;
 GO
 USE datadog_test_schemas_second;
+GO
 
 -- Create an alternate collation database to test handling of case sensitivity
 CREATE DATABASE datadog_test_collation
     COLLATE Latin1_General_100_BIN2;
 GO
 USE datadog_test_collation;
+GO
 
 CREATE SCHEMA test_schema;
 GO

--- a/sqlserver/tests/test_metadata.py
+++ b/sqlserver/tests/test_metadata.py
@@ -338,7 +338,7 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
     expected_data_for_db = {
         'datadog_test_schemas_second': exp_datadog_test,
         'datadog_test_schemas': exp_datadog_test_schemas,
-        'exp_datadog_test_collation': exp_datadog_test_collation,
+        'datadog_test_collation': exp_datadog_test_collation,
     }
 
     dbm_instance['database_autodiscovery'] = True

--- a/sqlserver/tests/test_metadata.py
+++ b/sqlserver/tests/test_metadata.py
@@ -326,7 +326,7 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
             }
         ],
     }
-    exp_datadog_test_collation = deepcopy(exp_datadog_test)
+    exp_datadog_test_collation = deepcopy(exp_datadog_test_schemas)
     exp_datadog_test_collation['name'] = 'datadog_test_collation'
     exp_datadog_test_collation['collation'] = 'Latin1_General_100_BIN2'
 

--- a/sqlserver/tests/test_metadata.py
+++ b/sqlserver/tests/test_metadata.py
@@ -383,10 +383,6 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
         normalize_ids(actual_payload)
         # index columns may be in any order
         normalize_indexes_columns(actual_payload)
-        logging.warning("db_name %s", db_name)
-        logging.warning("actual_payload %s", expected_data_for_db.keys())
-        if db_name not in expected_data_for_db:
-            logging.warning("db_name %s not found in expected_data_for_db %s", db_name, expected_data_for_db.keys())
         assert deep_compare(actual_payload, expected_data_for_db[db_name])
 
 

--- a/sqlserver/tests/test_metadata.py
+++ b/sqlserver/tests/test_metadata.py
@@ -326,13 +326,10 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
             }
         ],
     }
-    exp_datadog_test_collation = {
-        'id': 'normalized_value',
-        'name': 'exp_datadog_test_collation',
-        "collation": "Latin1_General_100_BIN2",
-        'owner': 'dbo',
-        'schemas': [],
-    }
+    exp_datadog_test_collation = copy.deepcopy(exp_datadog_test)
+    exp_datadog_test_collation['name'] = 'datadog_test_collation'
+    exp_datadog_test_collation['collation'] = 'Latin1_General_100_BIN2'
+
     if running_on_windows_ci():
         exp_datadog_test['owner'] = 'None'
         exp_datadog_test_schemas['owner'] = 'None'

--- a/sqlserver/tests/test_metadata.py
+++ b/sqlserver/tests/test_metadata.py
@@ -383,10 +383,10 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
         normalize_ids(actual_payload)
         # index columns may be in any order
         normalize_indexes_columns(actual_payload)
-        logging.warning("db_name {}", db_name)
-        logging.warning("actual_payload {}", expected_data_for_db.keys())
+        logging.warning("db_name %s", db_name)
+        logging.warning("actual_payload %s", expected_data_for_db.keys())
         if db_name not in expected_data_for_db:
-            logging.warning("db_name {} not found in expected_data_for_db {}", db_name, expected_data_for_db.keys())
+            logging.warning("db_name %s not found in expected_data_for_db %s", db_name, expected_data_for_db.keys())
         assert deep_compare(actual_payload, expected_data_for_db[db_name])
 
 

--- a/sqlserver/tests/test_metadata.py
+++ b/sqlserver/tests/test_metadata.py
@@ -385,7 +385,7 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
         normalize_indexes_columns(actual_payload)
         logging.warning(f"db_name {db_name}")
         logging.warning(f"actual_payload {expected_data_for_db.keys()}")
-        if db_name not in expected_data_for_db:            
+        if db_name not in expected_data_for_db:
             logging.warning(f"db_name {db_name} not found in expected_data_for_db {expected_data_for_db.keys()}")
         assert deep_compare(actual_payload, expected_data_for_db[db_name])
 

--- a/sqlserver/tests/test_metadata.py
+++ b/sqlserver/tests/test_metadata.py
@@ -96,7 +96,7 @@ def test_sqlserver_collect_settings(aggregator, dd_run_check, dbm_instance):
 
 
 def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
-    databases_to_find = ['datadog_test_schemas', 'datadog_test_schemas_second']
+    databases_to_find = ['datadog_test_schemas', 'datadog_test_schemas_second', 'datadog_test_collation']
     exp_datadog_test = {
         'id': 'normalized_value',
         'name': 'datadog_test_schemas_second',
@@ -326,18 +326,30 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
             }
         ],
     }
-
+    exp_datadog_test_collation = {
+        'id': 'normalized_value',
+        'name': 'exp_datadog_test_collation',
+        "collation": "Latin1_General_100_BIN2",
+        'owner': 'dbo',
+        'schemas': [],
+    }
     if running_on_windows_ci():
         exp_datadog_test['owner'] = 'None'
         exp_datadog_test_schemas['owner'] = 'None'
+        exp_datadog_test_collation['owner'] = 'None'
 
     expected_data_for_db = {
         'datadog_test_schemas_second': exp_datadog_test,
         'datadog_test_schemas': exp_datadog_test_schemas,
+        'exp_datadog_test_collation': exp_datadog_test_collation,
     }
 
     dbm_instance['database_autodiscovery'] = True
-    dbm_instance['autodiscovery_include'] = ['datadog_test_schemas', 'datadog_test_schemas_second']
+    dbm_instance['autodiscovery_include'] = [
+        'datadog_test_schemas',
+        'datadog_test_schemas_second',
+        'datadog_test_collation',
+    ]
     dbm_instance['dbm'] = True
     dbm_instance['schemas_collection'] = {"enabled": True}
 

--- a/sqlserver/tests/test_metadata.py
+++ b/sqlserver/tests/test_metadata.py
@@ -383,8 +383,10 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
         normalize_ids(actual_payload)
         # index columns may be in any order
         normalize_indexes_columns(actual_payload)
-        if db_name not in expected_data_for_db:
-            print (f"db_name {db_name} not found in expected_data_for_db {expected_data_for_db.keys()}")
+        logging.warning(f"db_name {db_name}")
+        logging.warning(f"actual_payload {expected_data_for_db.keys()}")
+        if db_name not in expected_data_for_db:            
+            logging.warning(f"db_name {db_name} not found in expected_data_for_db {expected_data_for_db.keys()}")
         assert deep_compare(actual_payload, expected_data_for_db[db_name])
 
 

--- a/sqlserver/tests/test_metadata.py
+++ b/sqlserver/tests/test_metadata.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 
 import logging
 import re
-from copy import copy
+from copy import copy, deepcopy
 
 import pytest
 
@@ -326,7 +326,7 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
             }
         ],
     }
-    exp_datadog_test_collation = copy.deepcopy(exp_datadog_test)
+    exp_datadog_test_collation = deepcopy(exp_datadog_test)
     exp_datadog_test_collation['name'] = 'datadog_test_collation'
     exp_datadog_test_collation['collation'] = 'Latin1_General_100_BIN2'
 

--- a/sqlserver/tests/test_metadata.py
+++ b/sqlserver/tests/test_metadata.py
@@ -383,6 +383,8 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
         normalize_ids(actual_payload)
         # index columns may be in any order
         normalize_indexes_columns(actual_payload)
+        if db_name not in expected_data_for_db:
+            print (f"db_name {db_name} not found in expected_data_for_db {expected_data_for_db.keys()}")
         assert deep_compare(actual_payload, expected_data_for_db[db_name])
 
 

--- a/sqlserver/tests/test_metadata.py
+++ b/sqlserver/tests/test_metadata.py
@@ -383,10 +383,10 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
         normalize_ids(actual_payload)
         # index columns may be in any order
         normalize_indexes_columns(actual_payload)
-        logging.warning(f"db_name {db_name}")
-        logging.warning(f"actual_payload {expected_data_for_db.keys()}")
+        logging.warning("db_name {}", db_name)
+        logging.warning("actual_payload {}", expected_data_for_db.keys())
         if db_name not in expected_data_for_db:
-            logging.warning(f"db_name {db_name} not found in expected_data_for_db {expected_data_for_db.keys()}")
+            logging.warning("db_name {} not found in expected_data_for_db {}", db_name, expected_data_for_db.keys())
         assert deep_compare(actual_payload, expected_data_for_db[db_name])
 
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add testing and support for case-sensitive collations in SQL Server.

### Motivation
<!-- What inspired you to submit this pull request? -->
Currently if users choose a case-sensitive collation one of our schema queries fails with the wrong case.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
