### PR TITLE
Increase clarity in the scontrol param and readme.

### DIFF
--- a/slurm/README.md
+++ b/slurm/README.md
@@ -6,9 +6,9 @@ This check monitors [Slurm][1] through the Datadog Agent.
 
 Slurm (Simple Linux Utility for Resource Management) is an open-source workload manager used to schedule and manage jobs on large-scale compute clusters. It allocates resources, monitors job queues, and ensures efficient execution of parallel and batch jobs in high-performance computing environments.
 
-The check gathers metrics from `slurmctld` by executing and parsing the output of several command-line binaries, including [`sinfo`][8], [`squeue`][9], [`sacct`][10], [`sdiag`][11], and [`sshare`][12]. These commands provide detailed information on resource availability, job queues, accounting, diagnostics, and share usage in a Slurm-managed cluster.
+The check collects metrics from the head node (`slurmctld`) by executing and parsing the output of several command-line binaries: [`sinfo`][8], [`squeue`][9], [`sacct`][10], [`sdiag`][11], and [`sshare`][12]. These commands provide detailed information about resource availability, job queues, accounting, diagnostics, and share usage in a Slurm-managed cluster.
 
-On worker nodes, a [scontrol][13] reported metric can also be collected, including the PID(s) of the job information that isn't available in slurmctld, along with other details.
+On worker nodes, the check can also collect metrics using [scontrol][13], which provides process IDs (PIDs) and other job information that is not available through the head node.
 
 ## Setup
 
@@ -22,6 +22,8 @@ The Slurm check is included in the [Datadog Agent][2] package.
 No additional installation is needed on your server.
 
 ### Configuration
+
+#### Head Node
 
 1. Ensure that the dd-agent user has execute permissions on the relevant command binaries and the necessary permissions to access the directories where these binaries are located.
 
@@ -77,6 +79,46 @@ instances:
     ## collects data from from individual nodes as well but is more verbose and includes data such as CPU and 
     ## memory usage as reported from the OS, as well as additional tags.
     #
+    sinfo_collection_level: 3
+
+    ## @param collect_scontrol_stats - boolean - optional - default: false
+    ## Whether or not to collect statistics from the scontrol command. This is mainly used in the worker 
+    ## node to collect the list of running jobs along with their PIDs.
+    collect_scontrol_stats: false # This should be only set on worker nodes and not the head node
+```
+
+#### Worker Nodes
+
+The `slurm.scontrol.job.info` metric can only be collected from worker nodes. This metric enables the submission of important tags
+that can be used to monitor the resource consumption of specific job steps.
+
+```yaml
+init_config:
+
+    ## Customize this part if the binaries are not located in the /usr/bin/ directory
+    ## @param slurm_binaries_dir - string - optional - default: /usr/bin/
+    ## The directory in which all the Slurm binaries are located. These are mainly:
+    ## sinfo, sacct, sdiag, sshare and sdiag.
+
+    slurm_binaries_dir: /usr/bin/
+
+instances:
+
+  - 
+    ## @param collect_scontrol_stats - boolean - optional - default: false
+    ## Whether or not to collect statistics from the scontrol command. This is mainly used in the worker 
+    ## node to collect the list of running jobs along with their PIDs.
+    collect_scontrol_stats: true
+
+    # The rest of these settings need to be turned off on the worker node because the information is specific
+    # to the head node and isn't retrievable on the worker node.
+    collect_scontrol_stats: false
+    collect_sinfo_stats: false
+    collect_sdiag_stats: false
+    collect_squeue_stats: false
+    collect_sacct_stats: false
+    collect_sshare_stats: false
+    collect_gpu_stats: false
     sinfo_collection_level: 1
 ```
 

--- a/slurm/assets/configuration/spec.yaml
+++ b/slurm/assets/configuration/spec.yaml
@@ -45,7 +45,7 @@ files:
         node to collect the list of running jobs along with their PIDs.
       value:
         type: boolean
-        example: True
+        example: False
     - name: collect_gpu_stats
       description: Whether or not to collect GPU statistics when Slurm is configured to use GPUs.
       value:

--- a/slurm/changelog.d/20541.fixed
+++ b/slurm/changelog.d/20541.fixed
@@ -1,0 +1,1 @@
+Update configuration spec to better match the code for the collect_scontrol_stats param

--- a/slurm/datadog_checks/slurm/config_models/defaults.py
+++ b/slurm/datadog_checks/slurm/config_models/defaults.py
@@ -21,7 +21,7 @@ def instance_collect_sacct_stats():
 
 
 def instance_collect_scontrol_stats():
-    return True
+    return False
 
 
 def instance_collect_sdiag_stats():

--- a/slurm/datadog_checks/slurm/data/conf.yaml.example
+++ b/slurm/datadog_checks/slurm/data/conf.yaml.example
@@ -45,11 +45,11 @@ instances:
     #
     # collect_sshare_stats: true
 
-    ## @param collect_scontrol_stats - boolean - optional - default: true
+    ## @param collect_scontrol_stats - boolean - optional - default: false
     ## Whether or not to collect statistics from the scontrol command. This is mainly used in the worker 
     ## node to collect the list of running jobs along with their PIDs.
     #
-    # collect_scontrol_stats: true
+    # collect_scontrol_stats: false
 
     ## @param collect_gpu_stats - boolean - optional - default: false
     ## Whether or not to collect GPU statistics when Slurm is configured to use GPUs.


### PR DESCRIPTION
### What does this PR do?
Readme update mostly. The spec default needed to be swapped to be more aligned with the code.
