### PR TITLE
[DSM][Kafka][RabbitMQ] - Add the dsm map to OOTB dashboards

### DIFF
--- a/kafka/assets/dashboards/kafka_dashboard.json
+++ b/kafka/assets/dashboards/kafka_dashboard.json
@@ -867,7 +867,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -908,7 +907,7 @@
             "id": 8236156193990667,
             "definition": {
               "type": "note",
-              "content": "Get insights into your topics' producers and consumers, including anomaly detection by instrumenting with Data Streams Monitoring. [Learn more](https://docs.datadoghq.com/data_streams/setup/technologies/kafka/?referrer=kafka)",
+              "content": "Get insights into your topics' producers and consumers, including anomaly detection by instrumenting with Data Streams Monitoring. [Learn more](https://docs.datadoghq.com/data_streams/setup/technologies/kafka/?referrer=kafka)\n\nAssign the **topic** variable to view insights about a specific topic",
               "background_color": "purple",
               "font_size": "14",
               "text_align": "center",
@@ -921,6 +920,27 @@
             "layout": { "x": 0, "y": 0, "width": 12, "height": 1 }
           },
           {
+            "id": 3148501078668227,
+            "definition": {
+              "title": "Kafka Topology for $topic, $env",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "topology_map",
+              "requests": [
+                {
+                  "request_type": "topology",
+                  "query": {
+                    "filters": ["$env"],
+                    "service": "",
+                    "data_source": "data_streams",
+                    "query_string": "traffic_type:kafka queue:$topic.value"
+                  }
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 1, "width": 6, "height": 6 }
+          },
+          {
             "id": 2184446562382655,
             "definition": {
               "title": "Top 10 Max Kafka Lag by env",
@@ -929,7 +949,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -958,7 +977,7 @@
                 }
               ]
             },
-            "layout": { "x": 0, "y": 1, "width": 12, "height": 4 }
+            "layout": { "x": 6, "y": 1, "width": 6, "height": 6 }
           },
           {
             "id": 1870414104649433,
@@ -1008,7 +1027,7 @@
                 }
               ]
             },
-            "layout": { "x": 0, "y": 5, "width": 6, "height": 2 }
+            "layout": { "x": 0, "y": 7, "width": 6, "height": 2 }
           },
           {
             "id": 944656656985134,
@@ -1058,7 +1077,7 @@
                 }
               ]
             },
-            "layout": { "x": 6, "y": 5, "width": 6, "height": 2 }
+            "layout": { "x": 6, "y": 7, "width": 6, "height": 2 }
           },
           {
             "id": 6058441691900230,
@@ -1069,7 +1088,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -1106,7 +1124,7 @@
                 }
               ]
             },
-            "layout": { "x": 0, "y": 7, "width": 6, "height": 2 }
+            "layout": { "x": 0, "y": 9, "width": 6, "height": 2 }
           },
           {
             "id": 3284852106159467,
@@ -1115,7 +1133,6 @@
               "title_size": "16",
               "title_align": "left",
               "show_legend": true,
-              "time": {},
               "type": "distribution",
               "xaxis": {
                 "scale": "linear",
@@ -1147,11 +1164,11 @@
                 }
               ]
             },
-            "layout": { "x": 6, "y": 7, "width": 6, "height": 2 }
+            "layout": { "x": 6, "y": 9, "width": 6, "height": 2 }
           }
         ]
       },
-      "layout": { "x": 0, "y": 18, "width": 12, "height": 10 }
+      "layout": { "x": 0, "y": 18, "width": 12, "height": 12 }
     },
     {
       "id": 6693725981895002,
@@ -1368,7 +1385,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 28,
+        "y": 30,
         "width": 12,
         "height": 6,
         "is_column_break": true
@@ -1408,7 +1425,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -1449,7 +1465,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -1483,7 +1498,7 @@
           }
         ]
       },
-      "layout": { "x": 0, "y": 34, "width": 12, "height": 5 }
+      "layout": { "x": 0, "y": 36, "width": 12, "height": 5 }
     },
     {
       "id": 8466685701903458,
@@ -1584,7 +1599,7 @@
           }
         ]
       },
-      "layout": { "x": 0, "y": 39, "width": 12, "height": 6 }
+      "layout": { "x": 0, "y": 41, "width": 12, "height": 6 }
     }
   ],
   "template_variables": [

--- a/rabbitmq/assets/dashboards/rabbitmq_dashboard.json
+++ b/rabbitmq/assets/dashboards/rabbitmq_dashboard.json
@@ -192,7 +192,6 @@
               "show_legend": false,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -241,7 +240,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -275,7 +273,6 @@
               "show_legend": true,
               "legend_layout": "horizontal",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -363,7 +360,6 @@
               "show_legend": false,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -412,7 +408,6 @@
               "show_legend": false,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -534,7 +529,6 @@
               "show_legend": false,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -612,7 +606,6 @@
               "show_legend": true,
               "legend_layout": "horizontal",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -757,7 +750,6 @@
               "title": "Packets in a Connection",
               "title_size": "16",
               "title_align": "left",
-              "time": {},
               "requests": [
                 {
                   "response_format": "scalar",
@@ -824,7 +816,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -864,7 +855,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -904,7 +894,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -944,7 +933,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -984,7 +972,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -1024,7 +1011,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -1064,7 +1050,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -1104,7 +1089,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -1144,7 +1128,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -1192,6 +1175,27 @@
             "layout": { "x": 0, "y": 15, "width": 12, "height": 1 }
           },
           {
+            "id": 3489646968696908,
+            "definition": {
+              "title": "RabbitMQ Topology for $queue",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "topology_map",
+              "requests": [
+                {
+                  "request_type": "topology",
+                  "query": {
+                    "filters": [],
+                    "service": "",
+                    "data_source": "data_streams",
+                    "query_string": "traffic_type:rabbitmq $queue"
+                  }
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 16, "width": 6, "height": 6 }
+          },
+          {
             "id": 5864725959970603,
             "definition": {
               "title": "Top 10 Max Time in Queue by env",
@@ -1200,7 +1204,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -1234,7 +1237,7 @@
                 }
               ]
             },
-            "layout": { "x": 0, "y": 16, "width": 12, "height": 3 }
+            "layout": { "x": 6, "y": 16, "width": 6, "height": 6 }
           },
           {
             "id": 5210683934287696,
@@ -1245,7 +1248,6 @@
               "show_legend": false,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -1285,7 +1287,7 @@
                 }
               ]
             },
-            "layout": { "x": 0, "y": 19, "width": 6, "height": 3 }
+            "layout": { "x": 0, "y": 22, "width": 6, "height": 3 }
           },
           {
             "id": 5255514887441810,
@@ -1296,7 +1298,6 @@
               "show_legend": false,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -1336,7 +1337,7 @@
                 }
               ]
             },
-            "layout": { "x": 6, "y": 19, "width": 6, "height": 3 }
+            "layout": { "x": 6, "y": 22, "width": 6, "height": 3 }
           },
           {
             "id": 2382382132630298,
@@ -1347,7 +1348,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -1384,7 +1384,7 @@
                 }
               ]
             },
-            "layout": { "x": 0, "y": 22, "width": 6, "height": 2 }
+            "layout": { "x": 0, "y": 25, "width": 6, "height": 2 }
           },
           {
             "id": 4910867072087173,
@@ -1393,7 +1393,6 @@
               "title_size": "16",
               "title_align": "left",
               "show_legend": true,
-              "time": {},
               "type": "distribution",
               "xaxis": {
                 "scale": "linear",
@@ -1425,11 +1424,11 @@
                 }
               ]
             },
-            "layout": { "x": 6, "y": 22, "width": 6, "height": 2 }
+            "layout": { "x": 6, "y": 25, "width": 6, "height": 2 }
           }
         ]
       },
-      "layout": { "x": 0, "y": 24, "width": 12, "height": 25 }
+      "layout": { "x": 0, "y": 24, "width": 12, "height": 28 }
     },
     {
       "id": 3412626217094282,
@@ -1484,7 +1483,7 @@
                           "should_exclude_missing": true
                         }
                       ],
-                      "storage": "online_archives"
+                      "storage": "flex_tier"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1529,7 +1528,7 @@
           }
         ]
       },
-      "layout": { "x": 0, "y": 49, "width": 12, "height": 6 }
+      "layout": { "x": 0, "y": 52, "width": 12, "height": 6 }
     }
   ],
   "template_variables": [

--- a/rabbitmq/assets/dashboards/rabbitmq_screenboard_dashboard.json
+++ b/rabbitmq/assets/dashboards/rabbitmq_screenboard_dashboard.json
@@ -397,7 +397,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -460,7 +459,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -500,7 +498,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -540,7 +537,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -580,7 +576,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -620,7 +615,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -738,7 +732,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -778,7 +771,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -818,7 +810,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -858,7 +849,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -906,6 +896,27 @@
             "layout": { "x": 0, "y": 20, "width": 12, "height": 1 }
           },
           {
+            "id": 6240500969948076,
+            "definition": {
+              "title": "RabbitMQ Topology for $rabbitmq_queue",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "topology_map",
+              "requests": [
+                {
+                  "request_type": "topology",
+                  "query": {
+                    "filters": [],
+                    "service": "",
+                    "data_source": "data_streams",
+                    "query_string": "traffic_type:rabbitmq queue:$rabbitmq_queue.value"
+                  }
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 21, "width": 6, "height": 7 }
+          },
+          {
             "id": 1004918787475990,
             "definition": {
               "title": "Top 10 Max Time in Queue by env",
@@ -914,7 +925,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -948,7 +958,7 @@
                 }
               ]
             },
-            "layout": { "x": 0, "y": 21, "width": 12, "height": 3 }
+            "layout": { "x": 6, "y": 21, "width": 6, "height": 7 }
           },
           {
             "id": 4857249869480403,
@@ -959,7 +969,6 @@
               "show_legend": false,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -999,7 +1008,7 @@
                 }
               ]
             },
-            "layout": { "x": 0, "y": 24, "width": 6, "height": 3 }
+            "layout": { "x": 0, "y": 28, "width": 6, "height": 3 }
           },
           {
             "id": 4843650565249063,
@@ -1010,7 +1019,6 @@
               "show_legend": false,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -1050,7 +1058,7 @@
                 }
               ]
             },
-            "layout": { "x": 6, "y": 24, "width": 6, "height": 3 }
+            "layout": { "x": 6, "y": 28, "width": 6, "height": 3 }
           },
           {
             "id": 5940920806415761,
@@ -1061,7 +1069,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -1098,7 +1105,7 @@
                 }
               ]
             },
-            "layout": { "x": 0, "y": 27, "width": 6, "height": 2 }
+            "layout": { "x": 0, "y": 31, "width": 6, "height": 2 }
           },
           {
             "id": 8291016456385819,
@@ -1107,7 +1114,6 @@
               "title_size": "16",
               "title_align": "left",
               "show_legend": true,
-              "time": {},
               "type": "distribution",
               "xaxis": {
                 "scale": "linear",
@@ -1139,11 +1145,11 @@
                 }
               ]
             },
-            "layout": { "x": 6, "y": 27, "width": 6, "height": 2 }
+            "layout": { "x": 6, "y": 31, "width": 6, "height": 2 }
           }
         ]
       },
-      "layout": { "x": 0, "y": 17, "width": 12, "height": 30 }
+      "layout": { "x": 0, "y": 17, "width": 12, "height": 34 }
     },
     {
       "id": 5826491008040891,
@@ -1179,7 +1185,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -1219,7 +1224,6 @@
               "show_legend": true,
               "legend_layout": "auto",
               "legend_columns": ["avg", "min", "max", "value", "sum"],
-              "time": {},
               "type": "timeseries",
               "requests": [
                 {
@@ -1252,7 +1256,7 @@
           }
         ]
       },
-      "layout": { "x": 0, "y": 47, "width": 12, "height": 5 }
+      "layout": { "x": 0, "y": 51, "width": 12, "height": 5 }
     }
   ],
   "template_variables": [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds the DSM map to the kafka and rabbitmq ootb dashboards

Example dashboards of the changes made

- [Rabbitmq management](https://app.datadoghq.com/dashboard/de4-5kb-m62?fromUser=false&refresh_mode=sliding&from_ts=1751299225819&to_ts=1751302825819&live=true)
- [Rabbitmq open metrics](https://app.datadoghq.com/dashboard/c86-zwv-fxt?fromUser=false&refresh_mode=sliding&from_ts=1751299236023&to_ts=1751302836023&live=true)
- [Kafka](https://app.datadoghq.com/dashboard/7wg-48i-ir7?fromUser=false&refresh_mode=sliding&from_ts=1751298414774&to_ts=1751302014774&live=true)

Example change (they all add the map next to the lag/time in queue graph)
![image](https://github.com/user-attachments/assets/e0dcf138-a8b5-49f3-b17c-c3eb49c80331)

### Motivation
<!-- What inspired you to submit this pull request? -->

Improved display of topology for customers that have DSM, adding visibility for DSM on ootb dashboards

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
