### PR TITLE
[SDBM-1807] Do not submit plan events when plan definition has been evicted from cache

### DIFF
--- a/sqlserver/changelog.d/20584.fixed
+++ b/sqlserver/changelog.d/20584.fixed
@@ -1,0 +1,1 @@
+Only submit plan events when we have a plan definition

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -626,11 +626,11 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                 plan_key = row['plan_handle']
             if self._seen_plans_ratelimiter.acquire(plan_key):
                 raw_plan, is_plan_encrypted = self._load_plan(row['plan_handle'], cursor)
-
                 obfuscated_plan, collection_errors = None, None
 
                 try:
-                    obfuscated_plan = obfuscate_xml_plan(raw_plan, self._config.obfuscator_options)
+                    if raw_plan:
+                        obfuscated_plan = obfuscate_xml_plan(raw_plan, self._config.obfuscator_options)
                 except Exception as e:
                     context = (
                         "query_signature=[{0}] query_hash=[{1}] query_plan_hash=[{2}] plan_handle=[{3}] err=[{4}]"

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -626,11 +626,11 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                 plan_key = row['plan_handle']
             if self._seen_plans_ratelimiter.acquire(plan_key):
                 raw_plan, is_plan_encrypted = self._load_plan(row['plan_handle'], cursor)
-                
+
                 # Do not submit plan events if no plan is available
                 if not raw_plan:
                     continue
-                    
+
                 obfuscated_plan, collection_errors = None, None
 
                 try:

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -627,7 +627,6 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             if self._seen_plans_ratelimiter.acquire(plan_key):
                 raw_plan, is_plan_encrypted = self._load_plan(row['plan_handle'], cursor)
 
-
                 obfuscated_plan, collection_errors = None, None
 
                 try:

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -626,11 +626,15 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                 plan_key = row['plan_handle']
             if self._seen_plans_ratelimiter.acquire(plan_key):
                 raw_plan, is_plan_encrypted = self._load_plan(row['plan_handle'], cursor)
+                
+                # Do not submit plan events if no plan is available
+                if not raw_plan:
+                    continue
+                    
                 obfuscated_plan, collection_errors = None, None
 
                 try:
-                    if raw_plan:
-                        obfuscated_plan = obfuscate_xml_plan(raw_plan, self._config.obfuscator_options)
+                    obfuscated_plan = obfuscate_xml_plan(raw_plan, self._config.obfuscator_options)
                 except Exception as e:
                     context = (
                         "query_signature=[{0}] query_hash=[{1}] query_plan_hash=[{2}] plan_handle=[{3}] err=[{4}]"

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -1001,13 +1001,7 @@ def test_statement_conditional_stored_procedure_with_temp_table(
     assert dbm_samples, "should have collected at least one sample"
 
     matched_events = [s for s in dbm_samples if s['dbm_type'] == "plan" and "#Ids" in s['db']['statement']]
-    assert matched_events, "should have collected plan event"
-
-    for event in matched_events:
-        assert event['db']['plan']['definition'] is None
-        assert event['sqlserver']['plan_handle'] is not None
-        assert event['sqlserver']['query_hash'] is not None
-        assert event['sqlserver']['query_plan_hash'] is not None
+    assert not matched_events, "should not have collected plan event because there is no plan definition"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
There are cases where we are not able get a plan from the cache (ex. sqlserver evicted the relevant plan to free up memory). When this happens, we still submit a plan event with a plan signature but no plan definition. When querying for plans this is a bit weird since we say we've collected a plan because we see a plan event with a plan signature but we don't have the actual plan to show the user.

I see a few options here:
1. We can not submit plan events if we don't have the plan definition. This makes the most sense to me right now but would appreciate other perspectives/things I may be missing
2. We could submit the plan with a collection_error that says the plan is null because it was not found
3. We could leave plan collection as is and change the way we query for plans on the front end (only query for plan events with a plan definition)

This PR is for option 1. If there is a collection errors, then we still submit the plan but if there's not collection error and no plan definition, we skip the plan event. We have a log line when we fail to load plan, so users can still see when this happens and we can see it in debug flares.

If a plan is encrypted, we don't get a plan definition. In this case, I am adding a collection error. I will update the front end to have support for this error in https://github.com/DataDog/web-ui/pull/212997.

Support ticket: https://datadoghq.atlassian.net/browse/SDBM-1807