### PR TITLE
Add `NoSuchProcess` exception handling

### DIFF
--- a/gunicorn/changelog.d/20059.added
+++ b/gunicorn/changelog.d/20059.added
@@ -1,0 +1,1 @@
+Add NoSuchProcess exception handling during initial proc search

--- a/gunicorn/datadog_checks/gunicorn/gunicorn.py
+++ b/gunicorn/datadog_checks/gunicorn/gunicorn.py
@@ -151,10 +151,10 @@ class GUnicornCheck(AgentCheck):
             try:
                 if p.cmdline()[0] == master_name:
                     master_procs.append(p)
-            except (IndexError, psutil.Error) as e:
-                self.log.debug("Cannot read information from process %s: %s", p.name(), e, exc_info=True)
             except psutil.NoSuchProcess:
                 self.log.debug("Process %s disappeared while scanning", p.name())
+            except (IndexError, psutil.Error) as e:
+                self.log.debug("Cannot read information from process %s: %s", p.name(), e, exc_info=True)
         self.log.debug("There are %s master process(es) with the name %s", len(master_procs), name)
         return master_procs
 

--- a/gunicorn/datadog_checks/gunicorn/gunicorn.py
+++ b/gunicorn/datadog_checks/gunicorn/gunicorn.py
@@ -153,6 +153,8 @@ class GUnicornCheck(AgentCheck):
                     master_procs.append(p)
             except (IndexError, psutil.Error) as e:
                 self.log.debug("Cannot read information from process %s: %s", p.name(), e, exc_info=True)
+            except psutil.NoSuchProcess:
+                self.log.debug("Process %s disappeared while scanning", p.name())
         self.log.debug("There are %s master process(es) with the name %s", len(master_procs), name)
         return master_procs
 

--- a/gunicorn/tests/test_unit.py
+++ b/gunicorn/tests/test_unit.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import logging
+
 import mock
 import psutil
 import pytest
@@ -25,14 +27,16 @@ def test_collect_metadata_parsing_matching(aggregator, datadog_agent, stdout, st
     datadog_agent.assert_metadata_count(expect_metadata_count)
 
 
-def test_process_disappearing_during_scan(aggregator):
+def test_process_disappearing_during_scan(aggregator, caplog):
     """Test handling of processes that disappear during scanning"""
-    check = GUnicornCheck(CHECK_NAME, {}, [INSTANCE])
-
+    caplog.clear()
     # Create a mock process that will raise NoSuchProcess when cmdline() is called
     mock_process = mock.Mock()
-    mock_process.cmdline.side_effect = psutil.NoSuchProcess(0)  # 0 is the pid
+    mock_process.cmdline.side_effect = psutil.NoSuchProcess(1234)  # 1234 is the pid
     mock_process.name.return_value = "dd-test-gunicorn"  # For the debug log message
+
+    check = GUnicornCheck(CHECK_NAME, {}, [INSTANCE])
+    caplog.set_level(logging.DEBUG)
 
     # Mock process_iter to return our disappearing process
     with mock.patch('psutil.process_iter', return_value=[mock_process]):
@@ -45,3 +49,5 @@ def test_process_disappearing_during_scan(aggregator):
         tags=['app:' + INSTANCE['proc_name']],
         message="No gunicorn process with name {} found, skipping worker metrics".format(INSTANCE['proc_name']),
     )
+
+    assert "Process dd-test-gunicorn disappeared while scanning" in caplog.text

--- a/gunicorn/tests/test_unit.py
+++ b/gunicorn/tests/test_unit.py
@@ -2,8 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import mock
-import pytest
 import psutil
+import pytest
 
 from datadog_checks.gunicorn import GUnicornCheck
 
@@ -28,20 +28,20 @@ def test_collect_metadata_parsing_matching(aggregator, datadog_agent, stdout, st
 def test_process_disappearing_during_scan(aggregator):
     """Test handling of processes that disappear during scanning"""
     check = GUnicornCheck(CHECK_NAME, {}, [INSTANCE])
-    
+
     # Create a mock process that will raise NoSuchProcess when cmdline() is called
     mock_process = mock.Mock()
     mock_process.cmdline.side_effect = psutil.NoSuchProcess(0)  # 0 is the pid
     mock_process.name.return_value = "dd-test-gunicorn"  # For the debug log message
-    
+
     # Mock process_iter to return our disappearing process
     with mock.patch('psutil.process_iter', return_value=[mock_process]):
         check.check(INSTANCE)
-    
+
     # Verify the service check shows critical since no processes were found
     aggregator.assert_service_check(
         "gunicorn.is_running",
         check.CRITICAL,
         tags=['app:' + INSTANCE['proc_name']],
-        message="No gunicorn process with name {} found, skipping worker metrics".format(INSTANCE['proc_name'])
+        message="No gunicorn process with name {} found, skipping worker metrics".format(INSTANCE['proc_name']),
     )

--- a/gunicorn/tests/test_unit.py
+++ b/gunicorn/tests/test_unit.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import mock
 import pytest
+import psutil
 
 from datadog_checks.gunicorn import GUnicornCheck
 
@@ -22,3 +23,25 @@ def test_collect_metadata_parsing_matching(aggregator, datadog_agent, stdout, st
         check.check(INSTANCE)
 
     datadog_agent.assert_metadata_count(expect_metadata_count)
+
+
+def test_process_disappearing_during_scan(aggregator):
+    """Test handling of processes that disappear during scanning"""
+    check = GUnicornCheck(CHECK_NAME, {}, [INSTANCE])
+    
+    # Create a mock process that will raise NoSuchProcess when cmdline() is called
+    mock_process = mock.Mock()
+    mock_process.cmdline.side_effect = psutil.NoSuchProcess(0)  # 0 is the pid
+    mock_process.name.return_value = "dd-test-gunicorn"  # For the debug log message
+    
+    # Mock process_iter to return our disappearing process
+    with mock.patch('psutil.process_iter', return_value=[mock_process]):
+        check.check(INSTANCE)
+    
+    # Verify the service check shows critical since no processes were found
+    aggregator.assert_service_check(
+        "gunicorn.is_running",
+        check.CRITICAL,
+        tags=['app:' + INSTANCE['proc_name']],
+        message="No gunicorn process with name {} found, skipping worker metrics".format(INSTANCE['proc_name'])
+    )


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds NoSuchProcess during search for master process.

### Motivation
<!-- What inspired you to submit this pull request? -->
While we have NoSuchProcess exception handling while scraping GUnicorn workers, we don't have that functionality when looking at master procs during the first scan. This has caused issues like: https://github.com/DataDog/integrations-core/issues/19637.
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
