### PR TITLE
Downgrade windows runners to 2022 from 2025

### DIFF
--- a/.ddev/config.toml
+++ b/.ddev/config.toml
@@ -42,7 +42,7 @@ platforms = ["linux", "windows"]
 
 [overrides.ci.sqlserver]
 platforms = ["windows", "linux"]
-runners = { windows = ["windows-2025"] }
+runners = { windows = ["windows-2022"] }
 
 [overrides.ci.tcp_check]
 platforms = ["linux", "windows"]

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -3560,7 +3560,7 @@ jobs:
       job-name: SQL Server on Windows
       target: sqlserver
       platform: windows
-      runner: '["windows-2025"]'
+      runner: '["windows-2022"]'
       repo: "${{ inputs.repo }}"
       python-version: "${{ inputs.python-version }}"
       standard: ${{ inputs.standard }}

--- a/docs/developer/meta/ci/testing.md
+++ b/docs/developer/meta/ci/testing.md
@@ -130,7 +130,7 @@ To override the runners for each platform, one can set the `overrides.ci.<TARGET
 
 ```toml
 [overrides.ci.sqlserver]
-runners = { windows = ["windows-2025"] }
+runners = { windows = ["windows-2022"] }
 ```
 
 ### Exclusion


### PR DESCRIPTION
### What does this PR do?
Windows Runner 2025 seem to be having issues with some tests. Downgrading it to 2022 to see if CI does any better.