### PR TITLE
force maxTimeMS for mongo integration queries

### DIFF
--- a/mongo/changelog.d/20515.fixed
+++ b/mongo/changelog.d/20515.fixed
@@ -1,0 +1,1 @@
+Add `maxTimeMS` to limit agent resource consumption and prevent operations from running indefinitely on the server side. 

--- a/mongo/datadog_checks/mongo/api.py
+++ b/mongo/datadog_checks/mongo/api.py
@@ -97,7 +97,9 @@ class MongoApi(object):
         # Because the currentOp command and db.currentOp() helper method return the results in a single document,
         # the total size of the currentOp result set is subject to the maximum 16MB BSON size limit for documents.
         # The $currentOp stage returns a cursor over a stream of documents, each of which reports a single operation.
-        return self["admin"].aggregate([{'$currentOp': {'allUsers': True}}], session=session)
+        return self["admin"].aggregate(
+            [{'$currentOp': {'allUsers': True}}], session=session, maxTimeMS=self._config.timeout
+        )
 
     def get_collection_stats(self, db_name, coll_name, stats=None, session=None):
         if not self.coll_stats_pipeline_supported:
@@ -129,23 +131,28 @@ class MongoApi(object):
                 },
             ],
             session=session,
+            maxTimeMS=self._config.timeout,
         )
 
     def coll_stats_compatible(self, db_name, coll_name, session=None):
         # collStats is deprecated in MongoDB 6.2. Use the $collStats aggregation stage instead.
-        return self[db_name].command({'collStats': coll_name}, session=session)
+        return self[db_name].command({'collStats': coll_name}, session=session, maxTimeMS=self._config.timeout)
 
     def index_stats(self, db_name, coll_name, session=None):
-        return self[db_name][coll_name].aggregate([{"$indexStats": {}}], session=session)
+        return self[db_name][coll_name].aggregate(
+            [{"$indexStats": {}}], session=session, maxTimeMS=self._config.timeout
+        )
 
     def index_information(self, db_name, coll_name, session=None):
         return self[db_name][coll_name].index_information(session=session)
 
     def list_search_indexes(self, db_name, coll_name, session=None):
-        return self[db_name][coll_name].list_search_indexes(session=session)
+        return self[db_name][coll_name].list_search_indexes(session=session, maxTimeMS=self._config.timeout)
 
     def sharded_data_distribution_stats(self, session=None):
-        return self["admin"].aggregate([{"$shardedDataDistribution": {}}], session=session)
+        return self["admin"].aggregate(
+            [{"$shardedDataDistribution": {}}], session=session, maxTimeMS=self._config.timeout
+        )
 
     def _is_auth_required(self, options):
         # Check if the node is an arbiter. If it is, usually it does not require authentication.
@@ -162,17 +169,23 @@ class MongoApi(object):
             return True
 
     def get_profiling_level(self, db_name, session=None):
-        return self[db_name].command('profile', -1, session=session)
+        return self[db_name].command('profile', -1, session=session, maxTimeMS=self._config.timeout)
 
     def get_profiling_data(self, db_name, ts, session=None):
         filter = {'ts': {'$gt': ts}}
-        return self[db_name]['system.profile'].find(filter, session=session).sort('ts', 1)
+        return (
+            self[db_name]['system.profile']
+            .find(filter, session=session, max_time_ms=self._config.timeout)
+            .sort('ts', 1)
+        )
 
     def get_log_data(self, session=None):
-        return self['admin'].command("getLog", "global", session=session)
+        return self['admin'].command("getLog", "global", session=session, maxTimeMS=self._config.timeout)
 
     def sample(self, db_name, coll_name, sample_size, session=None):
-        return self[db_name][coll_name].aggregate([{"$sample": {"size": sample_size}}], session=session)
+        return self[db_name][coll_name].aggregate(
+            [{"$sample": {"size": sample_size}}], session=session, maxTimeMS=self._config.timeout
+        )
 
     def get_cmdline_opts(self):
         return self["admin"].command("getCmdLineOpts")["parsed"]
@@ -202,11 +215,14 @@ class MongoApi(object):
             coll_names = self[db_name].list_collection_names(
                 filter={"type": "collection"},  # Only return collections, not views
                 authorizedCollections=True,
+                maxTimeMS=self._config.timeout,
             )
         except OperationFailure as e:
             if e.code == 303 and e.details.get("errmsg") == "Field 'type' is currently not supported":
                 # Filter by type is not supported on AWS DocumentDB
-                coll_names = self[db_name].list_collection_names(authorizedCollections=True)
+                coll_names = self[db_name].list_collection_names(
+                    authorizedCollections=True, maxTimeMS=self._config.timeout
+                )
             else:
                 # The user is not authorized to run listCollections on this database.
                 # This is NOT a critical error, so we log it as a warning.
@@ -224,14 +240,18 @@ class MongoApi(object):
         try:
             # Check if the collection is sharded by looking for the collection config
             # in the config.collections collection.
-            collection_config = self["config"]["collections"].find_one({"_id": f"{db_name}.{coll_name}"})
+            collection_config = self["config"]["collections"].find_one(
+                {"_id": f"{db_name}.{coll_name}"}, max_time_ms=self._config.timeout
+            )
             return collection_config is not None
         except OperationFailure as e:
             self._log.warning("Could not determine if collection %s.%s is sharded: %s", db_name, coll_name, e)
             return False
 
     def explain_command(self, db_name, command, verbosity="queryPlanner", session=None):
-        return self[db_name].command("explain", command, verbosity=verbosity, session=session)
+        return self[db_name].command(
+            "explain", command, verbosity=verbosity, session=session, maxTimeMS=self._config.timeout
+        )
 
     @property
     def hostname(self):

--- a/mongo/datadog_checks/mongo/api.py
+++ b/mongo/datadog_checks/mongo/api.py
@@ -41,12 +41,13 @@ class MongoApi(object):
     def __init__(self, config, log, replicaset: str = None):
         self._config = config
         self._log = log
+        self._timeout = self._config.timeout
         options = {
             'host': self._config.server if self._config.server else self._config.hosts,
-            'socketTimeoutMS': self._config.timeout,
-            'connectTimeoutMS': self._config.timeout,
-            'serverSelectionTimeoutMS': self._config.timeout,
-            'timeoutMS': self._config.timeout,
+            'socketTimeoutMS': self._timeout,
+            'connectTimeoutMS': self._timeout,
+            'serverSelectionTimeoutMS': self._timeout,
+            'timeoutMS': self._timeout,
             'directConnection': True,
             'read_preference': ReadPreference.PRIMARY_PREFERRED,
             'appname': DD_APP_NAME,
@@ -97,9 +98,7 @@ class MongoApi(object):
         # Because the currentOp command and db.currentOp() helper method return the results in a single document,
         # the total size of the currentOp result set is subject to the maximum 16MB BSON size limit for documents.
         # The $currentOp stage returns a cursor over a stream of documents, each of which reports a single operation.
-        return self["admin"].aggregate(
-            [{'$currentOp': {'allUsers': True}}], session=session, maxTimeMS=self._config.timeout
-        )
+        return self["admin"].aggregate([{'$currentOp': {'allUsers': True}}], session=session, maxTimeMS=self._timeout)
 
     def get_collection_stats(self, db_name, coll_name, stats=None, session=None):
         if not self.coll_stats_pipeline_supported:
@@ -131,28 +130,24 @@ class MongoApi(object):
                 },
             ],
             session=session,
-            maxTimeMS=self._config.timeout,
+            maxTimeMS=self._timeout,
         )
 
     def coll_stats_compatible(self, db_name, coll_name, session=None):
         # collStats is deprecated in MongoDB 6.2. Use the $collStats aggregation stage instead.
-        return self[db_name].command({'collStats': coll_name}, session=session, maxTimeMS=self._config.timeout)
+        return self[db_name].command({'collStats': coll_name}, session=session, maxTimeMS=self._timeout)
 
     def index_stats(self, db_name, coll_name, session=None):
-        return self[db_name][coll_name].aggregate(
-            [{"$indexStats": {}}], session=session, maxTimeMS=self._config.timeout
-        )
+        return self[db_name][coll_name].aggregate([{"$indexStats": {}}], session=session, maxTimeMS=self._timeout)
 
     def index_information(self, db_name, coll_name, session=None):
         return self[db_name][coll_name].index_information(session=session)
 
     def list_search_indexes(self, db_name, coll_name, session=None):
-        return self[db_name][coll_name].list_search_indexes(session=session, maxTimeMS=self._config.timeout)
+        return self[db_name][coll_name].list_search_indexes(session=session, maxTimeMS=self._timeout)
 
     def sharded_data_distribution_stats(self, session=None):
-        return self["admin"].aggregate(
-            [{"$shardedDataDistribution": {}}], session=session, maxTimeMS=self._config.timeout
-        )
+        return self["admin"].aggregate([{"$shardedDataDistribution": {}}], session=session, maxTimeMS=self._timeout)
 
     def _is_auth_required(self, options):
         # Check if the node is an arbiter. If it is, usually it does not require authentication.
@@ -169,22 +164,18 @@ class MongoApi(object):
             return True
 
     def get_profiling_level(self, db_name, session=None):
-        return self[db_name].command('profile', -1, session=session, maxTimeMS=self._config.timeout)
+        return self[db_name].command('profile', -1, session=session, maxTimeMS=self._timeout)
 
     def get_profiling_data(self, db_name, ts, session=None):
         filter = {'ts': {'$gt': ts}}
-        return (
-            self[db_name]['system.profile']
-            .find(filter, session=session, max_time_ms=self._config.timeout)
-            .sort('ts', 1)
-        )
+        return self[db_name]['system.profile'].find(filter, session=session, max_time_ms=self._timeout).sort('ts', 1)
 
     def get_log_data(self, session=None):
-        return self['admin'].command("getLog", "global", session=session, maxTimeMS=self._config.timeout)
+        return self['admin'].command("getLog", "global", session=session, maxTimeMS=self._timeout)
 
     def sample(self, db_name, coll_name, sample_size, session=None):
         return self[db_name][coll_name].aggregate(
-            [{"$sample": {"size": sample_size}}], session=session, maxTimeMS=self._config.timeout
+            [{"$sample": {"size": sample_size}}], session=session, maxTimeMS=self._timeout
         )
 
     def get_cmdline_opts(self):
@@ -215,14 +206,12 @@ class MongoApi(object):
             coll_names = self[db_name].list_collection_names(
                 filter={"type": "collection"},  # Only return collections, not views
                 authorizedCollections=True,
-                maxTimeMS=self._config.timeout,
+                maxTimeMS=self._timeout,
             )
         except OperationFailure as e:
             if e.code == 303 and e.details.get("errmsg") == "Field 'type' is currently not supported":
                 # Filter by type is not supported on AWS DocumentDB
-                coll_names = self[db_name].list_collection_names(
-                    authorizedCollections=True, maxTimeMS=self._config.timeout
-                )
+                coll_names = self[db_name].list_collection_names(authorizedCollections=True, maxTimeMS=self._timeout)
             else:
                 # The user is not authorized to run listCollections on this database.
                 # This is NOT a critical error, so we log it as a warning.
@@ -241,7 +230,7 @@ class MongoApi(object):
             # Check if the collection is sharded by looking for the collection config
             # in the config.collections collection.
             collection_config = self["config"]["collections"].find_one(
-                {"_id": f"{db_name}.{coll_name}"}, max_time_ms=self._config.timeout
+                {"_id": f"{db_name}.{coll_name}"}, max_time_ms=self._timeout
             )
             return collection_config is not None
         except OperationFailure as e:
@@ -249,9 +238,7 @@ class MongoApi(object):
             return False
 
     def explain_command(self, db_name, command, verbosity="queryPlanner", session=None):
-        return self[db_name].command(
-            "explain", command, verbosity=verbosity, session=session, maxTimeMS=self._config.timeout
-        )
+        return self[db_name].command("explain", command, verbosity=verbosity, session=session, maxTimeMS=self._timeout)
 
     @property
     def hostname(self):

--- a/mongo/datadog_checks/mongo/collectors/conn_pool_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/conn_pool_stats.py
@@ -24,5 +24,5 @@ class ConnPoolStatsCollector(MongoCollector):
 
     def collect(self, api):
         db = api["admin"]
-        stats = {'connection_pool': db.command('connPoolStats', maxTimeMS=api._config.timeout)}
+        stats = {'connection_pool': db.command('connPoolStats', maxTimeMS=api._timeout)}
         self._submit_payload(stats)

--- a/mongo/datadog_checks/mongo/collectors/conn_pool_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/conn_pool_stats.py
@@ -24,5 +24,5 @@ class ConnPoolStatsCollector(MongoCollector):
 
     def collect(self, api):
         db = api["admin"]
-        stats = {'connection_pool': db.command('connPoolStats')}
+        stats = {'connection_pool': db.command('connPoolStats', maxTimeMS=api._config.timeout)}
         self._submit_payload(stats)

--- a/mongo/datadog_checks/mongo/collectors/fsynclock.py
+++ b/mongo/datadog_checks/mongo/collectors/fsynclock.py
@@ -25,6 +25,6 @@ class FsyncLockCollector(MongoCollector):
 
     def collect(self, api):
         db = api['admin']
-        ops = db.command('currentOp')
+        ops = db.command('currentOp', maxTimeMS=api._config.timeout)
         payload = {'fsyncLocked': 1 if ops.get('fsyncLock') else 0}
         self._submit_payload(payload)

--- a/mongo/datadog_checks/mongo/collectors/fsynclock.py
+++ b/mongo/datadog_checks/mongo/collectors/fsynclock.py
@@ -25,6 +25,6 @@ class FsyncLockCollector(MongoCollector):
 
     def collect(self, api):
         db = api['admin']
-        ops = db.command('currentOp', maxTimeMS=api._config.timeout)
+        ops = db.command('currentOp', maxTimeMS=api._timeout)
         payload = {'fsyncLocked': 1 if ops.get('fsyncLock') else 0}
         self._submit_payload(payload)

--- a/mongo/datadog_checks/mongo/collectors/host_info.py
+++ b/mongo/datadog_checks/mongo/collectors/host_info.py
@@ -17,5 +17,5 @@ class HostInfoCollector(MongoCollector):
         return True
 
     def collect(self, api):
-        host_info = api['admin'].command('hostInfo')
+        host_info = api['admin'].command('hostInfo', maxTimeMS=api._config.timeout)
         return self._submit_payload({'system': host_info.get('system', {})})

--- a/mongo/datadog_checks/mongo/collectors/host_info.py
+++ b/mongo/datadog_checks/mongo/collectors/host_info.py
@@ -17,5 +17,5 @@ class HostInfoCollector(MongoCollector):
         return True
 
     def collect(self, api):
-        host_info = api['admin'].command('hostInfo', maxTimeMS=api._config.timeout)
+        host_info = api['admin'].command('hostInfo', maxTimeMS=api._timeout)
         return self._submit_payload({'system': host_info.get('system', {})})

--- a/mongo/datadog_checks/mongo/collectors/replica.py
+++ b/mongo/datadog_checks/mongo/collectors/replica.py
@@ -123,7 +123,7 @@ class ReplicaCollector(MongoCollector):
                     " Votes metrics won't be reported."
                 )
                 return None
-        return api['local']['system.replset'].find_one()
+        return api['local']['system.replset'].find_one(max_time_ms=api._config.timeout)
 
     def collect(self, api):
         status = api.replset_get_status()

--- a/mongo/datadog_checks/mongo/collectors/replica.py
+++ b/mongo/datadog_checks/mongo/collectors/replica.py
@@ -123,7 +123,7 @@ class ReplicaCollector(MongoCollector):
                     " Votes metrics won't be reported."
                 )
                 return None
-        return api['local']['system.replset'].find_one(max_time_ms=api._config.timeout)
+        return api['local']['system.replset'].find_one(max_time_ms=api._timeout)
 
     def collect(self, api):
         status = api.replset_get_status()

--- a/mongo/datadog_checks/mongo/collectors/replication_info.py
+++ b/mongo/datadog_checks/mongo/collectors/replication_info.py
@@ -70,8 +70,16 @@ class ReplicationOpLogCollector(MongoCollector):
                 if oplog_data_size is not None:
                     oplog_data['usedSizeMB'] = round_value(oplog_data_size / 2.0**20, 2)
 
-                op_asc_cursor = oplog.find({"ts": {"$exists": 1}}).sort("$natural", pymongo.ASCENDING).limit(1)
-                op_dsc_cursor = oplog.find({"ts": {"$exists": 1}}).sort("$natural", pymongo.DESCENDING).limit(1)
+                op_asc_cursor = (
+                    oplog.find({"ts": {"$exists": 1}}, max_time_ms=api._config.timeout)
+                    .sort("$natural", pymongo.ASCENDING)
+                    .limit(1)
+                )
+                op_dsc_cursor = (
+                    oplog.find({"ts": {"$exists": 1}}, max_time_ms=api._config.timeout)
+                    .sort("$natural", pymongo.DESCENDING)
+                    .limit(1)
+                )
 
                 try:
                     first_timestamp = op_asc_cursor[0]['ts'].as_datetime()

--- a/mongo/datadog_checks/mongo/collectors/replication_info.py
+++ b/mongo/datadog_checks/mongo/collectors/replication_info.py
@@ -71,12 +71,12 @@ class ReplicationOpLogCollector(MongoCollector):
                     oplog_data['usedSizeMB'] = round_value(oplog_data_size / 2.0**20, 2)
 
                 op_asc_cursor = (
-                    oplog.find({"ts": {"$exists": 1}}, max_time_ms=api._config.timeout)
+                    oplog.find({"ts": {"$exists": 1}}, max_time_ms=api._timeout)
                     .sort("$natural", pymongo.ASCENDING)
                     .limit(1)
                 )
                 op_dsc_cursor = (
-                    oplog.find({"ts": {"$exists": 1}}, max_time_ms=api._config.timeout)
+                    oplog.find({"ts": {"$exists": 1}}, max_time_ms=api._timeout)
                     .sort("$natural", pymongo.DESCENDING)
                     .limit(1)
                 )

--- a/mongo/datadog_checks/mongo/collectors/server_status.py
+++ b/mongo/datadog_checks/mongo/collectors/server_status.py
@@ -36,7 +36,7 @@ class ServerStatusCollector(MongoCollector):
     def collect(self, api):
         db = api[self.db_name]
         # No need to check for `result['ok']`, already handled by pymongo
-        payload = db.command('serverStatus', tcmalloc=self.collect_tcmalloc_metrics)
+        payload = db.command('serverStatus', tcmalloc=self.collect_tcmalloc_metrics, maxTimeMS=api._config.timeout)
 
         # If these keys exist, remove them for now as they cannot be serialized.
         payload.get('backgroundFlushing', {}).pop('last_finished', None)

--- a/mongo/datadog_checks/mongo/collectors/server_status.py
+++ b/mongo/datadog_checks/mongo/collectors/server_status.py
@@ -36,7 +36,7 @@ class ServerStatusCollector(MongoCollector):
     def collect(self, api):
         db = api[self.db_name]
         # No need to check for `result['ok']`, already handled by pymongo
-        payload = db.command('serverStatus', tcmalloc=self.collect_tcmalloc_metrics, maxTimeMS=api._config.timeout)
+        payload = db.command('serverStatus', tcmalloc=self.collect_tcmalloc_metrics, maxTimeMS=api._timeout)
 
         # If these keys exist, remove them for now as they cannot be serialized.
         payload.get('backgroundFlushing', {}).pop('last_finished', None)

--- a/mongo/datadog_checks/mongo/collectors/top.py
+++ b/mongo/datadog_checks/mongo/collectors/top.py
@@ -22,7 +22,7 @@ class TopCollector(MongoCollector):
         return True
 
     def collect(self, api):
-        dbtop = api["admin"].command('top', maxTimeMS=api._config.timeout)
+        dbtop = api["admin"].command('top', maxTimeMS=api._timeout)
         for ns, ns_metrics in dbtop['totals'].items():
             if "." not in ns:
                 continue

--- a/mongo/datadog_checks/mongo/collectors/top.py
+++ b/mongo/datadog_checks/mongo/collectors/top.py
@@ -22,7 +22,7 @@ class TopCollector(MongoCollector):
         return True
 
     def collect(self, api):
-        dbtop = api["admin"].command('top')
+        dbtop = api["admin"].command('top', maxTimeMS=api._config.timeout)
         for ns, ns_metrics in dbtop['totals'].items():
             if "." not in ns:
                 continue


### PR DESCRIPTION
### What does this PR do?
This PR adds `maxTimeMS` to limit agent resource consumption and prevent operations from running indefinitely on the server side. 
[maxTimeMS](https://www.mongodb.com/docs/manual/tutorial/terminate-running-operations/#maxtimems) ensures queries are properly terminated in addition to the client side operation timeout set by `timeoutMS`. 

### Motivation
https://datadoghq.atlassian.net/browse/SDBM-1738

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
