### PR TITLE
Fix: Handle optional .exe suffix for process search on Windows

### DIFF
--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -161,7 +161,9 @@ class ProcessCheck(AgentCheck):
                             found = True
                         if exact_match:
                             if os.name == 'nt':
-                                if proc.name().lower() == string.lower():
+                                lproc_name = proc.name().lower()
+                                lstring = string.lower()
+                                if lproc_name == lstring or lproc_name == lstring + ".exe":
                                     found = True
                             else:
                                 if proc.name() == string:


### PR DESCRIPTION
### What does this PR do?
This PR addresses an inconsistency in how search_strings with exact_match: true behaves on Windows systems compared to the behavior suggested by Datadog documentation (conf.yaml.example#L76). The documentation implies equivalence to Get-Process, but this isn't always the case because the psutil library sometimes includes the .exe suffix when reporting process names on Windows.

This commit updates the search logic to correctly handle this discrepancy. Now, exact_match will reliably find Windows processes whether the search string includes the .exe suffix (e.g., "process.exe") or not (e.g., "process").


### Motivation
The current behavior can lead to unexpected failures when monitoring processes on Windows using exact_match, as users might not know whether to include the .exe suffix. This was discovered after encountering difficulties getting consistent process matches.

This change improves the reliability and usability of the process integration for Windows users, making configuration simpler and less error-prone.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
