### PR TITLE
Add a step to guide users in case the pinact workflow is failing

### DIFF
--- a/.github/workflows/validate-pinned-actions.yml
+++ b/.github/workflows/validate-pinned-actions.yml
@@ -19,6 +19,7 @@ jobs:
           persist-credentials: false
 
       - name: Pin actions
+        id: pin-actions
         # Relies on the following actions that need to be allowed in the repo:
         # aquaproj/aqua-installer@e2d0136abcf70b7a2f6f505720640750557c4b33
         # suzuki-shunsuke/commit-action@04e7ae80e6b3c584ba8a4d98ab64474963d854eb
@@ -27,3 +28,24 @@ jobs:
         uses: suzuki-shunsuke/pinact-action@d735505f3decf76fca3fdbb4c952e5b3eba0ffdd # v0.1.2
         with:
           skip_push: true
+
+      - name: Output pin actions failure message
+        if: failure() && steps.pin-actions.outcome == 'failure'
+        run: |
+          cat >> $GITHUB_STEP_SUMMARY << 'EOF'
+          ## ⚠️ Action Pinning Validation Failed
+
+          This check ensures actions are pinned to a specific commit SHA for security and reliability. This validation did not pass for your workflow.
+
+          Here's how to resolve this:
+
+          **1. If you added or modified an action:**
+          * Ensure it's pinned to a full commit SHA (e.g., `actions/checkout@a12b34cdef567890...`), not a tag or branch.
+          * For new actions or versions, please ping `@agent-integrations` in your pull request to validate and allow-list its usage.
+
+          **2. If you have *not* changed any actions in this branch:**
+          * An allowed action version may have been updated centrally, and your branch is now using an older, unpermitted version.
+          * Update your branch with the latest changes from `master` (or your repository's main branch) to get the current allowed actions.
+
+          If the issue persists after these steps, please contact `@agent-integrations` for assistance.
+          EOF


### PR DESCRIPTION
### What does this PR do?
Adds a message to clarify why pinact failed to help the user troubleshooting it.

### Motivation
Make sure that when we want to update a pinned action we do not need to care about any pending PR using an older version as this message should help the user know they need to rebase their branch

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
