### PR TITLE
Add allow list configuration for Consul service tags to Consul check

### DIFF
--- a/consul/assets/configuration/spec.yaml
+++ b/consul/assets/configuration/spec.yaml
@@ -109,6 +109,20 @@ files:
           - <SERVICE_1>
           - <SERVICE_2>
 
+    - name: services_tags_keys_include
+      description: |
+        If set, only tags with keys matching this list will be sent to Datadog.
+        This is helpful if you have a lot of tags on services that are not
+        relevant to Datadog (ingress routing tags, etc). Tags should be specified
+        here in lowercase, the check will downcase tags from Consul before comparing.
+      value:
+        type: array
+        items:
+          type: string
+        example:
+          - <TAG_1>
+          - <TAG_2>
+
     - name: max_services
       description: |
         Increase the maximum number of queried services.

--- a/consul/datadog_checks/consul/config_models/instance.py
+++ b/consul/datadog_checks/consul/config_models/instance.py
@@ -91,6 +91,7 @@ class InstanceConfig(BaseModel):
     service: Optional[str] = None
     services_exclude: Optional[tuple[str, ...]] = None
     services_include: Optional[tuple[str, ...]] = None
+    services_tags_keys_include: Optional[tuple[str, ...]] = None
     single_node_install: Optional[bool] = None
     skip_proxy: Optional[bool] = None
     tags: Optional[tuple[str, ...]] = None

--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -106,6 +106,7 @@ class ConsulCheck(OpenMetricsBaseCheck):
             'service_whitelist', self.instance.get('services_include', default_services_include)
         )
         self.services_exclude = set(self.instance.get('services_exclude', self.init_config.get('services_exclude', [])))
+        self.services_tags_keys_include = set(self.instance.get("services_tags_keys_include", self.init_config.get("services_tags_keys_include", [])))
         self.max_services = self.instance.get('max_services', self.init_config.get('max_services', MAX_SERVICES))
         self.threads_count = self.instance.get('threads_count', self.init_config.get('threads_count', THREADS_COUNT))
         if self.threads_count > 1:
@@ -312,6 +313,18 @@ class ConsulCheck(OpenMetricsBaseCheck):
 
         return services
 
+    def _cull_services_tags_list(self, services):
+        if self.services_tags_keys_include:
+            # services is a dict of {service_name: [tags]} where tags is a list
+            # of string having the form of "tagkey=tagvalue"
+            for service in services:
+                tags = services[service]
+                # get the tagkey (the part before the "=") and check it against the include list
+                tags = [t for t in tags if t.split("=")[0].lower() in self.services_tags_keys_include]
+                services[service] = tags
+
+        return services
+
     @staticmethod
     def _get_service_tags(service, tags):
         service_tags = ['consul_service_id:{}'.format(service)]
@@ -397,6 +410,7 @@ class ConsulCheck(OpenMetricsBaseCheck):
             self.count_all_nodes(main_tags)
 
             services = self._cull_services_list(services)
+            tags = self._cull_services_tags_list(services)
 
             # {node_id: {"up: 0, "passing": 0, "warning": 0, "critical": 0}
             nodes_to_service_status = defaultdict(lambda: defaultdict(int))

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -126,6 +126,16 @@ instances:
     #   - <SERVICE_1>
     #   - <SERVICE_2>
 
+    ## @param services_tags_keys_include - list of strings - optional
+    ## If set, only tags with keys matching this list will be sent to Datadog.
+    ## This is helpful if you have a lot of tags on services that are not
+    ## relevant to Datadog (ingress routing tags, etc). Tags should be specified
+    ## here in lowercase, the check will downcase tags from Consul before comparing.
+    #
+    # services_tags_keys_include:
+    #   - <TAG_1>
+    #   - <TAG_2>
+
     ## @param max_services - number - optional - default: 50
     ## Increase the maximum number of queried services.
     #

--- a/consul/tests/consul_mocks.py
+++ b/consul/tests/consul_mocks.py
@@ -92,6 +92,12 @@ def mock_get_services_in_cluster():
         "service-6": ["active", "standby"],
     }
 
+def mock_get_n_custom_tagged_services_in_cluster(n, tags):
+    svcs = {}
+    for i in range(n):
+        k = "service-{}".format(i)
+        svcs[k] = tags
+    return svcs
 
 def mock_get_n_services_in_cluster(n):
     dct = {}

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -54,6 +54,47 @@ def test_get_nodes_with_service(aggregator):
     aggregator.assert_metric('consul.catalog.services_count', value=1, tags=expected_tags)
 
 
+def test_cull_services_tags_keys(aggregator):
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG])
+    consul_mocks.mock_check(consul_check, consul_mocks._get_consul_mocks())
+
+    all_tags = set([
+        "active",
+        "standby",
+        "unwanted.tag=unwantedvalue",
+        "unwanted.tag.but.actually.wanted=wantedvalue",
+        "wanted.tag",
+        "unwanted.tag.noequals",
+    ])
+
+    include_tags = set([
+        'active',
+        'standby',
+        'unwanted.tag.but.actually.wanted',
+        'wanted.tag'
+    ])
+
+    expected_tags = set([
+        "active",
+        "standby",
+        "unwanted.tag.but.actually.wanted=wantedvalue",
+        "wanted.tag",
+    ])
+
+    unwanted_tags = set([
+        "unwanted.tag=unwantedvalue",
+        "unwanted.tag.noequals",
+    ])
+
+    consul_check.services_tags_keys_include = include_tags
+    services = consul_mocks.mock_get_n_custom_tagged_services_in_cluster(6, all_tags)
+
+    services = consul_check._cull_services_tags_list(services)
+    for service in services:
+        assert unwanted_tags.isdisjoint(set(services[service]))
+        assert expected_tags == set(services[service])
+
+
 def test_get_peers_in_cluster(aggregator):
     my_mocks = consul_mocks._get_consul_mocks()
     consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG])


### PR DESCRIPTION
### What does this PR do?
- add a configuration option `services_tags_keys_include` to the consul check to allow specification of a list of allowed tag keys to be sent to Datadog, all other tags will be removed (this name is kind of awkward, I was trying to match existing options but very open to suggestions)
- if the allow list is empty/not set, all tags are sent (matching existing behavior)

### Motivation
We have a lot of tags (50+) on some of our consul services (for traefik routing and other purposes) that are not needed in Datadog, and would like to filter them out. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
