### PR TITLE
[MLOB-2838] add nanodollar unit to list of valid metric units

### DIFF
--- a/ddev/changelog.d/20341.added
+++ b/ddev/changelog.d/20341.added
@@ -1,0 +1,1 @@
+Add nanodollar as valid metric units

--- a/ddev/src/ddev/cli/validate/metadata_utils.py
+++ b/ddev/src/ddev/cli/validate/metadata_utils.py
@@ -196,6 +196,7 @@ VALID_UNIT_NAMES = {
     'terawatt',
     'view',
     'microdollar',
+    'nanodollar',
     'euro',
     'pound',
     'penny',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds nanodollar unit to the list of valid units. See https://github.com/DataDog/dd-source/pull/220160 and https://github.com/DataDog/dogweb/pull/142407 for corresponding PRs to add the nanodollar unit.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
