### PR TITLE
Remove non-parent relative imports to comply with linting rules.

### DIFF
--- a/gitlab/datadog_checks/gitlab/gitlab_v2.py
+++ b/gitlab/datadog_checks/gitlab/gitlab_v2.py
@@ -7,9 +7,9 @@ from collections import ChainMap
 import requests
 
 from datadog_checks.base import AgentCheck, OpenMetricsBaseCheckV2
+from datadog_checks.base.checks.openmetrics.v2.scraper import OpenMetricsCompatibilityScraper
 from datadog_checks.gitlab.config_models import ConfigMixin
 
-from datadog_checks.base.checks.openmetrics.v2.scraper import OpenMetricsCompatibilityScraper
 from .common import get_gitlab_version, get_tags
 from .metrics import GITALY_METRICS_MAP, METRICS_MAP, construct_metrics_config
 

--- a/gitlab/datadog_checks/gitlab/gitlab_v2.py
+++ b/gitlab/datadog_checks/gitlab/gitlab_v2.py
@@ -9,7 +9,7 @@ import requests
 from datadog_checks.base import AgentCheck, OpenMetricsBaseCheckV2
 from datadog_checks.gitlab.config_models import ConfigMixin
 
-from ..base.checks.openmetrics.v2.scraper import OpenMetricsCompatibilityScraper
+from datadog_checks.base.checks.openmetrics.v2.scraper import OpenMetricsCompatibilityScraper
 from .common import get_gitlab_version, get_tags
 from .metrics import GITALY_METRICS_MAP, METRICS_MAP, construct_metrics_config
 

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
@@ -5,9 +5,8 @@ from typing import Callable, Dict, List  # noqa: F401
 
 from datadog_checks.base import AgentCheck, to_string
 from datadog_checks.base.log import CheckLoggingAdapter  # noqa: F401
-
-from .. import metrics
-from ..config import IBMMQConfig  # noqa: F401
+from datadog_checks.ibm_mq import metrics
+from datadog_checks.ibm_mq.config import IBMMQConfig  # noqa: F401
 
 try:
     import pymqi

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
@@ -7,8 +7,8 @@ from typing import Any, Callable, Dict, List, Set  # noqa: F401
 from datadog_checks.base import AgentCheck, to_string
 from datadog_checks.base.types import ServiceCheck  # noqa: F401
 from datadog_checks.ibm_mq import metrics
-from datadog_checks.ibm_mq.metrics import GAUGE
 from datadog_checks.ibm_mq.config import IBMMQConfig  # noqa: F401
+from datadog_checks.ibm_mq.metrics import GAUGE
 
 try:
     import pymqi

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
@@ -6,10 +6,9 @@ from typing import Any, Callable, Dict, List, Set  # noqa: F401
 
 from datadog_checks.base import AgentCheck, to_string
 from datadog_checks.base.types import ServiceCheck  # noqa: F401
+from datadog_checks.ibm_mq import metrics
 from datadog_checks.ibm_mq.metrics import GAUGE
-
-from .. import metrics
-from ..config import IBMMQConfig  # noqa: F401
+from datadog_checks.ibm_mq.config import IBMMQConfig  # noqa: F401
 
 try:
     import pymqi

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/stats_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/stats_collector.py
@@ -8,8 +8,8 @@ from pymqi.CMQCFC import MQCMD_STATISTICS_CHANNEL, MQCMD_STATISTICS_Q
 from datadog_checks.ibm_mq.stats.base_stats import BaseStats
 from datadog_checks.ibm_mq.stats.queue_stats import QueueStats
 
-from ..metrics import METRIC_PREFIX, channel_stats_metrics, queue_stats_metrics
-from ..stats import ChannelStats
+from datadog_checks.ibm_mq.metrics import METRIC_PREFIX, channel_stats_metrics, queue_stats_metrics
+from datadog_checks.ibm_mq.stats import ChannelStats
 
 try:
     import pymqi

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/stats_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/stats_collector.py
@@ -5,11 +5,10 @@
 from dateutil.tz import UTC
 from pymqi.CMQCFC import MQCMD_STATISTICS_CHANNEL, MQCMD_STATISTICS_Q
 
-from datadog_checks.ibm_mq.stats.base_stats import BaseStats
-from datadog_checks.ibm_mq.stats.queue_stats import QueueStats
-
 from datadog_checks.ibm_mq.metrics import METRIC_PREFIX, channel_stats_metrics, queue_stats_metrics
 from datadog_checks.ibm_mq.stats import ChannelStats
+from datadog_checks.ibm_mq.stats.base_stats import BaseStats
+from datadog_checks.ibm_mq.stats.queue_stats import QueueStats
 
 try:
     import pymqi

--- a/ibm_mq/datadog_checks/ibm_mq/stats/base_stats.py
+++ b/ibm_mq/datadog_checks/ibm_mq/stats/base_stats.py
@@ -6,7 +6,7 @@ import datetime as dt
 from dateutil.tz import UTC
 from pymqi.CMQCFC import MQCAMO_START_DATE, MQCAMO_START_TIME
 
-from ..utils import sanitize_strings
+from datadog_checks.ibm_mq.utils import sanitize_strings
 
 try:
     import pymqi

--- a/ibm_mq/datadog_checks/ibm_mq/stats/channel_stats.py
+++ b/ibm_mq/datadog_checks/ibm_mq/stats/channel_stats.py
@@ -5,7 +5,6 @@ from pymqi.CMQC import MQCA_REMOTE_Q_MGR_NAME
 from pymqi.CMQCFC import MQCACH_CHANNEL_NAME, MQCACH_CONNECTION_NAME, MQGACF_CHL_STATISTICS_DATA, MQIACH_CHANNEL_TYPE
 
 from datadog_checks.ibm_mq.stats.base_stats import BaseStats
-
 from datadog_checks.ibm_mq.utils import sanitize_strings
 
 try:

--- a/ibm_mq/datadog_checks/ibm_mq/stats/channel_stats.py
+++ b/ibm_mq/datadog_checks/ibm_mq/stats/channel_stats.py
@@ -6,7 +6,7 @@ from pymqi.CMQCFC import MQCACH_CHANNEL_NAME, MQCACH_CONNECTION_NAME, MQGACF_CHL
 
 from datadog_checks.ibm_mq.stats.base_stats import BaseStats
 
-from ..utils import sanitize_strings
+from datadog_checks.ibm_mq.utils import sanitize_strings
 
 try:
     import pymqi

--- a/ibm_mq/datadog_checks/ibm_mq/stats/queue_stats.py
+++ b/ibm_mq/datadog_checks/ibm_mq/stats/queue_stats.py
@@ -5,7 +5,6 @@ from pymqi.CMQC import MQCA_Q_NAME, MQIA_DEFINITION_TYPE, MQIA_Q_TYPE
 from pymqi.CMQCFC import MQGACF_Q_STATISTICS_DATA
 
 from datadog_checks.ibm_mq.stats.base_stats import BaseStats
-
 from datadog_checks.ibm_mq.utils import sanitize_strings
 
 try:

--- a/ibm_mq/datadog_checks/ibm_mq/stats/queue_stats.py
+++ b/ibm_mq/datadog_checks/ibm_mq/stats/queue_stats.py
@@ -6,7 +6,7 @@ from pymqi.CMQCFC import MQGACF_Q_STATISTICS_DATA
 
 from datadog_checks.ibm_mq.stats.base_stats import BaseStats
 
-from ..utils import sanitize_strings
+from datadog_checks.ibm_mq.utils import sanitize_strings
 
 try:
     import pymqi

--- a/marklogic/datadog_checks/marklogic/parsers/common.py
+++ b/marklogic/datadog_checks/marklogic/parsers/common.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from typing import Any, List, Optional, Tuple  # noqa: F401
 
-from ..constants import GAUGE_UNITS
+from datadog_checks.marklogic.constants import GAUGE_UNITS
 
 
 class MarkLogicParserException(RuntimeError):

--- a/marklogic/datadog_checks/marklogic/parsers/health.py
+++ b/marklogic/datadog_checks/marklogic/parsers/health.py
@@ -4,7 +4,6 @@
 from typing import Any, Dict  # noqa: F401
 
 from datadog_checks.base import AgentCheck
-
 from datadog_checks.marklogic.constants import STATE_HEALTH_MAPPER
 
 

--- a/marklogic/datadog_checks/marklogic/parsers/health.py
+++ b/marklogic/datadog_checks/marklogic/parsers/health.py
@@ -5,7 +5,7 @@ from typing import Any, Dict  # noqa: F401
 
 from datadog_checks.base import AgentCheck
 
-from ..constants import STATE_HEALTH_MAPPER
+from datadog_checks.marklogic.constants import STATE_HEALTH_MAPPER
 
 
 def parse_summary_health(data):

--- a/marklogic/datadog_checks/marklogic/parsers/resources.py
+++ b/marklogic/datadog_checks/marklogic/parsers/resources.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from typing import Any, Dict, List  # noqa: F401
 
-from ..constants import BASE_ENDPOINT, RESOURCE_TYPES
+from datadog_checks.marklogic.constants import BASE_ENDPOINT, RESOURCE_TYPES
 
 
 def parse_resources(data):

--- a/marklogic/datadog_checks/marklogic/parsers/status.py
+++ b/marklogic/datadog_checks/marklogic/parsers/status.py
@@ -3,8 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from typing import Any, Dict, Generator, List, Tuple  # noqa: F401
 
-from ..constants import RESOURCE_TYPES
-from .common import build_metric_to_submit, is_metric
+from datadog_checks.marklogic.constants import RESOURCE_TYPES
+from datadog_checks.marklogic.parsers.common import build_metric_to_submit, is_metric
 
 
 def parse_summary_status_resource_metrics(resource_type, data, tags):

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -50,7 +50,7 @@ from . import metrics
 try:
     import datadog_agent
 except ImportError:
-    from ..stubs import datadog_agent
+    from datadog_checks.base.stubs import datadog_agent
 
 long = int
 

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -23,7 +23,7 @@ from .util import DatabaseConfigurationError, connect_with_autocommit, get_trunc
 try:
     import datadog_agent
 except ImportError:
-    from ..stubs import datadog_agent
+    from datadog_checks.base.stubs import datadog_agent
 
 
 ACTIVITY_QUERY = """\

--- a/mysql/datadog_checks/mysql/databases_data.py
+++ b/mysql/datadog_checks/mysql/databases_data.py
@@ -5,7 +5,7 @@
 try:
     import datadog_agent
 except ImportError:
-    from ..stubs import datadog_agent
+    from datadog_checks.base.stubs import datadog_agent
 import json
 import time
 from collections import defaultdict

--- a/mysql/datadog_checks/mysql/metadata.py
+++ b/mysql/datadog_checks/mysql/metadata.py
@@ -15,7 +15,7 @@ from .util import connect_with_autocommit
 try:
     import datadog_agent
 except ImportError:
-    from ..stubs import datadog_agent
+    from datadog_checks.base.stubs import datadog_agent
 
 from datadog_checks.base import is_affirmative
 from datadog_checks.base.utils.db.utils import (

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -93,7 +93,7 @@ except ImportError:
 try:
     import datadog_agent
 except ImportError:
-    from ..stubs import datadog_agent
+    from datadog_checks.base.stubs import datadog_agent
 
 
 class MySql(AgentCheck):

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -17,7 +17,7 @@ from datadog_checks.mysql.cursor import CommenterCursor, CommenterDictCursor
 try:
     import datadog_agent
 except ImportError:
-    from ..stubs import datadog_agent
+    from datadog_checks.base.stubs import datadog_agent
 
 from datadog_checks.base import is_affirmative
 from datadog_checks.base.utils.common import to_native_string

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -25,7 +25,7 @@ from .util import DatabaseConfigurationError, connect_with_autocommit, warning_w
 try:
     import datadog_agent
 except ImportError:
-    from ..stubs import datadog_agent
+    from datadog_checks.base.stubs import datadog_agent
 
 PyMysqlRow = Dict[str, Any]
 Row = Dict[str, Any]

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -13,7 +13,7 @@ from datadog_checks.postgres.cursor import CommenterDictCursor
 try:
     import datadog_agent
 except ImportError:
-    from ..stubs import datadog_agent
+    from datadog_checks.base.stubs import datadog_agent
 
 from datadog_checks.base import is_affirmative
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -78,7 +78,7 @@ from .version_utils import V9, V9_2, V10, V12, V13, V14, V15, V16, V17, VersionU
 try:
     import datadog_agent
 except ImportError:
-    from ..stubs import datadog_agent
+    from datadog_checks.base.stubs import datadog_agent
 
 MAX_CUSTOM_RESULTS = 100
 

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -16,7 +16,7 @@ from datadog_checks.postgres.cursor import CommenterCursor, CommenterDictCursor
 try:
     import datadog_agent
 except ImportError:
-    from ..stubs import datadog_agent
+    from datadog_checks.base.stubs import datadog_agent
 
 from datadog_checks.base import is_affirmative
 from datadog_checks.base.utils.common import to_native_string

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -26,7 +26,7 @@ from .version_utils import V9_4, V10, V14
 try:
     import datadog_agent
 except ImportError:
-    from ..stubs import datadog_agent
+    from datadog_checks.base.stubs import datadog_agent
 
 QUERYID_TO_CALLS_QUERY = """
 SELECT queryid, calls

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,13 +70,7 @@ namespace-packages = ["datadog_checks"]
 # Rules were ported over from the legacy flake8 settings for parity
 # All the rules can be found here: https://beta.ruff.rs/docs/rules/
 select = [
-  "B",
-  "C",
-  "E",
-  "F",
-  "G",
-  "W",
-  "I",
+  "TID",
 ]
 ignore = [
   # From legacy flake8 settings
@@ -101,7 +95,7 @@ unfixable = [
 known-first-party = ["{template_config['package_name']}"]
 
 [tool.ruff.lint.flake8-tidy-imports]
-ban-relative-imports = "all"
+ban-relative-imports = "parents"
 
 [tool.ruff.lint.per-file-ignores]
 #Tests can use assertions and relative imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,13 @@ namespace-packages = ["datadog_checks"]
 # Rules were ported over from the legacy flake8 settings for parity
 # All the rules can be found here: https://beta.ruff.rs/docs/rules/
 select = [
+  "B",
+  "C",
+  "E",
+  "F",
+  "G",
+  "W",
+  "I",
   "TID",
 ]
 ignore = [

--- a/snmp/datadog_checks/snmp/parsing/metric_tags.py
+++ b/snmp/datadog_checks/snmp/parsing/metric_tags.py
@@ -8,10 +8,10 @@ import re
 from typing import Dict, List, NamedTuple, TypedDict
 
 from datadog_checks.base import ConfigurationError
-
 from datadog_checks.snmp.models import OID
 from datadog_checks.snmp.pysnmp_types import ObjectIdentity
 from datadog_checks.snmp.resolver import OIDResolver  # noqa: F401
+
 from .parsed_metrics import ParsedMatchMetricTag, ParsedMetricTag, ParsedSimpleMetricTag
 
 SymbolTag = NamedTuple('SymbolTag', [('parsed_metric_tag', ParsedMetricTag), ('symbol', str)])

--- a/snmp/datadog_checks/snmp/parsing/metric_tags.py
+++ b/snmp/datadog_checks/snmp/parsing/metric_tags.py
@@ -9,9 +9,9 @@ from typing import Dict, List, NamedTuple, TypedDict
 
 from datadog_checks.base import ConfigurationError
 
-from ..models import OID
-from ..pysnmp_types import ObjectIdentity
-from ..resolver import OIDResolver  # noqa: F401
+from datadog_checks.snmp.models import OID
+from datadog_checks.snmp.pysnmp_types import ObjectIdentity
+from datadog_checks.snmp.resolver import OIDResolver  # noqa: F401
 from .parsed_metrics import ParsedMatchMetricTag, ParsedMetricTag, ParsedSimpleMetricTag
 
 SymbolTag = NamedTuple('SymbolTag', [('parsed_metric_tag', ParsedMetricTag), ('symbol', str)])

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -9,10 +9,10 @@ from logging import Logger  # noqa: F401
 from typing import Dict, List, NamedTuple, Optional, Pattern, Sequence, TypedDict, Union, cast
 
 from datadog_checks.base import ConfigurationError
-
 from datadog_checks.snmp.models import OID
 from datadog_checks.snmp.pysnmp_types import ObjectIdentity
 from datadog_checks.snmp.resolver import OIDResolver  # noqa: F401
+
 from .metric_tags import MetricTag, parse_metric_tag
 from .metrics_types import (
     ColumnTableMetricTag,

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -10,9 +10,9 @@ from typing import Dict, List, NamedTuple, Optional, Pattern, Sequence, TypedDic
 
 from datadog_checks.base import ConfigurationError
 
-from ..models import OID
-from ..pysnmp_types import ObjectIdentity
-from ..resolver import OIDResolver  # noqa: F401
+from datadog_checks.snmp.models import OID
+from datadog_checks.snmp.pysnmp_types import ObjectIdentity
+from datadog_checks.snmp.resolver import OIDResolver  # noqa: F401
 from .metric_tags import MetricTag, parse_metric_tag
 from .metrics_types import (
     ColumnTableMetricTag,

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -24,7 +24,7 @@ from datadog_checks.sqlserver.utils import extract_sql_comments, extract_sql_com
 try:
     import datadog_agent
 except ImportError:
-    from ..stubs import datadog_agent
+    from datadog_checks.base.stubs import datadog_agent
 
 DEFAULT_COLLECTION_INTERVAL = 10
 MAX_PAYLOAD_BYTES = 19e6

--- a/sqlserver/datadog_checks/sqlserver/agent_history.py
+++ b/sqlserver/datadog_checks/sqlserver/agent_history.py
@@ -12,7 +12,7 @@ from datadog_checks.sqlserver.const import STATIC_INFO_ENGINE_EDITION, STATIC_IN
 try:
     import datadog_agent
 except ImportError:
-    from ..stubs import datadog_agent
+    from datadog_checks.base.stubs import datadog_agent
 
 DEFAULT_COLLECTION_INTERVAL = 15
 DEFAULT_ROW_LIMIT = 10000

--- a/sqlserver/datadog_checks/sqlserver/deadlocks.py
+++ b/sqlserver/datadog_checks/sqlserver/deadlocks.py
@@ -27,7 +27,7 @@ from datadog_checks.sqlserver.utils import is_azure_sql_database
 try:
     import datadog_agent
 except ImportError:
-    from ..stubs import datadog_agent
+    from datadog_checks.base.stubs import datadog_agent
 
 DEFAULT_COLLECTION_INTERVAL = 600
 MAX_DEADLOCKS = 100

--- a/sqlserver/datadog_checks/sqlserver/metadata.py
+++ b/sqlserver/datadog_checks/sqlserver/metadata.py
@@ -15,7 +15,7 @@ from datadog_checks.sqlserver.config import SQLServerConfig
 try:
     import datadog_agent
 except ImportError:
-    from ..stubs import datadog_agent
+    from datadog_checks.base.stubs import datadog_agent
 
 from datadog_checks.sqlserver.const import STATIC_INFO_ENGINE_EDITION, STATIC_INFO_VERSION
 

--- a/sqlserver/datadog_checks/sqlserver/schemas.py
+++ b/sqlserver/datadog_checks/sqlserver/schemas.py
@@ -5,7 +5,7 @@
 try:
     import datadog_agent
 except ImportError:
-    from ..stubs import datadog_agent
+    from datadog_checks.base.stubs import datadog_agent
 
 import json
 import time

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -54,7 +54,7 @@ from datadog_checks.sqlserver.utils import Database, construct_use_statement, pa
 try:
     import datadog_agent
 except ImportError:
-    from ..stubs import datadog_agent
+    from datadog_checks.base.stubs import datadog_agent
 
 from datadog_checks.sqlserver import metrics
 from datadog_checks.sqlserver.__about__ import __version__

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -28,7 +28,7 @@ from datadog_checks.sqlserver.utils import extract_sql_comments_and_procedure_na
 try:
     import datadog_agent
 except ImportError:
-    from ..stubs import datadog_agent
+    from datadog_checks.base.stubs import datadog_agent
 
 from datadog_checks.sqlserver.const import STATIC_INFO_ENGINE_EDITION, STATIC_INFO_VERSION
 

--- a/sqlserver/datadog_checks/sqlserver/stored_procedures.py
+++ b/sqlserver/datadog_checks/sqlserver/stored_procedures.py
@@ -17,7 +17,7 @@ from datadog_checks.sqlserver.config import SQLServerConfig
 try:
     import datadog_agent
 except ImportError:
-    from ..stubs import datadog_agent
+    from datadog_checks.base.stubs import datadog_agent
 
 from datadog_checks.sqlserver.const import STATIC_INFO_ENGINE_EDITION, STATIC_INFO_VERSION
 

--- a/vsphere/datadog_checks/vsphere/legacy/vsphere_legacy.py
+++ b/vsphere/datadog_checks/vsphere/legacy/vsphere_legacy.py
@@ -24,8 +24,8 @@ from datadog_checks.base.checks.libs.timer import Timer
 from datadog_checks.base.checks.libs.vmware.all_metrics import ALL_METRICS
 from datadog_checks.base.checks.libs.vmware.basic_metrics import BASIC_METRICS
 from datadog_checks.base.config import is_affirmative
+from datadog_checks.vsphere.event import VSphereEvent
 
-from ..event import VSphereEvent
 from .cache_config import CacheConfig
 from .common import REALTIME_RESOURCES, SOURCE_TYPE
 from .errors import BadConfigError, ConnectionError


### PR DESCRIPTION
### What does this PR do?
Removes non-parent relative import to prevent circular imports