### PR TITLE
[Kafka][DSM] Update kafka ootb dashboard with dsm metrics

### DIFF
--- a/kafka/assets/dashboards/kafka_dashboard.json
+++ b/kafka/assets/dashboards/kafka_dashboard.json
@@ -24,18 +24,13 @@
               "vertical_align": "center",
               "horizontal_align": "center"
             },
-            "layout": {
-              "x": 0,
-              "y": 0,
-              "width": 6,
-              "height": 3
-            }
+            "layout": { "x": 0, "y": 0, "width": 6, "height": 3 }
           },
           {
             "id": 2594907126478070,
             "definition": {
               "type": "note",
-              "content": "**Kafka Integration Overview Dashboard**\n\nThis dashboard provides an overview of your Kafka environment. It displays metrics from Kafka, Zookeeper and Kafka Consumer Integrations with Datadog, giving you a 360-view of the health and observability measures of your Kafka Cluster. To have the all groups populated with data, you will have to enable all 3 integrations. However, enabling the Kafka integration alone will populate most of the dashboard widgets.\n\nIf you would benefit from visualizing the topology of your streaming data pipelines, or from investigating localized bottlenecks within your data streams setup, check out [Data Streams Monitoring](https://www.datadoghq.com/product/data-streams-monitoring/).",
+              "content": "**Kafka Integration Overview Dashboard**\n\nThis dashboard provides an overview of your Kafka environment. It displays metrics from Kafka, Zookeeper and Kafka Consumer Integrations with Datadog, giving you a 360-view of the health and observability measures of your Kafka Cluster. To have the all groups populated with data, you will have to enable all 3 integrations. However, enabling the Kafka integration alone will populate most of the dashboard widgets.\n\nIf you would benefit from visualizing the topology of your streaming data pipelines, or from investigating localized bottlenecks within your data streams setup, check out [Data Streams Monitoring](https://docs.datadoghq.com/data_streams/setup/technologies/kafka/?referrer=kafka).",
               "background_color": "white",
               "font_size": "14",
               "text_align": "left",
@@ -45,18 +40,13 @@
               "tick_edge": "left",
               "has_padding": true
             },
-            "layout": {
-              "x": 0,
-              "y": 3,
-              "width": 3,
-              "height": 4
-            }
+            "layout": { "x": 0, "y": 3, "width": 3, "height": 4 }
           },
           {
             "id": 7914240170882312,
             "definition": {
               "type": "note",
-              "content": "**Useful Links**\n\n* [Kafka Integration Doc](https://docs.datadoghq.com/integrations/kafka/?tab=host)\n* [Kafka Blog by Datadog](https://www.datadoghq.com/blog/monitor-kafka-with-datadog/)\n* [ZooKeeper Integration Doc](https://docs.datadoghq.com/integrations/zk/?tab=host)\n* [Data Streams Monitoring](https://www.datadoghq.com/product/data-streams-monitoring/)",
+              "content": "**Useful Links**\n\n* [Kafka Integration Doc](https://docs.datadoghq.com/integrations/kafka/?tab=host)\n* [Kafka Blog by Datadog](https://www.datadoghq.com/blog/monitor-kafka-with-datadog/)\n* [ZooKeeper Integration Doc](https://docs.datadoghq.com/integrations/zk/?tab=host)\n* [Data Streams Monitoring](https://docs.datadoghq.com/data_streams/setup/technologies/kafka/?referrer=kafka/)",
               "background_color": "white",
               "font_size": "16",
               "text_align": "left",
@@ -66,21 +56,11 @@
               "tick_edge": "left",
               "has_padding": true
             },
-            "layout": {
-              "x": 3,
-              "y": 3,
-              "width": 3,
-              "height": 4
-            }
+            "layout": { "x": 3, "y": 3, "width": 3, "height": 4 }
           }
         ]
       },
-      "layout": {
-        "x": 0,
-        "y": 0,
-        "width": 6,
-        "height": 8
-      }
+      "layout": { "x": 0, "y": 0, "width": 6, "height": 8 }
     },
     {
       "id": 1458255527068538,
@@ -105,12 +85,7 @@
               "tick_edge": "left",
               "has_padding": true
             },
-            "layout": {
-              "x": 0,
-              "y": 0,
-              "width": 6,
-              "height": 1
-            }
+            "layout": { "x": 0, "y": 0, "width": 6, "height": 1 }
           },
           {
             "id": 5429446961227528,
@@ -118,7 +93,6 @@
               "title": "Under Replicated ",
               "title_size": "16",
               "title_align": "left",
-              "time": {},
               "type": "query_value",
               "requests": [
                 {
@@ -139,17 +113,13 @@
                       "value": 10
                     }
                   ],
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
+                  "formulas": [{ "formula": "query1" }],
                   "queries": [
                     {
                       "aggregator": "avg",
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:kafka.replication.under_replicated_partitions{$datacenter}.weighted()"
+                      "query": "sum:kafka.replication.under_replicated_partitions{$env}.weighted()"
                     }
                   ],
                   "response_format": "scalar"
@@ -157,16 +127,9 @@
               ],
               "autoscale": true,
               "precision": 2,
-              "timeseries_background": {
-                "type": "bars"
-              }
+              "timeseries_background": { "type": "bars" }
             },
-            "layout": {
-              "x": 0,
-              "y": 1,
-              "width": 2,
-              "height": 1
-            }
+            "layout": { "x": 0, "y": 1, "width": 2, "height": 1 }
           },
           {
             "id": 7126099834297418,
@@ -176,6 +139,8 @@
               "display_format": "countsAndList",
               "color_preference": "text",
               "hide_zero_counts": true,
+              "show_status": true,
+              "last_triggered_format": "relative",
               "query": "Kafka",
               "sort": "status,asc",
               "count": 50,
@@ -184,12 +149,7 @@
               "show_priority": false,
               "show_last_triggered": false
             },
-            "layout": {
-              "x": 2,
-              "y": 1,
-              "width": 4,
-              "height": 6
-            }
+            "layout": { "x": 2, "y": 1, "width": 4, "height": 6 }
           },
           {
             "id": 5329136028287784,
@@ -217,23 +177,19 @@
                       "value": 0
                     }
                   ],
-                  "formulas": [
-                    {
-                      "formula": "query1 - query2"
-                    }
-                  ],
+                  "formulas": [{ "formula": "query1 - query2" }],
                   "queries": [
                     {
                       "aggregator": "avg",
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "max:kafka.replication.isr_expands.rate{$datacenter}"
+                      "query": "max:kafka.replication.isr_expands.rate{$env}"
                     },
                     {
                       "aggregator": "avg",
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "max:kafka.replication.isr_shrinks.rate{$datacenter}"
+                      "query": "max:kafka.replication.isr_shrinks.rate{$env}"
                     }
                   ],
                   "response_format": "scalar"
@@ -243,17 +199,10 @@
               "precision": 2,
               "timeseries_background": {
                 "type": "area",
-                "yaxis": {
-                  "include_zero": false
-                }
+                "yaxis": { "include_zero": false }
               }
             },
-            "layout": {
-              "x": 0,
-              "y": 2,
-              "width": 2,
-              "height": 1
-            }
+            "layout": { "x": 0, "y": 2, "width": 2, "height": 1 }
           },
           {
             "id": 595300252374894,
@@ -276,17 +225,13 @@
                       "value": 0
                     }
                   ],
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
+                  "formulas": [{ "formula": "query1" }],
                   "queries": [
                     {
                       "aggregator": "avg",
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:kafka.replication.offline_partitions_count{$datacenter}.weighted()"
+                      "query": "sum:kafka.replication.offline_partitions_count{$env}.weighted()"
                     }
                   ],
                   "response_format": "scalar"
@@ -294,16 +239,9 @@
               ],
               "autoscale": true,
               "precision": 0,
-              "timeseries_background": {
-                "type": "bars"
-              }
+              "timeseries_background": { "type": "bars" }
             },
-            "layout": {
-              "x": 0,
-              "y": 3,
-              "width": 2,
-              "height": 1
-            }
+            "layout": { "x": 0, "y": 3, "width": 2, "height": 1 }
           },
           {
             "id": 6283188824779080,
@@ -326,17 +264,13 @@
                       "value": 300
                     }
                   ],
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
+                  "formulas": [{ "formula": "query1" }],
                   "queries": [
                     {
                       "aggregator": "avg",
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:kafka.request.fetch_follower.time.avg{$datacenter}"
+                      "query": "avg:kafka.request.fetch_follower.time.avg{$env}"
                     }
                   ],
                   "response_format": "scalar"
@@ -345,16 +279,9 @@
               "autoscale": false,
               "custom_unit": "ms",
               "precision": 2,
-              "timeseries_background": {
-                "type": "area"
-              }
+              "timeseries_background": { "type": "area" }
             },
-            "layout": {
-              "x": 0,
-              "y": 4,
-              "width": 2,
-              "height": 1
-            }
+            "layout": { "x": 0, "y": 4, "width": 2, "height": 1 }
           },
           {
             "id": 7120815629099702,
@@ -377,17 +304,13 @@
                       "value": 300
                     }
                   ],
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
+                  "formulas": [{ "formula": "query1" }],
                   "queries": [
                     {
                       "aggregator": "avg",
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:kafka.request.fetch_consumer.time.avg{$datacenter}"
+                      "query": "avg:kafka.request.fetch_consumer.time.avg{$env}"
                     }
                   ],
                   "response_format": "scalar"
@@ -396,16 +319,9 @@
               "autoscale": false,
               "custom_unit": "ms",
               "precision": 2,
-              "timeseries_background": {
-                "type": "area"
-              }
+              "timeseries_background": { "type": "area" }
             },
-            "layout": {
-              "x": 0,
-              "y": 5,
-              "width": 2,
-              "height": 1
-            }
+            "layout": { "x": 0, "y": 5, "width": 2, "height": 1 }
           },
           {
             "id": 6153358611007182,
@@ -428,17 +344,13 @@
                       "value": 1000
                     }
                   ],
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
+                  "formulas": [{ "formula": "query1" }],
                   "queries": [
                     {
                       "aggregator": "avg",
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:kafka.request.produce.time.avg{$datacenter}"
+                      "query": "avg:kafka.request.produce.time.avg{$env}"
                     }
                   ],
                   "response_format": "scalar"
@@ -447,25 +359,13 @@
               "autoscale": false,
               "custom_unit": "ms",
               "precision": 2,
-              "timeseries_background": {
-                "type": "area"
-              }
+              "timeseries_background": { "type": "area" }
             },
-            "layout": {
-              "x": 0,
-              "y": 6,
-              "width": 2,
-              "height": 1
-            }
+            "layout": { "x": 0, "y": 6, "width": 2, "height": 1 }
           }
         ]
       },
-      "layout": {
-        "x": 6,
-        "y": 0,
-        "width": 6,
-        "height": 8
-      }
+      "layout": { "x": 6, "y": 0, "width": 6, "height": 8 }
     },
     {
       "id": 4734964335590552,
@@ -490,60 +390,47 @@
               "tick_edge": "left",
               "has_padding": true
             },
-            "layout": {
-              "x": 0,
-              "y": 0,
-              "width": 4,
-              "height": 1
-            }
+            "layout": { "x": 0, "y": 0, "width": 4, "height": 1 }
           },
           {
             "id": 75077178454600,
             "definition": {
-                "title": "Clean and Unclean Leader Elections",
-                "title_size": "16",
-                "title_align": "left",
-                "show_legend": true,
-                "legend_layout": "auto",
-                "legend_columns": [
-                    "avg",
-                    "min",
-                    "max",
-                    "value",
-                    "sum"
-                ],
-                "time": {},
-                "type": "timeseries",
-                "requests": [
+              "title": "Clean and Unclean Leader Elections",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    { "alias": "Clean", "formula": "query2" },
+                    { "alias": "Unclean", "formula": "query1" }
+                  ],
+                  "queries": [
                     {
-                        "formulas": [
-                            {
-                                "formula": "query2"
-                            }
-                        ],
-                        "queries": [
-                            {
-                                "data_source": "metrics",
-                                "name": "query2",
-                                "query": "sum:kafka.replication.leader_elections.rate{$datacenter}"
-                            }
-                        ],
-                        "response_format": "timeseries",
-                        "style": {
-                            "palette": "dog_classic",
-                            "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "bars"
+                      "data_source": "metrics",
+                      "name": "query2",
+                      "query": "avg:kafka.replication.leader_elections.rate{$env}"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:kafka.replication.unclean_leader_elections.rate{$env}"
                     }
-                ]
+                  ],
+                  "response_format": "timeseries",
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "bars"
+                }
+              ]
             },
-            "layout": {
-                "x": 0,
-                "y": 1,
-                "width": 4,
-                "height": 2
-            }
+            "layout": { "x": 0, "y": 1, "width": 4, "height": 2 }
           },
           {
             "id": 813550024104470,
@@ -553,42 +440,24 @@
               "title_align": "left",
               "show_legend": true,
               "legend_layout": "auto",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
               "type": "timeseries",
               "requests": [
                 {
                   "formulas": [
-                    {
-                      "formula": "query1",
-                      "style": {
-                        "palette": "classic",
-                        "palette_index": 0
-                      }
-                    },
-                    {
-                      "formula": "query2",
-                      "style": {
-                        "palette": "classic",
-                        "palette_index": 3
-                      }
-                    }
+                    { "alias": "Bytes In", "formula": "query1" },
+                    { "alias": "Bytes Out", "formula": "query2" }
                   ],
                   "queries": [
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:kafka.net.bytes_in.rate{$datacenter}.weighted()"
+                      "query": "sum:kafka.net.bytes_in.rate{$env} by {env}.weighted()"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:kafka.net.bytes_out.rate{$datacenter}.weighted()"
+                      "query": "sum:kafka.net.bytes_out.rate{$env} by {env}.weighted()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -601,12 +470,7 @@
                 }
               ]
             },
-            "layout": {
-              "x": 0,
-              "y": 3,
-              "width": 4,
-              "height": 2
-            }
+            "layout": { "x": 0, "y": 3, "width": 4, "height": 2 }
           },
           {
             "id": 2542338265763338,
@@ -616,34 +480,24 @@
               "title_align": "left",
               "show_legend": true,
               "legend_layout": "auto",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
               "type": "timeseries",
               "requests": [
                 {
                   "formulas": [
-                    {
-                      "formula": "query1"
-                    },
-                    {
-                      "formula": "query2"
-                    }
+                    { "alias": "Producer", "formula": "query1" },
+                    { "alias": "Fetch", "formula": "query2" }
                   ],
                   "queries": [
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:kafka.request.producer_request_purgatory.size{$datacenter}.weighted()"
+                      "query": "sum:kafka.request.producer_request_purgatory.size{$env} by {env}.weighted()"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:kafka.request.fetch_request_purgatory.size{$datacenter}.weighted()"
+                      "query": "sum:kafka.request.fetch_request_purgatory.size{$env} by {env}.weighted()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -656,12 +510,7 @@
                 }
               ]
             },
-            "layout": {
-              "x": 0,
-              "y": 5,
-              "width": 4,
-              "height": 2
-            }
+            "layout": { "x": 0, "y": 5, "width": 4, "height": 2 }
           },
           {
             "id": 715154928904470,
@@ -671,42 +520,24 @@
               "title_align": "left",
               "show_legend": true,
               "legend_layout": "auto",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
               "type": "timeseries",
               "requests": [
                 {
                   "formulas": [
-                    {
-                      "formula": "query1"
-                    },
-                    {
-                      "formula": "query2"
-                    },
-                    {
-                      "formula": "query3"
-                    }
+                    { "alias": "Produce", "formula": "query1" },
+                    { "alias": "Fetch", "formula": "query2" }
                   ],
                   "queries": [
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:kafka.request.produce.time.avg{$datacenter}"
+                      "query": "avg:kafka.request.produce.time.avg{$env} by {env}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:kafka.request.fetch_consumer.time.avg{$datacenter}"
-                    },
-                    {
-                      "data_source": "metrics",
-                      "name": "query3",
-                      "query": "avg:kafka.request.fetch_consumer.time.avg{$datacenter}"
+                      "query": "avg:kafka.request.fetch_consumer.time.avg{$env} by {env}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -719,21 +550,11 @@
                 }
               ]
             },
-            "layout": {
-              "x": 0,
-              "y": 7,
-              "width": 4,
-              "height": 2
-            }
+            "layout": { "x": 0, "y": 7, "width": 4, "height": 2 }
           }
         ]
       },
-      "layout": {
-        "x": 0,
-        "y": 0,
-        "width": 4,
-        "height": 10
-      }
+      "layout": { "x": 0, "y": 0, "width": 4, "height": 10 }
     },
     {
       "id": 214934188085478,
@@ -758,12 +579,7 @@
               "tick_edge": "left",
               "has_padding": true
             },
-            "layout": {
-              "x": 0,
-              "y": 0,
-              "width": 4,
-              "height": 1
-            }
+            "layout": { "x": 0, "y": 0, "width": 4, "height": 1 }
           },
           {
             "id": 1710406769010256,
@@ -773,26 +589,16 @@
               "title_align": "left",
               "show_legend": true,
               "legend_layout": "auto",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
               "type": "timeseries",
               "requests": [
                 {
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
+                  "formulas": [{ "formula": "query1" }],
                   "queries": [
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:kafka.producer.bytes_out{$datacenter} by {topic}.weighted()"
+                      "query": "sum:kafka.producer.bytes_out{$env} by {topic,env}.weighted()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -805,12 +611,7 @@
                 }
               ]
             },
-            "layout": {
-              "x": 0,
-              "y": 1,
-              "width": 4,
-              "height": 2
-            }
+            "layout": { "x": 0, "y": 1, "width": 4, "height": 2 }
           },
           {
             "id": 2772867130889104,
@@ -820,34 +621,24 @@
               "title_align": "left",
               "show_legend": true,
               "legend_layout": "auto",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
               "type": "timeseries",
               "requests": [
                 {
                   "formulas": [
-                    {
-                      "formula": "abs(query1)"
-                    },
-                    {
-                      "formula": "abs(query2)"
-                    }
+                    { "alias": "Request", "formula": "abs(query1)" },
+                    { "alias": "Response", "formula": "abs(query2)" }
                   ],
                   "queries": [
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:kafka.producer.request_rate{$datacenter} by {host}.weighted()"
+                      "query": "sum:kafka.producer.request_rate{$env} by {host}.weighted()"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:kafka.producer.response_rate{$datacenter} by {host}.weighted()"
+                      "query": "sum:kafka.producer.response_rate{$env} by {host}.weighted()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -860,12 +651,7 @@
                 }
               ]
             },
-            "layout": {
-              "x": 0,
-              "y": 3,
-              "width": 4,
-              "height": 2
-            }
+            "layout": { "x": 0, "y": 3, "width": 4, "height": 2 }
           },
           {
             "id": 4449092387768158,
@@ -875,26 +661,16 @@
               "title_align": "left",
               "show_legend": true,
               "legend_layout": "auto",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
               "type": "timeseries",
               "requests": [
                 {
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
+                  "formulas": [{ "formula": "query1" }],
                   "queries": [
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:kafka.producer.request_latency_avg{$datacenter}.weighted()"
+                      "query": "sum:kafka.producer.request_latency_avg{$env} by {env}.weighted()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -907,12 +683,7 @@
                 }
               ]
             },
-            "layout": {
-              "x": 0,
-              "y": 5,
-              "width": 4,
-              "height": 2
-            }
+            "layout": { "x": 0, "y": 5, "width": 4, "height": 2 }
           },
           {
             "id": 672205362131494,
@@ -922,26 +693,16 @@
               "title_align": "left",
               "show_legend": true,
               "legend_layout": "auto",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
               "type": "timeseries",
               "requests": [
                 {
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
+                  "formulas": [{ "formula": "query1" }],
                   "queries": [
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:kafka.producer.io_wait{$datacenter}.weighted()"
+                      "query": "sum:kafka.producer.io_wait{$env} by {env}.weighted()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -954,21 +715,11 @@
                 }
               ]
             },
-            "layout": {
-              "x": 0,
-              "y": 7,
-              "width": 4,
-              "height": 2
-            }
+            "layout": { "x": 0, "y": 7, "width": 4, "height": 2 }
           }
         ]
       },
-      "layout": {
-        "x": 4,
-        "y": 0,
-        "width": 4,
-        "height": 10
-      }
+      "layout": { "x": 4, "y": 0, "width": 4, "height": 10 }
     },
     {
       "id": 7612648335779806,
@@ -993,12 +744,7 @@
               "tick_edge": "left",
               "has_padding": true
             },
-            "layout": {
-              "x": 0,
-              "y": 0,
-              "width": 4,
-              "height": 1
-            }
+            "layout": { "x": 0, "y": 0, "width": 4, "height": 1 }
           },
           {
             "id": 7608752991496422,
@@ -1008,40 +754,32 @@
               "title_align": "left",
               "show_legend": true,
               "legend_layout": "auto",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
               "type": "timeseries",
               "requests": [
                 {
                   "formulas": [
                     {
-                      "formula": "query1",
-                      "style": {
-                        "palette": "green"
-                      }
+                      "style": { "palette": "green" },
+                      "alias": "Lag",
+                      "formula": "query1"
                     },
                     {
-                      "formula": "query2",
-                      "style": {
-                        "palette": "purple"
-                      }
+                      "style": { "palette": "purple" },
+                      "alias": "Offset",
+                      "formula": "query2"
                     }
                   ],
                   "queries": [
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:kafka.consumer_lag{$datacenter,$consumer_group} by {host,consumer_group}"
+                      "query": "sum:kafka.consumer_lag{$env,$consumer_group} by {host,consumer_group,env}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:kafka.consumer_offset{$datacenter,$consumer_group} by {host,consumer_group}"
+                      "query": "sum:kafka.consumer_offset{$env,$consumer_group} by {host,consumer_group,env}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1054,12 +792,7 @@
                 }
               ]
             },
-            "layout": {
-              "x": 0,
-              "y": 1,
-              "width": 4,
-              "height": 2
-            }
+            "layout": { "x": 0, "y": 1, "width": 4, "height": 2 }
           },
           {
             "id": 8458681128381916,
@@ -1069,26 +802,16 @@
               "title_align": "left",
               "show_legend": true,
               "legend_layout": "auto",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
               "type": "timeseries",
               "requests": [
                 {
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
+                  "formulas": [{ "formula": "query1" }],
                   "queries": [
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:kafka.consumer.bytes_in{$datacenter,$consumer_group}.weighted()"
+                      "query": "sum:kafka.consumer.bytes_in{$env,$consumer_group} by {consumer_group,env}.weighted()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1101,12 +824,7 @@
                 }
               ]
             },
-            "layout": {
-              "x": 0,
-              "y": 3,
-              "width": 4,
-              "height": 2
-            }
+            "layout": { "x": 0, "y": 3, "width": 4, "height": 2 }
           },
           {
             "id": 2830450524878806,
@@ -1116,26 +834,16 @@
               "title_align": "left",
               "show_legend": true,
               "legend_layout": "auto",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
               "type": "timeseries",
               "requests": [
                 {
-                  "formulas": [
-                    {
-                      "formula": "abs(query1)"
-                    }
-                  ],
+                  "formulas": [{ "formula": "abs(query1)" }],
                   "queries": [
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:kafka.consumer.messages_in{$datacenter,$consumer_group} by {client-id}.weighted()"
+                      "query": "sum:kafka.consumer.messages_in{$env,$consumer_group} by {client-id,env}.weighted()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1148,12 +856,7 @@
                 }
               ]
             },
-            "layout": {
-              "x": 0,
-              "y": 5,
-              "width": 4,
-              "height": 2
-            }
+            "layout": { "x": 0, "y": 5, "width": 4, "height": 2 }
           },
           {
             "id": 3805366576951434,
@@ -1163,26 +866,17 @@
               "title_align": "left",
               "show_legend": true,
               "legend_layout": "auto",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
+              "time": {},
               "type": "timeseries",
               "requests": [
                 {
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
+                  "formulas": [{ "formula": "query1" }],
                   "queries": [
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:kafka.consumer.fetch_rate{$datacenter,$consumer_group}.weighted()"
+                      "query": "sum:kafka.consumer.fetch_rate{$env,$consumer_group} by {env,consumer_group}.weighted()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1195,21 +889,269 @@
                 }
               ]
             },
-            "layout": {
-              "x": 0,
-              "y": 7,
-              "width": 4,
-              "height": 2
-            }
+            "layout": { "x": 0, "y": 7, "width": 4, "height": 2 }
           }
         ]
       },
-      "layout": {
-        "x": 8,
-        "y": 0,
-        "width": 4,
-        "height": 10
-      }
+      "layout": { "x": 8, "y": 0, "width": 4, "height": 10 }
+    },
+    {
+      "id": 6246186854446866,
+      "definition": {
+        "title": "Lag, Throughput and Message Size",
+        "background_color": "vivid_purple",
+        "show_title": true,
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 8236156193990667,
+            "definition": {
+              "type": "note",
+              "content": "Get insights into your topics' producers and consumers, including anomaly detection by instrumenting with Data Streams Monitoring. [Learn more](https://docs.datadoghq.com/data_streams/setup/technologies/kafka/?referrer=kafka)",
+              "background_color": "purple",
+              "font_size": "14",
+              "text_align": "center",
+              "vertical_align": "center",
+              "show_tick": true,
+              "tick_pos": "50%",
+              "tick_edge": "bottom",
+              "has_padding": true
+            },
+            "layout": { "x": 0, "y": 0, "width": 12, "height": 1 }
+          },
+          {
+            "id": 2184446562382655,
+            "definition": {
+              "title": "Top 10 Max Kafka Lag by env",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
+              "time": {},
+              "type": "timeseries",
+              "requests": [
+                {
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "max:data_streams.latency{type:kafka AND (pathway_type:edge) AND direction:in AND $topic} by {env,topic}"
+                    }
+                  ],
+                  "formulas": [{ "formula": "top(query1, 10, 'max', 'desc')" }],
+                  "style": {
+                    "palette": "dog_classic",
+                    "order_by": "values",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                }
+              ],
+              "custom_links": [
+                {
+                  "label": "View in Data Streams Monitoring",
+                  "link": "/data-streams/map?query=queue:{{topic.value}}&env={{env.value}}&referrer=kafka"
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 1, "width": 12, "height": 4 }
+          },
+          {
+            "id": 1870414104649433,
+            "definition": {
+              "title": "Incoming messages by env, producing service for $topic",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": false,
+              "legend_layout": "auto",
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "upstream_services_throughput",
+                      "query": "count(v: v>=0):data_streams.latency{direction:out,pathway_type:full,type:kafka,$topic,$env} by {service,env}.as_rate().rollup(10)"
+                    }
+                  ],
+                  "formulas": [
+                    {
+                      "alias": "producer_throughput",
+                      "number_format": {
+                        "unit": {
+                          "type": "canonical_unit",
+                          "unit_name": "message",
+                          "per_unit_name": "second"
+                        }
+                      },
+                      "formula": "default_zero(upstream_services_throughput)"
+                    }
+                  ],
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "area"
+                }
+              ],
+              "custom_links": [
+                {
+                  "label": "View in Data Streams Monitoring",
+                  "link": "/data-streams/map?query={{service}} queue:{{$queuename.value}}&referrer=kafka&env={{env.value}}"
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 5, "width": 6, "height": 2 }
+          },
+          {
+            "id": 944656656985134,
+            "definition": {
+              "title": "Outgoing messages by env, consuming service for $topic",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": false,
+              "legend_layout": "auto",
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "downstream_services_throughput_by_queues",
+                      "query": "count(v: v>=0):data_streams.latency{direction:in,pathway_type:full,type:kafka,$topic,$env} by {service,env}.as_rate().rollup(10)"
+                    }
+                  ],
+                  "formulas": [
+                    {
+                      "alias": "consumer_throughput",
+                      "number_format": {
+                        "unit": {
+                          "type": "canonical_unit",
+                          "unit_name": "message",
+                          "per_unit_name": "second"
+                        }
+                      },
+                      "formula": "default_zero(downstream_services_throughput_by_queues)"
+                    }
+                  ],
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "area"
+                }
+              ],
+              "custom_links": [
+                {
+                  "label": "View in Data Streams Monitoring",
+                  "link": "/data-streams/map?query={{service}} queue:{{$queuename.value}}&referrer=kafka&env={{env.value}}"
+                }
+              ]
+            },
+            "layout": { "x": 6, "y": 5, "width": 6, "height": 2 }
+          },
+          {
+            "id": 6058441691900230,
+            "definition": {
+              "title": "Top 10 p95 message size by env for $topic",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
+              "time": {},
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    { "formula": "top(query1, 10, 'mean', 'desc')" }
+                  ],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "p95:data_streams.payload_size{type:kafka,$topic,$env} by {topic,env}"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "style": {
+                    "palette": "dog_classic",
+                    "order_by": "values",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                }
+              ],
+              "yaxis": {
+                "scale": "linear",
+                "include_zero": true,
+                "min": "auto",
+                "max": "auto"
+              },
+              "custom_links": [
+                {
+                  "label": "View in Data Streams Monitoring",
+                  "link": "/data-streams/map?query=queue:{{topic.value}}&referrer=kafka&env={{env.value}}"
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 7, "width": 6, "height": 2 }
+          },
+          {
+            "id": 3284852106159467,
+            "definition": {
+              "title": "Distribution of message size for $topic",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "time": {},
+              "type": "distribution",
+              "xaxis": {
+                "scale": "linear",
+                "min": "auto",
+                "max": "auto",
+                "include_zero": true
+              },
+              "yaxis": {
+                "scale": "linear",
+                "min": "auto",
+                "max": "auto",
+                "include_zero": true
+              },
+              "custom_links": [
+                {
+                  "label": "View in Data Streams Monitoring",
+                  "link": "/data-streams/map?query=traffic_type%3Akafka&referrer=kafka"
+                }
+              ],
+              "requests": [
+                {
+                  "request_type": "histogram",
+                  "query": {
+                    "data_source": "metrics",
+                    "name": "query1",
+                    "aggregator": "avg",
+                    "query": "avg:data_streams.payload_size{type:kafka,$topic,$env}"
+                  }
+                }
+              ]
+            },
+            "layout": { "x": 6, "y": 7, "width": 6, "height": 2 }
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 18, "width": 12, "height": 10 }
     },
     {
       "id": 6693725981895002,
@@ -1234,12 +1176,7 @@
               "tick_edge": "left",
               "has_padding": true
             },
-            "layout": {
-              "x": 0,
-              "y": 0,
-              "width": 12,
-              "height": 1
-            }
+            "layout": { "x": 0, "y": 0, "width": 12, "height": 1 }
           },
           {
             "id": 1082500062594226,
@@ -1249,34 +1186,24 @@
               "title_align": "left",
               "show_legend": true,
               "legend_layout": "auto",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
               "type": "timeseries",
               "requests": [
                 {
                   "formulas": [
-                    {
-                      "formula": "query1"
-                    },
-                    {
-                      "formula": "query2"
-                    }
+                    { "formula": "query1" },
+                    { "formula": "query2" }
                   ],
                   "queries": [
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:zookeeper.max_file_descriptor_count{$datacenter} by {host}"
+                      "query": "avg:zookeeper.max_file_descriptor_count{$env} by {host}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:zookeeper.open_file_descriptor_count{$datacenter} by {host}"
+                      "query": "avg:zookeeper.open_file_descriptor_count{$env} by {host}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1289,12 +1216,7 @@
                 }
               ]
             },
-            "layout": {
-              "x": 0,
-              "y": 1,
-              "width": 4,
-              "height": 2
-            }
+            "layout": { "x": 0, "y": 1, "width": 4, "height": 2 }
           },
           {
             "id": 2464018598303636,
@@ -1306,31 +1228,20 @@
               "type": "heatmap",
               "requests": [
                 {
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
+                  "formulas": [{ "formula": "query1" }],
                   "queries": [
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:zookeeper.connections{$datacenter} by {service,host}"
+                      "query": "sum:zookeeper.connections{$env} by {service,host}"
                     }
                   ],
                   "response_format": "timeseries",
-                  "style": {
-                    "palette": "dog_classic"
-                  }
+                  "style": { "palette": "dog_classic" }
                 }
               ]
             },
-            "layout": {
-              "x": 4,
-              "y": 1,
-              "width": 4,
-              "height": 2
-            }
+            "layout": { "x": 4, "y": 1, "width": 4, "height": 2 }
           },
           {
             "id": 1672495146907534,
@@ -1340,26 +1251,16 @@
               "title_align": "left",
               "show_legend": true,
               "legend_layout": "auto",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
               "type": "timeseries",
               "requests": [
                 {
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
+                  "formulas": [{ "formula": "query1" }],
                   "queries": [
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:zookeeper.pending_syncs{$datacenter}"
+                      "query": "sum:zookeeper.pending_syncs{$env}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1372,12 +1273,7 @@
                 }
               ]
             },
-            "layout": {
-              "x": 8,
-              "y": 1,
-              "width": 4,
-              "height": 2
-            }
+            "layout": { "x": 8, "y": 1, "width": 4, "height": 2 }
           },
           {
             "id": 1648173259960202,
@@ -1387,26 +1283,16 @@
               "title_align": "left",
               "show_legend": true,
               "legend_layout": "auto",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
               "type": "timeseries",
               "requests": [
                 {
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
+                  "formulas": [{ "formula": "query1" }],
                   "queries": [
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:zookeeper.avg_latency{$datacenter}"
+                      "query": "sum:zookeeper.avg_latency{$env}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1419,12 +1305,7 @@
                 }
               ]
             },
-            "layout": {
-              "x": 0,
-              "y": 3,
-              "width": 4,
-              "height": 2
-            }
+            "layout": { "x": 0, "y": 3, "width": 4, "height": 2 }
           },
           {
             "id": 622016484301358,
@@ -1436,31 +1317,20 @@
               "type": "heatmap",
               "requests": [
                 {
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
+                  "formulas": [{ "formula": "query1" }],
                   "queries": [
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:zookeeper.outstanding_requests{$datacenter} by {host}"
+                      "query": "sum:zookeeper.outstanding_requests{$env} by {host}"
                     }
                   ],
                   "response_format": "timeseries",
-                  "style": {
-                    "palette": "dog_classic"
-                  }
+                  "style": { "palette": "dog_classic" }
                 }
               ]
             },
-            "layout": {
-              "x": 4,
-              "y": 3,
-              "width": 4,
-              "height": 2
-            }
+            "layout": { "x": 4, "y": 3, "width": 4, "height": 2 }
           },
           {
             "id": 1229030254709744,
@@ -1470,26 +1340,16 @@
               "title_align": "left",
               "show_legend": true,
               "legend_layout": "auto",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
               "type": "timeseries",
               "requests": [
                 {
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
+                  "formulas": [{ "formula": "query1" }],
                   "queries": [
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:zookeeper.commit_count{$datacenter,$consumer_group}"
+                      "query": "sum:zookeeper.commit_count{$env,$consumer_group}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1502,18 +1362,13 @@
                 }
               ]
             },
-            "layout": {
-              "x": 8,
-              "y": 3,
-              "width": 4,
-              "height": 2
-            }
+            "layout": { "x": 8, "y": 3, "width": 4, "height": 2 }
           }
         ]
       },
       "layout": {
         "x": 0,
-        "y": 0,
+        "y": 28,
         "width": 12,
         "height": 6,
         "is_column_break": true
@@ -1522,155 +1377,114 @@
     {
       "id": 4737895714824992,
       "definition": {
-          "title": "Broker JVM Metrics",
-          "background_color": "purple",
-          "show_title": true,
-          "type": "group",
-          "layout_type": "ordered",
-          "widgets": [
-              {
-                  "id": 5500612573375596,
-                  "definition": {
-                      "type": "note",
-                      "content": "Kafka brokers are Java applications that expose JVM metrics to inform on the broker's system health. Garbage collection metrics like those below provide key insights into free memory, broker performance, and heap size. You need to enable [new_gc_metrics](https://docs.datadoghq.com/integrations/java/?tab=host#configuration-options) for this section to populate. \n",
-                      "background_color": "gray",
-                      "font_size": "14",
-                      "text_align": "center",
-                      "vertical_align": "top",
-                      "show_tick": false,
-                      "tick_pos": "50%",
-                      "tick_edge": "left",
-                      "has_padding": true
+        "title": "Broker JVM Metrics",
+        "background_color": "purple",
+        "show_title": true,
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 5500612573375596,
+            "definition": {
+              "type": "note",
+              "content": "Kafka brokers are Java applications that expose JVM metrics to inform on the broker's system health. Garbage collection metrics like those below provide key insights into free memory, broker performance, and heap size. You need to enable [new_gc_metrics](https://docs.datadoghq.com/integrations/java/?tab=host#configuration-options) for this section to populate. \n",
+              "background_color": "gray",
+              "font_size": "14",
+              "text_align": "center",
+              "vertical_align": "top",
+              "show_tick": false,
+              "tick_pos": "50%",
+              "tick_edge": "left",
+              "has_padding": true
+            },
+            "layout": { "x": 0, "y": 0, "width": 12, "height": 1 }
+          },
+          {
+            "id": 5260033322648958,
+            "definition": {
+              "title": "JVM GC Count by Type",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
+              "time": {},
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    { "alias": "Major GC", "formula": "query1" },
+                    { "alias": "Minor GC", "formula": "query2" }
+                  ],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "sum:jvm.gc.major_collection_count{$env} by {type,env}.weighted()"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "query2",
+                      "query": "sum:jvm.gc.minor_collection_count{$env} by {type,env}.weighted()"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
                   },
-                  "layout": {
-                      "x": 0,
-                      "y": 0,
-                      "width": 12,
-                      "height": 1
-                  }
-              },
-              {
-                  "id": 5260033322648958,
-                  "definition": {
-                      "title": "JVM GC Count by Type",
-                      "title_size": "16",
-                      "title_align": "left",
-                      "show_legend": true,
-                      "legend_layout": "auto",
-                      "legend_columns": [
-                          "avg",
-                          "min",
-                          "max",
-                          "value",
-                          "sum"
-                      ],
-                      "time": {},
-                      "type": "timeseries",
-                      "requests": [
-                          {
-                              "formulas": [
-                                  {
-                                      "formula": "query1"
-                                  },
-                                  {
-                                      "formula": "query2"
-                                  }
-                              ],
-                              "queries": [
-                                  {
-                                      "data_source": "metrics",
-                                      "name": "query1",
-                                      "query": "sum:jvm.gc.major_collection_count{$datacenter} by {type}.weighted()"
-                                  },
-                                  {
-                                      "data_source": "metrics",
-                                      "name": "query2",
-                                      "query": "sum:jvm.gc.minor_collection_count{$datacenter} by {type}.weighted()"
-                                  }
-                              ],
-                              "response_format": "timeseries",
-                              "style": {
-                                  "palette": "dog_classic",
-                                  "line_type": "solid",
-                                  "line_width": "normal"
-                              },
-                              "display_type": "area"
-                          }
-                      ]
+                  "display_type": "area"
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 1, "width": 6, "height": 3 }
+          },
+          {
+            "id": 3147053810778090,
+            "definition": {
+              "title": "JVM GC Time by Type",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
+              "time": {},
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    { "alias": "Major GC", "formula": "query1" },
+                    { "alias": "Minor GC", "formula": "query2" }
+                  ],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "sum:jvm.gc.major_collection_time{$env} by {type,env}.weighted()"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "query2",
+                      "query": "sum:jvm.gc.minor_collection_time{$env} by {type,env}.weighted()"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
                   },
-                  "layout": {
-                      "x": 0,
-                      "y": 1,
-                      "width": 6,
-                      "height": 3
-                  }
-              },
-              {
-                  "id": 3147053810778090,
-                  "definition": {
-                      "title": "JVM GC Time by Type",
-                      "title_size": "16",
-                      "title_align": "left",
-                      "show_legend": true,
-                      "legend_layout": "auto",
-                      "legend_columns": [
-                          "avg",
-                          "min",
-                          "max",
-                          "value",
-                          "sum"
-                      ],
-                      "time": {},
-                      "type": "timeseries",
-                      "requests": [
-                          {
-                              "formulas": [
-                                  {
-                                      "formula": "query1"
-                                  },
-                                  {
-                                      "formula": "query2"
-                                  }
-                              ],
-                              "queries": [
-                                  {
-                                      "data_source": "metrics",
-                                      "name": "query1",
-                                      "query": "sum:jvm.gc.major_collection_time{$datacenter} by {type}.weighted()"
-                                  },
-                                  {
-                                      "data_source": "metrics",
-                                      "name": "query2",
-                                      "query": "sum:jvm.gc.minor_collection_time{$datacenter} by {type}.weighted()"
-                                  }
-                              ],
-                              "response_format": "timeseries",
-                              "style": {
-                                  "palette": "dog_classic",
-                                  "line_type": "solid",
-                                  "line_width": "normal"
-                              },
-                              "display_type": "line"
-                          }
-                      ]
-                  },
-                  "layout": {
-                      "x": 6,
-                      "y": 1,
-                      "width": 6,
-                      "height": 3
-                  }
-              }
-          ]
+                  "display_type": "line"
+                }
+              ]
+            },
+            "layout": { "x": 6, "y": 1, "width": 6, "height": 3 }
+          }
+        ]
       },
-      "layout": {
-          "x": 0,
-          "y": 1,
-          "width": 12,
-          "height": 5
-      }
-  },
-
+      "layout": { "x": 0, "y": 34, "width": 12, "height": 5 }
+    },
     {
       "id": 8466685701903458,
       "definition": {
@@ -1694,12 +1508,7 @@
               "tick_edge": "left",
               "has_padding": true
             },
-            "layout": {
-              "x": 0,
-              "y": 0,
-              "width": 12,
-              "height": 1
-            }
+            "layout": { "x": 0, "y": 0, "width": 12, "height": 1 }
           },
           {
             "id": 4450446556187890,
@@ -1709,46 +1518,27 @@
               "title_align": "left",
               "show_legend": true,
               "legend_layout": "horizontal",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
               "type": "timeseries",
               "requests": [
                 {
-                  "formulas": [
-                    {
-                      "formula": "a"
-                    }
-                  ],
+                  "formulas": [{ "formula": "a" }],
                   "queries": [
                     {
-                      "compute": {
-                        "aggregation": "count"
-                      },
+                      "compute": { "aggregation": "count" },
                       "data_source": "logs",
                       "group_by": [
                         {
                           "facet": "status",
                           "limit": 50,
                           "should_exclude_missing": true,
-                          "sort": {
-                            "aggregation": "count",
-                            "order": "desc"
-                          }
+                          "sort": { "aggregation": "count", "order": "desc" }
                         }
                       ],
-                      "indexes": [
-                        "*"
-                      ],
+                      "indexes": ["*"],
                       "name": "a",
-                      "search": {
-                        "query": "source:kafka"
-                      },
-                      "storage": "online_archives"
+                      "search": { "query": "source:kafka" },
+                      "storage": "flex_tier"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1761,12 +1551,7 @@
                 }
               ]
             },
-            "layout": {
-              "x": 0,
-              "y": 1,
-              "width": 8,
-              "height": 4
-            }
+            "layout": { "x": 0, "y": 1, "width": 8, "height": 4 }
           },
           {
             "id": 2559718770477840,
@@ -1774,32 +1559,15 @@
               "title": "Error Logs",
               "title_size": "16",
               "title_align": "left",
-              "time": {
-                "live_span": "1mo"
-              },
+              "time": { "live_span": "1mo" },
               "requests": [
                 {
                   "columns": [
-                    {
-                      "field": "status_line",
-                      "width": "auto"
-                    },
-                    {
-                      "field": "timestamp",
-                      "width": "auto"
-                    },
-                    {
-                      "field": "host",
-                      "width": "auto"
-                    },
-                    {
-                      "field": "service",
-                      "width": "auto"
-                    },
-                    {
-                      "field": "content",
-                      "width": "compact"
-                    }
+                    { "field": "status_line", "width": "auto" },
+                    { "field": "timestamp", "width": "auto" },
+                    { "field": "host", "width": "auto" },
+                    { "field": "service", "width": "auto" },
+                    { "field": "content", "width": "compact" }
                   ],
                   "query": {
                     "data_source": "logs_stream",
@@ -1812,24 +1580,15 @@
               ],
               "type": "list_stream"
             },
-            "layout": {
-              "x": 8,
-              "y": 1,
-              "width": 4,
-              "height": 4
-            }
+            "layout": { "x": 8, "y": 1, "width": 4, "height": 4 }
           }
         ]
       },
-      "layout": {
-        "x": 0,
-        "y": 11,
-        "width": 12,
-        "height": 6
-      }
+      "layout": { "x": 0, "y": 39, "width": 12, "height": 6 }
     }
   ],
   "template_variables": [
+    { "name": "env", "prefix": "env", "available_values": [], "default": "*" },
     {
       "name": "consumer_group",
       "prefix": "consumer_group",
@@ -1839,12 +1598,6 @@
     {
       "name": "topic",
       "prefix": "topic",
-      "available_values": [],
-      "default": "*"
-    },
-    {
-      "name": "datacenter",
-      "prefix": "datacenter",
       "available_values": [],
       "default": "*"
     }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

https://datadoghq.atlassian.net/browse/DSMON-748

Update the kafka dashboard to include DSM metrics, with a callout to instrument with DSM

Current OOT Dashboard: https://app.datadoghq.com/dash/integration/50/kafka-zookeeper-and-kafka-consumer-overview

New version (feel free to copy + past json from diff if you'd like): https://app.datadoghq.com/dashboard/pqw-u3q-5tj/kafka-zookeeper-and-kafka-consumer-overview?fromUser=false&refresh_mode=sliding&from_ts=1747853399177&to_ts=1747856999177&live=true

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
