### PR TITLE
Remove extra space in metrics fixture

### DIFF
--- a/teleport/tests/fixtures/metrics.txt
+++ b/teleport/tests/fixtures/metrics.txt
@@ -775,7 +775,7 @@ teleport_cache_events{cache_component="auth"} 21
 teleport_cache_events{cache_component="node"} 11
 teleport_cache_events{cache_component="proxy"} 20
 # HELP teleport_cache_stale_events Number of stale events received by a Teleport service cache. A high percentage of stale events can indicate a degraded backend.
-# TYPE teleport_cache_stale_events  counter
+# TYPE teleport_cache_stale_events counter
 teleport_cache_stale_events {cache_component="auth"} 1
 teleport_cache_stale_events {cache_component="node"} 2
 teleport_cache_stale_events {cache_component="proxy"} 3


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Teleport tests are failing because of an extra space in the test fixtures. This removes that whitespace

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
