### PR TITLE
Modify local_clone fixture logic to ensure we use proper origin

### DIFF
--- a/ddev/tests/conftest.py
+++ b/ddev/tests/conftest.py
@@ -172,6 +172,10 @@ def isolation() -> Generator[Path, None, None]:
 def local_clone(isolation, local_repo) -> Generator[ClonedRepo, None, None]:
     cloned_repo_path = isolation / local_repo.name
 
+    # Get the current origin remote url
+    with local_repo.as_cwd():
+        origin_url = PLATFORM.check_command_output(['git', 'remote', 'get-url', 'origin']).strip()
+
     PLATFORM.check_command_output(
         ['git', 'clone', '--local', '--shared', '--no-tags', str(local_repo), str(cloned_repo_path)]
     )
@@ -179,6 +183,11 @@ def local_clone(isolation, local_repo) -> Generator[ClonedRepo, None, None]:
         PLATFORM.check_command_output(['git', 'config', 'user.name', 'Foo Bar'])
         PLATFORM.check_command_output(['git', 'config', 'user.email', 'foo@bar.baz'])
         PLATFORM.check_command_output(['git', 'config', 'commit.gpgsign', 'false'])
+
+        # Set url to point to the origin of the local source and not to the local repo
+        PLATFORM.check_command_output(['git', 'remote', 'set-url', 'origin', origin_url])
+        # Now fetch latest updates
+        PLATFORM.check_command_output(['git', 'fetch', 'origin'])
 
     cloned_repo = ClonedRepo(cloned_repo_path, 'origin/master', 'ddev-testing')
     cloned_repo.reset_branch()


### PR DESCRIPTION
### What does this PR do?
This is a small PR to ensure that the `local_clone` fixture does what we expect it to do. This fixture relies on the current state of the developer local repo which can cause tests to not have the lates version of origin. The test `test__utils.py` validates we are not too far behind with the number of integrations in our local repo but since we create `ddev-testing` by running

`git checkout -fB ddev-testing origin/master`

but after we have cloned the repo to a temporary directory, here, `origin` refers to our local repo not to the `origin` set in our local repo.

This causes that if the developr rarely uses their local `master` branch (work mostly with fetch rebase, for example), the expected fixture state is not ensured.

### Motivation
Ensure tests behave as expected independently of the current local repo of the developer.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
