### PR TITLE
[Backport] [Release] Bumped sqlserver version to 22.5.0

### DIFF
--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -186,7 +186,7 @@ datadog-sonarqube==5.2.1
 datadog-sonatype-nexus==1.1.0; sys_platform != 'darwin'
 datadog-sonicwall-firewall==1.0.0
 datadog-spark==6.4.0
-datadog-sqlserver==22.4.0
+datadog-sqlserver==22.5.0
 datadog-squid==4.1.0
 datadog-ssh-check==4.2.1
 datadog-statsd==3.0.0

--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 22.5.0 / 2025-05-15
+
+***Added***:
+
+* Add database and Azure name to SQL Server database identifier template variables ([#20301](https://github.com/DataDog/integrations-core/pull/20301))
+
 ## 22.4.0 / 2025-05-15
 
 ***Added***:

--- a/sqlserver/changelog.d/20301.added
+++ b/sqlserver/changelog.d/20301.added
@@ -1,1 +1,0 @@
-Add database and Azure name to SQL Server database identifier template variables

--- a/sqlserver/datadog_checks/sqlserver/__about__.py
+++ b/sqlserver/datadog_checks/sqlserver/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = '22.4.0'
+__version__ = '22.5.0'


### PR DESCRIPTION
### What does this PR do?
 Backport sqlserver version 22.5.0 release
### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
