### PR TITLE
[ABLD-28] Bump `delocate` for better macOS multiarch support

### DIFF
--- a/.builders/images/runner_dependencies.txt
+++ b/.builders/images/runner_dependencies.txt
@@ -2,4 +2,4 @@ python-dotenv==1.0.0
 urllib3==2.2.0
 auditwheel==6.0.0; sys_platform == 'linux'
 delvewheel==1.5.2; sys_platform == 'win32'
-delocate==0.10.7; sys_platform == 'darwin'
+delocate==0.13.0; sys_platform == 'darwin'


### PR DESCRIPTION
### What does this PR do?
Bump `delocate` to a version that better supports Python wheels embedding multiple macOS architectures.

### Motivation
Working on adding support for macOS AArch64/ARM64 "native" build, I faced that:
```py
Using existing wheel
--> cm_client-45.0.4-py3-none-any.whl
--> confluent_kafka-2.8.0-cp312-cp312-macosx_11_0_universal2.whl
Traceback (most recent call last):
[...]
NotImplementedError: This function does not support separate values per-architecture: {'x86_64': [('/usr/lib/libSystem.B.dylib', '1.0.0', '1336.61.1')], 'arm64': [('/Users/runner/builder_root/prefix/lib/librdkafka.1.dylib', '0.0.0', '0.0.0'), ('/usr/lib/libSystem.B.dylib', '1.0.0', '1336.61.1')]}
```
See https://github.com/DataDog/integrations-core/actions/runs/15850271495/job/44681764771?pr=20455#step:7:17535

It turns out this issue got resolved through:
- https://github.com/matthew-brett/delocate/pull/230

... and shipped with `delocate` **0.13.0**:
- https://github.com/matthew-brett/delocate/releases/tag/0.13.0
- https://pypi.org/project/delocate/0.13.0/

The present change aims at taking advantage of it, which indeed seems to work as intended:
```py
Using existing wheel
--> cm_client-45.0.4-py3-none-any.whl
--> confluent_kafka-2.8.0-cp312-cp312-macosx_11_0_universal2.whl
Repaired wheel
Libraries copied into the wheel:
/Users/runner/builder_root/prefix/lib/librdkafka.1.dylib
/Users/runner/builder_root/prefix/lib/liblmdb.so
/Users/runner/builder_root/prefix/lib/libcurl.4.dylib
/Users/runner/builder_root/prefix/lib/libssl.3.dylib
/Users/runner/builder_root/prefix/lib/libcrypto.3.dylib
/Users/runner/builder_root/prefix/lib/libz.1.3.1.dylib
```
See https://github.com/DataDog/integrations-core/actions/runs/15851063188/job/44684393512?pr=20455#step:7:17513

### Review checklist (to be filled by reviewers)
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged