### PR TITLE
[DBM] [MySQL] Hides the query_activity.collection_interval option to prevent misuse

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -564,6 +564,7 @@ files:
                 value:
                   type: number
                   example: 10
+                hidden: true
               - name: collect_blocking_queries
                 description: |
                   Enable collection of blocking queries.

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -535,11 +535,6 @@ instances:
         #
         # enabled: true
 
-        ## @param collection_interval - number - optional - default: 10
-        ## Set the activity collection interval (in seconds).
-        #
-        # collection_interval: 10
-
         ## @param collect_blocking_queries - boolean - optional - default: false
         ## Enable collection of blocking queries.
         #


### PR DESCRIPTION
### What does this PR do?
This PR will just hid the query_activity.collection_interval option in the conf.yaml to prevent misuse.

### Motivation
[DBMON-5021](https://datadoghq.atlassian.net/browse/DBMON-5021)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[DBMON-5021]: https://datadoghq.atlassian.net/browse/DBMON-5021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ