### PR TITLE
Remove "run" from Kuma process signature

### DIFF
--- a/kuma/manifest.json
+++ b/kuma/manifest.json
@@ -43,8 +43,8 @@
         "metadata_path": "assets/service_checks.json"
       },
       "process_signatures": [
-        "kuma-cp run",
-        "kuma-dp run"
+        "kuma-cp",
+        "kuma-dp"
       ]
     }
   },


### PR DESCRIPTION
### What does this PR do?
Remove "run" from Kuma process signature, so that it's `kuma-cp` instead of `kuma-cp run`.

### Motivation
At the RFC discussion we settled on making the process signature less specific.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
