### PR TITLE
Replace `patch_all` with modern config option `ddtrace.auto`

### DIFF
--- a/datadog_checks_base/changelog.d/20651.fixed
+++ b/datadog_checks_base/changelog.d/20651.fixed
@@ -1,0 +1,1 @@
+Replace patch_all with modern config ddtrace.auto

--- a/datadog_checks_base/datadog_checks/base/utils/tracing.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tracing.py
@@ -123,9 +123,9 @@ def traced_class(cls):
         try:
             integration_tracing_exhaustive = is_affirmative(datadog_agent.get_config('integration_tracing_exhaustive'))
 
-            from ddtrace import patch_all, tracer
-
-            patch_all()
+            # https://ddtrace.readthedocs.io/en/stable/basic_usage.html#ddtrace-auto
+            import ddtrace.auto  # noqa: F401
+            from ddtrace import tracer
 
             def decorate(cls):
                 for attr in cls.__dict__:

--- a/datadog_checks_base/tests/base/utils/db/test_db_statements.py
+++ b/datadog_checks_base/tests/base/utils/db/test_db_statements.py
@@ -278,7 +278,7 @@ class TestStatementMetrics:
         This test is skipped if tracemalloc is not available
         '''
         # The memory usage threshold takes tracing overhead into account
-        MEMORY_USAGE_THRESHOLD = 10 * 1024 * 1024  # 8 MB
+        MEMORY_USAGE_THRESHOLD = 10 * 1024 * 1024  # 10 MB
 
         try:
             import tracemalloc

--- a/datadog_checks_base/tests/base/utils/db/test_db_statements.py
+++ b/datadog_checks_base/tests/base/utils/db/test_db_statements.py
@@ -278,7 +278,7 @@ class TestStatementMetrics:
         This test is skipped if tracemalloc is not available
         '''
         # The memory usage threshold takes tracing overhead into account
-        MEMORY_USAGE_THRESHOLD = 8 * 1024 * 1024  # 8 MB
+        MEMORY_USAGE_THRESHOLD = 10 * 1024 * 1024  # 8 MB
 
         try:
             import tracemalloc


### PR DESCRIPTION
### What does this PR do?

Getting the following warning:

```
/home/runner/.local/share/hatch/env/virtual/datadog-ibm-mq/4jzrwvHc/py3.12-9/lib/python3.12/site-packages/ddtrace/_monkey.py:325: DDTraceDeprecationWarning: patch_all is deprecated and will be removed in a future version of the tracer.: patch_all is deprecated in favor of ``import ddtrace.auto`` and ``DD_PATCH_MODULES``
          environment variable if needed.
    deprecate(
```

https://ddtrace.readthedocs.io/en/stable/basic_usage.html#ddtrace-auto