### PR TITLE
Modernize bs4 interface

### DIFF
--- a/spark/datadog_checks/spark/spark.py
+++ b/spark/datadog_checks/spark/spark.py
@@ -412,7 +412,7 @@ class SparkCheck(AgentCheck):
                 yield (response.json(), [f'app_name:{app_name}'] + addl_tags)
             except JSONDecodeError:
                 self.log.debug(
-                    'Skipping metrics for %s from app %s due to unparseable JSON payload.', property, app_name
+                    'Skipping metrics for %s from app %s due to unparsable JSON payload.', property, app_name
                 )
                 continue
 
@@ -698,7 +698,7 @@ class SparkCheck(AgentCheck):
 
         soup = BeautifulSoup(html_content, 'html.parser')
         redirect_link = None
-        for link in soup.findAll('a'):
+        for link in soup.find_all('a'):
             href = link.get('href')
             if 'proxyapproved' in href:
                 redirect_link = href


### PR DESCRIPTION
### What does this PR do?
This PR resolves the deprecation warnings of the `bs4` library:
```python
DeprecationWarning: Call to deprecated method findAll. (Replaced by find_all) -- Deprecated since version 4.0.0.
```
It fixes a typo along the way.

### Motivation
[CI logs](https://github.com/datadog/integrations-core/actions/runs/15343400218) throw those warnings.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
