### PR TITLE
Add Cisco ACI critical fault sample monitor.  Add Faults to Cisco ACI dashboard.

### DIFF
--- a/cisco_aci/assets/dashboards/cisco_aci_dashboard.json
+++ b/cisco_aci/assets/dashboards/cisco_aci_dashboard.json
@@ -1413,6 +1413,91 @@
                 "width": 12,
                 "height": 8
             }
+        },
+        {
+          "id": 2956975389292306,
+          "definition": {
+            "title": "Faults",
+            "background_color": "vivid_purple",
+            "show_title": true,
+            "type": "group",
+            "layout_type": "ordered",
+            "widgets": []
+          },
+          "layout": {
+            "x": 0,
+            "y": 34,
+            "width": 12,
+            "height": 1
+          }
+        },
+        {
+          "id": 987022990164424,
+          "definition": {
+            "title": "",
+            "title_size": "16",
+            "title_align": "left",
+            "requests": [
+              {
+                "response_format": "event_list",
+                "query": {
+                  "data_source": "logs_stream",
+                  "query_string": "source:cisco-aci",
+                  "indexes": [],
+                  "storage": "hot"
+                },
+                "columns": [
+                  {
+                    "field": "status_line",
+                    "width": "auto"
+                  },
+                  {
+                    "field": "timestamp",
+                    "width": "auto"
+                  },
+                  {
+                    "field": "host",
+                    "width": "auto"
+                  },
+                  {
+                    "field": "status",
+                    "width": "auto"
+                  },
+                  {
+                    "field": "content",
+                    "width": "compact"
+                  },
+                  {
+                    "field": "@cisco_aci.ack",
+                    "width": "auto"
+                  },
+                  {
+                    "field": "@cisco_aci.cause",
+                    "width": "auto"
+                  },
+                  {
+                    "field": "@cisco_aci.code",
+                    "width": "auto"
+                  },
+                  {
+                    "field": "@cisco_aci.occur",
+                    "width": "auto"
+                  },
+                  {
+                    "field": "@cisco_aci.severity",
+                    "width": "auto"
+                  }
+                ]
+              }
+            ],
+            "type": "list_stream"
+          },
+          "layout": {
+            "x": 0,
+            "y": 0,
+            "width": 12,
+            "height": 7
+          }
         }
     ],
     "template_variables": [

--- a/cisco_aci/assets/dashboards/cisco_aci_dashboard.json
+++ b/cisco_aci/assets/dashboards/cisco_aci_dashboard.json
@@ -1442,7 +1442,7 @@
                 "response_format": "event_list",
                 "query": {
                   "data_source": "logs_stream",
-                  "query_string": "source:cisco-aci",
+                  "query_string": "service:cisco-aci source:cisco-aci",
                   "indexes": [],
                   "storage": "hot"
                 },

--- a/cisco_aci/assets/monitors/critical_fault.json
+++ b/cisco_aci/assets/monitors/critical_fault.json
@@ -7,7 +7,7 @@
 	"definition": {
 		"name": "[Cisco ACI] critical fault received, {{[@cisco_aci.severity].name}} severity,  code {{[@cisco_aci.code].name}}, dn {{[@cisco_aci.dn].name}}",
 		"type": "log alert",
-		"query": "logs(\"source:cisco-aci @cisco_aci.severity:critical\").index(\"*\").rollup(\"count\").by(\"@cisco_aci.code,@cisco_aci.dn,@cisco_aci.severity\").last(\"5m\") > 0",
+		"query": "logs(\"service:cisco-aci source:cisco-aci @cisco_aci.severity:critical\").index(\"*\").rollup(\"count\").by(\"@cisco_aci.code,@cisco_aci.dn,@cisco_aci.severity\").last(\"5m\") > 0",
 		"message": "{{#is_alert}}\n{{[@cisco_aci.severity].name}} severity,  code {{[@cisco_aci.code].name}}  for dn {{[@cisco_aci.dn].name}}\n\n@example@example.com \n{{/is_alert}}",
 		"tags": [],
 		"options": {

--- a/cisco_aci/assets/monitors/critical_fault.json
+++ b/cisco_aci/assets/monitors/critical_fault.json
@@ -1,0 +1,29 @@
+{
+	"version": 2,
+	"created_at": "2025-04-08",
+	"last_updated_at": "2025-04-08",
+	"title": "Cisco ACI critical fault received",
+	"description": "This monitor alerts if a Cisco ACI critical fault is received",
+	"definition": {
+		"name": "[Cisco ACI] critical fault received, {{[@cisco_aci.severity].name}} severity,  code {{[@cisco_aci.code].name}}, dn {{[@cisco_aci.dn].name}}",
+		"type": "log alert",
+		"query": "logs(\"source:cisco-aci @cisco_aci.severity:critical\").index(\"*\").rollup(\"count\").by(\"@cisco_aci.code,@cisco_aci.dn,@cisco_aci.severity\").last(\"5m\") > 0",
+		"message": "{{#is_alert}}\n{{[@cisco_aci.severity].name}} severity,  code {{[@cisco_aci.code].name}}  for dn {{[@cisco_aci.dn].name}}\n\n@example@example.com \n{{/is_alert}}",
+		"tags": [],
+		"options": {
+			"thresholds": {
+				"critical": 0
+			},
+			"enable_logs_sample": true,
+			"notify_audit": false,
+			"on_missing_data": "default",
+			"include_tags": true,
+			"new_group_delay": 60,
+			"avalanche_window": 10,
+			"groupby_simple_monitor": false
+		}
+	},
+	"tags": [
+		"integration:cisco-aci"
+	]
+}

--- a/cisco_aci/manifest.json
+++ b/cisco_aci/manifest.json
@@ -52,7 +52,8 @@
     "monitors": {
       "CPU usage is high for Cisco ACI device": "assets/monitors/cpu_high.json",
       "Health score of device is critical": "assets/monitors/critical_health_score.json",
-      "Interface for a Cisco ACI device is down": "assets/monitors/interface_down.json"
+      "Interface for a Cisco ACI device is down": "assets/monitors/interface_down.json",
+      "Cisco ACI critical severity fault": "assets/monitors/critical_fault.json"
     },
     "logs": {
       "source": "cisco-aci"


### PR DESCRIPTION
### What does this PR do?
Add Cisco ACI critical fault sample monitor.  Add Faults to Cisco ACI dashboard.
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
