### PR TITLE
Add excluded emails to mergegate configuration

### DIFF
--- a/repository.datadog.yaml
+++ b/repository.datadog.yaml
@@ -13,4 +13,6 @@ rules:
   - require: commit-signatures
     excluded_emails:
       - '41898282+github-actions[bot]@users.noreply.github.com'
+      - '159767151+datadog-agent-integrations-bot[bot]@users.noreply.github.com'
+      - 'packages@datadoghq.com'
     allow_unsigned_external: true


### PR DESCRIPTION
### What does this PR do?
This PR adds excluded emails for our bots for the mergegate validation.

The emails are for the bot that creates PRs from actions and the email used from the release pipeline.

### Motivation
Mergegate enforces commit signing before reaching our default branch

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
