### PR TITLE
Fix test_e2e_python by specifying Python loader in config

### DIFF
--- a/snmp/tests/test_e2e_python.py
+++ b/snmp/tests/test_e2e_python.py
@@ -15,6 +15,7 @@ pytestmark = pytest.mark.e2e
 def test_e2e_python(dd_agent_check):
     metrics = common.SUPPORTED_METRIC_TYPES
     config = common.generate_container_instance_config(metrics)
+    config['init_config']['loader'] = 'python'
     instance = config['instances'][0]
     aggregator = dd_agent_check(config, rate=True)
     tags = ['snmp_device:{}'.format(instance['ip_address'])]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Since PR https://github.com/DataDog/datadog-agent/pull/36207, the loader by default for SNMP is the Core one. This PR fix the failing `test_e2e_python` test which assumed that the loader by default is Python.

Tested with `ddev`, the `test_e2e_python` test was failing before the change, and it succeeds with the change.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
