### PR TITLE
Add Contact Support details

### DIFF
--- a/solr/README.md
+++ b/solr/README.md
@@ -210,6 +210,8 @@ The `datadog-agent jmx` command was added in version 4.1.0.
 - Start the collection of metrics based on your current configuration and display them in the console:
   `sudo datadog-agent jmx collect`
 
+Need help? Contact [Datadog support](https://docs.datadoghq.com/help/).
+
 ## Further Reading
 
 ### Parsing a string value into a number


### PR DESCRIPTION
### What does this PR do?
At the end of the Troubleshooting section, adding a note to contact Datadog support in case that additional assistance is needed.

### Motivation
This is as per the standard of other core Agent integration documentation pages.
