### PR TITLE
Display Windows Certificate integration docs

### DIFF
--- a/windows_certificate/manifest.json
+++ b/windows_certificate/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "67feed3c-1676-4d6b-9d72-3ca8c0a6e3dc",
   "app_id": "windows-certificate",
-  "display_on_public_website": false,
+  "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This makes the Windows Certificate Integration documentation public for the release of Agent v7.67

### Motivation
<!-- What inspired you to submit this pull request? -->
Agent 7.67 is set to be released on June 18th, 2024 and this integration is ready to be public.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
