### PR TITLE
Reenable HA

### DIFF
--- a/mysql/changelog.d/20226.fixed
+++ b/mysql/changelog.d/20226.fixed
@@ -1,0 +1,1 @@
+Reenable HA for MySQL

--- a/mysql/changelog.d/20226.fixed
+++ b/mysql/changelog.d/20226.fixed
@@ -1,1 +1,0 @@
-Reenable HA for MySQL

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -104,6 +104,7 @@ class MySql(AgentCheck):
     REPLICA_SERVICE_CHECK_NAME = 'mysql.replication.replica_running'
     GROUP_REPLICATION_SERVICE_CHECK_NAME = 'mysql.replication.group.status'
     DEFAULT_MAX_CUSTOM_QUERIES = 20
+    HA_SUPPORTED = True
 
     def __init__(self, name, init_config, instances):
         super(MySql, self).__init__(name, init_config, instances)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Restores `HA_SUPPORTED = True`, which was inadvertently removed in a previous PR.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
