### PR TITLE
Cast pg_extension id to text

### DIFF
--- a/postgres/changelog.d/20605.fixed
+++ b/postgres/changelog.d/20605.fixed
@@ -1,0 +1,1 @@
+Ensure extension IDs are sent as text, not integer

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -35,7 +35,7 @@ DEFAULT_SETTINGS_IGNORED_PATTERNS = ["plpgsql%"]
 # spective catalog tables.
 PG_EXTENSION_INFO_QUERY = """
 SELECT
-e.oid AS id,
+e.oid::text AS id,
 e.extname AS name,
 r.rolname AS owner,
 ns.nspname AS schema_name,

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -45,6 +45,7 @@ def test_collect_extensions(integration_check, dbm_instance, aggregator):
     assert event['kind'] == "pg_extension"
     assert len(event["metadata"]) > 0
     assert set(event["metadata"][0].keys()) == {'id', 'name', 'owner', 'relocatable', 'schema_name', 'version'}
+    assert type(event["metadata"][0]["id"]) is str
     assert next((k for k in event['metadata'] if k['name'].startswith('plpgsql')), None) is not None
 
 


### PR DESCRIPTION
Metadata processor expects it this way.

### What does this PR do?
Changes the type used by the agent to submit extension ids.

### Motivation
Logs such as [these](https://ddstaging.datadoghq.com/logs?query=service%3Adbm-metadata-redapl-writer%20pg_extension&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1750965568564&to_ts=1751051968564&live=true) showed that the metadata processor was failing to deserialize this field.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
