### PR TITLE
display wlan integration on docs

### DIFF
--- a/wlan/manifest.json
+++ b/wlan/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "dbf0f387-cef7-4694-9001-b7bb5c1c1274",
   "app_id": "wlan",
-  "display_on_public_website": false,
+  "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?
makes the wlan integration public on the docs page

### Motivation
The agent release is live, and this integration is ready to be public. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
