### PR TITLE
Remove ddev tests from the test agent release workflow

### DIFF
--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -48,7 +48,7 @@ jobs:
       agent-image-py2: "${{ inputs.agent-image-py2 }}"
       agent-image-windows: "${{ inputs.agent-image-windows }}"
       agent-image-windows-py2: "${{ inputs.agent-image-windows-py2 }}"
-      skip-ddev-jobs: true
+      skip-ddev-tests: true
     secrets: inherit
     permissions:
        # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github

--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -48,6 +48,7 @@ jobs:
       agent-image-py2: "${{ inputs.agent-image-py2 }}"
       agent-image-windows: "${{ inputs.agent-image-windows }}"
       agent-image-windows-py2: "${{ inputs.agent-image-windows-py2 }}"
+      skip-ddev-jobs: true
     secrets: inherit
     permissions:
        # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -52,6 +52,10 @@ on:
         required: false
         type: string
         default: ""
+      skip-ddev-jobs:
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   jd316aba:
@@ -74,6 +78,7 @@ jobs:
       minimum-base-package: ${{ inputs.minimum-base-package }}
       pytest-args: ${{ inputs.pytest-args }}
     secrets: inherit
+    if: ${{ inputs.skip-ddev-jobs == false }}
   j6712d43:
     uses: ./.github/workflows/test-target.yml
     with:
@@ -94,6 +99,7 @@ jobs:
       minimum-base-package: ${{ inputs.minimum-base-package }}
       pytest-args: ${{ inputs.pytest-args }}
     secrets: inherit
+    if: ${{ inputs.skip-ddev-jobs == false }}
   jb232c8c:
     uses: ./.github/workflows/test-target.yml
     with:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -52,7 +52,7 @@ on:
         required: false
         type: string
         default: ""
-      skip-ddev-jobs:
+      skip-ddev-tests:
         required: false
         default: false
         type: boolean
@@ -78,7 +78,7 @@ jobs:
       minimum-base-package: ${{ inputs.minimum-base-package }}
       pytest-args: ${{ inputs.pytest-args }}
     secrets: inherit
-    if: ${{ inputs.skip-ddev-jobs == false }}
+    if: ${{ inputs.skip-ddev-tests == false }}
   j6712d43:
     uses: ./.github/workflows/test-target.yml
     with:
@@ -99,7 +99,7 @@ jobs:
       minimum-base-package: ${{ inputs.minimum-base-package }}
       pytest-args: ${{ inputs.pytest-args }}
     secrets: inherit
-    if: ${{ inputs.skip-ddev-jobs == false }}
+    if: ${{ inputs.skip-ddev-tests == false }}
   jb232c8c:
     uses: ./.github/workflows/test-target.yml
     with:


### PR DESCRIPTION
### What does this PR do?
We currently run test all with the agent release pipeline. The tests keep failing for ddev. This change aims to remove ddev from being tested in that pipeline. 

- The test fails because it tries to compare repo that is tagged with master so if there's any new changes added to master, it will find differences and cause the test to fail
- The agent isn't shipped with ddev. So testing for ddev with the agent doesn't quite make sense (to me atleast)
