### PR TITLE
Add metric ibm_mq.channel.conns to ibm mq integration, add channel and connection metric tests

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
@@ -171,6 +171,17 @@ class ChannelMetricCollector(object):
             if pymqi_type not in channel_info:
                 self.log.debug("metric '%s' not found in channel: %s", metric_name, channel_name)
                 continue
+
+            # Special handling for connection metric
+            if metric_name == 'conns':
+                connection_name = to_string(channel_info[pymqi_type]).strip()
+                if not connection_name:
+                    continue
+                connection_tags = tags + ["connection:{}".format(connection_name)]
+                self.gauge(metric_full_name, 1, tags=connection_tags, hostname=self.config.hostname)
+                continue
+
+            # Regular metric handling
             metric_value = int(channel_info[pymqi_type])
             self.gauge(metric_full_name, metric_value, tags=tags, hostname=self.config.hostname)
 

--- a/ibm_mq/datadog_checks/ibm_mq/metrics.py
+++ b/ibm_mq/datadog_checks/ibm_mq/metrics.py
@@ -109,6 +109,7 @@ def channel_status_metrics():
         'batches': pymqi.CMQCFC.MQIACH_BATCHES,
         'current_msgs': pymqi.CMQCFC.MQIACH_CURRENT_MSGS,
         'indoubt_status': pymqi.CMQCFC.MQIACH_INDOUBT_STATUS,
+        'conns': pymqi.CMQCFC.MQCACH_CONNECTION_NAME,
     }
 
 

--- a/ibm_mq/tests/test_channel_metric_collector.py
+++ b/ibm_mq/tests/test_channel_metric_collector.py
@@ -4,6 +4,7 @@
 
 import pytest
 from mock import Mock
+import pymqi
 
 from datadog_checks.ibm_mq.collectors import ChannelMetricCollector
 from datadog_checks.ibm_mq.config import IBMMQConfig
@@ -29,6 +30,88 @@ def test_enable_auto_discover_channels(instance):
 
     collector.get_pcf_channel_metrics(queue_manager)
     collector._submit_channel_status.assert_called_once()
+
+
+def test_channel_metrics(instance):
+    collector = _get_mocked_instance(instance)
+    queue_manager = Mock()
+    # Mock channel info with both regular metrics and connection
+    channel_info = {
+        pymqi.CMQCFC.MQCACH_CHANNEL_NAME: b'TEST.CHANNEL',
+        pymqi.CMQCFC.MQCACH_CONNECTION_NAME: b'192.168.1.1(1414)',
+        pymqi.CMQCFC.MQIACH_BUFFERS_RCVD: 100,
+        pymqi.CMQCFC.MQIACH_BYTES_SENT: 5000,
+    }
+    collector._discover_channels = Mock(return_value=[channel_info])
+    collector.gauge = Mock()
+    collector.get_pcf_channel_metrics(queue_manager)
+    # Verify regular metrics were submitted
+    collector.gauge.assert_any_call(
+        'ibm_mq.channel.buffers_rcvd',
+        100,
+        tags=['channel:TEST.CHANNEL'],
+        hostname=None
+    )
+    collector.gauge.assert_any_call(
+        'ibm_mq.channel.bytes_sent',
+        5000,
+        tags=['channel:TEST.CHANNEL'],
+        hostname=None
+    )
+    # Verify the connection metric was submitted
+    collector.gauge.assert_any_call(
+        'ibm_mq.channel.conns',
+        1,
+        tags=['channel:TEST.CHANNEL', 'connection:192.168.1.1(1414)'],
+        hostname=None
+    )
+
+
+def test_channel_metrics_no_connection(instance):
+    collector = _get_mocked_instance(instance)
+    queue_manager = Mock()
+    # Mock channel info without connection
+    channel_info = {
+        pymqi.CMQCFC.MQCACH_CHANNEL_NAME: b'TEST.CHANNEL',
+        pymqi.CMQCFC.MQIACH_BUFFERS_RCVD: 100,
+    }
+    collector._discover_channels = Mock(return_value=[channel_info])
+    collector.gauge = Mock()
+    collector.get_pcf_channel_metrics(queue_manager)
+    # Verify regular metrics were submitted
+    collector.gauge.assert_any_call(
+        'ibm_mq.channel.buffers_rcvd',
+        100,
+        tags=['channel:TEST.CHANNEL'],
+        hostname=None
+    )
+    # Verify connection metric was not submitted
+    for call in collector.gauge.call_args_list:
+        assert call[0][0] != 'ibm_mq.channel.conns'
+
+
+def test_channel_metrics_empty_connection(instance):
+    collector = _get_mocked_instance(instance)
+    queue_manager = Mock()
+    # Mock channel info with empty connection
+    channel_info = {
+        pymqi.CMQCFC.MQCACH_CHANNEL_NAME: b'TEST.CHANNEL',
+        pymqi.CMQCFC.MQCACH_CONNECTION_NAME: b'',
+        pymqi.CMQCFC.MQIACH_BUFFERS_RCVD: 100,
+    }
+    collector._discover_channels = Mock(return_value=[channel_info])
+    collector.gauge = Mock()
+    collector.get_pcf_channel_metrics(queue_manager)
+    # Verify regular metrics were submitted
+    collector.gauge.assert_any_call(
+        'ibm_mq.channel.buffers_rcvd',
+        100,
+        tags=['channel:TEST.CHANNEL'],
+        hostname=None
+    )
+    # Verify connection metric was not submitted
+    for call in collector.gauge.call_args_list:
+        assert call[0][0] != 'ibm_mq.channel.conns'
 
 
 def _get_mocked_instance(instance):


### PR DESCRIPTION
### What does this PR do?
This PR adds a new metric `ibm_mq.channel.conns` to the IBM MQ integration. This metric is a gauge that indicates active connections per channel, with a value of 1 for each active connection. It is tagged with both the channel name and connection information, allowing users to monitor which specific connections are active for each channel.

### Motivation
The motivation behind this PR is to enhance the monitoring capabilities of the IBM MQ integration by providing visibility into active connections per channel. This feature allows users to track connection changes over time and identify which connections are active, which is crucial for maintaining the health and performance of the messaging system.

This was requested in escalation [AGENT-13489](https://datadoghq.atlassian.net/browse/AGENT-13489)/[FRAGENT-3166](https://datadoghq.atlassian.net/browse/FRAGENT-3166) by customer Broadridge (GTO) (org ID: 345886). 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [not applicable] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
