### PR TITLE
Fix `sonatype_nexus` tests in CI

### DIFF
--- a/sonatype_nexus/tests/test_e2e.py
+++ b/sonatype_nexus/tests/test_e2e.py
@@ -8,6 +8,7 @@ import pytest
 from datadog_checks.dev import run_command
 
 
+# TODO: move logic to conftest and pin sonatype_nexus image version
 def get_nexus_password(max_retries=5, retry_interval=10):
     try:
         run_command("docker run -d -p 8081:8081 --name sonatype_nexus_3 sonatype/nexus3")


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix `sonatype_nexus` CI failures.

### Motivation
<!-- What inspired you to submit this pull request? -->
The `sonatype_nexus` E2E test has been failing consistently in CI since April 1st: [example failure](https://github.com/DataDog/integrations-core/actions/runs/14245392267/job/39925187959).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged