### PR TITLE
Blocking queries for older MySQL releases

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -544,7 +544,7 @@ files:
                   example: 10
               - name: collect_blocking_queries
                 description: |
-                  Enable collection of blocking queries.
+                  Enable collection of blocking queries. Not supported on MariaDB.
                 value:
                   type: boolean
                   example: false

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -544,7 +544,7 @@ files:
                   example: 10
               - name: collect_blocking_queries
                 description: |
-                  Enable collection of blocking queries. Supported only on MySQL 8.0.
+                  Enable collection of blocking queries.
                 value:
                   type: boolean
                   example: false

--- a/mysql/changelog.d/20068.added
+++ b/mysql/changelog.d/20068.added
@@ -1,0 +1,1 @@
+Blocking queries for older MySQL 5.7

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -230,7 +230,7 @@ class MySQLActivity(DBMAsyncJob):
 
     def _should_collect_blocking_queries(self):
         # type: () -> bool
-        return self._config.activity_config.get("collect_blocking_queries", False)
+        return self._config.activity_config.get("collect_blocking_queries", False) and not self._check.is_mariadb
 
     def _get_activity_query(self):
         # type: () -> str

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -228,10 +228,7 @@ class MySQLActivity(DBMAsyncJob):
 
     def _should_collect_blocking_queries(self):
         # type: () -> bool
-        blocking_queries_configured = self._config.activity_config.get("collect_blocking_queries", False)
-        return (
-            blocking_queries_configured # and self._db_version == MySQLVersion.VERSION_80 and not self._check.is_mariadb
-        )
+        return self._config.activity_config.get("collect_blocking_queries", False)
 
     def _get_activity_query(self):
         # type: () -> str

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -116,7 +116,8 @@ BLOCKING_JOINS_MYSQL7 = """\
     LEFT JOIN information_schema.INNODB_TRX AS trx ON thread_a.processlist_id = trx.trx_mysql_thread_id
     LEFT JOIN information_schema.INNODB_LOCK_WAITS AS lock_waits ON trx.trx_id = lock_waits.requesting_trx_id
     LEFT JOIN information_schema.INNODB_TRX AS blocking_trx ON lock_waits.blocking_trx_id = blocking_trx.trx_id
-    LEFT JOIN performance_schema.threads AS blocking_thread ON blocking_trx.trx_mysql_thread_id = blocking_thread.processlist_id
+    LEFT JOIN performance_schema.threads AS blocking_thread
+        ON blocking_trx.trx_mysql_thread_id = blocking_thread.processlist_id
 """
 
 IDLE_BLOCKERS_SUBQUERY_MYSQL7 = """\

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -88,22 +88,43 @@ WHERE
     {idle_blockers_subquery};
 """
 
-BLOCKING_COLUMNS = """\
+BLOCKING_COLUMNS_MYSQL8 = """\
     ,blocking_thread.thread_id AS blocking_thread_id,
     blocking_thread.processlist_id AS blocking_processlist_id
 """
 
-BLOCKING_JOINS = """\
+BLOCKING_JOINS_MYSQL8 = """\
     LEFT JOIN performance_schema.data_lock_waits AS lock_waits ON thread_a.thread_id = lock_waits.requesting_thread_id
     LEFT JOIN performance_schema.threads AS blocking_thread ON lock_waits.blocking_thread_id = blocking_thread.thread_id
 """
 
-IDLE_BLOCKERS_SUBQUERY = """\
+IDLE_BLOCKERS_SUBQUERY_MYSQL8 = """\
         OR
         -- Include idle sessions that are blocking others
         thread_a.thread_id IN (
             SELECT blocking_thread_id
             FROM performance_schema.data_lock_waits
+        )
+"""
+
+BLOCKING_COLUMNS_MYSQL7 = """\
+    ,blocking_trx.trx_mysql_thread_id AS blocking_thread_id,
+    blocking_trx.trx_id AS blocking_processlist_id
+"""
+
+BLOCKING_JOINS_MYSQL7 = """\
+    LEFT JOIN information_schema.INNODB_TRX AS trx ON thread_a.processlist_id = trx.trx_mysql_thread_id
+    LEFT JOIN information_schema.INNODB_LOCK_WAITS AS lock_waits ON trx.trx_id = lock_waits.requesting_trx_id
+    LEFT JOIN information_schema.INNODB_TRX AS blocking_trx ON lock_waits.blocking_trx_id = blocking_trx.trx_id
+"""
+
+IDLE_BLOCKERS_SUBQUERY_MYSQL7 = """\
+        OR
+        -- Include idle sessions that are blocking others
+        thread_a.processlist_id IN (
+            SELECT blocking_trx.trx_mysql_thread_id
+            FROM information_schema.INNODB_LOCK_WAITS AS lock_waits
+            JOIN information_schema.INNODB_TRX AS blocking_trx ON lock_waits.blocking_trx_id = blocking_trx.trx_id
         )
 """
 
@@ -209,7 +230,7 @@ class MySQLActivity(DBMAsyncJob):
         # type: () -> bool
         blocking_queries_configured = self._config.activity_config.get("collect_blocking_queries", False)
         return (
-            blocking_queries_configured and self._db_version == MySQLVersion.VERSION_80 and not self._check.is_mariadb
+            blocking_queries_configured # and self._db_version == MySQLVersion.VERSION_80 and not self._check.is_mariadb
         )
 
     def _get_activity_query(self):
@@ -220,9 +241,14 @@ class MySQLActivity(DBMAsyncJob):
         blocking_joins = ""
         idle_blockers_subquery = ""
         if self._should_collect_blocking_queries():
-            blocking_columns = BLOCKING_COLUMNS
-            blocking_joins = BLOCKING_JOINS
-            idle_blockers_subquery = IDLE_BLOCKERS_SUBQUERY
+            if self._db_version == MySQLVersion.VERSION_80:
+                blocking_columns = BLOCKING_COLUMNS_MYSQL8
+                blocking_joins = BLOCKING_JOINS_MYSQL8
+                idle_blockers_subquery = IDLE_BLOCKERS_SUBQUERY_MYSQL8
+            else:
+                blocking_columns = BLOCKING_COLUMNS_MYSQL7
+                blocking_joins = BLOCKING_JOINS_MYSQL7
+                idle_blockers_subquery = IDLE_BLOCKERS_SUBQUERY_MYSQL7
         return ACTIVITY_QUERY.format(
             blocking_columns=blocking_columns,
             blocking_joins=blocking_joins,

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -108,14 +108,15 @@ IDLE_BLOCKERS_SUBQUERY_MYSQL8 = """\
 """
 
 BLOCKING_COLUMNS_MYSQL7 = """\
-    ,blocking_trx.trx_mysql_thread_id AS blocking_thread_id,
-    blocking_trx.trx_id AS blocking_processlist_id
+    ,blocking_thread.thread_id AS blocking_thread_id,
+    blocking_thread.processlist_id AS blocking_processlist_id
 """
 
 BLOCKING_JOINS_MYSQL7 = """\
     LEFT JOIN information_schema.INNODB_TRX AS trx ON thread_a.processlist_id = trx.trx_mysql_thread_id
     LEFT JOIN information_schema.INNODB_LOCK_WAITS AS lock_waits ON trx.trx_id = lock_waits.requesting_trx_id
     LEFT JOIN information_schema.INNODB_TRX AS blocking_trx ON lock_waits.blocking_trx_id = blocking_trx.trx_id
+    LEFT JOIN performance_schema.threads AS blocking_thread ON blocking_trx.trx_mysql_thread_id = blocking_thread.processlist_id
 """
 
 IDLE_BLOCKERS_SUBQUERY_MYSQL7 = """\

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -521,7 +521,7 @@ instances:
         # collection_interval: 10
 
         ## @param collect_blocking_queries - boolean - optional - default: false
-        ## Enable collection of blocking queries. Supported only on MySQL 8.0.
+        ## Enable collection of blocking queries.
         #
         # collect_blocking_queries: false
 

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -521,7 +521,7 @@ instances:
         # collection_interval: 10
 
         ## @param collect_blocking_queries - boolean - optional - default: false
-        ## Enable collection of blocking queries.
+        ## Enable collection of blocking queries. Not supported on MariaDB.
         #
         # collect_blocking_queries: false
 


### PR DESCRIPTION
### What does this PR do?
Adds blocking queries support for MySQL versions lower than 8.

### Test

<img width="1158" alt="image" src="https://github.com/user-attachments/assets/0952cfbc-55c1-47e5-ae45-c5efbd4c6a16" />

### Performance degradation

<img width="840" alt="image" src="https://github.com/user-attachments/assets/363a78b6-28c5-496f-ae69-249d9918c180" />

### Motivation
High demand


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
