### PR TITLE
doc(nginx-ingress-controller): mention the additional parameter required for histogram metrics

### DIFF
--- a/nginx_ingress_controller/README.md
+++ b/nginx_ingress_controller/README.md
@@ -64,8 +64,8 @@ See the [sample nginx_ingress_controller.d/conf.yaml][3] for all available confi
     }
 ```
 
-**Note2**: Histogram metrics (like `nginx_ingress.controller.response.*` metrics) will not be collected by default and will require the additionnal [collect_nginx_histograms][12] instance config parameter
-to be set to `true`. The parameter defauls to `false` because the histogram metrics are known to have high tag cardinality.
+**Note**: Histogram metrics (like `nginx_ingress.controller.response.*` metrics) are not collected by default and require the additional [collect_nginx_histograms][12] instance config parameter
+to be set to `true`. The parameter defaults to `false` because the histogram metrics are known to have high tag cardinality.
 
 | Parameter            | Value                                                                                                              |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------ |

--- a/nginx_ingress_controller/README.md
+++ b/nginx_ingress_controller/README.md
@@ -64,6 +64,14 @@ See the [sample nginx_ingress_controller.d/conf.yaml][3] for all available confi
     }
 ```
 
+**Note2**: Histogram metrics (like `nginx_ingress.controller.response.*` metrics) will not be collected by default and will require the additionnal [collect_nginx_histograms][12] instance config parameter
+to be set to `true`. The parameter defauls to `false` because the histogram metrics are known to have high tag cardinality.
+
+| Parameter            | Value                                                                                                              |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `<INSTANCE_CONFIG>`  | `[{"nginx_status_url": "http://%%host%%:18080/nginx_status"},{"prometheus_url": "http://%%host%%:10254/metrics", "collect_nginx_histograms": true}]` |
+
+
 #### Log collection
 
 _Available for Agent versions >6.0_
@@ -107,3 +115,4 @@ Need help? Contact [Datadog support][9].
 [9]: https://docs.datadoghq.com/help/
 [10]: https://docs.datadoghq.com/agent/kubernetes/prometheus/
 [11]: https://github.com/nginxinc/nginx-prometheus-exporter#exported-metrics
+[12]: https://github.com/DataDog/integrations-core/blob/master/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example#L59C7-L59C31


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add a mention in the documentation for the `collect_nginx_histograms` boolean that is required to have the histogram metrics collected by the agent.

### Motivation
<!-- What inspired you to submit this pull request? -->

The integration documentation lists metrics that will not be visible in datadog unless one provides the parameter in the instances configuration. This can easily lead to believing there is an issue with metrics collection since the additional (required) parameter to have all listed metrics is not mentioned in the page.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
