### PR TITLE
[DBMON-5158] Fix duplicate mysql explain plan samples submitting in the past

### DIFF
--- a/mysql/changelog.d/20095.fixed
+++ b/mysql/changelog.d/20095.fixed
@@ -1,0 +1,1 @@
+Fix duplicate explain plan sampling on idle clients and incorrect event timestamp

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -1033,35 +1033,19 @@ def test_statement_samples_calculate_timer_end(dbm_instance, timer_end, now, upt
     "end_event_id,timer_end,uptime,event_timestamp_offset,window_seconds,expected_result",
     [
         # Test case 1: Event timestamp is within the window (should return False)
-        pytest.param(
-            123, 3019558487284095384, 21466230, 5000, 60, False,
-            id="within_window"
-        ),
+        pytest.param(123, 3019558487284095384, 21466230, 5000, 60, False, id="within_window"),
         # Test case 2: Event timestamp is outside the window (should return True)
-        pytest.param(
-            123, 3019558487284095384, 21466230, 65000, 60, True,
-            id="outside_window"
-        ),
+        pytest.param(123, 3019558487284095384, 21466230, 65000, 60, True, id="outside_window"),
         # Test case 3: No end_event_id (should return False)
-        pytest.param(
-            None, 3019558487284095384, 21466230, 65000, 60, False,
-            id="no_end_event_id"
-        ),
+        pytest.param(None, 3019558487284095384, 21466230, 65000, 60, False, id="no_end_event_id"),
         # Test case 4: Event timestamp is before query end time (should return False)
-        pytest.param(
-            123, 3019558487284095384, 21466230, -5000, 60, False,
-            id="before_query_end"
-        ),
+        pytest.param(123, 3019558487284095384, 21466230, -5000, 60, False, id="before_query_end"),
         # Test case 5: Edge case - exactly at window boundary (should return True)
-        pytest.param(
-            123, 3019558487284095384, 21466230, 60000, 60, False,
-            id="at_window_boundary"
-        ),
+        pytest.param(123, 3019558487284095384, 21466230, 60000, 60, False, id="at_window_boundary"),
     ],
 )
 def test_has_sampled_since_completion(
-    dbm_instance, end_event_id, timer_end, uptime, event_timestamp_offset,
-    window_seconds, expected_result
+    dbm_instance, end_event_id, timer_end, uptime, event_timestamp_offset, window_seconds, expected_result
 ):
     """Test the _has_sampled_since_completion method with various scenarios."""
     mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -14,7 +14,7 @@ import pytest
 from packaging.version import parse as parse_version
 
 from datadog_checks.base.utils.db.sql import compute_sql_signature
-from datadog_checks.base.utils.db.utils import DBMAsyncJob
+from datadog_checks.base.utils.db.utils import DBMAsyncJob, RateLimitingTTLCache
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.mysql import MySql, statements
 from datadog_checks.mysql.statement_samples import StatementTruncationState
@@ -554,6 +554,7 @@ def test_missing_explain_procedure(dbm_instance, dd_run_check, aggregator, state
         'uptime': '21466230',
         'timer_end': 3019558487284095384,
         'timer_wait_ns': 12.9,
+        'end_event_id': None,
     }
 
     mysql_check._statement_samples._collect_plan_for_statement(row)
@@ -1025,3 +1026,66 @@ def test_statement_samples_calculate_timer_end(dbm_instance, timer_end, now, upt
         'uptime': uptime,
     }
     assert check._statement_samples._calculate_timer_end(row) == expected_timestamp
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "end_event_id,timer_end,uptime,event_timestamp_offset,window_seconds,expected_result",
+    [
+        # Test case 1: Event timestamp is within the window (should return False)
+        pytest.param(
+            123, 3019558487284095384, 21466230, 5000, 60, False,
+            id="within_window"
+        ),
+        # Test case 2: Event timestamp is outside the window (should return True)
+        pytest.param(
+            123, 3019558487284095384, 21466230, 65000, 60, True,
+            id="outside_window"
+        ),
+        # Test case 3: No end_event_id (should return False)
+        pytest.param(
+            None, 3019558487284095384, 21466230, 65000, 60, False,
+            id="no_end_event_id"
+        ),
+        # Test case 4: Event timestamp is before query end time (should return False)
+        pytest.param(
+            123, 3019558487284095384, 21466230, -5000, 60, False,
+            id="before_query_end"
+        ),
+        # Test case 5: Edge case - exactly at window boundary (should return True)
+        pytest.param(
+            123, 3019558487284095384, 21466230, 60000, 60, False,
+            id="at_window_boundary"
+        ),
+    ],
+)
+def test_has_sampled_since_completion(
+    dbm_instance, end_event_id, timer_end, uptime, event_timestamp_offset,
+    window_seconds, expected_result
+):
+    """Test the _has_sampled_since_completion method with various scenarios."""
+    mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
+
+    now = 1708025457
+
+    # Create a mock row with the provided parameters
+    row = {
+        'end_event_id': end_event_id,
+        'timer_end': timer_end,
+        'now': now,
+        'uptime': uptime,
+    }
+
+    # Calculate the query end time
+    query_end_time = mysql_check._statement_samples._calculate_timer_end(row)
+
+    # Set the window size
+    mysql_check._statement_samples._seen_samples_ratelimiter = RateLimitingTTLCache(
+        maxsize=10000,
+        ttl=window_seconds,
+    )
+
+    # Calculate event timestamp based on offset from query end time
+    event_timestamp = query_end_time + event_timestamp_offset
+
+    assert mysql_check._statement_samples._has_sampled_since_completion(row, event_timestamp) == expected_result


### PR DESCRIPTION
### What does this PR do?
This fixes two issues observed with collection of mysql explain plan samples
1. Explain plan samples were incorrectly using the query end time as the event timestamp. This can lead to events populating in the past and if too far back will get rejected. We're now using collection time as the event timestamp. This brings us in line with how we generate events elsewhere in mysql and our other DBM supported dbms types.


2. Upon fixing this timestamp issue it became prevalent that some explain plans seem to be emitted every 4 minutes indefinitely. This was tracked down to opening a connection session, issuing a query and sitting idle on the connection. Queries will remain in `performance_schema.events_statements_current` until the connection is closed or the next query is issued. The `_seen_samples_ratelimiter` by default will suppress these for 4 minutes. This issue was fixed by now checking for completed queries on the `performance_schema.events_statements_current` table and avoiding emitting plan sample events if the query finished before the previous `_seen_samples_ratelimiter` would have triggerd. We should now see at most 2 explain plans in these cases. One issued during initial collection time, and one additional one that would report stats on the finished query

This was tested by issuing the following query that takes ~70s to complete against a table of 70k records from a mysql shell and then leaving it idle
```sql
SELECT 
    id,
    dbm_order_id,
    sku,
    SLEEP(0.0005)  -- sleep half a millisecond per row
FROM order_item
WHERE price IS NOT NULL;
```

Current functionality can be seen here where leaving it for a long period of time lead to the same explain plan stacking on the same timestamp
<img width="1346" alt="Screenshot 2025-04-17 at 1 17 18 PM" src="https://github.com/user-attachments/assets/6eb4a1f0-6531-4fea-bb71-03104aaba507" />

After the change we can now see that we see one in flight explain plan, and one explain plan from after the query completed consisting of full duration and row counts retrieved
<img width="1349" alt="Screenshot 2025-04-17 at 2 04 14 PM" src="https://github.com/user-attachments/assets/e264d43b-0df9-4703-a0bc-4ab103f94430" />





### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
