### PR TITLE
Release `postgres`, `mysql`, and `sqlserver` (#20102)

### DIFF
--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- towncrier release notes start -->
 
+## 15.1.0 / 2025-04-18
+
+***Added***:
+
+* Added a new configuration option `database_identifier.template`. Use this template to specify the unique identifier for a database instance, separate from the underlying host.
+  The `empty_default_hostname` configuration option is now respected and will omit the `host` tag from database instances when enabled. ([#19341](https://github.com/DataDog/integrations-core/pull/19341))
+
 ## 15.0.0 / 2025-04-17
 
 ***Changed***:

--- a/mysql/changelog.d/19341.added
+++ b/mysql/changelog.d/19341.added
@@ -1,2 +1,0 @@
-Added a new configuration option `database_identifier.template`. Use this template to specify the unique identifier for a database instance, separate from the underlying host.
-The `empty_default_hostname` configuration option is now respected and will omit the `host` tag from database instances when enabled.

--- a/mysql/datadog_checks/mysql/__about__.py
+++ b/mysql/datadog_checks/mysql/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "15.0.0"
+__version__ = "15.1.0"

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- towncrier release notes start -->
 
+## 22.10.0 / 2025-04-18
+
+***Added***:
+
+* Added a new configuration option `database_identifier.template`. Use this template to specify the unique identifier for a database instance, separate from the underlying host.
+  The `empty_default_hostname` configuration option is now respected and will omit the `host` tag from database instances when enabled. ([#19341](https://github.com/DataDog/integrations-core/pull/19341))
+
 ## 22.9.0 / 2025-04-17
 
 ***Added***:

--- a/postgres/changelog.d/19341.added
+++ b/postgres/changelog.d/19341.added
@@ -1,2 +1,0 @@
-Added a new configuration option `database_identifier.template`. Use this template to specify the unique identifier for a database instance, separate from the underlying host.
-The `empty_default_hostname` configuration option is now respected and will omit the `host` tag from database instances when enabled.

--- a/postgres/datadog_checks/postgres/__about__.py
+++ b/postgres/datadog_checks/postgres/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "22.9.0"
+__version__ = "22.10.0"

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -130,7 +130,7 @@ datadog-mesos-master==5.1.0; sys_platform != 'win32'
 datadog-mesos-slave==5.1.0; sys_platform != 'win32'
 datadog-milvus==1.2.0
 datadog-mongo==9.0.1
-datadog-mysql==15.0.0
+datadog-mysql==15.1.0
 datadog-nagios==3.0.0
 datadog-network==5.2.0
 datadog-nfsstat==3.0.0; sys_platform == 'linux2'
@@ -152,7 +152,7 @@ datadog-pgbouncer==8.1.2; sys_platform != 'win32'
 datadog-php-fpm==5.1.0
 datadog-ping-federate==2.0.0
 datadog-postfix==3.0.0; sys_platform != 'win32'
-datadog-postgres==22.9.0
+datadog-postgres==22.10.0
 datadog-powerdns-recursor==4.1.0
 datadog-presto==3.1.0
 datadog-process==5.0.0
@@ -180,7 +180,7 @@ datadog-sonarqube==5.2.1
 datadog-sonatype-nexus==1.1.0; sys_platform != 'darwin'
 datadog-sonicwall-firewall==1.0.0
 datadog-spark==6.3.0
-datadog-sqlserver==22.1.0
+datadog-sqlserver==22.2.0
 datadog-squid==4.1.0
 datadog-ssh-check==4.2.1
 datadog-statsd==3.0.0

--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- towncrier release notes start -->
 
+## 22.2.0 / 2025-04-18
+
+***Added***:
+
+* Added a new configuration option `database_identifier.template`. Use this template to specify the unique identifier for a database instance, separate from the underlying host.
+  The `empty_default_hostname` configuration option is now respected and will omit the `host` tag from database instances when enabled. ([#19341](https://github.com/DataDog/integrations-core/pull/19341))
+
 ## 22.1.0 / 2025-04-17
 
 ***Added***:

--- a/sqlserver/changelog.d/19341.added
+++ b/sqlserver/changelog.d/19341.added
@@ -1,2 +1,0 @@
-Added a new configuration option `database_identifier.template`. Use this template to specify the unique identifier for a database instance, separate from the underlying host.
-The `empty_default_hostname` configuration option is now respected and will omit the `host` tag from database instances when enabled.

--- a/sqlserver/datadog_checks/sqlserver/__about__.py
+++ b/sqlserver/datadog_checks/sqlserver/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = '22.1.0'
+__version__ = '22.2.0'


### PR DESCRIPTION
* [Release] Bumped mysql version to 15.1.0

* [Release] Bumped postgres version to 22.10.0

* [Release] Bumped sqlserver version to 22.2.0

* [Release] Update metadata

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
