### PR TITLE
Bump datadog_checks_base on integrations that needed update after TLS fix

### DIFF
--- a/aerospike/changelog.d/20711.changed
+++ b/aerospike/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/aerospike/pyproject.toml
+++ b/aerospike/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/airflow/changelog.d/20711.changed
+++ b/airflow/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/airflow/pyproject.toml
+++ b/airflow/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/amazon_msk/changelog.d/20711.changed
+++ b/amazon_msk/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/amazon_msk/pyproject.toml
+++ b/amazon_msk/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/apache/changelog.d/20711.changed
+++ b/apache/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/apache/pyproject.toml
+++ b/apache/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/appgate_sdp/changelog.d/20711.changed
+++ b/appgate_sdp/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/appgate_sdp/pyproject.toml
+++ b/appgate_sdp/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/arangodb/changelog.d/20711.changed
+++ b/arangodb/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/arangodb/pyproject.toml
+++ b/arangodb/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/argo_rollouts/changelog.d/20711.changed
+++ b/argo_rollouts/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/argo_rollouts/pyproject.toml
+++ b/argo_rollouts/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/argo_workflows/changelog.d/20711.changed
+++ b/argo_workflows/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/argo_workflows/pyproject.toml
+++ b/argo_workflows/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/argocd/changelog.d/20711.changed
+++ b/argocd/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/argocd/pyproject.toml
+++ b/argocd/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/avi_vantage/changelog.d/20711.changed
+++ b/avi_vantage/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/avi_vantage/pyproject.toml
+++ b/avi_vantage/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/aws_neuron/changelog.d/20711.changed
+++ b/aws_neuron/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/aws_neuron/pyproject.toml
+++ b/aws_neuron/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/boundary/changelog.d/20711.changed
+++ b/boundary/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/boundary/pyproject.toml
+++ b/boundary/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/calico/changelog.d/20711.changed
+++ b/calico/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/calico/pyproject.toml
+++ b/calico/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/celery/changelog.d/20711.changed
+++ b/celery/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/celery/pyproject.toml
+++ b/celery/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.0.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/cert_manager/changelog.d/20711.changed
+++ b/cert_manager/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/cert_manager/pyproject.toml
+++ b/cert_manager/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/cilium/changelog.d/20711.changed
+++ b/cilium/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/cilium/pyproject.toml
+++ b/cilium/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/citrix_hypervisor/changelog.d/20711.changed
+++ b/citrix_hypervisor/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/citrix_hypervisor/pyproject.toml
+++ b/citrix_hypervisor/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.9.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/cockroachdb/changelog.d/20711.changed
+++ b/cockroachdb/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/cockroachdb/pyproject.toml
+++ b/cockroachdb/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/consul/changelog.d/20711.changed
+++ b/consul/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/consul/pyproject.toml
+++ b/consul/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/coredns/changelog.d/20711.changed
+++ b/coredns/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/coredns/pyproject.toml
+++ b/coredns/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/couch/changelog.d/20711.changed
+++ b/couch/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/couch/pyproject.toml
+++ b/couch/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/couchbase/changelog.d/20711.changed
+++ b/couchbase/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/couchbase/pyproject.toml
+++ b/couchbase/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/crio/changelog.d/20711.changed
+++ b/crio/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/crio/pyproject.toml
+++ b/crio/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/datadog_cluster_agent/changelog.d/20711.changed
+++ b/datadog_cluster_agent/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/datadog_cluster_agent/pyproject.toml
+++ b/datadog_cluster_agent/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/dcgm/changelog.d/20711.changed
+++ b/dcgm/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/dcgm/pyproject.toml
+++ b/dcgm/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/druid/changelog.d/20711.changed
+++ b/druid/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/druid/pyproject.toml
+++ b/druid/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/ecs_fargate/changelog.d/20711.changed
+++ b/ecs_fargate/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/ecs_fargate/pyproject.toml
+++ b/ecs_fargate/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/elastic/changelog.d/20711.changed
+++ b/elastic/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/elastic/pyproject.toml
+++ b/elastic/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/envoy/changelog.d/20711.changed
+++ b/envoy/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/envoy/pyproject.toml
+++ b/envoy/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/etcd/changelog.d/20711.changed
+++ b/etcd/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/etcd/pyproject.toml
+++ b/etcd/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/external_dns/changelog.d/20711.changed
+++ b/external_dns/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/external_dns/pyproject.toml
+++ b/external_dns/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/falco/changelog.d/20711.changed
+++ b/falco/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/falco/pyproject.toml
+++ b/falco/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.0.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/fluxcd/changelog.d/20711.changed
+++ b/fluxcd/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/fluxcd/pyproject.toml
+++ b/fluxcd/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/fly_io/changelog.d/20711.changed
+++ b/fly_io/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/fly_io/pyproject.toml
+++ b/fly_io/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/gitlab/changelog.d/20711.changed
+++ b/gitlab/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/gitlab/pyproject.toml
+++ b/gitlab/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/gitlab_runner/changelog.d/20711.changed
+++ b/gitlab_runner/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/gitlab_runner/pyproject.toml
+++ b/gitlab_runner/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/go_expvar/changelog.d/20711.changed
+++ b/go_expvar/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/go_expvar/pyproject.toml
+++ b/go_expvar/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/haproxy/changelog.d/20711.changed
+++ b/haproxy/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/haproxy/pyproject.toml
+++ b/haproxy/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/harbor/changelog.d/20711.changed
+++ b/harbor/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/harbor/pyproject.toml
+++ b/harbor/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/hdfs_datanode/changelog.d/20711.changed
+++ b/hdfs_datanode/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/hdfs_datanode/pyproject.toml
+++ b/hdfs_datanode/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/hdfs_namenode/changelog.d/20711.changed
+++ b/hdfs_namenode/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/hdfs_namenode/pyproject.toml
+++ b/hdfs_namenode/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/http_check/changelog.d/20711.changed
+++ b/http_check/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/http_check/pyproject.toml
+++ b/http_check/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/impala/changelog.d/20711.changed
+++ b/impala/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/impala/pyproject.toml
+++ b/impala/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/istio/changelog.d/20711.changed
+++ b/istio/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/istio/pyproject.toml
+++ b/istio/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/karpenter/changelog.d/20711.changed
+++ b/karpenter/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/karpenter/pyproject.toml
+++ b/karpenter/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/keda/changelog.d/20711.changed
+++ b/keda/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/keda/pyproject.toml
+++ b/keda/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.0.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/kong/changelog.d/20711.changed
+++ b/kong/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/kong/pyproject.toml
+++ b/kong/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/krakend/changelog.d/20711.changed
+++ b/krakend/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/krakend/pyproject.toml
+++ b/krakend/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
 ]
-dependencies = ["datadog-checks-base>=37.0.0"]
+dependencies = ["datadog-checks-base>=37.16.0"]
 dynamic = ["version"]
 
 [project.optional-dependencies]

--- a/kube_apiserver_metrics/changelog.d/20711.changed
+++ b/kube_apiserver_metrics/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/kube_apiserver_metrics/pyproject.toml
+++ b/kube_apiserver_metrics/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/kube_controller_manager/changelog.d/20711.changed
+++ b/kube_controller_manager/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/kube_controller_manager/pyproject.toml
+++ b/kube_controller_manager/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/kube_dns/changelog.d/20711.changed
+++ b/kube_dns/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/kube_dns/pyproject.toml
+++ b/kube_dns/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/kube_metrics_server/changelog.d/20711.changed
+++ b/kube_metrics_server/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/kube_metrics_server/pyproject.toml
+++ b/kube_metrics_server/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/kube_proxy/changelog.d/20711.changed
+++ b/kube_proxy/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/kube_proxy/pyproject.toml
+++ b/kube_proxy/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/kube_scheduler/changelog.d/20711.changed
+++ b/kube_scheduler/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/kube_scheduler/pyproject.toml
+++ b/kube_scheduler/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/kubeflow/changelog.d/20711.changed
+++ b/kubeflow/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/kubeflow/pyproject.toml
+++ b/kubeflow/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/kubelet/changelog.d/20711.changed
+++ b/kubelet/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/kubelet/pyproject.toml
+++ b/kubelet/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/kubernetes_cluster_autoscaler/changelog.d/20711.changed
+++ b/kubernetes_cluster_autoscaler/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/kubernetes_cluster_autoscaler/pyproject.toml
+++ b/kubernetes_cluster_autoscaler/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/kubevirt_api/changelog.d/20711.changed
+++ b/kubevirt_api/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/kubevirt_api/pyproject.toml
+++ b/kubevirt_api/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/kubevirt_controller/changelog.d/20711.changed
+++ b/kubevirt_controller/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/kubevirt_controller/pyproject.toml
+++ b/kubevirt_controller/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/kubevirt_handler/changelog.d/20711.changed
+++ b/kubevirt_handler/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/kubevirt_handler/pyproject.toml
+++ b/kubevirt_handler/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/kuma/changelog.d/20711.changed
+++ b/kuma/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/kuma/pyproject.toml
+++ b/kuma/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.0.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/kyverno/changelog.d/20711.changed
+++ b/kyverno/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/kyverno/pyproject.toml
+++ b/kyverno/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/linkerd/changelog.d/20711.changed
+++ b/linkerd/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/linkerd/pyproject.toml
+++ b/linkerd/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/litellm/changelog.d/20711.changed
+++ b/litellm/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/litellm/pyproject.toml
+++ b/litellm/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.0.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/mapreduce/changelog.d/20711.changed
+++ b/mapreduce/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/mapreduce/pyproject.toml
+++ b/mapreduce/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/marathon/changelog.d/20711.changed
+++ b/marathon/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/marathon/pyproject.toml
+++ b/marathon/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/mesos_master/changelog.d/20711.changed
+++ b/mesos_master/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/mesos_master/pyproject.toml
+++ b/mesos_master/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/mesos_slave/changelog.d/20711.changed
+++ b/mesos_slave/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/mesos_slave/pyproject.toml
+++ b/mesos_slave/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/milvus/changelog.d/20711.changed
+++ b/milvus/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/milvus/pyproject.toml
+++ b/milvus/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/nginx/changelog.d/20711.changed
+++ b/nginx/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/nginx/pyproject.toml
+++ b/nginx/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/nginx_ingress_controller/changelog.d/20711.changed
+++ b/nginx_ingress_controller/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/nginx_ingress_controller/pyproject.toml
+++ b/nginx_ingress_controller/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/nvidia_nim/changelog.d/20711.changed
+++ b/nvidia_nim/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/nvidia_nim/pyproject.toml
+++ b/nvidia_nim/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/nvidia_triton/changelog.d/20711.changed
+++ b/nvidia_triton/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/nvidia_triton/pyproject.toml
+++ b/nvidia_triton/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/octopus_deploy/changelog.d/20711.changed
+++ b/octopus_deploy/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/octopus_deploy/pyproject.toml
+++ b/octopus_deploy/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/openmetrics/changelog.d/20711.changed
+++ b/openmetrics/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/openmetrics/pyproject.toml
+++ b/openmetrics/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/openstack_controller/changelog.d/20711.changed
+++ b/openstack_controller/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/openstack_controller/pyproject.toml
+++ b/openstack_controller/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/php_fpm/changelog.d/20711.changed
+++ b/php_fpm/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/php_fpm/pyproject.toml
+++ b/php_fpm/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/powerdns_recursor/changelog.d/20711.changed
+++ b/powerdns_recursor/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/powerdns_recursor/pyproject.toml
+++ b/powerdns_recursor/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/prometheus/changelog.d/20711.changed
+++ b/prometheus/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/prometheus/pyproject.toml
+++ b/prometheus/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.0.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/proxmox/changelog.d/20711.added
+++ b/proxmox/changelog.d/20711.added
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/proxmox/pyproject.toml
+++ b/proxmox/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/quarkus/changelog.d/20711.changed
+++ b/quarkus/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/quarkus/pyproject.toml
+++ b/quarkus/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/rabbitmq/changelog.d/20711.changed
+++ b/rabbitmq/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/rabbitmq/pyproject.toml
+++ b/rabbitmq/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/ray/changelog.d/20711.changed
+++ b/ray/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/ray/pyproject.toml
+++ b/ray/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/scylla/changelog.d/20711.changed
+++ b/scylla/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/scylla/pyproject.toml
+++ b/scylla/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/sonatype_nexus/changelog.d/20711.changed
+++ b/sonatype_nexus/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/sonatype_nexus/pyproject.toml
+++ b/sonatype_nexus/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.0.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/spark/changelog.d/20711.changed
+++ b/spark/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/spark/pyproject.toml
+++ b/spark/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/squid/changelog.d/20711.changed
+++ b/squid/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/squid/pyproject.toml
+++ b/squid/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/strimzi/changelog.d/20711.changed
+++ b/strimzi/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/strimzi/pyproject.toml
+++ b/strimzi/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/supabase/changelog.d/20711.changed
+++ b/supabase/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/supabase/pyproject.toml
+++ b/supabase/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/teamcity/changelog.d/20711.changed
+++ b/teamcity/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/teamcity/pyproject.toml
+++ b/teamcity/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/tekton/changelog.d/20711.changed
+++ b/tekton/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/tekton/pyproject.toml
+++ b/tekton/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/teleport/changelog.d/20711.changed
+++ b/teleport/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/teleport/pyproject.toml
+++ b/teleport/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/temporal/changelog.d/20711.changed
+++ b/temporal/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/temporal/pyproject.toml
+++ b/temporal/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/tls/changelog.d/20711.changed
+++ b/tls/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/tls/pyproject.toml
+++ b/tls/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.7.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/torchserve/changelog.d/20711.changed
+++ b/torchserve/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/torchserve/pyproject.toml
+++ b/torchserve/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/traefik_mesh/changelog.d/20711.changed
+++ b/traefik_mesh/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/traefik_mesh/pyproject.toml
+++ b/traefik_mesh/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/twistlock/changelog.d/20711.changed
+++ b/twistlock/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/twistlock/pyproject.toml
+++ b/twistlock/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/vault/changelog.d/20711.changed
+++ b/vault/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/vault/pyproject.toml
+++ b/vault/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/velero/changelog.d/20711.changed
+++ b/velero/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/velero/pyproject.toml
+++ b/velero/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.0.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/vllm/changelog.d/20711.changed
+++ b/vllm/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/vllm/pyproject.toml
+++ b/vllm/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/voltdb/changelog.d/20711.changed
+++ b/voltdb/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/voltdb/pyproject.toml
+++ b/voltdb/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/vsphere/changelog.d/20711.changed
+++ b/vsphere/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/vsphere/pyproject.toml
+++ b/vsphere/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/weaviate/changelog.d/20711.changed
+++ b/weaviate/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/weaviate/pyproject.toml
+++ b/weaviate/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",

--- a/yarn/changelog.d/20711.changed
+++ b/yarn/changelog.d/20711.changed
@@ -1,0 +1,1 @@
+Bump datadog_checks_base to 37.16.0

--- a/yarn/pyproject.toml
+++ b/yarn/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.4.0",
+    "datadog-checks-base>=37.16.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Bump datadog_checks_base for all integrations that needed updated tests with the TLS ciphers update.

This has been added for all files that were modified on the PR #20179

Run of the nightly check over this branch: https://github.com/DataDog/integrations-core/actions/runs/16195574743/job/45721110412

### Motivation
<!-- What inspired you to submit this pull request? -->
Needed for the nighly minimum base check workflow to pass

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
