### PR TITLE
[OTELS-583] Fix DD connector & exporter graphs on OTel dashboard

### DIFF
--- a/otel/assets/dashboards/otel_collector_metrics_dashboard.json
+++ b/otel/assets/dashboards/otel_collector_metrics_dashboard.json
@@ -1999,7 +1999,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_traces{source:datadogexporter,$service}",
+                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_traces{source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2044,7 +2044,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_spans{source:datadogexporter,$service}",
+                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_spans{source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2172,7 +2172,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_bytes{source:datadogexporter,$service}",
+                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_bytes{source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2224,7 +2224,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_payloads{source:datadogexporter,$service}",
+                                            "query": "sum:otelcol_datadog_trace_agent_trace_writer_payloads{source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2363,7 +2363,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_otlp_traces{source:datadogexporter,$service}",
+                                            "query": "sum:otelcol_datadog_trace_agent_otlp_traces{source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2415,7 +2415,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_otlp_spans{source:datadogexporter,$service}",
+                                            "query": "sum:otelcol_datadog_trace_agent_otlp_spans{source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2631,7 +2631,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_otlp_traces{source:datadogconnector,$service}",
+                                            "query": "sum:otelcol_datadog_trace_agent_otlp_traces{source:datadogconnector,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2683,7 +2683,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_otlp_spans{source:datadogconnector,$service}",
+                                            "query": "sum:otelcol_datadog_trace_agent_otlp_spans{source:datadogconnector,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2735,7 +2735,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_payloads{source:datadogexporter,$service}",
+                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_payloads{source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2780,7 +2780,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_bytes{source:datadogexporter,$service}",
+                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_bytes{source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -2891,7 +2891,7 @@
                                     ],
                                     "queries": [
                                         {
-                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_stats_entries{source:datadogexporter,$service}",
+                                            "query": "sum:otelcol_datadog_trace_agent_stats_writer_stats_entries{source:datadogexporter,$service}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }


### PR DESCRIPTION
### What does this PR do?
Fix DD connector & exporter graphs on OTel dashboard

Those graphs used to have as_rate() but  as_rate()  doesn't work with equiv_otel so we replaced  as_rate()  with per_second. It looks like for per_second  to work properly, the graphs need as_count() too

Tested in org [Datadog OpenTelemetry](http://app.datadoghq.com/dashboard/miv-gng-wvk/opentelemetry-collector-metrics-dashboard-with-equivotel?fromUser=false&refresh_mode=sliding&from_ts=1747152563648&to_ts=1747156163648&live=true). Graphs do show a difference in values before and after adding as_count()

<img width="855" alt="Screenshot 2025-05-13 at 1 08 03 PM" src="https://github.com/user-attachments/assets/dbc6bc11-76f2-4281-b442-5ef9f90bcb0c" />
<img width="892" alt="Screenshot 2025-05-13 at 1 07 49 PM" src="https://github.com/user-attachments/assets/85799092-6878-43b3-b7cd-78f779286f10" />


### Motivation
[#incident-38288](https://dd.slack.com/archives/C08RQ56NV39/p1747148094858549)

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
