### PR TITLE
Add App & API Protection to the Envoy integration tile

### DIFF
--- a/envoy/README.md
+++ b/envoy/README.md
@@ -170,6 +170,48 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 
 [Run the Agent's status subcommand][13] and look for `envoy` under the Checks section.
 
+## Security
+
+### Overview
+
+[Datadog App & API Protection][30] extends visibility and inline threat mitigation to your Envoy proxy instance.
+
+With this integration, you can detect and block attacks such as API abuse, business logic exploitation, and code layer threats directly at the edge of your cloud infrastructure.
+
+Key Benefits:
+- **Inline threat detection and blocking** at the load balancer using Datadog Security Signals
+- **Real-time insights** into application-layer attacks with traces and logs in one unified view
+- **Edge enforcement** against OWASP API threats, credential stuffing, injection attacks, and more
+
+### Installation
+
+The installation process requires a different approach than enabling this integration.
+
+#### Envoy
+
+The installation instructions are available in the [Enabling App & API Protection for Envoy][31] documentation.
+
+#### Istio
+
+The installation instructions are available in the [Enabling App and API Protection for Istio][32] documentation.
+
+### Validation
+
+To validate App & API Protection threat detection, send known attack patterns to your Envoy instance. For example, you can trigger the Security Scanner Detected rule by running the following curl script:
+
+```sh
+for ((i=1;i<=250;i++)); 
+do
+    # Target existing service's routes
+    curl https://your-envoy-url/existing-route -A dd-test-scanner-log;
+
+    # Target non existing service's routes
+    curl https://your-envoy-url/non-existing-route -A dd-test-scanner-log;
+done
+```
+
+A few minutes after enabling the App & API Protection for Envoy and sending known attack patterns, threat information will appear in the Application Signals Explorer.
+
 ## Data Collected
 
 ### Metrics
@@ -215,3 +257,6 @@ Need help? Contact [Datadog support][16].
 [16]: https://docs.datadoghq.com/help/
 [17]: https://docs.datadoghq.com/integrations/openmetrics/
 [18]: https://github.com/DataDog/integrations-core/blob/7.33.x/envoy/datadog_checks/envoy/data/conf.yaml.example
+[30]: https://docs.datadoghq.com/security/application_security/
+[31]: https://docs.datadoghq.com/security/application_security/setup/standalone/envoy/
+[32]: https://docs.datadoghq.com/security/application_security/setup/standalone/istio/

--- a/envoy/manifest.json
+++ b/envoy/manifest.json
@@ -18,6 +18,7 @@
       "Supported OS::Windows",
       "Supported OS::macOS",
       "Category::Network",
+      "Category::Security",
       "Submitted Data Type::Metrics",
       "Submitted Data Type::Logs",
       "Offering::Integration"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR adds a "Security" tab inside the Envoy integration tile.

This tile is advertising, via the Security tab, the [App & API Protection](https://docs.datadoghq.com/security/application_security/) capabilities that can be installed inside Envoy instances.
Public documentation is available:
- For [Envoy](https://docs.datadoghq.com/security/application_security/setup/standalone/envoy/)
- For [Istio](https://docs.datadoghq.com/security/application_security/setup/standalone/istio/)

### Motivation
<!-- What inspired you to submit this pull request? -->

The motivation behind this PR is to add more visibility to our Security Products and available integrations.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
