### PR TITLE
Only query aurora_version() if aurora postgres extensions are available 

### DIFF
--- a/postgres/changelog.d/20310.fixed
+++ b/postgres/changelog.d/20310.fixed
@@ -1,0 +1,1 @@
+Check for aws extensions before querying aurora_version()

--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -42,7 +42,11 @@ class VersionUtils(object):
             return self._is_aurora
         with db as conn:
             with conn.cursor(cursor_factory=CommenterCursor) as cursor:
-                cursor.execute("SELECT 1 FROM pg_available_extension_versions WHERE name ILIKE '%aurora%' OR comment ILIKE '%aurora%' LIMIT 1;")
+                cursor.execute(
+                    "SELECT 1 FROM pg_available_extension_versions "
+                    "WHERE name ILIKE '%aurora%' OR comment ILIKE '%aurora%' "
+                    "LIMIT 1;"
+                )
                 if cursor.fetchone():
                     # This query will pollute PG logs in non aurora versions,
                     # but is the only reliable way to detect aurora.

--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -42,8 +42,8 @@ class VersionUtils(object):
             return self._is_aurora
         with db as conn:
             with conn.cursor(cursor_factory=CommenterCursor) as cursor:
-                cursor.execute("SELECT * FROM pg_available_extension_versions WHERE name ILIKE '%aurora%' OR comment ILIKE '%aurora%';")
-                if len(cursor.fetchall()) > 0:
+                cursor.execute("SELECT 1 FROM pg_available_extension_versions WHERE name ILIKE '%aurora%' OR comment ILIKE '%aurora%' LIMIT 1;")
+                if cursor.fetchone():
                     # This query will pollute PG logs in non aurora versions,
                     # but is the only reliable way to detect aurora.
                     # Since we found aurora extensions, this should exist.

--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -27,7 +27,7 @@ V17 = VersionInfo.parse("17.0.0")
 class VersionUtils(object):
     def __init__(self):
         self.log = get_check_logger()
-        self._seen_aurora_exception = False
+        self._is_aurora = None
 
     @staticmethod
     def get_raw_version(db):
@@ -38,21 +38,25 @@ class VersionUtils(object):
                 return raw_version
 
     def is_aurora(self, db):
-        if self._seen_aurora_exception:
-            return False
+        if self._is_aurora is not None:
+            return self._is_aurora
         with db as conn:
             with conn.cursor(cursor_factory=CommenterCursor) as cursor:
-                # This query will pollute PG logs in non aurora versions,
-                # but is the only reliable way to detect aurora
-                try:
-                    cursor.execute('select AURORA_VERSION();')
-                    return True
-                except Exception as e:
-                    self.log.debug(
-                        "Captured exception %s while determining if the DB is aurora. Assuming is not", str(e)
-                    )
-                    self._seen_aurora_exception = True
-                    return False
+                cursor.execute("SELECT * FROM pg_available_extension_versions WHERE name ILIKE '%aurora%' OR comment ILIKE '%aurora%';")
+                if len(cursor.fetchall()) > 0:
+                    # This query will pollute PG logs in non aurora versions,
+                    # but is the only reliable way to detect aurora.
+                    # Since we found aurora extensions, this should exist.
+                    try:
+                        cursor.execute('select AURORA_VERSION();')
+                        self._is_aurora = True
+                        return self._is_aurora
+                    except Exception as e:
+                        self.log.debug(
+                            "Captured exception %s while determining if the DB is aurora. Assuming is not", str(e)
+                        )
+                self._is_aurora = False
+                return self._is_aurora
 
     @staticmethod
     def parse_version(raw_version):


### PR DESCRIPTION
### What does this PR do?
Currently the Postgres integration always calls `aurora_version()` to check if the database is running on AWS Aurora. If it's not, the query fails with a function not found error. This leads to query errors in database logs. To avoid calling a function that won't exist outside of AWS Aurora environment, we will now lookup available postgres extensions. If aurora related extensions are available, we can assume we're running in AWS and will verify by querying the `aurora_version()`. Changes were made to the `VersionUtils.is_aurora()` to cache the results of the first execution as this shouldn't change over the lifetime of the connection.

Running this query on Aurora Postgres will return the following extensions
```sql
SELECT * FROM pg_available_extension_versions WHERE name ILIKE '%aurora%' OR comment ILIKE '%aurora%';
       name        | version | installed | superuser | relocatable |    schema     | requires |                              comment                              
-------------------+---------+-----------+-----------+-------------+---------------+----------+-------------------------------------------------------------------
 rds_tools         | 1.0     | f         | t         | f           | rds_tools     |          | miscellaneous administrative functions for Aurora PostgreSQL
 aurora_stat_utils | 1.0     | f         | t         | f           |               |          | Statistics utility functions
 apg_plan_mgmt     | 2.1     | f         | t         | f           | apg_plan_mgmt |          | Amazon Aurora with PostgreSQL compatibility Query Plan Management
 apg_plan_mgmt     | 1.0.1   | f         | t         | f           | apg_plan_mgmt |          | Amazon Aurora with PostgreSQL compatibility Query Plan Management
 apg_plan_mgmt     | 1.0     | f         | t         | f           | apg_plan_mgmt |          | Amazon Aurora with PostgreSQL compatibility Query Plan Management
 apg_plan_mgmt     | 2.0     | f         | t         | f           | apg_plan_mgmt |          | Amazon Aurora with PostgreSQL compatibility Query Plan Management
```

Running it on non Aurora Postgres instances will return zero rows.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
