### PR TITLE
AGENT-14107 - update metrics.py

### DIFF
--- a/external_dns/datadog_checks/external_dns/metrics.py
+++ b/external_dns/datadog_checks/external_dns/metrics.py
@@ -4,7 +4,7 @@
 DEFAULT_METRICS = {
     'external_dns_registry_endpoints_total': 'registry.endpoints.total',
     'external_dns_source_endpoints_total': 'source.endpoints.total',
-    'source_errors_total': 'source.errors.total',
-    'registry_errors_total': 'registry.errors.total',
+    'external_dns_source_errors_total': 'source.errors.total',
+    'external_dns_registry_errors_total': 'registry.errors.total',
     'external_dns_controller_last_sync_timestamp_seconds': 'controller.last_sync',
 }


### PR DESCRIPTION
### What does this PR do?
Updates metric.py to keep the standard metric name for `source.errors.total` and `registry.errors.total`

### Motivation
https://datadoghq.atlassian.net/browse/AGENT-14107

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
