### PR TITLE
Fix tekton E2E tests

### DIFF
--- a/tekton/changelog.d/20721.fixed
+++ b/tekton/changelog.d/20721.fixed
@@ -1,1 +1,0 @@
-Move E2E tests to the latest release. Need to ensure we are not using grc images.

--- a/tekton/changelog.d/20721.fixed
+++ b/tekton/changelog.d/20721.fixed
@@ -1,0 +1,1 @@
+Move E2E tests to the latest release. Need to ensure we are not using grc images.

--- a/tekton/pyproject.toml
+++ b/tekton/pyproject.toml
@@ -58,3 +58,6 @@ include = [
 dev-mode-dirs = [
     ".",
 ]
+
+[tool.ruff]
+extend = "../pyproject.toml"

--- a/tekton/tests/conftest.py
+++ b/tekton/tests/conftest.py
@@ -17,11 +17,13 @@ HERE = get_here()
 def setup_tekton():
     run_command(["kubectl", "create", "namespace", "tekton-operator"])
     run_command(["kubectl", "apply", "-f", os.path.join(HERE, "kind", "tekton-operator.yaml"), "-n", "tekton-operator"])
+    print("Waiting for tekton-operator to be ready...")
     time.sleep(30)
     run_command(
         ["kubectl", "wait", "pods", "--all", "--for=condition=Ready", "--timeout=300s", "-n", "tekton-operator"]
     )
     time.sleep(60)
+    print("Waiting for tekton-pipelines-controller to be ready...")
     run_command(
         [
             "kubectl",
@@ -35,6 +37,7 @@ def setup_tekton():
             "tekton-pipelines",
         ]
     )
+    print("Waiting for tekton-triggers-controller to be ready...")
     run_command(
         [
             "kubectl",
@@ -49,40 +52,16 @@ def setup_tekton():
         ]
     )
 
-    run_command(
-        ["kubectl", "apply", "-f", os.path.join(HERE, "kind", "tekton-pipeline-hello.yaml"), "-n", "tekton-pipelines"]
-    )
+    configs_to_apply = ["pipeline", "pipelinerun", "task", "taskrun"]
 
-    run_command(
-        [
-            "kubectl",
-            "apply",
-            "-f",
-            os.path.join(HERE, "kind", "tekton-pipelinerun-hello.yaml"),
-            "-n",
-            "tekton-pipelines",
-        ]
-    )
-
-    for task in ("hello", "sleep"):
-        for kind in ("task", "pipeline"):
+    for config in configs_to_apply:
+        for action in ["hello", "sleep"]:
             run_command(
                 [
                     "kubectl",
                     "apply",
                     "-f",
-                    os.path.join(HERE, "kind", f"tekton-{kind}-{task}.yaml"),
-                    "-n",
-                    "tekton-pipelines",
-                ]
-            )
-
-            run_command(
-                [
-                    "kubectl",
-                    "apply",
-                    "-f",
-                    os.path.join(HERE, "kind", f"tekton-{kind}run-{task}.yaml"),
+                    os.path.join(HERE, "kind", f"tekton-{config}-{action}.yaml"),
                     "-n",
                     "tekton-pipelines",
                 ]

--- a/tekton/tests/kind/tekton-operator.yaml
+++ b/tekton/tests/kind/tekton-operator.yaml
@@ -1032,7 +1032,7 @@ spec:
             - name: IMAGE_PIPELINES_PROXY
               value: ghcr.io/tektoncd/github.com/tektoncd/operator/cmd/kubernetes/proxy-webhook:v0.69.1@sha256:f6224b715671cbbcfd3a164e3557ff533b47e39a5a689a0d818fd2fd1f027016
             - name: IMAGE_JOB_PRUNER_TKN
-              value: ghcr.io/tektoncd/plumbing/tkn: v20241224-afeb9554b4
+              value: ghcr.io/tektoncd/plumbing/tkn:v20241224-afeb9554b4
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
             - name: VERSION

--- a/tekton/tests/kind/tekton-operator.yaml
+++ b/tekton/tests/kind/tekton-operator.yaml
@@ -1032,7 +1032,7 @@ spec:
             - name: IMAGE_PIPELINES_PROXY
               value: ghcr.io/tektoncd/github.com/tektoncd/operator/cmd/kubernetes/proxy-webhook:v0.69.1@sha256:f6224b715671cbbcfd3a164e3557ff533b47e39a5a689a0d818fd2fd1f027016
             - name: IMAGE_JOB_PRUNER_TKN
-              value: ghcr.io/tektoncd/plumbing/tkn@sha256:a572f1748eb5c0e8002dd0a83ee836ad9d755d035cbd5bfbdef5de810d2bea0b
+              value: ghcr.io/tektoncd/plumbing/tkn:v20231231-c22406d05b@sha256:bf35f429855dc2fc45284543c1ddd41696c7785549f79fe148b09b8b899dffe0
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
             - name: VERSION

--- a/tekton/tests/kind/tekton-operator.yaml
+++ b/tekton/tests/kind/tekton-operator.yaml
@@ -1032,7 +1032,7 @@ spec:
             - name: IMAGE_PIPELINES_PROXY
               value: ghcr.io/tektoncd/github.com/tektoncd/operator/cmd/kubernetes/proxy-webhook:v0.69.1@sha256:f6224b715671cbbcfd3a164e3557ff533b47e39a5a689a0d818fd2fd1f027016
             - name: IMAGE_JOB_PRUNER_TKN
-              value: ghcr.io/tektoncd/plumbing/tkn:v20231231-c22406d05b
+              value: ghcr.io/tektoncd/plumbing/tkn: v20241224-afeb9554b4
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
             - name: VERSION

--- a/tekton/tests/kind/tekton-operator.yaml
+++ b/tekton/tests/kind/tekton-operator.yaml
@@ -1030,9 +1030,9 @@ spec:
             - name: OPERATOR_NAME
               value: tekton-operator
             - name: IMAGE_PIPELINES_PROXY
-              value: ghcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/proxy-webhook:v0.69.1@sha256:f6224b715671cbbcfd3a164e3557ff533b47e39a5a689a0d818fd2fd1f027016
+              value: ghcr.io/tektoncd/github.com/tektoncd/operator/cmd/kubernetes/proxy-webhook:v0.69.1@sha256:f6224b715671cbbcfd3a164e3557ff533b47e39a5a689a0d818fd2fd1f027016
             - name: IMAGE_JOB_PRUNER_TKN
-              value: ghcr.io/tekton-releases/dogfooding/tkn@sha256:a572f1748eb5c0e8002dd0a83ee836ad9d755d035cbd5bfbdef5de810d2bea0b
+              value: ghcr.io/tektoncd/dogfooding/tkn@sha256:a572f1748eb5c0e8002dd0a83ee836ad9d755d035cbd5bfbdef5de810d2bea0b
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
             - name: VERSION
@@ -1049,7 +1049,7 @@ spec:
                 configMapKeyRef:
                   key: DEFAULT_TARGET_NAMESPACE
                   name: tekton-config-defaults
-          image: ghcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.69.1@sha256:142c59f97aac2fba714e928012b5576476313c7cd4394b568df656b0693dbea0
+          image: ghcr.io/tektoncd/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.69.1@sha256:142c59f97aac2fba714e928012b5576476313c7cd4394b568df656b0693dbea0
           imagePullPolicy: Always
           name: tekton-operator-lifecycle
         - args:
@@ -1074,7 +1074,7 @@ spec:
               value: v0.69.1
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
-          image: ghcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.69.1@sha256:142c59f97aac2fba714e928012b5576476313c7cd4394b568df656b0693dbea0
+          image: ghcr.io/tektoncd/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.69.1@sha256:142c59f97aac2fba714e928012b5576476313c7cd4394b568df656b0693dbea0
           imagePullPolicy: Always
           name: tekton-operator-cluster-operations
       serviceAccountName: tekton-operator
@@ -1116,7 +1116,7 @@ spec:
               value: tekton-operator-webhook-certs
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
-          image: ghcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/webhook:v0.69.1@sha256:6e56a9a25b74c3758fd9d2f57aa9e2984a0a41477b1a4cde63e4e20160d02800
+          image: ghcr.io/tektoncd/github.com/tektoncd/operator/cmd/kubernetes/webhook:v0.69.1@sha256:6e56a9a25b74c3758fd9d2f57aa9e2984a0a41477b1a4cde63e4e20160d02800
           name: tekton-operator-webhook
           ports:
             - containerPort: 8443

--- a/tekton/tests/kind/tekton-operator.yaml
+++ b/tekton/tests/kind/tekton-operator.yaml
@@ -7,8 +7,48 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.69.1
-    version: v0.69.1
+    operator.tekton.dev/release: v0.76.0
+    version: v0.76.0
+  name: manualapprovalgates.operator.tekton.dev
+spec:
+  group: operator.tekton.dev
+  names:
+    kind: ManualApprovalGate
+    listKind: ManualApprovalGateList
+    plural: manualapprovalgates
+    shortNames:
+      - mag
+    singular: manualapprovalgate
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.version
+          name: Version
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Schema for the ManualApprovalGate API
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.tekton.dev/release: v0.76.0
+    version: v0.76.0
   name: tektonchains.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -45,8 +85,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.69.1
-    version: v0.69.1
+    operator.tekton.dev/release: v0.76.0
+    version: v0.76.0
   name: tektonconfigs.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -83,8 +123,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.69.1
-    version: v0.69.1
+    operator.tekton.dev/release: v0.76.0
+    version: v0.76.0
   name: tektondashboards.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -121,8 +161,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.69.1
-    version: v0.69.1
+    operator.tekton.dev/release: v0.76.0
+    version: v0.76.0
   name: tektonhubs.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -165,8 +205,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.69.1
-    version: v0.69.1
+    operator.tekton.dev/release: v0.76.0
+    version: v0.76.0
   name: tektoninstallersets.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -200,8 +240,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.69.1
-    version: v0.69.1
+    operator.tekton.dev/release: v0.76.0
+    version: v0.76.0
   name: tektonpipelines.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -238,8 +278,46 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.69.1
-    version: v0.69.1
+    operator.tekton.dev/release: v0.76.0
+    version: v0.76.0
+  name: tektonpruners.operator.tekton.dev
+spec:
+  group: operator.tekton.dev
+  names:
+    kind: TektonPruner
+    listKind: TektonPrunerList
+    plural: tektonpruners
+    singular: tektonpruner
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.version
+          name: Version
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Schema for the tektonpruners API
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.tekton.dev/release: v0.76.0
+    version: v0.76.0
   name: tektonresults.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -276,8 +354,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.69.1
-    version: v0.69.1
+    operator.tekton.dev/release: v0.76.0
+    version: v0.76.0
   name: tektontriggers.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -744,6 +822,21 @@ rules:
       - delete
       - update
       - patch
+  - apiGroups:
+      - openshift-pipelines.org
+    resources:
+      - approvaltasks
+      - approvaltasks/status
+    verbs:
+      - add
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - deletecollection
+      - patch
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -854,12 +947,13 @@ data:
           "callerEncoder": ""
         }
       }
-  loglevel.controller: info
-  loglevel.webhook: info
+  loglevel.tekton-operator-cluster-operations: info
+  loglevel.tekton-operator-lifecycle: info
+  loglevel.tekton-operator-webhook: info
   zap-logger-config: |
     {
-      "level": "debug",
-      "development": true,
+      "level": "info",
+      "development": false,
       "sampling": {
         "initial": 100,
         "thereafter": 100
@@ -868,7 +962,7 @@ data:
       "errorOutputPaths": ["stderr"],
       "encoding": "json",
       "encoderConfig": {
-        "timeKey": "",
+        "timeKey": "timestamp",
         "levelKey": "level",
         "nameKey": "logger",
         "callerKey": "caller",
@@ -876,7 +970,7 @@ data:
         "stacktraceKey": "stacktrace",
         "lineEnding": "",
         "levelEncoder": "",
-        "timeEncoder": "",
+        "timeEncoder": "iso8601",
         "durationEncoder": "",
         "callerEncoder": ""
       }
@@ -884,7 +978,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    operator.tekton.dev/release: v0.69.1
+    operator.tekton.dev/release: v0.76.0
   name: config-logging
   namespace: tekton-operator
 ---
@@ -895,7 +989,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    operator.tekton.dev/release: v0.69.1
+    operator.tekton.dev/release: v0.76.0
   name: tekton-config-defaults
   namespace: tekton-operator
 ---
@@ -939,12 +1033,90 @@ metadata:
 ---
 apiVersion: v1
 data:
-  version: v0.69.1
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+    # lease-duration is how long non-leaders will wait to try to acquire the
+    # lock; 15 seconds is the value used by core kubernetes controllers.
+    lease-duration: "60s"
+    # renew-deadline is how long a leader will try to renew the lease before
+    # giving up; 10 seconds is the value used by core kubernetes controllers.
+    renew-deadline: "40s"
+    # retry-period is how long the leader election client waits between tries of
+    # actions; 2 seconds is the value used by core kubernetes controllers.
+    retry-period: "10s"
+    # buckets is the number of buckets used to partition key space of each
+    # Reconciler. If this number is M and the replica number of the controller
+    # is N, the N replicas will compete for the M buckets. The owner of a
+    # bucket will take care of the reconciling for the keys partitioned into
+    # that bucket.
+    buckets: "1"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: default
+    operator.tekton.dev/release: v0.76.0
+  name: tekton-operator-controller-config-leader-election
+  namespace: tekton-operator
+---
+apiVersion: v1
+data:
+  version: v0.76.0
 kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: default
   name: tekton-operator-info
+  namespace: tekton-operator
+---
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+    # lease-duration is how long non-leaders will wait to try to acquire the
+    # lock; 15 seconds is the value used by core kubernetes controllers.
+    lease-duration: "60s"
+    # renew-deadline is how long a leader will try to renew the lease before
+    # giving up; 10 seconds is the value used by core kubernetes controllers.
+    renew-deadline: "40s"
+    # retry-period is how long the leader election client waits between tries of
+    # actions; 2 seconds is the value used by core kubernetes controllers.
+    retry-period: "10s"
+    # buckets is the number of buckets used to partition key space of each
+    # Reconciler. If this number is M and the replica number of the controller
+    # is N, the N replicas will compete for the M buckets. The owner of a
+    # bucket will take care of the reconciling for the keys partitioned into
+    # that bucket.
+    buckets: "1"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: default
+    operator.tekton.dev/release: devel
+  name: tekton-operator-webhook-config-leader-election
   namespace: tekton-operator
 ---
 apiVersion: v1
@@ -961,7 +1133,7 @@ kind: Service
 metadata:
   labels:
     app: tekton-pipelines-controller
-    version: v0.69.1
+    version: v0.76.0
   name: tekton-operator
   namespace: tekton-operator
 spec:
@@ -980,8 +1152,8 @@ metadata:
   labels:
     app: tekton-operator
     name: tekton-operator-webhook
-    operator.tekton.dev/release: v0.69.1
-    version: v0.69.1
+    operator.tekton.dev/release: devel
+    version: devel
   name: tekton-operator-webhook
   namespace: tekton-operator
 spec:
@@ -997,8 +1169,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    operator.tekton.dev/release: v0.69.1
-    version: v0.69.1
+    operator.tekton.dev/release: v0.76.0
+    version: v0.76.0
   name: tekton-operator
   namespace: tekton-operator
 spec:
@@ -1015,10 +1187,12 @@ spec:
       containers:
         - args:
             - -controllers
-            - tektonconfig,tektonpipeline,tektontrigger,tektonhub,tektonchain,tektonresult,tektondashboard
+            - tektonconfig,tektonpipeline,tektontrigger,tektonhub,tektonchain,tektonresult,tektondashboard,manualapprovalgate,tektonpruner
             - -unique-process-name
             - tekton-operator-lifecycle
           env:
+            - name: KUBERNETES_MIN_VERSION
+              value: v1.0.0
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -1030,15 +1204,17 @@ spec:
             - name: OPERATOR_NAME
               value: tekton-operator
             - name: IMAGE_PIPELINES_PROXY
-              value: ghcr.io/tektoncd/github.com/tektoncd/operator/cmd/kubernetes/proxy-webhook:v0.69.1@sha256:f6224b715671cbbcfd3a164e3557ff533b47e39a5a689a0d818fd2fd1f027016
+              value: ghcr.io/tektoncd/operator/proxy-webhook-f6167da7bc41b96a27c5529f850e63d1:v0.76.0@sha256:6a14dd2e0fa7fdfd69246bb2831c80319c1d9ea1e210626efa16ad6e843a691b
             - name: IMAGE_JOB_PRUNER_TKN
-              value: ghcr.io/tektoncd/plumbing/tkn:v20241224-afeb9554b4
+              value: ghcr.io/tektoncd/plumbing/tkn@sha256:233de6c8b8583a34c2379fa98d42dba739146c9336e8d41b66030484357481ed
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
             - name: VERSION
-              value: v0.69.1
+              value: v0.76.0
             - name: CONFIG_OBSERVABILITY_NAME
               value: tekton-config-observability
+            - name: CONFIG_LEADERELECTION_NAME
+              value: tekton-operator-controller-config-leader-election
             - name: AUTOINSTALL_COMPONENTS
               valueFrom:
                 configMapKeyRef:
@@ -1049,15 +1225,25 @@ spec:
                 configMapKeyRef:
                   key: DEFAULT_TARGET_NAMESPACE
                   name: tekton-config-defaults
-          image: ghcr.io/tektoncd/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.69.1@sha256:142c59f97aac2fba714e928012b5576476313c7cd4394b568df656b0693dbea0
+          image: ghcr.io/tektoncd/operator/operator-303303c315a48490ba6517859ef65b77:v0.76.0@sha256:b2b41515debf1c8ac3bbeaf81c12badc3deb71249fbf5d51e78804e189d2e432
           imagePullPolicy: Always
           name: tekton-operator-lifecycle
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
         - args:
             - -controllers
             - tektoninstallerset
             - -unique-process-name
             - tekton-operator-cluster-operations
           env:
+            - name: KUBERNETES_MIN_VERSION
+              value: v1.0.0
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -1071,20 +1257,30 @@ spec:
             - name: PROFILING_PORT
               value: "9009"
             - name: VERSION
-              value: v0.69.1
+              value: v0.76.0
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
-          image: ghcr.io/tektoncd/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.69.1@sha256:142c59f97aac2fba714e928012b5576476313c7cd4394b568df656b0693dbea0
+            - name: CONFIG_LEADERELECTION_NAME
+              value: tekton-operator-controller-config-leader-election
+          image: ghcr.io/tektoncd/operator/operator-303303c315a48490ba6517859ef65b77:v0.76.0@sha256:b2b41515debf1c8ac3bbeaf81c12badc3deb71249fbf5d51e78804e189d2e432
           imagePullPolicy: Always
           name: tekton-operator-cluster-operations
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
       serviceAccountName: tekton-operator
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    operator.tekton.dev/release: v0.69.1
-    version: v0.69.1
+    operator.tekton.dev/release: v0.76.0
+    version: v0.76.0
   name: tekton-operator-webhook
   namespace: tekton-operator
 spec:
@@ -1100,6 +1296,8 @@ spec:
     spec:
       containers:
         - env:
+            - name: KUBERNETES_MIN_VERSION
+              value: v1.0.0
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -1110,17 +1308,27 @@ spec:
                   fieldPath: metadata.name
             - name: CONFIG_LOGGING_NAME
               value: config-logging
+            - name: CONFIG_LEADERELECTION_NAME
+              value: tekton-operator-webhook-config-leader-election
             - name: WEBHOOK_SERVICE_NAME
               value: tekton-operator-webhook
             - name: WEBHOOK_SECRET_NAME
               value: tekton-operator-webhook-certs
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
-          image: ghcr.io/tektoncd/github.com/tektoncd/operator/cmd/kubernetes/webhook:v0.69.1@sha256:6e56a9a25b74c3758fd9d2f57aa9e2984a0a41477b1a4cde63e4e20160d02800
+          image: ghcr.io/tektoncd/operator/webhook-f2bb711aa8f0c0892856a4cbf6d9ddd8:v0.76.0@sha256:4e2186083522dd4b9c4d21cc6de3ca1c1767c1d02c6f24391356acbb6ae8aaf0
           name: tekton-operator-webhook
           ports:
             - containerPort: 8443
               name: https-webhook
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
       serviceAccountName: tekton-operator
 
 ---

--- a/tekton/tests/kind/tekton-operator.yaml
+++ b/tekton/tests/kind/tekton-operator.yaml
@@ -1032,7 +1032,7 @@ spec:
             - name: IMAGE_PIPELINES_PROXY
               value: ghcr.io/tektoncd/github.com/tektoncd/operator/cmd/kubernetes/proxy-webhook:v0.69.1@sha256:f6224b715671cbbcfd3a164e3557ff533b47e39a5a689a0d818fd2fd1f027016
             - name: IMAGE_JOB_PRUNER_TKN
-              value: ghcr.io/tektoncd/dogfooding/tkn@sha256:a572f1748eb5c0e8002dd0a83ee836ad9d755d035cbd5bfbdef5de810d2bea0b
+              value: ghcr.io/tektoncd/plumbing/tkn@sha256:a572f1748eb5c0e8002dd0a83ee836ad9d755d035cbd5bfbdef5de810d2bea0b
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
             - name: VERSION

--- a/tekton/tests/kind/tekton-operator.yaml
+++ b/tekton/tests/kind/tekton-operator.yaml
@@ -1030,9 +1030,9 @@ spec:
             - name: OPERATOR_NAME
               value: tekton-operator
             - name: IMAGE_PIPELINES_PROXY
-              value: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/proxy-webhook:v0.69.1@sha256:f6224b715671cbbcfd3a164e3557ff533b47e39a5a689a0d818fd2fd1f027016
+              value: ghcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/proxy-webhook:v0.69.1@sha256:f6224b715671cbbcfd3a164e3557ff533b47e39a5a689a0d818fd2fd1f027016
             - name: IMAGE_JOB_PRUNER_TKN
-              value: gcr.io/tekton-releases/dogfooding/tkn@sha256:a572f1748eb5c0e8002dd0a83ee836ad9d755d035cbd5bfbdef5de810d2bea0b
+              value: ghcr.io/tekton-releases/dogfooding/tkn@sha256:a572f1748eb5c0e8002dd0a83ee836ad9d755d035cbd5bfbdef5de810d2bea0b
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
             - name: VERSION
@@ -1049,7 +1049,7 @@ spec:
                 configMapKeyRef:
                   key: DEFAULT_TARGET_NAMESPACE
                   name: tekton-config-defaults
-          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.69.1@sha256:142c59f97aac2fba714e928012b5576476313c7cd4394b568df656b0693dbea0
+          image: ghcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.69.1@sha256:142c59f97aac2fba714e928012b5576476313c7cd4394b568df656b0693dbea0
           imagePullPolicy: Always
           name: tekton-operator-lifecycle
         - args:
@@ -1074,7 +1074,7 @@ spec:
               value: v0.69.1
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
-          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.69.1@sha256:142c59f97aac2fba714e928012b5576476313c7cd4394b568df656b0693dbea0
+          image: ghcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.69.1@sha256:142c59f97aac2fba714e928012b5576476313c7cd4394b568df656b0693dbea0
           imagePullPolicy: Always
           name: tekton-operator-cluster-operations
       serviceAccountName: tekton-operator
@@ -1116,7 +1116,7 @@ spec:
               value: tekton-operator-webhook-certs
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
-          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/webhook:v0.69.1@sha256:6e56a9a25b74c3758fd9d2f57aa9e2984a0a41477b1a4cde63e4e20160d02800
+          image: ghcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/webhook:v0.69.1@sha256:6e56a9a25b74c3758fd9d2f57aa9e2984a0a41477b1a4cde63e4e20160d02800
           name: tekton-operator-webhook
           ports:
             - containerPort: 8443

--- a/tekton/tests/kind/tekton-operator.yaml
+++ b/tekton/tests/kind/tekton-operator.yaml
@@ -1032,7 +1032,7 @@ spec:
             - name: IMAGE_PIPELINES_PROXY
               value: ghcr.io/tektoncd/github.com/tektoncd/operator/cmd/kubernetes/proxy-webhook:v0.69.1@sha256:f6224b715671cbbcfd3a164e3557ff533b47e39a5a689a0d818fd2fd1f027016
             - name: IMAGE_JOB_PRUNER_TKN
-              value: ghcr.io/tektoncd/plumbing/tkn:v20231231-c22406d05b@sha256:bf35f429855dc2fc45284543c1ddd41696c7785549f79fe148b09b8b899dffe0
+              value: ghcr.io/tektoncd/plumbing/tkn:v20231231-c22406d05b
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
             - name: VERSION


### PR DESCRIPTION
### What does this PR do?
fixes tekton e2e tests 
### Motivation
Tekton E2e end tests are failing to start up due to their migration from gcr.io to ghcr.io: https://tekton.dev/blog/2025/04/03/migration-to-github-container-registry/

we're seeing errors such as:
```
timed out waiting for the condition on pods/tekton-operator-76dc68cf47-pk95w
timed out waiting for the condition on pods/tekton-operator-webhook-76bd499ff7-6w5cg
error: no matching resources found
error: no matching resources found
error: resource mapping not found for name: "hello-pipeline" namespace: "" from "/home/runner/work/integrations-core/integrations-core/tekton/tests/kind/tekton-pipeline-hello.yaml": no matches for kind "Pipeline" in version "tekton.dev/v1beta1"
```
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
