### PR TITLE
Ensure that ddev does not treat worktrees as extra packages

### DIFF
--- a/ddev/changelog.d/20444.added
+++ b/ddev/changelog.d/20444.added
@@ -1,0 +1,1 @@
+Ensure ddev understands and differentiate worktrees from other packages ignoring them as possible candidates as integrations source

--- a/ddev/src/ddev/repo/core.py
+++ b/ddev/src/ddev/repo/core.py
@@ -80,7 +80,7 @@ class IntegrationRegistry:
             return self.__cache[name]
 
         path = self.repo.path / name
-        if not path.is_dir():
+        if not (path.is_dir() and not self.repo.git.is_worktree(path)):
             raise OSError(f'Integration does not exist: {Path(self.repo.path.name, name)}')
 
         integration = Integration(path, self.repo.path, self.repo.config)
@@ -176,7 +176,12 @@ class IntegrationRegistry:
             return
 
         for path in sorted(self.repo.path.iterdir()):
+            # Ignore any subdirectory that is a worktree
+            if self.repo.git.is_worktree(path):
+                continue
+
             integration = self.__get_from_path(path)
+
             if selected and integration.name not in selected:
                 continue
 

--- a/ddev/src/ddev/utils/git.py
+++ b/ddev/src/ddev/utils/git.py
@@ -3,10 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from ddev.utils.fs import Path
+from ddev.utils.fs import Path
 
 
 class GitCommit:
@@ -32,6 +29,37 @@ class GitRepository:
     @property
     def repo_root(self) -> Path:
         return self.__repo_root
+
+    def worktrees(self, include_root=False, only_subpaths=True) -> list[Path]:
+        """Returns a list of paths to the worktrees in the repo.
+
+        If `include_root` is True, the worktree representing the root of the repo is included.
+        If `only_subpaths` is True, worktrees outside of the repo root are not included.
+        """
+        worktree_output = self.capture('worktree', 'list', '--porcelain')
+
+        worktree_paths = [Path(line.split()[1]) for line in worktree_output.splitlines() if line.startswith('worktree')]
+
+        # Use the resolved repo path because git will show the resolved path of the worktrees
+        # in the porcelain output
+        repo_root = self.repo_root.resolve()
+
+        if only_subpaths:
+            worktree_paths = [
+                worktree_path for worktree_path in worktree_paths if worktree_path.is_relative_to(repo_root)
+            ]
+
+        result = [worktree_path for worktree_path in worktree_paths if include_root or worktree_path != repo_root]
+        return result
+
+    def is_worktree(self, path: Path, include_root=False, only_subpaths=True) -> bool:
+        """
+        Check if a path is a worktree.
+
+        If `include_root` is True, the root of the repo is considered a worktree.
+        If `only_subpaths` is True, worktrees outside of the repo root are not considered.
+        """
+        return path.resolve() in self.worktrees(include_root=include_root, only_subpaths=only_subpaths)
 
     def current_branch(self) -> str:
         return self.capture('rev-parse', '--abbrev-ref', 'HEAD').strip()
@@ -87,7 +115,12 @@ class GitRepository:
                 changed_files.add(line)
 
         # Untracked
-        changed_files.update(self.capture('ls-files', '--others', '--exclude-standard').splitlines())
+        # Remove worktrees within the repo root as they can be untracked and should not be taken into account
+        changed_files.update(
+            untracked_file
+            for untracked_file in self.capture('ls-files', '--others', '--exclude-standard').splitlines()
+            if not self.is_worktree(self.repo_root / untracked_file)
+        )
 
         return sorted(changed_files, key=lambda relative_path: (-relative_path.count('/'), relative_path))
 

--- a/ddev/tests/cli/env/conftest.py
+++ b/ddev/tests/cli/env/conftest.py
@@ -36,3 +36,12 @@ def write_result_file(mocker):
         return _write
 
     return _write_result_file
+
+
+@pytest.fixture(autouse=True)
+def mock_repo_worktrees(mocker):
+    from ddev.utils.git import GitRepository
+
+    # Patch 'worktrees' on the Repository class
+    # For all instances, it will now return an empty list, bypassing the git call.
+    mocker.patch.object(GitRepository, "worktrees", return_value=[])

--- a/ddev/tests/cli/meta/scripts/conftest.py
+++ b/ddev/tests/cli/meta/scripts/conftest.py
@@ -4,6 +4,7 @@
 import pytest
 
 from ddev.repo.core import Repository
+from ddev.utils.git import GitRepository
 
 # Whenenever we bump python version, we also need to bump the python
 # version in the conftest.py.
@@ -12,11 +13,13 @@ NEW_PYTHON_VERSION = "3.13"
 
 
 @pytest.fixture
-def fake_repo(tmp_path_factory, config_file, ddev):
+def fake_repo(tmp_path_factory, config_file, ddev, mocker):
     repo_path = tmp_path_factory.mktemp('integrations-core')
     repo = Repository('integrations-core', str(repo_path))
 
-    config_file.model.repos['core'] = str(repo.path)
+    mocker.patch.object(GitRepository, 'worktrees', return_value=[])
+
+    config_file.model.repos["core"] = str(repo.path)
     config_file.save()
 
     write_file(

--- a/ddev/tests/cli/release/test_changelog.py
+++ b/ddev/tests/cli/release/test_changelog.py
@@ -267,6 +267,7 @@ class TestNew:
                 '0000000000000000000000000000000000000000\nFoo',
             ],
         )
+        mocker.patch('ddev.utils.git.GitRepository.worktrees', return_value=[])
         return repo_with_towncrier.path / 'ddev' / 'changelog.d'
 
     def test_start(self, ddev, fragments_dir, helpers, mocker):

--- a/ddev/tests/cli/test/test_test.py
+++ b/ddev/tests/cli/test/test_test.py
@@ -14,6 +14,13 @@ from tests.helpers.assertions import assert_calls
 from tests.helpers.mocks import MockPopen
 
 
+@pytest.fixture(autouse=True)
+def mock_worktrees(mocker):
+    # Mock the access to worktrees because these tests mock the global subprocess run
+    # Should be refactored to avoid such a broad mock
+    mocker.patch('ddev.utils.git.GitRepository.worktrees', return_value=[])
+
+
 class TestInputValidation:
     @pytest.mark.parametrize('flag', ('--lint', '--fmt', '--bench', '--latest'))
     def test_specific_environment_and_functionality(self, ddev, helpers, flag):

--- a/ddev/tests/cli/test_dep.py
+++ b/ddev/tests/cli/test_dep.py
@@ -291,13 +291,16 @@ def mock_async_http_get_json():
 
 
 @pytest.fixture
-def fake_repo(tmp_path, config_file):
+def fake_repo(tmp_path, config_file, mocker):
     data_folder = tmp_path / 'datadog_checks_base' / 'datadog_checks' / 'base' / 'data'
     data_folder.mkdir(parents=True)
 
     # Set this as core repo in the config
     config_file.model.repos['core'] = str(tmp_path)
     config_file.save()
+
+    # Mock the access to worktrees because this is a fake repo
+    mocker.patch('ddev.utils.git.GitRepository.worktrees', return_value=[])
 
     yield tmp_path
 

--- a/ddev/tests/cli/validate/test_codeowners.py
+++ b/ddev/tests/cli/validate/test_codeowners.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2024-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from .conftest import write_file
+from tests.helpers.api import write_file
 
 
 def test_codeowners_integrations_core(fake_repo, ddev):

--- a/ddev/tests/cli/validate/test_version.py
+++ b/ddev/tests/cli/validate/test_version.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.helpers.api import write_file as _write_file
+
 TOWNCRIER_CHANGELOG_TPL = """\
 # CHANGELOG - dummy
 
@@ -35,9 +37,7 @@ __version__ = '{}'
 
 def write_file(fake_repo, fpath, content):
     full_path = fake_repo.path / fpath
-
-    full_path.parent.mkdir(exist_ok=True, parents=True)
-    full_path.write_text(content)
+    _write_file(fake_repo.path, fpath, content)
     return full_path
 
 

--- a/ddev/tests/conftest.py
+++ b/ddev/tests/conftest.py
@@ -172,6 +172,11 @@ def local_clone(isolation, local_repo) -> Generator[ClonedRepo, None, None]:
         # Now fetch latest updates
         PLATFORM.check_command_output(['git', 'fetch', 'origin'])
 
+        # Add a worktree within the repo and one outside of it that should be ignored by ddev
+        # It is not a fast operation so lets do it once per session
+        PLATFORM.check_command_output(['git', 'worktree', 'add', 'wt', 'HEAD'])
+        PLATFORM.check_command_output(['git', 'worktree', 'add', '../wt2', 'HEAD'])
+
     cloned_repo = ClonedRepo(cloned_repo_path, 'origin/master', 'ddev-testing')
     cloned_repo.reset_branch()
 

--- a/ddev/tests/helpers/api.py
+++ b/ddev/tests/helpers/api.py
@@ -33,3 +33,9 @@ def changed_file_processes(files: list[str]):
         CompletedProcess([], 0, stdout=''),
         CompletedProcess([], 0, stdout=''),
     ]
+
+
+def write_file(folder, file, content):
+    (folder / file).parent.mkdir(exist_ok=True, parents=True)
+    file_path = folder / file
+    file_path.write_text(content)

--- a/ddev/tests/integration/test_core.py
+++ b/ddev/tests/integration/test_core.py
@@ -3,6 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 
+import pytest
+
 from ddev.repo.core import Repository
 from ddev.utils.fs import Path
 
@@ -191,6 +193,22 @@ class TestPackageDirectory:
 
         assert integration.package_directory == local_repo / integration.name / 'datadog_checks' / 'go_metro'
 
+    def test_non_existent_package(self, local_repo):
+        repo = Repository(local_repo.name, str(local_repo))
+
+        with pytest.raises(OSError):
+            repo.integrations.get('non_existent_package')
+
+    def test_non_existent_when_worktree(self, local_clone):
+        repo = Repository(local_clone.path.name, str(local_clone.path))
+
+        with pytest.raises(OSError):
+            repo.integrations.get('wt')
+
+    def test_worktree_not_in_package_iterator(self, local_clone):
+        repo = Repository(local_clone.path.name, str(local_clone.path))
+        assert 'wt' not in set(repo.integrations.iter_all())
+
 
 class TestPackageFiles:
     def test_base_package_file(self, local_repo):
@@ -227,6 +245,11 @@ class TestReleaseTagPattern:
 
 
 class TestMetrics:
+    @pytest.fixture(autouse=True)
+    def mock_worktrees(self, mocker):
+        # This fake repo is another different fake repo, so we need to mock the worktrees to avoid
+        mocker.patch('ddev.utils.git.GitRepository.worktrees', return_value=[])
+
     def test_has_metrics(self, fake_repo):
         integration = fake_repo.integrations.get('dummy')
 

--- a/ddev/tests/repo/test_core.py
+++ b/ddev/tests/repo/test_core.py
@@ -49,19 +49,37 @@ class TestIntegrationsIteration:
         pytest.param("iter", lambda path: (path / 'manifest.json').is_file(), id="only integrations"),
         pytest.param(
             "iter_all",
-            lambda path: (path / 'manifest.json').is_file() or (path / 'pyproject.toml').is_file(),
+            lambda path: ((path / 'manifest.json').is_file() or (path / 'pyproject.toml').is_file())
+            # Is not a worktree
+            and not (path / ".git").is_file(),
             id="all valid",
         ),
-        pytest.param("iter_packages", lambda path: (path / 'pyproject.toml').is_file(), id="packages"),
+        pytest.param(
+            "iter_packages",
+            lambda path: (path / 'pyproject.toml').is_file()
+            # Is not a worktree
+            and not (path / ".git").is_file(),
+            id="packages",
+        ),
         pytest.param(
             "iter_tiles",
-            lambda path: (path / 'manifest.json').is_file() and not (path / 'pyproject.toml').is_file(),
+            lambda path: ((path / 'manifest.json').is_file() and not (path / 'pyproject.toml').is_file())
+            # Is not a worktree
+            and not (path / ".git").is_file(),
             id="tiles",
         ),
-        pytest.param("iter_testable", lambda path: (path / 'hatch.toml').is_file()),
+        pytest.param(
+            "iter_testable",
+            lambda path: (path / 'hatch.toml').is_file()
+            # Is not a worktree
+            and not (path / ".git").is_file(),
+            id="testable",
+        ),
         pytest.param(
             "iter_shippable",
-            lambda path: (path / 'pyproject.toml').is_file() and path.name not in NOT_SHIPPABLE,
+            lambda path: ((path / 'pyproject.toml').is_file() and path.name not in NOT_SHIPPABLE)
+            # Is not a worktree
+            and not (path / ".git").is_file(),
             id="shippable",
         ),
         pytest.param(
@@ -69,12 +87,16 @@ class TestIntegrationsIteration:
             lambda path: (
                 package_root := path / 'datadog_checks' / path.name.replace('-', '_') / '__init__.py'
             ).is_file()
-            and package_root.read_text().count('import ') > 1,
+            and package_root.read_text().count('import ') > 1
+            # Is not a worktree
+            and not (path / ".git").is_file(),
             id="agent checks",
         ),
         pytest.param(
             "iter_jmx_checks",
-            lambda path: (path / 'datadog_checks' / path.name.replace('-', '_') / 'data' / 'metrics.yaml').is_file(),
+            lambda path: ((path / 'datadog_checks' / path.name.replace('-', '_') / 'data' / 'metrics.yaml').is_file())
+            # Is not a worktree
+            and not (path / ".git").is_file(),
             id="jmx checks",
         ),
     ]

--- a/ddev/tests/utils/test_git.py
+++ b/ddev/tests/utils/test_git.py
@@ -3,7 +3,11 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import subprocess
 
+import pytest
+
 from ddev.repo.core import Repository
+from ddev.utils.fs import Path
+from tests.helpers.git import ClonedRepo
 
 
 def test_current_branch(repository):
@@ -12,22 +16,22 @@ def test_current_branch(repository):
     assert repo.git.current_branch() == repository.testing_branch
 
     new_branch = repository.new_branch()
-    repo.git.capture('checkout', '-b', new_branch)
+    repo.git.capture("checkout", "-b", new_branch)
     assert repo.git.current_branch() == new_branch
 
 
 def test_get_latest_commit(repository):
     repo = Repository(repository.path.name, str(repository.path))
 
-    (repo.path / 'test1.txt').touch()
-    repo.git.capture('add', '.')
-    commit_status1 = repo.git.capture('commit', '-m', 'test1')
+    (repo.path / "test1.txt").touch()
+    repo.git.capture("add", ".")
+    commit_status1 = repo.git.capture("commit", "-m", "test1")
     commit1 = repo.git.latest_commit()
     assert len(commit1.sha) == 40
 
-    (repo.path / 'test2.txt').touch()
-    repo.git.capture('add', '.')
-    commit_status2 = repo.git.capture('commit', '-m', 'test2')
+    (repo.path / "test2.txt").touch()
+    repo.git.capture("add", ".")
+    commit_status2 = repo.git.capture("commit", "-m", "test2")
     commit2 = repo.git.latest_commit()
     assert len(commit2.sha) == 40
 
@@ -45,61 +49,61 @@ def test_tags(repository):
 
     assert repo.git.tags() == []
 
-    repo.git.capture('tag', 'foo')
-    repo.git.capture('tag', 'bar')
+    repo.git.capture("tag", "foo")
+    repo.git.capture("tag", "bar")
 
-    assert repo.git.tags() == ['bar', 'foo']
+    assert repo.git.tags() == ["bar", "foo"]
 
 
 def test_changed_files(repository):
     repo = Repository(repository.path.name, str(repository.path))
 
     # Committed
-    with (repo.path / 'pyproject.toml').open(mode='a') as f:
-        f.write('\n')
+    with (repo.path / "pyproject.toml").open(mode="a") as f:
+        f.write("\n")
 
-    repo.git.capture('add', 'pyproject.toml')
-    repo.git.capture('commit', '-m', 'test commit')
+    repo.git.capture("add", "pyproject.toml")
+    repo.git.capture("commit", "-m", "test commit")
 
     # Tracked
-    zoo_dir = repo.path / 'zoo'
+    zoo_dir = repo.path / "zoo"
     zoo_dir.mkdir()
-    (zoo_dir / 'bar.txt').touch()
-    repo.git.capture('add', 'zoo/bar.txt')
+    (zoo_dir / "bar.txt").touch()
+    repo.git.capture("add", "zoo/bar.txt")
 
     # Untracked
-    zoo_subdir = zoo_dir / 'sub'
+    zoo_subdir = zoo_dir / "sub"
     zoo_subdir.mkdir()
-    (zoo_subdir / 'foo.txt').touch()
+    (zoo_subdir / "foo.txt").touch()
 
-    changed_files = ['zoo/sub/foo.txt', 'zoo/bar.txt', 'pyproject.toml']
+    changed_files = ["zoo/sub/foo.txt", "zoo/bar.txt", "pyproject.toml"]
     assert repo.git.changed_files() == changed_files
 
-    (zoo_subdir / 'baz.txt').touch()
-    changed_files.insert(0, 'zoo/sub/baz.txt')
+    (zoo_subdir / "baz.txt").touch()
+    changed_files.insert(0, "zoo/sub/baz.txt")
     assert repo.git.changed_files() == changed_files
 
 
 def test_filtered_tags(repository):
     repo = Repository(repository.path.name, str(repository.path))
 
-    repo.git.capture('tag', 'foo')
-    repo.git.capture('tag', 'bar')
-    repo.git.capture('tag', 'baz')
+    repo.git.capture("tag", "foo")
+    repo.git.capture("tag", "bar")
+    repo.git.capture("tag", "baz")
 
-    assert repo.git.filter_tags('^ba') == ['bar', 'baz']
+    assert repo.git.filter_tags("^ba") == ["bar", "baz"]
 
 
 def test_fetch_tags(repository, mocker):
-    mock = mocker.patch('subprocess.run')
+    mock = mocker.patch("subprocess.run")
     repo = Repository(repository.path.name, str(repository.path))
     repo.git.fetch_tags()
     assert mock.call_args_list == [
         mocker.call(
-            ['git', 'fetch', '--all', '--tags', '--force'],
+            ["git", "fetch", "--all", "--tags", "--force"],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            encoding='utf-8',
+            encoding="utf-8",
             check=True,
         ),
     ]
@@ -141,3 +145,64 @@ def test_get_merge_base_two_branches(repository):
     repo.git.capture('commit', '-m', 'test2')
     base = repo.git.merge_base('origin/master')
     assert base == base_commit.sha
+
+
+def expected_worktrees(repo: Repository, include_root: bool, only_subpaths: bool) -> list[Path]:
+    result = [repo.path / "wt"]
+
+    if include_root:
+        result.append(repo.path)
+    if not only_subpaths:
+        result.append(repo.path.parent / "wt2")
+
+    return result
+
+
+@pytest.mark.parametrize("include_root", [True, False], ids=["include_root", "exclude_root"])
+@pytest.mark.parametrize("only_subpaths", [True, False], ids=["only_subpaths", "not_only_subpaths"])
+def test_worktrees(repository: ClonedRepo, include_root: bool, only_subpaths: bool):
+    repo = Repository(repository.path.name, str(repository.path))
+
+    worktrees = expected_worktrees(repo, include_root, only_subpaths)
+
+    assert set(repo.git.worktrees(include_root=include_root, only_subpaths=only_subpaths)) == set(worktrees)
+
+    # Add a new worktree
+    repo.git.capture("worktree", "add", "t2", "HEAD")
+    assert set(repo.git.worktrees(include_root=include_root, only_subpaths=only_subpaths)) == set(
+        worktrees + [repo.path / "t2"]
+    )
+
+    # Remove it
+    repo.git.capture("worktree", "remove", "t2")
+    assert set(repo.git.worktrees(include_root=include_root, only_subpaths=only_subpaths)) == set(worktrees)
+
+
+@pytest.mark.parametrize(
+    "include_root, only_subpaths",
+    [
+        (True, True),
+        (True, False),
+        (False, True),
+        (False, False),
+    ],
+    ids=[
+        "include_root_only_subpaths",
+        "include_root_not_only_subpaths",
+        "exclude_root_only_subpaths",
+        "exclude_root_not_only_subpaths",
+    ],
+)
+def test_is_worktree(
+    repository,
+    include_root: bool,
+    only_subpaths: bool,
+):
+    repo = Repository(repository.path.name, str(repository.path))
+
+    assert repo.git.is_worktree(repo.path / "wt", include_root=include_root, only_subpaths=only_subpaths)
+    assert repo.git.is_worktree(repo.path, include_root=include_root, only_subpaths=only_subpaths) is include_root
+    assert (
+        repo.git.is_worktree(repo.path.parent / "wt2", include_root=include_root, only_subpaths=only_subpaths)
+        is not only_subpaths
+    )


### PR DESCRIPTION
### What does this PR do?
Updates ddev to ensure that when scaning packages in the repo, any git worktree found is not treated as a possible integration.

### Motivation
When working with worktrees it is common to define the worktree as a folder within your repository directory. When ddev scans pacakges within the repo it checks all directory as possible integrations/packages, this includes worktrees folders. This triggers undesired side effect like slow linting and format checks. This is because `ddev test -s` also runs on untracked items and worktrees will likely be untracked.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
