### PR TITLE
[OTAGENT-359] use equiv_otel in DD exporter and connector graphs

### DIFF
--- a/otel/assets/dashboards/otel_collector_metrics_dashboard.json
+++ b/otel/assets/dashboards/otel_collector_metrics_dashboard.json
@@ -1,6 +1,6 @@
 {
     "title": "OpenTelemetry Collector Metrics Dashboard",
-    "description": "Default dashboard to visualize metrics for the OpenTelemetry Collector.\n\nNote: To view these metrics, enable the Prometheus receiver in the collector configuration, as shown in [this example](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/6946b963820d391325254cb9cc6bb34ae12907a0/exporter/datadogexporter/examples/collector.yaml#L37).",
+    "description": "Default dashboard to visualize metrics for the OpenTelemetry Collector.\n\nNote: To view these metrics, enable the Prometheus receiver in the collector configuration, as shown in [this example](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/6946b963820d391325254cb9cc6bb34ae12907a0/exporter/datadogexporter/examples/collector.yaml#L37).\n\nNote the 2 sections `Datadog Exporter: Traffic Sent` and `Datadog Connector: Stats Sent` have the `equiv_otel` function in some graphs. If you need to use `equiv_otel` in other queries, monitors or alerts, please opt in to the [Preview](http://docs.datadoghq.com/opentelemetry/guide/combining_otel_and_datadog_metrics/).",
     "widgets": [
         {
             "id": 7581494098406438,
@@ -1994,12 +1994,12 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "per_second(equiv_otel(query1))"
                                         }
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_traces{$host,source:datadogexporter,$service}.as_rate()",
+                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_traces{source:datadogexporter,$service}",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2039,12 +2039,12 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "per_second(equiv_otel(query1))"
                                         }
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_spans{$host,source:datadogexporter,$service}.as_rate()",
+                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_spans{source:datadogexporter,$service}",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2106,21 +2106,21 @@
                                     "formulas": [
                                         {
                                             "alias": "Max",
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         },
                                         {
                                             "alias": "Avg",
-                                            "formula": "query2"
+                                            "formula": "equiv_otel(query2)"
                                         }
                                     ],
                                     "queries": [
                                         {
-                                            "query": "max:otelcol_datadog_trace_agent_trace_writer_flush_duration_max{$host,source:datadogexporter,$service}",
+                                            "query": "max:otelcol_datadog_trace_agent_trace_writer_flush_duration_max{source:datadogexporter,$service}",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         },
                                         {
-                                            "query": "avg:otelcol_datadog_trace_agent_trace_writer_flush_duration_avg{$host,source:datadogexporter,$service}",
+                                            "query": "avg:otelcol_datadog_trace_agent_trace_writer_flush_duration_avg{source:datadogexporter,$service}",
                                             "data_source": "metrics",
                                             "name": "query2"
                                         }
@@ -2167,12 +2167,12 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "per_second(equiv_otel(query1))"
                                         }
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_bytes{$host,source:datadogexporter,$service}.as_rate()",
+                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_bytes{source:datadogexporter,$service}",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2219,12 +2219,12 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "per_second(equiv_otel(query1))"
                                         }
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_payloads{$host,source:datadogexporter,$service}.as_rate()",
+                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_payloads{source:datadogexporter,$service}",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2292,12 +2292,12 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         }
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_errors{$host,source:datadogexporter,$service}.as_count()",
+                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_errors{source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2358,12 +2358,12 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "per_second(equiv_otel(query1))"
                                         }
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_otlp_traces{$host,source:datadogexporter,$service}.as_rate()",
+                                            "query": "sum:otelcol_datadog_trace_agent_otlp_traces{source:datadogexporter,$service}",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2410,12 +2410,12 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "per_second(equiv_otel(query1))"
                                         }
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_otlp_spans{$host,source:datadogexporter,$service}.as_rate()",
+                                            "query": "sum:otelcol_datadog_trace_agent_otlp_spans{source:datadogexporter,$service}",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2483,12 +2483,12 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         }
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_retries{$host,source:datadogexporter,$service}.as_count()",
+                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_retries{source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2538,15 +2538,14 @@
                                     "response_format": "scalar",
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_stats_entries{$host,source:datadogexporter,$service}.as_count()",
+                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_stats_entries{source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
-                                            "name": "query1",
-                                            "aggregator": "avg"
+                                            "name": "query1"
                                         }
                                     ],
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "reduce(equiv_otel(query1), 'avg')"
                                         }
                                     ]
                                 }
@@ -2627,12 +2626,12 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "per_second(equiv_otel(query1))"
                                         }
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_otlp_traces{$host,source:datadogconnector,$service}.as_rate()",
+                                            "query": "sum:otelcol_datadog_trace_agent_otlp_traces{source:datadogconnector,$service}",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2679,12 +2678,12 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "per_second(equiv_otel(query1))"
                                         }
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_otlp_spans{$host,source:datadogconnector,$service}.as_rate()",
+                                            "query": "sum:otelcol_datadog_trace_agent_otlp_spans{source:datadogconnector,$service}",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2731,12 +2730,12 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "per_second(equiv_otel(query1))"
                                         }
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_payloads{$host,source:datadogexporter,$service}.as_rate()",
+                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_payloads{source:datadogexporter,$service}",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2776,12 +2775,12 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "per_second(equiv_otel(query1))"
                                         }
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_bytes{$host,source:datadogexporter,$service}.as_rate()",
+                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_bytes{source:datadogexporter,$service}",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2842,12 +2841,12 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         }
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_retries{$host,source:datadogexporter,$service}.as_count()",
+                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_retries{source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2887,12 +2886,12 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "per_second(equiv_otel(query1))"
                                         }
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_stats_entries{$host,source:datadogexporter,$service}.as_rate()",
+                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_stats_entries{source:datadogexporter,$service}",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2932,12 +2931,12 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         }
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_stats_buckets{$host,source:datadogexporter,$service}.as_count()",
+                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_stats_buckets{source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2998,12 +2997,12 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "equiv_otel(query1)"
                                         }
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_errors{$host,source:datadogexporter,$service}.as_count()",
+                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_errors{source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }

--- a/otel/assets/dashboards/otel_collector_metrics_dashboard.json
+++ b/otel/assets/dashboards/otel_collector_metrics_dashboard.json
@@ -15,7 +15,7 @@
                         "id": 6416205973430436,
                         "definition": {
                             "type": "note",
-                            "content": "This is a default dashboard to visualize metrics from the OpenTelemetry Collector. [These metrics](https://app.datadoghq.com/metric/summary?filter=otelcol) are scraped by the Prometheus receiver.\n\n## To view these metrics, enable the Prometheus receiver in the collector configuration, as shown in [this example](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/6946b963820d391325254cb9cc6bb34ae12907a0/exporter/datadogexporter/examples/collector.yaml#L37).",
+                            "content": "This is a default dashboard to visualize metrics from the OpenTelemetry Collector. [These metrics](https://app.datadoghq.com/metric/summary?filter=otelcol) are scraped by the Prometheus receiver.\n\n## To view these metrics, enable the Prometheus receiver in the collector configuration, as shown in [this example](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/6946b963820d391325254cb9cc6bb34ae12907a0/exporter/datadogexporter/examples/collector.yaml#L37).\n\nNote the 2 sections `Datadog Exporter: Traffic Sent` and `Datadog Connector: Stats Sent` have the `equiv_otel` function in some graphs. If you need to use `equiv_otel` in other queries, monitors or alerts, please opt in to the [Preview](http://docs.datadoghq.com/opentelemetry/guide/combining_otel_and_datadog_metrics/).",
                             "background_color": "transparent",
                             "font_size": "18",
                             "text_align": "left",


### PR DESCRIPTION
### What does this PR do?
2nd attempt to roll forward https://github.com/DataDog/integrations-core/pull/19980
- Add equiv_otel to DD exporter and connector internal metrics on OOTB OTel collector health dashboard
- Remove group-by-host from these graphs. It is a bad practice and leads to pressure to queries
- Change as_rate to per_second in these graphs since as_rate does not work with equiv_otel. as_rate and per_second are semantically equivalent
- Add a note to the top that customers need to opt in to equiv_otel preview if they want to use it elsewhere

This is tested in [a cloned dashboard in org 2](http://app.datadoghq.com/dashboard/7k9-478-p8r/opentelemetry-collector-metrics-dashboard-with-equivotel?fromUser=false&refresh_mode=sliding&from_ts=1744919883623&to_ts=1744923483623&live=true).

### Motivation
[#incident-35946](https://dd.enterprise.slack.com/archives/C08H1D9S5AM)


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
