### PR TITLE
fix permissions to typosquatting github workflow

### DIFF
--- a/.github/workflows/claim-pypi-name.yaml
+++ b/.github/workflows/claim-pypi-name.yaml
@@ -23,6 +23,9 @@ jobs:
 
     environment: typo-squatting-release
 
+    permissions:
+      id-token: write
+
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
### What does this PR do?
This PR fixes the workflow that publishes package names for each integration to PyPi. The `id-token: write` permissions were missing.

### Motivation
Ensure the workflow can run.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
