### PR TITLE
MySQL IAM Auth

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -624,7 +624,40 @@ files:
                 value:
                   type: string
                   example: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
+              - name: region
+                description: |
+                  Equal to the region of the instance the agent is connecting to.
+                  This value is used to configure IAM authentication.
+                value:
+                  type: string
+                  example: us-east-1
+              - name: managed_authentication
+                description: |
+                  Configure section used for AWS IAM Authentication with RDS.
 
+                  This supports using IAM database authentication to connect to your database instance.
+
+                  For more information on configuration, see
+                  https://docs.datadoghq.com/database_monitoring/guide/managed_authentication
+
+                  For more information on RDS IAM Authentication, see the AWS docs
+                  https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Connecting.html
+
+                  To enable IAM Authentication, set `aws.managed_authentication.enabled` to `true`.
+                  If `aws.managed_authentication.enabled` is set, then the `password` fields will be ignored.
+                  `aws.region` is required to enable IAM Authentication.
+
+                  Optionally, you can set `aws.managed_authentication.role_arn` to specify the IAM role ARN.
+                  This can be used to perform cross-account authentication.
+                value:
+                  type: object
+                  properties:
+                  - name: enabled
+                    type: boolean
+                    example: false
+                  - name: role_arn
+                    type: string
+                    example: arn:aws:iam::123456789012:role/MyRole
           - name: gcp
             description: |
               This block defines the configuration for Google Cloud SQL instances.

--- a/mysql/changelog.d/20176.added
+++ b/mysql/changelog.d/20176.added
@@ -1,0 +1,1 @@
+Add support for IAM authentication with MySQL

--- a/mysql/datadog_checks/mysql/aws.py
+++ b/mysql/datadog_checks/mysql/aws.py
@@ -1,0 +1,25 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import boto3
+
+
+def generate_rds_iam_token(host, port, username, region, role_arn=None):
+    if role_arn:
+        # when role_arn is defined, assume the role to generate the token
+        # this can be used for cross-account access
+        sts_client = boto3.client("sts")
+        assumed_role = sts_client.assume_role(RoleArn=role_arn, RoleSessionName="datadog-rds-iam-auth-session")
+        credentials = assumed_role["Credentials"]
+        session = boto3.Session(
+            aws_access_key_id=credentials["AccessKeyId"],
+            aws_secret_access_key=credentials["SecretAccessKey"],
+            aws_session_token=credentials["SessionToken"],
+            region_name=region,
+        )
+    else:
+        session = boto3.Session(region_name=region)
+    client = session.client("rds")
+    token = client.generate_db_auth_token(DBHostname=host, Port=port, DBUsername=username)
+
+    return token

--- a/mysql/datadog_checks/mysql/aws.py
+++ b/mysql/datadog_checks/mysql/aws.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2023-present
+# (C) Datadog, Inc. 2025-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import boto3

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -12,12 +12,21 @@ from __future__ import annotations
 from types import MappingProxyType
 from typing import Any, Optional
 
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
 
 from . import defaults, validators
+
+
+class ManagedAuthentication(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    enabled: Optional[bool] = Field(None, examples=[False])
+    role_arn: Optional[str] = Field(None, examples=['arn:aws:iam::123456789012:role/MyRole'])
 
 
 class Aws(BaseModel):
@@ -26,6 +35,8 @@ class Aws(BaseModel):
         frozen=True,
     )
     instance_endpoint: Optional[str] = None
+    managed_authentication: Optional[ManagedAuthentication] = None
+    region: Optional[str] = None
 
 
 class Azure(BaseModel):

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -582,6 +582,32 @@ instances:
         #
         # instance_endpoint: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
 
+        ## @param region - string - optional - default: us-east-1
+        ## Equal to the region of the instance the agent is connecting to.
+        ## This value is used to configure IAM authentication.
+        #
+        # region: us-east-1
+
+        ## @param managed_authentication - mapping - optional
+        ## Configure section used for AWS IAM Authentication with RDS.
+        ##
+        ## This supports using IAM database authentication to connect to your database instance.
+        ##
+        ## For more information on configuration, see
+        ## https://docs.datadoghq.com/database_monitoring/guide/managed_authentication
+        ##
+        ## For more information on RDS IAM Authentication, see the AWS docs
+        ## https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Connecting.html
+        ##
+        ## To enable IAM Authentication, set `aws.managed_authentication.enabled` to `true`.
+        ## If `aws.managed_authentication.enabled` is set, then the `password` fields will be ignored.
+        ## `aws.region` is required to enable IAM Authentication.
+        ##
+        ## Optionally, you can set `aws.managed_authentication.role_arn` to specify the IAM role ARN.
+        ## This can be used to perform cross-account authentication.
+        #
+        # managed_authentication: {}
+
     ## This block defines the configuration for Google Cloud SQL instances.
     ##
     ## Complete this section if you have installed the Datadog GCP Integration

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -25,6 +25,7 @@ from datadog_checks.base.utils.db.utils import (
     resolve_db_host as agent_host_resolver,
 )
 from datadog_checks.base.utils.serialization import json
+from datadog_checks.mysql import aws
 from datadog_checks.mysql.cursor import CommenterCursor, CommenterDictCursor, CommenterSSCursor
 
 from .__about__ import __version__
@@ -103,8 +104,6 @@ class MySql(AgentCheck):
     REPLICA_SERVICE_CHECK_NAME = 'mysql.replication.replica_running'
     GROUP_REPLICATION_SERVICE_CHECK_NAME = 'mysql.replication.group.status'
     DEFAULT_MAX_CUSTOM_QUERIES = 20
-
-    HA_SUPPORTED = True
 
     def __init__(self, name, init_config, instances):
         super(MySql, self).__init__(name, init_config, instances)
@@ -480,6 +479,20 @@ class MySql(AgentCheck):
             return connection_args
 
         connection_args.update({'user': self._config.user, 'passwd': self._config.password})
+        if 'aws' in self.cloud_metadata and 'managed_authentication' in self.cloud_metadata['aws']:
+            # if we are running on AWS, check if IAM auth is enabled
+            aws_managed_authentication = self.cloud_metadata['aws']['managed_authentication']
+            if aws_managed_authentication['enabled']:
+                # if IAM auth is enabled, region must be set. Validation is done in the config
+                region = self.cloud_metadata['aws']['region']
+                password = aws.generate_rds_iam_token(
+                    host=self._config.host,
+                    username=self._config.user,
+                    port=self._config.port,
+                    region=region,
+                    role_arn=aws_managed_authentication.get('role_arn'),
+                )
+                connection_args.update({'user': self._config.user, 'passwd': password})
         if self._config.mysql_sock != '':
             self.service_check_tags = self._service_check_tags(self._config.mysql_sock)
             connection_args.update({'unix_socket': self._config.mysql_sock})

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -36,6 +36,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
+    "boto3==1.37.23",
     "cachetools==5.5.2",
     "cryptography==44.0.2",
     "pymysql==1.1.1",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds IAM authentication support to MySQL

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)
Validated this in `dbm-sandbox`:
```
instances:
- host: mysql-iam-auth-2-rdsinstance-g1qvdicrqyhg.cn6qqa2qkfmv.us-east-2.rds.amazonaws.com
  port: 3306
  dbm: true
  username: datadog
  ssl:
    ca: /usr/src/global-bundle.pem
    check_hostname: false
  aws:
    region: us-east-2
    instance_endpoint: mysql-iam-auth-2-rdsinstance-g1qvdicrqyhg.cn6qqa2qkfmv.us-east-2.rds.amazonaws.com
    managed_authentication:
      enabled: true
      role_arn: arn:aws:iam::074787506366:role/iam-ec2
```
<img width="596" alt="Screenshot 2025-05-05 at 4 23 00 PM" src="https://github.com/user-attachments/assets/c257cfc2-e252-45fe-9d45-e0aa6a3a7b5d" />


- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
