### PR TITLE
Make the pymysql connection ping() to reconnect for metadata collection

### DIFF
--- a/mysql/changelog.d/20092.fixed
+++ b/mysql/changelog.d/20092.fixed
@@ -1,0 +1,1 @@
+Make the pymysql connection ping() to reconnect for metadata collection. Sometimes, when a connection is held by pymysql for a long time without being used (such as during settings collection), the connection gets closed unexpectedly and attempting to re-use it will fail unless we validate that the connection is still valid.

--- a/mysql/datadog_checks/mysql/metadata.py
+++ b/mysql/datadog_checks/mysql/metadata.py
@@ -97,10 +97,10 @@ class MySQLMetadata(DBMAsyncJob):
             self._db = connect_with_autocommit(**self._connection_args)
         else:
             # Metadata checks runs far less frequently than other checks, and there are reports
-			# that unused pymysql connections sometimes end up being closed unexpectedly.
-			# This is a simple attempt to ensure that the connection is still valid before
-			# returning it. ping() will by default automatically reconnect
-			# if the connection is lost.
+            # that unused pymysql connections sometimes end up being closed unexpectedly.
+            # This is a simple attempt to ensure that the connection is still valid before
+            # returning it. ping() will by default automatically reconnect
+            # if the connection is lost.
             self._db.ping()
         return self._db
 

--- a/mysql/datadog_checks/mysql/metadata.py
+++ b/mysql/datadog_checks/mysql/metadata.py
@@ -96,9 +96,11 @@ class MySQLMetadata(DBMAsyncJob):
         if not self._db:
             self._db = connect_with_autocommit(**self._connection_args)
         else:
-            # Metadata checks runs far less frequently than other checks, and there are reports that unused pymysql connections
-            # sometimes end up being closed unexpectedly. This is a simple attempt to ensure that the connection is still
-            # valid before returning it. ping() will by default automatically reconnect if the connection is lost.
+            # Metadata checks runs far less frequently than other checks, and there are reports
+			# that unused pymysql connections sometimes end up being closed unexpectedly.
+			# This is a simple attempt to ensure that the connection is still valid before
+			# returning it. ping() will by default automatically reconnect
+			# if the connection is lost.
             self._db.ping()
         return self._db
 

--- a/mysql/datadog_checks/mysql/metadata.py
+++ b/mysql/datadog_checks/mysql/metadata.py
@@ -95,6 +95,11 @@ class MySQLMetadata(DBMAsyncJob):
         """
         if not self._db:
             self._db = connect_with_autocommit(**self._connection_args)
+        else:
+            # Metadata checks runs far less frequently than other checks, and there are reports that unused pymysql connections
+            # sometimes end up being closed unexpectedly. This is a simple attempt to ensure that the connection is still
+            # valid before returning it. ping() will by default automatically reconnect if the connection is lost.
+            self._db.ping()
         return self._db
 
     def _close_db_conn(self):


### PR DESCRIPTION
### What does this PR do?

During metadata collection for MySQL, we sometimes lose the connection on some databases due to it not being used for a while. This will call the pymysql ping() method which will trigger a check and reconnect if the connection was lost. 

### Motivation
A customer noticed that settings collection worked on the first fetch but then failed on the underlying connection being lost. Reducing the interval to 60s instead of 600s fixed it for them, which adds confidence that a check for the connection still being established (and potential reconnect) would be necessary.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
