### PR TITLE
Bump minimum base version and python to 3.12 for slurm, esxi and mongo

### DIFF
--- a/esxi/changelog.d/20271.changed
+++ b/esxi/changelog.d/20271.changed
@@ -1,0 +1,1 @@
+Bump datadog-checks-base to 37.10.1 and python to 3.12

--- a/esxi/pyproject.toml
+++ b/esxi/pyproject.toml
@@ -9,7 +9,7 @@ name = "datadog-esxi"
 description = "The ESXi check"
 readme = "README.md"
 license = "BSD-3-Clause"
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 keywords = [
     "datadog",
     "datadog agent",
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=34.1.2",
+    "datadog-checks-base>=37.10.1",
 ]
 dynamic = [
     "version",

--- a/mongo/changelog.d/20271.changed
+++ b/mongo/changelog.d/20271.changed
@@ -1,0 +1,1 @@
+Bump datadog-checks-base to 37.10.1 and python to 3.12

--- a/mongo/pyproject.toml
+++ b/mongo/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 name = "datadog-mongo"
 description = "The MongoDB check"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 keywords = [
     "datadog",
     "datadog agent",
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=36.11.0",
+    "datadog-checks-base>=37.10.1",
 ]
 dynamic = [
     "version",

--- a/slurm/changelog.d/20271.changed
+++ b/slurm/changelog.d/20271.changed
@@ -1,0 +1,1 @@
+Bump datadog-checks-base to 37.10.1

--- a/slurm/pyproject.toml
+++ b/slurm/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=33.0.0",
+    "datadog-checks-base>=37.10.1",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?
Bump the minimum base check dependency in `slurm`, `esxi` and `mongo` extensions to the latest one. These were the only integrations that still had a base checks version with support for python 2. 

For `mongo` and `esxi` the python version has also been bumped to 3.12 to be coherent with the latest requirement in the base package.

### Motivation
Get out of python 2 support and [fix our CI](https://github.com/DataDog/integrations-core/actions/runs/14988644575) where python 2 construct are not available anymore.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
