### PR TITLE
Ensure Validate Pinned Actions run on master

### DIFF
--- a/.github/workflows/validate-pinned-actions.yml
+++ b/.github/workflows/validate-pinned-actions.yml
@@ -1,6 +1,9 @@
 name: Validate Pinned Actions
 on:
   pull_request: {}
+  push:
+    branches:
+      - master
   merge_group:
     # Test requested to pass before merging
     # needs to trigger in merge queues


### PR DESCRIPTION
### What does this PR do?
This is a safe guard to ensure that master always run this in case someone merged skipping validations. This is also needed so the status check is visible in GitHub repo settings for some reason.

### Motivation
Allow the status check to be configured as a requried status check on PRs.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
