### PR TITLE
Add failover support with Agent High Availability feature

### DIFF
--- a/vsphere/changelog.d/19987.added
+++ b/vsphere/changelog.d/19987.added
@@ -1,0 +1,1 @@
+Add failover support with Agent High Availability feature

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -71,6 +71,7 @@ SERVICE_CHECK_NAME = 'can_connect'
 
 class VSphereCheck(AgentCheck):
     __NAMESPACE__ = 'vsphere'
+    HA_SUPPORTED = True
 
     def __new__(cls, name, init_config, instances):
         # type: (Type[VSphereCheck], str, Dict[str, Any], List[Dict[str, Any]]) -> VSphereCheck


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add failover support with Agent High Availability feature

### QA

HA Working as expected for vSphere:

<img width="1390" alt="image" src="https://github.com/user-attachments/assets/fa307446-3378-4998-abb3-a9c87a6500d0" />

^ as we can see, the `vsphere.cluster.count` metric is first reporting by the agent1 and then agent2 when the active agent switched.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
