### PR TITLE
Fix small typo in cursor rules

### DIFF
--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -3,5 +3,5 @@ description:
 globs: **/*.py
 alwaysApply: false
 ---
-Run unit and integration tests with `ddev --no-interactive test <INTEGRATION>`. For example, for the pbouncer integration, run `ddev --no-interactive test pgbouncer`.
-Run E2E tests with `ddev ddev --no-interactive env test <INTEGRATION> --dev`. For example, for the pbouncer integration, run `ddev ddev --no-interactive env test pgbouncer --dev`.
+Run unit and integration tests with `ddev --no-interactive test <INTEGRATION>`. For example, for the pgbouncer integration, run `ddev --no-interactive test pgbouncer`.
+Run E2E tests with `ddev ddev --no-interactive env test <INTEGRATION> --dev`. For example, for the pgbouncer integration, run `ddev ddev --no-interactive env test pgbouncer --dev`.


### PR DESCRIPTION
Fixes a small typo in the cursor rules: `pbouncer` -> `pgbouncer`