### PR TITLE
[MINPROC-2059] add ZillizCloud metric units

### DIFF
--- a/ddev/src/ddev/cli/validate/metadata_utils.py
+++ b/ddev/src/ddev/cli/validate/metadata_utils.py
@@ -396,6 +396,9 @@ VALID_UNIT_NAMES = {
     "byte_in_decimal_bytes_family",
     "bit_in_binary_bytes_family",
     "byte_in_binary_bytes_family",
+    "collection",
+    "entity",
+    "vector",
 }
 
 ALLOWED_PREFIXES = ('system.', 'jvm.', 'http.', 'datadog.', 'sftp.', 'process.', 'runtime.', 'otelcol_')


### PR DESCRIPTION
### What does this PR do?
- Adds customer ZillizCloud requested metrics units `collection`, `entity`, and `vector`.

### Motivation
https://datadoghq.atlassian.net/browse/MINPROC-2059

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
