### PR TITLE
add replication slot information and replication slot type to postgres replication stat metric

### DIFF
--- a/postgres/changelog.d/20035.added
+++ b/postgres/changelog.d/20035.added
@@ -1,0 +1,1 @@
+add replication slot information and replication slot type to postgres replication stat metric

--- a/postgres/datadog_checks/postgres/discovery.py
+++ b/postgres/datadog_checks/postgres/discovery.py
@@ -26,7 +26,7 @@ class PostgresAutodiscovery(Discovery):
         super(PostgresAutodiscovery, self).__init__(
             self._get_databases,
             # parent class asks for includelist to be a dictionary
-            include={db: 0 for db in autodiscovery_config.get("include", [".*"])},
+            include=dict.fromkeys(autodiscovery_config.get("include", [".*"]), 0),
             exclude=autodiscovery_config.get("exclude", DEFAULT_EXCLUDES),
             interval=autodiscovery_config.get("refresh", DEFAULT_REFRESH),
         )

--- a/postgres/datadog_checks/postgres/metrics_cache.py
+++ b/postgres/datadog_checks/postgres/metrics_cache.py
@@ -27,7 +27,6 @@ from .util import (
     REPLICATION_METRICS_9_1,
     REPLICATION_METRICS_9_2,
     REPLICATION_METRICS_10,
-    REPLICATION_STATS_METRICS,
 )
 from .version_utils import V8_3, V9, V9_1, V9_2, V9_4, V9_6, V10, V12, V14, V17
 
@@ -181,11 +180,6 @@ class PostgresMetricsCache:
             if version >= V9_2:
                 self.replication_metrics.update(REPLICATION_METRICS_9_2)
         return self.replication_metrics
-
-    def get_replication_stats_metrics(self, version):
-        if version >= V10 and self.replication_stats_metrics is None:
-            self.replication_stats_metrics = dict(REPLICATION_STATS_METRICS)
-        return self.replication_stats_metrics
 
     def get_activity_metrics(self, version):
         """Use ACTIVITY_METRICS_LT_8_3 or ACTIVITY_METRICS_8_3 or ACTIVITY_METRICS_9_2

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -51,6 +51,7 @@ from .util import (
     QUERY_PG_CONTROL_CHECKPOINT_LT_10,
     QUERY_PG_REPLICATION_SLOTS,
     QUERY_PG_REPLICATION_SLOTS_STATS,
+    QUERY_PG_REPLICATION_STATS_METRICS,
     QUERY_PG_STAT_DATABASE,
     QUERY_PG_STAT_DATABASE_CONFLICTS,
     QUERY_PG_STAT_WAL_RECEIVER,
@@ -320,6 +321,7 @@ class PostgreSql(AgentCheck):
             if self._config.collect_buffercache_metrics:
                 queries.append(BUFFERCACHE_METRICS)
             queries.append(QUERY_PG_REPLICATION_SLOTS)
+            queries.append(QUERY_PG_REPLICATION_STATS_METRICS)
             queries.append(VACUUM_PROGRESS_METRICS if self.version >= V17 else VACUUM_PROGRESS_METRICS_LT_17)
             queries.append(STAT_SUBSCRIPTION_METRICS)
 
@@ -739,10 +741,6 @@ class PostgreSql(AgentCheck):
             replication_metrics_query = copy.deepcopy(REPLICATION_METRICS)
             replication_metrics_query['metrics'] = replication_metrics
             metric_scope.append(replication_metrics_query)
-
-        replication_stats_metrics = self.metrics_cache.get_replication_stats_metrics(self.version)
-        if replication_stats_metrics:
-            metric_scope.append(replication_stats_metrics)
 
         with self.db() as conn:
             with conn.cursor(cursor_factory=CommenterCursor) as cursor:

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -383,44 +383,45 @@ SELECT {metrics_columns}
 # Requires postgres 10+
 REPLICATION_STATS_METRICS = {
     'descriptors': [
-        ('replication.application_name', 'wal_app_name'),
-        ('replication.state', 'wal_state'),
-        ('replication.sync_state', 'wal_sync_state'),
-        ('replication.client_addr', 'wal_client_addr'),
-        ('replication_slot.slot_name', 'slot_name'),
-        ('replication_slot.slot_type', 'slot_type'),
+        ('pg_stat_replication.application_name', 'wal_app_name'),
+        ('pg_stat_replication.state', 'wal_state'),
+        ('pg_stat_replication.sync_state', 'wal_sync_state'),
+        ('pg_stat_replication.client_addr', 'wal_client_addr'),
+        ('pg_stat_replication_slot.slot_name', 'slot_name'),
+        ('pg_stat_replication_slot.slot_type', 'slot_type'),
     ],
     'metrics': {
-        'GREATEST (0, EXTRACT(epoch from replication.write_lag)) as write_lag': (
-            'wal_write_lag',
+        'GREATEST (0, EXTRACT(epoch from pg_stat_replication.write_lag)) as write_lag': (
+            'replication.wal_write_lag',
             AgentCheck.gauge,
         ),
-        'GREATEST (0, EXTRACT(epoch from replication.flush_lag)) AS flush_lag': (
-            'wal_flush_lag',
+        'GREATEST (0, EXTRACT(epoch from pg_stat_replication.flush_lag)) AS flush_lag': (
+            'replication.wal_flush_lag',
             AgentCheck.gauge,
         ),
-        'GREATEST (0, EXTRACT(epoch from replication.replay_lag)) AS replay_lag': (
-            'wal_replay_lag',
+        'GREATEST (0, EXTRACT(epoch from pg_stat_replication.replay_lag)) AS replay_lag': (
+            'replication.wal_replay_lag',
             AgentCheck.gauge,
         ),
-        'GREATEST (0, age(replication.backend_xmin)) as backend_xmin_age': (
-            'backend_xmin_age',
+        'GREATEST (0, age(pg_stat_replication.backend_xmin)) as backend_xmin_age': (
+            'replication.backend_xmin_age',
             AgentCheck.gauge,
         ),
     },
     'relation': False,
     'query': """
-SELECT replication.application_name,
-replication.state,
-replication.sync_state,
-replication.client_addr,
-{metrics_columns},
-replication_slot.slot_name,
-replication_slot.slot_type,
-FROM pg_stat_replication as replication
-LEFT JOIN pg_replication_slots as replication_slot
-ON replication.pid = replication_slot.active_pid;
-""",
+SELECT 
+    pg_stat_replication.application_name,
+    pg_stat_replication.state,
+    pg_stat_replication.sync_state,
+    pg_stat_replication.client_addr,
+    pg_stat_replication_slot.slot_name,
+    pg_stat_replication_slot.slot_type,
+    {metrics_columns}
+FROM pg_stat_replication as pg_stat_replication
+LEFT JOIN pg_replication_slots as pg_stat_replication_slot
+ON pg_stat_replication.pid = pg_stat_replication_slot.active_pid;
+""".strip(),
     'name': 'replication_stats_metrics',
 }
 

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -410,7 +410,7 @@ REPLICATION_STATS_METRICS = {
     },
     'relation': False,
     'query': """
-SELECT 
+SELECT
     pg_stat_replication.application_name,
     pg_stat_replication.state,
     pg_stat_replication.sync_state,

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -383,33 +383,43 @@ SELECT {metrics_columns}
 # Requires postgres 10+
 REPLICATION_STATS_METRICS = {
     'descriptors': [
-        ('application_name', 'wal_app_name'),
-        ('state', 'wal_state'),
-        ('sync_state', 'wal_sync_state'),
-        ('client_addr', 'wal_client_addr'),
+        ('replication.application_name', 'wal_app_name'),
+        ('replication.state', 'wal_state'),
+        ('replication.sync_state', 'wal_sync_state'),
+        ('replication.client_addr', 'wal_client_addr'),
+        ('replication_slot.slot_name', 'slot_name'),
+        ('replication_slot.slot_type', 'slot_type'),
     ],
     'metrics': {
-        'GREATEST (0, EXTRACT(epoch from write_lag)) as write_lag': (
-            'replication.wal_write_lag',
+        'GREATEST (0, EXTRACT(epoch from replication.write_lag)) as write_lag': (
+            'wal_write_lag',
             AgentCheck.gauge,
         ),
-        'GREATEST (0, EXTRACT(epoch from flush_lag)) AS flush_lag': (
-            'replication.wal_flush_lag',
+        'GREATEST (0, EXTRACT(epoch from replication.flush_lag)) AS flush_lag': (
+            'wal_flush_lag',
             AgentCheck.gauge,
         ),
-        'GREATEST (0, EXTRACT(epoch from replay_lag)) AS replay_lag': (
-            'replication.wal_replay_lag',
+        'GREATEST (0, EXTRACT(epoch from replication.replay_lag)) AS replay_lag': (
+            'wal_replay_lag',
             AgentCheck.gauge,
         ),
-        'GREATEST (0, age(backend_xmin)) as backend_xmin_age': (
-            'replication.backend_xmin_age',
+        'GREATEST (0, age(replication.backend_xmin)) as backend_xmin_age': (
+            'backend_xmin_age',
             AgentCheck.gauge,
         ),
     },
     'relation': False,
     'query': """
-SELECT application_name, state, sync_state, client_addr, {metrics_columns}
-FROM pg_stat_replication
+SELECT replication.application_name,
+replication.state,
+replication.sync_state,
+replication.client_addr,
+{metrics_columns},
+replication_slot.slot_name,
+replication_slot.slot_type,
+FROM pg_stat_replication as replication
+LEFT JOIN pg_replication_slots as replication_slot
+ON replication.pid = replication_slot.active_pid;
 """,
     'name': 'replication_stats_metrics',
 }

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -269,6 +269,8 @@ def check_stat_replication(aggregator, expected_tags, count=1):
         'wal_client_addr:{}'.format(get_container_ip(REPLICA_CONTAINER_NAME)),
         'wal_state:streaming',
         'wal_sync_state:async',
+        'slot_name:replication_slot',
+        'slot_type:physical',
     ]
     for metric_name in _iterate_metric_name(REPLICATION_STATS_METRICS):
         aggregator.assert_metric(metric_name, count=count, tags=replication_tags)

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -15,9 +15,9 @@ from datadog_checks.postgres.util import (
     QUERY_PG_CONTROL_CHECKPOINT,
     QUERY_PG_REPLICATION_SLOTS,
     QUERY_PG_REPLICATION_SLOTS_STATS,
+    QUERY_PG_REPLICATION_STATS_METRICS,
     QUERY_PG_STAT_WAL_RECEIVER,
     QUERY_PG_UPTIME,
-    REPLICATION_STATS_METRICS,
     SLRU_METRICS,
     SNAPSHOT_TXID_METRICS,
     STAT_IO_METRICS,
@@ -42,7 +42,9 @@ DB_NAME = 'datadog_test'
 POSTGRES_VERSION = os.environ.get('POSTGRES_VERSION', None)
 POSTGRES_IMAGE = "alpine"
 
-REPLICA_CONTAINER_NAME = 'compose-postgres_replica-1'
+REPLICA_CONTAINER_1_NAME = 'compose-postgres_replica-1'
+REPLICA_CONTAINER_2_NAME = 'compose-postgres_replica2-1'
+REPLICA_LOGICAL_1_NAME = 'compose-postgres_logical_replica-1'
 USING_LATEST = False
 
 if POSTGRES_VERSION is not None:
@@ -261,18 +263,31 @@ def check_activity_metrics(aggregator, tags, hostname=None, count=1):
         aggregator.assert_metric(name, count=1, tags=tags, hostname=hostname)
 
 
-def check_stat_replication(aggregator, expected_tags, count=1):
+def check_stat_replication_physical_slot(aggregator, expected_tags, count=1):
     if float(POSTGRES_VERSION) < 10:
         return
     replication_tags = expected_tags + [
         'wal_app_name:walreceiver',
-        'wal_client_addr:{}'.format(get_container_ip(REPLICA_CONTAINER_NAME)),
+        f'wal_client_addr:{get_container_ip(REPLICA_CONTAINER_1_NAME)}',
         'wal_state:streaming',
         'wal_sync_state:async',
         'slot_name:replication_slot',
         'slot_type:physical',
     ]
-    for metric_name in _iterate_metric_name(REPLICATION_STATS_METRICS):
+    for metric_name in _iterate_metric_name(QUERY_PG_REPLICATION_STATS_METRICS):
+        aggregator.assert_metric(metric_name, count=count, tags=replication_tags)
+
+
+def check_stat_replication_no_slot(aggregator, expected_tags, count=1):
+    if float(POSTGRES_VERSION) < 10:
+        return
+    replication_tags = expected_tags + [
+        'wal_app_name:replica2',
+        f'wal_client_addr:{get_container_ip(REPLICA_CONTAINER_2_NAME)}',
+        'wal_state:streaming',
+        'wal_sync_state:async',
+    ]
+    for metric_name in _iterate_metric_name(QUERY_PG_REPLICATION_STATS_METRICS):
         aggregator.assert_metric(metric_name, count=count, tags=replication_tags)
 
 

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -281,8 +281,11 @@ def check_stat_replication_physical_slot(aggregator, expected_tags, count=1):
 def check_stat_replication_no_slot(aggregator, expected_tags, count=1):
     if float(POSTGRES_VERSION) < 10:
         return
+    wal_app_name = 'replica2'
+    if float(POSTGRES_VERSION) < 12:
+        wal_app_name = 'walreceiver'
     replication_tags = expected_tags + [
-        'wal_app_name:replica2',
+        f'wal_app_name:{wal_app_name}',
         f'wal_client_addr:{get_container_ip(REPLICA_CONTAINER_2_NAME)}',
         'wal_state:streaming',
         'wal_sync_state:async',

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -39,7 +39,8 @@ from .common import (
     check_slru_metrics,
     check_snapshot_txid_metrics,
     check_stat_io_metrics,
-    check_stat_replication,
+    check_stat_replication_no_slot,
+    check_stat_replication_physical_slot,
     check_stat_wal_metrics,
     check_uptime_metrics,
     check_wal_receiver_metrics,
@@ -81,7 +82,8 @@ def test_common_metrics(aggregator, integration_check, pg_instance, is_aurora):
     check_conflict_metrics(aggregator, expected_tags=expected_tags)
     check_db_count(aggregator, expected_tags=expected_tags)
     check_slru_metrics(aggregator, expected_tags=expected_tags)
-    check_stat_replication(aggregator, expected_tags=expected_tags)
+    check_stat_replication_physical_slot(aggregator, expected_tags=expected_tags)
+    check_stat_replication_no_slot(aggregator, expected_tags=expected_tags)
     if is_aurora is False:
         check_wal_receiver_metrics(aggregator, expected_tags=expected_tags, connected=0)
         check_file_wal_metrics(aggregator, expected_tags=expected_tags)

--- a/postgres/tests/test_replication_slot.py
+++ b/postgres/tests/test_replication_slot.py
@@ -11,7 +11,7 @@ from datadog_checks.postgres.util import QUERY_PG_REPLICATION_SLOTS_STATS, REPLI
 from .common import DB_NAME, HOST, _get_expected_tags, _iterate_metric_name, assert_metric_at_least
 from .utils import requires_over_10, requires_over_14
 
-pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]
+pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("dd_environment")]
 
 
 @requires_over_10
@@ -26,7 +26,7 @@ def test_physical_replication_slots(aggregator, integration_check, pg_instance):
         with conn.cursor() as cur:
             cur.execute("select pg_wal_lsn_diff(pg_current_wal_lsn(), redo_lsn) from pg_control_checkpoint();")
             redo_lsn_age = int(cur.fetchall()[0][0])
-            cur.execute('select age(xmin) FROM pg_replication_slots;')
+            cur.execute("select age(xmin) FROM pg_replication_slots;")
             bound = cur.fetchall()[0][0]
             xmin_age_higher_bound += int(bound) if bound is not None else 0
 
@@ -45,27 +45,27 @@ def test_physical_replication_slots(aggregator, integration_check, pg_instance):
     # Nothing reported for phys_1
     base_tags = _get_expected_tags(check, pg_instance)
     expected_phys2_tags = base_tags + [
-        'slot_name:phys_2',
-        'slot_persistence:permanent',
-        'slot_state:inactive',
-        'slot_type:physical',
+        "slot_name:phys_2",
+        "slot_persistence:permanent",
+        "slot_state:inactive",
+        "slot_type:physical",
     ]
     expected_phys3_tags = base_tags + [
-        'slot_name:phys_3',
-        'slot_persistence:temporary',
-        'slot_state:active',
-        'slot_type:physical',
+        "slot_name:phys_3",
+        "slot_persistence:temporary",
+        "slot_state:active",
+        "slot_type:physical",
     ]
     expected_repslot_tags = base_tags + [
-        'slot_name:replication_slot',
-        'slot_persistence:permanent',
-        'slot_state:active',
-        'slot_type:physical',
+        "slot_name:replication_slot",
+        "slot_persistence:permanent",
+        "slot_state:active",
+        "slot_type:physical",
     ]
 
     assert_metric_at_least(
         aggregator,
-        'postgresql.replication_slot.restart_delay_bytes',
+        "postgresql.replication_slot.restart_delay_bytes",
         lower_bound=redo_lsn_age,
         tags=expected_phys2_tags,
         count=1,
@@ -73,14 +73,14 @@ def test_physical_replication_slots(aggregator, integration_check, pg_instance):
 
     assert_metric_at_least(
         aggregator,
-        'postgresql.replication_slot.restart_delay_bytes',
+        "postgresql.replication_slot.restart_delay_bytes",
         lower_bound=redo_lsn_age,
         tags=expected_phys3_tags,
         count=1,
     )
     assert_metric_at_least(
         aggregator,
-        'postgresql.replication_slot.xmin_age',
+        "postgresql.replication_slot.xmin_age",
         higher_bound=xmin_age_higher_bound,
         tags=expected_repslot_tags,
         count=1,
@@ -99,22 +99,22 @@ def test_logical_replication_slots(aggregator, integration_check, pg_instance):
 
     base_tags = _get_expected_tags(check, pg_instance)
     expected_tags = base_tags + [
-        'slot_name:logical_slot',
-        'slot_persistence:permanent',
-        'slot_state:inactive',
-        'slot_type:logical',
+        "slot_name:logical_slot",
+        "slot_persistence:permanent",
+        "slot_state:inactive",
+        "slot_type:logical",
     ]
     # Both should be in the past
     assert_metric_at_least(
         aggregator,
-        'postgresql.replication_slot.confirmed_flush_delay_bytes',
+        "postgresql.replication_slot.confirmed_flush_delay_bytes",
         count=1,
         lower_bound=50,
         tags=expected_tags,
     )
     assert_metric_at_least(
         aggregator,
-        'postgresql.replication_slot.restart_delay_bytes',
+        "postgresql.replication_slot.restart_delay_bytes",
         count=1,
         lower_bound=restart_age,
         tags=expected_tags,
@@ -127,12 +127,13 @@ def test_replication_slot_stats(aggregator, integration_check, pg_instance):
     check.check(pg_instance)
 
     expected_tags = _get_expected_tags(check, pg_instance) + [
-        'slot_name:logical_slot',
-        'slot_state:inactive',
-        'slot_type:logical',
+        "slot_name:logical_slot",
+        "slot_state:inactive",
+        "slot_type:logical",
     ]
     for metric_name in _iterate_metric_name(QUERY_PG_REPLICATION_SLOTS_STATS):
         aggregator.assert_metric(metric_name, count=1, tags=expected_tags)
+
 
 @requires_over_10
 def test_replication_slot_information(aggregator, integration_check, pg_instance):
@@ -142,20 +143,21 @@ def test_replication_slot_information(aggregator, integration_check, pg_instance
     check.check(pg_instance)
     base_tags = _get_expected_tags(check, pg_instance)
     expected_tags = base_tags + [
-        'wal_app_name:subscription_cities',
-        'wal_state:streaming',
-        'wal_sync_state:async',
-        'wal_client_addr:'+client_address,
-        'slot_name:subscription_cities',
-        'slot_type:logical',
+        "wal_app_name:subscription_cities",
+        "wal_state:streaming",
+        "wal_sync_state:async",
+        "wal_client_addr:" + client_address,
+        "slot_name:subscription_cities",
+        "slot_type:logical",
     ]
 
     for metric_name in _iterate_metric_name(REPLICATION_STATS_METRICS):
         assert_metric_at_least(aggregator, metric_name, count=1, lower_bound=0, tags=expected_tags)
 
+
 def _get_client_addr() -> str:
     with psycopg2.connect(host=HOST, dbname=DB_NAME, user="postgres", password="datad0g") as conn:
         with conn.cursor() as cur:
-            cur.execute("select client_addr from pg_stat_replication where application_name=\'subscription_cities\';")
-            client_address = (cur.fetchone()[0])
+            cur.execute("select client_addr from pg_stat_replication where application_name='subscription_cities';")
+            client_address = cur.fetchone()[0]
     return client_address

--- a/postgres/tests/test_replication_slot.py
+++ b/postgres/tests/test_replication_slot.py
@@ -6,7 +6,7 @@ import time
 import psycopg2
 import pytest
 
-from datadog_checks.postgres.util import QUERY_PG_REPLICATION_SLOTS_STATS, REPLICATION_STATS_METRICS
+from datadog_checks.postgres.util import QUERY_PG_REPLICATION_SLOTS_STATS, QUERY_PG_REPLICATION_STATS_METRICS
 
 from .common import DB_NAME, HOST, _get_expected_tags, _iterate_metric_name, assert_metric_at_least
 from .utils import requires_over_10, requires_over_14
@@ -151,7 +151,7 @@ def test_replication_slot_information(aggregator, integration_check, pg_instance
         "slot_type:logical",
     ]
 
-    for metric_name in _iterate_metric_name(REPLICATION_STATS_METRICS):
+    for metric_name in _iterate_metric_name(QUERY_PG_REPLICATION_STATS_METRICS):
         assert_metric_at_least(aggregator, metric_name, count=1, lower_bound=0, tags=expected_tags)
 
 

--- a/postgres/tests/test_replication_slot.py
+++ b/postgres/tests/test_replication_slot.py
@@ -136,6 +136,7 @@ def test_replication_slot_stats(aggregator, integration_check, pg_instance):
 
 @requires_over_10
 def test_replication_slot_information(aggregator, integration_check, pg_instance):
+    client_address = None
     check = integration_check(pg_instance)
     client_address = _get_client_addr()
     check.check(pg_instance)
@@ -155,6 +156,6 @@ def test_replication_slot_information(aggregator, integration_check, pg_instance
 def _get_client_addr() -> str:
     with psycopg2.connect(host=HOST, dbname=DB_NAME, user="postgres", password="datad0g") as conn:
         with conn.cursor() as cur:
-            cur.execute("select client_addr from pg_stat_replication where application_name =  \'subscription_cities\';")
+            cur.execute("select client_addr from pg_stat_replication where application_name=\'subscription_cities\';")
             client_address = (cur.fetchone()[0])
     return client_address


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
(This is a draft PR)
JIRA - https://datadoghq.atlassian.net/browse/ADPPOS-2295 
This PR adds replication slot name and replication slot type to Postgres replication stat metrics.

Testing -
![Screenshot 2025-04-09 at 10 14 15 AM](https://github.com/user-attachments/assets/6d2d778e-8b80-482c-81fe-f52a87394789)

### Motivation
<!-- What inspired you to submit this pull request? -->

Getting Postgres replication slot information is helpful to know what type of replication (physical or logical) is lagging behind the primary instance and set up monitoring and alerting accordingly.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
