### PR TITLE
[DBMON-5356] Add server_uuid tag to mysql metrics and events

### DIFF
--- a/mysql/changelog.d/20446.added
+++ b/mysql/changelog.d/20446.added
@@ -1,0 +1,1 @@
+Add server_uuid tag to mysql metrics and events

--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -52,6 +52,9 @@ SELECT engine
 FROM information_schema.ENGINES
 WHERE engine='InnoDB' and support != 'no' and support != 'disabled'"""
 
+SQL_SERVER_UUID = """\
+SELECT @@server_uuid"""
+
 SQL_SERVER_ID_AWS_AURORA = """\
 SHOW VARIABLES LIKE 'aurora_server_id'"""
 

--- a/mysql/tests/tags.py
+++ b/mysql/tests/tags.py
@@ -40,3 +40,10 @@ SC_FAILURE_TAGS = (
     'port:unix_socket',
     *database_instance_resource_tags('stubbed.hostname'),
 )
+
+
+def metrics_tags_with_resource(mysql_check):
+    _tags = METRIC_TAGS_WITH_RESOURCE
+    if common.MYSQL_FLAVOR.lower() == 'mysql':
+        _tags += ("server_uuid:{}".format(mysql_check.server_uuid),)
+    return _tags

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -103,7 +103,7 @@ def test_complex_config(aggregator, dd_run_check, instance_complex):
     _assert_complex_config(
         aggregator,
         tags.SC_TAGS + tags.database_instance_resource_tags('stubbed.hostname'),
-        tags.METRIC_TAGS_WITH_RESOURCE,
+        tags.metrics_tags_with_resource(mysql_check),
     )
     aggregator.assert_metrics_using_metadata(
         get_metadata_metrics(),
@@ -338,6 +338,8 @@ def test_complex_config_replica(aggregator, dd_run_check, instance_complex):
             variables.COMMON_PERFORMANCE_OPERATION_TIME_METRICS + variables.PERFORMANCE_OPERATION_TIME_METRICS
         )
 
+    expected_tags = tags.metrics_tags_with_resource(mysql_check)
+
     # Test metrics
     for mname in testable_metrics:
         # These two are currently not guaranteed outside of a Linux
@@ -349,7 +351,7 @@ def test_complex_config_replica(aggregator, dd_run_check, instance_complex):
         if mname == 'mysql.performance.cpu_time' and Platform.is_windows():
             continue
         if mname == 'mysql.performance.query_run_time.avg':
-            aggregator.assert_metric(mname, tags=tags.METRIC_TAGS_WITH_RESOURCE + ('schema:testdb',), at_least=1)
+            aggregator.assert_metric(mname, tags=expected_tags + ('schema:testdb',), at_least=1)
 
         # Adding condition to no longer test for os_log_fsyncs in mariadb 10.8+
         # (https://mariadb.com/kb/en/innodb-status-variables/#innodb_os_log_fsyncs)
@@ -370,15 +372,11 @@ def test_complex_config_replica(aggregator, dd_run_check, instance_complex):
             continue
 
         elif mname == 'mysql.info.schema.size':
-            aggregator.assert_metric(mname, tags=tags.METRIC_TAGS_WITH_RESOURCE + ('schema:testdb',), count=1)
-            aggregator.assert_metric(
-                mname, tags=tags.METRIC_TAGS_WITH_RESOURCE + ('schema:information_schema',), count=1
-            )
-            aggregator.assert_metric(
-                mname, tags=tags.METRIC_TAGS_WITH_RESOURCE + ('schema:performance_schema',), count=1
-            )
+            aggregator.assert_metric(mname, tags=expected_tags + ('schema:testdb',), count=1)
+            aggregator.assert_metric(mname, tags=expected_tags + ('schema:information_schema',), count=1)
+            aggregator.assert_metric(mname, tags=expected_tags + ('schema:performance_schema',), count=1)
         else:
-            aggregator.assert_metric(mname, tags=tags.METRIC_TAGS_WITH_RESOURCE, at_least=0)
+            aggregator.assert_metric(mname, tags=expected_tags, at_least=0)
 
     # test custom query metrics
     aggregator.assert_metric('alice.age', value=25)
@@ -567,8 +565,8 @@ def test_custom_queries(aggregator, instance_custom_queries, dd_run_check):
     mysql_check = MySql(common.CHECK_NAME, {}, [instance_custom_queries])
     dd_run_check(mysql_check)
 
-    aggregator.assert_metric('alice.age', value=25, tags=tags.METRIC_TAGS_WITH_RESOURCE)
-    aggregator.assert_metric('bob.age', value=20, tags=tags.METRIC_TAGS_WITH_RESOURCE)
+    aggregator.assert_metric('alice.age', value=25, tags=tags.metrics_tags_with_resource(mysql_check))
+    aggregator.assert_metric('bob.age', value=20, tags=tags.metrics_tags_with_resource(mysql_check))
 
 
 @pytest.mark.usefixtures('dd_environment')
@@ -606,8 +604,8 @@ def test_only_custom_queries(aggregator, dd_run_check, instance_custom_queries):
     for m in internal_metrics:
         aggregator.assert_metric(m, at_least=0)
 
-    aggregator.assert_metric('alice.age', value=25, tags=tags.METRIC_TAGS_WITH_RESOURCE)
-    aggregator.assert_metric('bob.age', value=20, tags=tags.METRIC_TAGS_WITH_RESOURCE)
+    aggregator.assert_metric('alice.age', value=25, tags=tags.metrics_tags_with_resource(check))
+    aggregator.assert_metric('bob.age', value=20, tags=tags.metrics_tags_with_resource(check))
     aggregator.assert_all_metrics_covered()
 
 
@@ -622,8 +620,12 @@ def test_additional_status(aggregator, dd_run_check, instance_additional_status)
     if (
         MYSQL_FLAVOR.lower() == 'mariadb' and MYSQL_VERSION_PARSED < parse_version('10.10')
     ) or MYSQL_FLAVOR.lower() == 'mysql':
-        aggregator.assert_metric('mysql.innodb.rows_read', metric_type=1, tags=tags.METRIC_TAGS_WITH_RESOURCE)
-    aggregator.assert_metric('mysql.innodb.row_lock_time', metric_type=1, tags=tags.METRIC_TAGS_WITH_RESOURCE)
+        aggregator.assert_metric(
+            'mysql.innodb.rows_read', metric_type=1, tags=tags.metrics_tags_with_resource(mysql_check)
+        )
+    aggregator.assert_metric(
+        'mysql.innodb.row_lock_time', metric_type=1, tags=tags.metrics_tags_with_resource(mysql_check)
+    )
 
 
 @pytest.mark.integration
@@ -632,9 +634,13 @@ def test_additional_variable(aggregator, dd_run_check, instance_additional_varia
     mysql_check = MySql(common.CHECK_NAME, {}, [instance_additional_variable])
     dd_run_check(mysql_check)
 
-    aggregator.assert_metric('mysql.performance.long_query_time', metric_type=0, tags=tags.METRIC_TAGS_WITH_RESOURCE)
     aggregator.assert_metric(
-        'mysql.performance.innodb_flush_log_at_trx_commit', metric_type=0, tags=tags.METRIC_TAGS_WITH_RESOURCE
+        'mysql.performance.long_query_time', metric_type=0, tags=tags.metrics_tags_with_resource(mysql_check)
+    )
+    aggregator.assert_metric(
+        'mysql.performance.innodb_flush_log_at_trx_commit',
+        metric_type=0,
+        tags=tags.metrics_tags_with_resource(mysql_check),
     )
 
 
@@ -645,10 +651,13 @@ def test_additional_variable_unknown(aggregator, dd_run_check, instance_invalid_
     dd_run_check(mysql_check)
 
     aggregator.assert_metric(
-        'mysql.performance.longer_query_time', metric_type=0, tags=tags.METRIC_TAGS_WITH_RESOURCE, count=0
+        'mysql.performance.longer_query_time', metric_type=0, tags=tags.metrics_tags_with_resource(mysql_check), count=0
     )
     aggregator.assert_metric(
-        'mysql.performance.innodb_flush_log_at_trx_commit', metric_type=0, tags=tags.METRIC_TAGS_WITH_RESOURCE, count=1
+        'mysql.performance.innodb_flush_log_at_trx_commit',
+        metric_type=0,
+        tags=tags.metrics_tags_with_resource(mysql_check),
+        count=1,
     )
 
 
@@ -661,10 +670,10 @@ def test_additional_status_already_queried(aggregator, dd_run_check, instance_st
     dd_run_check(mysql_check)
 
     aggregator.assert_metric(
-        'mysql.performance.open_files_test', metric_type=0, tags=tags.METRIC_TAGS_WITH_RESOURCE, count=0
+        'mysql.performance.open_files_test', metric_type=0, tags=tags.metrics_tags_with_resource(mysql_check), count=0
     )
     aggregator.assert_metric(
-        'mysql.performance.open_files', metric_type=0, tags=tags.METRIC_TAGS_WITH_RESOURCE, count=1
+        'mysql.performance.open_files', metric_type=0, tags=tags.metrics_tags_with_resource(mysql_check), count=1
     )
 
     assert (
@@ -682,7 +691,7 @@ def test_additional_var_already_queried(aggregator, dd_run_check, instance_var_a
     dd_run_check(mysql_check)
 
     aggregator.assert_metric(
-        'mysql.myisam.key_buffer_size', metric_type=0, tags=tags.METRIC_TAGS_WITH_RESOURCE, count=1
+        'mysql.myisam.key_buffer_size', metric_type=0, tags=tags.metrics_tags_with_resource(mysql_check), count=1
     )
 
     assert (
@@ -806,6 +815,9 @@ def test_database_instance_metadata(aggregator, dd_run_check, instance_complex, 
 
     mysql_check = MySql(common.CHECK_NAME, {}, [instance_complex])
     dd_run_check(mysql_check)
+
+    if MYSQL_FLAVOR.lower() == 'mysql':
+        expected_tags += ("server_uuid:{}".format(mysql_check.server_uuid),)
 
     dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
     event = next((e for e in dbm_metadata if e['kind'] == 'database_instance'), None)

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -156,7 +156,7 @@ def test_statement_metrics(
     assert event['mysql_flavor'] == mysql_check.version.flavor
     assert event['timestamp'] > 0
     assert event['min_collection_interval'] == dbm_instance['query_metrics']['collection_interval']
-    expected_tags = set(_expected_dbm_instance_tags(dbm_instance))
+    expected_tags = set(_expected_dbm_instance_tags(dbm_instance, mysql_check))
     if aurora_replication_role:
         expected_tags.add("replication_role:" + aurora_replication_role)
     assert set(event['tags']) == expected_tags
@@ -425,7 +425,7 @@ def test_statement_samples_collect(
     if explain_strategy:
         mysql_check._statement_samples._preferred_explain_strategies = [explain_strategy]
 
-    expected_tags = set(_expected_dbm_instance_tags(dbm_instance))
+    expected_tags = set(_expected_dbm_instance_tags(dbm_instance, mysql_check))
     if aurora_replication_role:
         expected_tags.add("replication_role:" + aurora_replication_role)
 
@@ -836,7 +836,8 @@ def test_async_job_inactive_stop(aggregator, dd_run_check, dbm_instance):
     mysql_check._statement_metrics._job_loop_future.result()
     for job in ['statement-metrics', 'statement-samples']:
         aggregator.assert_metric(
-            "dd.mysql.async_job.inactive_stop", tags=_expected_dbm_job_err_tags(dbm_instance) + ('job:' + job,)
+            "dd.mysql.async_job.inactive_stop",
+            tags=_expected_dbm_job_err_tags(dbm_instance, mysql_check) + ('job:' + job,),
         )
 
 
@@ -858,24 +859,27 @@ def test_async_job_cancel(aggregator, dd_run_check, dbm_instance):
     assert mysql_check._statement_metrics._db is None, "metrics db connection should be gone"
     for job in ['statement-metrics', 'statement-samples']:
         aggregator.assert_metric(
-            "dd.mysql.async_job.cancel", tags=_expected_dbm_job_err_tags(dbm_instance) + ('job:' + job,)
+            "dd.mysql.async_job.cancel", tags=_expected_dbm_job_err_tags(dbm_instance, mysql_check) + ('job:' + job,)
         )
 
 
-def _expected_dbm_instance_tags(dbm_instance):
-    return dbm_instance.get('tags', ()) + (
+def _expected_dbm_instance_tags(dbm_instance, check):
+    _tags = dbm_instance.get('tags', ()) + (
         'database_hostname:{}'.format('stubbed.hostname'),
         'database_instance:{}'.format('stubbed.hostname'),
         'server:{}'.format(common.HOST),
         'port:{}'.format(common.PORT),
         'dbms_flavor:{}'.format(MYSQL_FLAVOR.lower()),
     )
+    if MYSQL_FLAVOR.lower() == 'mysql':
+        _tags += ("server_uuid:{}".format(check.server_uuid),)
+    return _tags
 
 
 # the inactive job metrics are emitted from the main integrations
 # directly to metrics-intake, so they should also be properly tagged with a resource
-def _expected_dbm_job_err_tags(dbm_instance):
-    return dbm_instance['tags'] + (
+def _expected_dbm_job_err_tags(dbm_instance, check):
+    _tags = dbm_instance['tags'] + (
         'database_hostname:{}'.format('stubbed.hostname'),
         'database_instance:{}'.format('stubbed.hostname'),
         'port:{}'.format(common.PORT),
@@ -883,6 +887,9 @@ def _expected_dbm_job_err_tags(dbm_instance):
         'dd.internal.resource:database_instance:stubbed.hostname',
         'dbms_flavor:{}'.format(common.MYSQL_FLAVOR.lower()),
     )
+    if MYSQL_FLAVOR.lower() == 'mysql':
+        _tags += ("server_uuid:{}".format(check.server_uuid),)
+    return _tags
 
 
 @pytest.mark.parametrize("statement_samples_enabled", [True, False])


### PR DESCRIPTION
### What does this PR do?
Adds `server_uuid` tag to mysql metrics and events. This is a unique uuid generated when the database is first created. We want to start adding this in preparation for identifying and building out a topology graph of replicated databases.

Note that server_uuid doesn't exist in MariaDB. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
