### PR TITLE
Fail ddev macos signing faster for better debugging

### DIFF
--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -434,6 +434,7 @@ jobs:
     - name: Set reusable script - Notarize binaries
       id: script-notarize
       # https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution
+      # We pass the --wait flag to catch problems with signing sooner at the cost of slowing down the job a little bit.
       run: |-
         cat <<"OUTER" >> $GITHUB_OUTPUT
         script<<INNER
@@ -447,6 +448,7 @@ jobs:
         cd ../notarize-bin
         for f in *; do
           rcodesign notary-submit -vv \
+          -- wait \
           --api-key-path /tmp/app-store-connect.json \
           "$f"
         done


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
#### Before
Our CI would fail when we try to sign the macos installer even if the failure originated earlier in the pipeline.

#### After
Our CI will fail already when we sign the binaries, so earlier in the process.

### Motivation
<!-- What inspired you to submit this pull request? -->
Better debugging.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
