### PR TITLE
Disable mongodb schema collection by default

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -269,7 +269,7 @@ files:
             Enable collection of schemas. Requires `dbm: true`.
           value:
             type: boolean
-            example: true
+            example: false
         - name: collection_interval
           description: |
             Set the schemas collection interval in seconds. Each collection involves sampling documents

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -214,8 +214,8 @@ class MongoConfig(object):
     @property
     def schemas(self):
         enabled = False
-        if self.dbm_enabled is True and self._schemas_config.get('enabled') is not False:
-            # if DBM is enabled and the schemas config is not explicitly disabled, then it is enabled
+        if self.dbm_enabled is True and self._schemas_config.get('enabled') is True:
+            # if DBM is enabled and the schemas config is not explicitly enabled, then it is disabled
             enabled = True
         max_collections = self._schemas_config.get('max_collections')
         return {

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -227,10 +227,10 @@ instances:
     #
     # schemas:
 
-        ## @param enabled - boolean - optional - default: true
+        ## @param enabled - boolean - optional - default: false
         ## Enable collection of schemas. Requires `dbm: true`.
         #
-        # enabled: true
+        # enabled: false
 
         ## @param collection_interval - number - optional - default: 3600
         ## Set the schemas collection interval in seconds. Each collection involves sampling documents


### PR DESCRIPTION
### What does this PR do?
This PR disables MongoDB schema collection (DBM only) by default. MongoDB schema collection uses `$sample` aggregation to randomly select documents from monitored collections. `$sample` can run slow on large collection event with small sample size (i.e. 1). To avoid additional performance overhead, schema collection is now disabled by default. 
To (re)enable MongoDB schema collection, set `schemas.enabled: true`. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
