### PR TITLE
Add TID ruff ruleset for relative imports

### DIFF
--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -95,6 +95,7 @@ select = [
   "G",
   "W",
   "I",
+  "TID",
 ]
 ignore = [
   # From legacy flake8 settings
@@ -116,7 +117,7 @@ unfixable = [
 known-first-party = ["ddev"]
 
 [tool.ruff.lint.flake8-tidy-imports]
-ban-relative-imports = "all"
+ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 #Tests can use assertions and relative imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ select = [
   "G",
   "W",
   "I",
+  "TID",
 ]
 ignore = [
   # From legacy flake8 settings
@@ -101,7 +102,7 @@ unfixable = [
 known-first-party = ["{template_config['package_name']}"]
 
 [tool.ruff.lint.flake8-tidy-imports]
-ban-relative-imports = "all"
+ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 #Tests can use assertions and relative imports


### PR DESCRIPTION
### What does this PR do?
Add TID ruleset for ruff to check for relative imports.

Allow for parents relative imports only

https://docs.astral.sh/ruff/rules/#flake8-tidy-imports-tid
