### PR TITLE
Revert "Update confluent-kafka OpenSSL to 3.4.1 (#19589)"

### DIFF
--- a/.builders/images/linux-aarch64/Dockerfile
+++ b/.builders/images/linux-aarch64/Dockerfile
@@ -19,8 +19,8 @@ ENV LDFLAGS="-Wl,-rpath,'\$\$ORIGIN' -Wl,--strip-debug"
 RUN yum install -y perl-IPC-Cmd perl-CPANPLUS && \
  cpanp -i List::Util 1.66 && \
  DOWNLOAD_URL="https://www.openssl.org/source/openssl-{{version}}.tar.gz" \
- VERSION="3.4.1" \
- SHA256="002a2d6b30b58bf4bea46c43bdd96365aaf8daa6c428782aa4feee06da197df3" \
+ VERSION="3.4.0" \
+ SHA256="e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf" \
  RELATIVE_PATH="openssl-{{version}}" \
  # https://docs.python.org/3/using/unix.html#custom-openssl
  INSTALL_COMMAND="make install_sw" \

--- a/.builders/images/linux-x86_64/Dockerfile
+++ b/.builders/images/linux-x86_64/Dockerfile
@@ -19,8 +19,8 @@ ENV LDFLAGS="-Wl,-rpath,'\$\$ORIGIN' -Wl,--strip-debug"
 RUN yum install -y perl-IPC-Cmd perl-CPANPLUS && \
  cpanp -i List::Util 1.66 && \
  DOWNLOAD_URL="https://www.openssl.org/source/openssl-{{version}}.tar.gz" \
- VERSION="3.4.1" \
- SHA256="002a2d6b30b58bf4bea46c43bdd96365aaf8daa6c428782aa4feee06da197df3" \
+ VERSION="3.4.0" \
+ SHA256="e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf" \
  RELATIVE_PATH="openssl-{{version}}" \
  # https://docs.python.org/3/using/unix.html#custom-openssl
  INSTALL_COMMAND="make install_sw" \

--- a/.builders/images/macos-x86_64/builder_setup.sh
+++ b/.builders/images/macos-x86_64/builder_setup.sh
@@ -23,8 +23,8 @@ cp -R /opt/mqm "${DD_PREFIX_PATH}"
 
 # openssl
 DOWNLOAD_URL="https://www.openssl.org/source/openssl-{{version}}.tar.gz" \
-VERSION="3.4.1" \
-SHA256="002a2d6b30b58bf4bea46c43bdd96365aaf8daa6c428782aa4feee06da197df3" \
+VERSION="3.4.0" \
+SHA256="e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf" \
 RELATIVE_PATH="openssl-{{version}}" \
 CONFIGURE_SCRIPT="./config" \
   install-from-source \

--- a/.builders/images/windows-x86_64/Dockerfile
+++ b/.builders/images/windows-x86_64/Dockerfile
@@ -114,7 +114,7 @@ RUN Get-RemoteFile `
     Add-ToPath -Append "C:\perl\perl\bin" && `
     Remove-Item "strawberry-perl-$Env:PERL_VERSION-64bit.zip"
 
-ENV OPENSSL_VERSION="3.4.1"
+ENV OPENSSL_VERSION="3.4.0"
 
 ENV CURL_VERSION="8.12.1"
 

--- a/.builders/images/windows-x86_64/build_script.ps1
+++ b/.builders/images/windows-x86_64/build_script.ps1
@@ -24,7 +24,9 @@ Remove-Item "librdkafka-${kafka_version}.tar.gz"
 $triplet = "x64-windows"
 $vcpkg_dir = "C:\vcpkg"
 $librdkafka_dir = "C:\librdkafka\librdkafka-${kafka_version}"
-$desired_commit = "master" # Set the commit to master so we don't have to update manually
+# We set the desired tag to the latest release tag to ensure that we are building with the latest stable version.
+# The desired tag should be updated periodically or when critical fixes or features are released.
+$desired_tag = "2024.12.16"
 
 # Clone and configure vcpkg
 if (-Not (Test-Path -Path "$vcpkg_dir\.git")) {
@@ -32,7 +34,7 @@ if (-Not (Test-Path -Path "$vcpkg_dir\.git")) {
 }
 
 Set-Location $vcpkg_dir
-git checkout $desired_commit
+git checkout $desired_tag
 
 Write-Host "Bootstrapping vcpkg..."
 .\bootstrap-vcpkg.bat


### PR DESCRIPTION
This reverts commit ea7bcce3b96f4e5d41500adcf137364444796da8.

#incident-37187

Reverting openssl3 bump, related to https://github.com/DataDog/datadog-agent/pull/36174

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
