### PR TITLE
Use json-based PyPI API instead of html-based one to determine whether a build was built

### DIFF
--- a/.builders/scripts/repair_wheels.py
+++ b/.builders/scripts/repair_wheels.py
@@ -22,7 +22,11 @@ def get_wheel_hashes(project) -> dict[str, str]:
     retry_wait = 2
     while True:
         try:
-            response = urllib3.request('GET', f'https://pypi.org/simple/{project}')
+            response = urllib3.request(
+                'GET',
+                f'https://pypi.org/simple/{project}',
+                headers={"Accept": "application/vnd.pypi.simple.v1+json"},
+            )
         except urllib3.exceptions.HTTPError as e:
             err_msg = f'Failed to fetch hashes for `{project}`: {e}'
         else:
@@ -37,14 +41,8 @@ def get_wheel_hashes(project) -> dict[str, str]:
         retry_wait *= 2
         continue
 
-    html = response.data.decode('utf-8')
-    hashes: dict[str, str] = {}
-    for line in html.splitlines():
-        match = re.search(r'<a href="(?:.+?/)?([^"]+)#sha256=([^"]+)"[^>]*>\1</a>', line)
-        if match:
-            file_name, file_hash = match.groups()
-            if file_name.endswith('.whl'):
-                hashes[file_name] = file_hash
+    data = response.json()
+    hashes = {file['filename']: file['hashes']['sha256'] for file in data['files']}
 
     return hashes
 

--- a/.builders/scripts/repair_wheels.py
+++ b/.builders/scripts/repair_wheels.py
@@ -42,7 +42,11 @@ def get_wheel_hashes(project) -> dict[str, str]:
         continue
 
     data = response.json()
-    hashes = {file['filename']: file['hashes']['sha256'] for file in data['files']}
+    hashes: dict[str, str] = {}
+    for file in data['files']:
+        file_name = file['filename']
+        if file_name.endswith('.whl') and 'sha256' in file['hashes']:
+            hashes[file_name] = file['hashes']['sha256']
 
     return hashes
 

--- a/.builders/scripts/repair_wheels.py
+++ b/.builders/scripts/repair_wheels.py
@@ -42,13 +42,11 @@ def get_wheel_hashes(project) -> dict[str, str]:
         continue
 
     data = response.json()
-    hashes: dict[str, str] = {}
-    for file in data['files']:
-        file_name = file['filename']
-        if file_name.endswith('.whl') and 'sha256' in file['hashes']:
-            hashes[file_name] = file['hashes']['sha256']
-
-    return hashes
+    return {
+        file['filename']: file['hashes']['sha256']
+        for file in data['files']
+        if file['filename'].endswith('.whl') and 'sha256' in file['hashes']
+    }
 
 
 def iter_wheels(source_dir: str) -> Iterator[Path]:


### PR DESCRIPTION
### What does this PR do?

Use JSON-based PyPI API instead of html-based one to determine whether a build was built.

### Motivation

I was seeing [this sort](https://github.com/DataDog/integrations-core/actions/runs/15675912436/job/44156055521?pr=20513) of failures while working on a PR. Digging a bit I realized that the logic that we use to determine whether a wheel was built by us or not, used to determine whether it needs to go through the repairing or not, wasn't properly filtering out wheels that shouldn't be repaired (ddtrace was the one with which it was failing).

What I found was that the page we were parsing ([ddtrace example](https://pypi.org/simple/ddtrace/)) has some extra newlines that split the link in two lines in the html source, breaking the regex-based parsing.

I found out that there's now a [JSON-based API](https://docs.pypi.org/api/index-api/#json_1) to retrieve that same information, which saves us from having to parse anything.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
