### PR TITLE
Remove public facing docs for Kaspersky from being displayed

### DIFF
--- a/kaspersky/manifest.json
+++ b/kaspersky/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "c6a4b38e-c5c1-4e5a-9290-54e89bb3b35f",
   "app_id": "kaspersky",
-  "display_on_public_website": true,
+  "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?
Remove public facing docs for Kaspersky from being displayed
