### PR TITLE
Update GH workflows to use new PiPy keys

### DIFF
--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -604,7 +604,7 @@ jobs:
       with:
         skip-existing: true
         user: __token__
-        password: ${{ secrets.PYPI_TOKEN_DDEV }}
+        password: ${{ secrets.PYPI_TOKEN_DDEV_2 }}
 
     - name: Add assets to current release
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/claim-pypi-name.yaml
+++ b/.github/workflows/claim-pypi-name.yaml
@@ -46,4 +46,4 @@ jobs:
         # Only uploading the missing wheels makes this job idempotent and reduces its complexity.
         skip-existing: true
         user: __token__
-        password: ${{ secrets.INTEGRATIONS_PYPI_NAME_CLAIM }}
+        password: ${{ secrets.INTEGRATIONS_PYPI_NAME_CLAIM_2 }}

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -34,4 +34,4 @@ jobs:
       run: ddev release upload -s datadog_checks_base
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_BASE }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_BASE_2 }}

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -34,4 +34,4 @@ jobs:
       run: ddev release upload -s datadog_checks_dev
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_DEV }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_DEV_2 }}


### PR DESCRIPTION
### What does this PR do?
This PR updates the PyPi tokens used to publish images using the new created ones. After validating that workflows work we will replace them back with the proper naming.

### Motivation
Scheduled secrets rotation

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
