### PR TITLE
Fix inconsistent capitalization of `Fluentd`

### DIFF
--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -54,7 +54,7 @@ To configure this check for an Agent running on a host:
 
 ##### Log collection
 
-You can use the [Datadog FluentD plugin][6] to forward the logs directly from FluentD to your Datadog account.
+You can use the [Datadog Fluentd plugin][6] to forward the logs directly from Fluentd to your Datadog account.
 
 ###### Add metadata to your logs
 
@@ -132,7 +132,7 @@ If your logs contain any of the following attributes, these attributes are autom
 - `kubernetes.pod_name`
 - `docker.container_id`
 
-While the Datadog Agent collects Docker and Kubernetes metadata automatically, FluentD requires a plugin for this. Datadog recommends using [fluent-plugin-kubernetes_metadata_filter][12] to collect this metadata.
+While the Datadog Agent collects Docker and Kubernetes metadata automatically, Fluentd requires a plugin for this. Datadog recommends using [fluent-plugin-kubernetes_metadata_filter][12] to collect this metadata.
 
 Configuration example:
 
@@ -173,7 +173,7 @@ See [metadata.csv][15] for a list of metrics provided by this integration.
 
 ### Events
 
-The FluentD check does not include any events.
+The Fluentd check does not include any events.
 
 ### Service Checks
 


### PR DESCRIPTION
### What does this PR do?

Changed `FluentD` to `Fluentd` for consistency.

### Motivation

There were inconsistencies in the capitalization of `Fluentd` and `FluentD`. If both `FluentD` and `Fluentd` are mixed in a single document, it is unclear whether they refer to the same thing. In fact, I am a beginner with Fluentd, and it took me a little time to determine whether they are the same or different.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

### Question

Should the following `manifest.json` and `fluentd_dashboard.json` also be changed?

- https://github.com/DataDog/integrations-core/blob/f8afb3ad7ad24f4e0a768ff2cacd3e9ef83b81c1/fluentd/manifest.json
- https://github.com/DataDog/integrations-core/blob/f8afb3ad7ad24f4e0a768ff2cacd3e9ef83b81c1/fluentd/assets/dashboards/fluentd_dashboard.json

