### PR TITLE
Add meta prom dump command to ddev

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Install ddev
       run: |
         pip install -e ./datadog_checks_dev[cli]
-        pip install -e ./ddev
+        pip install -e ./ddev[base]
 
     - name: Configure ddev
       run: |
@@ -73,7 +73,7 @@ jobs:
 
     permissions:
       contents: write
-      
+
     steps:
     - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:

--- a/ddev/changelog.d/20551.added
+++ b/ddev/changelog.d/20551.added
@@ -1,0 +1,1 @@
+Add new dump command to the meta group

--- a/ddev/hatch.toml
+++ b/ddev/hatch.toml
@@ -14,4 +14,5 @@ dependencies = [
 # TODO: remove this when the old CLI is gone
 pre-install-commands = [
   "python -m pip install --disable-pip-version-check {verbosity:flag:-1} -e ../datadog_checks_dev[cli]",
+  "python -m pip install --disable-pip-version-check {verbosity:flag:-1} -e ../datadog_checks_base[deps]",
 ]

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -47,6 +47,11 @@ dependencies = [
 ]
 dynamic = ["version"]
 
+[project.optional-dependencies]
+base = [
+    "datadog-checks-base[deps]~=37.0",
+]
+
 [project.urls]
 Source = "https://github.com/DataDog/integrations-core"
 

--- a/ddev/src/ddev/cli/meta/__init__.py
+++ b/ddev/src/ddev/cli/meta/__init__.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import importlib.util
+
 import click
 from datadog_checks.dev.tooling.commands.meta.catalog import catalog
 from datadog_checks.dev.tooling.commands.meta.changes import changes
@@ -22,6 +24,12 @@ def meta():
     This `meta` namespace can be used for an arbitrary number of
     niche or beta features without bloating the root namespace.
     """
+
+
+if importlib.util.find_spec('datadog_checks.base'):
+    from ddev.cli.meta.prometheus import dump
+
+    prom.add_command(dump)
 
 
 meta.add_command(catalog)

--- a/ddev/src/ddev/cli/meta/prometheus.py
+++ b/ddev/src/ddev/cli/meta/prometheus.py
@@ -1,0 +1,46 @@
+import click
+
+from ddev.cli.application import Application
+
+
+@click.command(short_help="Run a bare OpenMetrics check on an OpenMetrics endpoint")
+@click.option("-e", "--endpoint", help="The OpenMetrics endpoint to run the check on")
+@click.option("-n", "--namespace", help="The namespace to use for the check", default="test", show_default=True)
+@click.pass_obj
+def dump(app: Application, endpoint: str, namespace: str):
+    """
+    Run a bare OpenMetrics check and dump all metrics as a check would see them.
+
+    This command is useful if you want to see the full list of metrics exposed by an OpenMetrics endpoint
+    as they will be emitted by a check. It does not include any custom metrics/tags renaming.
+
+    !!! warning "Base extra"
+        This command is only available if ddev is installed with the `base` extra.
+
+        ```
+        pipx install ddev[base]
+        ```
+    """
+    import os
+
+    from datadog_checks.base.checks.openmetrics.v2.base import OpenMetricsBaseCheckV2
+    from datadog_checks.base.stubs import aggregator
+
+    os.environ["DDEV_SKIP_GENERIC_TAGS_CHECK"] = "true"
+
+    class BareCheck(OpenMetricsBaseCheckV2):
+        __NAMESPACE__ = namespace
+
+    check = BareCheck(namespace, {}, [{"metrics": [".*"], "openmetrics_endpoint": endpoint}])
+    errors = check.run()
+
+    if errors:
+        import json
+
+        body = json.loads(errors)[0]
+        app.display_error(f"\nError Message: {body['message']}")
+        app.display_error(body["traceback"])
+        return
+
+    for metric_name in aggregator._metrics:
+        app.display(metric_name)

--- a/ddev/tests/cli/meta/test_dump.py
+++ b/ddev/tests/cli/meta/test_dump.py
@@ -1,0 +1,101 @@
+from collections.abc import Callable
+
+import pytest
+from _pytest.mark.structures import ParameterSet
+from datadog_checks.base.utils.tagging import GENERIC_TAGS
+from datadog_checks.dev.http import MockResponse
+from pytest_mock import MockerFixture
+
+from tests.helpers.runner import CliRunner
+
+OPEN_METRICS_CONTENT = """
+# HELP go_goroutines Number of currently active goroutines.
+# TYPE go_goroutines gauge
+go_goroutines 18
+
+# HELP go_heap_objects Number of allocated Go heap objects.
+# TYPE go_heap_objects gauge
+go_heap_objects 45049
+
+# HELP go_heap_alloc_total_bytes Total bytes allocated in Go heap.
+# TYPE go_heap_alloc_total_bytes counter
+go_heap_alloc_total_bytes 1.028797712e+09
+
+# HELP go_gc_duration_seconds Summary of Go GC pause duration.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0.5"} 3.4001e-05
+go_gc_duration_seconds{quantile="0.9"} 0.00062
+go_gc_duration_seconds_sum 0.007118091
+go_gc_duration_seconds_count 132
+
+# HELP http_client_duration HTTP client request duration.
+# TYPE http_client_duration histogram
+# Using 'endpoint' as a simplified single tag from the original multi-tag metric.
+http_client_duration_bucket{endpoint="/v1/users",le="0.05"} 4
+http_client_duration_bucket{endpoint="/v1/users",le="0.1"} 4
+http_client_duration_bucket{endpoint="/v1/users",le="0.25"} 4
+http_client_duration_bucket{endpoint="/v1/users",le="0.5"} 5
+http_client_duration_bucket{endpoint="/v1/users",le="+Inf"} 5
+http_client_duration_sum{endpoint="/v1/users"} 0.311033333
+http_client_duration_count{endpoint="/v1/users"} 5
+"""
+
+
+@pytest.fixture
+def command_output(ddev: CliRunner, mocker: MockerFixture) -> set[str]:
+    dynamic_metrics = [
+        "# HELP generic_tagged_metric A metric with a generic tag.",
+        "# TYPE generic_tagged_metric gauge",
+    ]
+    for tag in GENERIC_TAGS:
+        dynamic_metrics.append(f'generic_tagged_metric{{{tag}="some-value"}} 1')
+
+    content = f"{OPEN_METRICS_CONTENT}\n{'\n'.join(dynamic_metrics)}"
+
+    mock_http = mocker.patch("requests.get")
+    mock_http.return_value = MockResponse(content)
+
+    result = ddev("meta", "prom", "dump", "-e", "http://localhost:9090/metrics")
+    return set(result.output.splitlines())
+
+
+def expected_metrics(namespace: str) -> list[ParameterSet]:
+    return [
+        pytest.param(
+            [
+                f"{namespace}.go_goroutines",
+                f"{namespace}.go_heap_objects",
+                f"{namespace}.go_heap_alloc_total_bytes.count",
+            ],
+            id="gauge",
+        ),
+        pytest.param(
+            [
+                f"{namespace}.go_gc_duration_seconds.quantile",
+                f"{namespace}.go_gc_duration_seconds.sum",
+                f"{namespace}.go_gc_duration_seconds.count",
+            ],
+            id="summary",
+        ),
+        pytest.param(
+            [
+                f"{namespace}.http_client_duration.bucket",
+                f"{namespace}.http_client_duration.sum",
+                f"{namespace}.http_client_duration.count",
+            ],
+            id="histogram",
+        ),
+        pytest.param([f"{namespace}.generic_tagged_metric"], id="generic_tags"),
+    ]
+
+
+@pytest.mark.parametrize("metric_names", expected_metrics("test"))
+def test_dump(command_output: set[str], metric_names: list[str]):
+    assert set(metric_names) <= command_output
+
+
+def test_dump_with_errors(ddev: CliRunner, mock_http_response: Callable):
+    mock_http_response(status_code=500)
+    result = ddev("meta", "prom", "dump", "-e", "http://localhost:9090/metrics")
+
+    assert "500 Server Error" in result.output


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds a new command named `dump` to the `meta` group in `ddev`. The command requires `datadog_checks_base` as a dependency of `ddev`. To avoid bringing this for just this command, the command will only be accesible if `ddev` has been installed requiring the `base` extra dependencies. This way anyone that does not need this command does not really need to get the `base` dependency with `ddev`.

### Motivation
<!-- What inspired you to submit this pull request? -->
While parse is usefull to generate a list of metric names from the prometheus endpoint applying some renaming. Sometimes the interactive nature of the command makes it hard to use with long payloads. It also ignores the processing done by an OpenMetrics check transformer (sufixes added to metric names, for example).

The `dump` command creates a bare OpenMetrics check and parses the output of a given endpoint serving metrics, printing the full list of metrics, including namespace, that the check will eventually be serving. This is usually a better starting point for metadata.csv and metric mappings that can later be processed easily by an LLM.

The next step is to add a cursor rule to the project that includes instructions about how to use this command and use the output to generate the metadata.csv and metric mappings.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
