### PR TITLE
MySQL blocking queries

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -381,6 +381,13 @@ files:
                 value:
                   type: number
                   example: 600
+          - name: collect_blocking_queries
+            description: |
+              Enable collection of blocking queries. Supported only on MySQL 8.0.
+            value:
+              type: boolean
+              example: false
+              display_default: false
           - name: schemas_collection 
             description: |
               Configure collection of schemas (databases).

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -381,13 +381,6 @@ files:
                 value:
                   type: number
                   example: 600
-          - name: collect_blocking_queries
-            description: |
-              Enable collection of blocking queries. Supported only on MySQL 8.0.
-            value:
-              type: boolean
-              example: false
-              display_default: false
           - name: schemas_collection 
             description: |
               Configure collection of schemas (databases).
@@ -549,6 +542,13 @@ files:
                 value:
                   type: number
                   example: 10
+              - name: collect_blocking_queries
+                description: |
+                  Enable collection of blocking queries. Supported only on MySQL 8.0.
+                value:
+                  type: boolean
+                  example: false
+                  display_default: false
           - name: index_metrics
             description: |
               Configure collection of index metrics.

--- a/mysql/changelog.d/20008.added
+++ b/mysql/changelog.d/20008.added
@@ -1,1 +1,1 @@
-Add blocking queries support for MySQL
+Add blocking queries support for MySQL 8

--- a/mysql/changelog.d/20008.added
+++ b/mysql/changelog.d/20008.added
@@ -1,0 +1,1 @@
+Add blocking queries support for MySQL

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -151,6 +151,7 @@ class MySQLActivity(DBMAsyncJob):
         self._db = None
         self._db_version = None
         self._obfuscator_options = to_native_string(json.dumps(self._config.obfuscator_options))
+        self._activity_query = None
 
     def run_job(self):
         # type: () -> None
@@ -211,7 +212,8 @@ class MySQLActivity(DBMAsyncJob):
 
     def _get_activity_query(self):
         # type: () -> str
-        # TODO: cache the query
+        if self._activity_query:
+            return self._activity_query
         blocking_columns = ""
         blocking_joins = ""
         idle_blockers_subquery = ""

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -205,7 +205,7 @@ class MySQLActivity(DBMAsyncJob):
     def _should_collect_blocking_sessions(self):
         # type: () -> bool
         # TODO: add the configuration to enable/disable blocking sessions collection
-        return self._db_version == MySQLVersion.VERSION_80
+        return self._db_version == MySQLVersion.VERSION_80 and not self._check.is_mariadb
 
     def _get_activity_query(self):
         # type: () -> str

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -204,10 +204,10 @@ class MySQLActivity(DBMAsyncJob):
                 tags=tags + self._check._get_debug_tags(),
             )
 
-    def _should_collect_blocking_sessions(self):
+    def _should_collect_blocking_queries(self):
         # type: () -> bool
-        # TODO: add the configuration to enable/disable blocking sessions collection
-        return self._db_version == MySQLVersion.VERSION_80 and not self._check.is_mariadb
+        blocking_queries_configured = self._config.collect_blocking_queries
+        return blocking_queries_configured and self._db_version == MySQLVersion.VERSION_80 and not self._check.is_mariadb
 
     def _get_activity_query(self):
         # type: () -> str
@@ -215,7 +215,7 @@ class MySQLActivity(DBMAsyncJob):
         blocking_columns = ""
         blocking_joins = ""
         idle_blockers_subquery = ""
-        if self._should_collect_blocking_sessions():
+        if self._should_collect_blocking_queries():
             blocking_columns = BLOCKING_COLUMNS
             blocking_joins = BLOCKING_JOINS
             idle_blockers_subquery = IDLE_BLOCKERS_SUBQUERY

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -57,14 +57,13 @@ SELECT
     waits_a.object_name,
     waits_a.index_name,
     waits_a.object_type,
-    waits_a.source,
-    blocking_thread.processlist_id AS blocking_pid
+    waits_a.source
+    {blocking_column}
 FROM
     performance_schema.threads AS thread_a
     LEFT JOIN performance_schema.events_waits_current AS waits_a ON waits_a.thread_id = thread_a.thread_id
     LEFT JOIN performance_schema.events_statements_current AS statement ON statement.thread_id = thread_a.thread_id
-    LEFT JOIN performance_schema.data_lock_waits AS lock_waits ON lock_waits.requesting_thread_id = thread_a.thread_id
-    LEFT JOIN performance_schema.threads AS blocking_thread ON blocking_thread.thread_id = lock_waits.blocking_thread_id
+    {blocking_joins}
 WHERE
     thread_a.processlist_state IS NOT NULL
     AND thread_a.processlist_id != CONNECTION_ID()

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -207,7 +207,7 @@ class MySQLActivity(DBMAsyncJob):
 
     def _should_collect_blocking_queries(self):
         # type: () -> bool
-        blocking_queries_configured = self._config.collect_blocking_queries
+        blocking_queries_configured = self._config.activity_config.get("collect_blocking_queries", False)
         return (
             blocking_queries_configured and self._db_version == MySQLVersion.VERSION_80 and not self._check.is_mariadb
         )

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -82,7 +82,7 @@ WHERE
     ) OR waits_a.event_id is NULL)
     -- We ignore rows without SQL text because there will be rows for background operations that do not have
     -- SQL text associated with it.
-    AND COALESCE(statement.sql_text, thread_a.PROCESSLIST_info) != '';
+    AND COALESCE(statement.sql_text, thread_a.PROCESSLIST_info) != ''
 """
 
 BLOCKING_COLUMN = ",blocking_thread.processlist_id AS blocking_pid"
@@ -194,7 +194,8 @@ class MySQLActivity(DBMAsyncJob):
         return self._db_version == MySQLVersion.VERSION_80
 
     def _get_activity_query(self):
-        # type: () -> str   
+        # type: () -> str
+        # TODO: cache the query
         blocking_column = ""
         blocking_joins = ""
         if self._should_collect_blocking_sessions():

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -208,7 +208,9 @@ class MySQLActivity(DBMAsyncJob):
     def _should_collect_blocking_queries(self):
         # type: () -> bool
         blocking_queries_configured = self._config.collect_blocking_queries
-        return blocking_queries_configured and self._db_version == MySQLVersion.VERSION_80 and not self._check.is_mariadb
+        return (
+            blocking_queries_configured and self._db_version == MySQLVersion.VERSION_80 and not self._check.is_mariadb
+        )
 
     def _get_activity_query(self):
         # type: () -> str

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -72,8 +72,8 @@ WHERE
         AND thread_a.processlist_command != 'Sleep'
         AND (waits_a.EVENT_NAME != 'idle' OR waits_a.EVENT_NAME IS NULL)
         AND (waits_a.operation != 'idle' OR waits_a.operation IS NULL)
-        -- events_waits_current can have multiple rows per thread, thus we use EVENT_ID to identify the row we want to use.
-        -- Additionally, we want the row with the highest EVENT_ID which reflects the most recent and current wait.
+        -- events_waits_current can have multiple rows per thread, thus we use EVENT_ID to identify the row
+        -- we want to use. Additionally, we want the row with the highest EVENT_ID which reflects the most recent wait.
         AND (
             waits_a.event_id = (
             SELECT

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -101,10 +101,11 @@ IDLE_BLOCKERS_SUBQUERY = """\
         OR
         -- Include idle sessions that are blocking others
         thread_a.thread_id IN (
-            SELECT blocking_thread_id 
+            SELECT blocking_thread_id
             FROM performance_schema.data_lock_waits
         )
 """
+
 
 class MySQLVersion(Enum):
     # 8.0
@@ -228,7 +229,7 @@ class MySQLActivity(DBMAsyncJob):
         # type: (pymysql.cursor) -> List[Dict[str]]
         query = self._get_activity_query()
         self._log.debug("Running activity query [%s]", query)
-        cursor.execute(query) 
+        cursor.execute(query)
         return cursor.fetchall()
 
     def _normalize_rows(self, rows):

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -48,6 +48,7 @@ class MySQLConfig(object):
         self.activity_config = instance.get('query_activity', {}) or {}
         self.schemas_config: dict = instance.get('schemas_collection', {}) or {}
         self.index_config: dict = instance.get('index_metrics', {}) or {}
+        self.collect_blocking_queries = is_affirmative(instance.get('collect_blocking_queries', False))
 
         self.cloud_metadata = {}
         aws = instance.get('aws', {})

--- a/mysql/datadog_checks/mysql/config_models/defaults.py
+++ b/mysql/datadog_checks/mysql/config_models/defaults.py
@@ -12,6 +12,10 @@ def shared_propagate_agent_tags():
     return False
 
 
+def instance_collect_blocking_queries():
+    return False
+
+
 def instance_connect_timeout():
     return 10
 

--- a/mysql/datadog_checks/mysql/config_models/defaults.py
+++ b/mysql/datadog_checks/mysql/config_models/defaults.py
@@ -12,10 +12,6 @@ def shared_propagate_agent_tags():
     return False
 
 
-def instance_collect_blocking_queries():
-    return False
-
-
 def instance_connect_timeout():
     return 10
 

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -195,6 +195,7 @@ class InstanceConfig(BaseModel):
     aws: Optional[Aws] = None
     azure: Optional[Azure] = None
     charset: Optional[str] = None
+    collect_blocking_queries: Optional[bool] = None
     collect_settings: Optional[CollectSettings] = None
     connect_timeout: Optional[float] = None
     custom_queries: Optional[tuple[CustomQuery, ...]] = None

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -129,6 +129,7 @@ class QueryActivity(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    collect_blocking_queries: Optional[bool] = None
     collection_interval: Optional[float] = None
     enabled: Optional[bool] = None
 
@@ -195,7 +196,6 @@ class InstanceConfig(BaseModel):
     aws: Optional[Aws] = None
     azure: Optional[Azure] = None
     charset: Optional[str] = None
-    collect_blocking_queries: Optional[bool] = None
     collect_settings: Optional[CollectSettings] = None
     connect_timeout: Optional[float] = None
     custom_queries: Optional[tuple[CustomQuery, ...]] = None

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -379,6 +379,11 @@ instances:
         #
         # collection_interval: 600
 
+    ## @param collect_blocking_queries - boolean - optional - default: false
+    ## Enable collection of blocking queries. Supported only on MySQL 8.0.
+    #
+    # collect_blocking_queries: false
+
     ## Configure collection of schemas (databases).
     ## Only tables and schemas for which the user has been granted SELECT privileges are collected.
     #

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -379,11 +379,6 @@ instances:
         #
         # collection_interval: 600
 
-    ## @param collect_blocking_queries - boolean - optional - default: false
-    ## Enable collection of blocking queries. Supported only on MySQL 8.0.
-    #
-    # collect_blocking_queries: false
-
     ## Configure collection of schemas (databases).
     ## Only tables and schemas for which the user has been granted SELECT privileges are collected.
     #
@@ -524,6 +519,11 @@ instances:
         ## Set the activity collection interval (in seconds).
         #
         # collection_interval: 10
+
+        ## @param collect_blocking_queries - boolean - optional - default: false
+        ## Enable collection of blocking queries. Supported only on MySQL 8.0.
+        #
+        # collect_blocking_queries: false
 
     ## Configure collection of index metrics.
     ## Metrics provided by the options:

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -78,11 +78,13 @@ def dbm_instance(instance_complex):
         ),
     ],
 )
-def test_activity_collection(aggregator, dbm_instance, dd_run_check, query, query_signature, expected_query_truncated, collect_blocking_queries):
+def test_activity_collection(
+    aggregator, dbm_instance, dd_run_check, query, query_signature, expected_query_truncated, collect_blocking_queries
+):
     config = deepcopy(dbm_instance)
     config['query_activity']['collect_blocking_queries'] = collect_blocking_queries
     check = MySql(CHECK_NAME, {}, instances=[config])
-    
+
     blocking_query = 'SELECT id FROM testdb.users FOR UPDATE'
 
     def _run_query(conn, _query):

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -100,6 +100,7 @@ def test_activity_collection(aggregator, dbm_instance, dd_run_check, query, quer
     executor.submit(_run_blocking, bob_conn)
     # fred's query will get blocked by bob's TX
     executor.submit(_run_query, fred_conn, query)
+    time.sleep(0.1)
 
     dd_run_check(check)
     bob_conn.commit()

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -80,7 +80,7 @@ def dbm_instance(instance_complex):
 )
 def test_activity_collection(aggregator, dbm_instance, dd_run_check, query, query_signature, expected_query_truncated, collect_blocking_queries):
     config = deepcopy(dbm_instance)
-    config['collect_blocking_queries'] = collect_blocking_queries
+    config['query_activity']['collect_blocking_queries'] = collect_blocking_queries
     check = MySql(CHECK_NAME, {}, instances=[config])
     
     blocking_query = 'SELECT id FROM testdb.users FOR UPDATE'
@@ -125,7 +125,8 @@ def test_activity_collection(aggregator, dbm_instance, dd_run_check, query, quer
     }
     assert type(activity['collection_interval']) in (float, int), "invalid collection_interval"
 
-    assert len(activity['mysql_activity']) == 1, "incorrect number of activity rows"
+    expected_activity_rows = 2 if check._query_activity._should_collect_blocking_queries() else 1
+    assert len(activity['mysql_activity']) == expected_activity_rows, "incorrect number of activity rows"
 
     # The blocked row should be fred, which is currently blocked by bob's TX
     blocked_row = None

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -128,7 +128,7 @@ def test_activity_collection(
     assert type(activity['collection_interval']) in (float, int), "invalid collection_interval"
 
     assert activity['mysql_activity'], "should have at least one activity row"
-    
+
     # The blocked row should be fred, which is currently blocked by bob's TX
     blocked_row = None
     for activity in dbm_activity:
@@ -164,6 +164,7 @@ def test_activity_collection(
                 if row['processlist_user'] == 'bob':
                     captured_idle_blocker = True
         assert captured_idle_blocker, "should have captured the idle blocker"
+
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -102,7 +102,6 @@ def test_activity_collection(
     executor.submit(_run_blocking, bob_conn)
     # fred's query will get blocked by bob's TX
     executor.submit(_run_query, fred_conn, query)
-    time.sleep(1)
 
     dd_run_check(check)
     bob_conn.commit()
@@ -155,12 +154,11 @@ def test_activity_collection(
     assert blocked_row['wait_timer_end'], "missing wait timer end"
     assert blocked_row['event_timer_start'], "missing event timer start"
     assert blocked_row['event_timer_end'], "missing event timer end"
-    assert blocked_row['lock_time'], "missing lock time"
     assert blocked_row['query_truncated'] == expected_query_truncated
 
-    captured_idle_blocker = False
     if check._query_activity._should_collect_blocking_queries():
         assert len(activity['mysql_activity']) >= 2, "should have collected at least two activity payloads"
+        captured_idle_blocker = False
         for activity in dbm_activity:
             for row in activity['mysql_activity']:
                 if row['processlist_user'] == 'bob':


### PR DESCRIPTION
### What does this PR do?

Implements MySQL blocking queries for MySQL 8.

### Motivation

High demand.

### Test in integration env

#### Performance

A slight decrease in performance when grabbing active sessions:

<img width="889" alt="image" src="https://github.com/user-attachments/assets/351e1fe6-0f51-44df-bfeb-e68f82371ac7" />

28.8% might look severe, but the response times are still under 10ms.

#### Correctness

<img width="1175" alt="image" src="https://github.com/user-attachments/assets/925e37a0-5c42-463c-8aef-ad26bd4183c8" />


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
