### PR TITLE
Follow-up: stop loading manifest.json when validating configs

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
@@ -13,14 +13,12 @@ from ...config_validator.validator_errors import SEVERITY_ERROR, SEVERITY_WARNIN
 from ...configuration import ConfigSpec
 from ...configuration.consumers import ExampleConsumer
 from ...constants import get_root
-from ...manifest_utils import Manifest
 from ...testing import process_checks_option
 from ...utils import complete_valid_checks, get_config_files, get_data_directory, get_version_string
 from ..console import (
     CONTEXT_SETTINGS,
     abort,
     annotate_error,
-    echo_debug,
     echo_failure,
     echo_info,
     echo_success,
@@ -63,11 +61,6 @@ def config(ctx, check, sync, verbose):
     for check in checks:
         check_display_queue = []
 
-        manifest = Manifest.load_manifest(check)
-        if not manifest:
-            echo_debug(f"Skipping validation for check: {check}; can't process manifest")
-            continue
-
         spec_file_path = path_join(get_root(), check, 'assets', 'configuration', 'spec.yaml')
         if not file_exists(spec_file_path):
             example_location = get_data_directory(check)
@@ -96,11 +89,9 @@ def config(ctx, check, sync, verbose):
 
         # source is the default file name
         if check == 'agent':
-            display_name = 'Datadog Agent'
             source = 'datadog'
             version = None
         else:
-            display_name = manifest.get_display_name()
             source = check
             version = get_version_string(check)
 
@@ -119,12 +110,6 @@ def config(ctx, check, sync, verbose):
             for error in spec.errors:
                 check_display_queue.append(lambda error=error, **kwargs: echo_failure(error, **kwargs))
         else:
-            if spec.data['name'] != display_name:
-                files_failed[spec_file_path] = True
-                message = f"Spec  name `{spec.data['name']}` should be `{display_name}`"
-                check_display_queue.append(lambda message=message, **kwargs: echo_failure(message, **kwargs))
-                annotate_error(spec_file_path, message)
-
             example_location = get_data_directory(check)
             example_consumer = ExampleConsumer(spec.data)
             for example_file, (contents, errors) in example_consumer.render().items():


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This is a follow-up to https://github.com/DataDog/integrations-core/pull/20398, so no separate changelog!

### Motivation
<!-- What inspired you to submit this pull request? -->
I forgot to include these changes in an earlier PR.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
