### PR TITLE
Add configuration value to Consul check to not send service metrics containing service name

### DIFF
--- a/consul/assets/configuration/spec.yaml
+++ b/consul/assets/configuration/spec.yaml
@@ -109,6 +109,14 @@ files:
           - <SERVICE_1>
           - <SERVICE_2>
 
+    - name: services_tags_include_service_name
+      description: |
+        Whether to produce additional service tags that include the service
+        name in the tag key for each service.
+      value:
+        type: boolean
+        example: true
+
     - name: max_services
       description: |
         Increase the maximum number of queried services.

--- a/consul/changelog.d/20309.added
+++ b/consul/changelog.d/20309.added
@@ -1,0 +1,1 @@
+Add a new feature to remove Consul service name from service check tag keys sent to Datadog.

--- a/consul/datadog_checks/consul/config_models/defaults.py
+++ b/consul/datadog_checks/consul/config_models/defaults.py
@@ -84,6 +84,10 @@ def instance_self_leader_check():
     return False
 
 
+def instance_services_tags_include_service_name():
+    return True
+
+
 def instance_single_node_install():
     return False
 

--- a/consul/datadog_checks/consul/config_models/instance.py
+++ b/consul/datadog_checks/consul/config_models/instance.py
@@ -91,6 +91,7 @@ class InstanceConfig(BaseModel):
     service: Optional[str] = None
     services_exclude: Optional[tuple[str, ...]] = None
     services_include: Optional[tuple[str, ...]] = None
+    services_tags_include_service_name: Optional[bool] = None
     single_node_install: Optional[bool] = None
     skip_proxy: Optional[bool] = None
     tags: Optional[tuple[str, ...]] = None

--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -106,6 +106,9 @@ class ConsulCheck(OpenMetricsBaseCheck):
             'service_whitelist', self.instance.get('services_include', default_services_include)
         )
         self.services_exclude = set(self.instance.get('services_exclude', self.init_config.get('services_exclude', [])))
+        self.services_tags_include_service_name = is_affirmative(
+            self.instance.get('services_tags_include_service_name', True)
+        )
         self.max_services = self.instance.get('max_services', self.init_config.get('max_services', MAX_SERVICES))
         self.threads_count = self.instance.get('threads_count', self.init_config.get('threads_count', THREADS_COUNT))
         if self.threads_count > 1:
@@ -313,11 +316,12 @@ class ConsulCheck(OpenMetricsBaseCheck):
         return services
 
     @staticmethod
-    def _get_service_tags(service, tags):
+    def _get_service_tags(service, tags, include_service_name):
         service_tags = ['consul_service_id:{}'.format(service)]
 
         for tag in tags:
-            service_tags.append('consul_{}_service_tag:{}'.format(service, tag))
+            if include_service_name:
+                service_tags.append('consul_{}_service_tag:{}'.format(service, tag))
             service_tags.append('consul_service_tag:{}'.format(tag))
 
         return service_tags
@@ -483,7 +487,7 @@ class ConsulCheck(OpenMetricsBaseCheck):
         # `consul.catalog.nodes_passing` : # of Nodes with service status `passing` from those registered
         # `consul.catalog.nodes_warning` : # of Nodes with service status `warning` from those registered
         # `consul.catalog.nodes_critical` : # of Nodes with service status `critical` from those registered
-        all_service_tags = self._get_service_tags(service, service_tags)
+        all_service_tags = self._get_service_tags(service, service_tags, self.services_tags_include_service_name)
         # {'up': 0, 'passing': 0, 'warning': 0, 'critical': 0}
         node_count_per_status = defaultdict(int)
         for node in nodes_with_service:

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -126,6 +126,12 @@ instances:
     #   - <SERVICE_1>
     #   - <SERVICE_2>
 
+    ## @param services_tags_include_service_name - boolean - optional - default: true
+    ## Whether to produce additional service tags that include the service
+    ## name in the tag key for each service.
+    #
+    # services_tags_include_service_name: true
+
     ## @param max_services - number - optional - default: 50
     ## Increase the maximum number of queried services.
     #

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -54,6 +54,25 @@ def test_get_nodes_with_service(aggregator):
     aggregator.assert_metric('consul.catalog.services_count', value=1, tags=expected_tags)
 
 
+def test_get_nodes_with_service_remove_service_tagkey(aggregator):
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG])
+    consul_check.services_tags_include_service_name = False
+    consul_mocks.mock_check(consul_check, consul_mocks._get_consul_mocks())
+    consul_check.check(None)
+
+    expected_tags = [
+        'consul_datacenter:dc1',
+        'consul_service_id:service-1',
+        'consul_service_tag:active',
+        'consul_service_tag:standby',
+    ]
+
+    aggregator.assert_metric('consul.catalog.nodes_up', value=4, tags=expected_tags)
+    aggregator.assert_metric('consul.catalog.nodes_passing', value=4, tags=expected_tags)
+    aggregator.assert_metric('consul.catalog.nodes_warning', value=0, tags=expected_tags)
+    aggregator.assert_metric('consul.catalog.nodes_critical', value=0, tags=expected_tags)
+
+
 def test_get_peers_in_cluster(aggregator):
     my_mocks = consul_mocks._get_consul_mocks()
     consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG])


### PR DESCRIPTION
### What does this PR do?
- add a new option `services_tags_include_service_name` to the Consul check configuration (this name is kind of awkward, I was trying to match existing options but very open to suggestions)
- if set to false, the consul checks will not produce the service tags that look like `consul_<servicename>_service_tag:<consultag>` in addition to the `consul_service_tag:<consultag>`
- defaults to true, to maintain backward compatibility
- this substantially reduces the number of tags that the check produces

### Motivation
We have a lot of Consul services and a lot of tags, and the additional `consul_<servicename>_service_tag:<consultag>` for every consul tag makes an explosion of tags that we don't use, since we can combine `service:` and `consul_service_tag` in queries to get the same result, and that is clearer. We would like to turn these off so we have fewer tags around.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
