### PR TITLE
Don't submit property metrics with unknown hostname

### DIFF
--- a/vsphere/changelog.d/19944.fixed
+++ b/vsphere/changelog.d/19944.fixed
@@ -1,0 +1,1 @@
+Don't submit property metrics with unknown hostname.

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -1039,7 +1039,7 @@ class VSphereCheck(AgentCheck):
         # type: (...) -> None
         resource_metric_suffix = MOR_TYPE_AS_STRING[resource_type]
         mor_name = to_string(mor_props.get('name', 'unknown'))
-        hostname = mor_props.get('hostname', 'unknown')
+        hostname = mor_props.get('hostname')
 
         all_properties = mor_props.get('properties', None)
         if not all_properties:

--- a/vsphere/tests/test_unit.py
+++ b/vsphere/tests/test_unit.py
@@ -2851,7 +2851,7 @@ def test_historical_property_metrics_empty_hostname(
     dd_run_check(check)
 
     # assert historical metrics sent with empty hostname
-    # ultimately these will be submitted with the agent hostname, but that logic is
+    # these can be submitted with the agent hostname if empty_default_hostname is False, but that logic is
     # in the agent code https://github.com/DataDog/datadog-agent/blob/7.65.x/pkg/aggregator/sender.go#L209-L211
     aggregator.assert_metric('vsphere.cluster.configuration.drsConfig.enabled', hostname='')
     aggregator.assert_metric('vsphere.datastore.summary.capacity', hostname='')

--- a/vsphere/tests/test_unit.py
+++ b/vsphere/tests/test_unit.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import contextlib
-import copy
 import logging
 
 import pytest
@@ -2839,15 +2838,13 @@ def test_datastore_property_metrics(aggregator, historical_instance, dd_run_chec
 
 
 def test_historical_property_metrics_empty_hostname(
-    aggregator, historical_instance, dd_run_check, service_instance, vm_properties_ex, caplog
+    aggregator, historical_instance, dd_run_check, service_instance, vm_properties_ex
 ):
-    instance = copy.deepcopy(historical_instance)
-    instance['collect_property_metrics'] = True
+    historical_instance['collect_property_metrics'] = True
 
     service_instance.content.propertyCollector.RetrievePropertiesEx = vm_properties_ex
 
-    caplog.set_level(logging.DEBUG)
-    check = VSphereCheck('vsphere', {}, [instance])
+    check = VSphereCheck('vsphere', {}, [historical_instance])
     dd_run_check(check)
 
     # assert historical metrics sent with empty hostname

--- a/vsphere/tests/test_unit.py
+++ b/vsphere/tests/test_unit.py
@@ -2838,7 +2838,6 @@ def test_datastore_property_metrics(aggregator, historical_instance, dd_run_chec
     aggregator.assert_metric('vsphere.datastore.summary.capacity', count=1, value=100, tags=base_tags)
 
 
-
 def test_historical_property_metrics_empty_hostname(
     aggregator, historical_instance, dd_run_check, service_instance, vm_properties_ex, caplog
 ):

--- a/vsphere/tests/test_unit.py
+++ b/vsphere/tests/test_unit.py
@@ -2,9 +2,9 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import contextlib
+import copy
 import logging
 
-import copy
 import pytest
 from mock import MagicMock, mock, patch
 from pyVmomi import vim, vmodl

--- a/vsphere/tests/test_unit.py
+++ b/vsphere/tests/test_unit.py
@@ -4,6 +4,7 @@
 import contextlib
 import logging
 
+import copy
 import pytest
 from mock import MagicMock, mock, patch
 from pyVmomi import vim, vmodl
@@ -11,7 +12,7 @@ from pyVmomi import vim, vmodl
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.utils.time import get_current_datetime
 from datadog_checks.vsphere import VSphereCheck
-from datadog_checks.vsphere.constants import DEFAULT_MAX_QUERY_METRICS
+from datadog_checks.vsphere.constants import DEFAULT_MAX_QUERY_METRICS, PROPERTY_METRICS_BY_RESOURCE_TYPE
 
 from .common import (
     EVENTS,
@@ -2835,6 +2836,32 @@ def test_datastore_property_metrics(aggregator, historical_instance, dd_run_chec
     dd_run_check(check)
     aggregator.assert_metric('vsphere.datastore.summary.freeSpace', count=1, value=305, tags=base_tags)
     aggregator.assert_metric('vsphere.datastore.summary.capacity', count=1, value=100, tags=base_tags)
+
+
+
+def test_historical_property_metrics_empty_hostname(
+    aggregator, historical_instance, dd_run_check, service_instance, vm_properties_ex, caplog
+):
+    instance = copy.deepcopy(historical_instance)
+    instance['collect_property_metrics'] = True
+
+    service_instance.content.propertyCollector.RetrievePropertiesEx = vm_properties_ex
+
+    caplog.set_level(logging.DEBUG)
+    check = VSphereCheck('vsphere', {}, [instance])
+    dd_run_check(check)
+
+    # assert historical metrics sent with empty hostname
+    # ultimately these will be submitted with the agent hostname, but that logic is
+    # in the agent code https://github.com/DataDog/datadog-agent/blob/7.65.x/pkg/aggregator/sender.go#L209-L211
+    aggregator.assert_metric('vsphere.cluster.configuration.drsConfig.enabled', hostname='')
+    aggregator.assert_metric('vsphere.datastore.summary.capacity', hostname='')
+
+    historical_resources_with_property_metrics = ['cluster', 'datastore']
+    for resource_type in historical_resources_with_property_metrics:
+        metrics = PROPERTY_METRICS_BY_RESOURCE_TYPE[resource_type]
+        for metric in metrics:
+            aggregator.assert_metric(f"vsphere.{resource_type}.{metric}", hostname='')
 
 
 def test_property_metrics_resource_filters(


### PR DESCRIPTION
### What does this PR do?
Stops submitting property metrics with 'unknown' hostname, now sends with None so it is either empty or the agent default hostname.
### Motivation
support case 
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
