### PR TITLE
Update pan_firewall README.md to include enabling logs

### DIFF
--- a/pan_firewall/README.md
+++ b/pan_firewall/README.md
@@ -18,7 +18,7 @@ Firewall authentication logs provide detailed information on users as they authe
 
 ### Log collection
 
- 1. [Install the Datadog Agent][1] on a machine that is reachable by the firewall and can connect to the internet. Confirm that log collection is enabled. To enable log collection, change `logs_enabled: false` to `logs_enabled: true` in your Agent's main configuration file (datadog.yaml). See the [Host Agent Log collection documentation](https://docs.datadoghq.com/agent/logs/) for more information and examples.
+ 1. [Install the Datadog Agent][1] on a machine that is reachable by the firewall and can connect to the internet. Confirm that log collection is enabled. To enable log collection, change `logs_enabled: false` to `logs_enabled: true` in your Agent's main configuration file (datadog.yaml). See the [Host Agent Log collection documentation][10] for more information and examples.
  2. In PanOS, Select Device >> Server Profiles >> Syslog , add a name for the server profile. Follow the Syslog log forwarding [configuration steps][2]. Same steps listed below.
  3. Click Add and provide the following details of the server:
  	* Name of the server
@@ -96,4 +96,5 @@ Need help? Contact [Datadog support][7].
 [7]: https://docs.datadoghq.com/help/
 [8]: https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-admin/monitoring/use-syslog-for-monitoring/syslog-field-descriptions
 [9]: https://docs.datadoghq.com/network_monitoring/devices/supported_devices/
+[10]: https://docs.datadoghq.com/agent/logs/
 


### PR DESCRIPTION
The previous documentation didn't include the note that log collection had to be enabled. My customer didn't have logs enabled in their test environment and had to debug to see the issue.

### What does this PR do?
Adds a note about making sure that log_collection is enabled.

### Motivation
My customer is testing PAN and didn't have logs enabled in test. They found the error in logs, but it should be specified in docs.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
