### PR TITLE
[postgres] Add calls to query metrics derivative compute execution_indicators

### DIFF
--- a/postgres/changelog.d/20096.added
+++ b/postgres/changelog.d/20096.added
@@ -1,0 +1,1 @@
+Added query call count `calls` to StatementMetrics execution indicators to filter out false positives from normalized queries being evicted and re-inserted with same call count and slight duration change.

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -613,7 +613,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
         available_columns = set(rows[0].keys())
         metric_columns = available_columns & PG_STAT_STATEMENTS_METRICS_COLUMNS
 
-        rows = self._state.compute_derivative_rows(rows, metric_columns, key=_row_key)
+        rows = self._state.compute_derivative_rows(rows, metric_columns, key=_row_key, execution_indicators=['calls'])
         self._check.gauge(
             'dd.postgres.queries.query_rows_raw',
             len(rows),

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.10.0",
 ]
 dynamic = [
     "version",

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -2097,6 +2097,7 @@ def test_statement_metrics_execution_indicators(prev_row, curr_row, expected_inc
         assert result[0]["total_time"] == curr_row["total_time"] - prev_row["total_time"]
 
 
+@requires_over_13
 def test_plan_time_metrics(aggregator, integration_check, dbm_instance):
     dbm_instance['pg_stat_statements_view'] = "pg_stat_statements"
     # don't need samples for this test


### PR DESCRIPTION
### What does this PR do?
This is a follow up PR to https://github.com/DataDog/integrations-core/pull/20037. Adding `calls` to statement metrics `execution_indicators` to ensure the integration does not emit query metrics with `count=0`. 

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4170

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
