### PR TITLE
[DBMON-5404] Add TagManager class to dbm base utils

### DIFF
--- a/datadog_checks_base/changelog.d/20397.added
+++ b/datadog_checks_base/changelog.d/20397.added
@@ -1,0 +1,1 @@
+Add TagManager class to dbm base utils

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -11,8 +11,9 @@ import socket
 import threading
 import time
 from concurrent.futures.thread import ThreadPoolExecutor
+from enum import Enum, auto
 from ipaddress import IPv4Address
-from typing import Any, Callable, Dict, List, Tuple  # noqa: F401
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union  # noqa: F401
 
 from cachetools import TTLCache
 
@@ -441,3 +442,128 @@ def tracked_query(check, operation, tags=None):
     yield
     elapsed_ms = (time.time() - start_time) * 1000
     check.histogram("dd.{}.operation.time".format(check.name), elapsed_ms, **stats_kwargs)
+
+
+class TagType(Enum):
+    """Enum for different types of tags"""
+
+    KEYLESS = auto()
+
+
+class TagManager:
+    """
+    Manages tags for a check. Tags are stored as a dictionary of key-value pairs
+    for key-value tags and as a list of values for keyless tags useful for easy update and deletion.
+    There's an internal cache of the tag list to avoid generating the list of tag strings
+    multiple times.
+    """
+
+    def __init__(self) -> None:
+        self._tags: Dict[Union[str, TagType], List[str]] = {}
+        self._cached_tag_list: Optional[tuple[str, ...]] = None
+        self._keyless: TagType = TagType.KEYLESS
+
+    def set_tag(self, key: Optional[str], value: str, replace: bool = False) -> None:
+        """
+        Set a tag with the given key and value.
+        If key is None or empty, the value is stored as a keyless tag.
+        Args:
+            key (str): The tag key, or None/empty for keyless tags
+            value (str): The tag value
+            replace (bool): If True, replaces all existing values for this key
+                           If False, appends the value if it doesn't exist
+        """
+        if not key:
+            key = self._keyless
+
+        if replace or key not in self._tags:
+            self._tags[key] = [value]
+            # Invalidate the cache since tags have changed
+            self._cached_tag_list = None
+        elif value not in self._tags[key]:
+            self._tags[key].append(value)
+            # Invalidate the cache since tags have changed
+            self._cached_tag_list = None
+
+    def set_tags_from_list(self, tag_list: List[str], replace: bool = False) -> None:
+        """
+        Set multiple tags from a list of strings.
+        Strings can be in "key:value" format or just "value" format.
+        Args:
+            tag_list (List[str]): List of tags in "key:value" format or just "value"
+            replace (bool): If True, replaces all existing tags with the new tags list
+        """
+        if replace:
+            self._tags.clear()
+            self._cached_tag_list = None
+
+        for tag in tag_list:
+            if ':' in tag:
+                key, value = tag.split(':', 1)
+                self.set_tag(key, value)
+            else:
+                self.set_tag(None, tag)
+
+    def delete_tag(self, key: Optional[str], value: Optional[str] = None) -> bool:
+        """
+        Delete a tag or specific value for a tag.
+        For keyless tags, use None or empty string as the key.
+        Args:
+            key (str): The tag key to delete, or None/empty for keyless tags
+            value (str, optional): If provided, only deletes this specific value for the key.
+                                 If None, deletes all values for the key.
+        Returns:
+            bool: True if something was deleted, False otherwise
+        """
+        if not key:
+            key = self._keyless
+
+        if key not in self._tags:
+            return False
+
+        if value is None:
+            # Delete the entire key
+            del self._tags[key]
+            # Invalidate the cache
+            self._cached_tag_list = None
+            return True
+        else:
+            # Delete specific value if it exists
+            if value in self._tags[key]:
+                self._tags[key].remove(value)
+                # Clean up empty lists
+                if not self._tags[key]:
+                    del self._tags[key]
+                # Invalidate the cache
+                self._cached_tag_list = None
+                return True
+        return False
+
+    def _generate_tag_strings(self, tags_dict: Dict[Union[str, TagType], List[str]]) -> tuple[str, ...]:
+        """
+        Generate a tuple of tag strings from a tags dictionary.
+        Args:
+            tags_dict (Dict[Union[str, TagType], List[str]]): Dictionary of tags to convert to strings
+        Returns:
+            tuple[str, ...]: Tuple of tag strings
+        """
+        return tuple(
+            value if key == self._keyless else f"{key}:{value}" for key, values in tags_dict.items() for value in values
+        )
+
+    def get_tags(self) -> List[str]:
+        """
+        Get a list of tag strings.
+        For key-value tags, returns "key:value" format.
+        For keyless tags, returns just the value.
+        The returned list is always sorted alphabetically.
+        Returns:
+            list: Sorted list of tag strings
+        """
+        # Return cached list if available
+        if self._cached_tag_list is not None:
+            return list(self._cached_tag_list)
+
+        # Generate and cache regular tags
+        self._cached_tag_list = self._generate_tag_strings(self._tags)
+        return list(self._cached_tag_list)

--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -17,6 +17,8 @@ from datadog_checks.base.utils.db.utils import (
     ConstantRateLimiter,
     DBMAsyncJob,
     RateLimitingTTLCache,
+    TagManager,
+    TagType,
     default_json_event_encoding,
     get_agent_host_tags,
     obfuscate_sql_with_metadata,
@@ -388,3 +390,211 @@ def test_tracked_query(aggregator):
         aggregator.assert_metric(
             "dd.testcheck.operation.time", tags=["test:tag", "operation:test_query"], count=1, value=1000.0
         )
+
+
+class TestTagManager:
+    def test_init(self):
+        """Test initialization of TagManager"""
+        tag_manager = TagManager()
+        assert tag_manager._tags == {}
+        assert tag_manager._cached_tag_list is None
+        assert tag_manager._keyless == TagType.KEYLESS
+
+    @pytest.mark.parametrize(
+        'key,value,expected_tags',
+        [
+            ('test_key', 'test_value', {'test_key': ['test_value']}),
+            (None, 'test_value', {TagType.KEYLESS: ['test_value']}),
+        ],
+    )
+    def test_set_tag(self, key, value, expected_tags):
+        """Test setting tags with various combinations of key and value"""
+        tag_manager = TagManager()
+        tag_manager.set_tag(key, value)
+        assert tag_manager._tags == expected_tags
+        assert tag_manager._cached_tag_list is None
+
+    def test_set_tag_existing_key_append(self):
+        """Test appending a value to an existing key"""
+        tag_manager = TagManager()
+        tag_manager.set_tag('test_key', 'value1')
+        tag_manager.set_tag('test_key', 'value2')
+        assert tag_manager._tags == {'test_key': ['value1', 'value2']}
+        assert tag_manager._cached_tag_list is None
+
+    def test_set_tag_existing_key_replace(self):
+        """Test replacing values for an existing key"""
+        tag_manager = TagManager()
+        tag_manager.set_tag('test_key', 'value1')
+        tag_manager.set_tag('test_key', 'value2', replace=True)
+        assert tag_manager._tags == {'test_key': ['value2']}
+        assert tag_manager._cached_tag_list is None
+
+    def test_set_tag_duplicate_value(self):
+        """Test setting a duplicate value for a key"""
+        tag_manager = TagManager()
+        tag_manager.set_tag('test_key', 'test_value')
+        tag_manager.set_tag('test_key', 'test_value')
+        assert tag_manager._tags == {'test_key': ['test_value']}
+        assert tag_manager._cached_tag_list is None
+
+    @pytest.mark.parametrize(
+        'key,values,delete_key,delete_value,expected_tags,description',
+        [
+            (
+                'test_key',
+                ['value1', 'value2'],
+                'test_key',
+                'value1',
+                {'test_key': ['value2']},
+                'deleting specific value',
+            ),
+            ('test_key', ['value1', 'value2'], 'test_key', None, {}, 'deleting all values for key'),
+            (
+                None,
+                ['value1', 'value2'],
+                None,
+                'value1',
+                {TagType.KEYLESS: ['value2']},
+                'deleting specific keyless value',
+            ),
+            (None, ['value1', 'value2'], None, None, {}, 'deleting all keyless values'),
+        ],
+    )
+    def test_delete_tag(self, key, values, delete_key, delete_value, expected_tags, description):
+        """Test various tag deletion scenarios"""
+        tag_manager = TagManager()
+        # Set up initial tags
+        for value in values:
+            tag_manager.set_tag(key, value)
+
+        # Generate initial cache
+        tag_manager.get_tags()
+        assert tag_manager._cached_tag_list is not None
+
+        # Perform deletion
+        assert tag_manager.delete_tag(delete_key, delete_value)
+
+        # Verify cache is invalidated
+        assert tag_manager._cached_tag_list is None
+
+        # Verify internal state
+        assert tag_manager._tags == expected_tags
+
+    @pytest.mark.parametrize(
+        'initial_tags,tag_list,replace,expected_tags,description',
+        [
+            (
+                [],
+                ['key1:value1', 'key2:value2', 'value3'],
+                False,
+                ['key1:value1', 'key2:value2', 'value3'],
+                'setting new tags',
+            ),
+            (
+                ['key1:old_value', 'key2:old_value', 'keyless1'],
+                ['key1:new_value', 'key3:new_value', 'keyless2'],
+                True,
+                ['key1:new_value', 'key3:new_value', 'keyless2'],
+                'replacing all existing tags with new ones',
+            ),
+            (
+                ['key1:old_value'],
+                ['key1:new_value'],
+                False,
+                ['key1:new_value', 'key1:old_value'],
+                'appending to existing tags',
+            ),
+            ([], ['key1:value1', 'key1:value1'], False, ['key1:value1'], 'setting duplicate values'),
+            (
+                [],
+                ['key1:value1', 'value2', 'key2:value3'],
+                False,
+                ['key1:value1', 'key2:value3', 'value2'],
+                'setting mixed format tags',
+            ),
+        ],
+    )
+    def test_set_tags_from_list(self, initial_tags, tag_list, replace, expected_tags, description):
+        """Test various tag list setting scenarios"""
+        tag_manager = TagManager()
+        # Set up initial tags if any
+        for tag in initial_tags:
+            if ':' in tag:
+                key, value = tag.split(':', 1)
+                tag_manager.set_tag(key, value)
+            else:
+                tag_manager.set_tag(None, tag)
+
+        # Generate cache to ensure it exists
+        _ = tag_manager.get_tags()
+        assert tag_manager._cached_tag_list is not None
+
+        tag_manager.set_tags_from_list(tag_list, replace=replace)
+
+        # Verify cache was invalidated when needed
+        if replace:
+            assert tag_manager._cached_tag_list is None
+
+        # Verify final state
+        assert sorted(tag_manager.get_tags()) == sorted(expected_tags)
+
+    def test_get_tags_empty(self):
+        tag_manager = TagManager()
+        assert tag_manager.get_tags() == []
+
+    @pytest.mark.parametrize(
+        'regular_tags,expected_tags',
+        [
+            ({'key1': ['value1']}, ['key1:value1']),
+            ({'key1': ['value1', 'value2']}, ['key1:value1', 'key1:value2']),
+        ],
+    )
+    def test_get_tags(self, regular_tags, expected_tags):
+        """Test getting tags with various combinations of regular tags"""
+        tag_manager = TagManager()
+
+        # Set up regular tags
+        for key, values in regular_tags.items():
+            for value in values:
+                tag_manager.set_tag(key, value)
+
+        # Verify tags
+        assert sorted(tag_manager.get_tags()) == sorted(expected_tags)
+
+    def test_cache_management(self):
+        """Test that tag caches are properly managed"""
+        tag_manager = TagManager()
+
+        # Set initial tags
+        tag_manager.set_tag('regular_key', 'regular_value')
+
+        # First call should generate cache
+        _ = tag_manager.get_tags()
+        assert tag_manager._cached_tag_list is not None
+
+        # Modify regular tags
+        tag_manager.set_tag('regular_key2', 'regular_value2')
+        assert tag_manager._cached_tag_list is None
+
+        # Verify all tags are included
+        second_result = tag_manager.get_tags()
+        assert sorted(second_result) == sorted(['regular_key:regular_value', 'regular_key2:regular_value2'])
+
+    def test_get_tags_mutation(self):
+        """Test that modifying the returned list from get_tags() does not affect the internal cache"""
+        tag_manager = TagManager()
+        tag_manager.set_tag('test_key', 'test_value')
+
+        # Get the tags list
+        tags = tag_manager.get_tags()
+        assert tags == ['test_key:test_value']
+
+        # Modify the returned list
+        tags.append('modified_tag')
+        tags[0] = 'modified_existing_tag'
+
+        # Get tags again - should be unchanged
+        new_tags = tag_manager.get_tags()
+        assert new_tags == ['test_key:test_value']
+        assert new_tags != tags  # The lists should be different objects


### PR DESCRIPTION
### What does this PR do?
Adds a new class TagManager to dbm's base utils module. This will be used to replace our current naive tag lists we maintain in the various dbms integrations. The goal of this class is to have an easy an efficient wrapper around tags that can allow us to efficiently perform CRUD type of operations on our list of tags in order to ensure that we can accurately modify tags over the life of the integration check as the source database values change and avoid emitting stale or inaccurate values.

### Motivation
This is being added in order to fix an issue that affects all of our python dbms integrations. Having shared logic will allow us to ensure tagging logic is implemented the same across integrations

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
