### PR TITLE
[NWL-807] Add empty dashboard + set up dashboard in manifest

### DIFF
--- a/gpu/assets/dashboards/network_metrics.json
+++ b/gpu/assets/dashboards/network_metrics.json
@@ -1,0 +1,9 @@
+{
+  "title": "Network Metrics",
+  "description": "[[suggested_dashboards]]",
+  "widgets": [],
+  "template_variables": [],
+  "layout_type": "ordered",
+  "notify_list": [],
+  "reflow_type": "fixed"
+}

--- a/gpu/manifest.json
+++ b/gpu/manifest.json
@@ -24,6 +24,9 @@
     "sales_email": "info@datadoghq.com"
   },
   "assets": {
+    "dashboards": {
+      "network_metrics": "assets/dashboards/network_metrics.json"
+    },
     "integration": {
       "source_type_name": "GPU",
       "configuration": {},
@@ -37,9 +40,6 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      },
-      "dashboards": {
-        "network_metrics": "assets/dashboards/network_metrics.json"
       },
       "source_type_id": 23066,
       "auto_install": true

--- a/gpu/manifest.json
+++ b/gpu/manifest.json
@@ -38,6 +38,9 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       },
+      "dashboards": {
+        "network_metrics": "assets/dashboards/network_metrics.json"
+      },
       "source_type_id": 23066,
       "auto_install": true
     }


### PR DESCRIPTION
### What does this PR do?

Sets up a skeleton for an empty dashboard for networking metrics
