### PR TITLE
Add the skip-ddev option to ci validation script

### DIFF
--- a/ddev/changelog.d/20708.added
+++ b/ddev/changelog.d/20708.added
@@ -1,0 +1,1 @@
+Add the skip-ddev option to ci validation script

--- a/ddev/src/ddev/cli/validate/ci.py
+++ b/ddev/src/ddev/cli/validate/ci.py
@@ -113,6 +113,9 @@ def ci(app: Application, sync: bool):
 
         jobs[job_id] = {'uses': test_workflow, 'with': config, 'secrets': 'inherit'}
 
+        if data['target'] == 'ddev':
+            jobs[job_id]['if'] = '${{ inputs.skip-ddev-tests == false }}'
+
     jobs_component = yaml.safe_dump({'jobs': jobs}, default_flow_style=False, sort_keys=False)
 
     # Enforce proper string types


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add the new option added in #20704 to the ci validation job

### Motivation
<!-- What inspired you to submit this pull request? -->
CI is failing after the merge to master yesterday if we don't

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
