### PR TITLE
[DBMON-5438] Update out of date postgres tag_replication_role config example

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -349,10 +349,11 @@ files:
         type: string
         example: /usr/local/pgsql/data
     - name: tag_replication_role
+      hidden: true
       description: Tag metrics and checks with `replication_role:<master|standby>`.
       value:
         type: boolean
-        example: false
+        example: true
     - name: table_count_limit
       description: The maximum number of tables to collect metrics from.
       value:

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -157,7 +157,7 @@ def instance_table_count_limit():
 
 
 def instance_tag_replication_role():
-    return False
+    return True
 
 
 def instance_use_global_custom_queries():

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -282,10 +282,10 @@ instances:
     #
     # data_directory: /usr/local/pgsql/data
 
-    ## @param tag_replication_role - boolean - optional - default: false
+    ## @param tag_replication_role - boolean - optional - default: true
     ## Tag metrics and checks with `replication_role:<master|standby>`.
     #
-    # tag_replication_role: false
+    # tag_replication_role: true
 
     ## @param table_count_limit - integer - optional - default: 200
     ## The maximum number of tables to collect metrics from.

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -282,11 +282,6 @@ instances:
     #
     # data_directory: /usr/local/pgsql/data
 
-    ## @param tag_replication_role - boolean - optional - default: true
-    ## Tag metrics and checks with `replication_role:<master|standby>`.
-    #
-    # tag_replication_role: true
-
     ## @param table_count_limit - integer - optional - default: 200
     ## The maximum number of tables to collect metrics from.
     #


### PR DESCRIPTION
### What does this PR do?
This config option has been enabled by default in code since https://github.com/DataDog/integrations-core/pull/16895 but the example config still shows it disabled by default. Updating the example config to reflect reality also sets the `tag_replication_role` to hidden as we want this enabled by default and will be relied on for cluster support

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
