### PR TITLE
Add new scraper decorator that adds http code class to OpenMetrics

### DIFF
--- a/datadog_checks_base/changelog.d/20528.added
+++ b/datadog_checks_base/changelog.d/20528.added
@@ -1,0 +1,1 @@
+Add OpenMetrics decorator to add code_class to metrics that have an HTTP status code tag

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper/__init__.py
@@ -1,0 +1,8 @@
+# (C) Datadog, Inc. 2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from . import decorators
+from .base_scraper import OpenMetricsCompatibilityScraper, OpenMetricsScraper
+
+__all__ = ["OpenMetricsScraper", "OpenMetricsCompatibilityScraper", "decorators"]

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper/base_scraper.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper/base_scraper.py
@@ -14,15 +14,14 @@ from prometheus_client.parser import text_fd_to_metric_families as parse_prometh
 from requests.exceptions import ConnectionError
 
 from datadog_checks.base.agent import datadog_agent
-
-from ....config import is_affirmative
-from ....constants import ServiceCheck
-from ....errors import ConfigurationError
-from ....utils.functions import no_op, return_true
-from ....utils.http import RequestsWrapper
-from .first_scrape_handler import first_scrape_handler
-from .labels import LabelAggregator, get_label_normalizer
-from .transform import MetricTransformer
+from datadog_checks.base.checks.openmetrics.v2.first_scrape_handler import first_scrape_handler
+from datadog_checks.base.checks.openmetrics.v2.labels import LabelAggregator, get_label_normalizer
+from datadog_checks.base.checks.openmetrics.v2.transform import MetricTransformer
+from datadog_checks.base.config import is_affirmative
+from datadog_checks.base.constants import ServiceCheck
+from datadog_checks.base.errors import ConfigurationError
+from datadog_checks.base.utils.functions import no_op, return_true
+from datadog_checks.base.utils.http import RequestsWrapper
 
 
 class OpenMetricsScraper:

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper/decorators.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper/decorators.py
@@ -1,0 +1,42 @@
+# (C) Datadog, Inc. 2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base_scraper import OpenMetricsScraper
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from prometheus_client.metrics_core import Metric
+
+
+class WithHttpCodeClass(OpenMetricsScraper):
+    """
+    Scraper decorator that parses the HTTP status code from the metric and adds a new tag named
+    `code_class` to the metric.
+
+    The HTTP status code is parsed and a new tag named `code_class` is added to the metric
+    stating whether the status code is in the 1xx, 2xx, 3xx, 4xx, or 5xx range.
+    """
+
+    def __init__(self, scraper: OpenMetricsScraper, http_status_tag: str):
+        self.scraper = scraper
+        self.http_status_tag = http_status_tag
+        super().__init__(scraper.check, scraper.config)
+
+    def consume_metrics(self, runtime_data) -> Generator[Metric]:
+        for metric in self.scraper.consume_metrics(runtime_data):
+            for sample in metric.samples:
+                if (
+                    (code := sample.labels.get(self.http_status_tag))
+                    and isinstance(code, str)
+                    and len(code) == 3
+                    and code.isdigit()
+                ):
+                    sample.labels["code_class"] = f"{code[0]}xx"
+
+            yield metric

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/scraper/test_first_scrape_handler.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/scraper/test_first_scrape_handler.py
@@ -4,8 +4,7 @@
 import pytest
 
 from datadog_checks.base.stubs import datadog_agent
-
-from .utils import get_check
+from tests.base.checks.openmetrics.test_v2.utils import get_check
 
 test_use_process_start_time_data = """\
 # HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/scraper/test_http_status_class_scraper.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/scraper/test_http_status_class_scraper.py
@@ -1,0 +1,95 @@
+# (C) Datadog, Inc.2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from collections.abc import Callable
+from string import Template
+from typing import Optional
+
+import pytest
+
+from datadog_checks.base.checks.openmetrics.v2.base import OpenMetricsBaseCheckV2
+from datadog_checks.base.checks.openmetrics.v2.scraper import OpenMetricsScraper, decorators
+from datadog_checks.base.stubs.aggregator import AggregatorStub
+
+RESPONSE_TEMPLATE = """
+# HELP http_client_request_size_total
+# TYPE http_client_request_size_total counter
+http_client_request_size_total{http_request_method="GET",$status_label="$status_code"} 0
+# HELP http_client_request_started_count_total
+# TYPE http_client_request_started_count_total counter
+http_client_request_started_count_total{http_request_method="GET",$status_label="$status_code"} 5
+# HELP http_client_routes_total
+# TYPE http_client_routes_total counter
+http_client_routes_total{} 5
+"""
+
+
+def get_check(status_label: str):
+    class Check(OpenMetricsBaseCheckV2):
+        __NAMESPACE__ = "test"
+
+        def create_scraper(self, config):
+            scraper = OpenMetricsScraper(self, config)
+            return decorators.WithHttpCodeClass(scraper, http_status_tag=status_label)
+
+    return Check("test", {}, [{"metrics": [".*"], "openmetrics_endpoint": "test"}])
+
+
+def response(status_label: str, status_code: str) -> str:
+    template = Template(RESPONSE_TEMPLATE)
+
+    return template.substitute(status_label=status_label, status_code=status_code)
+
+
+@pytest.mark.parametrize(
+    "status_label, status_code, expected_class",
+    [
+        ("http_response_status_code", "101", "1xx"),
+        ("http_response_status_code", "200", "2xx"),
+        ("http_response_status_code", "302", "3xx"),
+        ("http_response_status_code", "404", "4xx"),
+        ("http_response_status_code", "523", "5xx"),
+        ("code", "201", "2xx"),
+        ("code", "403", "4xx"),
+        ("http_response_status_code", "abc", None),
+        ("http_response_status_code", "99", None),
+    ],
+    ids=[
+        "1xx",
+        "2xx",
+        "3xx",
+        "4xx",
+        "5xx",
+        "Custom label 2xx",
+        "Custom label 4xx",
+        "Invalid status code (abc)",
+        "Invalid status code (99)",
+    ],
+)
+def test_http_status_class_scraper(
+    status_label: str,
+    status_code: str,
+    expected_class: Optional[str],
+    aggregator: AggregatorStub,
+    mock_http_response: Callable,
+    dd_run_check: Callable,
+):
+    mock_http_response(response(status_label, status_code))
+
+    check = get_check(status_label=status_label)
+    dd_run_check(check)
+
+    expected_tag_count = 1 if expected_class else 0
+
+    aggregator.assert_metric("test.http_client_request_size.count", count=1)
+    aggregator.assert_metric_has_tag(
+        "test.http_client_request_size.count", f"code_class:{expected_class}", count=expected_tag_count
+    )
+
+    aggregator.assert_metric("test.http_client_request_started_count.count", count=1)
+    aggregator.assert_metric_has_tag(
+        "test.http_client_request_started_count.count", f"code_class:{expected_class}", count=expected_tag_count
+    )
+
+    aggregator.assert_metric("test.http_client_routes.count", count=1)
+    aggregator.assert_metric_has_tag("test.http_client_routes.count", f"code_class:{expected_class}", count=0)


### PR DESCRIPTION
### What does this PR do?
This PR adds a OpenMetricsScraper decorator that automatically adds `code_class` to the loaded OpenMetrics if an http code tag is configured.

It also moves the scraper module to a package preserving the existing import mechanism while allowing it to grow without making the scraper module too big.

### Motivation
When dealing with metrics that track HTTP requests it is common to include the response code in the tags. These tags are useful but can contribute to busy dashboards and a common approach is to group them by 2xx, 4xx etc.

The Kuma integration already does this and likely the KrakenD integration will as well. This centralizes the logic of such approach to easily load this in the future.

#### Why a decorator?
I thought that we might want to do these kind of things often for common practices and having it as a decorator means that we can easily compose them. On top of that is an extension with no impact on the existing scraper.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
