### PR TITLE
Fix the valid repos in the documentation page for the override command

### DIFF
--- a/docs/developer/ddev/multirepo.md
+++ b/docs/developer/ddev/multirepo.md
@@ -22,12 +22,12 @@ The `ddev config override` command creates the `.ddev.toml` file in your working
 # pyproject.toml
 
 [tool.ddev]
-repo = "integrations-core"
+repo = "core"
 # The valid options for this value are
-# "integrations-core"
-# "integrations-extras"
-# "integrations-internal"
-# "datadog-agent"
+# "core"
+# "extras"
+# "internal"
+# "agent"
 # "marketplace"
 # "integrations-internal-core"
 ```


### PR DESCRIPTION
### What does this PR do?
This PR fixes the valid repo names for the `ddev config override`. Before releasing the final version of the command we decided to simplify these names but forgot to update the documentation.

### Motivation
Proper docs.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
