### PR TITLE
Bump codecov action hash

### DIFF
--- a/.github/workflows/test-fips-e2e.yml
+++ b/.github/workflows/test-fips-e2e.yml
@@ -155,7 +155,7 @@ jobs:
       if: >
         !github.event.repository.private &&
         always()
-      uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d
+      uses: codecov/codecov-action@15559ed290fa727036809b67ab0f646ffa6c5158
       with:
         use_oidc: true
         files: "${{ inputs.target || 'tls' }}/coverage.xml"

--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -415,7 +415,7 @@ jobs:
         always() &&
         inputs.pytest-args != '-m flaky'
       # Flaky tests will have low coverage, don't upload it to avoid pipeline failure
-      uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d
+      uses: codecov/codecov-action@15559ed290fa727036809b67ab0f646ffa6c5158
       with:
         use_oidc: true
         files: "${{ inputs.target }}/coverage.xml"

--- a/arangodb/tests/conftest.py
+++ b/arangodb/tests/conftest.py
@@ -16,7 +16,6 @@ URL = 'http://{}:{}/_admin/metrics/v2'
 
 @pytest.fixture(scope='session')
 def dd_environment(instance):
-    # test
     with docker_run(
         os.path.join(DOCKER_DIR, 'docker-compose.yaml'),
     ):

--- a/arangodb/tests/conftest.py
+++ b/arangodb/tests/conftest.py
@@ -16,6 +16,7 @@ URL = 'http://{}:{}/_admin/metrics/v2'
 
 @pytest.fixture(scope='session')
 def dd_environment(instance):
+    # test
     with docker_run(
         os.path.join(DOCKER_DIR, 'docker-compose.yaml'),
     ):


### PR DESCRIPTION
### What does this PR do?
bumps codecov pin to > `4.2.0` to fix codecov uploads on forks

### Motivation
we're running into this issue: https://github.com/codecov/codecov-action/issues/1821
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
