### PR TITLE
Run `PR All` on stacked PRs

### DIFF
--- a/.github/workflows/pr-all.yml
+++ b/.github/workflows/pr-all.yml
@@ -2,8 +2,6 @@ name: PR All
 
 on:
   pull_request:
-    branches:
-    - master
     paths:
     - datadog_checks_base/datadog_checks/**
     - datadog_checks_dev/datadog_checks/dev/*.py


### PR DESCRIPTION
### What does this PR do?
Removes condition for pr all
### Motivation
Currently, when making stacked PRs that target `ddev` or `datadog_checks_base`, no tests are run since PR All isn't triggered and compute-matrix returns empty

Additionally, the PR workflow is not restricted in this way: https://github.com/DataDog/integrations-core/blob/master/.github/workflows/pr.yml#L4-L13
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
