### PR TITLE
Stop relying on manifest.json to validate spec.yaml

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
@@ -12,6 +12,7 @@ from ...config_validator.validator import validate_config
 from ...config_validator.validator_errors import SEVERITY_ERROR, SEVERITY_WARNING
 from ...configuration import ConfigSpec
 from ...configuration.consumers import ExampleConsumer
+from ...constants import get_root
 from ...manifest_utils import Manifest
 from ...testing import process_checks_option
 from ...utils import complete_valid_checks, get_config_files, get_data_directory, get_version_string
@@ -67,7 +68,7 @@ def config(ctx, check, sync, verbose):
             echo_debug(f"Skipping validation for check: {check}; can't process manifest")
             continue
 
-        spec_file_path = manifest.get_config_spec()
+        spec_file_path = path_join(get_root(), check, 'assets', 'configuration', 'spec.yaml')
         if not file_exists(spec_file_path):
             example_location = get_data_directory(check)
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/models.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/models.py
@@ -16,7 +16,6 @@ from ....fs import (
 from ...configuration import ConfigSpec
 from ...configuration.consumers import ModelConsumer
 from ...constants import get_root
-from ...manifest_utils import Manifest
 from ...testing import process_checks_option
 from ...utils import (
     CUSTOM_FILES,
@@ -31,7 +30,6 @@ from ..console import (
     abort,
     annotate_display_queue,
     annotate_error,
-    echo_debug,
     echo_failure,
     echo_info,
     echo_success,
@@ -108,11 +106,7 @@ def models(ctx, check, sync, verbose):
             source = 'test'
             version = '0.0.1'
         else:
-            manifest = Manifest.load_manifest(check)
-            if not manifest:
-                echo_debug(f"Skipping validation for check: {check}; can't process manifest")
-                continue
-            spec_path = manifest.get_config_spec()
+            spec_path = path_join(root, check, 'assets', 'configuration', 'spec.yaml')
             if not file_exists(spec_path):
                 continue
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
@@ -10,15 +10,6 @@ def spec_validator(spec: dict, loader) -> None:
         loader.errors.append(f'{loader.source}: Configuration specifications must be a mapping object')
         return
 
-    if 'name' not in spec:
-        loader.errors.append(f'{loader.source}: Configuration specifications must contain a top-level `name` attribute')
-        return
-
-    name = spec['name']
-    if not isinstance(name, str):
-        loader.errors.append(f'{loader.source}: The top-level `name` attribute must be a string')
-        return
-
     release_version = spec.setdefault('version', loader.version)
     if not release_version:
         loader.errors.append(

--- a/datadog_checks_dev/tests/tooling/configuration/test_load.py
+++ b/datadog_checks_dev/tests/tooling/configuration/test_load.py
@@ -37,32 +37,28 @@ def test_not_map():
 
 
 def test_no_name():
+    """
+    We used to have a top-level "name" field that we enforced.
+
+    We no longer need this field, we keep this test as proof.
+    """
+
     spec = get_spec(
         """
-        foo:
-        - bar
+        version: 0.0.0
+        files:
+        - name: test.yaml
+          options: []
         """
     )
     spec.load()
 
-    assert 'test: Configuration specifications must contain a top-level `name` attribute' in spec.errors
-
-
-def test_name_not_string():
-    spec = get_spec(
-        """
-        name: 123
-        """
-    )
-    spec.load()
-
-    assert 'test: The top-level `name` attribute must be a string' in spec.errors
+    assert not spec.errors
 
 
 def test_no_version():
     spec = get_spec(
         """
-        name: foo
         """
     )
     spec.load()
@@ -73,7 +69,6 @@ def test_no_version():
 def test_version_not_string():
     spec = get_spec(
         """
-        name: foo
         version: 123
         """
     )
@@ -85,7 +80,6 @@ def test_version_not_string():
 def test_version_loaded():
     spec = get_spec(
         """
-        name: foo
         """,
         version='0.0.0',
     )
@@ -97,7 +91,6 @@ def test_version_loaded():
 def test_no_files():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         """
     )
@@ -109,7 +102,6 @@ def test_no_files():
 def test_files_not_array():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
           foo: bar
@@ -123,7 +115,6 @@ def test_files_not_array():
 def test_file_not_map():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - 5
@@ -139,7 +130,6 @@ def test_file_not_map():
 def test_file_no_name():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - foo: bar
@@ -155,7 +145,6 @@ def test_file_no_name():
 def test_file_name_duplicate():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -170,7 +159,6 @@ def test_file_name_duplicate():
 def test_example_file_name_duplicate():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -187,7 +175,6 @@ def test_example_file_name_duplicate():
 def test_file_name_not_string():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: 123
@@ -202,7 +189,6 @@ def test_file_name_not_string():
 def test_example_file_name_not_string():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -217,7 +203,6 @@ def test_example_file_name_not_string():
 def test_file_name_standard_incorrect():
     spec = get_spec(
         """
-        name: IBM Db2
         version: 0.0.0
         files:
         - name: foo.yaml
@@ -232,7 +217,6 @@ def test_file_name_standard_incorrect():
 def test_example_file_name_autodiscovery_incorrect():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: auto_conf.yaml
@@ -247,7 +231,6 @@ def test_example_file_name_autodiscovery_incorrect():
 def test_example_file_name_core_check_incorrect():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: conf.yaml.default
@@ -262,7 +245,6 @@ def test_example_file_name_core_check_incorrect():
 def test_example_file_name_standard_default():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -276,7 +258,6 @@ def test_example_file_name_standard_default():
 def test_example_file_name_autodiscovery_default():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: auto_conf.yaml
@@ -290,7 +271,6 @@ def test_example_file_name_autodiscovery_default():
 def test_example_file_name_core_check_default():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: conf.yaml.default
@@ -304,7 +284,6 @@ def test_example_file_name_core_check_default():
 def test_no_options():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -319,7 +298,6 @@ def test_no_options():
 def test_sections_not_array():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -336,7 +314,6 @@ def test_sections_not_array():
 def test_section_not_map():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -355,7 +332,6 @@ def test_section_not_map():
 def test_section_no_name():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -372,7 +348,6 @@ def test_section_no_name():
 def test_section_name_not_string():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -389,7 +364,6 @@ def test_section_name_not_string():
 def test_section_name_duplicate():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -407,7 +381,6 @@ def test_section_name_duplicate():
 def test_options_not_array():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -427,7 +400,6 @@ def test_options_not_array():
 def test_option_not_map():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -449,7 +421,6 @@ def test_option_not_map():
 def test_option_no_name():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -469,7 +440,6 @@ def test_option_no_name():
 def test_option_name_not_string():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -489,7 +459,6 @@ def test_option_name_not_string():
 def test_option_name_duplicate():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -510,7 +479,6 @@ def test_option_name_duplicate():
 def test_option_no_description():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -530,7 +498,6 @@ def test_option_no_description():
 def test_option_description_not_string():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -551,7 +518,6 @@ def test_option_description_not_string():
 def test_option_required_not_boolean():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -573,7 +539,6 @@ def test_option_required_not_boolean():
 def test_option_required_default():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -594,7 +559,6 @@ def test_option_required_default():
 def test_option_hidden_not_boolean():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -616,7 +580,6 @@ def test_option_hidden_not_boolean():
 def test_option_hidden_default():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -637,7 +600,6 @@ def test_option_hidden_default():
 def test_option_display_priority_not_integer():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -659,7 +621,6 @@ def test_option_display_priority_not_integer():
 def test_option_display_priority_default():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -680,7 +641,6 @@ def test_option_display_priority_default():
 def test_option_deprecation_not_mapping():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -702,7 +662,6 @@ def test_option_deprecation_not_mapping():
 def test_option_deprecation_value_not_string():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -725,7 +684,6 @@ def test_option_deprecation_value_not_string():
 def test_option_deprecation_default():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -746,7 +704,6 @@ def test_option_deprecation_default():
 def test_option_deprecation_ok():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -769,7 +726,6 @@ def test_option_deprecation_ok():
 def test_option_metadata_tags_not_array():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -791,7 +747,6 @@ def test_option_metadata_tags_not_array():
 def test_option_metadata_tags_value_not_string():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -814,7 +769,6 @@ def test_option_metadata_tags_value_not_string():
 def test_option_metadata_tags_default():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -835,7 +789,6 @@ def test_option_metadata_tags_default():
 def test_option_metadata_tags_ok():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -858,7 +811,6 @@ def test_option_metadata_tags_ok():
 def test_option_no_value_nor_options():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -876,7 +828,6 @@ def test_option_no_value_nor_options():
 def test_option_value_and_options():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -901,7 +852,6 @@ def test_option_value_and_options():
 def test_option_value_not_map():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -924,7 +874,6 @@ def test_option_value_not_map():
 def test_option_secret_not_boolean():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -948,7 +897,6 @@ def test_option_secret_not_boolean():
 def test_option_secret_default():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -971,7 +919,6 @@ def test_option_secret_default():
 def test_value_no_type():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -994,7 +941,6 @@ def test_value_no_type():
 def test_value_type_string_valid_basic():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1017,7 +963,6 @@ def test_value_type_string_valid_basic():
 def test_value_type_not_string():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1040,7 +985,6 @@ def test_value_type_not_string():
 def test_value_type_string_example_default_no_depth():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1063,7 +1007,6 @@ def test_value_type_string_example_default_no_depth():
 def test_value_type_string_example_default_nested():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1089,7 +1032,6 @@ def test_value_type_string_example_default_nested():
 def test_value_type_string_example_not_string():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1113,7 +1055,6 @@ def test_value_type_string_example_not_string():
 def test_value_type_string_example_valid():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1137,7 +1078,6 @@ def test_value_type_string_example_valid():
 def test_value_type_string_pattern_not_string():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1161,7 +1101,6 @@ def test_value_type_string_pattern_not_string():
 def test_value_type_integer_valid_basic():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1184,7 +1123,6 @@ def test_value_type_integer_valid_basic():
 def test_value_type_integer_example_default_no_depth():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1207,7 +1145,6 @@ def test_value_type_integer_example_default_no_depth():
 def test_value_type_integer_example_default_nested():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1233,7 +1170,6 @@ def test_value_type_integer_example_default_nested():
 def test_value_type_integer_example_not_number():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1257,7 +1193,6 @@ def test_value_type_integer_example_not_number():
 def test_value_type_integer_example_valid():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1281,7 +1216,6 @@ def test_value_type_integer_example_valid():
 def test_value_type_integer_correct_minimum():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1305,7 +1239,6 @@ def test_value_type_integer_correct_minimum():
 def test_value_type_integer_incorrect_minimum():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1329,7 +1262,6 @@ def test_value_type_integer_incorrect_minimum():
 def test_value_type_integer_correct_maximum():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1353,7 +1285,6 @@ def test_value_type_integer_correct_maximum():
 def test_value_type_integer_incorrect_maximum():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1377,7 +1308,6 @@ def test_value_type_integer_incorrect_maximum():
 def test_value_type_integer_correct_minimum_maximum():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1402,7 +1332,6 @@ def test_value_type_integer_correct_minimum_maximum():
 def test_value_type_integer_incorrect_minimum_maximum():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1430,7 +1359,6 @@ def test_value_type_integer_incorrect_minimum_maximum():
 def test_value_type_number_valid_basic():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1453,7 +1381,6 @@ def test_value_type_number_valid_basic():
 def test_value_type_number_example_default_no_depth():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1476,7 +1403,6 @@ def test_value_type_number_example_default_no_depth():
 def test_value_type_number_example_default_nested():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1502,7 +1428,6 @@ def test_value_type_number_example_default_nested():
 def test_value_type_number_example_not_number():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1526,7 +1451,6 @@ def test_value_type_number_example_not_number():
 def test_value_type_number_example_valid():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1550,7 +1474,6 @@ def test_value_type_number_example_valid():
 def test_value_type_number_correct_minimum():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1574,7 +1497,6 @@ def test_value_type_number_correct_minimum():
 def test_value_type_number_incorrect_minimum():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1598,7 +1520,6 @@ def test_value_type_number_incorrect_minimum():
 def test_value_type_number_correct_maximum():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1622,7 +1543,6 @@ def test_value_type_number_correct_maximum():
 def test_value_type_number_incorrect_maximum():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1646,7 +1566,6 @@ def test_value_type_number_incorrect_maximum():
 def test_value_type_number_correct_minimum_maximum():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1671,7 +1590,6 @@ def test_value_type_number_correct_minimum_maximum():
 def test_value_type_number_incorrect_minimum_maximum():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1699,7 +1617,6 @@ def test_value_type_number_incorrect_minimum_maximum():
 def test_value_type_boolean_example_default_no_depth():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1722,7 +1639,6 @@ def test_value_type_boolean_example_default_no_depth():
 def test_value_type_boolean_example_default_nested():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1748,7 +1664,6 @@ def test_value_type_boolean_example_default_nested():
 def test_value_type_boolean_example_not_boolean():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1774,7 +1689,6 @@ def test_value_type_boolean_example_not_boolean():
 def test_value_type_boolean_example_valid():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1798,7 +1712,6 @@ def test_value_type_boolean_example_valid():
 def test_value_type_array_example_default_no_depth():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1823,7 +1736,6 @@ def test_value_type_array_example_default_no_depth():
 def test_value_type_array_example_default_nested():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1851,7 +1763,6 @@ def test_value_type_array_example_default_nested():
 def test_value_type_array_example_not_array():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1877,7 +1788,6 @@ def test_value_type_array_example_not_array():
 def test_value_type_array_example_valid():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1905,7 +1815,6 @@ def test_value_type_array_example_valid():
 def test_value_type_array_no_items():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1928,7 +1837,6 @@ def test_value_type_array_no_items():
 def test_value_type_array_items_not_array():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1952,7 +1860,6 @@ def test_value_type_array_items_not_array():
 def test_value_type_array_unique_items_not_boolean():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -1980,7 +1887,6 @@ def test_value_type_array_unique_items_not_boolean():
 def test_value_type_array_correct_min_items():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2006,7 +1912,6 @@ def test_value_type_array_correct_min_items():
 def test_value_type_array_incorrect_min_items():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2032,7 +1937,6 @@ def test_value_type_array_incorrect_min_items():
 def test_value_type_array_correct_max_items():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2058,7 +1962,6 @@ def test_value_type_array_correct_max_items():
 def test_value_type_array_incorrect_max_items():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2084,7 +1987,6 @@ def test_value_type_array_incorrect_max_items():
 def test_value_type_array_correct_min_items_max_items():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2111,7 +2013,6 @@ def test_value_type_array_correct_min_items_max_items():
 def test_value_type_array_incorrect_min_items_max_items():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2143,7 +2044,6 @@ def test_value_type_array_incorrect_min_items_max_items():
 def test_value_type_object_example_default_no_depth():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2167,7 +2067,6 @@ def test_value_type_object_example_default_no_depth():
 def test_value_type_object_example_default_nested():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2193,7 +2092,6 @@ def test_value_type_object_example_default_nested():
 def test_value_type_object_example_not_map():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2219,7 +2117,6 @@ def test_value_type_object_example_not_map():
 def test_value_type_object_example_valid():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2246,7 +2143,6 @@ def test_value_type_object_example_valid():
 def test_value_type_object_required_not_array():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2270,7 +2166,6 @@ def test_value_type_object_required_not_array():
 def test_value_type_object_required_empty():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2296,7 +2191,6 @@ def test_value_type_object_required_empty():
 def test_value_type_object_required_not_unique():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2324,7 +2218,6 @@ def test_value_type_object_required_not_unique():
 def test_value_type_object_properties_default():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2348,7 +2241,6 @@ def test_value_type_object_properties_default():
 def test_value_type_object_properties_not_array():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2372,7 +2264,6 @@ def test_value_type_object_properties_not_array():
 def test_value_type_object_properties_entry_not_map():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2399,7 +2290,6 @@ def test_value_type_object_properties_entry_not_map():
 def test_value_type_object_properties_entry_no_name():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2426,7 +2316,6 @@ def test_value_type_object_properties_entry_no_name():
 def test_value_type_object_properties_entry_name_not_string():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2452,7 +2341,6 @@ def test_value_type_object_properties_entry_name_not_string():
 def test_value_type_object_properties_valid():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2478,7 +2366,6 @@ def test_value_type_object_properties_valid():
 def test_value_type_object_properties_entry_name_not_unique():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2509,7 +2396,6 @@ def test_value_type_object_properties_entry_name_not_unique():
 def test_value_type_object_properties_required_not_met():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2541,7 +2427,6 @@ def test_value_type_object_properties_required_not_met():
 def test_value_type_object_additional_properties_invalid_type():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2568,7 +2453,6 @@ def test_value_type_object_additional_properties_invalid_type():
 def test_value_type_object_additional_properties_nested_error():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2602,7 +2486,6 @@ def test_value_type_object_additional_properties_nested_error():
 def test_value_type_object_additional_properties_nested_ok():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2635,7 +2518,6 @@ def test_value_type_object_additional_properties_nested_ok():
 def test_value_type_object_additional_properties_true_ok():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2659,7 +2541,6 @@ def test_value_type_object_additional_properties_true_ok():
 def test_value_type_unknown():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2685,7 +2566,6 @@ def test_value_type_unknown():
 def test_option_no_section():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2707,7 +2587,6 @@ def test_option_no_section():
 def test_multiple_default():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2730,7 +2609,6 @@ def test_multiple_default():
 def test_multiple_not_boolean():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2754,7 +2632,6 @@ def test_multiple_not_boolean():
 def test_template_unknown():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2782,7 +2659,6 @@ def test_template_unknown():
 def test_template_mapping():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2830,7 +2706,6 @@ def test_template_mapping():
 def test_template_array():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2905,8 +2780,7 @@ def test_template_array_empty():
 
         spec = get_spec(
             """
-            name: foo
-            version: 0.0.0
+                version: 0.0.0
             files:
             - name: test.yaml
               example_name: test.yaml.example
@@ -2939,8 +2813,7 @@ def test_template_array_primitive():
 
         spec = get_spec(
             """
-            name: foo
-            version: 0.0.0
+                version: 0.0.0
             files:
             - name: test.yaml
               example_name: test.yaml.example
@@ -2968,7 +2841,6 @@ def test_template_array_primitive():
 def test_template_primitive():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -2996,7 +2868,6 @@ def test_template_primitive():
 def test_template_hide_duplicate():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -3016,7 +2887,6 @@ def test_template_hide_duplicate():
 def test_value_one_of_with_type():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -3043,7 +2913,6 @@ def test_value_one_of_with_type():
 def test_value_one_of_not_array():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -3066,7 +2935,6 @@ def test_value_one_of_not_array():
 def test_value_one_of_single_type():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -3093,7 +2961,6 @@ def test_value_one_of_single_type():
 def test_value_one_of_type_not_mapping():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -3118,7 +2985,6 @@ def test_value_one_of_type_not_mapping():
 def test_value_one_of_type_recursive_validation_error():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -3148,7 +3014,6 @@ def test_value_one_of_type_recursive_validation_error():
 def test_value_one_of_type_super_recursive_validation_error():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml
@@ -3182,7 +3047,6 @@ def test_value_one_of_type_super_recursive_validation_error():
 def test_value_one_of_type_recursive_validation_success():
     spec = get_spec(
         """
-        name: foo
         version: 0.0.0
         files:
         - name: test.yaml


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

1. Don't load `manifest.json` when validating the config and models we genreate from `spec.yaml`.
2. Drop requirement for `name` field in `spec.yaml`. We don't use it anywhere.

### Motivation
<!-- What inspired you to submit this pull request? -->
We're moving `manifest.json` to Publishing Platform, so we can't rely on it being present.
This is one step to reduce our dependency on it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
