### PR TITLE
Bump redis dependency to 6.0.0

### DIFF
--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -52,7 +52,7 @@ python3-gearman==0.1.0; sys_platform != 'win32'
 pyvmomi==8.0.3.0.1
 pywin32==310; sys_platform == 'win32'
 pyyaml==6.0.2
-redis==5.2.1
+redis==6.0.0
 requests-kerberos==0.15.0
 requests-ntlm==1.3.0
 requests-oauthlib==2.0.0

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -176,8 +176,6 @@ class Redis(AgentCheck):
                     'password',
                     'socket_timeout',
                     'connection_pool',
-                    'charset',
-                    'errors',
                     'unix_socket_path',
                     'ssl',
                     'ssl_certfile',

--- a/redisdb/pyproject.toml
+++ b/redisdb/pyproject.toml
@@ -36,7 +36,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "redis==5.2.1",
+    "redis==6.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?
Bumps redis version to 6.0.0: https://github.com/redis/redis-py/releases/tag/v6.0.0
It includes some breaking changes such as removing previously deprecated fields that we supported 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
