### PR TITLE
[Backport 7.66.x] Update singlestore image and version used in CI (#20207)

### DIFF
--- a/.ddev/ci/scripts/singlestore/linux/55_set_license_secret.sh
+++ b/.ddev/ci/scripts/singlestore/linux/55_set_license_secret.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-
-set +x
-
-echo "SINGLESTORE_LICENSE=$SINGLESTORE_LICENSE" >> "${GITHUB_ENV:-/tmp/gh-output}"
-
-set -x

--- a/.github/workflows/test-fips-e2e.yml
+++ b/.github/workflows/test-fips-e2e.yml
@@ -98,7 +98,6 @@ jobs:
         DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
         ORACLE_DOCKER_USERNAME: ${{ secrets.ORACLE_DOCKER_USERNAME }}
         ORACLE_DOCKER_PASSWORD: ${{ secrets.ORACLE_DOCKER_PASSWORD }}
-        SINGLESTORE_LICENSE: ${{ secrets.SINGLESTORE_LICENSE }}
         DD_GITHUB_USER: ${{ github.actor }}
         DD_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: ddev ci setup ${{ inputs.target || 'tls' }}

--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -199,15 +199,13 @@ jobs:
             "DOCKER_ACCESS_TOKEN": "{1}",
             "ORACLE_DOCKER_USERNAME": "{2}",
             "ORACLE_DOCKER_PASSWORD": "{3}",
-            "SINGLESTORE_LICENSE": "{4}",
-            "DD_GITHUB_USER": "{5}",
-            "DD_GITHUB_TOKEN": "{6}"
+            "DD_GITHUB_USER": "{4}",
+            "DD_GITHUB_TOKEN": "{5}"
           }}',
           secrets.DOCKER_USERNAME,
           secrets.DOCKER_ACCESS_TOKEN,
           secrets.ORACLE_DOCKER_USERNAME,
           secrets.ORACLE_DOCKER_PASSWORD,
-          secrets.SINGLESTORE_LICENSE,
           github.actor,
           secrets.GITHUB_TOKEN
         ))}}

--- a/singlestore/tests/compose/docker-compose.yaml
+++ b/singlestore/tests/compose/docker-compose.yaml
@@ -1,10 +1,11 @@
 services:
   singlestore:
-    image: 'singlestore/cluster-in-a-box:centos-7.5.9-a8744b5453-3.2.11-1.12.1'
+    image: ghcr.io/singlestore-labs/singlestoredb-dev:0.2.51
     ports:
       - 3306:3306
       - 8080:8080
+    # follow these steps if running on m1: https://github.com/singlestore-labs/singlestoredb-dev-image?tab=readme-ov-file#how-to-run-the-docker-image-on-apple-silicon-m1m2-chips
+    platform: linux/amd64
     environment:
-      LICENSE_KEY: ${LICENSE_KEY}
       ROOT_PASSWORD: 'password'
       START_AFTER_INIT: 'Y'

--- a/singlestore/tests/conftest.py
+++ b/singlestore/tests/conftest.py
@@ -27,11 +27,7 @@ def _mock_execute(query):
 @pytest.fixture(scope='session')
 def dd_environment():
     compose_file = os.path.join(HERE, 'compose', 'docker-compose.yaml')
-    license_key = os.environ.get('SINGLESTORE_LICENSE')
-    if not license_key:
-        raise Exception("Please set SINGLESTORE_LICENSE environment variable to a valid base64-encoded license.")
-
-    with docker_run(compose_file, env_vars={'LICENSE_KEY': license_key}, log_patterns=r'Listening on 0\.0\.0\.0'):
+    with docker_run(compose_file, log_patterns=r'Listening on 0\.0\.0\.0.'):
         yield {
             'host': get_docker_hostname(),
             'username': 'root',

--- a/singlestore/tests/test_integration.py
+++ b/singlestore/tests/test_integration.py
@@ -14,10 +14,10 @@ def test_integration(dd_environment, dd_run_check, datadog_agent, aggregator):
     aggregator.assert_all_metrics_covered()
     version_metadata = {
         'version.scheme': 'semver',
-        'version.major': '7',
-        'version.minor': '5',
-        'version.patch': '9',
-        'version.raw': '7.5.9',
+        'version.major': '8',
+        'version.minor': '9',
+        'version.patch': '19',
+        'version.raw': '8.9.19',
     }
     datadog_agent.assert_metadata('', version_metadata)
     aggregator.assert_service_check(


### PR DESCRIPTION
### What does this PR do?
backports "update singlestore image and version used in CI (#20207)" to fix ci
### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
