### PR TITLE
Add a config option for process cache reset trigger

### DIFF
--- a/process/assets/configuration/spec.yaml
+++ b/process/assets/configuration/spec.yaml
@@ -27,6 +27,14 @@ files:
         value:
           type: integer
           example: 120
+      - name: reset_cache_on_process_changes
+        description: |
+          When set to true, the shared process list cache is reset (forced to refresh) when a process disappears 
+          during scanning or when no matching processes are found for an instance. This ensures fresh process data 
+          but may impact performance on systems with frequent process changes.
+        value:
+          type: boolean
+          example: true
       - name: procfs_path
         description: |
           Used to override the default procfs path, e.g. for docker containers with the outside fs mounted at /host/proc

--- a/process/datadog_checks/process/config_models/defaults.py
+++ b/process/datadog_checks/process/config_models/defaults.py
@@ -16,6 +16,10 @@ def shared_pid_cache_duration():
     return 120
 
 
+def shared_reset_cache_on_process_changes():
+    return True
+
+
 def shared_shared_process_list_cache_duration():
     return 120
 

--- a/process/datadog_checks/process/config_models/shared.py
+++ b/process/datadog_checks/process/config_models/shared.py
@@ -28,6 +28,7 @@ class SharedConfig(BaseModel):
     access_denied_cache_duration: Optional[int] = None
     pid_cache_duration: Optional[int] = None
     procfs_path: Optional[str] = None
+    reset_cache_on_process_changes: Optional[bool] = None
     service: Optional[str] = None
     shared_process_list_cache_duration: Optional[int] = None
 

--- a/process/datadog_checks/process/data/conf.yaml.example
+++ b/process/datadog_checks/process/data/conf.yaml.example
@@ -22,6 +22,13 @@ init_config:
     #
     # shared_process_list_cache_duration: 120
 
+    ## @param reset_cache_on_process_changes - boolean - optional - default: true
+    ## When set to true, the shared process list cache is reset (forced to refresh) when a process disappears 
+    ## during scanning or when no matching processes are found for an instance. This ensures fresh process data 
+    ## but may impact performance on systems with frequent process changes.
+    #
+    # reset_cache_on_process_changes: true
+
     ## @param procfs_path - string - optional
     ## Used to override the default procfs path, e.g. for docker containers with the outside fs mounted at /host/proc
     ## DEPRECATED: please specify `procfs_path` globally in `datadog.conf` instead

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -94,6 +94,11 @@ class ProcessCheck(AgentCheck):
         self.pid_cache = {}
         self.pid_cache_duration = int(init_config.get('pid_cache_duration', DEFAULT_PID_CACHE_DURATION))
 
+        # Control whether to reset the shared process list cache on process changes
+        self.reset_cache_on_process_changes = is_affirmative(
+            init_config.get('reset_cache_on_process_changes', True)
+        )
+
         self._conflicting_procfs = False
         self._deprecated_init_procfs = False
         if Platform.is_linux():
@@ -288,7 +293,8 @@ class ProcessCheck(AgentCheck):
                     self.log.debug('Process %s disappeared while scanning', pid)
                     # reset the process caches now, something changed
                     self.last_pid_cache_ts[name] = 0
-                    self.process_list_cache.reset()
+                    if self.reset_cache_on_process_changes:
+                        self.process_list_cache.reset()
                     continue
 
             p = self.process_cache[name][pid]
@@ -461,7 +467,8 @@ class ProcessCheck(AgentCheck):
             self.log.debug("No matching process '%s' was found", self.name)
             # reset the process caches now, something changed
             self.last_pid_cache_ts[self.name] = 0
-            self.process_list_cache.reset()
+            if self.reset_cache_on_process_changes:
+                self.process_list_cache.reset()
 
         for attr, mname in ATTR_TO_METRIC.items():
             vals = [x for x in proc_state[attr] if x is not None]

--- a/process/tests/test_process.py
+++ b/process/tests/test_process.py
@@ -399,3 +399,21 @@ def test_process_service_check(aggregator):
     aggregator.assert_service_check('process.up', count=1, tags=['process:warning'], status=process.WARNING)
     aggregator.assert_service_check('process.up', count=1, tags=['process:no_top_ok'], status=process.OK)
     aggregator.assert_service_check('process.up', count=1, tags=['process:no_top_critical'], status=process.CRITICAL)
+
+
+def test_reset_cache_on_process_changes_config(aggregator, dd_run_check):
+    """Test that reset() is called/not called based on reset_cache_on_process_changes config."""
+    # Test 1: Config=True (default)
+    init_config = {'reset_cache_on_process_changes': True}
+    instance = {'name': 'nonexistent_process_12345', 'search_string': ['nonexistent_process_12345']}
+    process = ProcessCheck(common.CHECK_NAME, init_config, [instance])
+    with patch.object(process.process_list_cache, 'reset') as mock_reset:
+        dd_run_check(process)
+        mock_reset.assert_called()  # Should call reset when no processes found
+    # Test 2: Config=False
+    init_config = {'reset_cache_on_process_changes': False}
+    instance = {'name': 'nonexistent_process_12345', 'search_string': ['nonexistent_process_12345']}
+    process = ProcessCheck(common.CHECK_NAME, init_config, [instance])
+    with patch.object(process.process_list_cache, 'reset') as mock_reset:
+        dd_run_check(process)
+        mock_reset.assert_not_called()  # Should NOT call reset

--- a/process/tests/test_process.py
+++ b/process/tests/test_process.py
@@ -403,17 +403,19 @@ def test_process_service_check(aggregator):
 
 def test_reset_cache_on_process_changes_config(aggregator, dd_run_check):
     """Test that reset() is called/not called based on reset_cache_on_process_changes config."""
-    # Test 1: Config=True (default)
+    # Config=True (default)
     init_config = {'reset_cache_on_process_changes': True}
     instance = {'name': 'nonexistent_process_12345', 'search_string': ['nonexistent_process_12345']}
     process = ProcessCheck(common.CHECK_NAME, init_config, [instance])
     with patch.object(process.process_list_cache, 'reset') as mock_reset:
         dd_run_check(process)
-        mock_reset.assert_called()  # Should call reset when no processes found
-    # Test 2: Config=False
+         # Should call reset when no processes found since the config is true
+        mock_reset.assert_called()
+    # Config=False
     init_config = {'reset_cache_on_process_changes': False}
     instance = {'name': 'nonexistent_process_12345', 'search_string': ['nonexistent_process_12345']}
     process = ProcessCheck(common.CHECK_NAME, init_config, [instance])
     with patch.object(process.process_list_cache, 'reset') as mock_reset:
         dd_run_check(process)
-        mock_reset.assert_not_called()  # Should NOT call reset
+        # Should NOT call reset since the config is false
+        mock_reset.assert_not_called()


### PR DESCRIPTION
### What does this PR do?
This PR adds a config option to toggle the behavior of process cache reset. 

### Motivation
Resetting process cache was having a perf impact. While it technically was a correct behavior (to update cache as soon as a pid was gone or no specified process had been detected), it could and did cause a high churn. This behavior is now behind a config, so the default is still true, but can we set to false if there's a perf impact and customers are ok for stale data for the duration of the  shared_process_list_cache_duration seconds (defaults to 120, but configurable).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
