### PR TITLE
[mongo] serverStatus cannot be explained

### DIFF
--- a/mongo/changelog.d/20149.fixed
+++ b/mongo/changelog.d/20149.fixed
@@ -1,0 +1,1 @@
+Skips explaining serverStatus command.

--- a/mongo/datadog_checks/mongo/dbm/utils.py
+++ b/mongo/datadog_checks/mongo/dbm/utils.py
@@ -59,6 +59,7 @@ UNEXPLAINABLE_COMMANDS = frozenset(
         'dbStats',
         'createIndexes',
         'shardCollection',
+        'serverStatus',
     ]
 )
 


### PR DESCRIPTION
### What does this PR do?
This PR skips explaining `serverStatus` command. 

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-5242

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
