### PR TITLE
Unpin ddtrace dependency

### DIFF
--- a/.ddev/config.toml
+++ b/.ddev/config.toml
@@ -149,7 +149,6 @@ unsorted = [
 
 [overrides.dep.updates]
 exclude = [
-    'ddtrace',  # https://github.com/DataDog/integrations-core/pull/9132
     'pyasn1',  # https://github.com/pyasn1/pyasn1/issues/52
     'pysmi', # pysnmp dependent on pysmi version 1.2.1
     'pysnmp',  # Breaking snmp tests


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Allow our weekly dependency update bot to bump `ddtrace`.

### Motivation
<!-- What inspired you to submit this pull request? -->
After https://github.com/DataDog/integrations-core/pull/20358 we don't have any reason not to update the library.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
