### PR TITLE
Fix collection of source and registry error metrics

### DIFF
--- a/external_dns/changelog.d/20682.fixed
+++ b/external_dns/changelog.d/20682.fixed
@@ -1,0 +1,1 @@
+fix collection of source and registry error metrics

--- a/external_dns/datadog_checks/external_dns/metrics.py
+++ b/external_dns/datadog_checks/external_dns/metrics.py
@@ -4,6 +4,8 @@
 DEFAULT_METRICS = {
     'external_dns_registry_endpoints_total': 'registry.endpoints.total',
     'external_dns_source_endpoints_total': 'source.endpoints.total',
+    'external_dns_source_errors_total': 'source.errors.total',
+    'external_dns_registry_errors_total': 'registry.errors.total',
     'source_errors_total': 'source.errors.total',
     'registry_errors_total': 'registry.errors.total',
     'external_dns_controller_last_sync_timestamp_seconds': 'controller.last_sync',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes the collection of the `external_dns.registry.errors.total` and `external_dns.source.errors.total` metrics as the payload changed after External DNS v0.14.x

### Motivation
<!-- What inspired you to submit this pull request? -->
https://datadoghq.atlassian.net/browse/AGENT-14107

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
