### PR TITLE
[AGENT-13541] Properly support for custom tags in esxi

### DIFF
--- a/esxi/changelog.d/20022.fixed
+++ b/esxi/changelog.d/20022.fixed
@@ -1,1 +1,1 @@
-Add support for custom tags.
+Properly support custom tags.

--- a/esxi/changelog.d/20022.fixed
+++ b/esxi/changelog.d/20022.fixed
@@ -1,0 +1,1 @@
+Add support for custom tags.

--- a/esxi/datadog_checks/esxi/check.py
+++ b/esxi/datadog_checks/esxi/check.py
@@ -61,7 +61,8 @@ class EsxiCheck(AgentCheck):
         self.ssl_verify = is_affirmative(self.instance.get('ssl_verify', True))
         self.ssl_capath = self.instance.get("ssl_capath")
         self.ssl_cafile = self.instance.get("ssl_cafile")
-        self.tags = [f"esxi_url:{self.host}"]
+        self.tags = self.instance.get("tags", [])
+        self.tags.append(f"esxi_url:{self.host}")
         self.proxy_host = None
         self.proxy_port = None
         proxy = self.instance.get('proxy', init_config.get('proxy'))

--- a/esxi/tests/test_unit.py
+++ b/esxi/tests/test_unit.py
@@ -1271,3 +1271,16 @@ def test_cant_get_version(vcsim_instance, dd_run_check, caplog, service_instance
     )
     aggregator.assert_metric('esxi.host.can_connect', 0, count=1)
     aggregator.assert_all_metrics_covered()
+
+
+@pytest.mark.usefixtures("service_instance")
+def test_esxi_custom_tags(vcsim_instance, dd_run_check, aggregator, caplog):
+    vcsim_instance['tags'] = ['test:tag']
+    check = EsxiCheck('esxi', {}, [vcsim_instance])
+    caplog.set_level(logging.DEBUG)
+    dd_run_check(check)
+
+    base_tags = ["esxi_url:127.0.0.1:8989", "test:tag"]
+    aggregator.assert_metric("esxi.cpu.usage.avg", value=0.26, tags=base_tags, hostname="localhost.localdomain")
+    aggregator.assert_metric("esxi.mem.granted.avg", value=80, tags=base_tags, hostname="localhost.localdomain")
+    aggregator.assert_metric("esxi.host.can_connect", 1, count=2, tags=base_tags)

--- a/esxi/tests/test_unit.py
+++ b/esxi/tests/test_unit.py
@@ -1274,10 +1274,9 @@ def test_cant_get_version(vcsim_instance, dd_run_check, caplog, service_instance
 
 
 @pytest.mark.usefixtures("service_instance")
-def test_esxi_custom_tags(vcsim_instance, dd_run_check, aggregator, caplog):
+def test_esxi_custom_tags(vcsim_instance, dd_run_check, aggregator):
     vcsim_instance['tags'] = ['test:tag']
     check = EsxiCheck('esxi', {}, [vcsim_instance])
-    caplog.set_level(logging.DEBUG)
     dd_run_check(check)
 
     base_tags = ["esxi_url:127.0.0.1:8989", "test:tag"]


### PR DESCRIPTION
### What does this PR do?
Add support for custom tags in esxi integration
### Motivation
customer request and we should have supported this before
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
