### PR TITLE
[PostgreSQL] Add handling for IndeterminateDatatype error

### DIFF
--- a/postgres/changelog.d/19969.fixed
+++ b/postgres/changelog.d/19969.fixed
@@ -1,0 +1,1 @@
+Add handling for IndeterminateDatatype error in explain plan collection

--- a/postgres/datadog_checks/postgres/explain_parameterized_queries.py
+++ b/postgres/datadog_checks/postgres/explain_parameterized_queries.py
@@ -88,6 +88,8 @@ class ExplainParameterizedQueries:
         query_signature = compute_sql_signature(obfuscated_statement)
         try:
             self._create_prepared_statement(dbname, statement, obfuscated_statement, query_signature)
+        except psycopg2.errors.IndeterminateDatatype as e:
+            return None, DBExplainError.indeterminate_datatype, '{}'.format(type(e))
         except Exception as e:
             # if we fail to create a prepared statement, we cannot explain the query
             return None, DBExplainError.failed_to_explain_with_prepared_statement, '{}'.format(type(e))

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -772,7 +772,7 @@ class PostgresStatementSamples(DBMAsyncJob):
             return cached_error_response
 
         try:
-            # if the statement is a parameteredzied query, then we can't explain it directly
+            # if the statement is a parameterized query, then we can't explain it directly
             # we should directly jump into self._explain_parameterized_queries.explain_statement
             # instead of trying to explain it then failing
             if self._explain_parameterized_queries._is_parameterized_query(statement):
@@ -796,6 +796,12 @@ class PostgresStatementSamples(DBMAsyncJob):
             error_response = None, DBExplainError.undefined_table, '{}'.format(type(e))
             self._explain_errors_cache[query_signature] = error_response
             self._emit_run_explain_error(dbname, DBExplainError.undefined_table, e)
+            return error_response
+        except psycopg2.errors.IndeterminateDatatype as e:
+            self._log.debug("Failed to collect execution plan: %s", repr(e))
+            error_response = None, DBExplainError.indeterminate_datatype, '{}'.format(type(e))
+            self._explain_errors_cache[query_signature] = error_response
+            self._emit_run_explain_error(dbname, DBExplainError.indeterminate_datatype, e)
             return error_response
         except psycopg2.errors.DatabaseError as e:
             self._log.debug("Failed to collect execution plan: %s", repr(e))

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -77,11 +77,14 @@ class DBExplainError(Enum):
     # the statement was explained with the prepared statement workaround
     explained_with_prepared_statement = 'explained_with_prepared_statement'
 
-    # the statement was tried to be explained with the prepared statement workaround but failedd
+    # the statement was tried to be explained with the prepared statement workaround but failed
     failed_to_explain_with_prepared_statement = 'failed_to_explain_with_prepared_statement'
 
     # the statement was tried to be explained with the prepared statement workaround but no plan was returned
     no_plan_returned_with_prepared_statement = 'no_plan_returned_with_prepared_statement'
+
+    # PostgreSQL cannot determine the data type of a parameter in the query
+    indeterminate_datatype = 'indeterminate_datatype'
 
 
 class DatabaseHealthCheckError(Exception):

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1509,8 +1509,8 @@ def test_statement_run_explain_errors(
     [
         (
             "select * from pg_settings where name = $1",
-            DBExplainError.indeterminate_datatype,
-            'indeterminate_datatype',
+            DBExplainError.explained_with_prepared_statement,
+            None,
         ),
     ],
 )

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1509,8 +1509,8 @@ def test_statement_run_explain_errors(
     [
         (
             "select * from pg_settings where name = $1",
-            DBExplainError.explained_with_prepared_statement,
-            None,
+            DBExplainError.indeterminate_datatype,
+            'indeterminate_datatype',
         ),
     ],
 )


### PR DESCRIPTION
This PR adds error handling for the `IndeterminateDatatype` error in the Postgres statement samples collection. This error occurs when PostgreSQL cannot determine the data type of a parameter in a query and explicitly handling this case  will allow us to surface a clearer error message in the agent logs and in the UI.

Jira tickets:
- https://datadoghq.atlassian.net/browse/DBMON-5129
- https://datadoghq.atlassian.net/browse/SDBM-1618
- https://datadoghq.atlassian.net/browse/SDBM-1494
