### PR TITLE
chore: Bump requests to newer patch version

### DIFF
--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -48,7 +48,7 @@ deps = [
     "pyyaml==6.0.2",
     "requests-toolbelt==1.0.0",
     "requests-unixsocket2==1.0.0",
-    "requests==2.32.3",
+    "requests==2.32.4",
     "simplejson==3.20.1",
     "urllib3==2.4.0",
     "wrapt==1.17.2",


### PR DESCRIPTION

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Updated the pinned version of requests in `datadog_checks_base` to a version without known CVEs.

### Motivation
<!-- What inspired you to submit this pull request? -->

This PR addresses the CVE issue described in https://github.com/DataDog/integrations-core/issues/20493.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
