### PR TITLE
[OTAGENT-359] use equiv_otel in DD exporter and connector metrics

### DIFF
--- a/otel/assets/dashboards/otel_collector_metrics_dashboard.json
+++ b/otel/assets/dashboards/otel_collector_metrics_dashboard.json
@@ -1994,7 +1994,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         }
                                     ],
                                     "queries": [
@@ -2039,7 +2039,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         }
                                     ],
                                     "queries": [
@@ -2106,11 +2106,11 @@
                                     "formulas": [
                                         {
                                             "alias": "Max",
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         },
                                         {
                                             "alias": "Avg",
-                                            "formula": "query2"
+                                            "formula": "equiv_otel(query2)"
                                         }
                                     ],
                                     "queries": [
@@ -2167,7 +2167,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         }
                                     ],
                                     "queries": [
@@ -2219,7 +2219,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         }
                                     ],
                                     "queries": [
@@ -2292,7 +2292,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         }
                                     ],
                                     "queries": [
@@ -2358,7 +2358,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         }
                                     ],
                                     "queries": [
@@ -2410,7 +2410,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         }
                                     ],
                                     "queries": [
@@ -2483,7 +2483,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         }
                                     ],
                                     "queries": [
@@ -2540,13 +2540,12 @@
                                         {
                                             "query": "sum:otelcol_datadog_trace_agent_stats_writer_stats_entries{$host,source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
-                                            "name": "query1",
-                                            "aggregator": "avg"
+                                            "name": "query1"
                                         }
                                     ],
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "reduce(equiv_otel(query1), 'avg')"
                                         }
                                     ]
                                 }
@@ -2627,7 +2626,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         }
                                     ],
                                     "queries": [
@@ -2679,7 +2678,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         }
                                     ],
                                     "queries": [
@@ -2731,7 +2730,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         }
                                     ],
                                     "queries": [
@@ -2776,7 +2775,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         }
                                     ],
                                     "queries": [
@@ -2842,7 +2841,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         }
                                     ],
                                     "queries": [
@@ -2887,7 +2886,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         }
                                     ],
                                     "queries": [
@@ -2932,7 +2931,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         }
                                     ],
                                     "queries": [
@@ -2998,7 +2997,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         }
                                     ],
                                     "queries": [


### PR DESCRIPTION
### What does this PR do?
Add `equiv_otel` to DD exporter and connector internal metrics on OOTB OTel collector health dashboard.
This is tested in [org 2](https://app.datadoghq.com/dashboard/7k9-478-p8r/opentelemetry-collector-metrics-dashboard-with-equivotel)

### Motivation
[#incident-35946](https://dd.enterprise.slack.com/archives/C08H1D9S5AM)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
