### PR TITLE
[cluster-agent] Add new cws instrumentation metrics

### DIFF
--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
@@ -6,8 +6,9 @@ from datadog_checks.base import OpenMetricsBaseCheck
 
 DEFAULT_METRICS = {
     'admission_webhooks_certificate_expiry': 'admission_webhooks.certificate_expiry',
-    'admission_webhooks_cws_exec_instrumentation_attempts': 'admission_webhooks.cws_exec_instrumentation_attempts',
-    'admission_webhooks_cws_pod_instrumentation_attempts': 'admission_webhooks.cws_pod_instrumentation_attempts',
+    'admission_webhooks_cws_exec_mutation_attempts': 'admission_webhooks.cws_exec_mutation_attempts',
+    'admission_webhooks_cws_pod_mutation_attempts': 'admission_webhooks.cws_pod_mutation_attempts',
+    'admission_webhooks_cws_response_duration': 'admission_webhooks.cws_response_duration',
     'admission_webhooks_library_injection_attempts': 'admission_webhooks.library_injection_attempts',
     'admission_webhooks_library_injection_errors': 'admission_webhooks.library_injection_errors',
     'admission_webhooks_mutation_attempts': 'admission_webhooks.mutation_attempts',

--- a/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
+++ b/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
@@ -14,10 +14,10 @@ NAMESPACE = 'datadog.cluster_agent'
 
 METRICS = [
     'admission_webhooks.certificate_expiry',
-    'admission_webhooks.cws_exec_instrumentation_attempts.count',
-    'admission_webhooks.cws_exec_instrumentation_attempts.sum',
-    'admission_webhooks.cws_pod_instrumentation_attempts.count',
-    'admission_webhooks.cws_pod_instrumentation_attempts.sum',
+    'admission_webhooks.cws_exec_mutation_attempts',
+    'admission_webhooks.cws_pod_mutation_attempts',
+    'admission_webhooks.cws_response_duration.count',
+    'admission_webhooks.cws_response_duration.sum',
     'admission_webhooks.library_injection_attempts',
     'admission_webhooks.library_injection_errors',
     'admission_webhooks.mutation_attempts',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR updates the metrics of the `cluster-agent` check to collect the new metrics of the `cws-instrumentation` webhook introduced in [this PR](https://github.com/DataDog/datadog-agent/pull/38045).

### Motivation
<!-- What inspired you to submit this pull request? -->

These metrics will help better understand the performance of the `cws-instrumentation` webhook.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
