### PR TITLE
Fix WithHttpCodeClass decorator to also add code class when running with target_info enabled

### DIFF
--- a/datadog_checks_base/changelog.d/20555.fixed
+++ b/datadog_checks_base/changelog.d/20555.fixed
@@ -1,0 +1,1 @@
+Add support for ingesting target_info when using the WithHttpCodeClass decorator

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper/decorators.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper/decorators.py
@@ -4,7 +4,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from functools import partial
+from typing import TYPE_CHECKING, Any
 
 from .base_scraper import OpenMetricsScraper
 
@@ -28,15 +29,17 @@ class WithHttpCodeClass(OpenMetricsScraper):
         self.http_status_tag = http_status_tag
         super().__init__(scraper.check, scraper.config)
 
-    def consume_metrics(self, runtime_data) -> Generator[Metric]:
-        for metric in self.scraper.consume_metrics(runtime_data):
-            for sample in metric.samples:
-                if (
-                    (code := sample.labels.get(self.http_status_tag))
-                    and isinstance(code, str)
-                    and len(code) == 3
-                    and code.isdigit()
-                ):
-                    sample.labels["code_class"] = f"{code[0]}xx"
+    def _add_http_code_class(self, metric: Metric, http_status_tag: str) -> Metric:
+        for sample in metric.samples:
+            if (
+                (code := sample.labels.get(http_status_tag))
+                and isinstance(code, str)
+                and len(code) == 3
+                and code.isdigit()
+            ):
+                sample.labels["code_class"] = f"{code[0]}xx"
+        return metric
 
-            yield metric
+    def yield_metrics(self, runtime_data: dict[str, Any]) -> Generator[Metric]:
+        add_http_code_class_func = partial(self._add_http_code_class, http_status_tag=self.http_status_tag)
+        yield from map(add_http_code_class_func, self.scraper.yield_metrics(runtime_data))


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR updates the new decorator that adds `code_class` as tag whenever an http code tag is present to also support running with target_info enabled.

### Motivation
<!-- What inspired you to submit this pull request? -->
The recently introduced version only covers the `consume_metrics` but if target info is requested the method that gets executed is `consume_metrics_w_target_info`. This ensures that whatever way we are running it we get the code class tag added.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
