### PR TITLE
Weaken conditions for applying the no-changelog label

### DIFF
--- a/.github/workflows/config/labeler.yml
+++ b/.github/workflows/config/labeler.yml
@@ -1,13 +1,10 @@
 base_package:
 - datadog_checks_base/**/*
 changelog/no-changelog:
+  # We apply no-changelog label for PRs that release integrations by bumping __about__.py.
 - any:
   - requirements-agent-release.txt
   - '**/__about__.py'
-- all:
-  - '!*/datadog_checks/**'
-  - '!*/pyproject.toml'
-  - '!ddev/src/**'
 ddev:
 - ddev/**/*
 dependencies:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
### Before
We'd apply the `changelog/no-changelog` label for any PRs that don't modify specific paths.

### After
Only apply `changelog/no-changelog` label for release PRs.

### Motivation
<!-- What inspired you to submit this pull request? -->
Firstly, the labeler config's logic is a subset of the changelog check github action. No point having this in 2 places, the changelog check has proven to be reliable.

Secondly, [PRs like this](https://github.com/DataDog/integrations-core/pull/19931) trick the labeler into applying the label and thus stopping the changelog check.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
