### PR TITLE
Backport: Use DB_NAME for query metrics in an azure sql database (#20097)

### DIFF
--- a/sqlserver/changelog.d/20097.fixed
+++ b/sqlserver/changelog.d/20097.fixed
@@ -1,0 +1,1 @@
+Use DB_NAME for query metrics in an azure sql database since joining on sys.databases doesn't always work. The dbid from dm_exec_query_stats doesn't match the one in sys.databases.


### PR DESCRIPTION
### What does this PR do?

It backports a fix for DBM query metrics collection for customers monitoring a SQL Server instance on Azure SQL DBs. 

### Motivation

We've had multiple customer reports of this issue.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
