### PR TITLE
Sdbm 1804 postgres error querying pg control checkpoint wal level must be set to logical

### DIFF
--- a/postgres/changelog.d/20490.fixed
+++ b/postgres/changelog.d/20490.fixed
@@ -1,0 +1,1 @@
+Checks wal_level before collecting control checkpoint metrics

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -111,6 +111,7 @@ class PostgreSql(AgentCheck):
         self.system_identifier = None
         self.cluster_name = None
         self.is_aurora = None
+        self.wal_level = None
         self._version_utils = VersionUtils()
         # Deprecate custom_metrics in favor of custom_queries
         if 'custom_metrics' in self.instance:
@@ -157,6 +158,7 @@ class PostgreSql(AgentCheck):
             maxsize=1,
             ttl=self._config.database_instance_collection_interval,
         )  # type: TTLCache
+
 
     def _build_autodiscovery(self):
         if not self._config.discovery_config['enabled']:
@@ -318,10 +320,17 @@ class PostgreSql(AgentCheck):
                 ]
             )
 
-        if self.version < V10:
-            queries.append(QUERY_PG_CONTROL_CHECKPOINT_LT_10)
+        if self.wal_level == 'logical':
+            self.log.debug("wal_level is logical, adding control checkpoint metrics")
+
+            if self.version < V10:
+                queries.append(QUERY_PG_CONTROL_CHECKPOINT_LT_10)
+
+            else:
+                queries.append(QUERY_PG_CONTROL_CHECKPOINT)
+
         else:
-            queries.append(QUERY_PG_CONTROL_CHECKPOINT)
+            self.log.debug("wal_level is not logical, skipping control checkpoint metrics")
 
         if self.version >= V10:
             # Wal receiver is not supported on aurora
@@ -474,6 +483,14 @@ class PostgreSql(AgentCheck):
         if self.is_aurora is None:
             self.is_aurora = self._version_utils.is_aurora(self.db())
         return self.is_aurora
+    
+    def _get_wal_level(self):
+        with self.db() as conn:
+            with conn.cursor(cursor_factory=CommenterCursor) as cursor:
+                cursor.execute('SHOW wal_level;')
+                wal_level = cursor.fetchone()[0]
+                return wal_level
+
 
     @property
     def reported_hostname(self):
@@ -1007,6 +1024,9 @@ class PostgreSql(AgentCheck):
             self._connect()
             # We don't want to cache versions between runs to capture minor updates for metadata
             self.load_version()
+
+            # Check wal_level
+            self.wal_level = self._get_wal_level()
 
             # Add raw version as a tag
             tags.append(f'postgresql_version:{self.raw_version}')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Makes sure that the `wal_level` is `logical` before trying to query for the control checkpoint metrics introduced in [this PR](https://github.com/DataDog/integrations-core/pull/20017).

### Motivation
<!-- What inspired you to submit this pull request? -->
The motivation was to address the issues brought up in [this case](https://datadoghq.atlassian.net/browse/SDBM-1804).

User was getting the error `Error querying pg_control_checkpoint: wal_level must be set to 'logical'` when the agent tries to collect the control checkpoint metrics.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
