### PR TITLE
Add Metrics Upload to diff Command

### DIFF
--- a/.github/workflows/measure-disk-usage.yml
+++ b/.github/workflows/measure-disk-usage.yml
@@ -49,7 +49,7 @@ jobs:
       run: | 
         BEFORE=$(git rev-parse HEAD^)
         AFTER=$(git rev-parse HEAD)
-        ddev size diff $BEFORE $AFTER > diff-uncompressed.txt
+        ddev size diff $BEFORE $AFTER --to-dd-key ${{secrets.DD_API_KEY}} > diff-uncompressed.txt
         ddev size diff $BEFORE $AFTER  --format png,csv,markdown
         cat diff-uncompressed.txt
         echo "# Size diff (uncompressed)" >> $GITHUB_STEP_SUMMARY
@@ -61,7 +61,7 @@ jobs:
       run: | 
         BEFORE=$(git rev-parse HEAD^)
         AFTER=$(git rev-parse HEAD)
-        ddev size diff $BEFORE $AFTER --compressed > diff-compressed.txt
+        ddev size diff $BEFORE $AFTER --compressed --to-dd-key ${{secrets.DD_API_KEY}} > diff-compressed.txt
         ddev size diff $BEFORE $AFTER --compressed  --format png,csv,markdown
         cat diff-compressed.txt
         echo "# Size diff (compressed)" >> $GITHUB_STEP_SUMMARY

--- a/ddev/src/ddev/cli/size/diff.py
+++ b/ddev/src/ddev/cli/size/diff.py
@@ -27,6 +27,7 @@ from .utils.common_funcs import (
     get_valid_versions,
     plot_treemap,
     print_table,
+    send_metrics_to_dd,
 )
 
 console = Console(stderr=True)
@@ -38,6 +39,8 @@ MINIMUM_LENGTH_COMMIT = 7
 @click.argument("first_commit")
 @click.argument("second_commit")
 @click.option("--python", "version", help="Python version (e.g 3.12).  If not specified, all versions will be analyzed")
+@click.option("--to-dd-org", type=str, help="Send metrics to Datadog using the specified organization name.")
+@click.option("--to-dd-key", type=str, help="Send metrics to datadoghq.com using the specified API key.")
 @common_params  # platform, compressed, format, show_gui
 @click.pass_obj
 def diff(
@@ -49,6 +52,8 @@ def diff(
     compressed: bool,
     format: list[str],
     show_gui: bool,
+    to_dd_org: str,
+    to_dd_key: str,
 ) -> None:
     """
     Compare the size of integrations and dependencies between two commits.
@@ -119,6 +124,10 @@ def diff(
                     )
                 if format:
                     export_format(app, format, modules_plat_ver, "diff", platform, version, compressed)
+                if to_dd_org or to_dd_key:
+                    send_metrics_to_dd(
+                        app, modules_plat_ver, to_dd_org, to_dd_key, compressed, "diff", [first_commit, second_commit]
+                    )
             except Exception as e:
                 progress.stop()
                 app.abort(str(e))

--- a/ddev/src/ddev/cli/size/historical_metrics.py
+++ b/ddev/src/ddev/cli/size/historical_metrics.py
@@ -39,6 +39,36 @@ def upload_historical_metrics(date_from_str: str, org: str) -> None:
                     )
                     print(f"Processing commit {i}/{len(commits)}: {commit[:8]} ({date})", flush=True)
                     gitRepo.checkout_commit(commit)
+                    if i > 1:
+                        result = subprocess.run(
+                            ["ddev", "--here", "size", "diff", "--to-dd-org", org, commits[i - 1], commit],
+                            cwd=gitRepo.repo_dir,
+                            text=True,
+                            capture_output=True,
+                        )
+                        if result.returncode != 0:
+                            console.print(f"[red]Error in commit {commit}: {result.stderr}")
+                            continue
+                        result = subprocess.run(
+                            [
+                                "ddev",
+                                "--here",
+                                "size",
+                                "diff",
+                                "--compressed",
+                                "--to-dd-org",
+                                org,
+                                commits[i - 1],
+                                commit,
+                            ],
+                            cwd=gitRepo.repo_dir,
+                            text=True,
+                            capture_output=True,
+                        )
+                        if result.returncode != 0:
+                            console.print(f"[red]Error in commit {commit}: {result.stderr}")
+                            continue
+
                     result = subprocess.run(
                         ["ddev", "--here", "size", "status", "--to-dd-org", org],
                         cwd=gitRepo.repo_dir,

--- a/ddev/src/ddev/cli/size/status.py
+++ b/ddev/src/ddev/cli/size/status.py
@@ -84,7 +84,7 @@ def status(
         if format:
             export_format(app, format, modules_plat_ver, "status", platform, version, compressed)
         if to_dd_org or to_dd_key:
-            send_metrics_to_dd(app, modules_plat_ver, to_dd_org, to_dd_key, compressed)
+            send_metrics_to_dd(app, modules_plat_ver, to_dd_org, to_dd_key, compressed, "status")
     except Exception as e:
         app.abort(str(e))
 

--- a/ddev/src/ddev/cli/size/status.py
+++ b/ddev/src/ddev/cli/size/status.py
@@ -4,7 +4,7 @@
 
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional
 
 import click
 from rich.console import Console
@@ -84,7 +84,8 @@ def status(
         if format:
             export_format(app, format, modules_plat_ver, "status", platform, version, compressed)
         if to_dd_org or to_dd_key:
-            send_metrics_to_dd(app, modules_plat_ver, to_dd_org, to_dd_key, compressed, "status")
+            mode: Literal["status"] = "status"
+            send_metrics_to_dd(app, modules_plat_ver, to_dd_org, to_dd_key, compressed, mode, None)
     except Exception as e:
         app.abort(str(e))
 

--- a/ddev/src/ddev/cli/size/utils/common_funcs.py
+++ b/ddev/src/ddev/cli/size/utils/common_funcs.py
@@ -323,43 +323,43 @@ def get_dependencies_sizes(
 
 
 def is_excluded_from_wheel(path: str) -> bool:
-    '''
+    """
     These files are excluded from the wheel in the agent build:
     https://github.com/DataDog/datadog-agent/blob/main/omnibus/config/software/datadog-agent-integrations-py3.rb
     In order to have more accurate results, this files are excluded when computing the size of the dependencies while
     the wheels still include them.
-    '''
+    """
     excluded_test_paths = [
         os.path.normpath(path)
         for path in [
-            'idlelib/idle_test',
-            'bs4/tests',
-            'Cryptodome/SelfTest',
-            'gssapi/tests',
-            'keystoneauth1/tests',
-            'openstack/tests',
-            'os_service_types/tests',
-            'pbr/tests',
-            'pkg_resources/tests',
-            'psutil/tests',
-            'securesystemslib/_vendor/ed25519/test_data',
-            'setuptools/_distutils/tests',
-            'setuptools/tests',
-            'simplejson/tests',
-            'stevedore/tests',
-            'supervisor/tests',
-            'test',  # cm-client
-            'vertica_python/tests',
-            'websocket/tests',
+            "idlelib/idle_test",
+            "bs4/tests",
+            "Cryptodome/SelfTest",
+            "gssapi/tests",
+            "keystoneauth1/tests",
+            "openstack/tests",
+            "os_service_types/tests",
+            "pbr/tests",
+            "pkg_resources/tests",
+            "psutil/tests",
+            "securesystemslib/_vendor/ed25519/test_data",
+            "setuptools/_distutils/tests",
+            "setuptools/tests",
+            "simplejson/tests",
+            "stevedore/tests",
+            "supervisor/tests",
+            "test",  # cm-client
+            "vertica_python/tests",
+            "websocket/tests",
         ]
     ]
 
     type_annot_libraries = [
-        'krb5',
-        'Cryptodome',
-        'ddtrace',
-        'pyVmomi',
-        'gssapi',
+        "krb5",
+        "Cryptodome",
+        "ddtrace",
+        "pyVmomi",
+        "gssapi",
     ]
     rel_path = Path(path).as_posix()
 
@@ -373,7 +373,7 @@ def is_excluded_from_wheel(path: str) -> bool:
     if path_parts:
         dependency_name = path_parts[0]
         if dependency_name in type_annot_libraries:
-            if path.endswith('.pyi') or os.path.basename(path) == 'py.typed':
+            if path.endswith(".pyi") or os.path.basename(path) == "py.typed":
                 return True
 
     return False
@@ -770,6 +770,8 @@ def send_metrics_to_dd(
     mode: Literal["status"],
     commits: None,
 ) -> None: ...
+
+
 @overload
 def send_metrics_to_dd(
     app: Application,
@@ -780,6 +782,8 @@ def send_metrics_to_dd(
     mode: Literal["diff"],
     commits: list[str],
 ) -> None: ...
+
+
 def send_metrics_to_dd(
     app: Application,
     modules: list[FileDataEntryPlatformVersion],
@@ -804,6 +808,9 @@ def send_metrics_to_dd(
         message, tickets, prs = get_last_commit_data()
         timestamp = get_last_commit_timestamp()
     elif mode == "diff":
+        if not commits:
+            raise Exception("commits must not be None or empty in diff mode")
+        prev_commit = check_commits(commits)
         message, tickets, prs = get_last_commit_data(commits[1])
         timestamp = get_last_commit_timestamp(commits[1])
 
@@ -813,7 +820,7 @@ def send_metrics_to_dd(
 
     n_integrations: dict[tuple[str, str], int] = {}
     n_dependencies: dict[tuple[str, str], int] = {}
-    prev_commit = check_commits(commits)
+
     for item in modules:
         metrics.append(
             {
@@ -837,14 +844,14 @@ def send_metrics_to_dd(
                 + ([f"to_prev_commit:{prev_commit}"] if mode == "diff" else []),
             }
         )
-        key_count = (item['Platform'], item['Python_Version'])
+        key_count = (item["Platform"], item["Python_Version"])
         if key_count not in n_integrations:
             n_integrations[key_count] = 0
         if key_count not in n_dependencies:
             n_dependencies[key_count] = 0
-        if item['Type'] == 'Integration':
+        if item["Type"] == "Integration":
             n_integrations[key_count] += 1
-        elif item['Type'] == 'Dependency':
+        elif item["Type"] == "Dependency":
             n_dependencies[key_count] += 1
 
     if mode == "status":
@@ -936,8 +943,8 @@ def get_last_commit_data(commit: Optional[str] = None) -> tuple[str, list[str], 
         result = subprocess.run(["git", "log", "-1", "--format=%s", commit], capture_output=True, text=True, check=True)
     else:
         result = subprocess.run(["git", "log", "-1", "--format=%s"], capture_output=True, text=True, check=True)
-    ticket_pattern = r'\b(?:DBMON|SAASINT|AGENT|AI)-\d+\b'
-    pr_pattern = r'#(\d+)'
+    ticket_pattern = r"\b(?:DBMON|SAASINT|AGENT|AI)-\d+\b"
+    pr_pattern = r"#(\d+)"
 
     message = result.stdout.strip()
     tickets = re.findall(ticket_pattern, message)
@@ -950,7 +957,7 @@ def get_last_commit_data(commit: Optional[str] = None) -> tuple[str, list[str], 
     return message, tickets, prs
 
 
-def check_commits(commits: list[str] | None) -> str:
+def check_commits(commits: list[str]) -> bool:
     # Check if commits are from master branch
     for commit in commits:
         result = subprocess.run(["git", "branch", "--contains", commit], capture_output=True, text=True, check=True)


### PR DESCRIPTION
### What does this PR do?
Adds support for sending metrics to Datadog using the `--to-dd-org` and `--to-dd-key` options in the `diff` command between two consecutive commits.

### Motivation
To provide more visibility into which PR introduced a size change.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
