### PR TITLE
Allow slowlog collection to fail

### DIFF
--- a/redisdb/changelog.d/20261.fixed
+++ b/redisdb/changelog.d/20261.fixed
@@ -1,0 +1,1 @@
+Allow slowlog collection to fail without error to support some managed Redis that do not allow SLOWLOG GET.

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -516,7 +516,11 @@ class Redis(AgentCheck):
             max_slow_entries = int(self.instance.get(MAX_SLOW_ENTRIES_KEY))
 
         # Get all slowlog entries
-        slowlogs = conn.slowlog_get(max_slow_entries)
+        try:
+            slowlogs = conn.slowlog_get(max_slow_entries)
+        except redis.ResponseError:
+            self.log.debug("Unable to collect slow log: SLOWLOG GET disabled in some managed Redis.")
+            return
 
         # Find slowlog entries between last timestamp and now using start_time
         slowlogs = [s for s in slowlogs if s['start_time'] > self.last_timestamp_seen]

--- a/redisdb/tests/test_unit.py
+++ b/redisdb/tests/test_unit.py
@@ -122,7 +122,7 @@ def test_slowlog_quiet_failure(check, aggregator, redis_instance):
         aggregator.assert_metric('redis.slowlog.micros', count=0)
 
 
-def test_slowlog_loud_failure(check, aggregator, redis_instance):
+def test_slowlog_loud_failure(check, redis_instance):
     """
     The check should fail if the slowlog command fails for any other reason
     """

--- a/redisdb/tests/test_unit.py
+++ b/redisdb/tests/test_unit.py
@@ -107,9 +107,32 @@ def test__check_total_commands_processed_present(check, aggregator, redis_instan
 
 def test_slowlog_quiet_failure(check, aggregator, redis_instance):
     """
-    The check should not fail if the slowlog command fails
+    The check should not fail if the slowlog command fails with redis.ResponseError
     """
-    with mock.patch('redis.Redis.slowlog_get', side_effect=ResponseError('ERR unknown command `SLOWLOG`')):
-        check(redis_instance)
+    redis_check = check(redis_instance)
+
+    # Mock the connection object returned by _get_conn
+    mock_conn = mock.MagicMock()
+    mock_conn.slowlog_get.side_effect = ResponseError('ERR unknown command `SLOWLOG`')
+    mock_conn.config_get.return_value = {'slowlog-max-len': '128'}
+
+    with mock.patch.object(redis_check, '_get_conn', return_value=mock_conn):
+        redis_check._check_slowlog()
         # Assert that no metrics were sent
         aggregator.assert_metric('redis.slowlog.micros', count=0)
+
+
+def test_slowlog_loud_failure(check, aggregator, redis_instance):
+    """
+    The check should fail if the slowlog command fails for any other reason
+    """
+    redis_check = check(redis_instance)
+
+    # Mock the connection object returned by _get_conn
+    mock_conn = mock.MagicMock()
+    mock_conn.slowlog_get.side_effect = RuntimeError('Some other error')
+    mock_conn.config_get.return_value = {'slowlog-max-len': '128'}
+
+    with mock.patch.object(redis_check, '_get_conn', return_value=mock_conn):
+        with pytest.raises(RuntimeError, match='Some other error'):
+            redis_check._check_slowlog()

--- a/redisdb/tests/test_unit.py
+++ b/redisdb/tests/test_unit.py
@@ -3,9 +3,9 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import mock
 import pytest
+from redis.exceptions import ResponseError
 
 from datadog_checks.dev.utils import get_metadata_metrics
-from redis.exceptions import ResponseError
 
 pytestmark = pytest.mark.unit
 
@@ -103,6 +103,7 @@ def test__check_total_commands_processed_present(check, aggregator, redis_instan
 
     # Assert that the `redis.net.commands` metric was sent
     aggregator.assert_metric('redis.net.commands', value=1000, tags=['test_total_commands_processed'])
+
 
 def test_slowlog_quiet_failure(check, aggregator, redis_instance):
     """


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Allow the slowlog collection to fail during the API call.

### Motivation
<!-- What inspired you to submit this pull request? -->
Some managed Redis do not allow the SLOWLOG GET command. 
This results in repeated error messages from the Redis CLI as there is no option to disable the slowlog collection.

>[!NOTE]
> Another solution would be to add a config parameter that allows to disable the slowlog collection.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
