### PR TITLE
PG: Add valid tag to index metrics

### DIFF
--- a/postgres/changelog.d/20731.added
+++ b/postgres/changelog.d/20731.added
@@ -1,0 +1,1 @@
+PG: Add valid tag to index metrics

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -344,7 +344,7 @@ def test_index_metrics(aggregator, integration_check, pg_instance):
     check.check(pg_instance)
 
     expected_tags = _get_expected_tags(
-        check, pg_instance, db="dogs", table="breed", index="breed_names", schema="public"
+        check, pg_instance, db="dogs", table="breed", index="breed_names", schema="public", valid="true"
     )
     for name in IDX_METRICS:
         aggregator.assert_metric(name, count=1, tags=expected_tags)

--- a/postgres/tests/test_relationsmanager.py
+++ b/postgres/tests/test_relationsmanager.py
@@ -113,4 +113,4 @@ def test_relkind_does_not_apply_to_index_metrics():
     relations = RelationsManager(relations_config, default_max_relations)
 
     query_filter = relations.filter_relation_query(query, SCHEMA_NAME)
-    assert 'relkind' not in query_filter
+    assert "relkind = ANY(array['r'])" not in query_filter


### PR DESCRIPTION
### What does this PR do?
Add a valid tag to index metrics. 

### Motivation
Indexes creating with `CREATE INDEX CONCURRENTLY` can fail and leave indexes in an invalid state. The valid tag will allow to track those invalid indexes.

The call to pg_stat_user_indexes was replaced by direct calls to `pg_stat_get*` functions in order to avoid unnecessary join to pg_index.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
