### PR TITLE
Bump minimum base check version for SNMP to 37.9.0

### DIFF
--- a/snmp/changelog.d/20021.changed
+++ b/snmp/changelog.d/20021.changed
@@ -1,0 +1,1 @@
+Bump the version of datadog-checks-base to 37.9.0

--- a/snmp/pyproject.toml
+++ b/snmp/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.0.0",
+    "datadog-checks-base>=37.9.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bumps the minimum datadog-base-check dependency version to >= 37.9.0.

### Motivation
<!-- What inspired you to submit this pull request? -->

Fix the Nightly minimum base check CI test because of a recent change in our pyyaml usage.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
