### PR TITLE
Fix broken link in Teleport documentation

### DIFF
--- a/teleport/README.md
+++ b/teleport/README.md
@@ -24,7 +24,7 @@ The Teleport check gathers Teleport's metrics and performance data using two dis
 - The [Health endpoint](https://goteleport.com/docs/management/diagnostics/monitoring/#healthz) provides the overall health status of your Teleport instance.
 - The [OpenMetrics endpoint](https://goteleport.com/docs/reference/metrics/#auth-service-and-backends) extracts metrics on the Teleport instance and the various services operating within that instance.
 
-These endpoints aren't activated by default. To enable the diagnostic HTTP endpoints in your Teleport instance, please refer to the public Teleport [documentation](https://goteleport.com/docs/management/diagnostics/monitoring/#enable-health-monitoring).
+These endpoints aren't activated by default. To enable the diagnostic HTTP endpoints in your Teleport instance, please refer to the public Teleport [documentation](https://goteleport.com/docs/admin-guides/management/diagnostics/monitoring/).
 
 ### Configuration
 


### PR DESCRIPTION
### What does this PR do?
Fix broken link to external Teleport documentation

### Motivation
Customer noted broken link in the ticket: https://datadog.zendesk.com/agent/tickets/2119183

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
