### PR TITLE
Rename the name squatting PyPi key after rotation

### DIFF
--- a/.github/workflows/claim-pypi-name.yaml
+++ b/.github/workflows/claim-pypi-name.yaml
@@ -46,4 +46,4 @@ jobs:
         # Only uploading the missing wheels makes this job idempotent and reduces its complexity.
         skip-existing: true
         user: __token__
-        password: ${{ secrets.INTEGRATIONS_PYPI_NAME_CLAIM_2 }}
+        password: ${{ secrets.INTEGRATIONS_PYPI_NAME_CLAIM }}


### PR DESCRIPTION
### What does this PR do?
After merging #20178 we have validated that the new key works. Successful run [here](https://github.com/DataDog/integrations-core/actions/runs/14755277804) that was run with the commit after merging the PR [234e046](https://github.com/DataDog/integrations-core/commit/234e04695bbad447a8d44c2eb031d976d7a6150e).

### Motivation
Finalize rotation of this PyPi secret

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
