### PR TITLE
Aarakke/fix typo squatting workflow

### DIFF
--- a/.github/workflows/claim-pypi-name.yaml
+++ b/.github/workflows/claim-pypi-name.yaml
@@ -23,9 +23,6 @@ jobs:
 
     environment: typo-squatting-release
 
-    permissions:
-      id-token: write
-
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
### What does this PR do?
Removes the permissions set since we are authenticating with username and password for typosquatting workflow. 

### Motivation
Ensure we are not giving more permissions than necessary. It was added assuming the issue was that it was missing and that is the reason why the workflow failed but the issue was related with the secret not being properly set. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
