### PR TITLE
Modify GitHub action that comments on major bump warning to multiple comments

### DIFF
--- a/.github/workflows/pr-quick-check.yml
+++ b/.github/workflows/pr-quick-check.yml
@@ -14,6 +14,7 @@ defaults:
 env:
   PYTHON_VERSION: "3.12"
   CHECK_SCRIPT: "ddev/src/ddev/utils/scripts/check_pr.py"
+  WARN_MAJOR_UPDATE_MESSAGE: "⚠️ **Major version bump**\nThe changelog type `changed` or `removed` was used in this Pull Request, so the next release will bump major version. Please make sure this is a breaking change, or use the `fixed` or `added` type instead."
 
 jobs:
   check:
@@ -73,11 +74,17 @@ jobs:
             - '*/changelog.d/*.removed'
             - '*/changelog.d/*.major'
 
-    - name: Comment
+    - name: Check for major version bump comment
       if: ${{ steps.changes.outputs.major_bump_fragments == 'true' }}
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      id: find_comment
+      uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
-          github.rest.issues.createComment({ issue_number, owner, repo, body: "The changelog type `changed` or `removed` was used in this Pull Request, so the next release will bump major version. Please make sure this is a breaking change, or use the `fixed` or `added` type instead." });
+        issue-number: ${{ github.event.issue.number }}
+        body-includes: ${{ env.WARN_MAJOR_UPDATE_MESSAGE }}
+
+    - name: Comment
+      if: ${{ steps.changes.outputs.major_bump_fragments == 'true' }} && ${{ steps.find_comment.outputs.comment-id == '' }}
+      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+      with:
+        issue-number: ${{ github.event.issue.number }}
+        body: ${{ env.WARN_MAJOR_UPDATE_MESSAGE }}


### PR DESCRIPTION
### What does this PR do?
Updates the GHA that creates a comment when a major version fragment is found to avoid commenting multiple times in the same issue. 

### Motivation
In PRs where a major bump will be issued any revision triggers the same comment which makes the PR hard to navigate full of duplicates.

For example: #20451

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
