### PR TITLE
[mongo] shardCollection operation is not explainable

### DIFF
--- a/mongo/changelog.d/19990.fixed
+++ b/mongo/changelog.d/19990.fixed
@@ -1,0 +1,1 @@
+Skip collect explain plan for shardCollection operation.

--- a/mongo/datadog_checks/mongo/dbm/utils.py
+++ b/mongo/datadog_checks/mongo/dbm/utils.py
@@ -58,6 +58,7 @@ UNEXPLAINABLE_COMMANDS = frozenset(
         "listDatabases",
         'dbStats',
         'createIndexes',
+        'shardCollection',
     ]
 )
 


### PR DESCRIPTION
### What does this PR do?
This PR skips explain `shardCollection` operation because it is not explainable. 

### Motivation
Fix error `not authorized on admin to execute command { explain: { shardCollection: "collection", key: { _id: "hashed" }`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
