### PR TITLE
Fix `scheduling-attemps` typo

### DIFF
--- a/kube_scheduler/assets/dashboards/overview.json
+++ b/kube_scheduler/assets/dashboards/overview.json
@@ -504,7 +504,7 @@
         {
             "id": 2358358132143955,
             "definition": {
-                "title": "Scheduling Attemps",
+                "title": "Scheduling Attempts",
                 "type": "group",
                 "background_color": "vivid_green",
                 "show_title": true,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR fixes a typo in the Kube Scheduler dashboard
<img width="1624" alt="Screenshot 2025-05-19 at 10 50 52 AM" src="https://github.com/user-attachments/assets/dfb4f183-4d77-406b-9ffa-e254e11548a2" />

### Motivation
<!-- What inspired you to submit this pull request? -->
Typo was found during a dash workshop dry run

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
