### PR TITLE
[Release] Bumped ddev version to 11.4.0

### DIFF
--- a/ddev/CHANGELOG.md
+++ b/ddev/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 <!-- towncrier release notes start -->
 
+## 11.4.0 / 2025-05-27
+
+***Added***:
+
+* Allow ddev to override configuration values from a local .ddev.toml file found either in the local directory or any parent directory. This allows modifying ddev behavior when running it in different directories. ([#19877](https://github.com/DataDog/integrations-core/pull/19877))
+* Added new commands to track and analyze size changes in integrations and dependencies:
+  - **`ddev size status`**: Shows current sizes of all modules.
+  - **`ddev size diff [COMMIT_BEFORE] [COMMIT_AFTER]`**: Compares size changes between two commits.
+  - **`ddev size timeline {integration | dependency} [INTEGRATION_NAME/DEPENDENCY_NAME]`**: Visualizes the size evolution of a module over time. ([#20128](https://github.com/DataDog/integrations-core/pull/20128))
+* Add ZillizCloud requested metric units ([#20195](https://github.com/DataDog/integrations-core/pull/20195))
+
 ## 11.3.0 / 2025-04-30
 
 ***Added***:

--- a/ddev/changelog.d/19877.added
+++ b/ddev/changelog.d/19877.added
@@ -1,1 +1,0 @@
-Allow ddev to override configuration values from a local .ddev.toml file found either in the local directory or any parent directory. This allows modifying ddev behavior when running it in different directories.

--- a/ddev/changelog.d/20128.added
+++ b/ddev/changelog.d/20128.added
@@ -1,4 +1,0 @@
-Added new commands to track and analyze size changes in integrations and dependencies:
-- **`ddev size status`**: Shows current sizes of all modules.
-- **`ddev size diff [COMMIT_BEFORE] [COMMIT_AFTER]`**: Compares size changes between two commits.
-- **`ddev size timeline {integration | dependency} [INTEGRATION_NAME/DEPENDENCY_NAME]`**: Visualizes the size evolution of a module over time.

--- a/ddev/changelog.d/20195.added
+++ b/ddev/changelog.d/20195.added
@@ -1,1 +1,0 @@
-Add ZillizCloud requested metric units


### PR DESCRIPTION
### What does this PR do?
Creates new ddev release

### Motivation
Get version 11.4.0 out with package size analyzer and local overrides

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
