### PR TITLE
Fix major version bump message workflow step

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -18,4 +18,4 @@ jobs:
     with:
       repo: core
     secrets: inherit
-      
+

--- a/.github/workflows/pr-quick-check.yml
+++ b/.github/workflows/pr-quick-check.yml
@@ -83,7 +83,7 @@ jobs:
         body-includes: ${{ env.WARN_MAJOR_UPDATE_MESSAGE }}
 
     - name: Comment
-      if: ${{ steps.changes.outputs.major_bump_fragments == 'true' }} && ${{ steps.find_comment.outputs.comment-id == '' }}
+      if: ${{ steps.changes.outputs.major_bump_fragments == 'true' && steps.find_comment.outputs.comment-id == '' }}
       uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
       with:
         issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
### What does this PR do?
This fixes the condition on the workflow steps that send a message when there is a major version bump changelog present.

### Motivation
Right now we are receiving false positives after the PR #20458 was merged. The reason is that GH evaluates any non empty string in if as true (unless it is the string `'false'`) and having 2 expressions translates into 

```
if: 'false && true`
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
