### PR TITLE
Add clarity around the gunicorn.workers definitions

### DIFF
--- a/gunicorn/metadata.csv
+++ b/gunicorn/metadata.csv
@@ -70,4 +70,4 @@ gunicorn.request.status.510,rate,10,request,second,The rate of requests that gen
 gunicorn.request.status.511,rate,10,request,second,The rate of requests that generate responses with a 511 status code.,0,gunicorn,511,
 gunicorn.request.status.512,rate,10,request,second,The rate of requests that generate responses with a 512 status code.,0,gunicorn,512,
 gunicorn.requests,rate,10,request,second,The rate of requests received.,0,gunicorn,requests,
-gunicorn.workers,gauge,10,worker,,The number of workers tagged by state (idle or working). A worker is busy if it has a recorded CPU-time increase over a 0.1-sec interval (through psutil). A worker is idle if no CPU-time change is detected, even if the worker is blocked on I/O (such as waiting on HTTP/database calls).,0,gunicorn,workers,
+gunicorn.workers,gauge,10,worker,,"The number of workers tagged by state (idle or working). A worker is busy if it has a recorded CPU-time increase over a 0.1-sec interval (through psutil). A worker is idle if no CPU-time change is detected, even if the worker is blocked on I/O (such as waiting on HTTP/database calls).",0,gunicorn,workers,

--- a/gunicorn/metadata.csv
+++ b/gunicorn/metadata.csv
@@ -70,4 +70,4 @@ gunicorn.request.status.510,rate,10,request,second,The rate of requests that gen
 gunicorn.request.status.511,rate,10,request,second,The rate of requests that generate responses with a 511 status code.,0,gunicorn,511,
 gunicorn.request.status.512,rate,10,request,second,The rate of requests that generate responses with a 512 status code.,0,gunicorn,512,
 gunicorn.requests,rate,10,request,second,The rate of requests received.,0,gunicorn,requests,
-gunicorn.workers,gauge,10,worker,,The number of workers tagged by state (idle or working).,0,gunicorn,workers,
+gunicorn.workers,gauge,10,worker,,The number of workers tagged by state (idle or working). A worker is busy if it has a recorded CPU-time increase over a 0.1-sec interval (through psutil). A worker is idle if no CPU-time change is detected, even if the worker is blocked on I/O (such as waiting on HTTP/database calls).,0,gunicorn,workers,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

DOCS-10879, a customer requested more clarity around the gunicorn.workers definition.

Local preview:
<img width="793" alt="Screenshot 2025-06-20 at 1 31 53 PM" src="https://github.com/user-attachments/assets/7f12799a-c5d8-4a2b-ae6a-8fb179bad7cc" />

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
