### PR TITLE
Temporarily handle new wheel build number format

### DIFF
--- a/.builders/lock.py
+++ b/.builders/lock.py
@@ -109,6 +109,11 @@ def generate_lock_file(
                 if not is_compatible_wheel(target, python_major, interpreter, abi, platform):
                     continue
 
+                if build and 'WID' in build:
+                    # TODO: we're skipping any wheels with WID in them until we merge
+                    # the final changes to use this format
+                    continue
+
                 build_number = int(build[0]) if build else -1
                 candidates[build_number] = blob
 


### PR DESCRIPTION
### What does this PR do?
We are currently modifying the dependency resolution process to create wheels with a new build number format which includes the workflow ID and the string 'WID' to distinguish this new format from the old one (timestamp): https://datadoghq.atlassian.net/browse/AI-5425

However, when we push the branch to make this update, the pipeline will start uploading wheels with this new format, which the current pipeline can't handle (we cast the build number to int). This PR is a temporary fix to make the pipeline pass in the time between us pushing the branch for the refactor, and merging that branch.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
