### PR TITLE
Dbmon 5125 collect postgres extensions in agent

### DIFF
--- a/postgres/changelog.d/20266.added
+++ b/postgres/changelog.d/20266.added
@@ -1,0 +1,1 @@
+Collect and forward list of PostgreSQL extensions

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -291,6 +291,7 @@ class PostgresMetadata(DBMAsyncJob):
         self.tags = [t for t in self._tags if not t.startswith("dd.internal")]
         self._tags_no_db = [t for t in self.tags if not t.startswith("db:")]
         self.report_postgres_metadata()
+        self.report_postgres_extensions()
         self._check.db_pool.prune_connections()
 
     @tracked_method(agent_check_getter=agent_check_getter)

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -35,12 +35,12 @@ DEFAULT_SETTINGS_IGNORED_PATTERNS = ["plpgsql%"]
 # spective catalog tables.
 PG_EXTENSION_INFO_QUERY = """
 SELECT
-e.oid id,
-e.extname name,
-r.rolname owner,
-ns.nspname schema_name,
-e.extrelocatable relocatable,
-e.extversion version
+e.oid AS id,
+e.extname AS name,
+r.rolname AS owner,
+ns.nspname AS schema_name,
+e.extrelocatable AS relocatable,
+e.extversion AS version
 FROM pg_extension e
 LEFT JOIN pg_namespace ns on e.extnamespace = ns.oid
      JOIN pg_roles r ON e.extowner = r.oid;

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -24,12 +24,29 @@ from .util import payload_pg_version
 from .version_utils import VersionUtils
 
 # default collection intervals in seconds
+DEFAULT_EXTENSIONS_COLLECTION_INTERVAL = 600
 DEFAULT_SETTINGS_COLLECTION_INTERVAL = 600
 DEFAULT_SCHEMAS_COLLECTION_INTERVAL = 600
 DEFAULT_RESOURCES_COLLECTION_INTERVAL = 300
 DEFAULT_SETTINGS_IGNORED_PATTERNS = ["plpgsql%"]
 
-# PG_SETTINGS_QURERY is used to collect all the settings from the pg_settings table
+# PG_EXTENSION_INFO_QUERY is used to collect extension names and versions from
+# the pg_extension table. Schema names and roles are retrieved from their re-
+# spective catalog tables.
+PG_EXTENSION_INFO_QUERY = """
+SELECT
+e.oid id,
+e.extname name,
+r.rolname owner,
+ns.nspname schema_name,
+e.extrelocatable relocatable,
+e.extversion version
+FROM pg_extension e
+LEFT JOIN pg_namespace ns on e.extnamespace = ns.oid
+     JOIN pg_roles r ON e.extowner = r.oid;
+"""
+
+# PG_SETTINGS_QUERY is used to collect all the settings from the pg_settings table
 # Edge case: If source is 'session', it uses reset_val
 # (which represents the value that the setting would revert to on session end or reset),
 # otherwise, it uses the current setting value.
@@ -211,6 +228,9 @@ class PostgresMetadata(DBMAsyncJob):
         self.pg_settings_ignored_patterns = config.settings_metadata_config.get(
             "ignored_settings_patterns", DEFAULT_SETTINGS_IGNORED_PATTERNS
         )
+        self.pg_extensions_collection_interval = config.settings_metadata_config.get(
+            "collection_interval", DEFAULT_EXTENSIONS_COLLECTION_INTERVAL
+        )
         self.pg_settings_collection_interval = config.settings_metadata_config.get(
             "collection_interval", DEFAULT_SETTINGS_COLLECTION_INTERVAL
         )
@@ -221,9 +241,12 @@ class PostgresMetadata(DBMAsyncJob):
             "collection_interval", DEFAULT_RESOURCES_COLLECTION_INTERVAL
         )
 
-        # by default, send resources every 5 minutes
+        # by default, send resources every 10 minutes
         self.collection_interval = min(
-            resources_collection_interval, self.pg_settings_collection_interval, self.schemas_collection_interval
+            resources_collection_interval,
+            self.pg_extensions_collection_interval,
+            self.pg_settings_collection_interval,
+            self.schemas_collection_interval,
         )
 
         super(PostgresMetadata, self).__init__(
@@ -240,10 +263,12 @@ class PostgresMetadata(DBMAsyncJob):
         self._check = check
         self._config = config
         self.db_pool = self._check.db_pool
+        self._collect_extensions_enabled = is_affirmative(config.settings_metadata_config.get("enabled", False))
         self._collect_pg_settings_enabled = is_affirmative(config.settings_metadata_config.get("enabled", False))
         self._collect_schemas_enabled = is_affirmative(config.schemas_metadata_config.get("enabled", False))
         self._is_schemas_collection_in_progress = False
         self._pg_settings_cached = None
+        self._time_since_last_extension_query = 0
         self._time_since_last_settings_query = 0
         self._last_schemas_query_time = 0
         self._conn_ttl_ms = self._config.idle_connection_timeout
@@ -267,6 +292,40 @@ class PostgresMetadata(DBMAsyncJob):
         self._tags_no_db = [t for t in self.tags if not t.startswith("db:")]
         self.report_postgres_metadata()
         self._check.db_pool.prune_connections()
+
+    @tracked_method(agent_check_getter=agent_check_getter)
+    def report_postgres_extensions(self):
+        # Only query if configured, according to interval
+        elapsed_s = time.time() - self._time_since_last_extension_query
+        if elapsed_s >= self.pg_extensions_collection_interval and self._collect_extensions_enabled:
+            self._extensions_cached = self._collect_postgres_extensions()
+        event = {
+            "host": self._check.reported_hostname,
+            "database_instance": self._check.database_identifier,
+            "agent_version": datadog_agent.get_version(),
+            "dbms": "postgres",
+            "kind": "pg_extension",
+            "collection_interval": self.collection_interval,
+            "dbms_version": payload_pg_version(self._check.version),
+            "tags": self._tags_no_db,
+            "timestamp": time.time() * 1000,
+            "cloud_metadata": self._check.cloud_metadata,
+            "metadata": self._extensions_cached,
+        }
+        self._check.database_monitoring_metadata(json.dumps(event, default=default_json_event_encoding))
+
+    @tracked_method(agent_check_getter=agent_check_getter)
+    def _collect_postgres_extensions(self):
+        with self._check._get_main_db() as conn:
+            with conn.cursor(cursor_factory=CommenterDictCursor) as cursor:
+                self._time_since_last_extension_query = time.time()
+
+                # Get loaded extensions
+                cursor.execute(PG_EXTENSION_INFO_QUERY)
+                rows = cursor.fetchall()
+
+                self._log.debug("Loaded %s rows from pg_extension", len(rows))
+                return [dict(row) for row in rows]
 
     @tracked_method(agent_check_getter=agent_check_getter)
     def report_postgres_metadata(self):


### PR DESCRIPTION
### What does this PR do?
Causes the agent to emit events with data about installed PostgreSQL extensions (i.e. sourced from `pg_extension`.

### Motivation
Scheduled feature development (see ticket)

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
