### PR TITLE
Exclude createIndexes operation in explain collection

### DIFF
--- a/mongo/datadog_checks/mongo/dbm/utils.py
+++ b/mongo/datadog_checks/mongo/dbm/utils.py
@@ -57,6 +57,7 @@ UNEXPLAINABLE_COMMANDS = frozenset(
         "listCollections",
         "listDatabases",
         'dbStats',
+        'createIndexes',
     ]
 )
 


### PR DESCRIPTION
### What does this PR do?
This PR excludes `createIndexes` operation in explain collection. 

### Motivation
`createIndexes` is not explanable.
```json
[{"code":"OperationFailure","message":"Cannot explain cmd: createIndexes, full error: {'ok': 0.0, 'errmsg': 'Cannot explain cmd: createIndexes', 'code': 20, 'codeName': 'IllegalOperation', '$clusterTime': {'clusterTime': Timestamp(1743171592, 5), 'signature': {'hash': b'\\x19\\x12[\\xea\\xc5\\xb0a6T.\\xd5\\xbeq\\xd6O\\x9a\\x88\\x02J\\xaf', 'keyId': 7486515201114636293}}, 'operationTime': Timestamp(1743171592, 5)}"}]
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
