### PR TITLE
add a periodic upgrade check for ddev

### DIFF
--- a/ddev/src/ddev/cli/__init__.py
+++ b/ddev/src/ddev/cli/__init__.py
@@ -9,6 +9,7 @@ from datadog_checks.dev.tooling.commands.create import create
 from datadog_checks.dev.tooling.commands.run import run
 
 from ddev._version import __version__
+from ddev.cli import upgrade_check
 from ddev.cli.application import Application
 from ddev.cli.ci import ci
 from ddev.cli.clean import clean
@@ -129,6 +130,12 @@ def ddev(
         app.config_file.load()
     except OSError as e:  # no cov
         app.abort(f'Error loading configuration: {e}')
+    if app.config.upgrade_check:
+        upgrade_check.upgrade_check(app, __version__)
+
+    if not ctx.invoked_subcommand:
+        app.display_info(ctx.get_help(), highlight=False)
+        return
 
     app.config.terminal.styles.parse_fields()
     errors = app.initialize_styles(app.config.terminal.styles.raw_data)

--- a/ddev/src/ddev/cli/upgrade_check.py
+++ b/ddev/src/ddev/cli/upgrade_check.py
@@ -1,0 +1,64 @@
+import atexit
+import json
+import logging
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import requests
+from packaging.version import InvalidVersion, Version
+
+PACKAGE_NAME = 'ddev'
+CACHE_FILE = Path.home() / ".cache" / "ddev" / "upgrade_check.json"
+PYPI_URL = "https://pypi.org/pypi/ddev/json"
+CHECK_INTERVAL = timedelta(days=7)
+
+
+def read_last_run():
+    # Read the last run from the cache file and return a version and a date.
+    # Format: {"version": "1.6.0", "date": "2023-04-11T10:56:39.786412"}
+    try:
+        with open(CACHE_FILE, "r") as f:
+            data = json.load(f)
+            return Version(data["version"]), datetime.fromisoformat(data["date"])
+    except (FileNotFoundError, json.JSONDecodeError, KeyError, InvalidVersion):
+        return None, None
+
+
+def write_last_run(version, date):
+    # Records/overwrites the run in the cache file. If the file isn't there, it will be created
+    CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(CACHE_FILE, "w") as f:
+        json.dump({"version": str(version), "date": date.isoformat()}, f)
+
+
+def exit_handler(app, msg):
+    return app.display_info(msg, highlight=False)
+
+
+def upgrade_check(app, version, cache_file=CACHE_FILE, pypi_url=PYPI_URL, check_interval=CHECK_INTERVAL):
+    current_version = Version(version)
+    last_version, last_date = read_last_run()
+    date_now = datetime.now()
+
+    # If cache does not exist or is older than check_interval, fetch from PyPI
+    if not last_version or not last_date or (date_now - last_date >= check_interval):
+        try:
+            resp = requests.get(pypi_url, timeout=5)
+            resp.raise_for_status()
+            latest_version = Version(resp.json()["info"]["version"])
+            write_last_run(latest_version, date_now)
+            if latest_version > current_version:
+                msg = (
+                    f'\n!!An upgrade to version {latest_version} is available for {PACKAGE_NAME}. '
+                    f'Your current version is {current_version}!!'
+                )
+                atexit.register(exit_handler, app, msg)
+        except requests.RequestException as e:
+            logging.debug(f"Upgrade check failed: {e}")
+    else:
+        if last_version > current_version:
+            msg = (
+                f'\n!!An upgrade to version {last_version} is available for {PACKAGE_NAME}. '
+                f'Your current version is {current_version}!!'
+            )
+            atexit.register(exit_handler, app, msg)

--- a/ddev/src/ddev/config/model.py
+++ b/ddev/src/ddev/config/model.py
@@ -71,6 +71,31 @@ class RootConfig(LazilyParsedConfig):
         self._field_pypi = FIELD_TO_PARSE
         self._field_trello = FIELD_TO_PARSE
         self._field_terminal = FIELD_TO_PARSE
+        self._field_upgrade_check = FIELD_TO_PARSE
+
+    @property
+    def upgrade_check(self):
+        if self._field_upgrade_check is FIELD_TO_PARSE:
+            raw_update = self.raw_data.get('upgrade_check', True)
+            if isinstance(raw_update, bool):
+                upgrade_check = raw_update
+            elif isinstance(raw_update, str):
+                if raw_update.lower() == 'true':
+                    upgrade_check = True
+                elif raw_update.lower() == 'false':
+                    upgrade_check = False
+                else:
+                    raise ValueError(f'Invalid value for upgrade_check, it must be True or False: {raw_update}')
+
+            else:
+                raise TypeError(f'Invalid value for upgrade_check, it must be True or False: {type(raw_update)}')
+            self._field_upgrade_check = upgrade_check
+        return self._field_upgrade_check
+
+    @upgrade_check.setter
+    def upgrade_check(self, value):
+        self.raw_data['upgrade_check'] = value
+        self._field_upgrade_check = FIELD_TO_PARSE
 
     @property
     def repo(self):


### PR DESCRIPTION
### What does this PR do?
Periodically check pypi for new versions of ddev. 

Config is on by default. But can be controlled with upgrade_check in the config toml file. It keeps track of this in a json file cache file. It saves the version and the date. 

Logic goes:

1. See if file exist or if the last time it checked was 7 days ago or older
2a. If file doesn't exist or is older than 7 days, ping pypi to get latest version and right it to file
2b. if file exist and is not older than 7 days, read from the json file
3 If current version is older than the checked latest version, print out a message after every ddev command

Example:
```
ddev test ddev -fs
────────────────────────────────────────────────────────────────────────────────────────────────────────────────── ddev ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────
────────────────────────────────────────────────────────────────────────────────────────────────────────────────── lint ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────
cmd [1] | ruff format  --config ./pyproject.toml .
2 files reformatted, 225 files left unchanged
cmd [2] | ruff check --fix --config ./pyproject.toml .
src/ddev/cli/upgrade_check.py:57:27: G004 Logging statement uses f-string
   |
55 |                 atexit.register(exit_handler, app, msg)
56 |         except requests.RequestException as e:
57 |             logging.debug(f"Upgrade check failed: {e}")
   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ G004
58 |     else:
59 |         if last_version < current_version:
   |

Found 2 errors (1 fixed, 1 remaining).
Some formatting errors are still found for which ruff has no fixes available. You would need to fix them manually.

!!An upgrade to version 12.0.0 is available for ddev. Your current version is 11.0.1.dev20!!
```


