### PR TITLE
Avoid overwriting AWS cloud_metadata

### DIFF
--- a/postgres/changelog.d/20774.fixed
+++ b/postgres/changelog.d/20774.fixed
@@ -1,0 +1,1 @@
+Fixed a bug where the AWS configuration was overwritten for the Postgres integration

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -203,9 +203,8 @@ class PostgreSql(AgentCheck):
             # allow for detecting if the host is an RDS host, and emit
             # the resource properly even if the `aws` config is unset
             self.tags.append("dd.internal.resource:aws_rds_instance:{}".format(self.resolved_hostname))
-            self.cloud_metadata["aws"] = {
-                "instance_endpoint": self.resolved_hostname,
-            }
+            self.cloud_metadata["aws"] = self.cloud_metadata["aws"] or {}
+            self.cloud_metadata["aws"]["instance_endpoint"] = self.resolved_hostname
         if self.cloud_metadata.get("azure") is not None:
             deployment_type = self.cloud_metadata.get("azure")["deployment_type"]
             # some `deployment_type`s map to multiple `resource_type`s

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -203,7 +203,7 @@ class PostgreSql(AgentCheck):
             # allow for detecting if the host is an RDS host, and emit
             # the resource properly even if the `aws` config is unset
             self.tags.append("dd.internal.resource:aws_rds_instance:{}".format(self.resolved_hostname))
-            self.cloud_metadata["aws"] = self.cloud_metadata["aws"] or {}
+            self.cloud_metadata["aws"] = self.cloud_metadata.get("aws", {})
             self.cloud_metadata["aws"]["instance_endpoint"] = self.resolved_hostname
         if self.cloud_metadata.get("azure") is not None:
             deployment_type = self.cloud_metadata.get("azure")["deployment_type"]

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -619,7 +619,7 @@ def test_wal_stats(aggregator, integration_check, pg_instance, is_aurora):
         cur.execute("insert into persons (lastname) values ('test');")
 
     # Wait for pg_stat_wal to be updated
-    for _ in range(10):
+    for _ in range(50):
         with conn.cursor() as cur:
             cur.execute("select wal_records, wal_bytes from pg_stat_wal;")
             new_wal_records = cur.fetchall()[0][0]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes a condition where the Postgres integration would inadvertantly overwrite the configured cloud metadata used for connecting to AWS.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
