### PR TITLE
Stop using deprecated `cert.not_valid_after` in favor of `cert.not_valid_after_utc`

### DIFF
--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -352,7 +352,7 @@ class HTTPCheck(AgentCheck):
 
         try:
             cert = x509.load_der_x509_certificate(binary_cert)
-            exp_date = cert.not_valid_after
+            exp_date = cert.not_valid_after_utc
         except Exception as e:
             msg = repr(e)
             self.log.debug('Unable to parse the certificate to get expiration: %s', e)

--- a/tls/datadog_checks/tls/tls.py
+++ b/tls/datadog_checks/tls/tls.py
@@ -179,7 +179,7 @@ class TLSCheck(AgentCheck):
 
         if self._send_cert_duration:
             self.log.debug('Checking issued days of certificate')
-            issued_delta = cert.not_valid_after - cert.not_valid_before
+            issued_delta = cert.not_valid_after_utc - cert.not_valid_before
             issued_seconds = issued_delta.total_seconds()
             issued_days = seconds_to_days(issued_seconds)
 
@@ -187,7 +187,7 @@ class TLSCheck(AgentCheck):
             self.count('tls.issued_seconds', issued_seconds, tags=self._tags)
 
         self.log.debug('Checking age of certificate')
-        delta = cert.not_valid_after - datetime.utcnow()
+        delta = cert.not_valid_after_utc - datetime.utcnow()
         seconds_left = delta.total_seconds()
         days_left = seconds_to_days(seconds_left)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
