### PR TITLE
Remove duplicate idle MySQL activity rows

### DIFF
--- a/mysql/changelog.d/20222.fixed
+++ b/mysql/changelog.d/20222.fixed
@@ -1,0 +1,1 @@
+Remove duplicate idle MySQL activity rows

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -266,8 +266,19 @@ class MySQLActivity(DBMAsyncJob):
         # type: (List[Dict[str]]) -> List[Dict[str]]
         rows = sorted(rows, key=lambda r: self._sort_key(r))
         normalized_rows = []
+        seen = {}
+        second_pass = {}
         estimated_size = 0
         for row in rows:
+            if row["thread_id"] in seen:
+                # `performance_schema.events_statements_current` can contain previous statements
+                # for the same thread. We only want the most recent one.
+                if row["event_timer_end"] < seen[row["thread_id"]]["event_timer_start"]:
+                    continue
+                else:
+                    second_pass[row["thread_id"]] = {"event_timer_start": row["event_timer_start"]}
+            else:
+                seen[row["thread_id"]] = {"event_timer_start": row["event_timer_start"]}
             if row["sql_text"] is not None:
                 row["query_truncated"] = get_truncation_state(row["sql_text"]).value
             row = self._obfuscate_and_sanitize_row(row)
@@ -275,7 +286,19 @@ class MySQLActivity(DBMAsyncJob):
             if estimated_size > MySQLActivity.MAX_PAYLOAD_BYTES:
                 return normalized_rows
             normalized_rows.append(row)
+        if second_pass:
+            normalized_rows = self._eliminate_duplicate_rows(normalized_rows, second_pass)
         return normalized_rows
+
+    @staticmethod
+    def _eliminate_duplicate_rows(rows, second_pass):
+        # type: (List[Dict[str]], Dict[str]) -> List[Dict[str]]
+        filtered_rows = []
+        for row in rows:
+            if row["thread_id"] in second_pass and row["event_timer_end"] < second_pass[row["thread_id"]]["event_timer_start"]:
+                continue
+            filtered_rows.append(row)
+        return filtered_rows
 
     @staticmethod
     def _sort_key(row):

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -295,7 +295,10 @@ class MySQLActivity(DBMAsyncJob):
         # type: (List[Dict[str]], Dict[str]) -> List[Dict[str]]
         filtered_rows = []
         for row in rows:
-            if row["thread_id"] in second_pass and row["event_timer_end"] < second_pass[row["thread_id"]]["event_timer_start"]:
+            if (
+                row["thread_id"] in second_pass
+                and row["event_timer_end"] < second_pass[row["thread_id"]]["event_timer_start"]
+            ):
                 continue
             filtered_rows.append(row)
         return filtered_rows

--- a/mysql/tests/test_unit.py
+++ b/mysql/tests/test_unit.py
@@ -500,7 +500,6 @@ def test_database_identifier(template, expected, tags):
 
 
 def test__eliminate_duplicate_rows():
-    mysql_check = MySql(common.CHECK_NAME, {}, instances=[{'server': 'localhost', 'user': 'datadog'}])
     rows = [
         {'thread_id': 1, 'event_timer_start': 1000, 'event_timer_end': 2000, 'sql_text': 'SELECT 1'},
         {'thread_id': 1, 'event_timer_start': 2001, 'event_timer_end': 3000, 'sql_text': 'SELECT 1'},

--- a/mysql/tests/test_unit.py
+++ b/mysql/tests/test_unit.py
@@ -11,6 +11,7 @@ import pymysql
 import pytest
 
 from datadog_checks.mysql import MySql
+from datadog_checks.mysql.activity import MySQLActivity
 from datadog_checks.mysql.databases_data import DatabasesData, SubmitData
 from datadog_checks.mysql.version_utils import get_version
 
@@ -496,3 +497,13 @@ def test_database_identifier(template, expected, tags):
     check = MySql(common.CHECK_NAME, {}, instances=[config])
 
     assert check.database_identifier == expected
+    
+    
+def test__eliminate_duplicate_rows():
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[{'server': 'localhost', 'user': 'datadog'}])
+    rows = [
+        {'thread_id': 1, 'event_timer_start': 1000, 'event_timer_end': 2000, 'sql_text': 'SELECT 1'},
+        {'thread_id': 1, 'event_timer_start': 2001, 'event_timer_end': 3000, 'sql_text': 'SELECT 1'},
+    ]
+    second_pass = {1: {'event_timer_start': 2001}}
+    assert MySQLActivity._eliminate_duplicate_rows(rows, second_pass) == [{'thread_id': 1, 'event_timer_start': 2001, 'event_timer_end': 3000, 'sql_text': 'SELECT 1'},]

--- a/mysql/tests/test_unit.py
+++ b/mysql/tests/test_unit.py
@@ -497,8 +497,8 @@ def test_database_identifier(template, expected, tags):
     check = MySql(common.CHECK_NAME, {}, instances=[config])
 
     assert check.database_identifier == expected
-    
-    
+
+
 def test__eliminate_duplicate_rows():
     mysql_check = MySql(common.CHECK_NAME, {}, instances=[{'server': 'localhost', 'user': 'datadog'}])
     rows = [
@@ -506,4 +506,6 @@ def test__eliminate_duplicate_rows():
         {'thread_id': 1, 'event_timer_start': 2001, 'event_timer_end': 3000, 'sql_text': 'SELECT 1'},
     ]
     second_pass = {1: {'event_timer_start': 2001}}
-    assert MySQLActivity._eliminate_duplicate_rows(rows, second_pass) == [{'thread_id': 1, 'event_timer_start': 2001, 'event_timer_end': 3000, 'sql_text': 'SELECT 1'},]
+    assert MySQLActivity._eliminate_duplicate_rows(rows, second_pass) == [
+        {'thread_id': 1, 'event_timer_start': 2001, 'event_timer_end': 3000, 'sql_text': 'SELECT 1'},
+    ]


### PR DESCRIPTION
### What does this PR do?

Remove duplicate idle MySQL activity rows

### Motivation

Sampling idle blockers can produce rows for the statements that were already completed, because sometimes it can take longer to purge old statements from `performance_schema.events_statements_current`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
