### PR TITLE
Add Fortigate port and switch table

### DIFF
--- a/snmp/datadog_checks/snmp/data/default_profiles/fortinet-fortigate.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/fortinet-fortigate.yaml
@@ -317,3 +317,71 @@ metrics:
       # Firewall policy6 ID. Only enabled policies are present in this table. Policy IDs are only unique within a virtual domain.
       - index: 2
         tag: policy6_index
+
+  ### Switch Controller
+  # Switch controller port statistics table.
+  - MIB: FORTINET-FORTIGATE-MIB
+    table:
+      name: fgSwPortTable
+      OID: 1.3.6.1.4.1.12356.101.24.2.1.1
+    symbols:
+      # Current operational status of the switch port.
+      - name: fgSwPortStatus
+        OID: 1.3.6.1.4.1.12356.101.24.2.1.1.6
+        metric_type: gauge
+      # Current power consumption of the PoE (Power over Ethernet) port.
+      - name: fgSwPortPOEPower
+        OID: 1.3.6.1.4.1.12356.101.24.2.1.1.14
+        metric_type: gauge
+    metric_tags:
+      # Name of the switch port (e.g., "port1", "port2").
+      - column:
+          name: fgSwPortName
+          OID: 1.3.6.1.4.1.12356.101.24.2.1.1.5
+        tag: port_name
+      # Serial number of the switch.
+      - column:
+          name: fgSwPortSwitchSerialNum
+          OID: 1.3.6.1.4.1.12356.101.24.2.1.1.4
+        tag: switch_serial
+      # Speed and duplex mode of the switch port (e.g., "auto", "100full").
+      - column:
+          name: fgSwPortSpeedDuplex
+          OID: 1.3.6.1.4.1.12356.101.24.2.1.1.7
+        tag: port_speed_duplex
+      # Name of the switch, extracted from the switch device table.
+      - symbol:
+          name: fgSwDeviceName
+          OID: 1.3.6.1.4.1.12356.101.24.1.1.1.4
+        table: fgSwDeviceTable
+        index_transform:
+          - start: 0
+            end: 2
+        tag: switch_name
+
+  # Switch controller device statistics table.
+  - MIB: FORTINET-FORTIGATE-MIB
+    table:
+      name: fgSwDeviceTable
+      OID: 1.3.6.1.4.1.12356.101.24.1.1.1
+    symbols:
+      # Current CPU utilization of the switch.
+      - name: fgSwCpu
+        OID: 1.3.6.1.4.1.12356.101.24.1.1.1.11
+        metric_type: gauge
+      # Current memory utilization of the switch.
+      - name: fgSwMemory
+        OID: 1.3.6.1.4.1.12356.101.24.1.1.1.12
+        metric_type: gauge
+    metric_tags:
+      # Name of the switch.
+      - column:
+          name: fgSwDeviceName
+          OID: 1.3.6.1.4.1.12356.101.24.1.1.1.4
+        tag: switch_name
+      # Serial number of the switch.
+      - column:
+          name: fgSwDeviceSerialNum
+          OID: 1.3.6.1.4.1.12356.101.24.1.1.1.3
+        tag: switch_serial
+


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

* Adds support for `FORTINET-FORTIGATE-MIB` `fgSwDeviceTable` and `fgSwPortTable` 
  * enables monitoring of managed switch ports and switch resource usage tagged by `switch_name` and `switch_serial`

### Motivation
<!-- What inspired you to submit this pull request? -->

* Zendesk support case #2013960

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
