### PR TITLE
[DJM-812] Airflow task logs child pipeline

### DIFF
--- a/airflow/assets/logs/airflow.yaml
+++ b/airflow/assets/logs/airflow.yaml
@@ -82,3 +82,29 @@ pipeline:
       enabled: true
       sources:
         - message
+    - type: pipeline
+      name: Task logs pipeline 
+      enabled: true
+      filter:
+        query: "dirname:*dag_id*"
+      processors:
+        - type: attribute-remapper
+          name: Map tag `dirname` to an attribute
+          enabled: true
+          sources:
+            - dirname
+          sourceType: tag
+          target: dirname
+          targetType: attribute
+          preserveSource: false
+          overrideOnConflict: false
+        - type: grok-parser
+          name: Task Attributes Parser
+          enabled: true
+          source: dirname
+          samples:
+            - path/to/airflow/logs/dag_id_airflow_dag_0/run_id_scheduled__2025-02-18T14_46_00+00_00/task_id_print_task_0/attempt_1.log
+          grok:
+            supportRules: ""
+            matchRules: default
+              (.*dag_id_%{word:airflow.dagRun.dag_id}/run_id_%{data:airflow.dagRun.run_id}/task_id_%{word:airflow.task.task_id}/attempt_%{word:airflow.task.attempt_id}.log)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR updates the Airflow integration logs pipeline to extract `dag_id`, `run_id`, and `task_id` from the dirname tag. Extraction is performed in a children subpipeline, which query checks for the presence of `dag_id` in `dirname` tag so that it's guaranteed that pipeline will find the attributes to be extracted.

### Motivation
<!-- What inspired you to submit this pull request? -->
Airflow DJM traces to logs correlation is made on `dag_id`, `run_id`, and `task_id` attributes so they need to be present on the logs. See logic here. T

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
