### PR TITLE
Migrate PyPi publishing to Trusted Publishers and environments

### DIFF
--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -604,6 +604,11 @@ jobs:
         path: installers
         merge-multiple: true
 
+    # Publish wheels to PyPI using Trusted Publishers.
+    # https://docs.pypi.org/trusted-publishers/using-a-publisher/
+    # This job needs to run from within the pypi-ddev environment. PyPi validates the
+    # workflow file name, environment and repository the request is comming from to
+    # provide the valid JWT token.
     - name: Push Python artifacts to PyPI
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
       with:

--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -579,6 +579,9 @@ jobs:
 
     permissions:
       contents: write
+      id-token: write
+
+    environment: pypi-ddev
 
     steps:
     - name: Download Python artifacts
@@ -605,8 +608,6 @@ jobs:
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
       with:
         skip-existing: true
-        user: __token__
-        password: ${{ secrets.PYPI_TOKEN_DDEV_2 }}
 
     - name: Add assets to current release
       uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2

--- a/.github/workflows/claim-pypi-name.yaml
+++ b/.github/workflows/claim-pypi-name.yaml
@@ -21,6 +21,8 @@ jobs:
     name: Build wheel
     runs-on: ubuntu-latest
 
+    environment: typo-squatting-release
+
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -46,4 +48,4 @@ jobs:
         # Only uploading the missing wheels makes this job idempotent and reduces its complexity.
         skip-existing: true
         user: __token__
-        password: ${{ secrets.INTEGRATIONS_PYPI_NAME_CLAIM }}
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -9,6 +9,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write
+
+    environment: pypi-datadog-checks-base
+
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -30,8 +35,11 @@ jobs:
         ddev config set repos.core .
         ddev config set repo core
 
-    - name: Release base package
-      run: ddev release upload -s datadog_checks_base
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_BASE_2 }}
+    - name: Build base package
+      run: ddev release build datadog_checks_base
+
+    - name: Release base package to PyPI
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+      with:
+        skip-existing: true
+        packages-dir: datadog_checks_base/dist

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -38,6 +38,11 @@ jobs:
     - name: Build base package
       run: ddev release build datadog_checks_base
 
+    # Publish wheels to PyPI using Trusted Publishers.
+    # https://docs.pypi.org/trusted-publishers/using-a-publisher/
+    # This job needs to run from within the pypi-datadog-checks-base environment. PyPi
+    # validates the workflow file name, environment and repository the request is
+    # comming from to provide the valid JWT token.
     - name: Release base package to PyPI
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
       with:

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -9,6 +9,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write
+
+    environment: pypi-datadog-checks-dev
+
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -30,8 +35,11 @@ jobs:
         ddev config set repos.core .
         ddev config set repo core
 
-    - name: Release dev package
-      run: ddev release upload -s datadog_checks_dev
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_DEV_2 }}
+    - name: Build dev package
+      run: ddev release build datadog_checks_dev
+
+    - name: Release dev package to PyPI
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+      with:
+        skip-existing: true
+        packages-dir: datadog_checks_dev/dist

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -38,6 +38,11 @@ jobs:
     - name: Build dev package
       run: ddev release build datadog_checks_dev
 
+    # Publish wheels to PyPI using Trusted Publishers.
+    # https://docs.pypi.org/trusted-publishers/using-a-publisher/
+    # This job needs to run from within the pypi-datadog-checks-dev environment. PyPi
+    # validates the workflow file name, environment and repository the request is
+    # comming from to provide the valid JWT token.
     - name: Release dev package to PyPI
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
       with:


### PR DESCRIPTION
### What does this PR do?
This PR updates the actions that publish new packages to PyPi to use trusted publishers and run behind a given environment. Any run outside the appropriate environment won't be able to retrieve the short-lived JWT token.

For the typo squatting an environment has been defined to run only in `master` and the secret has been moved to the environment secrets. This will allow to remove repository secrets.

### Motivation
Improved security and reduce token rotation requirements.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
