### PR TITLE
Fix WithHttpCodeClass to maintain scraper inner state

### DIFF
--- a/datadog_checks_base/changelog.d/20640.fixed
+++ b/datadog_checks_base/changelog.d/20640.fixed
@@ -1,0 +1,1 @@
+Fix WithHttpCodeClass decorator not keeping track of internal state of the scraper

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper/decorators.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper/decorators.py
@@ -27,7 +27,10 @@ class WithHttpCodeClass(OpenMetricsScraper):
     def __init__(self, scraper: OpenMetricsScraper, http_status_tag: str):
         self.scraper = scraper
         self.http_status_tag = http_status_tag
-        super().__init__(scraper.check, scraper.config)
+        self.decorated_methods = {"yield_metrics": self.yield_metrics}
+
+    def __getattr__(self, name: str) -> Any:
+        return self.decorated_methods.get(name, getattr(self.scraper, name))
 
     def _add_http_code_class(self, metric: Metric, http_status_tag: str) -> Metric:
         for sample in metric.samples:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix an issue by which the decorator to add http code class tag to OpenMetrics metric would fail to keep the inner state responsible for managing shared tags.

### Motivation
<!-- What inspired you to submit this pull request? -->
The OpenMetrics scraper maintains an internal state between executions that allows keeping tags to be added to metrics based on previous scrapes. The decorator failed to replicate this behavior because the instance variables used within the `scrape` method are different from the ones populated while `yield_metrics` is called in the decorated scraper.

The fix avoids instantiating all variables in the decorator instance and instead returns the inner scraper attributes except for the methods tat wer are overriding.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
