### PR TITLE
Add agent min version requirement to gpu integration docs

### DIFF
--- a/gpu/README.md
+++ b/gpu/README.md
@@ -12,6 +12,7 @@ Supported vendors: NVIDIA.
 ## Requirements
 
 - NVIDIA driver version: 450.51 and above
+- Datadog agent version: 7.65 and above
 - Supported OS: Linux only
 - Linux kernel version: 5.8 and above
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update GPU docs to mention that the minimum agent version is 7.65

### Motivation
<!-- What inspired you to submit this pull request? -->

I lost a day of my life trying to figure out why the GPU integration wasn't working on a machine with the agent version 7.63, it doesn't need to happen to anybody else.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
