### PR TITLE
Postgres: Add checkpoint byte delay metric

### DIFF
--- a/postgres/changelog.d/20017.added
+++ b/postgres/changelog.d/20017.added
@@ -1,0 +1,1 @@
+Postgres: Add checkpoint byte delay metric

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -48,6 +48,7 @@ from .util import (
     FUNCTION_METRICS,
     INDEX_PROGRESS_METRICS,
     QUERY_PG_CONTROL_CHECKPOINT,
+    QUERY_PG_CONTROL_CHECKPOINT_LT_10,
     QUERY_PG_REPLICATION_SLOTS,
     QUERY_PG_REPLICATION_SLOTS_STATS,
     QUERY_PG_STAT_DATABASE,
@@ -299,9 +300,13 @@ class PostgreSql(AgentCheck):
                     q_pg_stat_database,
                     q_pg_stat_database_conflicts,
                     QUERY_PG_UPTIME,
-                    QUERY_PG_CONTROL_CHECKPOINT,
                 ]
             )
+
+        if self.version < V10:
+            queries.append(QUERY_PG_CONTROL_CHECKPOINT_LT_10)
+        else:
+            queries.append(QUERY_PG_CONTROL_CHECKPOINT)
 
         if self.version >= V10:
             # Wal receiver is not supported on aurora

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -47,6 +47,8 @@ postgresql.conflicts.snapshot,count,,query,,"Number of queries in this database 
 postgresql.conflicts.tablespace,count,,query,,Number of queries in this database that have been canceled due to dropped tablespaces. This will occur when a temp_tablespace is dropped while being used on a standby. This metric is tagged with db.,-1,postgres,cfl tablespace,
 postgresql.connections,gauge,,connection,,"The number of active connections to this database. If DBM is enabled, this metric is tagged with state, app, db and user",0,postgres,conns,
 postgresql.control.checkpoint_delay,gauge,,second,,The time since the last checkpoint.,0,postgres,control checkpoint,
+postgresql.control.checkpoint_delay_bytes,gauge,,byte,,The amount of WAL bytes written since the last checkpoint.,0,postgres,control checkpoint byte,
+postgresql.control.redo_delay_bytes,gauge,,byte,,The amount of WAL bytes written since the last redo point.,0,postgres,control redo byte,
 postgresql.control.timeline_id,gauge,,,,The current timeline id.,0,postgres,control tid,
 postgresql.create_index.blocks_done,gauge,,,,"Number of blocks already processed in the current phase. Only available with PostgreSQL 12 and newer. This metric is tagged with db, table, index, command, phase.",0,postgres,postgres index blocks done,
 postgresql.create_index.blocks_total,gauge,,,,"Total number of blocks to be processed in the current phase. Only available with PostgreSQL 12 and newer. This metric is tagged with db, table, index, command, phase.",0,postgres,postgres index blocks total,

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -690,6 +690,15 @@ def test_pg_control(aggregator, integration_check, pg_instance):
     assert_metric_at_least(
         aggregator, 'postgresql.control.checkpoint_delay', count=1, higher_bound=2.0, tags=dd_agent_tags
     )
+    # After a checkpoint, we have the CHECKPOINT_ONLINE record (114 bytes) and also
+    # likely receive RUNNING_XACTS (50 bytes) record
+    assert_metric_at_least(
+        aggregator, 'postgresql.control.checkpoint_delay_bytes', count=1, higher_bound=250, tags=dd_agent_tags
+    )
+    # And restart should be slightly more than checkpoint delay
+    assert_metric_at_least(
+        aggregator, 'postgresql.control.redo_delay_bytes', count=1, higher_bound=300, tags=dd_agent_tags
+    )
 
 
 def test_config_tags_is_unchanged_between_checks(integration_check, pg_instance):

--- a/postgres/tests/test_pg_replication.py
+++ b/postgres/tests/test_pg_replication.py
@@ -8,6 +8,7 @@ import pytest
 from .common import (
     DB_NAME,
     _get_expected_replication_tags,
+    _get_expected_tags,
     assert_metric_at_least,
     check_bgw_metrics,
     check_common_metrics,
@@ -208,3 +209,37 @@ def test_conflicts_bufferpin(aggregator, integration_check, pg_instance, pg_repl
     check.check(pg_replica_instance2)
     expected_tags = _get_expected_replication_tags(check, pg_replica_instance2, db=DB_NAME)
     aggregator.assert_metric('postgresql.conflicts.bufferpin', value=1, tags=expected_tags)
+
+
+@requires_over_10
+def test_pg_control_replication(aggregator, integration_check, pg_instance, pg_replica_instance):
+    check = integration_check(pg_replica_instance)
+    check.run()
+
+    dd_agent_tags = _get_expected_tags(check, pg_replica_instance, role='standby')
+    aggregator.assert_metric('postgresql.control.timeline_id', count=1, value=1, tags=dd_agent_tags)
+
+    # Also checkpoint on primary to generate changes
+    master_conn = _get_superconn(pg_instance)
+    with master_conn.cursor() as cur:
+        cur.execute("CHECKPOINT;")
+
+    postgres_conn = _get_superconn(pg_replica_instance)
+    with postgres_conn.cursor() as cur:
+        cur.execute("CHECKPOINT;")
+
+    aggregator.reset()
+    check.run()
+    # checkpoint should be less than 2s old
+    assert_metric_at_least(
+        aggregator, 'postgresql.control.checkpoint_delay', count=1, higher_bound=2.0, tags=dd_agent_tags
+    )
+    # After a checkpoint, we have the CHECKPOINT_ONLINE record (114 bytes) and also
+    # likely receive RUNNING_XACTS (50 bytes) record
+    assert_metric_at_least(
+        aggregator, 'postgresql.control.checkpoint_delay_bytes', count=1, higher_bound=250, tags=dd_agent_tags
+    )
+    # And restart should be slightly more than checkpoint delay
+    assert_metric_at_least(
+        aggregator, 'postgresql.control.redo_delay_bytes', count=1, higher_bound=300, tags=dd_agent_tags
+    )


### PR DESCRIPTION
### What does this PR do?
Add 2 new metrics reporting the delay in bytes from the last redo_lsn and checkpoint_lsn, as reported by pg_control_checkpoint().

### Motivation
This will allow to provide the write rate on the WAL between checkpoints, which can then be used to estimate an appropriate value for max_wal_size.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
