### PR TITLE
Fix handling of special yaml values in config

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -1490,7 +1490,8 @@ class AgentCheck(object):
 
         decoded = stdout.strip().decode()
         try:
-            return eval(decoded)
+            special_values = {"nan": float("nan"), "inf": float("inf"), "-inf": float("-inf")}
+            return eval(decoded, special_values)
         # a single, literal unquoted string
         except Exception:
             return decoded


### PR DESCRIPTION
### What does this PR do?
#19863 introduced a regression in reading special float values in yaml config files. 

The yaml parsing was moved out of process. When it finds an inf value, the subprocess prints `inf` to stdout. The parent process tries to eval it, however `inf` is not a valid value in Python. This PR fixes the issue by remapping `inf` to `float('inf')`, and doing the equivalent for `nan` and `-inf`.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
