### PR TITLE
Fix `redisdb` check on Redis 8

### DIFF
--- a/redisdb/changelog.d/20227.added
+++ b/redisdb/changelog.d/20227.added
@@ -1,0 +1,1 @@
+Add support of Redis 8

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -23,7 +23,7 @@ DEFAULT_CLIENT_NAME = "unknown"
 
 
 class Redis(AgentCheck):
-    db_key_pattern = re.compile(r'^db\d+')
+    db_key_pattern = re.compile(r'^db\d+$')
     slave_key_pattern = re.compile(r'^slave\d+')
     subkeys = ['keys', 'expires']
 

--- a/redisdb/hatch.toml
+++ b/redisdb/hatch.toml
@@ -2,12 +2,12 @@
 
 [[envs.default.matrix]]
 python = ["3.12"]
-version = ["5.0", "6.0", "7.0", "cloud"]
+version = ["5.0", "6.0", "7.0", "8.0", "cloud"]
 
 [envs.default.overrides]
 matrix.version.env-vars = [
-  { key = "REDIS_VERSION", if = ["5.0", "6.0", "7.0"] },
-  { key = "CLOUD_ENV", value = "false", if = ["5.0", "6.0", "7.0"] },
+  { key = "REDIS_VERSION", if = ["5.0", "6.0", "7.0", "8.0"] },
+  { key = "CLOUD_ENV", value = "false", if = ["5.0", "6.0", "7.0", "8.0"] },
   { key = "REDIS_VERSION", value="7.0", if = ["cloud"] },
   { key = "CLOUD_ENV", value = "true", if = ["cloud"] },
 ]


### PR DESCRIPTION
### What does this PR do?

Fix the following error of the `redisdb` check when executed against a Redis 8+ server:

```
    redisdb (7.1.0)
    ---------------
      Instance ID: redisdb:83469dfb5c3328af [ERROR]
      Configuration Source: file:/etc/datadog-agent/conf.d/redisdb.d/auto_conf.yaml
      Total Runs: 1
      Metric Samples: Last Run: 7, Total: 7
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 1
      Average Execution Time : 275ms
      Last Execution Date : 2025-05-06 13:21:00 UTC (1746537660000)
      Last Successful Execution Date : Never
      Error: 'expires'
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.12/site-packages/datadog_checks/base/checks/base.py", line 1301, in run
          self.check(instance)
        File "/opt/datadog-agent/embedded/lib/python3.12/site-packages/datadog_checks/redisdb/redisdb.py", line 554, in check
          self._check_db()
        File "/opt/datadog-agent/embedded/lib/python3.12/site-packages/datadog_checks/redisdb/redisdb.py", line 245, in _check_db
          expires_keys = info[key]["expires"]
                         ~~~~~~~~~^^^^^^^^^^^
      KeyError: 'expires'
```

This error happened because `info` contains:
```
{…, 'db0': {'keys': 1, 'expires': 0, 'avg_ttl': 0, 'subexpiry': 0}, 'db0_distrib_strings_sizes': {'4': 1}}
```

And not only `db0` was matching `db_key_pattern`, but also `db0_distrib_strings_sizes`.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
