### PR TITLE
[FA] Always instrument methods

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/tracing.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tracing.py
@@ -102,7 +102,7 @@ def traced_warning(f, tracer):
         return f
 
 
-def generate_tracer_context(f, tracer):
+def configure_tracer(tracer):
     """
     Generate a tracer context for the given function with configurable sampling rate.
     If not set or invalid, defaults to 0 (no sampling).
@@ -176,7 +176,7 @@ def traced_class(cls):
                     setattr(cls, attr, traced_warning(attribute, tracer))
                 else:
                     if attr == 'run' or attr == 'check':
-                        generate_tracer_context(attribute, tracer)
+                        configure_tracer(tracer)
                     setattr(cls, attr, tracing_method(attribute, tracer))
             return cls
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR update the instrumentation logic of all the check methods.
Here are the following changes:
* All methods of `AGENT_CHECK_DEFAULT_TRACED_METHODS` are always instrumented (meaning wrapped with a `tracer.trace`)
* If the method is an entry-level method (meaning that it's called by the agent directly, and not one of the internal methods), it calls the `configure_tracer` method before running the method.
* `configure_tracer` samples all traces if `integration_tracing` or `integration_tracing_exhaustive` is true

### Motivation
<!-- What inspired you to submit this pull request? -->

The goal is to be able to enable or disable tracing at runtime. (PR in progress)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
