### PR TITLE
Fix builder jobs in gitlab pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -134,8 +134,7 @@ tagger-image-builder:
     - if: $CI_COMMIT_TAG
       when: never
     - if: $CI_COMMIT_BRANCH == 'master'
-      when: always
-    - changes:
+      changes:
         - .gitlab/tagger/**/*
         - ddev/**/*
         - .gitlab-ci.yml
@@ -155,8 +154,7 @@ validate-log-intgs-builder:
     - if: $CI_COMMIT_TAG
       when: never
     - if: $CI_COMMIT_BRANCH == 'master'
-      when: always
-    - changes:
+      changes:
         - .gitlab/validate-logs-intgs/**/*
         - .gitlab-ci.yml
   script:


### PR DESCRIPTION
### What does this PR do?
This PR fixes the builder jobs in GitLab pipeline to only run when in master and there are changes on the specified paths. The current behavior builds it whenever it is in master OR there are changes in the files. This triggers builds from PR which is undesirable.

### Motivation
Fix when the builders should run.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
