### PR TITLE
[elastic] Sanitize user and password from url tag

### DIFF
--- a/elastic/README.md
+++ b/elastic/README.md
@@ -36,6 +36,16 @@ To configure this check for an Agent running on a host:
      ## fetch statistics from the nodes and information about the cluster health.
      #
      - url: http://localhost:9200
+
+       ## @param username - string - optional
+       ## The username to authenticate with.
+       #
+       # username: elastic
+
+       ## @param password - string - optional
+       ## The password to authenticate with.
+       #
+       # password: changeme
    ```
 
     **Notes**:

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -37,15 +37,15 @@ To configure this check for an Agent running on a host:
      #
      - url: http://localhost:9200
 
-       ## @param username - string - optional
-       ## The username to authenticate with.
-       #
-       # username: elastic
+      ## @param username - string - optional
+      ## The username to use if services are behind basic or digest auth.
+      #
+      # username: <USERNAME>
 
-       ## @param password - string - optional
-       ## The password to authenticate with.
-       #
-       # password: changeme
+      ## @param password - string - optional
+      ## The password to use if services are behind basic or NTLM auth.
+      #
+      # password: <PASSWORD>
    ```
 
     **Notes**:

--- a/elastic/changelog.d/20121.added
+++ b/elastic/changelog.d/20121.added
@@ -1,0 +1,1 @@
+Adds sanitization to the url tag when user and password options are supplied to the user configured endpoint.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR sanitizes the user and password from our `url` tag when the `url` configuration option is supplied with them.

### Motivation
<!-- What inspired you to submit this pull request? -->

When setting up an instance of Elasticsearch, it can be set-up with a YAML file containing the url in the format `http://<USER>:<PASSWORD>@<ENDPOINT>`

ex: 
```
init_config: {}
instances:
  - url: http://user:hunter2@127.0.0.1:9200/
     cluster_stats: false
     index_stats: false
     pending_task_stats: false
 ```

In this case the full URL, including the `user:password` show up in the `url` tag  in the Web UI.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
