### PR TITLE
Update ci validation to include the new flag to skip ddev tests

### DIFF
--- a/ddev/changelog.d/20705.added
+++ b/ddev/changelog.d/20705.added
@@ -1,0 +1,1 @@
+Update ci validation command to account for the new ddev test skip params

--- a/ddev/src/ddev/cli/validate/ci.py
+++ b/ddev/src/ddev/cli/validate/ci.py
@@ -62,6 +62,7 @@ def ci(app: Application, sync: bool):
     )
     jobs_workflow_path = app.repo.path / '.github' / 'workflows' / 'test-all.yml'
     original_jobs_workflow = jobs_workflow_path.read_text() if jobs_workflow_path.is_file() else ''
+    ddev_jobs_id = ('jd316aba', 'j6712d43')
 
     jobs = {}
     for data in construct_job_matrix(app.repo.path, get_all_targets(app.repo.path)):
@@ -111,7 +112,10 @@ def ci(app: Application, sync: bool):
         job_id = hashlib.sha256(config['job-name'].encode('utf-8')).hexdigest()[:7]
         job_id = f'j{job_id}'
 
-        jobs[job_id] = {'uses': test_workflow, 'with': config, 'secrets': 'inherit'}
+        job_config = {'uses': test_workflow, 'with': config, 'secrets': 'inherit'}
+        if job_id in ddev_jobs_id:
+            job_config['if'] = '${{ inputs.skip-ddev-tests == false }}'
+        jobs[job_id] = job_config
 
     jobs_component = yaml.safe_dump({'jobs': jobs}, default_flow_style=False, sort_keys=False)
 
@@ -124,6 +128,7 @@ def ci(app: Application, sync: bool):
         'agent-image-py2',
         'agent-image-windows',
         'agent-image-windows-py2',
+        'skip-ddev-tests',
     ):
         jobs_component = jobs_component.replace(f'${{{{ inputs.{field} }}}}', f'"${{{{ inputs.{field} }}}}"')
 


### PR DESCRIPTION
### What does this PR do?
CI validation is failing for the below:
https://github.com/DataDog/integrations-core/pull/20704/s

This PR addresses the PR validation for the above. 