### PR TITLE
[DBM] [SQL Server] Hides the query_activity.collection_interval option to prevent misuse

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -640,6 +640,7 @@ files:
           value:
             type: number
             example: 10
+          hidden: true
     - name: stored_procedure_characters_limit
       description: |
         Limit the number of characters of the text of a stored procedure that is collected.

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -437,14 +437,6 @@ instances:
         #
         # enabled: true
 
-        ## @param collection_interval - number - optional - default: 10
-        ## Set the activity collection interval in seconds. Each collection involves querying several
-        ## different DMV tables such as `dm_exec_requests`, `dm_exec_sessions`, and `dm_exec_sql_text`.
-        ## If a non-default value is chosen, then that exact same value must be used for *every* check instance.
-        ## Running different instances with different collection intervals is not supported.
-        #
-        # collection_interval: 10
-
     ## @param stored_procedure_characters_limit - integer - optional - default: 500
     ## Limit the number of characters of the text of a stored procedure that is collected.
     ## The characters limit is applicable to both query metrics and query samples.


### PR DESCRIPTION
### What does this PR do?
This PR will just hid the query_activity.collection_interval option in the conf.yaml to prevent misuse.

### Motivation
[DBMON-5019](https://datadoghq.atlassian.net/browse/DBMON-5019)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[DBMON-5019]: https://datadoghq.atlassian.net/browse/DBMON-5019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ