### PR TITLE
Revert "[OTAGENT-359] use equiv_otel in DD exporter and connector metrics"

### DIFF
--- a/otel/assets/dashboards/otel_collector_metrics_dashboard.json
+++ b/otel/assets/dashboards/otel_collector_metrics_dashboard.json
@@ -1994,7 +1994,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "equiv_otel(query1)"
+                                            "formula": "query1"
                                         }
                                     ],
                                     "queries": [
@@ -2039,7 +2039,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "equiv_otel(query1)"
+                                            "formula": "query1"
                                         }
                                     ],
                                     "queries": [
@@ -2106,11 +2106,11 @@
                                     "formulas": [
                                         {
                                             "alias": "Max",
-                                            "formula": "equiv_otel(query1)"
+                                            "formula": "query1"
                                         },
                                         {
                                             "alias": "Avg",
-                                            "formula": "equiv_otel(query2)"
+                                            "formula": "query2"
                                         }
                                     ],
                                     "queries": [
@@ -2167,7 +2167,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "equiv_otel(query1)"
+                                            "formula": "query1"
                                         }
                                     ],
                                     "queries": [
@@ -2219,7 +2219,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "equiv_otel(query1)"
+                                            "formula": "query1"
                                         }
                                     ],
                                     "queries": [
@@ -2292,7 +2292,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "equiv_otel(query1)"
+                                            "formula": "query1"
                                         }
                                     ],
                                     "queries": [
@@ -2358,7 +2358,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "equiv_otel(query1)"
+                                            "formula": "query1"
                                         }
                                     ],
                                     "queries": [
@@ -2410,7 +2410,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "equiv_otel(query1)"
+                                            "formula": "query1"
                                         }
                                     ],
                                     "queries": [
@@ -2483,7 +2483,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "equiv_otel(query1)"
+                                            "formula": "query1"
                                         }
                                     ],
                                     "queries": [
@@ -2540,12 +2540,13 @@
                                         {
                                             "query": "sum:otelcol_datadog_trace_agent_stats_writer_stats_entries{$host,source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
-                                            "name": "query1"
+                                            "name": "query1",
+                                            "aggregator": "avg"
                                         }
                                     ],
                                     "formulas": [
                                         {
-                                            "formula": "reduce(equiv_otel(query1), 'avg')"
+                                            "formula": "query1"
                                         }
                                     ]
                                 }
@@ -2626,7 +2627,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "equiv_otel(query1)"
+                                            "formula": "query1"
                                         }
                                     ],
                                     "queries": [
@@ -2678,7 +2679,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "equiv_otel(query1)"
+                                            "formula": "query1"
                                         }
                                     ],
                                     "queries": [
@@ -2730,7 +2731,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "equiv_otel(query1)"
+                                            "formula": "query1"
                                         }
                                     ],
                                     "queries": [
@@ -2775,7 +2776,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "equiv_otel(query1)"
+                                            "formula": "query1"
                                         }
                                     ],
                                     "queries": [
@@ -2841,7 +2842,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "equiv_otel(query1)"
+                                            "formula": "query1"
                                         }
                                     ],
                                     "queries": [
@@ -2886,7 +2887,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "equiv_otel(query1)"
+                                            "formula": "query1"
                                         }
                                     ],
                                     "queries": [
@@ -2931,7 +2932,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "equiv_otel(query1)"
+                                            "formula": "query1"
                                         }
                                     ],
                                     "queries": [
@@ -2997,7 +2998,7 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "equiv_otel(query1)"
+                                            "formula": "query1"
                                         }
                                     ],
                                     "queries": [


### PR DESCRIPTION
Reverts DataDog/integrations-core#19980

leads to dashboard breakage