### PR TITLE
Add database to database identifier template variables

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -98,6 +98,9 @@ files:
             - resolved_hostname: The resolved hostname of the instance, which respects the `reported_hostname` option.
             - host: The provided host of the instance.
             - port: The port number of the instance.
+            - azure_name: The resolved hostname of the instance, which respects the `reported_hostname` option,
+              but removes `.database.windows.net`
+            - database: The connection database.
             - server_name: The resolved server name of the instance.
             - instance_name: The resolved instance name of the instance.
             In addition, you can use any key from the `tags` section of the configuration.

--- a/sqlserver/changelog.d/20301.added
+++ b/sqlserver/changelog.d/20301.added
@@ -1,0 +1,1 @@
+Add database to SQL Server database identifier template variables

--- a/sqlserver/changelog.d/20301.added
+++ b/sqlserver/changelog.d/20301.added
@@ -1,1 +1,1 @@
-Add database to SQL Server database identifier template variables
+Add database and Azure name to SQL Server database identifier template variables

--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -38,6 +38,8 @@ AZURE_DEPLOYMENT_TYPE_TO_RESOURCE_TYPES = {
     "managed_instance": "azure_sql_server_managed_instance",
     "virtual_machine": "azure_virtual_machine_instance",
 }
+AZURE_SERVER_SUFFIX = ".database.windows.net"
+
 
 # Metric discovery queries
 COUNTER_TYPE_QUERY = """select distinct cntr_type

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -100,6 +100,9 @@ instances:
         ## - resolved_hostname: The resolved hostname of the instance, which respects the `reported_hostname` option.
         ## - host: The provided host of the instance.
         ## - port: The port number of the instance.
+        ## - azure_name: The resolved hostname of the instance, which respects the `reported_hostname` option,
+        ##   but removes `.database.windows.net`
+        ## - database: The connection database.
         ## - server_name: The resolved server name of the instance.
         ## - instance_name: The resolved instance name of the instance.
         ## In addition, you can use any key from the `tags` section of the configuration.

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -330,7 +330,7 @@ class SQLServer(AgentCheck):
             tag_dict['resolved_hostname'] = self.resolved_hostname
             tag_dict['host'] = str(self.host)
             tag_dict['port'] = str(self.port)
-            print(self.static_info_cache)
+            tag_dict['database'] = str(self.instance.get('database', self.connection.DEFAULT_DATABASE))
             if self.static_info_cache.get(STATIC_INFO_SERVERNAME) is not None:
                 tag_dict['server_name'] = self.static_info_cache.get(STATIC_INFO_SERVERNAME)
             if self.static_info_cache.get(STATIC_INFO_INSTANCENAME) is not None:

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -330,7 +330,9 @@ class SQLServer(AgentCheck):
             tag_dict['resolved_hostname'] = self.resolved_hostname
             tag_dict['host'] = str(self.host)
             tag_dict['port'] = str(self.port)
-            tag_dict['database'] = str(self.instance.get('database', self.connection.DEFAULT_DATABASE))
+            tag_dict['database'] = str(
+                self.instance.get('database', self.connection.DEFAULT_DATABASE if self.connection else None)
+            )
             if self.static_info_cache.get(STATIC_INFO_SERVERNAME) is not None:
                 tag_dict['server_name'] = self.static_info_cache.get(STATIC_INFO_SERVERNAME)
             if self.static_info_cache.get(STATIC_INFO_INSTANCENAME) is not None:

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -67,6 +67,7 @@ from datadog_checks.sqlserver.const import (
     AUTODISCOVERY_QUERY,
     AWS_RDS_HOSTNAME_SUFFIX,
     AZURE_DEPLOYMENT_TYPE_TO_RESOURCE_TYPES,
+    AZURE_SERVER_SUFFIX,
     BASE_NAME_QUERY,
     COUNTER_TYPE_QUERY,
     DATABASE_SERVICE_CHECK_NAME,
@@ -333,6 +334,8 @@ class SQLServer(AgentCheck):
             tag_dict['database'] = str(
                 self.instance.get('database', self.connection.DEFAULT_DATABASE if self.connection else None)
             )
+            if self.resolved_hostname.endswith(AZURE_SERVER_SUFFIX):
+                tag_dict['azure_name'] = self.resolved_hostname[: -len(AZURE_SERVER_SUFFIX)]
             if self.static_info_cache.get(STATIC_INFO_SERVERNAME) is not None:
                 tag_dict['server_name'] = self.static_info_cache.get(STATIC_INFO_SERVERNAME)
             if self.static_info_cache.get(STATIC_INFO_INSTANCENAME) is not None:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
* Adds the connection database to SQL Server database identifier
* Adds the Azure hostname minus the windows suffix to the identifier variables

### Motivation
<!-- What inspired you to submit this pull request? -->
Azure SQL Server pool users often use the database to distinguish between multiple DBM instances and may want to refer to the hostname without the suffix due to previous DBM behavior

### Review checklist (to be filled by reviewers)
<img width="1046" alt="Screenshot 2025-05-15 at 12 41 44 PM" src="https://github.com/user-attachments/assets/9d9a6310-91c9-4cae-a8dd-08cb5f1a15db" />

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
