### PR TITLE
Remove AWS batch log collection unsupported note for Fluentbit Firelens

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -438,8 +438,6 @@ You can monitor Fargate logs by using either:
 
 Datadog recommends using AWS FireLens because you can configure Fluent Bit directly in your Fargate tasks.
 
-**Note**: Log collection with Fluent Bit and FireLens is not supported for AWS Batch on ECS Fargate.
-
 #### Fluent Bit and FireLens
 
 Configure the AWS FireLens integration built on Datadog's Fluent Bit output plugin to connect your FireLens monitored log data to Datadog Logs. You can find a full [sample task definition for this configuration here][19].


### PR DESCRIPTION
AWS announced support for Firelens now here: https://aws.amazon.com/about-aws/whats-new/2025/04/aws-batch-amazon-elastic-container-service-exec-firelens-log-router/#:~:text=AWS%20re:Post-,AWS%20Batch%20now%20supports%20Amazon%20Elastic%20Container,and%20AWS%20FireLens%20log%20router&text=AWS%20Batch%20now%20supports%20Amazon%20Elastic%20Container%20Service%20(ECS)%20Exec,where%20AWS%20Batch%20is%20available.

I have updated the other doc: https://docs.datadoghq.com/containers/guide/aws-batch-ecs-fargate/?tab=awswebui
Via this PR: https://github.com/DataDog/documentation/pull/30063

But the following line needs to be removed for now:
- Note: Log collection with Fluent Bit and FireLens is not supported for AWS Batch on ECS Fargate.