### PR TITLE
Add defaults for `days_critical` and `days_warning` config options

### DIFF
--- a/http_check/assets/configuration/spec.yaml
+++ b/http_check/assets/configuration/spec.yaml
@@ -139,10 +139,12 @@ files:
       description: Express warning threshold for the HTTP check in days
       value:
         type: integer
+        example: 14
     - name: days_critical
       description: Express critical threshold for the HTTP check in days
       value:
         type: integer
+        example: 7
     - name: seconds_warning
       description: |
         Alternatively to days_warning, seconds_warning expresses

--- a/http_check/changelog.d/20062.added
+++ b/http_check/changelog.d/20062.added
@@ -1,0 +1,1 @@
+Add defaults for `days_critical` and `days_warning` config options

--- a/http_check/datadog_checks/http_check/config_models/defaults.py
+++ b/http_check/datadog_checks/http_check/config_models/defaults.py
@@ -32,6 +32,14 @@ def instance_collect_response_time():
     return True
 
 
+def instance_days_critical():
+    return 7
+
+
+def instance_days_warning():
+    return 14
+
+
 def instance_disable_generic_tags():
     return False
 

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -153,15 +153,15 @@ instances:
     #
     # tls_retrieve_non_validated_cert: false
 
-    ## @param days_warning - integer - optional
+    ## @param days_warning - integer - optional - default: 14
     ## Express warning threshold for the HTTP check in days
     #
-    # days_warning: <DAYS_WARNING>
+    # days_warning: 14
 
-    ## @param days_critical - integer - optional
+    ## @param days_critical - integer - optional - default: 7
     ## Express critical threshold for the HTTP check in days
     #
-    # days_critical: <DAYS_CRITICAL>
+    # days_critical: 7
 
     ## @param seconds_warning - integer - optional
     ## Alternatively to days_warning, seconds_warning expresses


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add defaults for `days_critical` and `days_warning` config options
### Motivation
<!-- What inspired you to submit this pull request? -->
https://github.com/DataDog/integrations-core/issues/19416

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
