### PR TITLE
Attempt to fix flaky Harbor E2E setup

### DIFF
--- a/harbor/tests/conftest.py
+++ b/harbor/tests/conftest.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
-import time
 
 import pytest
 import requests
@@ -49,8 +48,7 @@ def dd_environment(e2e_instance):
     expected_log = "http server Running on" if HARBOR_VERSION < [1, 10, 0] else "API server is serving at"
     conditions = [
         CheckDockerLogs(compose_file, expected_log, wait=3),
-        lambda: time.sleep(4),
-        WaitFor(create_simple_user),
+        WaitFor(create_simple_user, wait=3),
     ]
     with docker_run(compose_file, conditions=conditions, attempts=5):
         yield e2e_instance


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The Harbor E2E tests failed [recently](https://github.com/DataDog/integrations-core/actions/runs/16020744131/job/45196949202) with the following error:
```
E           datadog_checks.dev.errors.RetryError: Result: None
E           Error: HTTPConnectionPool(host='localhost', port=80): Max retries exceeded with url: /api/v2.0/users/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7ff4b4ff1f70>: Failed to establish a new connection: [Errno 111] Connection refused'))
E           Function: create_simple_user, Args: (), Kwargs: {}
```

This PR tries to address that issue by increasing the wait time giving more time for the harbor users endpoint to be healthy.

### Motivation
<!-- What inspired you to submit this pull request? -->

Failing job: https://github.com/DataDog/integrations-core/actions/runs/16020744131/job/45196949202

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
