### PR TITLE
Fix Autodiscovery Annotations for Istio Control Plane

### DIFF
--- a/istio/README.md
+++ b/istio/README.md
@@ -65,9 +65,6 @@ Customize this file with any additional configurations. See the [sample istio.d/
 ##### Control plane configuration
 To monitor the Istio control plane and report the `mixer`, `galley`, `pilot`, and `citadel` metrics, you must configure the Agent to monitor the `istiod` deployment. In Istio v1.5 or later, apply the following pod annotations for the deployment `istiod` in the `istio-system` namespace:
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Annotations v1" xxx -->
-
 ```yaml
 ad.datadoghq.com/discovery.checks: |
   {
@@ -81,26 +78,7 @@ ad.datadoghq.com/discovery.checks: |
     }
   }
 ```
-
-<!-- xxz tab xxx -->
-<!-- xxx tab "Annotations v2" xxx -->
-
-**Note**: Annotations v2 is supported for Agent v7.36+.
-
-```yaml
-ad.datadoghq.com/<CONTAINER_IDENTIFIER>.checks: |
-  {
-    "Istio": {
-      "istiod_endpoint": "http://%%host%%:15014/metrics",
-      "use_openmetrics": "true"
-    }
-  }
-```
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
-
-
+**Note**: The Autodiscovery Annotations v2 syntax is supported for Agent v7.36+.
 
 This annotation specifies the container `discovery` to match the default container name of the Istio container in this pod. Replace this annotation `ad.datadoghq.com/<CONTAINER_NAME>.checks` with the name (`.spec.containers[i].name`) of your Istio container if yours differs.
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
There was a previous change (https://github.com/DataDog/integrations-core/pull/19344) which altered the Autodiscovery Annotations for the Control Plane (`istiod`) portion of the monitoring. This effectively reverts that change. 

### Motivation
<!-- What inspired you to submit this pull request? -->
The annotations provided were already the Autodiscovery V2 syntax, so it wasn't necessary to add these in. This placed the valid V2 annotations in the V1 tab. The V2 annotations added in are invalid. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
