### PR TITLE
Unmark integration test as flaky

### DIFF
--- a/marklogic/tests/metrics.py
+++ b/marklogic/tests/metrics.py
@@ -66,6 +66,8 @@ FOREST_STATUS_TREE_CACHE_METRICS = [
     'marklogic.forests.compressed-tree-cache-ratio',
 ]
 
+OPTIONAL_FOREST_METRICS = ['marklogic.forests.current-foreign-master-database']
+
 HOST_STATUS_METRICS_SPECIFIC_OPTIONAL = [
     # TODO: needs preprocessing to be available
     'marklogic.hosts.memory-process-huge-pages-size',
@@ -280,4 +282,4 @@ GLOBAL_METRICS = (
     + TRANSACTION_STATUS_METRICS
 )
 
-OPTIONAL_METRICS = HOST_STATUS_METRICS_SPECIFIC_OPTIONAL
+OPTIONAL_METRICS = HOST_STATUS_METRICS_SPECIFIC_OPTIONAL + OPTIONAL_FOREST_METRICS

--- a/marklogic/tests/test_marklogic.py
+++ b/marklogic/tests/test_marklogic.py
@@ -21,7 +21,12 @@ from .common import (
     assert_metrics,
     assert_service_checks,
 )
-from .metrics import RESOURCE_STATUS_DATABASE_METRICS, RESOURCE_STORAGE_FOREST_METRICS, STORAGE_HOST_METRICS
+from .metrics import (
+    OPTIONAL_METRICS,
+    RESOURCE_STATUS_DATABASE_METRICS,
+    RESOURCE_STORAGE_FOREST_METRICS,
+    STORAGE_HOST_METRICS,
+)
 
 
 @pytest.mark.integration
@@ -67,7 +72,6 @@ def test_check_simple_user(aggregator):
 
 
 @pytest.mark.integration
-@pytest.mark.flaky
 @pytest.mark.usefixtures("dd_environment")
 def test_check_with_filters(aggregator):
     # type: (AggregatorStub) -> None
@@ -88,6 +92,9 @@ def test_check_with_filters(aggregator):
         'marklogic.requests.update-count',
     ]:
         aggregator.assert_metric(metric, tags=COMMON_TAGS + ['server_name:Admin', 'group_name:Default'], count=1)
+
+    for metric in OPTIONAL_METRICS:
+        aggregator.assert_metric(metric, at_least=0)
 
     aggregator.assert_all_metrics_covered()
 


### PR DESCRIPTION
### What does this PR do?
Fixes flakey test to assert optional metrics and remove flakey label
### Motivation
We should aim to mark less tests as flaky because these are still run in the Test Agent Release workflow
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
