### PR TITLE
Ignore missing readmes in extras and marketplace repos

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/readmes.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/readmes.py
@@ -54,6 +54,11 @@ def readmes(ctx, check, format_links):
         display_queue = []
         readme_path = get_readme_file(integration)
 
+        if not os.path.exists(readme_path) and repo in ('extras', 'marketplace'):
+            # We are in the process of migrating extras and marketplace to manage READMEs in the Publishing Platform.
+            # We'll revisit this validation once we know for sure how we handle READMEs in the new world.
+            continue
+
         # Validate the README itself
         validate_readme(integration, repo, display_queue, files_failed, readme_counter)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
We're starting to get "implementation-only" PRs ([example](https://github.com/DataDog/integrations-extras/pull/2661)) in `integrations-extras` and `marketplace` which don't contain a README. This is because that file gets generated by the Publishing Platform.

This is a temporary measure to unblock those PRs. We are discussing how to handle these situations in a principled way.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
