### PR TITLE
[Release] Bumped ddev version to 11.3.0

### DIFF
--- a/ddev/CHANGELOG.md
+++ b/ddev/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 <!-- towncrier release notes start -->
 
+## 11.3.0 / 2025-04-30
+
+***Added***:
+
+* Add support for license-expression when retrieving licenses from PyPi ([#20117](https://github.com/DataDog/integrations-core/pull/20117))
+
+***Fixed***:
+
+* Diasble tag signing in unit tests for release agent CLI command ([#19971](https://github.com/DataDog/integrations-core/pull/19971))
+
 ## 11.2.0 / 2025-02-26
 
 ***Added***:

--- a/ddev/changelog.d/19971.fixed
+++ b/ddev/changelog.d/19971.fixed
@@ -1,1 +1,0 @@
-Diasble tag signing in unit tests for release agent CLI command

--- a/ddev/changelog.d/20117.added
+++ b/ddev/changelog.d/20117.added
@@ -1,1 +1,0 @@
-Add support for license-expression when retrieving licenses from PyPi


### PR DESCRIPTION
### What does this PR do?
[Bumped ddev version to 11.3.0](https://github.com/DataDog/integrations-core/commit/7f7f198958c3ded8a1265bf3703685e95edaeb05)
