### PR TITLE
[DBMON-5463] Switch sql index query resolution over to a static version check

### DIFF
--- a/mysql/changelog.d/20514.fixed
+++ b/mysql/changelog.d/20514.fixed
@@ -1,0 +1,1 @@
+Avoid querying INFORMATION_SCHEMA.COLUMNS in favor of a static version check

--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -120,14 +120,6 @@ FROM INFORMATION_SCHEMA.COLUMNS
 WHERE table_schema = %s AND table_name IN ({});
 """
 
-SQL_INDEXES_EXPRESSION_COLUMN_CHECK = """
-    SELECT COUNT(*) as column_count
-    FROM INFORMATION_SCHEMA.COLUMNS
-    WHERE TABLE_SCHEMA = 'information_schema'
-      AND TABLE_NAME = 'STATISTICS'
-      AND COLUMN_NAME = 'EXPRESSION';
-"""
-
 SQL_INDEXES = """\
 SELECT
     table_name as `table_name`,
@@ -268,3 +260,15 @@ def show_primary_replication_status_query(version, is_mariadb):
         return "SHOW BINARY LOG STATUS;"
     else:
         return "SHOW MASTER STATUS;"
+
+
+def get_indexes_query(version, is_mariadb, table_names):
+    """
+    Get the appropriate indexes query based on MySQL version and flavor.
+    The EXPRESSION column was introduced in MySQL 8.0.13 for functional indexes.
+    MariaDB doesn't support functional indexes.
+    """
+    if not is_mariadb and version.version_compatible((8, 0, 13)):
+        return SQL_INDEXES_8_0_13.format(table_names)
+    else:
+        return SQL_INDEXES.format(table_names)


### PR DESCRIPTION
### What does this PR do?
Avoids a query to `INFORMATION_SCEMA.COLUMNS` that's currently made when schema collection is enabled. This query currently gets executed one time per 500 tables in a schema per check run to determine if a column exists for a subsequent query for index usage information. The `EXPRESSION` column was added in mysql 8.0.13 as noted in information_schema.columns [docs](https://dev.mysql.com/doc/refman/8.0/en/information-schema-statistics-table.html) and MariaDB does not support this so we can statically check the version and flavor to determine which query we should run

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
