### PR TITLE
Include DD_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED in the ECS Fargat…

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -958,7 +958,16 @@ partial -->
 
 <div class="alert alert-warning">You can view your ECS Fargate processes in Datadog. To see their relationship to ECS Fargate containers, use the Datadog Agent v7.50.0 or later.</div>
 
-You can monitor processes in ECS Fargate in Datadog by using the [Live Processes page][56]. To enable process collection, add the [`PidMode` parameter][57] in the Task Definition and set it to `task` as follows:
+You can monitor processes in ECS Fargate in Datadog by using the [Live Processes page][56]. To enable process monitoring in ECS Fargate, set the `DD_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED` environment variable to `true` in the Datadog Agent container definition within the task definition:
+
+```
+{
+    "name": "DD_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED",
+    "value": "true"
+}
+```
+
+Then add the [`PidMode` parameter][57] in the Task Definition and set it to `task` as follows:
 
 ```text
 "pidMode": "task"


### PR DESCRIPTION
### What does this PR do?
Include DD_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED in the ECS Fargate process collection section which was documented in the Live Processes page: https://docs.datadoghq.com/infrastructure/process/?tab=awsecsfargate#installation

### Motivation
Customers might miss enabling this DD_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED step and may see no live process data showing up in Datadog.

