### PR TITLE
Add ddev udpate notice for lint failures

### DIFF
--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -190,7 +190,12 @@ jobs:
         ddev config set repo ${{ inputs.repo }}
 
     - name: Lint
-      run: ddev test --lint ${{ inputs.target }}
+      run: |
+        ddev test --lint ${{ inputs.target }} || {
+          echo "::error::Lint failed! ddev has been updated to version 12.0.0."
+          echo "::error::Please update to the latest version of ddev and then run 'ddev test --fmt ${{ inputs.target }}' to fix formatting issues."
+          exit 1
+        }
 
     - name: Prepare for testing
       env: >-


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update the lint workflow step to show instructions including the update to `ddev-12.0.0`.

<img width="902" alt="image" src="https://github.com/user-attachments/assets/31cd1886-654a-4fcf-95b8-52c18ea6cfb3" />

**Note**: I am not updating anything in velero, just used that integration as a test :)

### Motivation
<!-- What inspired you to submit this pull request? -->
Some partners might see CI failing  in linting and if they do not upgrade to the latest version of `ddev` they won't be able to fix it. This will give them the tools to handle the update on their own.

Eventually we should be able to remove the message.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
