### PR TITLE
[MySQL] Catching a missing exception

### DIFF
--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -1224,7 +1224,7 @@ class MySql(AgentCheck):
                 query_exec_time_95th_per = row[0]
 
                 return query_exec_time_95th_per
-        except (pymysql.err.InternalError, pymysql.err.OperationalError) as e:
+        except (pymysql.err.InternalError, pymysql.err.OperationalError, pymysql.err.InterfaceError) as e:
             self.warning("95th percentile performance metrics unavailable at this time: %s", e)
             return None
 


### PR DESCRIPTION
### What does this PR do?
This PR makes sure to catch an additional error type that [PyMySQL raises (InterfaceError)](https://github.com/PyMySQL/PyMySQL/blob/01af30fea0880c3b72e6c7b3b05d66a8c28ced7a/pymysql/connections.py#L844) at some point. 

### Motivation
The motivation comes from [This Case](https://datadoghq.atlassian.net/browse/SDBM-1704). Since we weren't catching this exception when [This Query](https://github.com/DataDog/integrations-core/blob/98ef5c6d8db2a392f524eafa5c3906c64ab2e212/mysql/datadog_checks/mysql/mysql.py#L1214) was being executed, the check execute execution would stop.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
