### PR TITLE
Fixes "Column 'sys.foreign_keys.object_id' is invalid in the select list ..." error with th FOREIGN_KEY_QUERY_PRE_2017 query

### DIFF
--- a/sqlserver/changelog.d/20542.fixed
+++ b/sqlserver/changelog.d/20542.fixed
@@ -1,0 +1,1 @@
+Fixes "Column 'sys.foreign_keys.object_id' is invalid in the select list ..." error with th FOREIGN_KEY_QUERY_PRE_2017 query

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -135,6 +135,7 @@ WHERE
     FK.parent_object_id IN ({})
 GROUP BY
     FK.name,
+    FK.object_id,
     FK.parent_object_id,
     FK.referenced_object_id,
     FK.delete_referential_action_desc,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR corrects the `FOREIGN_KEY_QUERY_PRE_2017` query to prevent the error below:

```
Column 'sys.foreign_keys.object_id' is invalid in the select list because it is not contained in either an aggregate function or the GROUP BY clause.
```

### Motivation
<!-- What inspired you to submit this pull request? -->

The motivation was [this](https://datadoghq.atlassian.net/browse/SDBM-1822) customer reported issues.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
