### PR TITLE
[DBMON-5453] Remove extra call to set internal database_instance tag

### DIFF
--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -1024,9 +1024,6 @@ class MySql(AgentCheck):
         # Extract tag keys from aurora_tags to identify which tags to remove
         for tag, value in aurora_tags.items():
             self.tag_manager.set_tag(tag, value, replace=True)
-        self.tag_manager.set_tag(
-            "dd.internal.resource", "database_instance:{}".format(self.database_identifier), replace=True
-        )
 
     def _collect_system_metrics(self, host, db, tags):
         pid = None


### PR DESCRIPTION
### What does this PR do?
The swap over from manual tag lists to TagManager in #20417 accidentally added this additional call to set `dd.internal.database_instance` tag inside the Aurora runtime tags function. Since this currently replaces the existing tag with the same value, there's no functional difference with or without this call, but removing it as its not necessary and unexpected

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
