### PR TITLE
Update process.d/conf.yaml

### DIFF
--- a/process/datadog_checks/process/data/conf.yaml.example
+++ b/process/datadog_checks/process/data/conf.yaml.example
@@ -72,7 +72,7 @@ instances:
     # pid_file: <PID_FILE>
 
     ## @param exact_match - boolean - optional - default: true
-    ## If you want to match your `search_string` on a substring within the list of process names, 
+    ## If you want to match your `search_string` against the exact full process name within the list of process names, 
     ## set this to true. This is equivalent to running `ps -e` on Linux or `Get-Process` on Windows.
     ##
     ## If you want to match your `search_string` on a substring within the list of process names


### PR DESCRIPTION
### What does this PR do?
This PR fixes the incorrect description of `exact_match` in process.d/conf.yaml

### Motivation
The current explanation for exact_match is, "If you want to match your \`search_string\` on **a substring** within the list of process names, set this to true."
```
    ## @param exact_match - boolean - optional - default: true
    ## If you want to match your `search_string` on a substring within the list of process names, 
    ## set this to true. This is equivalent to running `ps -e` on Linux or `Get-Process` on Windows.
```
It means `search_string: abc` would match process names such as "abc_process", "abc.exe", ...

but actual implementation is, when `exact_match` is True, `search_string` s**hould exactly match the process name, not just a substring.**

https://github.com/DataDog/integrations-core/blob/024592040086a7901ed3614a93c0a9355b313d6f/process/datadog_checks/process/process.py#L162C1-L168C49
```
                        if exact_match:
                            if os.name == 'nt':
                                if proc.name().lower() == string.lower():
                                    found = True
                            else:
                                if proc.name() == string:
                                    found = True
```

Additional Note:
When `exact_match` is false, regular expression matching is used, so the current description might seem accurate in that case.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
