### PR TITLE
Add comment and test about how to assert empty hostname in `assert_metric`

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -325,7 +325,6 @@ class AggregatorStub(object):
         metric_type=None,
         device=None,
         flush_first_value=None,
-        assert_empty_hostname=False,
     ):
         """
         Assert a metric was processed by this stub
@@ -342,10 +341,9 @@ class AggregatorStub(object):
             if expected_tags and expected_tags != sorted(metric.tags):
                 continue
 
-            if assert_empty_hostname and (metric.hostname is None):
-                continue
-
-            if not assert_empty_hostname and hostname is not None and hostname != metric.hostname:
+            # to assert hostname is None, pass in hostname as '':
+            # https://github.com/DataDog/integrations-core/blob/7.65.x/datadog_checks_base/datadog_checks/base/checks/base.py#L760
+            if hostname is not None and hostname != metric.hostname:
                 continue
 
             if metric_type is not None and metric_type != metric.type:

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -325,6 +325,7 @@ class AggregatorStub(object):
         metric_type=None,
         device=None,
         flush_first_value=None,
+        assert_empty_hostname=False,
     ):
         """
         Assert a metric was processed by this stub
@@ -341,7 +342,10 @@ class AggregatorStub(object):
             if expected_tags and expected_tags != sorted(metric.tags):
                 continue
 
-            if hostname is not None and hostname != metric.hostname:
+            if assert_empty_hostname and (metric.hostname is None):
+                continue
+
+            if not assert_empty_hostname and hostname is not None and hostname != metric.hostname:
                 continue
 
             if metric_type is not None and metric_type != metric.type:

--- a/datadog_checks_base/tests/stubs/test_assert_metric.py
+++ b/datadog_checks_base/tests/stubs/test_assert_metric.py
@@ -1,7 +1,6 @@
 # (C) Datadog, Inc. 2025-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
 
 from datadog_checks.base import AgentCheck
 

--- a/datadog_checks_base/tests/stubs/test_assert_metric.py
+++ b/datadog_checks_base/tests/stubs/test_assert_metric.py
@@ -1,0 +1,19 @@
+# (C) Datadog, Inc. 2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from datadog_checks.base import AgentCheck
+
+
+class TestAssertMetric:
+
+    def test_assert_metric_hostname(self, aggregator):
+        check = AgentCheck()
+
+        check.gauge('test.metric', 1, hostname=None)
+        check.gauge('test.metric_host', 1, hostname='hello')
+
+
+        aggregator.assert_metric('test.metric', 1, hostname='')
+        aggregator.assert_metric('test.metric_host', 1, hostname='hello')

--- a/datadog_checks_base/tests/stubs/test_assert_metric.py
+++ b/datadog_checks_base/tests/stubs/test_assert_metric.py
@@ -13,6 +13,5 @@ class TestAssertMetric:
         check.gauge('test.metric', 1, hostname=None)
         check.gauge('test.metric_host', 1, hostname='hello')
 
-
         aggregator.assert_metric('test.metric', 1, hostname='')
         aggregator.assert_metric('test.metric_host', 1, hostname='hello')


### PR DESCRIPTION
### What does this PR do?
Add comment describing how to assert a metric was submitted with an empty hostname in `assert_metric`. The base check's `_submit_metric` method converts a hostname submitted with None to "": https://github.com/DataDog/integrations-core/blob/7.65.x/datadog_checks_base/datadog_checks/base/checks/base.py#L760, so to assert that a metric has an empty hostname, you must assert `hostname=""`

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
