### PR TITLE
Switch table rows stats query over to performance_schema

### DIFF
--- a/mysql/changelog.d/20702.fixed
+++ b/mysql/changelog.d/20702.fixed
@@ -1,0 +1,1 @@
+Switch table rows stats query from information_schema to performance_schema

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -649,7 +649,7 @@ class MySql(AgentCheck):
                 results['information_schema_size'] = self._query_size_per_schema(db)
             metrics.update(SCHEMA_VARS)
 
-        if is_affirmative(self._config.options.get('table_rows_stats_metrics', False)) and self.userstat_enabled:
+        if self._config.table_rows_stats_enabled and self.userstat_enabled:
             # report size of tables in MiB to Datadog
             self.log.debug("Collecting Table Row Stats Metrics.")
             with tracked_query(self, operation="table_rows_stats_metrics"):

--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -13,8 +13,13 @@ ORDER BY `percentile` ASC
 LIMIT 1"""
 
 SQL_QUERY_TABLE_ROWS_STATS = """\
-SELECT table_schema, table_name, rows_read, rows_changed
-FROM information_schema.table_statistics"""
+SELECT
+    OBJECT_SCHEMA as table_schema,
+    OBJECT_NAME as table_name,
+    COUNT_READ as rows_read,
+    COUNT_WRITE as rows_changed
+FROM performance_schema.table_io_waits_summary_by_table
+WHERE OBJECT_SCHEMA NOT IN ('mysql', 'performance_schema', 'information_schema')"""
 
 SQL_QUERY_SCHEMA_SIZE = """\
 SELECT table_schema, IFNULL(SUM(data_length+index_length)/1024/1024,0) AS total_mb


### PR DESCRIPTION
### What does this PR do?
Switches the query used to collect table row stats on Percona Mysql and MariaDB flavors over to performance_schema as opposed to the heavier information_schema source.

### Motivation
information_schema is a heavier table to access. The old query can also be susceptible to triggering Percona Server bug [PS-8975](https://perconadev.atlassian.net/browse/PS-8975) on v8.0.34 on busy databases that have concurrent user privilege changes occurring alongside the agent check query.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
