### PR TITLE
Pass database instance for MySQL schema data

### DIFF
--- a/mysql/changelog.d/20089.fixed
+++ b/mysql/changelog.d/20089.fixed
@@ -1,0 +1,1 @@
+Include database_instance for MySQL schema data

--- a/mysql/datadog_checks/mysql/databases_data.py
+++ b/mysql/datadog_checks/mysql/databases_data.py
@@ -44,8 +44,9 @@ class SubmitData:
         self.db_to_tables = {}  # dbname : {"tables" : []}
         self.db_info = {}  # name to info
 
-    def set_base_event_data(self, hostname, tags, cloud_metadata, dbms_version, flavor):
+    def set_base_event_data(self, hostname, database_instance, tags, cloud_metadata, dbms_version, flavor):
         self._base_event["host"] = hostname
+        self._base_event["database_instance"] = database_instance
         self._base_event["tags"] = tags
         self._base_event["cloud_metadata"] = cloud_metadata
         self._base_event["dbms_version"] = dbms_version
@@ -157,7 +158,7 @@ class DatabasesData:
                 "dd.mysql.db.error",
                 1,
                 tags=self._tags + ["error:{}".format(type(e))] + self._check._get_debug_tags(),
-                hostname=self._check.reported_hostname,
+                hostname=self._check.resolved_hostname,
             )
             raise
 
@@ -251,7 +252,8 @@ class DatabasesData:
         self._tags = tags
         with closing(self._metadata.get_db_connection().cursor(CommenterDictCursor)) as cursor:
             self._data_submitter.set_base_event_data(
-                self._check.resolved_hostname,
+                self._check.reported_hostname,
+                self._check.database_identifier,
                 self._tags,
                 self._check._config.cloud_metadata,
                 self._check.version.version,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds `database_instance` to the MySQL schema data.

### Motivation
<!-- What inspired you to submit this pull request? -->
This fixes a problem where MySQL schema data isn't associated correctly in REDAPL.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
