### PR TITLE
Use Agent Integrations bot to open PR when resolving dependencies

### DIFF
--- a/.github/workflows/resolve-build-deps.yaml
+++ b/.github/workflows/resolve-build-deps.yaml
@@ -290,8 +290,8 @@ jobs:
       uses: actions/create-github-app-token@v1
       id: token-generator
       with:
-        app-id: ${{ vars.DD_GITHUB_TOKEN_GENERATOR_APP_ID }}
-        private-key: ${{ secrets.DD_GITHUB_TOKEN_GENERATOR_PRIVATE_KEY }}
+        app-id: ${{ vars.DD_AGENT_INTEGRATIONS_BOT_APP_ID }}
+        private-key: ${{ secrets.DD_AGENT_INTEGRATIONS_BOT_PRIVATE_KEY }}
         repositories: integrations-core
 
     - name: Create pull request
@@ -303,7 +303,7 @@ jobs:
         branch: bot/update-dependency-resolution
         branch-suffix: timestamp
         delete-branch: true
-        labels: bot,qa/skip-qa
+        labels: bot,qa/skip-qa,bot/resolve-build-deps
         body: |-
           ### Motivation
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
#### Before
We use the "Agent Platform" bot to open the PR after resolving and building dependencies.
#### After
We use the "Agent Integrations" bot to open the PR after resolving and building dependencies.
### Motivation
<!-- What inspired you to submit this pull request? -->
Easier maintenance: no need to coordinate between teams when rotating the token.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
