### PR TITLE
[DBMON-5429] Switch expected tags to tuples to avoid mutation leakage in tests

### DIFF
--- a/mysql/tests/tags.py
+++ b/mysql/tests/tags.py
@@ -5,38 +5,38 @@ from . import common
 
 
 def database_instance_resource_tags(hostname):
-    return [
+    return (
         f'dd.internal.resource:database_instance:{hostname}',
         f'database_hostname:{hostname}',
         f'database_instance:{hostname}',
-    ]
+    )
 
 
-METRIC_TAGS = ['tag1:value1', 'tag2:value2']
-METRIC_TAGS_WITH_RESOURCE = [
+METRIC_TAGS = ('tag1:value1', 'tag2:value2')
+METRIC_TAGS_WITH_RESOURCE = (
     'tag1:value1',
     'tag2:value2',
     *database_instance_resource_tags('stubbed.hostname'),
     'dbms_flavor:{}'.format(common.MYSQL_FLAVOR.lower()),
-]
-SC_TAGS = [
+)
+SC_TAGS = (
     'port:' + str(common.PORT),
     'tag1:value1',
     'tag2:value2',
-]
-SC_TAGS_MIN = [
+)
+SC_TAGS_MIN = (
     'port:' + str(common.PORT),
     *database_instance_resource_tags('stubbed.hostname'),
-]
-SC_TAGS_REPLICA = [
+)
+SC_TAGS_REPLICA = (
     'port:' + str(common.SLAVE_PORT),
     'tag1:value1',
     'tag2:value2',
     'dd.internal.resource:database_instance:stubbed.hostname',
     'database_hostname:stubbed.hostname',
     'database_instance:stubbed.hostname',
-]
-SC_FAILURE_TAGS = [
+)
+SC_FAILURE_TAGS = (
     'port:unix_socket',
     *database_instance_resource_tags('stubbed.hostname'),
-]
+)

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -540,14 +540,14 @@ def test_events_wait_current_disabled_no_warning_azure_flexible_server(
 # the inactive job metrics are emitted from the main integrations
 # directly to metrics-intake, so they should also be properly tagged with a resource
 def _expected_dbm_job_err_tags(dbm_instance):
-    return dbm_instance['tags'] + [
+    return dbm_instance['tags'] + (
         'database_hostname:stubbed.hostname',
         'database_instance:stubbed.hostname',
         'job:query-activity',
         'port:{}'.format(PORT),
         'dd.internal.resource:database_instance:stubbed.hostname',
         'dbms_flavor:{}'.format(MYSQL_FLAVOR.lower()),
-    ]
+    )
 
 
 @pytest.mark.integration

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -836,7 +836,7 @@ def test_async_job_inactive_stop(aggregator, dd_run_check, dbm_instance):
     mysql_check._statement_metrics._job_loop_future.result()
     for job in ['statement-metrics', 'statement-samples']:
         aggregator.assert_metric(
-            "dd.mysql.async_job.inactive_stop", tags=_expected_dbm_job_err_tags(dbm_instance) + ['job:' + job]
+            "dd.mysql.async_job.inactive_stop", tags=_expected_dbm_job_err_tags(dbm_instance) + ('job:' + job,)
         )
 
 
@@ -858,31 +858,31 @@ def test_async_job_cancel(aggregator, dd_run_check, dbm_instance):
     assert mysql_check._statement_metrics._db is None, "metrics db connection should be gone"
     for job in ['statement-metrics', 'statement-samples']:
         aggregator.assert_metric(
-            "dd.mysql.async_job.cancel", tags=_expected_dbm_job_err_tags(dbm_instance) + ['job:' + job]
+            "dd.mysql.async_job.cancel", tags=_expected_dbm_job_err_tags(dbm_instance) + ('job:' + job,)
         )
 
 
 def _expected_dbm_instance_tags(dbm_instance):
-    return dbm_instance.get('tags', []) + [
+    return dbm_instance.get('tags', ()) + (
         'database_hostname:{}'.format('stubbed.hostname'),
         'database_instance:{}'.format('stubbed.hostname'),
         'server:{}'.format(common.HOST),
         'port:{}'.format(common.PORT),
         'dbms_flavor:{}'.format(MYSQL_FLAVOR.lower()),
-    ]
+    )
 
 
 # the inactive job metrics are emitted from the main integrations
 # directly to metrics-intake, so they should also be properly tagged with a resource
 def _expected_dbm_job_err_tags(dbm_instance):
-    return dbm_instance['tags'] + [
+    return dbm_instance['tags'] + (
         'database_hostname:{}'.format('stubbed.hostname'),
         'database_instance:{}'.format('stubbed.hostname'),
         'port:{}'.format(common.PORT),
         'server:{}'.format(common.HOST),
         'dd.internal.resource:database_instance:stubbed.hostname',
         'dbms_flavor:{}'.format(common.MYSQL_FLAVOR.lower()),
-    ]
+    )
 
 
 @pytest.mark.parametrize("statement_samples_enabled", [True, False])


### PR DESCRIPTION
### What does this PR do?
This changes our expected tag constants to tuples instead of lists. This helps us guard against any accidental mutation of these tags which lead to leakage to our other tests and can cause difficult to debug unrelated to failures or incorrect test functionality.

Added skip-qa and no-changelog tags as these changes are only in our tests

### Motivation
While working on plumbing some new dynamic derived base tags this issue was a painful footgun to run into. Fixing this up to help avoid future toil and splitting it into its own PR for simple isolated review

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
