### PR TITLE
Allow users to specify supported client encodings for query text

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -462,6 +462,21 @@ files:
         type: string
         example: show_pg_stat_statements()
         display_default: pg_stat_statements
+    - name: query_encodings
+      description: |
+        Set this value if your database is encoded in SQL_ASCII and you have clients that use encodings other than UTF-8.
+        When attempting to decode stored query text for query metrics, samples and activity, the agent will use these
+        values in order and return the first successful decoding. Only supported for Postgres 10 and above.
+
+        Note that the values should be the Python versions of the encoding names, which can be referenced at:
+        https://docs.python.org/3/library/codecs.html#standard-encodings
+      value:
+        type: array
+        items:
+          type: string
+        example:
+          - utf8
+          - latin1
     - name: query_metrics
       description: Configure collection of query metrics
       options:

--- a/postgres/changelog.d/20441.added
+++ b/postgres/changelog.d/20441.added
@@ -1,0 +1,1 @@
+Added a configuration option to support SQL_ASCII encoded Postgres databases with clients making requests in other encodings

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -116,6 +116,7 @@ class PostgresConfig:
         self.resources_metadata_config = instance.get('collect_resources', {}) or {}
         self.statement_activity_config = instance.get('query_activity', {}) or {}
         self.statement_metrics_config = instance.get('query_metrics', {}) or {}
+        self.query_encodings = instance.get('query_encodings')
         self.managed_identity = instance.get('managed_identity', {})
         self.cloud_metadata = {}
         aws = instance.get('aws', {})

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -277,6 +277,7 @@ class InstanceConfig(BaseModel):
     port: Optional[int] = None
     propagate_agent_tags: Optional[bool] = None
     query_activity: Optional[QueryActivity] = None
+    query_encodings: Optional[tuple[str, ...]] = None
     query_metrics: Optional[QueryMetrics] = None
     query_samples: Optional[QuerySamples] = None
     query_timeout: Optional[int] = None

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -436,6 +436,18 @@ instances:
     #
     # pg_stat_statements_view: show_pg_stat_statements()
 
+    ## @param query_encodings - list of strings - optional
+    ## Set this value if your database is encoded in SQL_ASCII and you have clients that use encodings other than UTF-8.
+    ## When attempting to decode stored query text for query metrics, samples and activity, the agent will use these
+    ## values in order and return the first successful decoding. Only supported for Postgres 10 and above.
+    ##
+    ## Note that the values should be the Python versions of the encoding names, which can be referenced at:
+    ## https://docs.python.org/3/library/codecs.html#standard-encodings
+    #
+    # query_encodings:
+    #   - utf8
+    #   - latin1
+
     ## Configure collection of query metrics
     #
     # query_metrics:

--- a/postgres/datadog_checks/postgres/encoding.py
+++ b/postgres/datadog_checks/postgres/encoding.py
@@ -1,0 +1,17 @@
+# (C) Datadog, Inc. 2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from typing import List
+
+
+def decode_with_encodings(byte_array: bytes, encodings: List[str]) -> str:
+    encodings = encodings or ['utf-8']
+    # Try strict mode first, then fallback to 'backslashreplace' if strict fails
+    # This can happen if a statetment is truncated in the middle of a multibyte character
+    for mode in ['strict', 'backslashreplace']:
+        for encoding in encodings:
+            try:
+                return byte_array.decode(encoding, mode)
+            except Exception:
+                continue
+    raise ValueError("No valid encoding found for the given byte array.")

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -30,6 +30,7 @@ from datadog_checks.base.utils.db.utils import (
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.time import get_timestamp
 from datadog_checks.base.utils.tracking import tracked_method
+from datadog_checks.postgres.encoding import decode_with_encodings
 from datadog_checks.postgres.explain_parameterized_queries import ExplainParameterizedQueries
 
 from .util import DatabaseConfigurationError, DBExplainError, trim_leading_set_stmts, warning_with_tags
@@ -280,6 +281,10 @@ class PostgresStatementSamples(DBMAsyncJob):
         with self._check._get_main_db() as conn:
             with conn.cursor(cursor_factory=CommenterDictCursor) as cursor:
                 self._log.debug("Running query [%s] %s", query, params)
+                if conn.encoding == "SQLASCII":
+                    # SQLASCII can truncate encodings across bytes, e.g. UTF8 multi-byte characters
+                    # so we need to read in the data as bytes and then decode as best we can
+                    psycopg2.extensions.register_type(psycopg2.extensions.BYTES, cursor)
                 cursor.execute(query, params)
                 rows = cursor.fetchall()
 
@@ -343,16 +348,45 @@ class PostgresStatementSamples(DBMAsyncJob):
         insufficient_privilege_count = 0
         total_count = 0
         normalized_rows = []
-        for row in rows:
+        for raw_row in rows:
             total_count += 1
-            if row.get('backend_type') is not None:
+            row = {}
+            with self._check._get_main_db() as conn:
+                encoding = conn.encoding if conn.encoding != "SQLASCII" else 'utf-8'
+
+            for key, value in raw_row.items():
+                if type(value) is not bytes:
+                    row[key] = value
+                elif key == "query":
+                    try:
+                        # Attempt decoding query in potential encodings
+                        row[key] = decode_with_encodings(value, self._config.query_encodings)
+                    except Exception as e:
+                        # Log the unable to decode query error
+                        self._log.warning("Unable to decode query: %s | Error: %s", value, e)
+                        break
+                else:
+                    try:
+                        # Decode other columns as database encoding, or default to utf-8
+                        try:
+                            row[key] = value.decode(encoding)
+                        except Exception:
+                            # Fallback to trying utf-8
+                            row[key] = value.decode('utf-8', 'backslashreplace')
+                    except Exception as e:
+                        self._log.warning("Unable to decode column: %s: %s | Error: %s", key, value, e)
+                        row[key] = "unknown"
+            # We later on fallback to having the statement be set to the backend_type so it's important to only
+            # set it if it is not None
+            if row.get("backend_type") is not None:
+                # backend_type is always a bytea type because it can contain non-UTF8 characters
                 try:
-                    row['backend_type'] = row['backend_type'].tobytes().decode('utf-8')
-                except UnicodeDecodeError:
-                    row['backend_type'] = 'unknown'
-            if (not row['datname'] or not row['query']) and row.get(
-                'backend_type', 'client backend'
-            ) == 'client backend':
+                    row["backend_type"] = row.get("backend_type").tobytes().decode('utf-8', 'backslashreplace')
+                except Exception:
+                    row["backend_type"] = "unknown"
+            if not row.get('query'):
+                continue
+            if (not row.get('datname')) and row.get('backend_type', 'client backend') == 'client backend':
                 continue
             if row['client_addr']:
                 row['client_addr'] = str(row['client_addr'])
@@ -706,6 +740,13 @@ class PostgresStatementSamples(DBMAsyncJob):
     def _run_explain(self, dbname, statement, obfuscated_statement):
         start_time = time.time()
         with self.db_pool.get_connection(dbname, ttl_ms=self._conn_ttl_ms) as conn:
+            # When sending potentially non-ascii data, e.g. UTF8, we need to force
+            # the client encoding to UTF-8 to match Python string encoding
+            if conn.encoding == 'SQLASCII':
+                self._log.debug(
+                    "Setting client encoding to UTF-8 for dbname=%s, as the current encoding is SQLASCII", dbname
+                )
+                conn.set_client_encoding('utf-8')
             with conn.cursor(cursor_factory=CommenterCursor) as cursor:
                 self._log.debug(
                     "Running query on dbname=%s: %s(%s)", dbname, self._explain_function, obfuscated_statement

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -18,6 +18,7 @@ from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_e
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 from datadog_checks.postgres.cursor import CommenterCursor, CommenterDictCursor
+from datadog_checks.postgres.encoding import decode_with_encodings
 
 from .query_calls_cache import QueryCallsCache
 from .util import DatabaseConfigurationError, payload_pg_version, warning_with_tags
@@ -401,6 +402,10 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 params = params + tuple(self._config.ignore_databases)
             with self._check._get_main_db() as conn:
                 with conn.cursor(cursor_factory=CommenterDictCursor) as cursor:
+                    if conn.encoding == "SQLASCII":
+                        # SQLASCII can truncate encodings across bytes, e.g. UTF8 multi-byte characters
+                        # so we need to read in the data as bytes and then decode as best we can
+                        psycopg2.extensions.register_type(psycopg2.extensions.BYTES, cursor)
                     if len(self._query_calls_cache.cache) > 0:
                         return self._execute_query(
                             cursor,
@@ -625,11 +630,19 @@ class PostgresStatementMetrics(DBMAsyncJob):
         return rows
 
     def _normalize_queries(self, rows):
+        with self._check._get_main_db() as conn:
+            encoding = conn.encoding if conn.encoding != "SQLASCII" else 'utf-8'
+
         normalized_rows = []
         for row in rows:
             normalized_row = dict(copy.copy(row))
             try:
-                statement = obfuscate_sql_with_metadata(row['query'], self._obfuscate_options)
+                query_text = (
+                    decode_with_encodings(row['query'], self._config.query_encodings)
+                    if type(row['query']) is bytes
+                    else row['query']
+                )
+                statement = obfuscate_sql_with_metadata(query_text, self._obfuscate_options)
             except Exception as e:
                 if self._config.log_unobfuscated_queries:
                     self._log.warning("Failed to obfuscate query=[%s] | err=[%s]", row['query'], e)
@@ -640,6 +653,22 @@ class PostgresStatementMetrics(DBMAsyncJob):
             obfuscated_query = statement['query']
             normalized_row['query'] = obfuscated_query
             normalized_row['query_signature'] = compute_sql_signature(obfuscated_query)
+            for key in ['datname', 'rolname']:
+                value = row[key]
+                if type(value) is not bytes:
+                    normalized_row[key] = value
+                    continue
+                try:
+                    # Decode other columns as database encoding, or default to utf-8
+                    try:
+                        normalized_row[key] = value.decode(encoding)
+                    except Exception:
+                        # Fallback to trying utf-8
+                        normalized_row[key] = value.decode('utf-8', 'backslashreplace')
+                except Exception as e:
+                    self._log.warning("Unable to decode column: %s: %s | Error: %s", key, value, e)
+                    normalized_row[key] = "unknown"
+
             metadata = statement['metadata']
             normalized_row['dd_tables'] = metadata.get('tables', None)
             normalized_row['dd_commands'] = metadata.get('commands', None)

--- a/postgres/hatch.toml
+++ b/postgres/hatch.toml
@@ -13,6 +13,14 @@ mypy-deps = [
 [[envs.default.matrix]]
 python = ["3.12"]
 version = ["9.6", "10.0", "11.0", "12.17", "13.0", "14.0", "15.0", "16.0", "17.0"]
+locale = ["UTF8"]
+
+
+# We only support SQLASCII encoding in 10+
+[[envs.default.matrix]]
+python = ["3.12"]
+version = ["10.0", "11.0", "12.17", "13.0", "14.0", "15.0", "16.0", "17.0"]
+locale = ["C"]
 
 [envs.default.overrides]
 matrix.version.env-vars = [
@@ -24,6 +32,10 @@ matrix.version.env-vars = [
   { key = "POSTGRES_VERSION", value = "15", if = ["15.0"] },
   { key = "POSTGRES_VERSION", value = "16", if = ["16.0"] },
   { key = "POSTGRES_VERSION", value = "17", if = ["17.0"] },
+]
+matrix.locale.env-vars = [
+  { key = "POSTGRES_LOCALE", value = "C", if = ["C"] },
+  { key = "POSTGRES_LOCALE", value = "UTF8", if = ["UTF8"] },
 ]
 
 [envs.latest.env-vars]

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -42,6 +42,7 @@ PASSWORD_ADMIN = 'dd_admin'
 DB_NAME = 'datadog_test'
 POSTGRES_VERSION = os.environ.get('POSTGRES_VERSION', None)
 POSTGRES_IMAGE = "alpine"
+POSTGRES_LOCALE = os.environ.get('POSTGRES_LOCALE', "UTF8")
 
 REPLICA_CONTAINER_1_NAME = 'compose-postgres_replica-1'
 REPLICA_CONTAINER_2_NAME = 'compose-postgres_replica2-1'

--- a/postgres/tests/compose/docker-compose-replication.yaml
+++ b/postgres/tests/compose/docker-compose-replication.yaml
@@ -17,7 +17,7 @@ services:
       - ./etc/postgresql:/etc/postgresql/
     environment:
       POSTGRES_PASSWORD: datad0g
-      POSTGRES_INITDB_ARGS: --data-checksums
+      POSTGRES_INITDB_ARGS: "--data-checksums --locale=${POSTGRES_LOCALE}"
     command: postgres -c 'config_file=/etc/postgresql/postgresql.conf' -c 'hba_file=/etc/postgresql/pg_hba.conf'
 
   postgres_replica:
@@ -36,7 +36,7 @@ services:
       - ./etc/postgresql_replica:/etc/postgresql/
     environment:
       POSTGRES_PASSWORD: datad0g
-      POSTGRES_INITDB_ARGS: --data-checksums
+      POSTGRES_INITDB_ARGS: "--data-checksums --locale=${POSTGRES_LOCALE}"
     command: postgres -c 'config_file=/etc/postgresql/postgresql.conf'
 
   postgres_replica2:
@@ -55,7 +55,7 @@ services:
       - ./etc/postgresql_replica2:/etc/postgresql/
     environment:
       POSTGRES_PASSWORD: datad0g
-      POSTGRES_INITDB_ARGS: --data-checksums
+      POSTGRES_INITDB_ARGS: "--data-checksums --locale=${POSTGRES_LOCALE}"
     command: postgres -c 'config_file=/etc/postgresql/postgresql.conf'
 
   postgres_logical_replica:
@@ -74,5 +74,5 @@ services:
       - ./etc/postgresql_logical_replica:/etc/postgresql/
     environment:
       POSTGRES_PASSWORD: datad0g
-      POSTGRES_INITDB_ARGS: --data-checksums
+      POSTGRES_INITDB_ARGS: "--data-checksums --locale=${POSTGRES_LOCALE}"
     command: postgres -c 'config_file=/etc/postgresql/postgresql.conf'

--- a/postgres/tests/compose/docker-compose.yaml
+++ b/postgres/tests/compose/docker-compose.yaml
@@ -13,5 +13,5 @@ services:
       - ./etc/postgresql:/etc/postgresql/
     environment:
       POSTGRES_PASSWORD: datad0g
-      POSTGRES_INITDB_ARGS: --data-checksums
+      POSTGRES_INITDB_ARGS: "--data-checksums --locale=${POSTGRES_LOCALE}"
     command: postgres -c 'config_file=/etc/postgresql/postgresql.conf' -c 'hba_file=/etc/postgresql/pg_hba.conf'

--- a/postgres/tests/compose/resources/02_setup.sh
+++ b/postgres/tests/compose/resources/02_setup.sh
@@ -5,7 +5,7 @@ set -e
 # prior to version 10 there was no `pg_read_all_stats` role so by adding a database to which the agent can't connect
 # it causes many of the tests to fail since some stats queries fail (like reading the size of the database to which you can't connect)
 # therefore we will only add this database to which you can't connect in 10+ for testing purposes.
-if [[ !("$PG_MAJOR" == 9.* ) ]]; then
+if [[ ! ("$PG_MAJOR" == 9.* ) ]]; then
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" datadog_test <<-'EOSQL'
     GRANT pg_monitor TO datadog;
 EOSQL

--- a/postgres/tests/compose/resources/03_load_data.sh
+++ b/postgres/tests/compose/resources/03_load_data.sh
@@ -69,7 +69,7 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" datadog_test <<-EOSQL
 EOSQL
 
 # Create publication for logical replication tests
-if [[ !("$PG_MAJOR" == 9.*) ]]; then
+if [[ ! ("$PG_MAJOR" == 9.*) ]]; then
 psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -p5432 datadog_test <<-EOSQL
     CREATE PUBLICATION publication_persons for table persons_indexed;
     CREATE PUBLICATION publication_cities for table cities;
@@ -77,7 +77,7 @@ psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -p5432 datadog_test <<-EOSQL
 EOSQL
 fi
 
-if [[ !("$PG_MAJOR" == 9.*) && !("$PG_MAJOR" == 10) ]]; then
+if [[ ! ("$PG_MAJOR" == 9.*) && ! ("$PG_MAJOR" == 10) ]]; then
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" datadog_test <<-EOSQL
     CREATE TABLE test_part (id SERIAL PRIMARY KEY, filler text) PARTITION BY RANGE (id);
     CREATE TABLE test_part1 PARTITION OF test_part FOR VALUES FROM (MINVALUE) TO (500);

--- a/postgres/tests/compose/resources/04_mark_container_as_ready.sh
+++ b/postgres/tests/compose/resources/04_mark_container_as_ready.sh
@@ -1,1 +1,2 @@
+#!/bin/bash
 echo "ready" > /tmp/container_ready.txt

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -22,6 +22,7 @@ from .common import (
     PORT_REPLICA2,
     PORT_REPLICA_LOGICAL,
     POSTGRES_IMAGE,
+    POSTGRES_LOCALE,
     POSTGRES_VERSION,
     USER,
 )
@@ -57,7 +58,7 @@ def dd_environment(e2e_instance):
     with docker_run(
         os.path.join(HERE, 'compose', compose_file),
         conditions=[WaitFor(connect_to_pg)],
-        env_vars={"POSTGRES_IMAGE": POSTGRES_IMAGE},
+        env_vars={"POSTGRES_IMAGE": POSTGRES_IMAGE, "POSTGRES_LOCALE": POSTGRES_LOCALE},
     ):
         yield e2e_instance
 

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -9,7 +9,7 @@ import pytest
 
 from datadog_checks.base.utils.db.utils import DBMAsyncJob
 
-from .common import POSTGRES_VERSION
+from .common import POSTGRES_LOCALE, POSTGRES_VERSION
 from .utils import run_one_check
 
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]
@@ -144,7 +144,10 @@ def test_collect_schemas(integration_check, dbm_instance, aggregator, use_defaul
                 if table['name'] == "persons":
                     # check that foreign keys, indexes get reported
                     keys = list(table.keys())
-                    assert_fields(keys, ["foreign_keys", "columns", "toast_table", "id", "name", "owner"])
+                    assert_fields(keys, ["foreign_keys", "columns", "id", "name", "owner"])
+                    # The toast table doesn't seem to be created in the C locale
+                    if POSTGRES_LOCALE != 'C':
+                        assert_fields(keys, ["toast_table"])
                     assert_fields(list(table['foreign_keys'][0].keys()), ['name', 'definition'])
                     assert_fields(
                         list(table['columns'][0].keys()),
@@ -157,7 +160,9 @@ def test_collect_schemas(integration_check, dbm_instance, aggregator, use_defaul
                     )
                 if table['name'] == "cities":
                     keys = list(table.keys())
-                    assert_fields(keys, ["indexes", "columns", "toast_table", "id", "name", "owner"])
+                    assert_fields(keys, ["indexes", "columns", "id", "name", "owner"])
+                    if POSTGRES_LOCALE != 'C':
+                        assert_fields(keys, ["toast_table"])
                     assert len(table['indexes']) == 1
                     assert_fields(
                         list(table['indexes'][0].keys()),

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -15,34 +15,42 @@ from datadog_checks.postgres.relationsmanager import (
     RelationsManager,
 )
 
-from .common import DB_NAME, HOST, _get_expected_tags, _iterate_metric_name, assert_metric_at_least
+from .common import DB_NAME, HOST, POSTGRES_LOCALE, _get_expected_tags, _iterate_metric_name, assert_metric_at_least
 from .utils import _get_superconn, _wait_for_value, requires_over_11
 
 RELATION_INDEX_METRICS = [
-    'postgresql.index_scans',
-    'postgresql.index_rows_fetched',  # deprecated
-    'postgresql.index_rel_rows_fetched',
-    'postgresql.index_rel_scans',
-    'postgresql.individual_index_size',
+    "postgresql.index_scans",
+    "postgresql.index_rows_fetched",  # deprecated
+    "postgresql.index_rel_rows_fetched",
+    "postgresql.index_rel_scans",
+    "postgresql.individual_index_size",
     # From STATIO_METRICS
-    'postgresql.index_blocks_read',
-    'postgresql.index_blocks_hit',
+    "postgresql.index_blocks_read",
+    "postgresql.index_blocks_hit",
 ]
 
 MAINTENANCE_METRICS = [
-    'postgresql.last_vacuum_age',
-    'postgresql.last_analyze_age',
-    'postgresql.last_autovacuum_age',
-    'postgresql.last_autoanalyze_age',
-    'postgresql.toast.last_vacuum_age',
-    'postgresql.toast.last_autovacuum_age',
+    "postgresql.last_vacuum_age",
+    "postgresql.last_analyze_age",
+    "postgresql.last_autovacuum_age",
+    "postgresql.last_autoanalyze_age",
 ]
+if POSTGRES_LOCALE != "C":
+    # The C locale seems to prevent the creation of toast tables, so we don't collect these metrics
+    MAINTENANCE_METRICS += [
+        "postgresql.toast.last_vacuum_age",
+        "postgresql.toast.last_autovacuum_age",
+    ]
 
-IDX_METRICS = ['postgresql.index_scans', 'postgresql.index_rows_read', 'postgresql.index_rows_fetched']
+IDX_METRICS = ["postgresql.index_scans", "postgresql.index_rows_read", "postgresql.index_rows_fetched"]
 
 
 def _check_metrics_for_relation_wo_index(aggregator, expected_tags):
     for name in _iterate_metric_name(QUERY_PG_CLASS):
+        # Skip toast metrics if the locale is C
+        if "toast" in name and POSTGRES_LOCALE == "C":
+            continue
+
         # Skip vacuum metrics since autovacuum can make the state unpredictable
         if name in MAINTENANCE_METRICS:
             continue
@@ -54,10 +62,14 @@ def _check_metrics_for_relation_wo_index(aggregator, expected_tags):
 
     # Check metrics from QUERY_PG_CLASS_SIZE
     for name in _iterate_metric_name(QUERY_PG_CLASS_SIZE):
+        if "toast" in name and POSTGRES_LOCALE == "C":
+            continue
         aggregator.assert_metric(name, count=1, tags=expected_tags)
 
     # And metrics from STATIO_METRICS
     for name in _iterate_metric_name(STATIO_METRICS):
+        if "toast" in name and POSTGRES_LOCALE == "C":
+            continue
         if name in RELATION_INDEX_METRICS:
             aggregator.assert_metric(name, count=0, tags=expected_tags)
         else:
@@ -65,46 +77,46 @@ def _check_metrics_for_relation_wo_index(aggregator, expected_tags):
 
 
 @pytest.mark.integration
-@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.usefixtures("dd_environment")
 def test_relations_metrics(aggregator, integration_check, pg_instance):
-    pg_instance['relations'] = ['persons']
+    pg_instance["relations"] = ["persons"]
     check = integration_check(pg_instance)
     check.check(pg_instance)
 
-    expected_tags = _get_expected_tags(check, pg_instance, db=pg_instance['dbname'], table='persons', schema='public')
+    expected_tags = _get_expected_tags(check, pg_instance, db=pg_instance["dbname"], table="persons", schema="public")
     _check_metrics_for_relation_wo_index(aggregator, expected_tags)
 
 
 @pytest.mark.integration
-@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.usefixtures("dd_environment")
 def test_relations_metrics_access_exclusive_lock(aggregator, integration_check, pg_instance):
-    '''
+    """
     This test is an edge case where we want to make sure that relations metrics query does
     not timeout when a relation is locked with an AccessExclusiveLock.
     To do so, we lock the `persons` table with an AccessExclusiveLock and then run the check.
-    '''
-    pg_instance['relations'] = ['persons']
+    """
+    pg_instance["relations"] = ["persons"]
     check = integration_check(pg_instance)
 
     conn = _get_superconn(pg_instance)
     cursor = conn.cursor()
     # Lock the persons table with an AccessExclusiveLock
-    cursor.execute('BEGIN')  # must be in a transaction to lock a table
-    cursor.execute('LOCK persons IN ACCESS EXCLUSIVE MODE')
+    cursor.execute("BEGIN")  # must be in a transaction to lock a table
+    cursor.execute("LOCK persons IN ACCESS EXCLUSIVE MODE")
 
     # verify that the lock is in place
     cursor.execute(
-        '''
+        """
         SELECT mode, locktype, granted FROM pg_locks
         WHERE relation = (SELECT oid FROM pg_class WHERE relname = 'persons')
-        '''
+        """
     )
     row = cursor.fetchone()
     assert row is not None
-    assert row == ('AccessExclusiveLock', 'relation', True)
+    assert row == ("AccessExclusiveLock", "relation", True)
 
     check.check(pg_instance)
-    expected_tags = _get_expected_tags(check, pg_instance, db=pg_instance['dbname'], table='persons', schema='public')
+    expected_tags = _get_expected_tags(check, pg_instance, db=pg_instance["dbname"], table="persons", schema="public")
 
     for name in _iterate_metric_name(QUERY_PG_CLASS):
         # Expect no relation metrics to be collected for persons table
@@ -112,29 +124,29 @@ def test_relations_metrics_access_exclusive_lock(aggregator, integration_check, 
         aggregator.assert_metric(name, count=0, tags=expected_tags)
 
     # Release the lock
-    cursor.execute('COMMIT')
+    cursor.execute("COMMIT")
     cursor.close()
     conn.close()
 
 
 @pytest.mark.integration
-@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.usefixtures("dd_environment")
 def test_relations_metrics_share_lock(aggregator, integration_check, pg_instance):
-    '''
+    """
     This test is to verify the PG_CLASS query does not reporte duplicate metrics
     when a relation has multiple locks present in PG_LOCKS.
-    '''
-    pg_instance['relations'] = ['persons']
+    """
+    pg_instance["relations"] = ["persons"]
     check = integration_check(pg_instance)
 
     def access_share_lock():
         conn = _get_superconn(pg_instance)
         cursor = conn.cursor()
         try:
-            cursor.execute('BEGIN')
+            cursor.execute("BEGIN")
             cursor.execute("LOCK persons IN SHARE MODE;")  # Acquires SHARE LOCK
         finally:
-            cursor.execute('COMMIT')
+            cursor.execute("COMMIT")
             cursor.close()
             conn.close()
 
@@ -142,10 +154,10 @@ def test_relations_metrics_share_lock(aggregator, integration_check, pg_instance
         conn = _get_superconn(pg_instance)
         cursor = conn.cursor()
         try:
-            cursor.execute('BEGIN')
+            cursor.execute("BEGIN")
             cursor.execute("SELECT * FROM persons FOR SHARE;")  # Acquires ROW SHARE LOCK
         finally:
-            cursor.execute('COMMIT')
+            cursor.execute("COMMIT")
             cursor.close()
             conn.close()
             print("ROW SHARE LOCK released.")
@@ -158,9 +170,9 @@ def test_relations_metrics_share_lock(aggregator, integration_check, pg_instance
     t2.start()
 
     check.check(pg_instance)
-    expected_tags = _get_expected_tags(check, pg_instance, db=pg_instance['dbname'], table='persons', schema='public')
+    expected_tags = _get_expected_tags(check, pg_instance, db=pg_instance["dbname"], table="persons", schema="public")
 
-    for name in ('postgresql.rows_inserted', 'postgresql.rows_updated', 'postgresql.rows_deleted'):
+    for name in ("postgresql.rows_inserted", "postgresql.rows_updated", "postgresql.rows_deleted"):
         # Expect no relation metrics to be collected for persons table
         # because locked relations are skipped in the query
         aggregator.assert_metric(name, count=1, tags=expected_tags)
@@ -171,91 +183,93 @@ def test_relations_metrics_share_lock(aggregator, integration_check, pg_instance
 
 
 @pytest.mark.integration
-@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.usefixtures("dd_environment")
 @requires_over_11
 def test_partition_relation(aggregator, integration_check, pg_instance):
-    pg_instance['relations'] = [
-        {'relation_regex': 'test_.*'},
+    pg_instance["relations"] = [
+        {"relation_regex": "test_.*"},
     ]
 
     check = integration_check(pg_instance)
     check.check(pg_instance)
 
     part_1_tags = _get_expected_tags(
-        check, pg_instance, db=pg_instance['dbname'], table='test_part1', partition_of='test_part', schema='public'
+        check, pg_instance, db=pg_instance["dbname"], table="test_part1", partition_of="test_part", schema="public"
     )
-    aggregator.assert_metric('postgresql.relation.pages', value=3, count=1, tags=part_1_tags)
-    aggregator.assert_metric('postgresql.relation.tuples', value=499, count=1, tags=part_1_tags)
-    aggregator.assert_metric('postgresql.relation.all_visible', value=3, count=1, tags=part_1_tags)
-    aggregator.assert_metric('postgresql.table_size', value=24576, count=1, tags=part_1_tags)
-    aggregator.assert_metric('postgresql.relation_size', value=24576, count=1, tags=part_1_tags)
-    aggregator.assert_metric('postgresql.index_size', value=65536, count=1, tags=part_1_tags)
-    aggregator.assert_metric('postgresql.toast_size', value=0, count=1, tags=part_1_tags)
-    aggregator.assert_metric('postgresql.total_size', value=90112, count=1, tags=part_1_tags)
+    aggregator.assert_metric("postgresql.relation.pages", value=3, count=1, tags=part_1_tags)
+    aggregator.assert_metric("postgresql.relation.tuples", value=499, count=1, tags=part_1_tags)
+    aggregator.assert_metric("postgresql.relation.all_visible", value=3, count=1, tags=part_1_tags)
+    aggregator.assert_metric("postgresql.table_size", value=24576, count=1, tags=part_1_tags)
+    aggregator.assert_metric("postgresql.relation_size", value=24576, count=1, tags=part_1_tags)
+    aggregator.assert_metric("postgresql.index_size", value=65536, count=1, tags=part_1_tags)
+    if POSTGRES_LOCALE != "C":
+        aggregator.assert_metric("postgresql.toast_size", value=0, count=1, tags=part_1_tags)
+        aggregator.assert_metric("postgresql.total_size", value=90112, count=1, tags=part_1_tags)
 
     part_2_tags = _get_expected_tags(
-        check, pg_instance, db=pg_instance['dbname'], table='test_part2', partition_of='test_part', schema='public'
+        check, pg_instance, db=pg_instance["dbname"], table="test_part2", partition_of="test_part", schema="public"
     )
-    aggregator.assert_metric('postgresql.relation.pages', value=8, count=1, tags=part_2_tags)
-    aggregator.assert_metric('postgresql.relation.tuples', value=1502, count=1, tags=part_2_tags)
-    aggregator.assert_metric('postgresql.relation.all_visible', value=8, count=1, tags=part_2_tags)
-    aggregator.assert_metric('postgresql.table_size', value=73728, count=1, tags=part_2_tags)
-    aggregator.assert_metric('postgresql.relation_size', value=65536, count=1, tags=part_2_tags)
-    aggregator.assert_metric('postgresql.index_size', value=98304, count=1, tags=part_2_tags)
-    aggregator.assert_metric('postgresql.toast_size', value=8192, count=1, tags=part_2_tags)
-    aggregator.assert_metric('postgresql.total_size', value=172032, count=1, tags=part_2_tags)
+    aggregator.assert_metric("postgresql.relation.pages", value=8, count=1, tags=part_2_tags)
+    aggregator.assert_metric("postgresql.relation.tuples", value=1502, count=1, tags=part_2_tags)
+    aggregator.assert_metric("postgresql.relation.all_visible", value=8, count=1, tags=part_2_tags)
+    aggregator.assert_metric("postgresql.table_size", value=73728, count=1, tags=part_2_tags)
+    aggregator.assert_metric("postgresql.relation_size", value=65536, count=1, tags=part_2_tags)
+    aggregator.assert_metric("postgresql.index_size", value=98304, count=1, tags=part_2_tags)
+    if POSTGRES_LOCALE != "C":
+        aggregator.assert_metric("postgresql.toast_size", value=8192, count=1, tags=part_2_tags)
+        aggregator.assert_metric("postgresql.total_size", value=172032, count=1, tags=part_2_tags)
 
 
 @pytest.mark.integration
-@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.usefixtures("dd_environment")
 @pytest.mark.parametrize(
-    'collect_bloat_metrics, expected_count',
+    "collect_bloat_metrics, expected_count",
     [
-        pytest.param(True, 1, id='bloat enabled'),
-        pytest.param(False, 0, id='bloat disabled'),
+        pytest.param(True, 1, id="bloat enabled"),
+        pytest.param(False, 0, id="bloat disabled"),
     ],
 )
 def test_bloat_metrics(aggregator, collect_bloat_metrics, expected_count, integration_check, pg_instance):
-    pg_instance['relations'] = ['pg_index']
-    pg_instance['collect_bloat_metrics'] = collect_bloat_metrics
+    pg_instance["relations"] = ["pg_index"]
+    pg_instance["collect_bloat_metrics"] = collect_bloat_metrics
 
     check = integration_check(pg_instance)
     check.check(pg_instance)
 
-    base_tags = _get_expected_tags(check, pg_instance, db=pg_instance['dbname'], table='pg_index', schema='pg_catalog')
-    aggregator.assert_metric('postgresql.table_bloat', count=expected_count, tags=base_tags)
+    base_tags = _get_expected_tags(check, pg_instance, db=pg_instance["dbname"], table="pg_index", schema="pg_catalog")
+    aggregator.assert_metric("postgresql.table_bloat", count=expected_count, tags=base_tags)
 
-    indices = ['pg_index_indrelid_index', 'pg_index_indexrelid_index']
+    indices = ["pg_index_indrelid_index", "pg_index_indexrelid_index"]
     for index in indices:
-        expected_tags = base_tags + ['index:{}'.format(index)]
-        aggregator.assert_metric('postgresql.index_bloat', count=expected_count, tags=expected_tags)
+        expected_tags = base_tags + ["index:{}".format(index)]
+        aggregator.assert_metric("postgresql.index_bloat", count=expected_count, tags=expected_tags)
 
 
 @pytest.mark.integration
-@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.usefixtures("dd_environment")
 def test_relations_metrics_regex(aggregator, integration_check, pg_instance):
-    pg_instance['relations'] = [
-        {'relation_regex': '.*', 'schemas': ['hello', 'hello2']},
+    pg_instance["relations"] = [
+        {"relation_regex": ".*", "schemas": ["hello", "hello2"]},
         # Empty schemas means all schemas, even though the first relation matches first.
-        {'relation_regex': r'[pP]ersons[-_]?(dup\d)?'},
+        {"relation_regex": r"[pP]ersons[-_]?(dup\d)?"},
     ]
-    relations = ['persons', 'personsdup1', 'Personsdup2']
+    relations = ["persons", "personsdup1", "Personsdup2"]
     check = integration_check(pg_instance)
     check.check(pg_instance)
 
     expected_tags = {}
     for relation in relations:
         expected_tags[relation] = _get_expected_tags(
-            check, pg_instance, db=pg_instance['dbname'], table=relation.lower(), schema='public'
+            check, pg_instance, db=pg_instance["dbname"], table=relation.lower(), schema="public"
         )
     for relation in relations:
         _check_metrics_for_relation_wo_index(aggregator, expected_tags[relation])
 
 
 @pytest.mark.integration
-@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.usefixtures("dd_environment")
 def test_relations_xmin(aggregator, integration_check, pg_instance):
-    pg_instance['relations'] = ['persons']
+    pg_instance["relations"] = ["persons"]
 
     conn = _get_superconn(pg_instance)
     cursor = conn.cursor()
@@ -265,8 +279,8 @@ def test_relations_xmin(aggregator, integration_check, pg_instance):
     # Check that initial xmin metric match
     check = integration_check(pg_instance)
     check.check(pg_instance)
-    expected_tags = _get_expected_tags(check, pg_instance, db=pg_instance['dbname'], table='persons', schema='public')
-    aggregator.assert_metric('postgresql.relation.xmin', count=1, value=start_xmin, tags=expected_tags)
+    expected_tags = _get_expected_tags(check, pg_instance, db=pg_instance["dbname"], table="persons", schema="public")
+    aggregator.assert_metric("postgresql.relation.xmin", count=1, value=start_xmin, tags=expected_tags)
     aggregator.reset()
 
     # Run multiple DDL modifying the persons relation which will increase persons' xmin in pg_class
@@ -278,70 +292,74 @@ def test_relations_xmin(aggregator, integration_check, pg_instance):
     check.check(pg_instance)
 
     # xmin metric should be greater than initial xmin
-    assert_metric_at_least(aggregator, 'postgresql.relation.xmin', lower_bound=start_xmin + 1, tags=expected_tags)
+    assert_metric_at_least(aggregator, "postgresql.relation.xmin", lower_bound=start_xmin + 1, tags=expected_tags)
 
 
 @pytest.mark.integration
-@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.usefixtures("dd_environment")
 def test_max_relations(aggregator, integration_check, pg_instance):
-    pg_instance.update({'relations': [{'relation_regex': '.*'}], 'max_relations': 1})
+    pg_instance.update({"relations": [{"relation_regex": ".*"}], "max_relations": 1})
     check = integration_check(pg_instance)
     check.check(pg_instance)
 
     def _metric_name_to_relation_list(metric_name):
         relation_metrics = []
         for m in aggregator._metrics[metric_name]:
-            if any('table:' in tag for tag in m.tags):
+            if any("table:" in tag for tag in m.tags):
                 relation_metrics.append(m)
         return relation_metrics
 
     for name in _iterate_metric_name(QUERY_PG_CLASS):
         if name in RELATION_INDEX_METRICS + MAINTENANCE_METRICS:
             continue
+        if "toast" in name and POSTGRES_LOCALE == "C":
+            continue
         relation_metrics = _metric_name_to_relation_list(name)
-        assert len(relation_metrics) == 1, f'Expected 1 results for {name}'
+        assert len(relation_metrics) == 1, f"Expected 1 results for {name}"
 
     # Also check PG_CLASS_SIZE
     for name in _iterate_metric_name(QUERY_PG_CLASS_SIZE):
         relation_metrics = _metric_name_to_relation_list(name)
-        assert len(relation_metrics) == 1, f'Expected 1 results for {name}'
+        assert len(relation_metrics) == 1, f"Expected 1 results for {name}"
 
     # And STATIO metrics
     for name in _iterate_metric_name(STATIO_METRICS):
         if name in RELATION_INDEX_METRICS:
             # pg_statio_user_tables returns NULL if the relation doesn't have an index. Skip the index metrics
             continue
+        if "toast" in name and POSTGRES_LOCALE == "C":
+            continue
         relation_metrics = _metric_name_to_relation_list(name)
-        assert len(relation_metrics) == 1, f'Expected 1 results for {name}'
+        assert len(relation_metrics) == 1, f"Expected 1 results for {name}"
 
 
 @pytest.mark.integration
-@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.usefixtures("dd_environment")
 def test_index_metrics(aggregator, integration_check, pg_instance):
-    pg_instance['relations'] = ['breed']
-    pg_instance['dbname'] = 'dogs'
+    pg_instance["relations"] = ["breed"]
+    pg_instance["dbname"] = "dogs"
 
     check = integration_check(pg_instance)
     check.check(pg_instance)
 
     expected_tags = _get_expected_tags(
-        check, pg_instance, db='dogs', table='breed', index='breed_names', schema='public'
+        check, pg_instance, db="dogs", table="breed", index="breed_names", schema="public"
     )
     for name in IDX_METRICS:
         aggregator.assert_metric(name, count=1, tags=expected_tags)
 
 
 @pytest.mark.integration
-@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.usefixtures("dd_environment")
 @pytest.mark.flaky(max_runs=5)
 def test_vacuum_age(aggregator, integration_check, pg_instance):
-    pg_instance['relations'] = ['persons']
-    pg_instance['dbname'] = 'datadog_test'
+    pg_instance["relations"] = ["persons"]
+    pg_instance["dbname"] = "datadog_test"
 
     conn = _get_superconn(pg_instance)
     with conn.cursor() as cur:
-        cur.execute('select pg_stat_reset()')
-        cur.execute('VACUUM ANALYZE persons')
+        cur.execute("select pg_stat_reset()")
+        cur.execute("VACUUM ANALYZE persons")
     conn.close()
 
     _wait_for_value(
@@ -353,8 +371,11 @@ def test_vacuum_age(aggregator, integration_check, pg_instance):
     check = integration_check(pg_instance)
     check.check(pg_instance)
 
-    expected_tags = _get_expected_tags(check, pg_instance, db='datadog_test', table='persons', schema='public')
-    for name in ['postgresql.last_vacuum_age', 'postgresql.last_analyze_age', 'postgresql.toast.last_vacuum_age']:
+    expected_tags = _get_expected_tags(check, pg_instance, db="datadog_test", table="persons", schema="public")
+    metrics = ["postgresql.last_vacuum_age", "postgresql.last_analyze_age"]
+    if POSTGRES_LOCALE != "C":
+        metrics += ["postgresql.toast.last_vacuum_age"]
+    for name in metrics:
         assert_metric_at_least(
             aggregator,
             name,
@@ -366,75 +387,75 @@ def test_vacuum_age(aggregator, integration_check, pg_instance):
 
 
 @pytest.mark.integration
-@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.usefixtures("dd_environment")
 @pytest.mark.parametrize(
-    'relations, lock_count, lock_table_name, tags',
+    "relations, lock_count, lock_table_name, tags",
     [
         pytest.param(
-            ['persons'],
+            ["persons"],
             1,
-            'persons',
+            "persons",
             [
-                'db:datadog_test',
-                'lock_mode:AccessExclusiveLock',
-                'lock_type:relation',
-                'granted:True',
-                'fastpath:False',
-                'table:persons',
-                'schema:public',
+                "db:datadog_test",
+                "lock_mode:AccessExclusiveLock",
+                "lock_type:relation",
+                "granted:True",
+                "fastpath:False",
+                "table:persons",
+                "schema:public",
             ],
             id="test with single table lock should return 1",
         ),
         pytest.param(
-            [{'relation_regex': 'perso.*', 'relkind': ['r']}],
+            [{"relation_regex": "perso.*", "relkind": ["r"]}],
             1,
-            'persons',
+            "persons",
             None,
             id="test with matching relkind should return 1",
         ),
         pytest.param(
-            [{'relation_regex': 'perso.*', 'relkind': ['i']}],
+            [{"relation_regex": "perso.*", "relkind": ["i"]}],
             0,
-            'persons',
+            "persons",
             None,
             id="test without matching relkind should return 0",
         ),
         pytest.param(
-            ['pgtable'],
+            ["pgtable"],
             1,
-            'pgtable',
+            "pgtable",
             None,
             id="pgtable should be included in lock metrics",
         ),
         pytest.param(
-            ['pg_newtable'],
+            ["pg_newtable"],
             0,
-            'pg_newtable',
+            "pg_newtable",
             None,
             id="pg_newtable should be excluded from query since it starts with `pg_`",
         ),
     ],
 )
 def test_locks_metrics(aggregator, integration_check, pg_instance, relations, lock_count, lock_table_name, tags):
-    pg_instance['relations'] = relations
-    pg_instance['query_timeout'] = 1000  # One of the relation queries waits for the table to not be locked
+    pg_instance["relations"] = relations
+    pg_instance["query_timeout"] = 1000  # One of the relation queries waits for the table to not be locked
 
     check = integration_check(pg_instance)
     check_with_lock(check, pg_instance, lock_table_name)
 
     if tags is not None:
         expected_tags = _get_expected_tags(check, pg_instance) + tags
-        aggregator.assert_metric('postgresql.locks', count=lock_count, tags=expected_tags)
+        aggregator.assert_metric("postgresql.locks", count=lock_count, tags=expected_tags)
     else:
-        aggregator.assert_metric('postgresql.locks', count=lock_count)
+        aggregator.assert_metric("postgresql.locks", count=lock_count)
 
 
 @pytest.mark.integration
-@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.usefixtures("dd_environment")
 def check_with_lock(check, instance, lock_table=None):
-    lock_statement = 'LOCK persons'
+    lock_statement = "LOCK persons"
     if lock_table is not None:
-        lock_statement = 'LOCK {}'.format(lock_table)
+        lock_statement = "LOCK {}".format(lock_table)
     with psycopg2.connect(host=HOST, dbname=DB_NAME, user="postgres", password="datad0g") as conn:
         with conn.cursor() as cur:
             cur.execute(lock_statement)
@@ -445,11 +466,11 @@ def check_with_lock(check, instance, lock_table=None):
 def test_relations_validation_accepts_list_of_str_and_dict():
     RelationsManager.validate_relations_config(
         [
-            'alert_cycle_keys_aggregate',
-            'api_keys',
-            {'relation_regex': 'perso.*', 'relkind': ['i']},
-            {'relation_name': 'person', 'relkind': ['i']},
-            {'relation_name': 'person', 'schemas': ['foo']},
+            "alert_cycle_keys_aggregate",
+            "api_keys",
+            {"relation_regex": "perso.*", "relkind": ["i"]},
+            {"relation_name": "person", "relkind": ["i"]},
+            {"relation_name": "person", "schemas": ["foo"]},
         ]
     )
 
@@ -457,16 +478,16 @@ def test_relations_validation_accepts_list_of_str_and_dict():
 @pytest.mark.unit
 def test_relations_validation_fails_if_no_relname_or_regex():
     with pytest.raises(ConfigurationError):
-        RelationsManager.validate_relations_config([{'relkind': ['i']}])
+        RelationsManager.validate_relations_config([{"relkind": ["i"]}])
 
 
 @pytest.mark.unit
 def test_relations_validation_fails_if_schemas_is_wrong_type():
     with pytest.raises(ConfigurationError):
-        RelationsManager.validate_relations_config([{'relation_name': 'person', 'schemas': 'foo'}])
+        RelationsManager.validate_relations_config([{"relation_name": "person", "schemas": "foo"}])
 
 
 @pytest.mark.unit
 def test_relations_validation_fails_if_relkind_is_wrong_type():
     with pytest.raises(ConfigurationError):
-        RelationsManager.validate_relations_config([{'relation_name': 'person', 'relkind': 'foo'}])
+        RelationsManager.validate_relations_config([{"relation_name": "person", "relkind": "foo"}])

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -37,8 +37,11 @@ from datadog_checks.postgres.version_utils import V12
 from .common import (
     DB_NAME,
     HOST,
+    PASSWORD_ADMIN,
     PORT_REPLICA2,
+    POSTGRES_LOCALE,
     POSTGRES_VERSION,
+    USER_ADMIN,
     _get_expected_replication_tags,
     _get_expected_tags,
 )
@@ -61,7 +64,7 @@ SAMPLE_QUERIES = [
         "ON hello_how_is_it_going_this_is_a_very_long_table_alias_name.personid = B.personid WHERE B.city = %s",
         "hello",
     ),
-    ("dd_admin", "dd_admin", "dogs", "SELECT * FROM breed WHERE name = %s", "Labrador"),
+    (USER_ADMIN, PASSWORD_ADMIN, "dogs", "SELECT * FROM breed WHERE name = %s", "Labrador"),
 ]
 
 dbm_enabled_keys = ["dbm", "deep_database_monitoring"]
@@ -798,7 +801,7 @@ def test_failed_explain_handling(
             "FROM persons WHERE city = %s",
             # Use some multi-byte characters (the euro symbol) so we can validate that the code is correctly
             # looking at the length in bytes when testing for truncated statements
-            u'\u20ac\u20ac\u20ac\u20ac\u20ac\u20ac\u20ac\u20ac\u20ac\u20ac',
+            u"€€€€€€€€€€€€€€€€€€€€€€€€€€",
             "error:explain-query_truncated-track_activity_query_size=1024",
             [{'code': 'query_truncated', 'message': 'track_activity_query_size=1024'}],
             StatementTruncationState.truncated.value,
@@ -842,6 +845,7 @@ def test_statement_samples_collect(
     check._connect()
 
     conn = psycopg2.connect(host=HOST, dbname=dbname, user=user, password=password)
+    conn.set_client_encoding('utf8')
     # we are able to see the full query (including the raw parameters) in pg_stat_activity because psycopg2 uses
     # the simple query protocol, sending the whole query as a plain string to postgres.
     # if a client is using the extended query protocol with prepare then the query would appear as
@@ -2223,3 +2227,76 @@ def test_get_query_metrics_payload_rows():
         statement_metrics.batch_max_content_size = tc.max_size
         rows = statement_metrics._get_query_metrics_payloads(wrapper, tc.rows)
         assert len(rows) == tc.expected
+
+
+@requires_over_10
+def test_metrics_encoding(
+    aggregator,
+    integration_check,
+    dbm_instance,
+):
+    dbm_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
+    if POSTGRES_LOCALE == 'C':
+        dbm_instance['query_encodings'] = ['latin1', 'utf-8']
+    dbm_instance['query_samples'] = {'enabled': False}
+    dbm_instance['query_activity'] = {'enabled': False}
+    # dbm_instance['query_activity']['enabled'] = False
+    check = integration_check(dbm_instance)
+    check._connect()
+
+    with psycopg2.connect(host=HOST, dbname=DB_NAME, user='bob', password='bob') as conn:
+        with conn.cursor() as cursor:
+            conn.set_client_encoding('latin1')
+            # This should be funké in latin1
+            query = b"select 'funk\xe9' as funk\xe9;"
+            cursor.execute(query)
+            run_one_check(check, cancel=False)
+            cursor.execute(query)
+            run_one_check(check, cancel=False)
+
+    dbm_samples = aggregator.get_event_platform_events("dbm-metrics")
+
+    expected_query = "select $1 as funké"
+
+    # Find matching events by checking if the expected query starts with the event statement. Using this
+    # instead of a direct equality check covers cases of truncated statements
+    matching = [row for e in dbm_samples for row in e['postgres_rows'] if row['query'] == expected_query]
+
+    assert len(matching) == 1, "missing captured event"
+    event = matching[0]
+    # we expect to get a duration because the connections are in "idle" state
+    assert event['query_signature']
+
+
+@requires_over_10
+def test_samples_encoding(
+    aggregator,
+    integration_check,
+    dbm_instance,
+):
+    dbm_instance['query_metrics']['enabled'] = False
+    if POSTGRES_LOCALE == 'C':
+        dbm_instance['query_encodings'] = ['latin1', 'utf-8']
+    check = integration_check(dbm_instance)
+    check._connect()
+
+    with psycopg2.connect(host=HOST, dbname=DB_NAME, user='bob', password='bob') as conn:
+        with conn.cursor() as cursor:
+            conn.set_client_encoding('latin1')
+            # This should be funké in latin1
+            query = b"select 'funk\xe9' as funk\xe9;"
+            cursor.execute(query)
+            run_one_check(check, cancel=False)
+
+    dbm_samples = aggregator.get_event_platform_events("dbm-samples")
+
+    expected_query = "select 'funké' as funké;"
+
+    # Find matching events by checking if the expected query starts with the event statement. Using this
+    # instead of a direct equality check covers cases of truncated statements
+    matching = [e for e in dbm_samples if e['db']['statement'] == expected_query and e['dbm_type'] == 'plan']
+
+    assert len(matching) == 1, "missing captured event"
+    event = matching[0]
+    # we expect to get a duration because the connections are in "idle" state
+    assert event['duration']


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
* Adds a new `query_encodings` configuration to the Postgres integration
* Uses this configuration value to attempt to decode query text stored in `pg_stat` tables and returns the text in the first matching encoding

![](https://upload.wikimedia.org/wikipedia/commons/1/17/Digital_rain_animation_small_letters_clear.gif)

### Motivation
<!-- What inspired you to submit this pull request? -->
For Postgres users with SQL_ASCII encoded databases the query text in `pg_stat_activity` and `pg_stat_statements` is stored in the encoding of the originating client. When collecting this data, the Postgres integration needs to know which encodings to attempt to use.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
