### PR TITLE
Print permission mySQL warning

### DIFF
--- a/mysql/changelog.d/20090.added
+++ b/mysql/changelog.d/20090.added
@@ -1,0 +1,1 @@
+Print permission mySQL warning

--- a/mysql/datadog_checks/mysql/databases_data.py
+++ b/mysql/datadog_checks/mysql/databases_data.py
@@ -43,7 +43,7 @@ class SubmitData:
         self._total_columns_sent = 0
         self.db_to_tables = {}  # dbname : {"tables" : []}
         self.db_info = {}  # name to info
-        self.any_tables_found = False # Flag to track for permission issues
+        self.any_tables_found = False  # Flag to track for permission issues
 
     def set_base_event_data(self, hostname, tags, cloud_metadata, dbms_version, flavor):
         self._base_event["host"] = hostname
@@ -293,8 +293,7 @@ class DatabasesData:
         if db_infos and not self._data_submitter.any_tables_found:
             self._log.warning(
                 "No tables were found across any of the {} databases. This may indicate insufficient privileges "
-                "to view table metadata. The datadog user needs SELECT privileges on the tables."
-                .format(len(db_infos))
+                "to view table metadata. The datadog user needs SELECT privileges on the tables.".format(len(db_infos))
             )
 
     @tracked_method(agent_check_getter=agent_check_getter)

--- a/mysql/datadog_checks/mysql/databases_data.py
+++ b/mysql/datadog_checks/mysql/databases_data.py
@@ -43,6 +43,7 @@ class SubmitData:
         self._total_columns_sent = 0
         self.db_to_tables = {}  # dbname : {"tables" : []}
         self.db_info = {}  # name to info
+        self.any_tables_found = False # Flag to track for permission issues
 
     def set_base_event_data(self, hostname, tags, cloud_metadata, dbms_version, flavor):
         self._base_event["host"] = hostname
@@ -55,6 +56,7 @@ class SubmitData:
         self._total_columns_sent = 0
         self._columns_count = 0
         self.db_info.clear()
+        self.any_tables_found = False
 
     def store_db_infos(self, db_infos):
         for db_info in db_infos:
@@ -64,6 +66,8 @@ class SubmitData:
         self._columns_count += columns_count
         known_tables = self.db_to_tables.setdefault(db_name, [])
         known_tables.extend(tables)
+        if tables:
+            self.any_tables_found = True
 
     def columns_since_last_submit(self):
         return self._columns_count
@@ -282,6 +286,17 @@ class DatabasesData:
                     )
                 )
 
+        # Check if we found databases but no tables across all of them.
+        # This happens when the datadog user has permissions to see databases
+        # but lacks SELECT privileges on the tables themselves, which prevents
+        # the agent from collecting table metadata.
+        if db_infos and not self._data_submitter.any_tables_found:
+            self._log.warning(
+                "No tables were found across any of the {} databases. This may indicate insufficient privileges "
+                "to view table metadata. The datadog user needs SELECT privileges on the tables."
+                .format(len(db_infos))
+            )
+
     @tracked_method(agent_check_getter=agent_check_getter)
     def _query_db_information(self, cursor):
         self._cursor_run(cursor, query=SQL_DATABASES)
@@ -302,13 +317,12 @@ class DatabasesData:
     def _get_tables_data(self, table_list, db_name, cursor):
 
         if len(table_list) == 0:
-            return
+            return 0, []
+
         table_name_to_table_index = {}
-        table_names = ""
         for i, table in enumerate(table_list):
             table_name_to_table_index[table["name"]] = i
-            table_names += '"' + str(table["name"]) + '",'
-        table_names = table_names[:-1]
+        table_names = ','.join(f'"{str(table["name"])}"' for table in table_list)
         total_columns_number = self._populate_with_columns_data(
             table_name_to_table_index, table_list, table_names, db_name, cursor
         )


### PR DESCRIPTION
### What does this PR do?
When collecting mySQL schemas, if we lack proper permissions but the config is enabled, we will silently fail to pull table data. MySQL will not error. This PR adds a warning to indicate this case. Also small improvement to string concatenation logic and a missing return value. 

### Motivation
Experienced lack of visibility first hand.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
