### PR TITLE
chore: warn on unsigned commits

### DIFF
--- a/repository.datadog.yaml
+++ b/repository.datadog.yaml
@@ -6,3 +6,11 @@ max_age: 4380h # 6 months
 schema-version: v1
 kind: mergequeue
 enable: false
+---
+schema-version: v1
+kind: mergegate
+rules:
+  - require: commit-signatures
+    enforcement: warn
+    excluded_emails:
+      - '41898282+github-actions[bot]@users.noreply.github.com'

--- a/repository.datadog.yaml
+++ b/repository.datadog.yaml
@@ -14,3 +14,4 @@ rules:
     enforcement: warn
     excluded_emails:
       - '41898282+github-actions[bot]@users.noreply.github.com'
+    allow_unsigned_external: true


### PR DESCRIPTION
This patch enables warning messages sent over Slack to PR authors when the PR has an unsigned commit.

The warning is non-blocking to allow folks time to get their commits signed before enforcement goes into effect.