### PR TITLE
Remove usage of freezegun from Silk test

### DIFF
--- a/silk/hatch.toml
+++ b/silk/hatch.toml
@@ -4,6 +4,3 @@
 python = ["3.12"]
 
 [envs.default]
-dependencies = [
-  "freezegun==0.3.15",
-]

--- a/silk/tests/test_events.py
+++ b/silk/tests/test_events.py
@@ -81,19 +81,22 @@ def test_malformed_event(aggregator, instance, dd_run_check, file, log_warning, 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_events_test(aggregator, dd_run_check, instance):
-    # Freeze time when starting check to set initial time
-    with freeze_time("2012-01-13"):
+    # Mock timestamps instead of using freezegun
+    # First run to set the initial timestamp to 2012-01-13
+    with mock.patch('datadog_checks.silk.check.get_timestamp', return_value=1326412800):
         check = SilkCheck('silk', {}, [instance])
-
-    # Freeze time running check initially to query for events from 1-13 to 1-14
-    with freeze_time("2012-01-14"):
+    
+    # Second run to get events between 2012-01-13 and 2012-01-14 and set the timestamp to 2012-01-14
+    # Event 1 is between 2012-01-13 and 2012-01-14
+    with mock.patch('datadog_checks.silk.check.get_timestamp', return_value=1326499200):
         dd_run_check(check)
         aggregator.assert_event("Event 1", count=1)
         aggregator.assert_event("Event 2", count=0)
 
-    # freeze time finally when running check 2nd time to query for events from 1-14 to 1-15
-    with freeze_time("2012-01-15"):
-        aggregator.reset()
+    # Third run to get events between 2012-01-14 and 2012-01-15
+    # Event 2 is between 2012-01-14 and 2012-01-15
+    aggregator.reset()
+    with mock.patch('datadog_checks.silk.check.get_timestamp', return_value=1326585600):
         dd_run_check(check)
         aggregator.assert_event("Event 1", count=0)
         aggregator.assert_event("Event 2", count=1)


### PR DESCRIPTION
### What does this PR do?
The test started failing due to circular dependency with the recent dd-trace bump. This gets rid of freezegun to simplify the test and reliance on third party libs.
