### PR TITLE
[DBMON-5380] Fix incorrect tag assertion in tests

### DIFF
--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -912,7 +912,7 @@ def test_standalone(instance_integration, aggregator, check, dd_run_check):
     )
     assert len(aggregator._events) == 0
 
-    expected_tags = [f'server:{mongo_check._config.clean_server_name}']
+    expected_tags = [f'server:{mongo_check._config.clean_server_name}', 'hosting_type:self-hosted']
     _assert_mongodb_instance_event(
         aggregator,
         mongo_check,
@@ -1097,7 +1097,11 @@ def test_integration_reemit_mongodb_instance_on_deployment_change(
         'hosting_type:self-hosted',
     ]
 
-    expected_tags = replica_tags + [f'server:{mongo_check._config.clean_server_name}']
+    expected_tags = replica_tags + [
+        f'server:{mongo_check._config.clean_server_name}',
+        'clustername:my_cluster',
+        'replset_me:mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017',
+    ]
     _assert_mongodb_instance_event(
         aggregator,
         mongo_check,

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -42,7 +42,7 @@ def _assert_mongodb_instance_event(
     assert mongodb_instance_event['host'] == check._resolved_hostname
     assert mongodb_instance_event['host'] == check._resolved_hostname
     assert mongodb_instance_event['dbms'] == "mongo"
-    assert mongodb_instance_event['tags'].sort() == expected_tags.sort()
+    assert sorted(mongodb_instance_event['tags']) == sorted(expected_tags)
 
     expected_instance_metadata = {
         "replset_name": replset_name,
@@ -112,7 +112,12 @@ def test_integration_mongos(instance_integration_cluster, aggregator, check, dd_
     )
     assert len(aggregator._events) == 0
 
-    expected_tags = ['server:mongodb://localhost:27017/', 'sharding_cluster_role:mongos', 'hosting_type:self-hosted']
+    expected_tags = [
+        'server:mongodb://testUser2:*****@localhost:27017/test',
+        'sharding_cluster_role:mongos',
+        'hosting_type:self-hosted',
+        'clustername:my_cluster',
+    ]
     _assert_mongodb_instance_event(
         aggregator,
         mongos_check,

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -82,7 +82,7 @@ def instance_basic():
         'username': common.USER,
         'password': common.PASS,
         'port': common.PORT,
-        'disable_generic_tags': 'true',
+        'disable_generic_tags': True,
     }
 
 
@@ -93,7 +93,7 @@ def instance_complex():
         'username': common.USER,
         'password': common.PASS,
         'port': common.PORT,
-        'disable_generic_tags': 'true',
+        'disable_generic_tags': True,
         'options': {
             'replication': True,
             'extra_status_metrics': True,
@@ -131,7 +131,7 @@ def instance_additional_status():
         'password': common.PASS,
         'port': common.PORT,
         'tags': tags.METRIC_TAGS,
-        'disable_generic_tags': 'true',
+        'disable_generic_tags': True,
         'additional_status': [
             {
                 'name': "Innodb_rows_read",
@@ -179,7 +179,7 @@ def instance_status_already_queried():
         'password': common.PASS,
         'port': common.PORT,
         'tags': tags.METRIC_TAGS,
-        'disable_generic_tags': 'true',
+        'disable_generic_tags': True,
         'additional_status': [
             {
                 'name': "Open_files",
@@ -198,7 +198,7 @@ def instance_var_already_queried():
         'password': common.PASS,
         'port': common.PORT,
         'tags': tags.METRIC_TAGS,
-        'disable_generic_tags': 'true',
+        'disable_generic_tags': True,
         'additional_variable': [
             {
                 'name': "Key_buffer_size",
@@ -217,7 +217,7 @@ def instance_invalid_var():
         'password': common.PASS,
         'port': common.PORT,
         'tags': tags.METRIC_TAGS,
-        'disable_generic_tags': 'true',
+        'disable_generic_tags': True,
         'additional_status': [
             {
                 'name': "longer_query_time",
@@ -241,7 +241,7 @@ def instance_custom_queries():
         'password': common.PASS,
         'port': common.PORT,
         'tags': tags.METRIC_TAGS,
-        'disable_generic_tags': 'true',
+        'disable_generic_tags': True,
         'custom_queries': [
             {
                 'query': "SELECT name,age from testdb.users where name='Alice' limit 1;",

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -780,7 +780,7 @@ def test_set_resources(aggregator, dd_run_check, instance_basic, cloud_metadata,
         (True, None),
         (False, None),
         (True, 'forced_hostname'),
-        (True, 'forced_hostname'),
+        (False, 'forced_hostname'),
     ],
 )
 @pytest.mark.integration
@@ -793,18 +793,30 @@ def test_database_instance_metadata(aggregator, dd_run_check, instance_complex, 
         instance_complex['query_activity'] = {'collection_interval': 0.1}
         instance_complex['query_samples'] = {'collection_interval': 0.1}
         instance_complex['query_metrics'] = {'collection_interval': 0.1}
+
+    expected_host = expected_database_hostname = expected_database_instance = "stubbed.hostname"
     if reported_hostname:
         instance_complex['reported_hostname'] = reported_hostname
-    expected_host = reported_hostname if reported_hostname else 'stubbed.hostname'
+        expected_host = reported_hostname
+        expected_database_instance = reported_hostname
+
+    expected_tags = tags.METRIC_TAGS + [
+        "database_hostname:{}".format(expected_database_hostname),
+        "database_instance:{}".format(expected_database_instance),
+    ]
+
     mysql_check = MySql(common.CHECK_NAME, {}, [instance_complex])
     dd_run_check(mysql_check)
 
     dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
     event = next((e for e in dbm_metadata if e['kind'] == 'database_instance'), None)
+
     assert event is not None
     assert event['host'] == expected_host
+    assert event['database_instance'] == expected_database_instance
+    assert event['database_hostname'] == expected_database_hostname
     assert event['dbms'] == "mysql"
-    assert event['tags'].sort() == tags.METRIC_TAGS.sort()
+    assert sorted(event['tags']) == sorted(expected_tags)
     assert event['integration_version'] == __version__
     assert event['collection_interval'] == 300
     assert event['metadata'] == {

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -269,7 +269,7 @@ def test_autodiscovery_db_service_checks(
     for c in sc:
         if c.status == SQLServer.CRITICAL:
             db_critical_exists = True
-            assert c.tags.sort() == critical_tags.sort()
+            assert sorted(c.tags) == sorted(critical_tags)
     if service_check_enabled:
         assert db_critical_exists
 


### PR DESCRIPTION
### What does this PR do?
We had a couple of tests across the DBM integrations that were incorrectly doing assertion comparisons on `.sort()` which is an in place sort function that returns `None`. These changes fix the sorting to sort into a new list and actually compare the sorted results. It fixes expected tags where the tests were incorrect previously.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
