### PR TITLE
Update ddev validate licenses command to support license expression

### DIFF
--- a/ddev/changelog.d/20117.added
+++ b/ddev/changelog.d/20117.added
@@ -1,0 +1,1 @@
+Add support for license-expression when retrieving licenses from PyPi

--- a/ddev/src/ddev/cli/validate/licenses.py
+++ b/ddev/src/ddev/cli/validate/licenses.py
@@ -246,6 +246,9 @@ def scrape_license_data(urls, app):
                 else:
                     data['licenses'].add(package_license)
 
+            if license_expressions := info.get('license_expression'):
+                data['licenses'].add(license_expressions)
+
             if home_page := info['home_page']:
                 data['home_page'] = home_page
 
@@ -467,7 +470,7 @@ def licenses(app: Application, sync: bool):
         for package_name, package_errors in package_license_errors.items():
             for error in package_errors:
                 error_message += error + '\n'
-            validation_tracker.error((package_name), message=error_message)
+            validation_tracker.error((package_name,), message=error_message)
 
         validation_tracker.display()
         app.abort()


### PR DESCRIPTION
### What does this PR do?
In a recent run of the [Update Dependencies workflow](https://github.com/DataDog/integrations-core/actions/runs/14566016802/job/40855350575), the job failed because license could not be found for the `urlib3` package.

This PR updates the `ddev validate licenses` command to ensure that we evaluate the newer `license-expression` that caused this to fail.

#### Validation
Update all dependencies
```
hatch run ddev dep updates --sync
Files updated: 11
Updated 13 dependencies
```

Validate them before adding `license-expression` to ensure the display error was fixed
```
hatch run ddev validate licenses --sync
Validating main licenses.
Generating CSV lines.: 100%|██████████| 72/72 [00:19<00:00,  3.74pkgs/s]
Licenses
└── urllib3
    
    no license information
    

Errors: 1
```

Validate them after the full fix to ensure we now detect the correct license
```
hatch run ddev validate licenses --sync
Validating main licenses.
Generating CSV lines.: 100%|██████████| 72/72 [00:15<00:00,  4.73pkgs/s]
Validating extra licenses.
Licenses

Passed: 1
```

### Motivation
This happened because packages are moving to the newer license specification of using `license-expression` introduced [in version 2.4](https://packaging.python.org/en/latest/specifications/core-metadata/#license) of the python packaging tooling.

This was adopted by the `urllib3` package recently (this is [the PR](https://github.com/urllib3/urllib3/pull/3522)) and was released in [version 2.4.0](https://github.com/urllib3/urllib3/releases/tag/2.4.0).

While we could improve in general how to run this command, this is a fix for now so we can keep updating dependencies.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
