### PR TITLE
Update README.md for kubernetes_cluster_autoscaler

### DIFF
--- a/kubernetes_cluster_autoscaler/README.md
+++ b/kubernetes_cluster_autoscaler/README.md
@@ -48,7 +48,7 @@ prometheus.io/scrape: true
 The only parameters required for configuring the `kubernetes_cluster_autoscaler` check are:
 
 * CONTAINER_NAME
-  Describe the pod belonging to your cluster autoscaler, and find the container name.
+  Name of the container of the cluster autoscaler controller.
 * `openmetrics_endpoint`
   This parameter should be set to the location where the Prometheus-formatted metrics are exposed. The default port is `8085`. To configure a different port, use the `METRICS_PORT` [environment variable][10]. In containerized environments, `%%host%%` should be used for [host autodetection][3]. 
 

--- a/kubernetes_cluster_autoscaler/README.md
+++ b/kubernetes_cluster_autoscaler/README.md
@@ -73,7 +73,7 @@ metadata:
     # (...)
 spec:
   containers:
-    - name: 'controller'
+    - name: '<CONTAINER_NAME>'
 # (...)
 ```
 

--- a/kubernetes_cluster_autoscaler/README.md
+++ b/kubernetes_cluster_autoscaler/README.md
@@ -45,7 +45,12 @@ prometheus.io/scrape: true
 
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. 
 
-The only parameter required for configuring the `kubernetes_cluster_autoscaler` check is `openmetrics_endpoint`. This parameter should be set to the location where the Prometheus-formatted metrics are exposed. The default port is `8085`. To configure a different port, use the `METRICS_PORT` [environment variable][10]. In containerized environments, `%%host%%` should be used for [host autodetection][3]. 
+The only parameters required for configuring the `kubernetes_cluster_autoscaler` check are:
+
+* CONTAINER_NAME
+  Describe the pod belonging to your cluster autoscaler, and find the container name.
+* `openmetrics_endpoint`
+  This parameter should be set to the location where the Prometheus-formatted metrics are exposed. The default port is `8085`. To configure a different port, use the `METRICS_PORT` [environment variable][10]. In containerized environments, `%%host%%` should be used for [host autodetection][3]. 
 
 ```yaml
 apiVersion: v1
@@ -54,7 +59,7 @@ kind: Pod
 metadata:
   name: '<POD_NAME>'
   annotations:
-    ad.datadoghq.com/controller.checks: |
+    ad.datadoghq.com/<CONTAINER_NAME>.checks: |
       {
         "kubernetes_cluster_autoscaler": {
           "init_config": {},


### PR DESCRIPTION
### What does this PR do?
The Kubernetes Cluster Autoscaler does not work out of the box with the configuration listed in the README.md file.
The default container name changes depending on where it is deployed, and `controller` is not a valid container name for all deployments.
Abstracted the readme to highlight the fact that you need to specify the container name as part of the annotation instead of using `controller` for the container name.

### Motivation
In an AWS EKS deployment, the container name is `aws-cluster-autoscaler` and the integration didn't work out of the box with the instructions from the readme.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
