### PR TITLE
fix: Add support for AM/PM timestamp format for IBM MQ logs

### DIFF
--- a/ibm_mq/assets/logs/ibm_mq.yaml
+++ b/ibm_mq/assets/logs/ibm_mq.yaml
@@ -25,7 +25,7 @@ pipeline:
       source: message
       grok:
         supportRules: |
-          _date (%{date("MM/dd/yy HH:mm:ss"):timestamp}|%{date("dd/MM/yyyy  HH:mm:ss"):timestamp})
+          _date (%{date("MM/dd/yy HH:mm:ss"):timestamp}|%{date("dd/MM/yyyy  HH:mm:ss"):timestamp}|%{date("MM/dd/yyyy HH:mm:ss a"):timestamp})
         matchRules: |
           ibm_mq_rule %{_date}\s+- Process\(%{number:process}\) User\(%{notSpace:system.user}\)\s+Program\(%{notSpace:system.app}\)\s+Host\(%{notSpace:system.host}\)\s+Installation\(%{notSpace:system.installation}\)\s+VRMF\(%{notSpace:vrmf}\)%{data::keyvalue}(\n|\t|\s)+EXPLANATION:(\n|\s|\t)+%{data:error.message}(\n|\t|\s)+ACTION:(\n|\s|\t)+%{data:system.action}(\n|\t|\s)+-.*
 

--- a/ibm_mq/assets/logs/ibm_mq_tests.yaml
+++ b/ibm_mq/assets/logs/ibm_mq_tests.yaml
@@ -75,51 +75,50 @@ tests:
     tags:
      - "source:LOGS_SOURCE"
     timestamp: 1100687549000
- -
-  sample: |-
-    06/10/2025 08:08:56 AM - Process(91319.1) User(mqm) Program(runmqchl)
-                    Host(A.B.C) Installation(Installation1)
-                    VRMF(9.3.0.16) QMgr(QUEUEMGR)
-                    Time(2025-06-10T06:08:56.764Z)
-                    CommentInsert1(COMMENT)
+ - sample: |-
+     06/10/2025 08:08:56 AM - Process(91319.1) User(mqm) Program(runmqchl)
+                     Host(A.B.C) Installation(Installation1)
+                     VRMF(9.3.0.16) QMgr(QUEUEMGR)
+                     Time(2025-06-10T06:08:56.764Z)
+                     CommentInsert1(COMMENT)
 
-    AMQ9299I: Channel 'CHANNEL' has started.
+     AMQ9299I: Channel 'CHANNEL' has started.
 
-    EXPLANATION:
-    The channel 'CHANNEL' has finished starting.
-    ACTION:
-    No action required.
-    ----- amqrccca.c : 998 --------------------------------------------------------
-  result:
-    custom:
-      error:
-        message: "The channel 'CHANNE:' has finished starting."
-      level: "Error"
-      process: 91319.1
-      system:
-        action: "No action required."
-        app: "runmqch1"
-        host: "A.B.C"
-        installation: "Installation1"
-        user: "mqm"
-      timestamp: 1749535736000
-      vrmf: "9.3.0.16"
-    message: |-
-      06/10/2025 08:08:56 AM - Process(91319.1) User(mqm) Program(runmqchl)
-                      Host(A.B.C) Installation(Installation1)
-                      VRMF(9.3.0.16) QMgr(QUEUEMGR)
-                      Time(2025-06-10T06:08:56.764Z)
-                      CommentInsert1(COMMENT)
+     EXPLANATION:
+     The channel 'CHANNEL' has finished starting.
+     ACTION:
+     No action required.
+     ----- amqrccca.c : 998 --------------------------------------------------------
+   result:
+     custom:
+       error:
+         message: "The channel 'CHANNE:' has finished starting."
+       level: "Error"
+       process: 91319.1
+       system:
+         action: "No action required."
+         app: "runmqch1"
+         host: "A.B.C"
+         installation: "Installation1"
+         user: "mqm"
+       timestamp: 1749535736000
+       vrmf: "9.3.0.16"
+     message: |-
+       06/10/2025 08:08:56 AM - Process(91319.1) User(mqm) Program(runmqchl)
+                       Host(A.B.C) Installation(Installation1)
+                       VRMF(9.3.0.16) QMgr(QUEUEMGR)
+                       Time(2025-06-10T06:08:56.764Z)
+                       CommentInsert1(COMMENT)
 
-      AMQ9299I: Channel 'CHANNEL' has started.
+       AMQ9299I: Channel 'CHANNEL' has started.
 
-      EXPLANATION:
-      The channel 'CHANNEL' has finished starting.
-      ACTION:
-      No action required.
-      ----- amqrccca.c : 998 --------------------------------------------------------
-    status: "error"
-    tags:
-     - "source:LOGS_SOURCE"
-    timestamp: 1749535736000
+       EXPLANATION:
+       The channel 'CHANNEL' has finished starting.
+       ACTION:
+       No action required.
+       ----- amqrccca.c : 998 --------------------------------------------------------
+     status: "error"
+     tags:
+      - "source:LOGS_SOURCE"
+     timestamp: 1749535736000
 

--- a/ibm_mq/assets/logs/ibm_mq_tests.yaml
+++ b/ibm_mq/assets/logs/ibm_mq_tests.yaml
@@ -76,7 +76,7 @@ tests:
      - "source:LOGS_SOURCE"
     timestamp: 1100687549000
  - sample: |-
-     06/10/2025 08:08:56 AM - Process(91319.1) User(mqm) Program(runmqchl)
+     06/10/2025 06:08:56 AM - Process(91319.1) User(mqm) Program(runmqchl)
                      Host(A.B.C) Installation(Installation1)
                      VRMF(9.3.0.16) QMgr(QUEUEMGR)
                      Time(2025-06-10T06:08:56.764Z)
@@ -104,7 +104,7 @@ tests:
        timestamp: 1749535736000
        vrmf: "9.3.0.16"
      message: |-
-       06/10/2025 08:08:56 AM - Process(91319.1) User(mqm) Program(runmqchl)
+       06/10/2025 06:08:56 AM - Process(91319.1) User(mqm) Program(runmqchl)
                        Host(A.B.C) Installation(Installation1)
                        VRMF(9.3.0.16) QMgr(QUEUEMGR)
                        Time(2025-06-10T06:08:56.764Z)

--- a/ibm_mq/assets/logs/ibm_mq_tests.yaml
+++ b/ibm_mq/assets/logs/ibm_mq_tests.yaml
@@ -75,4 +75,51 @@ tests:
     tags:
      - "source:LOGS_SOURCE"
     timestamp: 1100687549000
+ -
+  sample: |-
+    06/10/2025 08:08:56 AM - Process(91319.1) User(mqm) Program(runmqchl)
+                    Host(A.B.C) Installation(Installation1)
+                    VRMF(9.3.0.16) QMgr(QUEUEMGR)
+                    Time(2025-06-10T06:08:56.764Z)
+                    CommentInsert1(COMMENT)
+
+    AMQ9299I: Channel 'CHANNEL' has started.
+
+    EXPLANATION:
+    The channel 'CHANNEL' has finished starting.
+    ACTION:
+    No action required.
+    ----- amqrccca.c : 998 --------------------------------------------------------
+  result:
+    custom:
+      error:
+        message: "The channel 'CHANNE:' has finished starting."
+      level: "Error"
+      process: 91319.1
+      system:
+        action: "No action required."
+        app: "runmqch1"
+        host: "A.B.C"
+        installation: "Installation1"
+        user: "mqm"
+      timestamp: 1749535736000
+      vrmf: "9.3.0.16"
+    message: |-
+      06/10/2025 08:08:56 AM - Process(91319.1) User(mqm) Program(runmqchl)
+                      Host(A.B.C) Installation(Installation1)
+                      VRMF(9.3.0.16) QMgr(QUEUEMGR)
+                      Time(2025-06-10T06:08:56.764Z)
+                      CommentInsert1(COMMENT)
+
+      AMQ9299I: Channel 'CHANNEL' has started.
+
+      EXPLANATION:
+      The channel 'CHANNEL' has finished starting.
+      ACTION:
+      No action required.
+      ----- amqrccca.c : 998 --------------------------------------------------------
+    status: "error"
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1749535736000
 


### PR DESCRIPTION
### What does this PR do?
IBM MQ has additional ways of printing timestamps, and this PR adds support for the AM/PM format.

### Motivation
I had a reported issue (Request #2060820) regarding this, and now that I found that this is defined here, I opted to create a PR for fixing the issue at the source.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [x] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
