### PR TITLE
Update SQL server to TagManager

### DIFF
--- a/sqlserver/changelog.d/20424.fixed
+++ b/sqlserver/changelog.d/20424.fixed
@@ -1,0 +1,1 @@
+Update SQL server to TagManager and fix race conditions in tag values dependent on server queries

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -176,7 +176,6 @@ class SqlserverActivity(DBMAsyncJob):
 
     def __init__(self, check, config: SQLServerConfig):
         # do not emit any dd.internal metrics for DBM specific check code
-        self.tags = [t for t in check.tags if not t.startswith('dd.internal')]
         self.log = check.log
         self._config = config
         self._obfuscator_options_for_tail_text = to_native_string(
@@ -322,7 +321,7 @@ class SqlserverActivity(DBMAsyncJob):
                 "ddagentversion": datadog_agent.get_version(),
                 "ddsource": "sqlserver",
                 "dbm_type": "rqt",
-                "ddtags": ",".join(self.tags),
+                "ddtags": ",".join(self._check.tag_manager.get_tags()),
                 'service': self._config.service,
                 "db": {
                     "instance": row.get('database_name', None),
@@ -461,7 +460,7 @@ class SqlserverActivity(DBMAsyncJob):
             "ddsource": "sqlserver",
             "dbm_type": "activity",
             "collection_interval": self.collection_interval,
-            "ddtags": self.tags,
+            "ddtags": self._check.tag_manager.get_tags(),
             "timestamp": time.time() * 1000,
             'sqlserver_version': self._check.static_info_cache.get(STATIC_INFO_VERSION, ""),
             'sqlserver_engine_edition': self._check.static_info_cache.get(STATIC_INFO_ENGINE_EDITION, ""),

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -175,7 +175,6 @@ class SqlserverActivity(DBMAsyncJob):
     """Collects query metrics and plans"""
 
     def __init__(self, check, config: SQLServerConfig):
-        # do not emit any dd.internal metrics for DBM specific check code
         self.log = check.log
         self._config = config
         self._obfuscator_options_for_tail_text = to_native_string(

--- a/sqlserver/datadog_checks/sqlserver/agent_history.py
+++ b/sqlserver/datadog_checks/sqlserver/agent_history.py
@@ -103,7 +103,6 @@ def agent_check_getter(self):
 
 class SqlserverAgentHistory(DBMAsyncJob):
     def __init__(self, check, config: SQLServerConfig):
-        # do not emit any dd.internal metrics for DBM specific check code
         self.log = check.log
         self._config = config
         collection_interval = float(self._config.agent_jobs_config.get('collection_interval', 15))

--- a/sqlserver/datadog_checks/sqlserver/agent_history.py
+++ b/sqlserver/datadog_checks/sqlserver/agent_history.py
@@ -104,7 +104,6 @@ def agent_check_getter(self):
 class SqlserverAgentHistory(DBMAsyncJob):
     def __init__(self, check, config: SQLServerConfig):
         # do not emit any dd.internal metrics for DBM specific check code
-        self.tags = [t for t in check.tags if not t.startswith('dd.internal')]
         self.log = check.log
         self._config = config
         collection_interval = float(self._config.agent_jobs_config.get('collection_interval', 15))
@@ -164,7 +163,7 @@ class SqlserverAgentHistory(DBMAsyncJob):
             "ddsource": "sqlserver",
             "dbm_type": "agent_jobs",
             "collection_interval": self.collection_interval,
-            "ddtags": self.tags,
+            "ddtags": self._check.tag_manager.get_tags(),
             "timestamp": time.time() * 1000,
             'sqlserver_version': self._check.static_info_cache.get(STATIC_INFO_VERSION, ""),
             'sqlserver_engine_edition': self._check.static_info_cache.get(STATIC_INFO_ENGINE_EDITION, ""),

--- a/sqlserver/datadog_checks/sqlserver/deadlocks.py
+++ b/sqlserver/datadog_checks/sqlserver/deadlocks.py
@@ -47,7 +47,6 @@ def agent_check_getter(self):
 
 class Deadlocks(DBMAsyncJob):
     def __init__(self, check, config: SQLServerConfig):
-        self.tags = [t for t in check.tags if not t.startswith('dd.internal')]
         self._check = check
         self._log = self._check.log
         self._config = config
@@ -275,7 +274,7 @@ class Deadlocks(DBMAsyncJob):
             "ddsource": "sqlserver",
             "dbm_type": "deadlocks",
             "collection_interval": self.collection_interval,
-            "ddtags": self.tags,
+            "ddtags": self._check.tag_manager.get_tags(),
             "timestamp": time() * 1000,
             'sqlserver_version': self._check.static_info_cache.get(STATIC_INFO_VERSION, ""),
             'sqlserver_engine_edition': self._check.static_info_cache.get(STATIC_INFO_ENGINE_EDITION, ""),

--- a/sqlserver/datadog_checks/sqlserver/metadata.py
+++ b/sqlserver/datadog_checks/sqlserver/metadata.py
@@ -58,7 +58,6 @@ class SqlserverMetadata(DBMAsyncJob):
 
     def __init__(self, check, config: SQLServerConfig):
         # do not emit any dd.internal metrics for DBM specific check code
-        self.tags = [t for t in check.tags if not t.startswith('dd.internal')]
         self.log = check.log
         self._config = config
         self.collection_interval = self._config.settings_config.get(
@@ -145,7 +144,7 @@ class SqlserverMetadata(DBMAsyncJob):
                         self._check.static_info_cache.get(STATIC_INFO_VERSION, ""),
                         self._check.static_info_cache.get(STATIC_INFO_ENGINE_EDITION, ""),
                     ),
-                    "tags": self.tags,
+                    "tags": self._check.tag_manager.get_tags(),
                     "timestamp": time.time() * 1000,
                     "cloud_metadata": self._check.cloud_metadata,
                     "metadata": settings_rows,

--- a/sqlserver/datadog_checks/sqlserver/metadata.py
+++ b/sqlserver/datadog_checks/sqlserver/metadata.py
@@ -57,7 +57,6 @@ class SqlserverMetadata(DBMAsyncJob):
     """
 
     def __init__(self, check, config: SQLServerConfig):
-        # do not emit any dd.internal metrics for DBM specific check code
         self.log = check.log
         self._config = config
         self.collection_interval = self._config.settings_config.get(

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -49,6 +49,7 @@ class BaseSqlServerMetric(object):
         self.instance = cfg_instance.get('instance_name', '')
         self.physical_db_name = cfg_instance.get('physical_db_name', '')
         self.object_name = cfg_instance.get('object_name', '')
+        self.tags = cfg_instance.get('tags', []) or []
         self.tag_by = cfg_instance.get('tag_by', None)
         self.column = column
         self.instances = None
@@ -105,7 +106,7 @@ class SqlSimpleMetric(BaseSqlServerMetric):
             object_name = object_name.strip()
             if counter_name.strip() == self.sql_name:
                 matched = False
-                metric_tags = list(self._check.tag_manager.get_tags())
+                metric_tags = list(self.tags)
 
                 if (self.instance == ALL_INSTANCES and instance_name != "_Total") or (
                     (instance_name == self.instance or instance_name == self.physical_db_name)
@@ -198,7 +199,7 @@ class SqlFractionMetric(BaseSqlServerMetric):
                     self.base_name,
                 )
 
-            metric_tags = list(self._check.tag_manager.get_tags())
+            metric_tags = list(self.tags)
             if self.instance == ALL_INSTANCES:
                 metric_tags.append('{}:{}'.format(self.tag_by, instance_name))
             self.report_fraction(
@@ -271,7 +272,7 @@ class SqlOsWaitStat(BaseSqlServerMetric):
 
         self.log.debug("Value for %s %s is %s", self.sql_name, self.column, value)
         metric_name = '{}.{}'.format(self.metric_name, self.column)
-        self.report_function(metric_name, value, tags=self._check.tag_manager.get_tags())
+        self.report_function(metric_name, value, tags=self.tags)
 
 
 # https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-io-virtual-file-stats-transact-sql
@@ -333,7 +334,7 @@ class SqlIoVirtualFileStat(BaseSqlServerMetric):
                 'database_id:{}'.format(str(dbid).strip()),
                 'file_id:{}'.format(str(fid).strip()),
             ]
-            metric_tags.extend(self._check.tag_manager.get_tags())
+            metric_tags.extend(self.tags)
             metric_name = '{}.{}'.format(self.metric_name, self.column)
             self.report_function(metric_name, report_value, tags=metric_tags)
 
@@ -365,7 +366,7 @@ class SqlOsMemoryClerksStat(BaseSqlServerMetric):
 
         for memory_node_id, column_val in sum_by_memory_node_id.items():
             metric_tags = ['memory_node_id:{}'.format(memory_node_id)]
-            metric_tags.extend(self._check.tag_manager.get_tags())
+            metric_tags.extend(self.tags)
             metric_name = '{}.{}'.format(self.metric_name, self.column)
             self.report_function(metric_name, column_val, tags=metric_tags)
 

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -49,7 +49,6 @@ class BaseSqlServerMetric(object):
         self.instance = cfg_instance.get('instance_name', '')
         self.physical_db_name = cfg_instance.get('physical_db_name', '')
         self.object_name = cfg_instance.get('object_name', '')
-        self.tags = cfg_instance.get('tags', []) or []
         self.tag_by = cfg_instance.get('tag_by', None)
         self.column = column
         self.instances = None
@@ -106,7 +105,7 @@ class SqlSimpleMetric(BaseSqlServerMetric):
             object_name = object_name.strip()
             if counter_name.strip() == self.sql_name:
                 matched = False
-                metric_tags = list(self.tags)
+                metric_tags = list(self._check.tag_manager.get_tags())
 
                 if (self.instance == ALL_INSTANCES and instance_name != "_Total") or (
                     (instance_name == self.instance or instance_name == self.physical_db_name)
@@ -199,7 +198,7 @@ class SqlFractionMetric(BaseSqlServerMetric):
                     self.base_name,
                 )
 
-            metric_tags = list(self.tags)
+            metric_tags = list(self._check.tag_manager.get_tags())
             if self.instance == ALL_INSTANCES:
                 metric_tags.append('{}:{}'.format(self.tag_by, instance_name))
             self.report_fraction(
@@ -272,7 +271,7 @@ class SqlOsWaitStat(BaseSqlServerMetric):
 
         self.log.debug("Value for %s %s is %s", self.sql_name, self.column, value)
         metric_name = '{}.{}'.format(self.metric_name, self.column)
-        self.report_function(metric_name, value, tags=self.tags)
+        self.report_function(metric_name, value, tags=self._check.tag_manager.get_tags())
 
 
 # https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-io-virtual-file-stats-transact-sql
@@ -334,7 +333,7 @@ class SqlIoVirtualFileStat(BaseSqlServerMetric):
                 'database_id:{}'.format(str(dbid).strip()),
                 'file_id:{}'.format(str(fid).strip()),
             ]
-            metric_tags.extend(self.tags)
+            metric_tags.extend(self._check.tag_manager.get_tags())
             metric_name = '{}.{}'.format(self.metric_name, self.column)
             self.report_function(metric_name, report_value, tags=metric_tags)
 
@@ -366,7 +365,7 @@ class SqlOsMemoryClerksStat(BaseSqlServerMetric):
 
         for memory_node_id, column_val in sum_by_memory_node_id.items():
             metric_tags = ['memory_node_id:{}'.format(memory_node_id)]
-            metric_tags.extend(self.tags)
+            metric_tags.extend(self._check.tag_manager.get_tags())
             metric_name = '{}.{}'.format(self.metric_name, self.column)
             self.report_function(metric_name, column_val, tags=metric_tags)
 

--- a/sqlserver/datadog_checks/sqlserver/schemas.py
+++ b/sqlserver/datadog_checks/sqlserver/schemas.py
@@ -175,7 +175,7 @@ class Schemas(DBMAsyncJob):
             "kind": "sqlserver_databases",
             "collection_interval": collection_interval,
             "dbms_version": None,
-            "tags": self._check.non_internal_tags,
+            "tags": self._check.tag_manager.get_tags(),
             "cloud_metadata": self._check.cloud_metadata,
         }
         self._data_submitter = SubmitData(self._check.database_monitoring_metadata, base_event, self._log)
@@ -291,7 +291,7 @@ class Schemas(DBMAsyncJob):
         self._data_submitter.set_base_event_data(
             self._check.reported_hostname,
             self._check.database_identifier,
-            self._check.non_internal_tags,
+            self._check.tag_manager.get_tags(),
             self._check.cloud_metadata,
             "{},{}".format(
                 self._check.static_info_cache.get(STATIC_INFO_VERSION, ""),

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -322,7 +322,17 @@ class SQLServer(AgentCheck):
         if self._database_identifier is None:
             template = Template(self._config.database_identifier.get('template') or '$resolved_hostname')
             # Copy self.tag_manager._tags and map values to single values instead of lists
-            tag_dict = {k: v[0] if isinstance(v, list) and v else v for k, v in self.tag_manager._tags.items()}
+            tag_dict = {}
+            tags = self.tag_manager.get_tags()
+            # sort tags to ensure consistent ordering
+            tags.sort()
+            for t in tags:
+                if ':' in t:
+                    key, value = t.split(':', 1)
+                    if key in tag_dict:
+                        tag_dict[key] += f",{value}"
+                    else:
+                        tag_dict[key] = value
             tag_dict['resolved_hostname'] = self.resolved_hostname
             tag_dict['host'] = str(self.host)
             tag_dict['port'] = str(self.port) if self.port is not None else None

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -4,7 +4,6 @@
 
 from __future__ import division
 
-import copy
 import time
 from collections import defaultdict
 from string import Template
@@ -15,6 +14,7 @@ from datadog_checks.base import AgentCheck
 from datadog_checks.base.config import is_affirmative
 from datadog_checks.base.utils.db import QueryExecutor, QueryManager
 from datadog_checks.base.utils.db.utils import (
+    TagManager,
     default_json_event_encoding,
     tracked_query,
 )
@@ -142,9 +142,11 @@ class SQLServer(AgentCheck):
 
         self._config = SQLServerConfig(self.init_config, self.instance, self.log)
         self.cloud_metadata = self._config.cloud_metadata
-        self.tags = self._config.tags
-        self.add_core_tags()
-        self.set_resource_tags()
+        self.tag_manager = TagManager()
+        self.tag_manager.set_tags_from_list(self._config.tags, replace=True)  # Initialize from static config tags
+
+        self.initialize_connection()
+        self.load_static_information()
 
         self.databases = set()
         self.autodiscovery_query = None
@@ -171,9 +173,6 @@ class SQLServer(AgentCheck):
         )  # type: TTLCache
         # Keep a copy of the tags before the internal resource tags are set so they can be used for paths that don't
         # go through the agent internal metrics submission processing those tags
-        self.non_internal_tags = copy.deepcopy(self.tags)
-        self.check_initializations.append(self.initialize_connection)
-        self.check_initializations.append(self.load_static_information)
         self.check_initializations.append(self.config_checks)
         self.check_initializations.append(self.make_metric_list_to_collect)
         self.check_initializations.append(self.initialize_xe_session_handlers)
@@ -221,7 +220,7 @@ class SQLServer(AgentCheck):
             )
 
     def _new_query_executor(self, queries, executor, extra_tags=None, track_operation_time=False):
-        tags = self.tags + (extra_tags or [])
+        tags = self._check.tag_manager.get_tags() + (extra_tags or [])
         return QueryExecutor(
             executor,
             self,
@@ -235,27 +234,29 @@ class SQLServer(AgentCheck):
         """
         Add tags that should be attached to every metric/event but which require check calculations outside the config.
         """
-        self.tags.append("database_hostname:{}".format(self.database_hostname))
-        self.tags.append("database_instance:{}".format(self.database_identifier))
+        self.tag_manager.set_tag("database_hostname", self.database_hostname, replace=True)
+        self.tag_manager.set_tag("database_instance", self.database_identifier, replace=True)
 
     def set_resource_tags(self):
         if self.cloud_metadata.get("gcp") is not None:
-            self.tags.append(
-                "dd.internal.resource:gcp_sql_database_instance:{}:{}".format(
+            self.tag_manager.set_tag(
+                "dd.internal.resource:gcp_sql_database_instance",
+                "{}:{}".format(
                     self.cloud_metadata.get("gcp")["project_id"],
                     self.cloud_metadata.get("gcp")["instance_id"],
-                )
+                ),
+                replace=True,
             )
         if self.cloud_metadata.get("aws") is not None:
-            self.tags.append(
-                "dd.internal.resource:aws_rds_instance:{}".format(
-                    self.cloud_metadata.get("aws")["instance_endpoint"],
-                )
+            self.tag_manager.set_tag(
+                "dd.internal.resource:aws_rds_instance",
+                self.cloud_metadata.get("aws")["instance_endpoint"],
+                replace=True,
             )
         elif AWS_RDS_HOSTNAME_SUFFIX in self.resolved_hostname:
             # allow for detecting if the host is an RDS host, and emit
             # the resource properly even if the `aws` config is unset
-            self.tags.append("dd.internal.resource:aws_rds_instance:{}".format(self.resolved_hostname))
+            self.tag_manager.set_tag("dd.internal.resource:aws_rds_instance", self.resolved_hostname, replace=True)
             self.cloud_metadata["aws"] = {
                 "instance_endpoint": self.resolved_hostname,
             }
@@ -272,14 +273,14 @@ class SQLServer(AgentCheck):
             resource_types = AZURE_DEPLOYMENT_TYPE_TO_RESOURCE_TYPES.get(deployment_type).split(",")
             for r_type in resource_types:
                 if "azure_sql_server_database" in r_type and db_instance:
-                    self.tags.append("dd.internal.resource:{}:{}".format(r_type, db_instance))
+                    self.tag_manager.set_tag("dd.internal.resource", "{}:{}".format(r_type, db_instance), replace=True)
                 else:
-                    self.tags.append("dd.internal.resource:{}:{}".format(r_type, name))
+                    self.tag_manager.set_tag("dd.internal.resource", "{}:{}".format(r_type, name), replace=True)
         # finally, emit a `database_instance` resource for this instance
-        self.tags.append(
-            "dd.internal.resource:database_instance:{}".format(
-                self.database_identifier,
-            )
+        self.tag_manager.set_tag(
+            "dd.internal.resource:database_instance",
+            self.database_identifier,
+            replace=True,
         )
 
     @property
@@ -319,23 +320,12 @@ class SQLServer(AgentCheck):
         # type: () -> str
         if self._database_identifier is None:
             template = Template(self._config.database_identifier.get('template') or '$resolved_hostname')
-            tag_dict = {}
-            tags = self.tags.copy()
-            # sort tags to ensure consistent ordering
-            tags.sort()
-            for t in tags:
-                if ':' in t:
-                    key, value = t.split(':', 1)
-                    if key in tag_dict:
-                        tag_dict[key] += f",{value}"
-                    else:
-                        tag_dict[key] = value
+            # Copy self.tag_manager._tags and map values to single values instead of lists
+            tag_dict = {k: v[0] if isinstance(v, list) and v else v for k, v in self.tag_manager._tags.items()}
             tag_dict['resolved_hostname'] = self.resolved_hostname
             tag_dict['host'] = str(self.host)
-            tag_dict['port'] = str(self.port)
-            tag_dict['database'] = str(
-                self.instance.get('database', self.connection.DEFAULT_DATABASE if self.connection else None)
-            )
+            tag_dict['port'] = str(self.port) if self.port is not None else None
+            tag_dict['database'] = self.instance.get('database', self.connection.DEFAULT_DATABASE)
             if self.resolved_hostname.endswith(AZURE_SERVER_SUFFIX):
                 tag_dict['azure_name'] = self.resolved_hostname[: -len(AZURE_SERVER_SUFFIX)]
             if self.static_info_cache.get(STATIC_INFO_SERVERNAME) is not None:
@@ -400,11 +390,9 @@ class SQLServer(AgentCheck):
                             self.static_info_cache[STATIC_INFO_INSTANCENAME] = instancename
                             self.static_info_cache[STATIC_INFO_FULL_SERVERNAME] = full_servername
 
-                            self.tags.append("sqlserver_servername:{}".format(servername))
-                            self.non_internal_tags.append("sqlserver_servername:{}".format(servername))
+                            self.tag_manager.set_tag("sqlserver_servername", servername, replace=True)
                             if instancename:
-                                self.tags.append("sqlserver_instancename:{}".format(instancename))
-                                self.non_internal_tags.append("sqlserver_instancename:{}".format(instancename))
+                                self.tag_manager.set_tag("sqlserver_instancename", instancename, replace=True)
                         else:
                             self.log.warning("failed to load servername static information due to empty results")
 
@@ -429,9 +417,12 @@ class SQLServer(AgentCheck):
                 self._resolved_hostname = None
             # re-initialize database_identifier to ensure we take into consideration any included static information
             self._database_identifier = None
+            # re-initialize tags dependent on database_identifier
+            self.add_core_tags()
+            self.set_resource_tags()
 
     def debug_tags(self):
-        return self.tags + ["agent_hostname:{}".format(self.agent_hostname)]
+        return self.tag_manager.get_tags() + ["agent_hostname:{}".format(self.agent_hostname)]
 
     def debug_stats_kwargs(self, tags=None):
         tags = tags if tags else []
@@ -449,6 +440,9 @@ class SQLServer(AgentCheck):
         return self._agent_hostname
 
     def initialize_connection(self):
+        if self.connection is not None:
+            return
+        # Initialize the connection object once
         self.connection = Connection(
             init_config=self.init_config,
             instance_config=self.instance,
@@ -492,8 +486,7 @@ class SQLServer(AgentCheck):
         ]
         if not disable_generic_tags:
             service_check_tags.append("host:{}".format(self.resolved_hostname))
-        if self.tags is not None:
-            service_check_tags.extend(self.tags)
+        service_check_tags.extend(self.tag_manager.get_tags())
         service_check_tags = list(set(service_check_tags))
 
         if status is AgentCheck.OK:
@@ -575,7 +568,7 @@ class SQLServer(AgentCheck):
                 # if autodiscovery is enabled, we report metrics from the
                 # INSTANCE_METRICS_DATABASE struct below, so do not double report here
                 common_metrics.extend(INSTANCE_METRICS_DATABASE)
-            self._add_performance_counters(common_metrics, metrics_to_collect, self.tags, db=None)
+            self._add_performance_counters(common_metrics, metrics_to_collect, self.tag_manager.get_tags(), db=None)
 
             # populated through autodiscovery
             if self.databases:
@@ -583,7 +576,7 @@ class SQLServer(AgentCheck):
                     self._add_performance_counters(
                         INSTANCE_METRICS_DATABASE,
                         metrics_to_collect,
-                        self.tags,
+                        self.tag_manager.get_tags(),
                         db=db.name,
                         physical_database_name=db.physical_db_name,
                     )
@@ -593,7 +586,7 @@ class SQLServer(AgentCheck):
             sql_counter_type = None
             base_name = None
 
-            custom_tags = self.tags + cfg.get("tags", [])
+            custom_tags = self.tag_manager.get_tags() + cfg.get("tags", [])
             cfg["tags"] = custom_tags
 
             db_table = cfg.get("table", DEFAULT_PERFORMANCE_TABLE)
@@ -821,7 +814,7 @@ class SQLServer(AgentCheck):
             if self._query_manager is None:
                 # use QueryManager to process custom queries
                 self._query_manager = QueryManager(
-                    self, self.execute_query_raw, tags=self.tags, hostname=self.reported_hostname
+                    self, self.execute_query_raw, tags=self.tag_manager.get_tags(), hostname=self.reported_hostname
                 )
                 self._query_manager.compile_queries()
             self._send_database_instance_metadata()
@@ -832,18 +825,18 @@ class SQLServer(AgentCheck):
             if self._config.autodiscovery and self._config.autodiscovery_db_service_check:
                 self._check_database_conns()
             if self._config.dbm_enabled:
-                self.agent_history.run_job_loop(self.tags)
-                self.statement_metrics.run_job_loop(self.tags)
-                self.procedure_metrics.run_job_loop(self.tags)
-                self.activity.run_job_loop(self.tags)
-                self.sql_metadata.run_job_loop(self.tags)
-                self._schemas.run_job_loop(self.tags)
-                self.deadlocks.run_job_loop(self.tags)
+                self.agent_history.run_job_loop(self.tag_manager.get_tags())
+                self.statement_metrics.run_job_loop(self.tag_manager.get_tags())
+                self.procedure_metrics.run_job_loop(self.tag_manager.get_tags())
+                self.activity.run_job_loop(self.tag_manager.get_tags())
+                self.sql_metadata.run_job_loop(self.tag_manager.get_tags())
+                self._schemas.run_job_loop(self.tag_manager.get_tags())
+                self.deadlocks.run_job_loop(self.tag_manager.get_tags())
 
                 # Run XE session handlers
                 for handler in self.xe_session_handlers:
                     try:
-                        handler.run_job_loop(self.tags)
+                        handler.run_job_loop(self.tag_manager.get_tags())
                     except Exception as e:
                         self.log.error("Error running XE session handler for %s: %s", handler.session_name, e)
         else:
@@ -1023,7 +1016,7 @@ class SQLServer(AgentCheck):
 
                 for row in rows:
                     tags = [] if row.tags is None or row.tags == "" else row.tags.split(",")
-                    tags.extend(self.tags)
+                    tags.extend(self.tag_manager.get_tags())
 
                     if row.type.lower() in self.proc_type_mapping:
                         self.proc_type_mapping[row.type](row.metric, row.value, tags, raw=True)
@@ -1076,7 +1069,7 @@ class SQLServer(AgentCheck):
                     self.static_info_cache.get(STATIC_INFO_ENGINE_EDITION, ""),
                 ),
                 "integration_version": __version__,
-                "tags": self.non_internal_tags,
+                "tags": self._check.tag_manager.get_tags(),
                 "timestamp": time.time() * 1000,
                 "cloud_metadata": self.cloud_metadata,
                 "metadata": {

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -510,7 +510,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             "database_instance": self._check.database_identifier,
             'timestamp': time.time() * 1000,
             'min_collection_interval': self.collection_interval,
-            'tags': self.tag_manager.get_tags(),
+            'tags': self._check.tag_manager.get_tags(),
             'kind': 'query_metrics',
             'cloud_metadata': self._check.cloud_metadata,
             'sqlserver_rows': [self._to_metrics_payload_row(r) for r in rows],
@@ -565,7 +565,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             if query_cache_key in self._full_statement_text_cache:
                 continue
             self._full_statement_text_cache[query_cache_key] = True
-            tags = copy(self._check.tag_manager.get_tags())
+            tags = copy.copy(self._check.tag_manager.get_tags())
             if 'database_name' in row:
                 tags += ["db:{}".format(row['database_name'])]
             yield {
@@ -645,7 +645,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                         1,
                         **self._check.debug_stats_kwargs(tags=["error:obfuscate-xml-plan-{}".format(type(e))]),
                     )
-                tags = copy(self._check.tag_manager.get_tags())
+                tags = copy.copy(self._check.tag_manager.get_tags())
 
                 # for stored procedures, we want to send the plan
                 # events with the full procedure text, not the text

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -255,7 +255,6 @@ class SqlserverStatementMetrics(DBMAsyncJob):
 
     def __init__(self, check, config: SQLServerConfig):
         # do not emit any dd.internal metrics for DBM specific check code
-        self.tags = [t for t in check.tags if not t.startswith('dd.internal')]
         self.log = check.log
         self._config = config
         collection_interval = float(
@@ -511,7 +510,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             "database_instance": self._check.database_identifier,
             'timestamp': time.time() * 1000,
             'min_collection_interval': self.collection_interval,
-            'tags': self.tags,
+            'tags': self.tag_manager.get_tags(),
             'kind': 'query_metrics',
             'cloud_metadata': self._check.cloud_metadata,
             'sqlserver_rows': [self._to_metrics_payload_row(r) for r in rows],
@@ -566,7 +565,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             if query_cache_key in self._full_statement_text_cache:
                 continue
             self._full_statement_text_cache[query_cache_key] = True
-            tags = list(self.tags)
+            tags = copy(self._check.tag_manager.get_tags())
             if 'database_name' in row:
                 tags += ["db:{}".format(row['database_name'])]
             yield {
@@ -646,7 +645,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                         1,
                         **self._check.debug_stats_kwargs(tags=["error:obfuscate-xml-plan-{}".format(type(e))]),
                     )
-                tags = list(self.tags)
+                tags = copy(self._check.tag_manager.get_tags())
 
                 # for stored procedures, we want to send the plan
                 # events with the full procedure text, not the text

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -565,7 +565,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             if query_cache_key in self._full_statement_text_cache:
                 continue
             self._full_statement_text_cache[query_cache_key] = True
-            tags = copy.copy(self._check.tag_manager.get_tags())
+            tags = self._check.tag_manager.get_tags()
             if 'database_name' in row:
                 tags += ["db:{}".format(row['database_name'])]
             yield {
@@ -645,7 +645,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                         1,
                         **self._check.debug_stats_kwargs(tags=["error:obfuscate-xml-plan-{}".format(type(e))]),
                     )
-                tags = copy.copy(self._check.tag_manager.get_tags())
+                tags = self._check.tag_manager.get_tags()
 
                 # for stored procedures, we want to send the plan
                 # events with the full procedure text, not the text

--- a/sqlserver/datadog_checks/sqlserver/stored_procedures.py
+++ b/sqlserver/datadog_checks/sqlserver/stored_procedures.py
@@ -159,6 +159,7 @@ class SqlserverProcedureMetrics(DBMAsyncJob):
             'ddagentversion': datadog_agent.get_version(),
             'ddagenthostname': self._check.agent_hostname,
             'service': self._config.service,
+            'tags': self._check.tag_manager.get_tags(),
         }
 
     @tracked_method(agent_check_getter=agent_check_getter)

--- a/sqlserver/datadog_checks/sqlserver/stored_procedures.py
+++ b/sqlserver/datadog_checks/sqlserver/stored_procedures.py
@@ -73,7 +73,6 @@ class SqlserverProcedureMetrics(DBMAsyncJob):
         self.log = check.log
         self._config = config
         # do not emit any dd.internal metrics for DBM specific check code
-        self.tags = [t for t in check.tags if not t.startswith('dd.internal')]
         collection_interval = float(
             self._config.procedure_metrics_config.get('collection_interval', DEFAULT_COLLECTION_INTERVAL)
         )
@@ -152,7 +151,6 @@ class SqlserverProcedureMetrics(DBMAsyncJob):
             "database_instance": self._check.database_identifier,
             'timestamp': time.time() * 1000,
             'min_collection_interval': self.collection_interval,
-            'tags': self.tags,
             'cloud_metadata': self._check.cloud_metadata,
             'kind': 'procedure_metrics',
             'sqlserver_rows': rows,

--- a/sqlserver/datadog_checks/sqlserver/xe_collection/base.py
+++ b/sqlserver/datadog_checks/sqlserver/xe_collection/base.py
@@ -110,7 +110,6 @@ class XESessionBase(DBMAsyncJob):
 
     def __init__(self, check, config, session_name):
         self.session_name = session_name
-        self.tags = [t for t in check.tags if not t.startswith('dd.internal')]
         self._check = check
         self._log = check.log
         self._config = config
@@ -450,7 +449,7 @@ class XESessionBase(DBMAsyncJob):
             "dbm_type": self._determine_dbm_type(),
             "event_source": self.session_name,
             "collection_interval": self.collection_interval,
-            "ddtags": self.tags,
+            "ddtags": self._check.tag_manager.get_tags(),
             "timestamp": time() * 1000,
             "sqlserver_version": self._check.static_info_cache.get(STATIC_INFO_VERSION, ""),
             "sqlserver_engine_edition": self._check.static_info_cache.get(STATIC_INFO_ENGINE_EDITION, ""),
@@ -582,7 +581,7 @@ class XESessionBase(DBMAsyncJob):
                 "dbm_type": self._determine_dbm_type(),
                 "event_source": self.session_name,
                 "collection_interval": self.collection_interval,
-                "ddtags": self.tags,
+                "ddtags": self._check.tag_manager.get_tags(),
                 "timestamp": time() * 1000,
                 "sqlserver_version": self._check.static_info_cache.get(STATIC_INFO_VERSION, ""),
                 "sqlserver_engine_edition": self._check.static_info_cache.get(STATIC_INFO_ENGINE_EDITION, ""),
@@ -780,7 +779,7 @@ class XESessionBase(DBMAsyncJob):
             "ddsource": "sqlserver",
             "dbm_type": "rqt",
             "event_source": self.session_name,
-            "ddtags": ",".join(self.tags),
+            "ddtags": ",".join(self._check.tag_manager.get_tags()),
             'service': self._config.service,
             "db": db_fields,
             "sqlserver": sqlserver_fields,

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.7.0",
+    "datadog-checks-base>=37.13.0",
 ]
 dynamic = [
     "version",

--- a/sqlserver/tests/test_database_metrics.py
+++ b/sqlserver/tests/test_database_metrics.py
@@ -13,6 +13,7 @@ from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.const import (
     STATIC_INFO_ENGINE_EDITION,
     STATIC_INFO_MAJOR_VERSION,
+    STATIC_INFO_SERVERNAME,
 )
 from datadog_checks.sqlserver.database_metrics import (
     SqlserverAoMetrics,
@@ -97,7 +98,12 @@ def test_sqlserver_file_stats_metrics(
     if not include_file_stats_metrics:
         assert file_stats_metrics.enabled is False
     else:
-        tags = sqlserver_check._config.tags
+        tags = sqlserver_check._config.tags + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
         for result in mocked_results:
             db, state, logical_name, file_location, *metric_values = result
             metrics = zip(file_stats_metrics.metric_names()[0], metric_values)
@@ -178,7 +184,12 @@ def test_sqlserver_ao_metrics(
     if not include_ao_metrics:
         assert ao_metrics.enabled is False
     else:
-        tags = sqlserver_check._config.tags
+        tags = sqlserver_check._config.tags + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
         for result in mocked_ao_availability_groups:
             (
                 replica_role,
@@ -294,7 +305,12 @@ def test_sqlserver_availability_groups_metrics(
     if not include_ao_metrics:
         assert availability_groups_metrics.enabled is False
     else:
-        tags = sqlserver_check._config.tags
+        tags = sqlserver_check._config.tags + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
         for result in mocked_results:
             ag, availability_group_name, synchronization_health_desc, *metric_values = result
             metrics = zip(availability_groups_metrics.metric_names()[0], metric_values)
@@ -385,7 +401,12 @@ def test_sqlserver_database_replication_stats_metrics(
     if not include_ao_metrics:
         assert database_replication_stats_metrics.enabled is False
     else:
-        tags = sqlserver_check._config.tags
+        tags = sqlserver_check._config.tags + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
         for result in mocked_results:
             ag, availability_group_name, replica_server_name, synchronization_state_desc, *metric_values = result
             metrics = zip(database_replication_stats_metrics.metric_names()[0], metric_values)
@@ -523,7 +544,12 @@ def test_sqlserver_availability_replicas_metrics(
     if not include_ao_metrics:
         assert availability_replicas_metrics.enabled is False
     else:
-        tags = sqlserver_check._config.tags
+        tags = sqlserver_check._config.tags + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
         for result in mocked_results:
             (
                 database_name,
@@ -588,7 +614,12 @@ def test_sqlserver_fci_metrics(
     if not include_fci_metrics:
         assert fci_metrics.enabled is False
     else:
-        tags = sqlserver_check._config.tags
+        tags = sqlserver_check._config.tags + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
         for result in mocked_results:
             node_name, status, failover_cluster, *metric_values = result
             metrics = zip(fci_metrics.metric_names()[0], metric_values)
@@ -636,7 +667,12 @@ def test_sqlserver_primary_log_shipping_metrics(
     if not include_primary_log_shipping_metrics:
         assert primary_log_shipping_metrics.enabled is False
     else:
-        tags = sqlserver_check._config.tags
+        tags = sqlserver_check._config.tags + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
         for result in mocked_results:
             primary_id, primary_server, primary_db, *metric_values = result
             metrics = zip(primary_log_shipping_metrics.metric_names()[0], metric_values)
@@ -696,7 +732,12 @@ def test_sqlserver_secondary_log_shipping_metrics(
     if not include_secondary_log_shipping_metrics:
         assert primary_log_shipping_metrics.enabled is False
     else:
-        tags = sqlserver_check._config.tags
+        tags = sqlserver_check._config.tags + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
         for result in mocked_results:
             secondary_server, secondary_db, secondary_id, primary_server, primary_db, *metric_values = result
             metrics = zip(primary_log_shipping_metrics.metric_names()[0], metric_values)
@@ -743,7 +784,12 @@ def test_sqlserver_server_state_metrics(
     if not include_server_state_metrics:
         assert server_state_metrics.enabled is False
     else:
-        tags = sqlserver_check._config.tags
+        tags = sqlserver_check._config.tags + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
         for result in mocked_results:
             metrics = zip(server_state_metrics.metric_names()[0], result)
             for metric_name, metric_value in metrics:
@@ -787,7 +833,12 @@ def test_sqlserver_tempdb_file_space_usage_metrics(
     if not include_tempdb_file_space_usage_metrics:
         assert tempdb_file_space_usage_metrics.enabled is False
     else:
-        tags = sqlserver_check._config.tags
+        tags = sqlserver_check._config.tags + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
         for result in mocked_results:
             database_id, *metric_values = result
             metrics = zip(tempdb_file_space_usage_metrics.metric_names()[0], metric_values)
@@ -869,7 +920,12 @@ def test_sqlserver_index_usage_metrics(
     if not include_index_usage_metrics:
         assert index_usage_metrics.enabled is False
     else:
-        tags = sqlserver_check._config.tags
+        tags = sqlserver_check._config.tags + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
         for result in mocked_results:
             for row in result:
                 db, index_name, schema, table, *metric_values = row
@@ -991,7 +1047,12 @@ def test_sqlserver_db_fragmentation_metrics(
     if not include_db_fragmentation_metrics:
         assert db_fragmentation_metrics.enabled is False
     else:
-        tags = sqlserver_check._config.tags
+        tags = sqlserver_check._config.tags + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
         for result in mocked_results:
             for row in result:
                 database_name, object_name, schema, index_id, index_name, *metric_values = row
@@ -1008,7 +1069,7 @@ def test_sqlserver_db_fragmentation_metrics(
                     aggregator.assert_metric(metric_name, value=metric_value, tags=expected_tags)
                     if db_fragmentation_object_names:
                         for m in aggregator.metrics(metric_name):
-                            tags_by_key = dict([t.split(':') for t in m.tags])
+                            tags_by_key = dict([t.split(':', 1) for t in m.tags])
                             assert tags_by_key['object_name'].lower() in db_fragmentation_object_names
                 if not include_db_fragmentation_metrics_tempdb:
                     assert database_name != 'tempdb'
@@ -1074,7 +1135,12 @@ def test_sqlserver_os_schedulers_metrics(
     if not include_task_scheduler_metrics:
         assert os_schedulers_metrics.enabled is False
     else:
-        tags = sqlserver_check._config.tags
+        tags = sqlserver_check._config.tags + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
         for result in mocked_results:
             scheduler_id, parent_node_id, *metric_values = result
             metrics = zip(os_schedulers_metrics.metric_names()[0], metric_values)
@@ -1139,7 +1205,12 @@ def test_sqlserver_os_tasks_metrics(
     if not include_task_scheduler_metrics:
         assert os_tasks_metrics.enabled is False
     else:
-        tags = sqlserver_check._config.tags
+        tags = sqlserver_check._config.tags + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
         for result in mocked_results:
             scheduler_id, *metric_values = result
             metrics = zip(os_tasks_metrics.metric_names()[0], metric_values)
@@ -1205,7 +1276,12 @@ def test_sqlserver_master_files_metrics(
     if not include_master_files_metrics:
         assert master_files_metrics.enabled is False
     else:
-        tags = sqlserver_check._config.tags
+        tags = sqlserver_check._config.tags + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
         for result in mocked_results:
             db, database, file_id, file_type, file_location, database_files_state_desc, size, state = result
             size *= 8  # size is in pages, 1 page = 8 KB
@@ -1281,7 +1357,12 @@ def test_sqlserver_database_files_metrics(
     if not include_database_files_metrics:
         assert database_files_metrics.enabled is False
     else:
-        tags = sqlserver_check._config.tags
+        tags = sqlserver_check._config.tags + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
         for db, result in zip(AUTODISCOVERY_DBS, mocked_results):
             for row in result:
                 file_id, file_type, file_location, file_name, database_files_state_desc, size, space_used, state = row
@@ -1344,7 +1425,12 @@ def test_sqlserver_table_size_metrics(
     if not include_table_size_metrics:
         assert table_size_metrics.enabled is False
     else:
-        tags = sqlserver_check._config.tags
+        tags = sqlserver_check._config.tags + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
         for mock_row in mocked_results:
             table_name, schema, database, *metric_values = mock_row
             metrics = zip(table_size_metrics.metric_names()[0], metric_values)
@@ -1400,7 +1486,12 @@ def test_sqlserver_database_stats_metrics(
     if not include_database_files_metrics:
         assert database_stats_metrics.enabled is False
     else:
-        tags = sqlserver_check._config.tags
+        tags = sqlserver_check._config.tags + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
         for result in mocked_results:
             db, database, database_state_desc, database_recovery_model_desc, *metric_values = result
             metrics = zip(database_stats_metrics.metric_names()[0], metric_values)
@@ -1464,7 +1555,12 @@ def test_sqlserver_database_backup_metrics(
     if not include_database_backup_metrics:
         assert database_backup_metrics.enabled is False
     else:
-        tags = sqlserver_check._config.tags
+        tags = sqlserver_check._config.tags + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
         for result in mocked_results:
             db, database, *metric_values = result
             metrics = zip(database_backup_metrics.metric_names()[0], metric_values)
@@ -1503,7 +1599,12 @@ def test_sqlserver_xe_session_metrics(
         modified_instance[key] = value
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [modified_instance])
     dd_run_check(sqlserver_check)
-    expected_tags = sqlserver_check._config.tags
+    expected_tags = sqlserver_check._config.tags + [
+        "database_hostname:{}".format("stubbed.hostname"),
+        "database_instance:{}".format("stubbed.hostname"),
+        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+        "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+    ]
     expected_tags.append('session_name:datadog')
     aggregator.assert_metric("sqlserver.xe.session_status", value=1, tags=expected_tags)
 

--- a/sqlserver/tests/test_database_metrics.py
+++ b/sqlserver/tests/test_database_metrics.py
@@ -1008,7 +1008,7 @@ def test_sqlserver_db_fragmentation_metrics(
                     aggregator.assert_metric(metric_name, value=metric_value, tags=expected_tags)
                     if db_fragmentation_object_names:
                         for m in aggregator.metrics(metric_name):
-                            tags_by_key = dict([t.split(':') for t in m.tags if not t.startswith('dd.internal')])
+                            tags_by_key = dict([t.split(':') for t in m.tags])
                             assert tags_by_key['object_name'].lower() in db_fragmentation_object_names
                 if not include_db_fragmentation_metrics_tempdb:
                     assert database_name != 'tempdb'

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -478,7 +478,7 @@ def test_index_fragmentation_metrics(aggregator, dd_run_check, instance_docker, 
     dd_run_check(sqlserver_check)
     seen_databases = set()
     for m in aggregator.metrics("sqlserver.database.avg_fragmentation_in_percent"):
-        tags_by_key = dict([t.split(':') for t in m.tags if not t.startswith('dd.internal')])
+        tags_by_key = dict([t.split(':') for t in m.tags])
         seen_databases.add(tags_by_key['database_name'])
         assert tags_by_key['object_name'].lower() != 'none'
 
@@ -496,25 +496,25 @@ def test_table_size_metrics(aggregator, dd_run_check, instance_docker, database_
     dd_run_check(sqlserver_check)
     seen_databases = set()
     for m in aggregator.metrics("sqlserver.table.row_count"):
-        tags_by_key = dict([t.split(':') for t in m.tags if not t.startswith('dd.internal')])
+        tags_by_key = dict([t.split(':') for t in m.tags])
         seen_databases.add(tags_by_key['database'])
         assert tags_by_key['table'].lower() != 'none'
         assert tags_by_key['schema'].lower() != 'none'
 
     for m in aggregator.metrics("sqlserver.table.data_size"):
-        tags_by_key = dict([t.split(':') for t in m.tags if not t.startswith('dd.internal')])
+        tags_by_key = dict([t.split(':') for t in m.tags])
         seen_databases.add(tags_by_key['database'])
         assert tags_by_key['table'].lower() != 'none'
         assert tags_by_key['schema'].lower() != 'none'
 
     for m in aggregator.metrics("sqlserver.table.total_size"):
-        tags_by_key = dict([t.split(':') for t in m.tags if not t.startswith('dd.internal')])
+        tags_by_key = dict([t.split(':') for t in m.tags])
         seen_databases.add(tags_by_key['database'])
         assert tags_by_key['table'].lower() != 'none'
         assert tags_by_key['schema'].lower() != 'none'
 
     for m in aggregator.metrics("sqlserver.table.used_size"):
-        tags_by_key = dict([t.split(':') for t in m.tags if not t.startswith('dd.internal')])
+        tags_by_key = dict([t.split(':') for t in m.tags])
         seen_databases.add(tags_by_key['database'])
         assert tags_by_key['table'].lower() != 'none'
         assert tags_by_key['schema'].lower() != 'none'
@@ -549,7 +549,7 @@ def test_custom_metrics_fraction_counters(aggregator, dd_run_check, instance_doc
     dd_run_check(sqlserver_check)
     seen_plan_type = set()
     for m in aggregator.metrics("sqlserver.custom.plan_cache_test"):
-        tags_by_key = dict([t.split(':') for t in m.tags if not t.startswith('dd.internal')])
+        tags_by_key = dict([t.split(':') for t in m.tags])
         seen_plan_type.add(tags_by_key['plan_type'])
         assert tags_by_key['optional_tag'].lower() == 'tagx'
     assert 'SQL Plans' in seen_plan_type
@@ -565,7 +565,7 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
     dd_run_check(sqlserver_check)
     seen_databases = set()
     for m in aggregator.metrics("sqlserver.tempdb.file_space_usage.free_space"):
-        tags_by_key = dict([t.split(':') for t in m.tags if not t.startswith('dd.internal')])
+        tags_by_key = dict([t.split(':') for t in m.tags])
         seen_databases.add(tags_by_key['database'])
         assert tags_by_key['database_id']
 

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -19,6 +19,7 @@ from datadog_checks.sqlserver.const import (
     INSTANCE_METRICS_DATABASE_SINGLE,
     STATIC_INFO_ENGINE_EDITION,
     STATIC_INFO_MAJOR_VERSION,
+    STATIC_INFO_SERVERNAME,
     STATIC_INFO_VERSION,
     TABLE_SIZE_METRICS,
 )
@@ -94,7 +95,13 @@ def test_check_docker(aggregator, dd_run_check, init_config, instance_docker, da
         instance_docker['autodiscovery_include'] = autodiscovery_dbs
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
     dd_run_check(sqlserver_check)
-    expected_tags = sqlserver_check._config.tags + [
+    expected_check_tags = sqlserver_check._config.tags + [
+        "database_hostname:{}".format("stubbed.hostname"),
+        "database_instance:{}".format("stubbed.hostname"),
+        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+        "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+    ]
+    expected_service_tags = expected_check_tags + [
         'connection_host:{}'.format(instance_docker.get('host')),
         'sqlserver_host:{}'.format(sqlserver_check.resolved_hostname),
         'db:master',
@@ -102,8 +109,8 @@ def test_check_docker(aggregator, dd_run_check, init_config, instance_docker, da
     assert_metrics(
         instance_docker,
         aggregator,
-        check_tags=sqlserver_check._config.tags,
-        service_tags=expected_tags,
+        check_tags=expected_check_tags,
+        service_tags=expected_service_tags,
         dbm_enabled=dbm_enabled,
         hostname=sqlserver_check.resolved_hostname,
         database_autodiscovery=database_autodiscovery,
@@ -121,7 +128,16 @@ def test_check_stored_procedure(aggregator, dd_run_check, init_config, instance_
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
     dd_run_check(sqlserver_check)
 
-    expected_tags = sqlserver_check._config.tags + sp_tags.split(',')
+    expected_tags = (
+        sqlserver_check._config.tags
+        + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
+        + sp_tags.split(',')
+    )
     aggregator.assert_metric('sql.sp.testa', value=100, tags=expected_tags, count=1)
     aggregator.assert_metric('sql.sp.testb', tags=expected_tags, count=2)
 
@@ -147,7 +163,16 @@ def test_check_stored_procedure_proc_if(aggregator, dd_run_check, init_config, i
 def test_custom_metrics_object_name(aggregator, dd_run_check, init_config_object_name, instance_docker):
     sqlserver_check = SQLServer(CHECK_NAME, init_config_object_name, [instance_docker])
     dd_run_check(sqlserver_check)
-    instance_tags = sqlserver_check._config.tags + ['optional_tag:tag1']
+    instance_tags = (
+        sqlserver_check._config.tags
+        + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
+        + ['optional_tag:tag1']
+    )
 
     aggregator.assert_metric('sqlserver.cache.hit_ratio', tags=instance_tags, count=1)
     aggregator.assert_metric('sqlserver.broker_activation.tasks_running', tags=instance_tags, count=1)
@@ -160,7 +185,12 @@ def test_custom_metrics_alt_tables(aggregator, dd_run_check, init_config_alt_tab
 
     sqlserver_check = SQLServer(CHECK_NAME, init_config_alt_tables, [instance_docker])
     dd_run_check(sqlserver_check)
-    instance_tags = sqlserver_check._config.tags
+    instance_tags = sqlserver_check._config.tags + [
+        "database_hostname:{}".format("stubbed.hostname"),
+        "database_instance:{}".format("stubbed.hostname"),
+        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+        "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+    ]
 
     aggregator.assert_metric('sqlserver.LCK_M_S.max_wait_time_ms', tags=instance_tags, count=1)
     aggregator.assert_metric('sqlserver.LCK_M_S.signal_wait_time_ms', tags=instance_tags, count=1)
@@ -189,7 +219,12 @@ def test_autodiscovery_database_metrics(aggregator, dd_run_check, instance_autod
     instance_autodiscovery['autodiscovery_include'] = ['master', 'msdb']
     check = SQLServer(CHECK_NAME, {}, [instance_autodiscovery])
     dd_run_check(check)
-    instance_tags = check._config.tags
+    instance_tags = check._config.tags + [
+        "database_hostname:{}".format("stubbed.hostname"),
+        "database_instance:{}".format("stubbed.hostname"),
+        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+        "sqlserver_servername:{}".format(check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+    ]
 
     master_tags = [
         'database:master',
@@ -230,7 +265,12 @@ def test_autodiscovery_db_service_checks(
     instance_autodiscovery['autodiscovery_db_service_check'] = service_check_enabled
     check = SQLServer(CHECK_NAME, {}, [instance_autodiscovery])
     dd_run_check(check)
-    instance_tags = check._config.tags
+    instance_tags = check._config.tags + [
+        "database_hostname:{}".format("stubbed.hostname"),
+        "database_instance:{}".format("stubbed.hostname"),
+        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+        "sqlserver_servername:{}".format(check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+    ]
 
     # verify that the old status check returns OK
     aggregator.assert_service_check(
@@ -281,9 +321,14 @@ def test_autodiscovery_exclude_db_service_checks(aggregator, dd_run_check, insta
     instance_autodiscovery['autodiscovery_include'] = ['master']
     instance_autodiscovery['autodiscovery_exclude'] = ['msdb']
     check = SQLServer(CHECK_NAME, {}, [instance_autodiscovery])
-    instance_tags = check._config.tags
-
     dd_run_check(check)
+
+    instance_tags = check._config.tags + [
+        "database_hostname:{}".format("stubbed.hostname"),
+        "database_instance:{}".format("stubbed.hostname"),
+        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+        "sqlserver_servername:{}".format(check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+    ]
 
     # assert no connection is created for an excluded database
     aggregator.assert_service_check(
@@ -325,7 +370,12 @@ def test_autodiscovery_perf_counters(aggregator, dd_run_check, instance_autodisc
     instance_autodiscovery['autodiscovery_include'] = ['master', 'msdb']
     check = SQLServer(CHECK_NAME, {}, [instance_autodiscovery])
     dd_run_check(check)
-    instance_tags = check._config.tags
+    instance_tags = check._config.tags + [
+        "database_hostname:{}".format("stubbed.hostname"),
+        "database_instance:{}".format("stubbed.hostname"),
+        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+        "sqlserver_servername:{}".format(check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+    ]
 
     expected_metrics = [m[0] for m in INSTANCE_METRICS_DATABASE_SINGLE]
     master_tags = ['database:master'] + instance_tags
@@ -342,7 +392,12 @@ def test_autodiscovery_perf_counters_ao(aggregator, dd_run_check, instance_autod
     instance_autodiscovery['autodiscovery_include'] = ['datadog_test-1']
     check = SQLServer(CHECK_NAME, {}, [instance_autodiscovery])
     dd_run_check(check)
-    instance_tags = check._config.tags
+    instance_tags = check._config.tags + [
+        "database_hostname:{}".format("stubbed.hostname"),
+        "database_instance:{}".format("stubbed.hostname"),
+        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+        "sqlserver_servername:{}".format(check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+    ]
 
     expected_metrics = [m[0] for m in INSTANCE_METRICS_DATABASE]
     tags = ['database:datadog_test-1'] + instance_tags
@@ -428,7 +483,16 @@ def test_custom_queries(aggregator, dd_run_check, instance_docker, custom_query,
 
     for metric_name, kwargs in assert_metrics:
         kwargs = copy(kwargs)
-        kwargs['tags'] = check._config.tags + kwargs.get('tags', [])
+        kwargs['tags'] = (
+            check._config.tags
+            + [
+                "database_hostname:{}".format("stubbed.hostname"),
+                "database_instance:{}".format("stubbed.hostname"),
+                "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+                "sqlserver_servername:{}".format(check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+            ]
+            + kwargs.get('tags', [])
+        )
         aggregator.assert_metric(metric_name, **kwargs)
 
 
@@ -478,7 +542,7 @@ def test_index_fragmentation_metrics(aggregator, dd_run_check, instance_docker, 
     dd_run_check(sqlserver_check)
     seen_databases = set()
     for m in aggregator.metrics("sqlserver.database.avg_fragmentation_in_percent"):
-        tags_by_key = dict([t.split(':') for t in m.tags])
+        tags_by_key = dict([t.split(':', 1) for t in m.tags])
         seen_databases.add(tags_by_key['database_name'])
         assert tags_by_key['object_name'].lower() != 'none'
 
@@ -496,25 +560,25 @@ def test_table_size_metrics(aggregator, dd_run_check, instance_docker, database_
     dd_run_check(sqlserver_check)
     seen_databases = set()
     for m in aggregator.metrics("sqlserver.table.row_count"):
-        tags_by_key = dict([t.split(':') for t in m.tags])
+        tags_by_key = dict([t.split(':', 1) for t in m.tags])
         seen_databases.add(tags_by_key['database'])
         assert tags_by_key['table'].lower() != 'none'
         assert tags_by_key['schema'].lower() != 'none'
 
     for m in aggregator.metrics("sqlserver.table.data_size"):
-        tags_by_key = dict([t.split(':') for t in m.tags])
+        tags_by_key = dict([t.split(':', 1) for t in m.tags])
         seen_databases.add(tags_by_key['database'])
         assert tags_by_key['table'].lower() != 'none'
         assert tags_by_key['schema'].lower() != 'none'
 
     for m in aggregator.metrics("sqlserver.table.total_size"):
-        tags_by_key = dict([t.split(':') for t in m.tags])
+        tags_by_key = dict([t.split(':', 1) for t in m.tags])
         seen_databases.add(tags_by_key['database'])
         assert tags_by_key['table'].lower() != 'none'
         assert tags_by_key['schema'].lower() != 'none'
 
     for m in aggregator.metrics("sqlserver.table.used_size"):
-        tags_by_key = dict([t.split(':') for t in m.tags])
+        tags_by_key = dict([t.split(':', 1) for t in m.tags])
         seen_databases.add(tags_by_key['database'])
         assert tags_by_key['table'].lower() != 'none'
         assert tags_by_key['schema'].lower() != 'none'
@@ -549,7 +613,7 @@ def test_custom_metrics_fraction_counters(aggregator, dd_run_check, instance_doc
     dd_run_check(sqlserver_check)
     seen_plan_type = set()
     for m in aggregator.metrics("sqlserver.custom.plan_cache_test"):
-        tags_by_key = dict([t.split(':') for t in m.tags])
+        tags_by_key = dict([t.split(':', 1) for t in m.tags])
         seen_plan_type.add(tags_by_key['plan_type'])
         assert tags_by_key['optional_tag'].lower() == 'tagx'
     assert 'SQL Plans' in seen_plan_type
@@ -565,7 +629,7 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
     dd_run_check(sqlserver_check)
     seen_databases = set()
     for m in aggregator.metrics("sqlserver.tempdb.file_space_usage.free_space"):
-        tags_by_key = dict([t.split(':') for t in m.tags])
+        tags_by_key = dict([t.split(':', 1) for t in m.tags])
         seen_databases.add(tags_by_key['database'])
         assert tags_by_key['database_id']
 
@@ -878,12 +942,21 @@ def test_index_usage_statistics(aggregator, dd_run_check, instance_docker, datab
 
     check = SQLServer(CHECK_NAME, {}, [instance_docker])
     dd_run_check(check)
-    expected_tags = check._config.tags + [
-        'db:datadog_test-1',
-        'table:ϑings',
-        'schema:dbo',
-        'index_name:thingsindex',
-    ]
+    expected_tags = (
+        check._config.tags
+        + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
+        + [
+            'db:datadog_test-1',
+            'table:ϑings',
+            'schema:dbo',
+            'index_name:thingsindex',
+        ]
+    )
     for m in DATABASE_INDEX_METRICS:
         aggregator.assert_metric(m, tags=expected_tags, count=1)
 
@@ -894,12 +967,21 @@ def test_database_state(aggregator, dd_run_check, init_config, instance_docker):
     instance_docker['database'] = 'master'
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
     dd_run_check(sqlserver_check)
-    expected_tags = sqlserver_check._config.tags + [
-        'database_recovery_model_desc:SIMPLE',
-        'database_state_desc:ONLINE',
-        'database:{}'.format(instance_docker['database']),
-        'db:{}'.format(instance_docker['database']),
-    ]
+    expected_tags = (
+        sqlserver_check._config.tags
+        + [
+            "database_hostname:{}".format("stubbed.hostname"),
+            "database_instance:{}".format("stubbed.hostname"),
+            "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+            "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+        ]
+        + [
+            'database_recovery_model_desc:SIMPLE',
+            'database_state_desc:ONLINE',
+            'database:{}'.format(instance_docker['database']),
+            'db:{}'.format(instance_docker['database']),
+        ]
+    )
     aggregator.assert_metric('sqlserver.database.state', tags=expected_tags, hostname=sqlserver_check.resolved_hostname)
 
 
@@ -938,13 +1020,22 @@ def test_propagate_agent_tags(
         check = SQLServer(CHECK_NAME, init_config, [instance_docker])
         assert check._config._should_propagate_agent_tags(instance_docker, init_config) == should_propagate_agent_tags
         if should_propagate_agent_tags:
-            assert all(tag in check.tags for tag in agent_tags)
+            assert all(tag in check.tag_manager.get_tags() for tag in agent_tags)
             dd_run_check(check)
-            expected_tags = check._config.tags + [
-                'connection_host:{}'.format(instance_docker.get('host')),
-                'sqlserver_host:{}'.format(check.resolved_hostname),
-                'db:master',
-            ]
+            expected_tags = (
+                check._config.tags
+                + [
+                    "database_hostname:{}".format("stubbed.hostname"),
+                    "database_instance:{}".format("stubbed.hostname"),
+                    "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+                    "sqlserver_servername:{}".format(check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+                ]
+                + [
+                    'connection_host:{}'.format(instance_docker.get('host')),
+                    'sqlserver_host:{}'.format(check.resolved_hostname),
+                    'db:master',
+                ]
+            )
             aggregator.assert_service_check(
                 'sqlserver.can_connect',
                 status=SQLServer.OK,

--- a/sqlserver/tests/test_metrics.py
+++ b/sqlserver/tests/test_metrics.py
@@ -26,6 +26,7 @@ from datadog_checks.sqlserver.const import (
     INSTANCE_METRICS_DATABASE_SINGLE,
     OS_SCHEDULER_METRICS,
     SERVICE_CHECK_NAME,
+    STATIC_INFO_SERVERNAME,
     TASK_SCHEDULER_METRICS,
     TEMPDB_FILE_SPACE_USAGE_METRICS,
 )
@@ -42,7 +43,7 @@ from .common import (
 )
 from .utils import always_on, is_always_on, not_windows_ci
 
-INCR_FRACTION_METRICS = {'sqlserver.latches.latch_wait_time'}
+INCR_FRACTION_METRICS = {'sqlserver.latches.latch_waits'}
 AUTODISCOVERY_DBS = ['master', 'msdb', 'datadog_test-1']
 
 
@@ -57,7 +58,12 @@ def test_check_server_metrics(
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
     dd_run_check(sqlserver_check)
 
-    tags = sqlserver_check._config.tags
+    tags = sqlserver_check._config.tags + [
+        "database_hostname:{}".format("stubbed.hostname"),
+        "database_instance:{}".format("stubbed.hostname"),
+        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+        "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+    ]
 
     check_sqlserver_can_connect(aggregator, instance_docker_metrics['host'], sqlserver_check.resolved_hostname, tags)
 
@@ -83,7 +89,12 @@ def test_check_instance_metrics(
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
     dd_run_check(sqlserver_check)
 
-    tags = sqlserver_check._config.tags
+    tags = sqlserver_check._config.tags + [
+        "database_hostname:{}".format("stubbed.hostname"),
+        "database_instance:{}".format("stubbed.hostname"),
+        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+        "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+    ]
 
     check_sqlserver_can_connect(
         aggregator, instance_docker_metrics['host'], sqlserver_check.resolved_hostname, tags, False
@@ -119,7 +130,12 @@ def test_check_instance_metrics_autodiscovery(
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
     dd_run_check(sqlserver_check)
 
-    tags = sqlserver_check._config.tags
+    tags = sqlserver_check._config.tags + [
+        "database_hostname:{}".format("stubbed.hostname"),
+        "database_instance:{}".format("stubbed.hostname"),
+        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+        "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+    ]
 
     check_sqlserver_can_connect(
         aggregator, instance_docker_metrics['host'], sqlserver_check.resolved_hostname, tags, True
@@ -167,7 +183,12 @@ def test_check_database_metrics(
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
     dd_run_check(sqlserver_check)
 
-    tags = sqlserver_check._config.tags
+    tags = sqlserver_check._config.tags + [
+        "database_hostname:{}".format("stubbed.hostname"),
+        "database_instance:{}".format("stubbed.hostname"),
+        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+        "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+    ]
 
     check_sqlserver_can_connect(
         aggregator, instance_docker_metrics['host'], sqlserver_check.resolved_hostname, tags, database_autodiscovery
@@ -246,7 +267,12 @@ def test_check_index_usage_metrics(
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
     dd_run_check(sqlserver_check)
 
-    tags = sqlserver_check._config.tags
+    tags = sqlserver_check._config.tags + [
+        "database_hostname:{}".format("stubbed.hostname"),
+        "database_instance:{}".format("stubbed.hostname"),
+        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+        "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+    ]
 
     check_sqlserver_can_connect(aggregator, instance_docker_metrics['host'], sqlserver_check.resolved_hostname, tags)
 
@@ -273,7 +299,12 @@ def test_check_task_scheduler_metrics(
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
     dd_run_check(sqlserver_check)
 
-    tags = sqlserver_check._config.tags
+    tags = sqlserver_check._config.tags + [
+        "database_hostname:{}".format("stubbed.hostname"),
+        "database_instance:{}".format("stubbed.hostname"),
+        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+        "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+    ]
 
     check_sqlserver_can_connect(aggregator, instance_docker_metrics['host'], sqlserver_check.resolved_hostname, tags)
 
@@ -301,7 +332,12 @@ def test_check_master_files_metrics(
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
     dd_run_check(sqlserver_check)
 
-    tags = sqlserver_check._config.tags
+    tags = sqlserver_check._config.tags + [
+        "database_hostname:{}".format("stubbed.hostname"),
+        "database_instance:{}".format("stubbed.hostname"),
+        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+        "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+    ]
 
     check_sqlserver_can_connect(aggregator, instance_docker_metrics['host'], sqlserver_check.resolved_hostname, tags)
 
@@ -340,7 +376,12 @@ def test_check_db_fragmentation_metrics(
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
     dd_run_check(sqlserver_check)
 
-    tags = sqlserver_check._config.tags
+    tags = sqlserver_check._config.tags + [
+        "database_hostname:{}".format("stubbed.hostname"),
+        "database_instance:{}".format("stubbed.hostname"),
+        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+        "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+    ]
 
     check_sqlserver_can_connect(
         aggregator, instance_docker_metrics['host'], sqlserver_check.resolved_hostname, tags, database_autodiscovery
@@ -370,7 +411,12 @@ def test_check_tempdb_file_space_usage_metrics(
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
     dd_run_check(sqlserver_check)
 
-    tags = sqlserver_check._config.tags
+    tags = sqlserver_check._config.tags + [
+        "database_hostname:{}".format("stubbed.hostname"),
+        "database_instance:{}".format("stubbed.hostname"),
+        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+        "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+    ]
 
     check_sqlserver_can_connect(aggregator, instance_docker_metrics['host'], sqlserver_check.resolved_hostname, tags)
 
@@ -424,15 +470,25 @@ def test_check_incr_fraction_metrics(
     sqlserver_check.run()
     cursor.close()
 
-    tags = sqlserver_check._config.tags
+    key_tags = sqlserver_check._config.tags
+    tags = key_tags + [
+        "database_hostname:{}".format("stubbed.hostname"),
+        "database_instance:{}".format("stubbed.hostname"),
+        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+        "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+    ]
 
     check_sqlserver_can_connect(aggregator, instance_docker_metrics['host'], sqlserver_check.resolved_hostname, tags)
 
     for metric_name in INCR_FRACTION_METRICS:
-        key = "{}:{}".format(metric_name, "".join(tags))
-        if previous_value[key] == sqlserver_check.sqlserver_incr_fraction_metric_previous_values[key]:
+        key = "{}:{}".format(metric_name, "".join(key_tags))
+        if (
+            key in previous_value
+            and key in sqlserver_check.sqlserver_incr_fraction_metric_previous_values
+            and previous_value[key] == sqlserver_check.sqlserver_incr_fraction_metric_previous_values[key]
+        ):
             continue
-        aggregator.assert_metric(metric_name, tags=tags, hostname=sqlserver_check.resolved_hostname, count=1)
+        aggregator.assert_metric(metric_name, tags=tags, hostname=sqlserver_check.resolved_hostname)
 
     sqlserver_check.cancel()
 

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -29,6 +29,7 @@ from datadog_checks.sqlserver.const import (
     ENGINE_EDITION_SQL_DATABASE,
     ENGINE_EDITION_STANDARD,
     STATIC_INFO_ENGINE_EDITION,
+    STATIC_INFO_SERVERNAME,
 )
 from datadog_checks.sqlserver.statements import SQL_SERVER_QUERY_METRICS_COLUMNS, obfuscate_xml_plan
 
@@ -351,13 +352,13 @@ def test_statement_metrics_and_plans(
         dbm_instance['query_metrics']['disable_secondary_tags'] = True
     dbm_instance['query_activity'] = {'enabled': True, 'collection_interval': 2}
     instance_tags = dbm_instance.get('tags', [])
-    expected_instance_tags = {t for t in instance_tags if not t.startswith('dd.internal')}
+    expected_instance_tags = set(instance_tags)
     if collect_raw_query_statement:
         dbm_instance["collect_raw_query_statement"] = {"enabled": True}
         expected_instance_tags.add("raw_query_statement:enabled")
     expected_instance_tags.add("database_hostname:stubbed.hostname")
     expected_instance_tags.add("database_instance:stubbed.hostname")
-    expected_instance_tags_with_db = expected_instance_tags | {"db:{}".format(database)}
+    expected_instance_tags.add("dd.internal.resource:database_instance:stubbed.hostname")
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
 
     def _obfuscate_sql(sql_query, options=None):
@@ -398,6 +399,9 @@ def test_statement_metrics_and_plans(
                 cursor, SQL_SERVER_QUERY_METRICS_COLUMNS
             )
 
+    expected_instance_tags.add("sqlserver_servername:{}".format(check.static_info_cache.get(STATIC_INFO_SERVERNAME)))
+    expected_instance_tags_with_db = expected_instance_tags | {"db:{}".format(database)}
+
     # dbm-metrics
     dbm_metrics = aggregator.get_event_platform_events("dbm-metrics")
     assert len(dbm_metrics) == 1, "should have collected exactly one dbm-metrics payload"
@@ -408,7 +412,6 @@ def test_statement_metrics_and_plans(
     assert payload['ddagenthostname'] == datadog_agent.get_hostname()
     tags = set(payload['tags'])
     assert tags == expected_instance_tags, "wrong instance tags for dbm-metrics event"
-    assert not any("dd.internal" in m for m in tags), "emitted dd.internal metrics from check"
     assert type(payload['min_collection_interval']) in (float, int), "invalid min_collection_interval"
     # metrics rows
     sqlserver_rows = payload.get('sqlserver_rows', [])
@@ -905,7 +908,12 @@ PORT = 1432
 
 
 def _expected_dbm_instance_tags(check):
-    return check._config.tags
+    return check._config.tags + [
+        "database_hostname:{}".format("stubbed.hostname"),
+        "database_instance:{}".format("stubbed.hostname"),
+        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+        "sqlserver_servername:{}".format(check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+    ]
 
 
 @pytest.mark.parametrize("statement_metrics_enabled", [True, False])

--- a/sqlserver/tests/test_stored_procedures.py
+++ b/sqlserver/tests/test_stored_procedures.py
@@ -17,6 +17,7 @@ from datadog_checks.sqlserver.const import (
     ENGINE_EDITION_EXPRESS,
     ENGINE_EDITION_PERSONAL,
     ENGINE_EDITION_STANDARD,
+    STATIC_INFO_SERVERNAME,
 )
 from datadog_checks.sqlserver.stored_procedures import SQL_SERVER_PROCEDURE_METRICS_COLUMNS
 
@@ -39,7 +40,12 @@ logger = logging.getLogger(__name__)
 
 
 def _expected_dbm_instance_tags(check):
-    return check._config.tags
+    return check._config.tags + [
+        "database_hostname:{}".format("stubbed.hostname"),
+        "database_instance:{}".format("stubbed.hostname"),
+        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+        "sqlserver_servername:{}".format(check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+    ]
 
 
 @pytest.fixture(autouse=True)
@@ -257,6 +263,8 @@ def test_procedure_metrics(
     expected_instance_tags = {t for t in instance_tags if not t.startswith('dd.internal')}
     expected_instance_tags.add("database_hostname:stubbed.hostname")
     expected_instance_tags.add("database_instance:stubbed.hostname")
+    expected_instance_tags.add("dd.internal.resource:database_instance:stubbed.hostname")
+    expected_instance_tags.add("sqlserver_servername:{}".format(check.static_info_cache.get(STATIC_INFO_SERVERNAME)))
 
     # dbm-metrics
     dbm_metrics = aggregator.get_event_platform_events("dbm-metrics")
@@ -346,12 +354,9 @@ def test_async_job_inactive_stop(aggregator, dd_run_check, dbm_instance):
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
     dd_run_check(check)
     check.procedure_metrics._job_loop_future.result()
-    print("natasha heree")
-    print(['job:procedure-metrics'] + _expected_dbm_instance_tags(check))
-    print(['job:procedure-metrics'] + check._config.tags)
     aggregator.assert_metric(
         "dd.sqlserver.async_job.inactive_stop",
-        tags=['job:procedure-metrics'] + check._config.tags,
+        tags=['job:procedure-metrics'] + _expected_dbm_instance_tags(check),
         hostname='',
     )
 

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -464,7 +464,12 @@ def test_set_default_driver_conf_linux():
 def test_check_local(aggregator, dd_run_check, init_config, instance_docker):
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
     dd_run_check(sqlserver_check)
-    check_tags = sqlserver_check._config.tags
+    check_tags = sqlserver_check._config.tags + [
+        "database_hostname:{}".format("stubbed.hostname"),
+        "database_instance:{}".format("stubbed.hostname"),
+        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
+        "sqlserver_servername:{}".format(sqlserver_check.static_info_cache.get(STATIC_INFO_SERVERNAME)),
+    ]
     expected_tags = check_tags + [
         'sqlserver_host:{}'.format(sqlserver_check.resolved_hostname),
         'connection_host:{}'.format(DOCKER_SERVER),

--- a/sqlserver/tests/test_xe_collection.py
+++ b/sqlserver/tests/test_xe_collection.py
@@ -10,6 +10,7 @@ from unittest.mock import Mock, patch
 import pytest
 from lxml import etree
 
+from datadog_checks.base.utils.db.utils import TagManager
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.xe_collection.base import TimestampHandler
 from datadog_checks.sqlserver.xe_collection.error_events import ErrorEventsHandler
@@ -101,7 +102,8 @@ def mock_check():
 
     check.static_info_cache = {'version': '2019', 'engine_edition': 'Standard Edition'}
     check.resolved_hostname = "test-host"
-    check.tags = ["test:tag"]
+    check.tag_manager = TagManager()
+    check.tag_manager.set_tag('test', 'tag')
     check.database_monitoring_query_activity = Mock()
     check.database_monitoring_query_sample = Mock()
     return check


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
* Migrates the SQLServer integration to use the new TagManager
* Fixes a race condition with certain database identifier template variables
### Motivation
<!-- What inspired you to submit this pull request? -->
Previously certain tags were set before the static info cache had been populated. This led to placeholders appearing in database instance identifiers.
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
