### PR TITLE
Add exclude_hostname to Postgres and MySQL specs

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -70,6 +70,13 @@ files:
               and can be useful to set a custom hostname when connecting to a remote database through a proxy.
             value:
               type: string
+          - name: exclude_hostname
+            description: |
+              Omit the hostname from tags and events. This is useful when the database host is not monitored by an agent.
+            value:
+              type: boolean
+              example: false
+            default: false
           - name: database_identifier
             description: |
               Controls how the database is identified. The default value is the resolved hostname for the instance,

--- a/mysql/datadog_checks/mysql/config_models/defaults.py
+++ b/mysql/datadog_checks/mysql/config_models/defaults.py
@@ -32,6 +32,10 @@ def instance_empty_default_hostname():
     return False
 
 
+def instance_exclude_hostname():
+    return False
+
+
 def instance_log_unobfuscated_plans():
     return False
 

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -224,6 +224,7 @@ class InstanceConfig(BaseModel):
     defaults_file: Optional[str] = None
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
+    exclude_hostname: Optional[bool] = None
     gcp: Optional[Gcp] = None
     host: Optional[str] = None
     index_metrics: Optional[IndexMetrics] = None

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -64,6 +64,11 @@ instances:
     #
     # reported_hostname: <REPORTED_HOSTNAME>
 
+    ## @param exclude_hostname - boolean - optional - default: false
+    ## Omit the hostname from tags and events. This is useful when the database host is not monitored by an agent.
+    #
+    # exclude_hostname: false
+
     ## Controls how the database is identified. The default value is the resolved hostname for the instance,
     ## which respects the `reported_hostname` option.
     ##

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -51,6 +51,13 @@ files:
         and can be useful to set a custom hostname when connecting to a remote database through a proxy.
       value:
         type: string
+    - name: exclude_hostname
+      description: |
+        Omit the hostname from tags and events. This is useful when the database host is not monitored by an agent.
+      value:
+        type: boolean
+        example: false
+      default: false
     - name: database_identifier
       description: |
         Controls how the database is identified. The default value is the resolved hostname for the instance, 

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -84,6 +84,10 @@ def instance_empty_default_hostname():
     return False
 
 
+def instance_exclude_hostname():
+    return False
+
+
 def instance_idle_connection_timeout():
     return 60000
 

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -257,6 +257,7 @@ class InstanceConfig(BaseModel):
     dbstrict: Optional[bool] = None
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
+    exclude_hostname: Optional[bool] = None
     gcp: Optional[Gcp] = None
     host: str
     idle_connection_timeout: Optional[int] = None

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -64,6 +64,11 @@ instances:
     #
     # reported_hostname: <REPORTED_HOSTNAME>
 
+    ## @param exclude_hostname - boolean - optional - default: false
+    ## Omit the hostname from tags and events. This is useful when the database host is not monitored by an agent.
+    #
+    # exclude_hostname: false
+
     ## Controls how the database is identified. The default value is the resolved hostname for the instance, 
     ## which respects the `reported_hostname` option.
     ##


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds `exclude_hostname` to Postgres and MySQL specs.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
