### PR TITLE
deprecate schemas_collection, deadlock_collection and xe_collection config option

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -907,8 +907,8 @@ files:
     - name: collect_raw_query_statement
       description: |
         Configure the collection of raw query statements in query activity, and XE events.
-        To collect raw query statements from XE events, set `xe_collection.query_completions.enabled` and
-        `xe_collection.query_errors.enabled` to `true`.
+        To collect raw query statements from XE events, set `collect_xe.query_completions.enabled` and
+        `collect_xe.query_errors.enabled` to `true`.
         Raw query statements and execution plans may contain sensitive information (e.g., passwords)
         or personally identifiable information in query text.
         Enabling this option will allow the collection and ingestion of raw query statements and
@@ -987,8 +987,38 @@ files:
         type: number
         example: 1800
         display_default: 300
-    - name: schemas_collection
+    - name: collect_schemas
       description: |
+        Available for Agent 7.56 and newer.
+        Configure collection of schemas. If `database_autodiscovery` is not enabled, data is collected
+        only for the database configured with `database` parameter.
+      options:
+        - name: enabled
+          description: |
+            Enable schema collection. Requires `dbm: true`. Defaults to false.
+          value:
+            type: boolean
+            example: false
+        - name: collection_interval
+          description: |
+            Set the database schema collection interval (in seconds). Defaults to 600 seconds.
+          value:
+            type: number
+            example: 600
+        - name: max_execution_time
+          description: |
+            Set the maximum time for schema collection (in seconds). Defaults to 10 seconds.
+            Capped by `collect_schemas.collection_interval`
+          value:
+            type: number
+            example: 10
+    - name: schemas_collection
+      hidden: true
+      deprecation:
+        Agent version: 7.59.0
+        Migration: Use `collect_schemas` instead.
+      description: |
+        DEPRECATED: Use `collect_schemas` instead.
         Available for Agent 7.56 and newer.
         Configure collection of schemas. If `database_autodiscovery` is not enabled, data is collected
         only for the database configured with `database` parameter.
@@ -1020,7 +1050,7 @@ files:
       value:
         example: false
         type: boolean
-    - name: xe_collection
+    - name: collect_xe
       description: |
         Configure the collection of events from XE (Extended Events) sessions. Requires `dbm: true`.
 
@@ -1089,8 +1119,109 @@ files:
               type: integer
               example: 1000
               display_default: 1000
-    - name: deadlocks_collection
+    - name: xe_collection
+      hidden: true
+      deprecation:
+        Agent version: 7.59.0
+        Migration: Use `collect_xe` instead.
       description: |
+        DEPRECATED: Use `collect_xe` instead.
+        Configure the collection of events from XE (Extended Events) sessions. Requires `dbm: true`.
+
+        Set `collect_raw_query_statement.enabled` to `true` to collect the raw query statements for each event.
+      options:
+        - name: debug_sample_events
+          description: |
+            Set the maximum number of XE events to log in debug mode per collection. Used for troubleshooting.
+            This only affects logging when debug mode is enabled. Defaults to 3.
+          hidden: true
+          value:
+            type: integer
+            example: 3
+            display_default: 3
+        - name: query_completions
+          description: |
+            Configure the collection of completed queries from the `datadog_query_completions` XE session.
+
+            Set `query_completions.enabled` to `true` to enable the collection of query completion events.
+
+            Use `query_completions.collection_interval` to set the interval (in seconds) for the collection of
+            query completion events. Defaults to 10 seconds. If you intend on updating this value,
+            it is strongly recommended to use a consistent value throughout all SQL Server agent deployments.
+
+            Use `query_completions.max_events` to set the maximum number of query completion events to process
+            per collection. Note that SQL Server's ring buffer has a maximum of 1000 events per query,
+            so values above 1000 will still be capped at 1000 by the database engine. Defaults to 1000.
+          value:
+            type: object
+            properties:
+            - name: enabled
+              type: boolean
+              example: false
+            - name: collection_interval
+              type: number
+              example: 10
+              display_default: 10
+            - name: max_events
+              type: integer
+              example: 1000
+              display_default: 1000
+        - name: query_errors
+          description: |
+            Configure the collection of query errors from the `datadog_query_errors` XE session.
+
+            Set `query_errors.enabled` to `true` to enable the collection of query error events.
+
+            Use `query_errors.collection_interval` to set the interval (in seconds) for the collection of
+            query error events. Defaults to 10 seconds. If you intend on updating this value,
+            it is strongly recommended to use a consistent value throughout all SQL Server agent deployments.
+
+            Use `query_errors.max_events` to set the maximum number of query error events to process
+            per collection. Note that SQL Server's ring buffer has a maximum of 1000 events per query,
+            so values above 1000 will still be capped at 1000 by the database engine. Defaults to 1000.
+          value:
+            type: object
+            properties:
+            - name: enabled
+              type: boolean
+              example: false
+            - name: collection_interval
+              type: number
+              example: 10
+              display_default: 10
+            - name: max_events
+              type: integer
+              example: 1000
+              display_default: 1000
+    - name: collect_deadlocks
+      description: |
+        Configure the collection of deadlock data.
+      options:
+        - name: enabled
+          description: |
+            Enable the collection of deadlock data. Requires `dbm: true`. Disabled by default.
+          value:
+            type: boolean
+            example: false
+        - name: collection_interval
+          description: |
+            Set the interval for collecting deadlock data, in seconds. Defaults to 600 seconds.
+          value:
+            type: number
+            example: 600
+        - name: max_deadlocks
+          description: |
+            Set the maximum number of deadlocks to retrieve per collection.
+          value:
+            type: number
+            example: 100
+    - name: deadlocks_collection
+      hidden: true
+      deprecation:
+        Agent version: 7.59.0
+        Migration: Use `collect_deadlocks` instead.
+      description: |
+        DEPRECATED: Use `collect_deadlocks` instead.
         Configure the collection of deadlock data.
       options:
         - name: enabled

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -1014,7 +1014,7 @@ files:
     - name: schemas_collection
       hidden: true
       deprecation:
-        Agent version: 7.59.0
+        Agent version: 7.69.0
         Migration: Use `collect_schemas` instead.
       description: |
         DEPRECATED: Use `collect_schemas` instead.
@@ -1120,7 +1120,7 @@ files:
     - name: xe_collection
       hidden: true
       deprecation:
-        Agent version: 7.59.0
+        Agent version: 7.69.0
         Migration: Use `collect_xe` instead.
       description: |
         DEPRECATED: Use `collect_xe` instead.
@@ -1216,7 +1216,7 @@ files:
     - name: deadlocks_collection
       hidden: true
       deprecation:
-        Agent version: 7.59.0
+        Agent version: 7.69.0
         Migration: Use `collect_deadlocks` instead.
       description: |
         DEPRECATED: Use `collect_deadlocks` instead.

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -989,7 +989,6 @@ files:
         display_default: 300
     - name: collect_schemas
       description: |
-        Available for Agent 7.56 and newer.
         Configure collection of schemas. If `database_autodiscovery` is not enabled, data is collected
         only for the database configured with `database` parameter.
       options:
@@ -1019,7 +1018,7 @@ files:
         Migration: Use `collect_schemas` instead.
       description: |
         DEPRECATED: Use `collect_schemas` instead.
-        Available for Agent 7.56 and newer.
+        Available for Agent 7.59 and newer.
         Configure collection of schemas. If `database_autodiscovery` is not enabled, data is collected
         only for the database configured with `database` parameter.
       options:

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -1018,7 +1018,6 @@ files:
         Migration: Use `collect_schemas` instead.
       description: |
         DEPRECATED: Use `collect_schemas` instead.
-        Available for Agent 7.59 and newer.
         Configure collection of schemas. If `database_autodiscovery` is not enabled, data is collected
         only for the database configured with `database` parameter.
       options:

--- a/sqlserver/changelog.d/20599.added
+++ b/sqlserver/changelog.d/20599.added
@@ -1,0 +1,1 @@
+Add new collect_* configuration options (collect_schemas, collect_deadlocks, collect_xe) to replace deprecated *_collection options while maintaining backward compatibility.

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -55,9 +55,10 @@ class SQLServerConfig:
         self.procedure_metrics_config: dict = instance.get('procedure_metrics', {}) or {}
         self.settings_config: dict = instance.get('collect_settings', {}) or {}
         self.activity_config: dict = instance.get('query_activity', {}) or {}
-        self.schema_config: dict = instance.get('schemas_collection', {}) or {}
-        self.deadlocks_config: dict = instance.get('deadlocks_collection', {}) or {}
-        self.xe_collection_config: dict = instance.get('xe_collection', {}) or {}
+        # Backward compatibility: check new names first, then fall back to old names
+        self.schema_config: dict = instance.get('collect_schemas', instance.get('schemas_collection', {})) or {}
+        self.deadlocks_config: dict = instance.get('collect_deadlocks', instance.get('deadlocks_collection', {})) or {}
+        self.xe_collection_config: dict = instance.get('collect_xe', instance.get('xe_collection', {})) or {}
         self.cloud_metadata: dict = {}
         aws: dict = instance.get('aws', {}) or {}
         gcp: dict = instance.get('gcp', {}) or {}

--- a/sqlserver/datadog_checks/sqlserver/config_models/deprecations.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/deprecations.py
@@ -5,7 +5,7 @@
 
 def instance():
     return {
-        'deadlocks_collection': {'Agent version': '7.59.0', 'Migration': 'Use `collect_deadlocks` instead.'},
-        'schemas_collection': {'Agent version': '7.59.0', 'Migration': 'Use `collect_schemas` instead.'},
-        'xe_collection': {'Agent version': '7.59.0', 'Migration': 'Use `collect_xe` instead.'},
+        'deadlocks_collection': {'Agent version': '7.69.0', 'Migration': 'Use `collect_deadlocks` instead.'},
+        'schemas_collection': {'Agent version': '7.69.0', 'Migration': 'Use `collect_schemas` instead.'},
+        'xe_collection': {'Agent version': '7.69.0', 'Migration': 'Use `collect_xe` instead.'},
     }

--- a/sqlserver/datadog_checks/sqlserver/config_models/deprecations.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/deprecations.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+
 def instance():
     return {
         'deadlocks_collection': {'Agent version': '7.59.0', 'Migration': 'Use `collect_deadlocks` instead.'},

--- a/sqlserver/datadog_checks/sqlserver/config_models/deprecations.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/deprecations.py
@@ -1,0 +1,11 @@
+# (C) Datadog, Inc. 2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+
+def instance():
+    return {
+        'deadlocks_collection': {'Agent version': '7.57.0', 'Migration': 'Use `collect_deadlocks` instead.'},
+        'schemas_collection': {'Agent version': '7.57.0', 'Migration': 'Use `collect_schemas` instead.'},
+        'xe_collection': {'Agent version': '7.57.0', 'Migration': 'Use `collect_xe` instead.'},
+    }

--- a/sqlserver/datadog_checks/sqlserver/config_models/deprecations.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/deprecations.py
@@ -2,10 +2,9 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-
 def instance():
     return {
-        'deadlocks_collection': {'Agent version': '7.57.0', 'Migration': 'Use `collect_deadlocks` instead.'},
-        'schemas_collection': {'Agent version': '7.57.0', 'Migration': 'Use `collect_schemas` instead.'},
-        'xe_collection': {'Agent version': '7.57.0', 'Migration': 'Use `collect_xe` instead.'},
+        'deadlocks_collection': {'Agent version': '7.59.0', 'Migration': 'Use `collect_deadlocks` instead.'},
+        'schemas_collection': {'Agent version': '7.59.0', 'Migration': 'Use `collect_schemas` instead.'},
+        'xe_collection': {'Agent version': '7.59.0', 'Migration': 'Use `collect_xe` instead.'},
     }

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
 
-from . import defaults, validators
+from . import defaults, deprecations, validators
 
 
 class AgentJobs(BaseModel):
@@ -48,12 +48,32 @@ class Azure(BaseModel):
     fully_qualified_domain_name: Optional[str] = None
 
 
+class CollectDeadlocks(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    collection_interval: Optional[float] = None
+    enabled: Optional[bool] = None
+    max_deadlocks: Optional[float] = None
+
+
 class CollectRawQueryStatement(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
         frozen=True,
     )
     enabled: Optional[bool] = None
+
+
+class CollectSchemas(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    collection_interval: Optional[float] = None
+    enabled: Optional[bool] = None
+    max_execution_time: Optional[float] = None
 
 
 class CollectSettings(BaseModel):
@@ -63,6 +83,36 @@ class CollectSettings(BaseModel):
     )
     collection_interval: Optional[float] = None
     enabled: Optional[bool] = None
+
+
+class QueryCompletions(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    collection_interval: Optional[float] = Field(None, examples=[10])
+    enabled: Optional[bool] = Field(None, examples=[False])
+    max_events: Optional[int] = Field(None, examples=[1000])
+
+
+class QueryErrors(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    collection_interval: Optional[float] = Field(None, examples=[10])
+    enabled: Optional[bool] = Field(None, examples=[False])
+    max_events: Optional[int] = Field(None, examples=[1000])
+
+
+class CollectXe(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    debug_sample_events: Optional[int] = None
+    query_completions: Optional[QueryCompletions] = None
+    query_errors: Optional[QueryErrors] = None
 
 
 class CustomQuery(BaseModel):
@@ -357,26 +407,6 @@ class SchemasCollection(BaseModel):
     max_execution_time: Optional[float] = None
 
 
-class QueryCompletions(BaseModel):
-    model_config = ConfigDict(
-        arbitrary_types_allowed=True,
-        frozen=True,
-    )
-    collection_interval: Optional[float] = Field(None, examples=[10])
-    enabled: Optional[bool] = Field(None, examples=[False])
-    max_events: Optional[int] = Field(None, examples=[1000])
-
-
-class QueryErrors(BaseModel):
-    model_config = ConfigDict(
-        arbitrary_types_allowed=True,
-        frozen=True,
-    )
-    collection_interval: Optional[float] = Field(None, examples=[10])
-    enabled: Optional[bool] = Field(None, examples=[False])
-    max_events: Optional[int] = Field(None, examples=[1000])
-
-
 class XeCollection(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -400,8 +430,11 @@ class InstanceConfig(BaseModel):
     autodiscovery_include: Optional[tuple[str, ...]] = None
     aws: Optional[Aws] = None
     azure: Optional[Azure] = None
+    collect_deadlocks: Optional[CollectDeadlocks] = None
     collect_raw_query_statement: Optional[CollectRawQueryStatement] = None
+    collect_schemas: Optional[CollectSchemas] = None
     collect_settings: Optional[CollectSettings] = None
+    collect_xe: Optional[CollectXe] = None
     command_timeout: Optional[int] = None
     connection_string: Optional[str] = None
     connector: Optional[str] = None
@@ -447,6 +480,12 @@ class InstanceConfig(BaseModel):
     use_global_custom_queries: Optional[str] = None
     username: Optional[str] = None
     xe_collection: Optional[XeCollection] = None
+
+    @model_validator(mode='before')
+    def _handle_deprecations(cls, values, info):
+        fields = info.context['configured_fields']
+        validation.utils.handle_deprecations('instances', deprecations.instance(), fields, info.context)
+        return values
 
     @model_validator(mode='before')
     def _initial_validation(cls, values):

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -783,7 +783,6 @@ instances:
     #
     # ignore_missing_database: false
 
-    ## Available for Agent 7.56 and newer.
     ## Configure collection of schemas. If `database_autodiscovery` is not enabled, data is collected
     ## only for the database configured with `database` parameter.
     #

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -657,8 +657,8 @@ instances:
         # keep_identifier_quotation: false
 
     ## Configure the collection of raw query statements in query activity, and XE events.
-    ## To collect raw query statements from XE events, set `xe_collection.query_completions.enabled` and
-    ## `xe_collection.query_errors.enabled` to `true`.
+    ## To collect raw query statements from XE events, set `collect_xe.query_completions.enabled` and
+    ## `collect_xe.query_errors.enabled` to `true`.
     ## Raw query statements and execution plans may contain sensitive information (e.g., passwords)
     ## or personally identifiable information in query text.
     ## Enabling this option will allow the collection and ingestion of raw query statements and
@@ -787,7 +787,7 @@ instances:
     ## Configure collection of schemas. If `database_autodiscovery` is not enabled, data is collected
     ## only for the database configured with `database` parameter.
     #
-    # schemas_collection:
+    # collect_schemas:
 
         ## @param enabled - boolean - optional - default: false
         ## Enable schema collection. Requires `dbm: true`. Defaults to false.
@@ -801,7 +801,7 @@ instances:
 
         ## @param max_execution_time - number - optional - default: 10
         ## Set the maximum time for schema collection (in seconds). Defaults to 10 seconds.
-        ## Capped by `schemas_collection.collection_interval`
+        ## Capped by `collect_schemas.collection_interval`
         #
         # max_execution_time: 10
 
@@ -816,7 +816,7 @@ instances:
     ##
     ## Set `collect_raw_query_statement.enabled` to `true` to collect the raw query statements for each event.
     #
-    # xe_collection:
+    # collect_xe:
 
         ## @param query_completions - mapping - optional
         ## Configure the collection of completed queries from the `datadog_query_completions` XE session.
@@ -850,7 +850,7 @@ instances:
 
     ## Configure the collection of deadlock data.
     #
-    # deadlocks_collection:
+    # collect_deadlocks:
 
         ## @param enabled - boolean - optional - default: false
         ## Enable the collection of deadlock data. Requires `dbm: true`. Disabled by default.

--- a/sqlserver/tests/test_deadlocks.py
+++ b/sqlserver/tests/test_deadlocks.py
@@ -368,14 +368,11 @@ def test_deadlock_calls_obfuscator(deadlocks_collection_instance):
 
 @pytest.mark.unit
 def test_collect_deadlocks_config(dbm_instance):
+    dbm_instance['collect_deadlocks'] = {"enabled": True, 'collection_interval': 0.2}
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
-    assert check.config.deadlocks_config == {}
-
-    dbm_instance['collect_deadlocks'] = {"enabled": True, "collection_interval": 0}
-    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
-    assert check.config.deadlocks_config == {"enabled": True, "collection_interval": 0}
+    assert check._config.deadlocks_config == {"enabled": True, 'collection_interval': 0.2}
 
     dbm_instance.pop('collect_deadlocks')
-    dbm_instance['deadlocks_collection'] = {"enabled": True, "collection_interval": 0}
+    dbm_instance['deadlocks_collection'] = {"enabled": True, 'collection_interval': 0.3}
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
-    assert check.config.deadlocks_config == {"enabled": True, "collection_interval": 0}
+    assert check._config.deadlocks_config == {"enabled": True, 'collection_interval': 0.3}

--- a/sqlserver/tests/test_deadlocks.py
+++ b/sqlserver/tests/test_deadlocks.py
@@ -364,3 +364,18 @@ def test_deadlock_calls_obfuscator(deadlocks_collection_instance):
         result_string = result_string.replace('\t', '').replace('\n', '')
         result_string = re.sub(r'\s{2,}', ' ', result_string)
         assert expected_xml_string == result_string
+
+
+@pytest.mark.unit
+def test_collect_deadlocks_config(dbm_instance):
+    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
+    assert check.config.deadlocks_config == {}
+
+    dbm_instance['collect_deadlocks'] = {"enabled": True, "collection_interval": 0}
+    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
+    assert check.config.deadlocks_config == {"enabled": True, "collection_interval": 0}
+
+    dbm_instance.pop('collect_deadlocks')
+    dbm_instance['deadlocks_collection'] = {"enabled": True, "collection_interval": 0}
+    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
+    assert check.config.deadlocks_config == {"enabled": True, "collection_interval": 0}

--- a/sqlserver/tests/test_metadata.py
+++ b/sqlserver/tests/test_metadata.py
@@ -404,3 +404,18 @@ def test_schemas_collection_truncated(aggregator, dd_run_check, dbm_instance):
             ):
                 found = True
     assert found
+
+
+@pytest.mark.unit
+def test_collect_schemas_config(dbm_instance):
+    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
+    assert check.config.schema_config == {}
+
+    dbm_instance['collect_schemas'] = {"enabled": True, "max_execution_time": 0}
+    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
+    assert check.config.schema_config == {"enabled": True, "max_execution_time": 0}
+
+    dbm_instance.pop('collect_schemas')
+    dbm_instance['schemas_collection'] = {"enabled": True, "max_execution_time": 0}
+    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
+    assert check.config.schema_config == {"enabled": True, "max_execution_time": 0}

--- a/sqlserver/tests/test_metadata.py
+++ b/sqlserver/tests/test_metadata.py
@@ -408,14 +408,11 @@ def test_schemas_collection_truncated(aggregator, dd_run_check, dbm_instance):
 
 @pytest.mark.unit
 def test_collect_schemas_config(dbm_instance):
-    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
-    assert check.config.schema_config == {}
-
     dbm_instance['collect_schemas'] = {"enabled": True, "max_execution_time": 0}
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
-    assert check.config.schema_config == {"enabled": True, "max_execution_time": 0}
+    assert check._config.schema_config == {"enabled": True, "max_execution_time": 0}
 
     dbm_instance.pop('collect_schemas')
     dbm_instance['schemas_collection'] = {"enabled": True, "max_execution_time": 0}
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
-    assert check.config.schema_config == {"enabled": True, "max_execution_time": 0}
+    assert check._config.schema_config == {"enabled": True, "max_execution_time": 0}

--- a/sqlserver/tests/test_xe_collection.py
+++ b/sqlserver/tests/test_xe_collection.py
@@ -1276,12 +1276,9 @@ class TestRunJob:
 
 @pytest.mark.unit
 def test_collect_xe_config(dbm_instance):
-    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
-    assert check.config.xe_collection_config == {}
-
     dbm_instance['collect_xe'] = {"query_completions": {"enabled": True}, "query_errors": {"enabled": True}}
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
-    assert check.config.xe_collection_config == {
+    assert check._config.xe_collection_config == {
         "query_completions": {"enabled": True},
         "query_errors": {"enabled": True},
     }
@@ -1289,7 +1286,7 @@ def test_collect_xe_config(dbm_instance):
     dbm_instance.pop('collect_xe')
     dbm_instance['xe_collection'] = {"query_completions": {"enabled": True}, "query_errors": {"enabled": True}}
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
-    assert check.config.xe_collection_config == {
+    assert check._config.xe_collection_config == {
         "query_completions": {"enabled": True},
         "query_errors": {"enabled": True},
     }

--- a/sqlserver/tests/test_xe_collection.py
+++ b/sqlserver/tests/test_xe_collection.py
@@ -1275,17 +1275,17 @@ class TestRunJob:
 
 
 @pytest.mark.unit
-def test_collect_xe_config(dbm_instance):
-    dbm_instance['collect_xe'] = {"query_completions": {"enabled": True}, "query_errors": {"enabled": True}}
-    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
+def test_collect_xe_config(instance_docker):
+    instance_docker['collect_xe'] = {"query_completions": {"enabled": True}, "query_errors": {"enabled": True}}
+    check = SQLServer(CHECK_NAME, {}, [instance_docker])
     assert check._config.xe_collection_config == {
         "query_completions": {"enabled": True},
         "query_errors": {"enabled": True},
     }
 
-    dbm_instance.pop('collect_xe')
-    dbm_instance['xe_collection'] = {"query_completions": {"enabled": True}, "query_errors": {"enabled": True}}
-    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
+    instance_docker.pop('collect_xe')
+    instance_docker['xe_collection'] = {"query_completions": {"enabled": True}, "query_errors": {"enabled": True}}
+    check = SQLServer(CHECK_NAME, {}, [instance_docker])
     assert check._config.xe_collection_config == {
         "query_completions": {"enabled": True},
         "query_errors": {"enabled": True},

--- a/sqlserver/tests/test_xe_collection.py
+++ b/sqlserver/tests/test_xe_collection.py
@@ -1272,3 +1272,24 @@ class TestRunJob:
             # Verify the batch exists and contains multiple events
             assert batch_key in original_payload, f"Missing '{batch_key}' array in payload"
             assert len(original_payload[batch_key]) > 1, "Expected multiple events in the batch"
+
+
+@pytest.mark.unit
+def test_collect_xe_config(dbm_instance):
+    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
+    assert check.config.xe_collection_config == {}
+
+    dbm_instance['collect_xe'] = {"query_completions": {"enabled": True}, "query_errors": {"enabled": True}}
+    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
+    assert check.config.xe_collection_config == {
+        "query_completions": {"enabled": True},
+        "query_errors": {"enabled": True},
+    }
+
+    dbm_instance.pop('collect_xe')
+    dbm_instance['xe_collection'] = {"query_completions": {"enabled": True}, "query_errors": {"enabled": True}}
+    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
+    assert check.config.xe_collection_config == {
+        "query_completions": {"enabled": True},
+        "query_errors": {"enabled": True},
+    }


### PR DESCRIPTION
### What does this PR do?
Add new collect_* configuration options (collect_schemas, collect_deadlocks, collect_xe) to replace deprecated *_collection options while maintaining backward compatibility.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
