### PR TITLE
[mongo] Provide a way to optionally disable collecting free storage metrics

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -448,6 +448,19 @@ files:
       value:
         type: boolean
         example: true
+    - name: free_storage_metrics
+      description: |
+        Enabled or disable the collection of free storage metrics.
+        By default, this option is enabled (`true`), meaning free storage metrics are collected. 
+        Set to `false` to disable collection of free storage metrics.
+
+        Note: If the instance has a large number of collections or indexes, obtaining free space usage data may cause 
+        processing delays and high CPU usage on the instance.
+        https://www.mongodb.com/docs/manual/reference/command/dbStats/#std-label-dbStats-freeStorage
+      value:
+        type: boolean
+        example: true
+        display_default: true
     - name: add_node_tag_to_events
       description: |
         Adds the Mongo node to events as a tag rather than creating a seperate host for the event.

--- a/mongo/changelog.d/20135.added
+++ b/mongo/changelog.d/20135.added
@@ -1,0 +1,1 @@
+[mongo] Provide a way to optionally disable collecting free storage metrics

--- a/mongo/datadog_checks/mongo/collectors/db_stat.py
+++ b/mongo/datadog_checks/mongo/collectors/db_stat.py
@@ -49,7 +49,7 @@ class DbStatCollector(MongoCollector):
             ]
         else:
             additional_tags = None
-        
+
         collect_free_storage_metrics = 1 if self.free_storage_metrics else 0
         stats = {'stats': db.command({'dbStats': 1, 'freeStorage': collect_free_storage_metrics})}
         return self._submit_payload(stats, additional_tags)

--- a/mongo/datadog_checks/mongo/collectors/db_stat.py
+++ b/mongo/datadog_checks/mongo/collectors/db_stat.py
@@ -18,6 +18,7 @@ class DbStatCollector(MongoCollector):
         self.db_name = db_name
         self.dbstats_tag_dbname = dbstats_tag_dbname
         self._collection_interval = check._config.metrics_collection_interval['db_stats']
+        self.free_storage_metrics = check._config.free_storage_metrics
         self._collector_key = (self.__class__.__name__, db_name)  # db_name is part of collector key
 
     def compatible_with(self, deployment):
@@ -48,5 +49,7 @@ class DbStatCollector(MongoCollector):
             ]
         else:
             additional_tags = None
-        stats = {'stats': db.command({'dbStats': 1, 'freeStorage': 1})}
+        
+        collect_free_storage_metrics = 1 if self.free_storage_metrics else 0
+        stats = {'stats': db.command({'dbStats': 1, 'freeStorage': collect_free_storage_metrics})}
         return self._submit_payload(stats, additional_tags)

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -97,6 +97,7 @@ class MongoConfig(object):
         self.custom_queries = instance.get("custom_queries", [])
         self._metrics_collection_interval = instance.get("metrics_collection_interval", {})
         self.system_database_stats = is_affirmative(instance.get('system_database_stats', True))
+        self.free_storage_metrics = is_affirmative(instance.get('free_storage_metrics', True))
 
         self._base_tags = list(set(instance.get('tags', [])))
 

--- a/mongo/datadog_checks/mongo/config_models/defaults.py
+++ b/mongo/datadog_checks/mongo/config_models/defaults.py
@@ -52,6 +52,10 @@ def instance_system_database_stats():
     return True
 
 
+def instance_free_storage_metrics():
+    return True
+
+
 def instance_timeout():
     return 30
 

--- a/mongo/datadog_checks/mongo/config_models/defaults.py
+++ b/mongo/datadog_checks/mongo/config_models/defaults.py
@@ -40,6 +40,10 @@ def instance_empty_default_hostname():
     return False
 
 
+def instance_free_storage_metrics():
+    return True
+
+
 def instance_min_collection_interval():
     return 15
 
@@ -49,10 +53,6 @@ def instance_replica_check():
 
 
 def instance_system_database_stats():
-    return True
-
-
-def instance_free_storage_metrics():
     return True
 
 

--- a/mongo/datadog_checks/mongo/config_models/instance.py
+++ b/mongo/datadog_checks/mongo/config_models/instance.py
@@ -141,6 +141,7 @@ class InstanceConfig(BaseModel):
     dbstats_tag_dbname: Optional[bool] = None
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
+    free_storage_metrics: Optional[bool] = None
     hosts: Optional[Union[str, tuple[str, ...]]] = None
     metric_patterns: Optional[MetricPatterns] = None
     metrics_collection_interval: Optional[MetricsCollectionInterval] = None
@@ -155,7 +156,6 @@ class InstanceConfig(BaseModel):
     service: Optional[str] = None
     slow_operations: Optional[SlowOperations] = None
     system_database_stats: Optional[bool] = None
-    free_storage_metrics: Optional[bool] = None
     tags: Optional[tuple[str, ...]] = None
     timeout: Optional[int] = None
     tls: Optional[bool] = None

--- a/mongo/datadog_checks/mongo/config_models/instance.py
+++ b/mongo/datadog_checks/mongo/config_models/instance.py
@@ -155,6 +155,7 @@ class InstanceConfig(BaseModel):
     service: Optional[str] = None
     slow_operations: Optional[SlowOperations] = None
     system_database_stats: Optional[bool] = None
+    free_storage_metrics: Optional[bool] = None
     tags: Optional[tuple[str, ...]] = None
     timeout: Optional[int] = None
     tls: Optional[bool] = None

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -359,6 +359,17 @@ instances:
     #
     # system_database_stats: true
 
+    ## @param free_storage_metrics - boolean - optional - default: true
+    ## Enabled or disable the collection of free storage metrics.
+    ## By default, this option is enabled (`true`), meaning free storage metrics are collected. 
+    ## Set to `false` to disable collection of free storage metrics.
+    ##
+    ## Note: If the instance has a large number of collections or indexes, obtaining free space usage data may cause 
+    ## processing delays and high CPU usage on the instance.
+    ## https://www.mongodb.com/docs/manual/reference/command/dbStats/#std-label-dbStats-freeStorage
+    #
+    # free_storage_metrics: true
+
     ## @param custom_queries - list of mappings - optional
     ## Define custom queries to collect custom metrics on your Mongo
     ## Note: Custom queries are ignored by default when the mongo node is a secondary of a replica set.

--- a/mongo/tests/fixtures/dbstats-non-free-storage-admin
+++ b/mongo/tests/fixtures/dbstats-non-free-storage-admin
@@ -1,0 +1,77 @@
+{
+    "raw": {
+        "shard01/shard01a:27018,shard01b:27018": {
+            "db": "admin",
+            "collections": 1,
+            "views": 0,
+            "objects": 2,
+            "avgObjSize": 111.0,
+            "dataSize": 222.0,
+            "storageSize": 32768.0,
+            "numExtents": 0,
+            "indexes": 1,
+            "indexSize": 32768.0,
+            "scaleFactor": 1.0,
+            "ok": 1.0
+        },
+        "shard03/shard03a:27020,shard03b:27020": {
+            "db": "admin",
+            "collections": 1,
+            "views": 0,
+            "objects": 2,
+            "avgObjSize": 111.0,
+            "dataSize": 222.0,
+            "storageSize": 32768.0,
+            "numExtents": 0,
+            "indexes": 1,
+            "indexSize": 32768.0,
+            "scaleFactor": 1.0,
+            "ok": 1.0
+        },
+        "shard02/shard02a:27019,shard02b:27019": {
+            "db": "admin",
+            "collections": 1,
+            "views": 0,
+            "objects": 2,
+            "avgObjSize": 111.0,
+            "dataSize": 222.0,
+            "storageSize": 32768.0,
+            "numExtents": 0,
+            "indexes": 1,
+            "indexSize": 32768.0,
+            "scaleFactor": 1.0,
+            "ok": 1.0
+        }
+    },
+    "objects": 6,
+    "avgObjSize": 111.0,
+    "dataSize": 666,
+    "storageSize": 98304,
+    "numExtents": 0,
+    "indexes": 3,
+    "indexSize": 98304,
+    "scaleFactor": 1,
+    "fileSize": 0,
+    "ok": 1.0,
+    "operationTime": {
+        "$timestamp": {
+            "t": 1600245945,
+            "i": 21
+        }
+    },
+    "$clusterTime": {
+        "clusterTime": {
+            "$timestamp": {
+                "t": 1600245948,
+                "i": 1
+            }
+        },
+        "signature": {
+            "hash": {
+                "$binary": "AAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+                "$type": "00"
+            },
+            "keyId": 0
+        }
+    }
+}

--- a/mongo/tests/fixtures/dbstats-non-free-storage-config
+++ b/mongo/tests/fixtures/dbstats-non-free-storage-config
@@ -1,0 +1,81 @@
+{
+    "raw": {
+        "shard01/shard01a:27018,shard01b:27018": {
+            "db": "config",
+            "collections": 5,
+            "views": 0,
+            "objects": 124,
+            "avgObjSize": 99.87096774193549,
+            "dataSize": 12384.0,
+            "storageSize": 90112.0,
+            "numExtents": 0,
+            "indexes": 7,
+            "indexSize": 155648.0,
+            "indexFreeStorageSize": 8556544.0,
+            "scaleFactor": 1.0,
+            "ok": 1.0
+        },
+        "shard03/shard03a:27020,shard03b:27020": {
+            "db": "config",
+            "collections": 4,
+            "views": 0,
+            "objects": 3,
+            "avgObjSize": 135.0,
+            "dataSize": 405.0,
+            "storageSize": 53248.0,
+            "numExtents": 0,
+            "indexes": 5,
+            "indexSize": 69632.0,
+            "indexFreeStorageSize": 8556544.0,
+            "scaleFactor": 1.0,
+            "ok": 1.0
+        },
+        "shard02/shard02a:27019,shard02b:27019": {
+            "db": "config",
+            "collections": 4,
+            "views": 0,
+            "objects": 4,
+            "avgObjSize": 128.25,
+            "dataSize": 513.0,
+            "storageSize": 69632.0,
+            "numExtents": 0,
+            "indexes": 5,
+            "indexSize": 86016.0,
+            "indexFreeStorageSize": 8556544.0,
+            "scaleFactor": 1.0,
+            "ok": 1.0
+        }
+    },
+    "objects": 131,
+    "avgObjSize": 100.70992366412214,
+    "dataSize": 13302,
+    "storageSize": 212992,
+    "numExtents": 0,
+    "indexes": 17,
+    "indexSize": 311296,
+    "indexFreeStorageSize": 8556544.0,
+    "scaleFactor": 1,
+    "fileSize": 0,
+    "ok": 1.0,
+    "operationTime": {
+        "$timestamp": {
+            "t": 1600245969,
+            "i": 1
+        }
+    },
+    "$clusterTime": {
+        "clusterTime": {
+            "$timestamp": {
+                "t": 1600245969,
+                "i": 1
+            }
+        },
+        "signature": {
+            "hash": {
+                "$binary": "AAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+                "$type": "00"
+            },
+            "keyId": 0
+        }
+    }
+}

--- a/mongo/tests/fixtures/dbstats-non-free-storage-local
+++ b/mongo/tests/fixtures/dbstats-non-free-storage-local
@@ -1,0 +1,64 @@
+{
+    "db": "local",
+    "collections": 7,
+    "views": 1,
+    "objects": 6938,
+    "avgObjSize": 214.15696166042088,
+    "dataSize": 1485821.0,
+    "storageSize": 430080.0,
+    "numExtents": 0,
+    "indexes": 6,
+    "indexSize": 98304.0,
+    "indexFreeStorageSize": 8556544.0,
+    "scaleFactor": 1.0,
+    "ok": 1.0,
+    "$gleStats": {
+        "lastOpTime": {
+            "$timestamp": {
+                "t": 0,
+                "i": 0
+            }
+        },
+        "electionId": {
+            "$oid": "7fffffff0000000000000004"
+        }
+    },
+    "lastCommittedOpTime": {
+        "$timestamp": {
+            "t": 1600249681,
+            "i": 1
+        }
+    },
+    "$configServerState": {
+        "opTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1600249677,
+                    "i": 1
+                }
+            },
+            "t": 8
+        }
+    },
+    "$clusterTime": {
+        "clusterTime": {
+            "$timestamp": {
+                "t": 1600249681,
+                "i": 1
+            }
+        },
+        "signature": {
+            "hash": {
+                "$binary": "AAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+                "$type": "00"
+            },
+            "keyId": 0
+        }
+    },
+    "operationTime": {
+        "$timestamp": {
+            "t": 1600249681,
+            "i": 1
+        }
+    }
+}

--- a/mongo/tests/fixtures/dbstats-non-free-storage-test
+++ b/mongo/tests/fixtures/dbstats-non-free-storage-test
@@ -1,0 +1,83 @@
+{
+    "raw": {
+        "shard01/shard01a:27018,shard01b:27018": {
+            "db": "test",
+            "collections": 0,
+            "views": 0,
+            "objects": 0,
+            "avgObjSize": 0,
+            "dataSize": 0,
+            "storageSize": 0,
+            "numExtents": 0,
+            "indexes": 0,
+            "indexSize": 0,
+            "indexFreeStorageSize": 0,
+            "scaleFactor": 1,
+            "fileSize": 0,
+            "ok": 1.0
+        },
+        "shard03/shard03a:27020,shard03b:27020": {
+            "db": "test",
+            "collections": 0,
+            "views": 0,
+            "objects": 0,
+            "avgObjSize": 0,
+            "dataSize": 0,
+            "storageSize": 0,
+            "numExtents": 0,
+            "indexes": 0,
+            "indexSize": 0,
+            "indexFreeStorageSize": 0,
+            "scaleFactor": 1,
+            "fileSize": 0,
+            "ok": 1.0
+        },
+        "shard02/shard02a:27019,shard02b:27019": {
+            "db": "test",
+            "collections": 3,
+            "views": 0,
+            "objects": 316,
+            "avgObjSize": 27.556962025316455,
+            "dataSize": 8708.0,
+            "storageSize": 49152.0,
+            "numExtents": 0,
+            "indexes": 3,
+            "indexSize": 49152.0,
+            "indexFreeStorageSize": 1.0,
+            "scaleFactor": 1.0,
+            "ok": 1.0
+        }
+    },
+    "objects": 316,
+    "avgObjSize": 27.0,
+    "dataSize": 8708,
+    "storageSize": 49152,
+    "numExtents": 0,
+    "indexes": 3,
+    "indexSize": 49152,
+    "indexFreeStorageSize": 8556544.0,
+    "scaleFactor": 1,
+    "fileSize": 0,
+    "ok": 1.0,
+    "operationTime": {
+        "$timestamp": {
+            "t": 1600245931,
+            "i": 1
+        }
+    },
+    "$clusterTime": {
+        "clusterTime": {
+            "$timestamp": {
+                "t": 1600245931,
+                "i": 1
+            }
+        },
+        "signature": {
+            "hash": {
+                "$binary": "AAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+                "$type": "00"
+            },
+            "keyId": 0
+        }
+    }
+}

--- a/mongo/tests/mocked_api.py
+++ b/mongo/tests/mocked_api.py
@@ -79,7 +79,7 @@ class MockedDB(object):
     def command(self, command, *args, **kwargs):
         filename = command
         if "dbStats" in command:
-            if "freeStorage: 0" in command:
+            if command.get("freeStorage") == 0:
                 filename = f"dbstats-non-free-storage-{self._db_name}"
             else:
                 filename = f"dbstats-{self._db_name}"

--- a/mongo/tests/mocked_api.py
+++ b/mongo/tests/mocked_api.py
@@ -79,7 +79,10 @@ class MockedDB(object):
     def command(self, command, *args, **kwargs):
         filename = command
         if "dbStats" in command:
-            filename = f"dbstats-{self._db_name}"
+            if "freeStorage: 0" in command:
+                filename = f"dbstats-non-free-storage-{self._db_name}"
+            else:
+                filename = f"dbstats-{self._db_name}"
         elif command == "collstats":
             coll_name = args[0]
             filename += f"-{coll_name}"

--- a/mongo/tests/results/metrics-dbstats-non-free-storage.json
+++ b/mongo/tests/results/metrics-dbstats-non-free-storage.json
@@ -1,0 +1,242 @@
+[
+  {
+        "name": "mongodb.stats.avgobjsize",
+        "type": 0,
+        "value": 27.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.stats.avgobjsize",
+        "type": 0,
+        "value": 111.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:admin",
+            "db:admin"
+        ]
+    },
+    {
+        "name": "mongodb.stats.avgobjsize",
+        "type": 0,
+        "value": 100.70992366412214,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:config",
+            "db:config"
+        ]
+    },
+    {
+        "name": "mongodb.stats.datasize",
+        "type": 0,
+        "value": 8708.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.stats.datasize",
+        "type": 0,
+        "value": 666.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:admin",
+            "db:admin"
+        ]
+    },
+    {
+        "name": "mongodb.stats.datasize",
+        "type": 0,
+        "value": 13302.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:config",
+            "db:config"
+        ]
+    },
+    {
+        "name": "mongodb.stats.filesize",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.stats.filesize",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:admin",
+            "db:admin"
+        ]
+    },
+    {
+        "name": "mongodb.stats.filesize",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:config",
+            "db:config"
+        ]
+    },
+    {
+        "name": "mongodb.stats.indexes",
+        "type": 0,
+        "value": 3.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.stats.indexes",
+        "type": 0,
+        "value": 3.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:admin",
+            "db:admin"
+        ]
+    },
+    {
+        "name": "mongodb.stats.indexes",
+        "type": 0,
+        "value": 17.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:config",
+            "db:config"
+        ]
+    },
+    {
+        "name": "mongodb.stats.indexsize",
+        "type": 0,
+        "value": 49152.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.stats.indexsize",
+        "type": 0,
+        "value": 98304.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:admin",
+            "db:admin"
+        ]
+    },
+    {
+        "name": "mongodb.stats.indexsize",
+        "type": 0,
+        "value": 311296.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:config",
+            "db:config"
+        ]
+    },
+    {
+        "name": "mongodb.stats.numextents",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.stats.numextents",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:admin",
+            "db:admin"
+        ]
+    },
+    {
+        "name": "mongodb.stats.numextents",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:config",
+            "db:config"
+        ]
+    },
+    {
+        "name": "mongodb.stats.objects",
+        "type": 0,
+        "value": 316.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.stats.objects",
+        "type": 0,
+        "value": 6.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:admin",
+            "db:admin"
+        ]
+    },
+    {
+        "name": "mongodb.stats.objects",
+        "type": 0,
+        "value": 131.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:config",
+            "db:config"
+        ]
+    },
+    {
+        "name": "mongodb.stats.storagesize",
+        "type": 0,
+        "value": 49152.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:test",
+            "db:test"
+        ]
+    },
+    {
+        "name": "mongodb.stats.storagesize",
+        "type": 0,
+        "value": 98304.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:admin",
+            "db:admin"
+        ]
+    },
+    {
+        "name": "mongodb.stats.storagesize",
+        "type": 0,
+        "value": 212992.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "cluster:db:config",
+            "db:config"
+        ]
+    }
+]

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -1256,18 +1256,10 @@ def test_integration_skip_free_storage_metrics(instance_integration, aggregator,
     instance_integration['free_storage_metrics'] = False
     mongo_check = check(instance_integration)
 
-    with mock_pymongo("replica-primary"):
+    with mock_pymongo("standalone"):
         dd_run_check(mongo_check)
 
-    replica_tags = [
-        'replset_name:replset',
-        'replset_state:primary',
-        'replset_me:replset-data-0.mongo.default.svc.cluster.local:27017',
-        'hosting_type:self-hosted',
-        'replset_nodetype:ELECTABLE',
-        'replset_workloadtype:OPERATIONAL',
-    ]
     metrics_categories = [
         'dbstats-non-free-storage',
     ]
-    assert_metrics(mongo_check, aggregator, metrics_categories, replica_tags)
+    assert_metrics(mongo_check, aggregator, metrics_categories, ['hosting_type:self-hosted'])

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -1251,6 +1251,7 @@ def test_integration_custom_metrics_collection_interval(
     # No new metrics should be collected as the interval is set to 300 seconds
     assert_metrics(mongo_check, aggregator, metrics_categories, replica_tags, count=0)
 
+
 def test_integration_skip_free_storage_metrics(instance_integration_autodiscovery, aggregator, check, dd_run_check):
     instance_integration_autodiscovery['free_storage_metrics'] = False
     mongo_check = check(instance_integration_autodiscovery)

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -1250,3 +1250,15 @@ def test_integration_custom_metrics_collection_interval(
 
     # No new metrics should be collected as the interval is set to 300 seconds
     assert_metrics(mongo_check, aggregator, metrics_categories, replica_tags, count=0)
+
+def test_integration_skip_free_storage_metrics(instance_integration_autodiscovery, aggregator, check, dd_run_check):
+    instance_integration_autodiscovery['free_storage_metrics'] = False
+    mongo_check = check(instance_integration_autodiscovery)
+
+    with mock_pymongo("replica-primary"):
+        dd_run_check(mongo_check)
+
+    metrics_categories = [
+        'dbstats-non-free-storage',
+    ]
+    assert_metrics(mongo_check, aggregator, metrics_categories)

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -1252,14 +1252,22 @@ def test_integration_custom_metrics_collection_interval(
     assert_metrics(mongo_check, aggregator, metrics_categories, replica_tags, count=0)
 
 
-def test_integration_skip_free_storage_metrics(instance_integration_autodiscovery, aggregator, check, dd_run_check):
-    instance_integration_autodiscovery['free_storage_metrics'] = False
-    mongo_check = check(instance_integration_autodiscovery)
+def test_integration_skip_free_storage_metrics(instance_integration, aggregator, check, dd_run_check):
+    instance_integration['free_storage_metrics'] = False
+    mongo_check = check(instance_integration)
 
     with mock_pymongo("replica-primary"):
         dd_run_check(mongo_check)
 
+    replica_tags = [
+        'replset_name:replset',
+        'replset_state:primary',
+        'replset_me:replset-data-0.mongo.default.svc.cluster.local:27017',
+        'hosting_type:self-hosted',
+        'replset_nodetype:ELECTABLE',
+        'replset_workloadtype:OPERATIONAL',
+    ]
     metrics_categories = [
         'dbstats-non-free-storage',
     ]
-    assert_metrics(mongo_check, aggregator, metrics_categories)
+    assert_metrics(mongo_check, aggregator, metrics_categories, replica_tags)


### PR DESCRIPTION
### What does this PR do?
This PR will add a new configuration called `free_storage_metrics` to the mongo integration that would allow customers to disable collecting free storage metrics.

### Motivation
[DBMON-5228](https://datadoghq.atlassian.net/browse/DBMON-5228)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[DBMON-5228]: https://datadoghq.atlassian.net/browse/DBMON-5228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ