### PR TITLE
deprecate schemas_collection config option

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -403,8 +403,37 @@ files:
                 value:
                   type: number
                   example: 600
-          - name: schemas_collection
+          - name: collect_schemas
             description: |
+              Configure collection of schemas (databases).
+              Only tables and schemas for which the user has been granted SELECT privileges are collected.
+            options:
+              - name: enabled
+                description: |
+                  Enable schema collection. Requires `dbm: true`. Defaults to false.
+                value:
+                  type: boolean
+                  example: false
+              - name: collection_interval
+                description: |
+                  Set the database schema collection interval (in seconds). Defaults to 600 seconds.
+                value:
+                  type: number
+                  example: 600
+              - name: max_execution_time
+                description: |
+                  Set the maximum time for schema collection (in seconds). Defaults to 60 seconds.
+                  Capped by `collect_schemas.collection_interval`
+                value:
+                  type: number
+                  example: 60
+          - name: schemas_collection
+            hidden: true
+            deprecation:
+              Agent version: 7.59.0
+              Migration: Use `collect_schemas` instead.
+            description: |
+              DEPRECATED: Use `collect_schemas` instead.
               Configure collection of schemas (databases).
               Only tables and schemas for which the user has been granted SELECT privileges are collected.
             options:

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -430,7 +430,7 @@ files:
           - name: schemas_collection
             hidden: true
             deprecation:
-              Agent version: 7.59.0
+              Agent version: 7.69.0
               Migration: Use `collect_schemas` instead.
             description: |
               DEPRECATED: Use `collect_schemas` instead.

--- a/mysql/changelog.d/20602.added
+++ b/mysql/changelog.d/20602.added
@@ -1,0 +1,1 @@
+Add new `collect_schemas` configuration options to replace deprecated `schemas_collection` options while maintaining backward compatibility.

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -49,7 +49,8 @@ class MySQLConfig(object):
         self.statement_metrics_config = instance.get('query_metrics', {}) or {}
         self.settings_config = instance.get('collect_settings', {}) or {}
         self.activity_config = instance.get('query_activity', {}) or {}
-        self.schemas_config: dict = instance.get('schemas_collection', {}) or {}
+        # Backward compatibility: check new names first, then fall back to old names
+        self.schemas_config: dict = instance.get('collect_schemas', instance.get('schemas_collection', {})) or {}
         self.index_config: dict = instance.get('index_metrics', {}) or {}
         self.collect_blocking_queries = is_affirmative(instance.get('collect_blocking_queries', False))
 

--- a/mysql/datadog_checks/mysql/config_models/deprecations.py
+++ b/mysql/datadog_checks/mysql/config_models/deprecations.py
@@ -1,0 +1,8 @@
+# (C) Datadog, Inc. 2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+
+
+def instance():
+    return {'schemas_collection': {'Agent version': '7.59.0', 'Migration': 'Use `collect_schemas` instead.'}}

--- a/mysql/datadog_checks/mysql/config_models/deprecations.py
+++ b/mysql/datadog_checks/mysql/config_models/deprecations.py
@@ -3,6 +3,5 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 
-
 def instance():
     return {'schemas_collection': {'Agent version': '7.59.0', 'Migration': 'Use `collect_schemas` instead.'}}

--- a/mysql/datadog_checks/mysql/config_models/deprecations.py
+++ b/mysql/datadog_checks/mysql/config_models/deprecations.py
@@ -4,4 +4,4 @@
 
 
 def instance():
-    return {'schemas_collection': {'Agent version': '7.59.0', 'Migration': 'Use `collect_schemas` instead.'}}
+    return {'schemas_collection': {'Agent version': '7.69.0', 'Migration': 'Use `collect_schemas` instead.'}}

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
 
-from . import defaults, validators
+from . import defaults, deprecations, validators
 
 
 class ManagedAuthentication(BaseModel):
@@ -46,6 +46,16 @@ class Azure(BaseModel):
     )
     deployment_type: Optional[str] = None
     fully_qualified_domain_name: Optional[str] = None
+
+
+class CollectSchemas(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    collection_interval: Optional[float] = None
+    enabled: Optional[bool] = None
+    max_execution_time: Optional[float] = None
 
 
 class CollectSettings(BaseModel):
@@ -215,6 +225,7 @@ class InstanceConfig(BaseModel):
     aws: Optional[Aws] = None
     azure: Optional[Azure] = None
     charset: Optional[str] = None
+    collect_schemas: Optional[CollectSchemas] = None
     collect_settings: Optional[CollectSettings] = None
     connect_timeout: Optional[float] = None
     custom_queries: Optional[tuple[CustomQuery, ...]] = None
@@ -252,6 +263,12 @@ class InstanceConfig(BaseModel):
     tags: Optional[tuple[str, ...]] = None
     use_global_custom_queries: Optional[str] = None
     username: Optional[str] = None
+
+    @model_validator(mode='before')
+    def _handle_deprecations(cls, values, info):
+        fields = info.context['configured_fields']
+        validation.utils.handle_deprecations('instances', deprecations.instance(), fields, info.context)
+        return values
 
     @model_validator(mode='before')
     def _initial_validation(cls, values):

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -402,7 +402,7 @@ instances:
     ## Configure collection of schemas (databases).
     ## Only tables and schemas for which the user has been granted SELECT privileges are collected.
     #
-    # schemas_collection:
+    # collect_schemas:
 
         ## @param enabled - boolean - optional - default: false
         ## Enable schema collection. Requires `dbm: true`. Defaults to false.
@@ -416,7 +416,7 @@ instances:
 
         ## @param max_execution_time - number - optional - default: 60
         ## Set the maximum time for schema collection (in seconds). Defaults to 60 seconds.
-        ## Capped by `schemas_collection.collection_interval`
+        ## Capped by `collect_schemas.collection_interval`
         #
         # max_execution_time: 60
 

--- a/mysql/tests/test_metadata.py
+++ b/mysql/tests/test_metadata.py
@@ -712,3 +712,18 @@ def test_schemas_collection_truncated(aggregator, dd_run_check, dbm_instance):
             ):
                 found = True
     assert found
+
+
+@pytest.mark.unit
+def test_schemas_collection_config(dbm_instance):
+    check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
+    assert check.config.schema_config == {}
+
+    dbm_instance['schemas_collection'] = {"enabled": True, "max_execution_time": 0}
+    check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
+    assert check._config.schema_config == {"enabled": True, "max_execution_time": 0}
+
+    dbm_instance.pop('schemas_collection')
+    dbm_instance['collect_schemas'] = {"enabled": True, "max_execution_time": 0}
+    check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
+    assert check._config.schema_config == {"enabled": True, "max_execution_time": 0}

--- a/mysql/tests/test_metadata.py
+++ b/mysql/tests/test_metadata.py
@@ -716,9 +716,6 @@ def test_schemas_collection_truncated(aggregator, dd_run_check, dbm_instance):
 
 @pytest.mark.unit
 def test_schemas_collection_config(dbm_instance):
-    check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
-    assert check.config.schema_config == {}
-
     dbm_instance['schemas_collection'] = {"enabled": True, "max_execution_time": 0}
     check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
     assert check._config.schema_config == {"enabled": True, "max_execution_time": 0}

--- a/mysql/tests/test_metadata.py
+++ b/mysql/tests/test_metadata.py
@@ -718,9 +718,9 @@ def test_schemas_collection_truncated(aggregator, dd_run_check, dbm_instance):
 def test_schemas_collection_config(dbm_instance):
     dbm_instance['schemas_collection'] = {"enabled": True, "max_execution_time": 0}
     check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
-    assert check._config.schema_config == {"enabled": True, "max_execution_time": 0}
+    assert check._config.schemas_config == {"enabled": True, "max_execution_time": 0}
 
     dbm_instance.pop('schemas_collection')
     dbm_instance['collect_schemas'] = {"enabled": True, "max_execution_time": 0}
     check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
-    assert check._config.schema_config == {"enabled": True, "max_execution_time": 0}
+    assert check._config.schemas_config == {"enabled": True, "max_execution_time": 0}


### PR DESCRIPTION
### What does this PR do?
Add new `collect_schemas` configuration options to replace deprecated `schemas_collection` options while maintaining backward compatibility.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
