### PR TITLE
[DBMON-5494] Change binlog enabled query to a lightweight lockless check

### DIFF
--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -52,6 +52,9 @@ SELECT engine
 FROM information_schema.ENGINES
 WHERE engine='InnoDB' and support != 'no' and support != 'disabled'"""
 
+SQL_BINLOG_ENABLED = """\
+SELECT @@log_bin AS binlog_enabled"""
+
 SQL_SERVER_UUID = """\
 SELECT @@server_uuid"""
 
@@ -253,13 +256,6 @@ def show_replica_status_query(version, is_mariadb, channel=''):
         return "{0} FOR CHANNEL '{1}';".format(base_query, channel)
     else:
         return "{0};".format(base_query)
-
-
-def show_primary_replication_status_query(version, is_mariadb):
-    if not is_mariadb and version.version_compatible((8, 4, 0)):
-        return "SHOW BINARY LOG STATUS;"
-    else:
-        return "SHOW MASTER STATUS;"
 
 
 def get_indexes_query(version, is_mariadb, table_names):


### PR DESCRIPTION
### What does this PR do?
Currently to determine if the binlog is enabled we’re querying `SHOW BINARY LOG STATUS` on mysql 8.4 and `SHOW MASTER STATUS` on older versions and MariaDB. These commands require acquiring a `LOCK_log` mutex for accessing current binlog file information. Under certain scenarios such as binlog file rotation, binlog purging, or a transaction holding onto a `LOCK_log` during the commit phase it's possible the query can get deadlocked causing the agent integration to choke and stop emitting metrics until manual intervention of killing the datadog query or restarting the integration.

This is an expensive query to make that we don't use any data from. Since we only issue it and mark replication as enabled if a row is returned we can switch to querying for [log_bin](https://dev.mysql.com/doc/refman/8.4/en/replication-options-binary-log.html#sysvar_log_bin) global variable which is a lighter weight in memory variable that notes if binary logging is on or off. The new query will remove any risk of lock contention for this check and simplifies logic as it exists across mysql versions and flavors.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
