### PR TITLE
[PostgreSQL] Add handling for UndefinedFunction error

### DIFF
--- a/postgres/changelog.d/19998.fixed
+++ b/postgres/changelog.d/19998.fixed
@@ -1,0 +1,1 @@
+Add handling for UndefinedFunction error in explain plan collection

--- a/postgres/datadog_checks/postgres/explain_parameterized_queries.py
+++ b/postgres/datadog_checks/postgres/explain_parameterized_queries.py
@@ -90,6 +90,8 @@ class ExplainParameterizedQueries:
             self._create_prepared_statement(dbname, statement, obfuscated_statement, query_signature)
         except psycopg2.errors.IndeterminateDatatype as e:
             return None, DBExplainError.indeterminate_datatype, '{}'.format(type(e))
+        except psycopg2.errors.UndefinedFunction as e:
+            return None, DBExplainError.undefined_function, '{}'.format(type(e))
         except Exception as e:
             # if we fail to create a prepared statement, we cannot explain the query
             return None, DBExplainError.failed_to_explain_with_prepared_statement, '{}'.format(type(e))

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -797,6 +797,12 @@ class PostgresStatementSamples(DBMAsyncJob):
             self._explain_errors_cache[query_signature] = error_response
             self._emit_run_explain_error(dbname, DBExplainError.undefined_table, e)
             return error_response
+        except psycopg2.errors.UndefinedFunction as e:
+            self._log.debug("Failed to collect execution plan: %s", repr(e))
+            error_response = None, DBExplainError.undefined_function, '{}'.format(type(e))
+            self._explain_errors_cache[query_signature] = error_response
+            self._emit_run_explain_error(dbname, DBExplainError.undefined_function, e)
+            return error_response
         except psycopg2.errors.IndeterminateDatatype as e:
             self._log.debug("Failed to collect execution plan: %s", repr(e))
             error_response = None, DBExplainError.indeterminate_datatype, '{}'.format(type(e))

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -74,6 +74,10 @@ class DBExplainError(Enum):
     # search path may be different when the client executed a query from where we executed it.
     undefined_table = 'undefined_table'
 
+    # we cannot create a prepared statement because this function is undefined with the given parameters
+    # this is likely because of an obfuscated parameter
+    undefined_function = 'undefined_function'
+
     # the statement was explained with the prepared statement workaround
     explained_with_prepared_statement = 'explained_with_prepared_statement'
 


### PR DESCRIPTION
This PR adds error handling for the `UndefinedFunction` error in the Postgres statement samples collection. This error can occur when a function is not given the right parameters in a statement. In our case, this is likely because of obfuscation (ex. original query `'hi' + myString`, new query `'hi' + $1` and `$1` is not a string). Explicitly handling this case  will allow us to surface a clearer error message in the agent logs and in the UI.

Jira ticket: https://datadoghq.atlassian.net/browse/SDBM-1611