### PR TITLE
Fix duplicate ddev command in cursor instructions

### DIFF
--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -4,4 +4,4 @@ globs: **/*.py
 alwaysApply: false
 ---
 Run unit and integration tests with `ddev --no-interactive test <INTEGRATION>`. For example, for the pgbouncer integration, run `ddev --no-interactive test pgbouncer`.
-Run E2E tests with `ddev ddev --no-interactive env test <INTEGRATION> --dev`. For example, for the pgbouncer integration, run `ddev ddev --no-interactive env test pgbouncer --dev`.
+Run E2E tests with `ddev --no-interactive env test <INTEGRATION> --dev`. For example, for the pgbouncer integration, run `ddev --no-interactive env test pgbouncer --dev`.


### PR DESCRIPTION
### What does this PR do?
Fixes the ddev word appearing twice in the cursor instructions.