### PR TITLE
Update nginx kerberos base image

### DIFF
--- a/datadog_checks_base/tests/compose/kerberos/kerberos-agent.yaml
+++ b/datadog_checks_base/tests/compose/kerberos/kerberos-agent.yaml
@@ -54,7 +54,7 @@ services:
       - "464:8464"
 
   web:
-    image: kerberos-nginx:1.17.3
+    image: kerberos-nginx:1.20.2
     build: ./kerberos-nginx
     environment:
       KRB5_KEYTAB: ${KRB5_KEYTAB}

--- a/datadog_checks_base/tests/compose/kerberos/kerberos-nginx/Dockerfile
+++ b/datadog_checks_base/tests/compose/kerberos/kerberos-nginx/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update -y -qq && apt-get install -y --no-install-recommends \
   git
 
 RUN cd /usr/src && mkdir nginx \
-  && curl -kfSL https://nginx.org/download/nginx-1.17.3.tar.gz -o nginx.tar.gz \
+  && curl -kfSL https://nginx.org/download/nginx-1.20.2.tar.gz -o nginx.tar.gz \
   && tar -xzf nginx.tar.gz -C nginx --strip-components=1
 
 RUN cd /usr/src/nginx \

--- a/datadog_checks_base/tests/compose/kerberos/kerberos.yaml
+++ b/datadog_checks_base/tests/compose/kerberos/kerberos.yaml
@@ -26,7 +26,7 @@ services:
       - "464:8464"
 
   web:
-    image: kerberos-nginx:1.17.3
+    image: kerberos-nginx:1.20.2
     build: ./kerberos-nginx
     container_name: kerberos-nginx
     environment:


### PR DESCRIPTION
### What does this PR do?
Update docker images for kerberos tests 

### Motivation
base check tests were [failing](https://github.com/DataDog/integrations-core/actions/runs/16284644697/job/45980916324) to build due to buster eol
```
#6 [web  2/11] RUN apt-get update -y -qq && apt-get install -y --no-install-recommends   build-essential   libkrb5-dev   libcurl4-openssl-dev   curl   libpcre3   libpcre3-dev   zlib1g-dev   krb5-user   ca-certificates   git
#6 0.157 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
#6 0.157 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
#6 0.157 E: The repository 'http://security.debian.org/debian-security buster/updates Release' does not have a Release file.
#6 ERROR: process "/bin/sh -c apt-get update -y -qq && apt-get install -y --no-install-recommends   build-essential   libkrb5-dev   libcurl4-openssl-dev   curl   libpcre3   libpcre3-dev   zlib1g-dev   krb5-user   ca-certificates   git" did not complete successfully: exit code: 100
------
 > [web  2/11] RUN apt-get update -y -qq && apt-get install -y --no-install-recommends   build-essential   libkrb5-dev   libcurl4-openssl-dev   curl   libpcre3   libpcre3-dev   zlib1g-dev   krb5-user   ca-certificates   git:
0.157 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
0.157 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
0.157 E: The repository 'http://security.debian.org/debian-security buster/updates Release' does not have a Release file.
------
```
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
