### PR TITLE
Provide small context on setup instructions in Kubernetes

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -316,7 +316,7 @@ Ensure that `url` matches your Airflow [webserver `base_url`][19], the URL used 
 
 If you are using Airflow's Helm chart, this [exposes the webserver as a ClusterIP service][22] that you should use in the `url` parameter.
 
-For example, your Autodiscovery annotations may look like the following:
+For example in Kubernetes, your Autodiscovery annotations may look like the following:
 
 ```
 apiVersion: v1


### PR DESCRIPTION
### What does this PR do?
Provide small context on those annotations in Kubernetes as it primarily focuses on setting up Airflow in Kubernetes so it makes a bit more sense.