### PR TITLE
Add  full_server_name support as template variable to sqlserver template config key

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -80,7 +80,7 @@ files:
       default: false
     - name: database_identifier
       description: |
-        Controls how the database is identified. The default value is the resolved hostname for the instance, 
+        Controls how the database is identified. The default value is the resolved hostname for the instance,
         which respects the `reported_hostname` option.
 
         This value will be used as-is for the display name of the instance but will be normalized
@@ -91,7 +91,7 @@ files:
           value:
             type: string
             display_default: "$resolved_hostname"
-            example: "$env-$resolved_hostname:$port"
+            example: "$env-$resolved_hostname-$full_server_name"
           description: |
             The template to use for the database identifier. The default value is `$resolved_hostname`.
             You can use the following variables, prefixed by `$` in the template:
@@ -103,6 +103,7 @@ files:
             - database: The connection database.
             - server_name: The resolved server name of the instance.
             - instance_name: The resolved instance name of the instance.
+            - full_server_name: The resolved full server name of the instance i.e. the value returned by `@@SERVERNAME`.
             In addition, you can use any key from the `tags` section of the configuration.
           default: "$resolved_hostname"
     - name: database_autodiscovery
@@ -173,9 +174,9 @@ files:
 
             Set `ao_metrics.enabled` to true to enable collection of AlwaysOn metrics. Defaults to false.
 
-            When `ao_metrics.enabled` is True, use `ao_metrics.availability_group` to specify the 
-            resource group id of a specific availability group that you would like to monitor. 
-            If no availability group is specified, then we will collect AlwaysOn metrics for all 
+            When `ao_metrics.enabled` is True, use `ao_metrics.availability_group` to specify the
+            resource group id of a specific availability group that you would like to monitor.
+            If no availability group is specified, then we will collect AlwaysOn metrics for all
             availability groups on the current replica.
 
             Primary replicas may emit metrics for remote secondary replicas
@@ -202,7 +203,7 @@ files:
 
             Set `db_backup_metrics.enabled` to true to enable collection of database backup metrics. Defaults to true.
 
-            Use `db_backup_metrics.collection_interval` to set the interval (in seconds) for the collection of 
+            Use `db_backup_metrics.collection_interval` to set the interval (in seconds) for the collection of
             database backup metrics. Defaults to 300 seconds (5 minutes). If you intend on updating this value,
             it is strongly recommended to use a consistent value throughout all SQL Server agent deployments.
           hidden: true
@@ -242,11 +243,11 @@ files:
               example: true
         - name: db_fragmentation_metrics
           description: |
-            Configure collection of database fragmentation metrics. 
-            Note these queries can be resource intensive on large datasets. Recommend to limit these via 
+            Configure collection of database fragmentation metrics.
+            Note these queries can be resource intensive on large datasets. Recommend to limit these via
             autodiscovery or specific database instances.
 
-            Set `db_fragmentation_metrics.enabled` to true to enable collection of 
+            Set `db_fragmentation_metrics.enabled` to true to enable collection of
             database index fragmentation statistics. Defaults to false.
 
             Use `db_fragmentation_metrics.enabled_tempdb` to enable collection of database index fragmentation statistics
@@ -343,7 +344,7 @@ files:
               type: boolean
               example: true
         - name: master_files_metrics
-          description: | 
+          description: |
             Configure collection of database file size and state from `sys.master_files`
 
             Set `master_files_metrics.enabled` to true to enable collection of database file size and state metrics.
@@ -356,7 +357,7 @@ files:
               example: false
         - name: primary_log_shipping_metrics
           description: |
-            Configure collection of metrics for a log shipping setup. Required to run against the 
+            Configure collection of metrics for a log shipping setup. Required to run against the
             primary instance in a transaction log shipping configuration. Note that
             the Datadog user needs to be present in msdb and must be added to the db_datareader role.
 
@@ -370,7 +371,7 @@ files:
               example: false
         - name: secondary_log_shipping_metrics
           description: |
-            Configure collection of metrics for a log shipping setup. Required to run against the 
+            Configure collection of metrics for a log shipping setup. Required to run against the
             secondary instance in a transaction log shipping configuration. Note that
             the Datadog user needs to be present in msdb and must be added to the db_datareader role.
 
@@ -410,7 +411,7 @@ files:
           description: |
             Configure collection of tempdb file space usage metrics for how space is used in tempdb data files.
 
-            Set `tempdb_file_space_usage_metrics.enabled` to true to enable collection of 
+            Set `tempdb_file_space_usage_metrics.enabled` to true to enable collection of
             tempdb file space usage metrics. Defaults to true.
           value:
             type: object
@@ -420,7 +421,7 @@ files:
               example: true
         - name: xe_metrics
           description: |
-            Configure collection of extended events (XE) metrics. 
+            Configure collection of extended events (XE) metrics.
 
             Set `xe_metrics.enabled` to true to enable collection of extended events metrics. Defaults to false.
           value:
@@ -889,12 +890,12 @@ files:
     - name: collect_raw_query_statement
       description: |
         Configure the collection of raw query statements in query activity, execution plans, and XE events.
-        To collect raw query statements from XE events, set `xe_collection.query_completions.enabled` and 
+        To collect raw query statements from XE events, set `xe_collection.query_completions.enabled` and
         `xe_collection.query_errors.enabled` to `true`.
         Raw query statements and execution plans may contain sensitive information (e.g., passwords)
         or personally identifiable information in query text.
-        Enabling this option will allow the collection and ingestion of raw query statements and 
-        execution plans into Datadog, which can then become viewable in query samples or explain plans. 
+        Enabling this option will allow the collection and ingestion of raw query statements and
+        execution plans into Datadog, which can then become viewable in query samples or explain plans.
         This option is disabled by default.
         Note: Collection of raw query statements is currently in preview.
         If you are interested in participating, please reach out to your Datadog Customer Success Manager.
@@ -1022,13 +1023,13 @@ files:
             Configure the collection of completed queries from the `datadog_query_completions` XE session.
 
             Set `query_completions.enabled` to `true` to enable the collection of query completion events.
-            
-            Use `query_completions.collection_interval` to set the interval (in seconds) for the collection of 
+
+            Use `query_completions.collection_interval` to set the interval (in seconds) for the collection of
             query completion events. Defaults to 10 seconds. If you intend on updating this value,
             it is strongly recommended to use a consistent value throughout all SQL Server agent deployments.
-            
-            Use `query_completions.max_events` to set the maximum number of query completion events to process 
-            per collection. Note that SQL Server's ring buffer has a maximum of 1000 events per query, 
+
+            Use `query_completions.max_events` to set the maximum number of query completion events to process
+            per collection. Note that SQL Server's ring buffer has a maximum of 1000 events per query,
             so values above 1000 will still be capped at 1000 by the database engine. Defaults to 1000.
           value:
             type: object
@@ -1049,13 +1050,13 @@ files:
             Configure the collection of query errors from the `datadog_query_errors` XE session.
 
             Set `query_errors.enabled` to `true` to enable the collection of query error events.
-            
-            Use `query_errors.collection_interval` to set the interval (in seconds) for the collection of 
+
+            Use `query_errors.collection_interval` to set the interval (in seconds) for the collection of
             query error events. Defaults to 10 seconds. If you intend on updating this value,
             it is strongly recommended to use a consistent value throughout all SQL Server agent deployments.
-            
-            Use `query_errors.max_events` to set the maximum number of query error events to process 
-            per collection. Note that SQL Server's ring buffer has a maximum of 1000 events per query, 
+
+            Use `query_errors.max_events` to set the maximum number of query error events to process
+            per collection. Note that SQL Server's ring buffer has a maximum of 1000 events per query,
             so values above 1000 will still be capped at 1000 by the database engine. Defaults to 1000.
           value:
             type: object

--- a/sqlserver/changelog.d/20342.added
+++ b/sqlserver/changelog.d/20342.added
@@ -1,0 +1,1 @@
+Add $full_server_name support as template variable to sqlserver template config key

--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -24,6 +24,7 @@ ENGINE_EDITION_AZURE_SYNAPSE_SERVERLESS_POOL = 11
 # Keys of the static info cache, used to cache server info which does not change
 STATIC_INFO_SERVERNAME = 'servername'
 STATIC_INFO_INSTANCENAME = 'instancename'
+STATIC_INFO_FULL_SERVERNAME = 'full_servername'
 STATIC_INFO_VERSION = 'version'
 STATIC_INFO_MAJOR_VERSION = 'major_version'
 STATIC_INFO_ENGINE_EDITION = 'engine_edition'

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -28,6 +28,7 @@ init_config:
     #   - query: <QUERY>
     #     columns: <COLUMNS>
     #     tags: <TAGS>
+    #     collection_interval: <COLLECTION_INTERVAL>
 
     ## @param service - string - optional
     ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
@@ -728,6 +729,14 @@ instances:
     ##              Columns without a name are ignored. To skip a column, enter:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
+    ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
+    ##     If collection_interval is not set, the query will be run every check run.
+    ##     If the collection interval is less than check collection interval, 
+    ##     the query will be run every check run.
+    ##     If the collection interval is greater than check collection interval, 
+    ##     the query will NOT BE RUN exactly at the collection interval.
+    ##     The query will be run at the next check run after the collection interval has passed.
+    ## 5. metric_prefix (optional) - The prefix to apply to each metric.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
@@ -738,6 +747,8 @@ instances:
     #       type: gauge
     #     tags:
     #     - test:<INTEGRATION>
+    #     collection_interval: 30
+    #     metric_prefix: foo_prefix
 
     ## @param stored_procedure - string - optional
     ## DEPRECATED - use `custom_queries` instead. For guidance, see:

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -28,7 +28,6 @@ init_config:
     #   - query: <QUERY>
     #     columns: <COLUMNS>
     #     tags: <TAGS>
-    #     collection_interval: <COLLECTION_INTERVAL>
 
     ## @param service - string - optional
     ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
@@ -105,15 +104,10 @@ instances:
         ## - database: The connection database.
         ## - server_name: The resolved server name of the instance.
         ## - instance_name: The resolved instance name of the instance.
-        ## - full_server_name: The resolved full server name of the instance, which is the combination of
-        ##   the server name and instance name, or more specifically, the exact value returned by `@@SERVERNAME`.
+        ## - full_server_name: The resolved full server name of the instance i.e. the value returned by `@@SERVERNAME`.
         ## In addition, you can use any key from the `tags` section of the configuration.
-		##
-		## Some examples:
-		#
-        # template: $full_server_name
-        # template: $env-$resolved_hostname:$port
-		# template: $resolved_hostname/$your-custom-tag
+        #
+        # template: $env-$resolved_hostname-$full_server_name
 
     ## @param database_autodiscovery - boolean - optional - default: false
     ## Auto-discover and monitor databases. Supported for the metrics check.
@@ -709,7 +703,7 @@ instances:
     ##                          of the item in this column:
     ##                           i. tag           - This is the default tag type
     ##                           ii. tag_list     - This allows multiple values to be attached
-    ##                                             to the tag name. For example:
+    ##                                             to the tag name. For example: 
     ##
     ##                                             query = {
     ##                                               "name": "example",
@@ -734,14 +728,6 @@ instances:
     ##              Columns without a name are ignored. To skip a column, enter:
     ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
-    ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
-    ##     If collection_interval is not set, the query will be run every check run.
-    ##     If the collection interval is less than check collection interval,
-    ##     the query will be run every check run.
-    ##     If the collection interval is greater than check collection interval,
-    ##     the query will NOT BE RUN exactly at the collection interval.
-    ##     The query will be run at the next check run after the collection interval has passed.
-    ## 5. metric_prefix (optional) - The prefix to apply to each metric.
     #
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
@@ -752,8 +738,6 @@ instances:
     #       type: gauge
     #     tags:
     #     - test:<INTEGRATION>
-    #     collection_interval: 30
-    #     metric_prefix: foo_prefix
 
     ## @param stored_procedure - string - optional
     ## DEPRECATED - use `custom_queries` instead. For guidance, see:

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -85,7 +85,7 @@ instances:
     #
     # exclude_hostname: false
 
-    ## Controls how the database is identified. The default value is the resolved hostname for the instance, 
+    ## Controls how the database is identified. The default value is the resolved hostname for the instance,
     ## which respects the `reported_hostname` option.
     ##
     ## This value will be used as-is for the display name of the instance but will be normalized
@@ -105,9 +105,11 @@ instances:
         ## - database: The connection database.
         ## - server_name: The resolved server name of the instance.
         ## - instance_name: The resolved instance name of the instance.
+        ## - full_server_name: The resolved full server name of the instance, which is the combination of
+        ##   the server name and instance name, or more specifically, the exact value returned by `@@SERVERNAME`.
         ## In addition, you can use any key from the `tags` section of the configuration.
         #
-        # template: $env-$resolved_hostname:$port
+        # template: $full_server_name
 
     ## @param database_autodiscovery - boolean - optional - default: false
     ## Auto-discover and monitor databases. Supported for the metrics check.
@@ -165,9 +167,9 @@ instances:
         ##
         ## Set `ao_metrics.enabled` to true to enable collection of AlwaysOn metrics. Defaults to false.
         ##
-        ## When `ao_metrics.enabled` is True, use `ao_metrics.availability_group` to specify the 
-        ## resource group id of a specific availability group that you would like to monitor. 
-        ## If no availability group is specified, then we will collect AlwaysOn metrics for all 
+        ## When `ao_metrics.enabled` is True, use `ao_metrics.availability_group` to specify the
+        ## resource group id of a specific availability group that you would like to monitor.
+        ## If no availability group is specified, then we will collect AlwaysOn metrics for all
         ## availability groups on the current replica.
         ##
         ## Primary replicas may emit metrics for remote secondary replicas
@@ -179,11 +181,11 @@ instances:
         # ao_metrics: {}
 
         ## @param db_fragmentation_metrics - mapping - optional
-        ## Configure collection of database fragmentation metrics. 
-        ## Note these queries can be resource intensive on large datasets. Recommend to limit these via 
+        ## Configure collection of database fragmentation metrics.
+        ## Note these queries can be resource intensive on large datasets. Recommend to limit these via
         ## autodiscovery or specific database instances.
         ##
-        ## Set `db_fragmentation_metrics.enabled` to true to enable collection of 
+        ## Set `db_fragmentation_metrics.enabled` to true to enable collection of
         ## database index fragmentation statistics. Defaults to false.
         ##
         ## Use `db_fragmentation_metrics.enabled_tempdb` to enable collection of database index fragmentation statistics
@@ -247,7 +249,7 @@ instances:
         # master_files_metrics: {}
 
         ## @param primary_log_shipping_metrics - mapping - optional
-        ## Configure collection of metrics for a log shipping setup. Required to run against the 
+        ## Configure collection of metrics for a log shipping setup. Required to run against the
         ## primary instance in a transaction log shipping configuration. Note that
         ## the Datadog user needs to be present in msdb and must be added to the db_datareader role.
         ##
@@ -257,7 +259,7 @@ instances:
         # primary_log_shipping_metrics: {}
 
         ## @param secondary_log_shipping_metrics - mapping - optional
-        ## Configure collection of metrics for a log shipping setup. Required to run against the 
+        ## Configure collection of metrics for a log shipping setup. Required to run against the
         ## secondary instance in a transaction log shipping configuration. Note that
         ## the Datadog user needs to be present in msdb and must be added to the db_datareader role.
         ##
@@ -277,13 +279,13 @@ instances:
         ## @param tempdb_file_space_usage_metrics - mapping - optional
         ## Configure collection of tempdb file space usage metrics for how space is used in tempdb data files.
         ##
-        ## Set `tempdb_file_space_usage_metrics.enabled` to true to enable collection of 
+        ## Set `tempdb_file_space_usage_metrics.enabled` to true to enable collection of
         ## tempdb file space usage metrics. Defaults to true.
         #
         # tempdb_file_space_usage_metrics: {}
 
         ## @param xe_metrics - mapping - optional
-        ## Configure collection of extended events (XE) metrics. 
+        ## Configure collection of extended events (XE) metrics.
         ##
         ## Set `xe_metrics.enabled` to true to enable collection of extended events metrics. Defaults to false.
         #
@@ -647,12 +649,12 @@ instances:
         # keep_identifier_quotation: false
 
     ## Configure the collection of raw query statements in query activity, execution plans, and XE events.
-    ## To collect raw query statements from XE events, set `xe_collection.query_completions.enabled` and 
+    ## To collect raw query statements from XE events, set `xe_collection.query_completions.enabled` and
     ## `xe_collection.query_errors.enabled` to `true`.
     ## Raw query statements and execution plans may contain sensitive information (e.g., passwords)
     ## or personally identifiable information in query text.
-    ## Enabling this option will allow the collection and ingestion of raw query statements and 
-    ## execution plans into Datadog, which can then become viewable in query samples or explain plans. 
+    ## Enabling this option will allow the collection and ingestion of raw query statements and
+    ## execution plans into Datadog, which can then become viewable in query samples or explain plans.
     ## This option is disabled by default.
     ## Note: Collection of raw query statements is currently in preview.
     ## If you are interested in participating, please reach out to your Datadog Customer Success Manager.
@@ -703,7 +705,7 @@ instances:
     ##                          of the item in this column:
     ##                           i. tag           - This is the default tag type
     ##                           ii. tag_list     - This allows multiple values to be attached
-    ##                                             to the tag name. For example: 
+    ##                                             to the tag name. For example:
     ##
     ##                                             query = {
     ##                                               "name": "example",
@@ -730,9 +732,9 @@ instances:
     ## 3. tags (optional) - A list of tags to apply to each metric.
     ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
     ##     If collection_interval is not set, the query will be run every check run.
-    ##     If the collection interval is less than check collection interval, 
+    ##     If the collection interval is less than check collection interval,
     ##     the query will be run every check run.
-    ##     If the collection interval is greater than check collection interval, 
+    ##     If the collection interval is greater than check collection interval,
     ##     the query will NOT BE RUN exactly at the collection interval.
     ##     The query will be run at the next check run after the collection interval has passed.
     ## 5. metric_prefix (optional) - The prefix to apply to each metric.
@@ -813,12 +815,12 @@ instances:
         ##
         ## Set `query_completions.enabled` to `true` to enable the collection of query completion events.
         ##
-        ## Use `query_completions.collection_interval` to set the interval (in seconds) for the collection of 
+        ## Use `query_completions.collection_interval` to set the interval (in seconds) for the collection of
         ## query completion events. Defaults to 10 seconds. If you intend on updating this value,
         ## it is strongly recommended to use a consistent value throughout all SQL Server agent deployments.
         ##
-        ## Use `query_completions.max_events` to set the maximum number of query completion events to process 
-        ## per collection. Note that SQL Server's ring buffer has a maximum of 1000 events per query, 
+        ## Use `query_completions.max_events` to set the maximum number of query completion events to process
+        ## per collection. Note that SQL Server's ring buffer has a maximum of 1000 events per query,
         ## so values above 1000 will still be capped at 1000 by the database engine. Defaults to 1000.
         #
         # query_completions: {}
@@ -828,12 +830,12 @@ instances:
         ##
         ## Set `query_errors.enabled` to `true` to enable the collection of query error events.
         ##
-        ## Use `query_errors.collection_interval` to set the interval (in seconds) for the collection of 
+        ## Use `query_errors.collection_interval` to set the interval (in seconds) for the collection of
         ## query error events. Defaults to 10 seconds. If you intend on updating this value,
         ## it is strongly recommended to use a consistent value throughout all SQL Server agent deployments.
         ##
-        ## Use `query_errors.max_events` to set the maximum number of query error events to process 
-        ## per collection. Note that SQL Server's ring buffer has a maximum of 1000 events per query, 
+        ## Use `query_errors.max_events` to set the maximum number of query error events to process
+        ## per collection. Note that SQL Server's ring buffer has a maximum of 1000 events per query,
         ## so values above 1000 will still be capped at 1000 by the database engine. Defaults to 1000.
         #
         # query_errors: {}

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -108,8 +108,12 @@ instances:
         ## - full_server_name: The resolved full server name of the instance, which is the combination of
         ##   the server name and instance name, or more specifically, the exact value returned by `@@SERVERNAME`.
         ## In addition, you can use any key from the `tags` section of the configuration.
-        #
+		##
+		## Some examples:
+		#
         # template: $full_server_name
+        # template: $env-$resolved_hostname:$port
+		# template: $resolved_hostname/$your-custom-tag
 
     ## @param database_autodiscovery - boolean - optional - default: false
     ## Auto-discover and monitor databases. Supported for the metrics check.

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -339,10 +339,8 @@ class SQLServer(AgentCheck):
                 tag_dict['azure_name'] = self.resolved_hostname[: -len(AZURE_SERVER_SUFFIX)]
             if self.static_info_cache.get(STATIC_INFO_SERVERNAME) is not None:
                 tag_dict['server_name'] = self.static_info_cache.get(STATIC_INFO_SERVERNAME)
-                # in many cases the instance name is not set, so we use an empty string as a fallback in the
-                # cases where we already have a server name. This usually means that the instance is not a named instance
-                # and the server name is the same as the instance name.
-                tag_dict['instance_name'] = self.static_info_cache.get(STATIC_INFO_INSTANCENAME) or ''
+            if self.static_info_cache.get(STATIC_INFO_INSTANCENAME) is not None:
+                tag_dict['instance_name'] = self.static_info_cache.get(STATIC_INFO_INSTANCENAME)
             if self.static_info_cache.get(STATIC_INFO_FULL_SERVERNAME) is not None:
                 tag_dict['full_server_name'] = self.static_info_cache.get(STATIC_INFO_FULL_SERVERNAME)
             self._database_identifier = template.safe_substitute(**tag_dict)

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -920,21 +920,21 @@ def test_check_static_information_expire(aggregator, dd_run_check, init_config, 
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
     dd_run_check(sqlserver_check)
     assert sqlserver_check.static_info_cache is not None
-    assert len(sqlserver_check.static_info_cache.keys()) == 6
+    assert len(sqlserver_check.static_info_cache.keys()) == 7
     assert sqlserver_check.resolved_hostname == 'stubbed.hostname'
 
     # manually clear static information cache
     sqlserver_check.static_info_cache.clear()
     dd_run_check(sqlserver_check)
     assert sqlserver_check.static_info_cache is not None
-    assert len(sqlserver_check.static_info_cache.keys()) == 6
+    assert len(sqlserver_check.static_info_cache.keys()) == 7
     assert sqlserver_check.resolved_hostname == 'stubbed.hostname'
 
     # manually pop STATIC_INFO_ENGINE_EDITION to make sure it is reloaded
     sqlserver_check.static_info_cache.pop(STATIC_INFO_ENGINE_EDITION)
     dd_run_check(sqlserver_check)
     assert sqlserver_check.static_info_cache is not None
-    assert len(sqlserver_check.static_info_cache.keys()) == 6
+    assert len(sqlserver_check.static_info_cache.keys()) == 7
     assert sqlserver_check.resolved_hostname == 'stubbed.hostname'
 
 

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -14,7 +14,7 @@ import pytest
 from datadog_checks.dev import EnvVars
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.connection import split_sqlserver_host_port
-from datadog_checks.sqlserver.const import STATIC_INFO_INSTANCENAME, STATIC_INFO_SERVERNAME
+from datadog_checks.sqlserver.const import STATIC_INFO_FULL_SERVERNAME, STATIC_INFO_INSTANCENAME, STATIC_INFO_SERVERNAME
 from datadog_checks.sqlserver.metrics import SqlFractionMetric
 from datadog_checks.sqlserver.schemas import Schemas, SubmitData
 from datadog_checks.sqlserver.sqlserver import SQLConnectionError
@@ -896,6 +896,7 @@ def test_get_unixodbc_sysconfig():
         ('$env-$resolved_hostname', '$env-stubbed.hostname', []),
         ('$env-$resolved_hostname', 'prod,staging-stubbed.hostname', ['env:prod', 'env:staging']),
         ('$env-$server_name/$instance_name', 'prod,staging-server/instance', ['env:prod', 'env:staging']),
+        ('$full_server_name', 'prod-server\\instance', ['env:prod']),
     ],
 )
 def test_database_identifier(instance_docker, template, expected, tags):
@@ -908,6 +909,7 @@ def test_database_identifier(instance_docker, template, expected, tags):
     check = SQLServer(CHECK_NAME, {}, [instance_docker])
     check.static_info_cache[STATIC_INFO_SERVERNAME] = 'server'
     check.static_info_cache[STATIC_INFO_INSTANCENAME] = 'instance'
+    check.static_info_cache[STATIC_INFO_FULL_SERVERNAME] = 'server\\instance'
     # Reset for recalculation with static info
     check._database_identifier = None
 

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -896,7 +896,7 @@ def test_get_unixodbc_sysconfig():
         ('$env-$resolved_hostname', '$env-stubbed.hostname', []),
         ('$env-$resolved_hostname', 'prod,staging-stubbed.hostname', ['env:prod', 'env:staging']),
         ('$env-$server_name/$instance_name', 'prod,staging-server/instance', ['env:prod', 'env:staging']),
-        ('$full_server_name', 'prod-server\\instance', ['env:prod']),
+        ('$full_server_name', 'server\\instance', ['env:prod']),
     ],
 )
 def test_database_identifier(instance_docker, template, expected, tags):


### PR DESCRIPTION
This pull request introduces support for a new `$full_server_name` variable in the SQL Server integration for the `template` config key, which represents the full server name as returned by `@@SERVERNAME`. The changes include updates to constants, configuration templates, caching mechanisms, and tests to incorporate this new field.

### Enhancements to SQL Server Integration:

#### Support for `full_server_name`:
* Added `STATIC_INFO_FULL_SERVERNAME` as a new constant in `sqlserver/datadog_checks/sqlserver/const.py` to represent the full server name.
* Updated the example configuration file (`sqlserver/datadog_checks/sqlserver/data/conf.yaml.example`) to include `full_server_name` as a new template option for identifying SQL Server instances.

#### Updates to Static Information Cache:
* Modified `load_static_information` in `sqlserver/datadog_checks/sqlserver/sqlserver.py` to cache the `full_server_name` value.
* Updated `database_identifier` in `sqlserver/datadog_checks/sqlserver/sqlserver.py` to use `STATIC_INFO_FULL_SERVERNAME` when applicable.
* When a servername is present, make sure the instancename fallsback to `''` if its value is `None` to avoid seeing `None` in the output. 

#### Test Coverage:
* Enhanced unit tests in `sqlserver/tests/test_unit.py` to validate `full_server_name` functionality, including its usage in templates and caching. [[1]](diffhunk://#diff-6d9aa168f975bdf165f3cdc4e234dd74949759d4c12b4e357e00cf42eece8c88R899) [[2]](diffhunk://#diff-6d9aa168f975bdf165f3cdc4e234dd74949759d4c12b4e357e00cf42eece8c88R912)