### PR TITLE
gpu: add missing volume mount to the operator

### DIFF
--- a/gpu/README.md
+++ b/gpu/README.md
@@ -238,7 +238,7 @@ spec:
   features:
     oomKill:
       # Only enable this feature if there is nothing else that requires the system-probe container in all Agent pods
-      # Examples of system-probe features are npm, cws, usm, oom_kill.
+      # Examples of system-probe features are npm, cws, usm
       enabled: true
 
 override:

--- a/gpu/README.md
+++ b/gpu/README.md
@@ -192,9 +192,15 @@ spec:
   features:
     gpu:
       enabled: true
-  # for operator versions 1.14.x and 1.15.x  add this section
+  # For operator versions below 1.18, add this section
   override:
     nodeAgent:
+     volumes:
+        # Add this volume for operator version below 1.18, unless other system-probe features
+        # such as npm, cws, usm or oom_kill are enabled.
+        - name: debugfs
+          hostPath:
+            path: /sys/kernel/debug
       containers:
         agent:
           env:
@@ -204,6 +210,13 @@ spec:
             # add this env var, if using operator versions 1.14.x or 1.15.x
             - name: DD_COLLECT_GPU_TAGS
               value: "true"
+        system-probe:
+          volumeMounts:
+            # Add this volume for operator version below 1.18, unless other system-probe features
+            # such as Cloud Network Monitoring, Cloud Workload Security or Universal Service Monitoring
+            # are enabled.
+            - name: debugfs
+              mountPath: /sys/kernel/debug
 ```
 
 For **mixed environments**, use the [DatadogAgentProfiles (DAP) feature](https://github.com/DataDog/datadog-operator/blob/main/docs/datadog_agent_profiles.md) of the operator, which allows different configurations to be deployed for different nodes. Note that this feature is disabled by default, so it needs to be enabled. For more information, see [Enabling DatadogAgentProfiles](https://github.com/DataDog/datadog-operator/blob/main/docs/datadog_agent_profiles.md#enabling-datadogagentprofiles).
@@ -223,7 +236,9 @@ In summary, the changes that need to be applied to the DatadogAgent manifest are
 ```yaml
 spec:
   features:
-    oomKill: # Only enable this feature if there is nothing else that requires the system-probe container in all Agent pods
+    oomKill:
+      # Only enable this feature if there is nothing else that requires the system-probe container in all Agent pods
+      # Examples of system-probe features are npm, cws, usm, oom_kill.
       enabled: true
 
 override:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds a missing volume mount that is required for operator versions < 1.18. Note that this is only necessary if there are no other system-probe features enabled, so the mount is not required for mixed-node deployments.

### Motivation

Correct deployment instructions.

Related ticket: https://datadoghq.atlassian.net/browse/EBPF-768

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
