### PR TITLE
[DBM] [Postgres] Hides the query_activity.collection_interval option to prevent misuse

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -553,6 +553,7 @@ files:
           value:
             type: number
             example: 10
+          hidden: true
         - name: payload_row_limit
           description: |
             Set the query activity maximum number of pg_stat_activity rows you want to report. If the table is larger

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -500,12 +500,6 @@ instances:
         #
         # enabled: true
 
-        ## @param collection_interval - number - optional - default: 10
-        ## Set the query activity collection interval (in seconds). This number cannot be smaller than
-        ## query_samples configured collection_interval.
-        #
-        # collection_interval: 10
-
         ## @param payload_row_limit - number - optional - default: 3500
         ## Set the query activity maximum number of pg_stat_activity rows you want to report. If the table is larger
         ## than the maximum rows set, then the top N longest running transactions will be reported.


### PR DESCRIPTION
### What does this PR do?
This PR will just hid the query_activity.collection_interval option in the `conf.yaml` to prevent misuse.

### Motivation
[DBMON-5020](https://datadoghq.atlassian.net/browse/DBMON-5020)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[DBMON-5020]: https://datadoghq.atlassian.net/browse/DBMON-5020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ