### PR TITLE
Add slurm_partition_name to job metrics

### DIFF
--- a/slurm/changelog.d/20170.added
+++ b/slurm/changelog.d/20170.added
@@ -1,0 +1,1 @@
+Add slurm_partition_name to job metrics

--- a/slurm/datadog_checks/slurm/check.py
+++ b/slurm/datadog_checks/slurm/check.py
@@ -215,8 +215,8 @@ class SlurmCheck(AgentCheck, ConfigMixin):
         self.gauge('sinfo.node.enabled', 1)
 
     def process_squeue(self, output):
-        # JOBID |      USER |      NAME |   STATE |            NODELIST |      CPUS |   NODELIST(REASON) | MIN_MEMORY # noqa: E501
-        #    31 |      root |      wrap | PENDING |                     |         1 |        (Resources) |       500M # noqa: E501
+        # JOBID |      USER |      NAME |   STATE |            NODELIST |      CPUS |   NODELIST(REASON) | MIN_MEMORY | Partition # noqa: E501
+        #    31 |      root |      wrap | PENDING |                     |         1 |        (Resources) |       500M | foo       # noqa: E501
         lines = output.strip().split('\n')
 
         if self.debug_squeue_stats:

--- a/slurm/datadog_checks/slurm/constants.py
+++ b/slurm/datadog_checks/slurm/constants.py
@@ -8,7 +8,7 @@ SINFO_PARTITION_PARAMS = [
 SINFO_NODE_PARAMS = ["-haNO", "PartitionName:|,Available:|,NodeList:|,NodeAIOT:|,Memory:|,Cluster:"]
 SINFO_ADDITIONAL_NODE_PARAMS = "|,CPUsLoad:|,FreeMem:|,Disk:|,StateLong:|,Reason:|,features_act:|,Threads:"
 GPU_PARAMS = "|,Gres:|,GresUsed:"
-SQUEUE_PARAMS = ["-aho", "%A|%u|%j|%T|%N|%C|%R|%m"]
+SQUEUE_PARAMS = ["-aho", "%A|%u|%j|%T|%N|%C|%R|%m|%P"]
 SSHARE_PARAMS = ["-alnPU"]
 SACCT_PARAMS = [
     "-anpo",
@@ -75,6 +75,7 @@ SQUEUE_MAP = {
         {"name": "slurm_job_cpus", "index": 5},
         {"name": "slurm_job_reason", "index": 6},
         {"name": "slurm_job_tres_per_node", "index": 7},
+        {"name": "slurm_partition_name", "index": 8},
     ],
 }
 
@@ -82,6 +83,7 @@ SACCT_MAP = {
     "tags": [
         {"name": "slurm_job_name", "index": 1},
         {"name": "slurm_job_partition", "index": 2},
+        {"name": "slurm_partition_name", "index": 2},
         {"name": "slurm_job_account", "index": 3},
         {"name": "slurm_job_cpus", "index": 4},
         {"name": "slurm_job_tres_per_node", "index": 5},

--- a/slurm/tests/common.py
+++ b/slurm/tests/common.py
@@ -817,8 +817,8 @@ SQUEUE_MAP = {
             'value': 1,
             'tags': [],
         },
-        # JOBID |USER |NAME    |STATE   |NODELIST |CPUS |NODELIST(REASON) |MIN_MEMORY   # noqa: E501
-        #    42 |root |wrap    |RUNNING |c1       |   1 |c1               |300M        # noqa: E501
+        # JOBID |USER |NAME    |STATE   |NODELIST |CPUS |NODELIST(REASON) |MIN_MEMORY | PARTITION # noqa: E501
+        #    42 |root |wrap    |RUNNING |c1       |   1 |c1               |300M       | foo       # noqa: E501
         {
             'name': 'slurm.squeue.job.info',
             'value': 1,
@@ -831,10 +831,11 @@ SQUEUE_MAP = {
                 'slurm_job_state:RUNNING',
                 'slurm_job_tres_per_node:300M',
                 'slurm_job_user:root',
+                'slurm_partition_name:foo',
             ],
         },
-        # JOBID |USER |NAME    |STATE   |NODELIST |CPUS |NODELIST(REASON) |MIN_MEMORY   # noqa: E501
-        #    44 |root |wrap    |RUNNING |c2       |   1 |c2               |400M       # noqa: E501
+        # JOBID |USER |NAME    |STATE   |NODELIST |CPUS |NODELIST(REASON) |MIN_MEMORY | PARTITION # noqa: E501
+        #    44 |root |wrap    |RUNNING |c2       |   1 |c2               |400M       | foo       # noqa: E501
         {
             'name': 'slurm.squeue.job.info',
             'value': 1,
@@ -847,10 +848,11 @@ SQUEUE_MAP = {
                 'slurm_job_state:RUNNING',
                 'slurm_job_tres_per_node:400M',
                 'slurm_job_user:root',
+                'slurm_partition_name:foo',
             ],
         },
-        # JOBID |USER |NAME    |STATE   |NODELIST |CPUS |NODELIST(REASON) |MIN_MEMORY   # noqa: E501
-        #    45 |root |test.py |PENDING |         |   1 |(Resources)      |100M      # noqa: E501
+        # JOBID |USER |NAME    |STATE   |NODELIST |CPUS |NODELIST(REASON) |MIN_MEMORY | PARTITION # noqa: E501
+        #    45 |root |test.py |PENDING |         |   1 |(Resources)      |100M       | foo       # noqa: E501
         {
             'name': 'slurm.squeue.job.info',
             'value': 1,
@@ -863,10 +865,11 @@ SQUEUE_MAP = {
                 'slurm_job_state:PENDING',
                 'slurm_job_tres_per_node:100M',
                 'slurm_job_user:root',
+                'slurm_partition_name:foo',
             ],
         },
-        # JOBID |USER |NAME    |STATE   |NODELIST |CPUS |NODELIST(REASON) |MIN_MEMORY   # noqa: E501
-        #    46 |root |test.py |PENDING |         |   1 |(Priority)       |200M     # noqa: E501
+        # JOBID |USER |NAME    |STATE   |NODELIST |CPUS |NODELIST(REASON) |MIN_MEMORY | PARTITION # noqa: E501
+        #    46 |root |test.py |PENDING |         |   1 |(Priority)       |200M       | foo       # noqa: E501
         {
             'name': 'slurm.squeue.job.info',
             'value': 1,
@@ -879,6 +882,7 @@ SQUEUE_MAP = {
                 'slurm_job_state:PENDING',
                 'slurm_job_tres_per_node:200M',
                 'slurm_job_user:root',
+                'slurm_partition_name:foo',
             ],
         },
     ]
@@ -905,6 +909,7 @@ SACCT_MAP = {
                 'slurm_job_name:wrap',
                 'slurm_job_node_list:c1',
                 'slurm_job_partition:normal',
+                'slurm_partition_name:normal',
                 'slurm_job_state:COMPLETED',
                 'slurm_job_tres_per_node:billing=1,cpu=1,mem=500M,node=1',
             ],
@@ -921,6 +926,7 @@ SACCT_MAP = {
                 'slurm_job_name:wrap',
                 'slurm_job_node_list:c1',
                 'slurm_job_partition:normal',
+                'slurm_partition_name:normal',
                 'slurm_job_state:COMPLETED',
                 'slurm_job_tres_per_node:billing=1,cpu=1,mem=500M,node=1',
             ],
@@ -937,6 +943,7 @@ SACCT_MAP = {
                 'slurm_job_name:wrap',
                 'slurm_job_node_list:c1',
                 'slurm_job_partition:normal',
+                'slurm_partition_name:normal',
                 'slurm_job_state:COMPLETED',
                 'slurm_job_tres_per_node:billing=1,cpu=1,mem=500M,node=1',
             ],
@@ -953,6 +960,7 @@ SACCT_MAP = {
                 'slurm_job_name:wrap',
                 'slurm_job_node_list:c1',
                 'slurm_job_partition:normal',
+                'slurm_partition_name:normal',
                 'slurm_job_state:COMPLETED',
                 'slurm_job_tres_per_node:billing=1,cpu=1,mem=500M,node=1',
             ],
@@ -969,6 +977,7 @@ SACCT_MAP = {
                 'slurm_job_name:wrap',
                 'slurm_job_node_list:c1',
                 'slurm_job_partition:normal',
+                'slurm_partition_name:normal',
                 'slurm_job_state:COMPLETED',
                 'slurm_job_tres_per_node:billing=1,cpu=1,mem=500M,node=1',
             ],
@@ -985,6 +994,7 @@ SACCT_MAP = {
                 'slurm_job_name:wrap',
                 'slurm_job_node_list:c1',
                 'slurm_job_partition:normal',
+                'slurm_partition_name:normal',
                 'slurm_job_state:COMPLETED',
                 'slurm_job_tres_per_node:billing=1,cpu=1,mem=500M,node=1',
             ],
@@ -1004,6 +1014,7 @@ SACCT_MAP = {
                 'slurm_job_name:batch',
                 'slurm_job_node_list:c1',
                 'slurm_job_partition:null',
+                'slurm_partition_name:null',
                 'slurm_job_state:COMPLETED',
                 'slurm_job_tres_per_node:cpu=1,mem=500M,node=1',
             ],
@@ -1021,6 +1032,7 @@ SACCT_MAP = {
                 'slurm_job_name:batch',
                 'slurm_job_node_list:c1',
                 'slurm_job_partition:null',
+                'slurm_partition_name:null',
                 'slurm_job_state:COMPLETED',
                 'slurm_job_tres_per_node:cpu=1,mem=500M,node=1',
             ],
@@ -1038,6 +1050,7 @@ SACCT_MAP = {
                 'slurm_job_name:batch',
                 'slurm_job_node_list:c1',
                 'slurm_job_partition:null',
+                'slurm_partition_name:null',
                 'slurm_job_state:COMPLETED',
                 'slurm_job_tres_per_node:cpu=1,mem=500M,node=1',
             ],
@@ -1055,6 +1068,7 @@ SACCT_MAP = {
                 'slurm_job_name:batch',
                 'slurm_job_node_list:c1',
                 'slurm_job_partition:null',
+                'slurm_partition_name:null',
                 'slurm_job_state:COMPLETED',
                 'slurm_job_tres_per_node:cpu=1,mem=500M,node=1',
             ],
@@ -1072,6 +1086,7 @@ SACCT_MAP = {
                 'slurm_job_name:batch',
                 'slurm_job_node_list:c1',
                 'slurm_job_partition:null',
+                'slurm_partition_name:null',
                 'slurm_job_state:COMPLETED',
                 'slurm_job_tres_per_node:cpu=1,mem=500M,node=1',
             ],
@@ -1089,6 +1104,7 @@ SACCT_MAP = {
                 'slurm_job_name:batch',
                 'slurm_job_node_list:c1',
                 'slurm_job_partition:null',
+                'slurm_partition_name:null',
                 'slurm_job_state:COMPLETED',
                 'slurm_job_tres_per_node:cpu=1,mem=500M,node=1',
             ],

--- a/slurm/tests/fixtures/squeue.txt
+++ b/slurm/tests/fixtures/squeue.txt
@@ -1,4 +1,4 @@
-45|root|test.py|PENDING||1|(Resources)|100M
-46|root|test.py|PENDING||1|(Priority)|200M
-42|root|wrap|RUNNING|c1|1|c1|300M
-44|root|wrap|RUNNING|c2|1|c2|400M
+45|root|test.py|PENDING||1|(Resources)|100M|foo
+46|root|test.py|PENDING||1|(Priority)|200M|foo
+42|root|wrap|RUNNING|c1|1|c1|300M|foo
+44|root|wrap|RUNNING|c2|1|c2|400M|foo


### PR DESCRIPTION
### What does this PR do?
Adding slurm_partition_name to job metrics. The tag is added in squeue metrics and duplicated in sacct metrics. This is to easier correlate them if they have a single unified tag.
