### PR TITLE
[MINPROC-2319] remove the integration exception mapper

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
@@ -235,9 +235,7 @@ def create(ctx, name, integration_type, location, non_interactive, quiet, dry_ru
             # Fill in all common non Marketplace fields
             template_fields['pricing_plan'] = ''
             if repo_choice in ['core', 'integrations-internal-core']:
-                template_fields[
-                    'author_info'
-                ] = """
+                template_fields['author_info'] = """
   "author": {
     "support_email": "help@datadoghq.com",
     "name": "Datadog",
@@ -247,9 +245,7 @@ def create(ctx, name, integration_type, location, non_interactive, quiet, dry_ru
             else:
                 prompt_and_update_if_missing(template_fields, 'email', 'Email used for support requests')
                 prompt_and_update_if_missing(template_fields, 'author', 'Your name')
-                template_fields[
-                    'author_info'
-                ] = f"""
+                template_fields['author_info'] = f"""
   "author": {{
     "support_email": "{template_fields['email']}",
     "name": "{template_fields['author']}",

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/validator.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/validator.py
@@ -271,9 +271,7 @@ class TableColumnHasTagValidator(ProfileValidator):
                     if not all_metric_tags_are_valid:
                         self.fail(
                             "metric_tables defined in lines {} are not valid. \
-                        \nmetric_tags must have 'column' or 'index' value".format(
-                                lines
-                            )
+                        \nmetric_tags must have 'column' or 'index' value".format(lines)
                         )
 
         if not self.result.failed:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -171,7 +171,13 @@ def initialize_root(config, agent=False, core=False, extras=False, marketplace=F
     repo_choice = (
         'core'
         if core
-        else 'extras' if extras else 'agent' if agent else 'marketplace' if marketplace else config.get('repo', 'core')
+        else 'extras'
+        if extras
+        else 'agent'
+        if agent
+        else 'marketplace'
+        if marketplace
+        else config.get('repo', 'core')
     )
     config['repo_choice'] = repo_choice
     message = None
@@ -183,7 +189,9 @@ def initialize_root(config, agent=False, core=False, extras=False, marketplace=F
             repo = (
                 'datadog-agent'
                 if repo_choice == 'agent'
-                else 'marketplace' if repo_choice == 'marketplace' else f'integrations-{repo_choice}'
+                else 'marketplace'
+                if repo_choice == 'marketplace'
+                else f'integrations-{repo_choice}'
             )
             message = f'`{repo}` directory `{root}` does not exist, defaulting to the current location.'
 

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
@@ -867,9 +867,7 @@ def test_section_description_length_limit():
               description: words
               value:
                 type: string
-        """.format(
-            'a' * DESCRIPTION_LINE_LENGTH_LIMIT
-        )
+        """.format('a' * DESCRIPTION_LINE_LENGTH_LIMIT)
     )
 
     files = consumer.render()
@@ -890,9 +888,7 @@ def test_option_description_length_limit():
             description: {}
             value:
               type: string
-        """.format(
-            'a' * DESCRIPTION_LINE_LENGTH_LIMIT
-        )
+        """.format('a' * DESCRIPTION_LINE_LENGTH_LIMIT)
     )
 
     files = consumer.render()
@@ -914,9 +910,7 @@ def test_option_description_length_limit_with_noqa():
             value:
               type: string
               example: something
-        """.format(
-            'a' * DESCRIPTION_LINE_LENGTH_LIMIT + ' /noqa'
-        )
+        """.format('a' * DESCRIPTION_LINE_LENGTH_LIMIT + ' /noqa')
     )
 
     files = consumer.render()
@@ -928,9 +922,7 @@ def test_option_description_length_limit_with_noqa():
         ## {}
         #
         # foo: something
-        """.format(
-            'a' * DESCRIPTION_LINE_LENGTH_LIMIT
-        )
+        """.format('a' * DESCRIPTION_LINE_LENGTH_LIMIT)
     )
 
 
@@ -1211,9 +1203,7 @@ def test_compact_example_long_line():
                 type: array
                 items:
                   type: string
-        """.format(
-            long_str
-        )
+        """.format(long_str)
     )
     files = consumer.render()
     contents, errors = files['test.yaml.example']
@@ -1225,9 +1215,7 @@ def test_compact_example_long_line():
         #
         # foo:
         #   - [{0}, {0}, {0}, {0}]
-        """.format(
-            long_str
-        )
+        """.format(long_str)
     )
 
 

--- a/ddev/src/ddev/integration/core.py
+++ b/ddev/src/ddev/integration/core.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
     from ddev.repo.config import RepositoryConfig
 
 
-
 class Integration:
     def __init__(self, path: Path, repo_path: Path, repo_config: RepositoryConfig):
         # Do nothing but simple assignment here as we initialize often without


### PR DESCRIPTION
### What does this PR do?
Removes the integration exception mapper. Although it would prevent errors, this allows an issue through the validation. `source_type_name` and the `integration` column value must match exactly or else the metrics will not show up in the integration tile page on the Datadog site. 

We are working to fix all integrations with mismatching values between `source_type_name` and the `integration` column value so there shouldn't be a need for exceptions anymore.

### Motivation
https://datadoghq.atlassian.net/browse/MINPROC-2319

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
