### PR TITLE
Fix flaky ddev override test

### DIFF
--- a/ddev/tests/cli/config/test_override.py
+++ b/ddev/tests/cli/config/test_override.py
@@ -156,7 +156,7 @@ def test_pyproject_not_found_ask_user(
         extras = "{extras_path}"
         """
     )
-    print(result.output)
+
     # Reload new values
     config_file.load()
     assert_valid_local_config(config_file, config_file.overrides_path.parent, result, expected_output)


### PR DESCRIPTION
### What does this PR do?
Fixes a test that could fail when run in a specific order for the new override ddev command. We do this by ensuring the local override file is removed after each test (since tests run sequentially that should be enough) and also improve it by avoiding deleting the pyproject.toml of the local clone.

### Motivation
Ensure tests are stable.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
