### PR TITLE
fix Postgresql replication stat metrics to include replication prefix

### DIFF
--- a/postgres/changelog.d/20316.fixed
+++ b/postgres/changelog.d/20316.fixed
@@ -1,1 +1,1 @@
-fix Postgresql replication stat metrics to include replication prefix
+fix Postgresql replication stat metrics to include `replication.` prefix

--- a/postgres/changelog.d/20316.fixed
+++ b/postgres/changelog.d/20316.fixed
@@ -1,0 +1,1 @@
+fix Postgresql replication stat metrics to include replication prefix

--- a/postgres/changelog.d/20316.fixed.1
+++ b/postgres/changelog.d/20316.fixed.1
@@ -1,1 +1,0 @@
-fix Postgresql replication stat metrics to include replication prefix

--- a/postgres/changelog.d/20316.fixed.1
+++ b/postgres/changelog.d/20316.fixed.1
@@ -1,0 +1,1 @@
+fix Postgresql replication stat metrics to include replication prefix

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -391,9 +391,10 @@ SELECT
     pg_stat_replication.client_addr,
     pg_stat_replication_slot.slot_name,
     pg_stat_replication_slot.slot_type,
+    GREATEST (0, age(backend_xmin)) as backend_xmin_age,
     GREATEST (0, EXTRACT(epoch from pg_stat_replication.write_lag)) as write_lag,
-    GREATEST (0, EXTRACT(epoch from pg_stat_replication.replay_lag)) AS replay_lag,
-    GREATEST (0, age(pg_stat_replication.backend_xmin)) AS backend_xmin_age
+    GREATEST (0, EXTRACT(epoch from pg_stat_replication.flush_lag)) as flush_lag,
+    GREATEST (0, EXTRACT(epoch from pg_stat_replication.replay_lag)) AS replay_lag
 FROM pg_stat_replication as pg_stat_replication
 LEFT JOIN pg_replication_slots as pg_stat_replication_slot
 ON pg_stat_replication.pid = pg_stat_replication_slot.active_pid;
@@ -405,6 +406,7 @@ ON pg_stat_replication.pid = pg_stat_replication_slot.active_pid;
         {'name': 'wal_client_addr', 'type': 'tag'},
         {'name': 'slot_name', 'type': 'tag_not_null'},
         {'name': 'slot_type', 'type': 'tag_not_null'},
+        {'name': 'replication.backend_xmin_age', 'type': 'gauge'},
         {'name': 'replication.wal_write_lag', 'type': 'gauge'},
         {'name': 'replication.wal_flush_lag', 'type': 'gauge'},
         {'name': 'replication.wal_replay_lag', 'type': 'gauge'},

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -405,9 +405,9 @@ ON pg_stat_replication.pid = pg_stat_replication_slot.active_pid;
         {'name': 'wal_client_addr', 'type': 'tag'},
         {'name': 'slot_name', 'type': 'tag_not_null'},
         {'name': 'slot_type', 'type': 'tag_not_null'},
-        {'name': 'wal_write_lag', 'type': 'gauge'},
-        {'name': 'wal_flush_lag', 'type': 'gauge'},
-        {'name': 'wal_replay_lag', 'type': 'gauge'},
+        {'name': 'replication.wal_write_lag', 'type': 'gauge'},
+        {'name': 'replication.wal_flush_lag', 'type': 'gauge'},
+        {'name': 'replication.wal_replay_lag', 'type': 'gauge'},
     ],
 }
 

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -391,7 +391,7 @@ SELECT
     pg_stat_replication.client_addr,
     pg_stat_replication_slot.slot_name,
     pg_stat_replication_slot.slot_type,
-    GREATEST (0, age(backend_xmin)) as backend_xmin_age,
+    GREATEST (0, age(pg_stat_replication.backend_xmin)) as backend_xmin_age,
     GREATEST (0, EXTRACT(epoch from pg_stat_replication.write_lag)) as write_lag,
     GREATEST (0, EXTRACT(epoch from pg_stat_replication.flush_lag)) as flush_lag,
     GREATEST (0, EXTRACT(epoch from pg_stat_replication.replay_lag)) AS replay_lag


### PR DESCRIPTION
This PR fixes a bug to add the `replication` prefix to our lag metrics - `postgresql.replication.wal_write_lag`, `postgresql.replication.wal_flush_lag`, `postgresql.replication.wal_replay._lag`. 

Earlier, this PR https://github.com/DataDog/integrations-core/pull/20035/files was created to add replication slot information to our existing lag metrics but in this change the lag metrics were not prefixed with `replication` . These metrics name got updated from `postgresql.replication.wal_write_lag`, `postgresql.replication.wal_flush_lag`, `postgresql.replication.wal_replay._lag` to postgresql.wal_write_lag`, `postgresql.wal_flush_lag`, `postgresql.wal_replay._lag` respectively in the latest agent release.

Test results
![Screenshot 2025-05-16 at 11 57 09 AM](https://github.com/user-attachments/assets/6f8874c2-e3b3-4c17-91ab-c78e542af00b)

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
