### PR TITLE
Fix service-checks validation and remove them from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,12 +18,6 @@ repos:
       language: system
       files: '.+\.py'
       pass_filenames: false
-    - id: service_checks
-      name: Validate service checks
-      entry: ddev validate service-checks
-      language: system
-      files: '.*/assets/service_checks\.json'
-      pass_filenames: false
     - id: labeler_config
       name: Validate labeler config
       entry: ddev validate labeler
@@ -36,3 +30,4 @@ repos:
       language: system
       files: '.*/metadata\.csv'
       pass_filenames: false
+

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/service_checks.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/service_checks.py
@@ -77,6 +77,10 @@ def service_checks(check, sync):
 
         manifest_file = get_manifest_file(check_name)
         service_check_relative = manifest.get_service_checks_path()
+        if service_check_relative is None:
+            echo_success(f"Skipping {check_name} - This check does not have service checks.")
+            continue
+
         service_checks_file = os.path.join(root, check_name, *service_check_relative.split('/'))
 
         if not file_exists(service_checks_file):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_utils.py
@@ -115,7 +115,7 @@ class ManifestV1:
         return self._manifest_json.get_path("/assets/metrics_metadata")
 
     def get_service_checks_path(self):
-        return self._manifest_json["assets"]["service_checks"]
+        return self._manifest_json.get("assets", {}).get("service_checks")
 
     def get_config_spec(self):
         path = self._manifest_json.get('assets', {}).get('configuration', {}).get('spec', '')


### PR DESCRIPTION
### What does this PR do?
Recently we have removed service checks validations from our CI since APW is doing this validation now (see #19835). Since CI is doing a more official validation of assets for us now, this PR removes the service checks validation from `pre-commit`.

It also fixes the validation, in case we want to run it, to ensure it does not break if no `service_checks` path is defined in the manifest of the integration. This is the case for more recent integrations like [infiniband](https://github.com/DataDog/integrations-core/blob/master/infiniband/manifest.json#L23-L38) and [check_point_harmony_email](https://github.com/DataDog/integrations-core/blob/master/checkpoint_harmony_email_and_collaboration/manifest.json#L39-L46). These do not have service checks and, therefore, there is no path for them in the manifest.

### Motivation
Align assets validation in pre-commit and fix the `validate service-checks` command that is failing with recent integrations.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
