### PR TITLE
Indicate recommended log collection method for ECS explorer correlation

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -436,7 +436,9 @@ You can monitor Fargate logs by using either:
 - The AWS FireLens integration built on Datadog's Fluent Bit output plugin to send logs directly to Datadog
 - Using the `awslogs` log driver to store the logs in a CloudWatch Log Group, and then a Lambda function to route logs to Datadog
 
-Datadog recommends using AWS FireLens because you can configure Fluent Bit directly in your Fargate tasks.
+Datadog recommends using AWS FireLens for the following reasons:
+- You can configure Fluent Bit directly in your Fargate tasks.
+- The Datadog Fluentbit output plugin provides additional tagging on logs which are also used to correlate with the [ECS Explorer](https://docs.datadoghq.com/infrastructure/containers/amazon_elastic_container_explorer).
 
 **Note**: Log collection with Fluent Bit and FireLens is not supported for AWS Batch on ECS Fargate.
 
@@ -1255,3 +1257,4 @@ Need help? Contact [Datadog support][18].
 [72]: https://github.com/datadog/datadog-cdk-constructs/
 [73]: https://docs.datadoghq.com/tracing/trace_collection/proxy_setup/apigateway
 [74]: https://registry.terraform.io/modules/DataDog/ecs-datadog/aws/latest/submodules/ecs_fargate
+[75]: https://docs.datadoghq.com/infrastructure/containers/amazon_elastic_container_explorer

--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -438,7 +438,7 @@ You can monitor Fargate logs by using either:
 
 Datadog recommends using AWS FireLens for the following reasons:
 - You can configure Fluent Bit directly in your Fargate tasks.
-- The Datadog Fluentbit output plugin provides additional tagging on logs which are also used to correlate with the [ECS Explorer](https://docs.datadoghq.com/infrastructure/containers/amazon_elastic_container_explorer).
+- The Datadog Fluent Bit output plugin provides additional tagging on logs. The [ECS Explorer][76] uses the tags to correlate logs with ECS resources.
 
 **Note**: Log collection with Fluent Bit and FireLens is not supported for AWS Batch on ECS Fargate.
 

--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -438,7 +438,7 @@ You can monitor Fargate logs by using either:
 
 Datadog recommends using AWS FireLens for the following reasons:
 - You can configure Fluent Bit directly in your Fargate tasks.
-- The Datadog Fluent Bit output plugin provides additional tagging on logs. The [ECS Explorer][76] uses the tags to correlate logs with ECS resources.
+- The Datadog Fluent Bit output plugin provides additional tagging on logs. The [ECS Explorer][75] uses the tags to correlate logs with ECS resources.
 
 **Note**: Log collection with Fluent Bit and FireLens is not supported for AWS Batch on ECS Fargate.
 


### PR DESCRIPTION
### What does this PR do?
Adds an additional reason behind recommending AWS FireLens for ECS fargate log collection.

### Motivation
The ECS explorer relies on tags like `service_name`, `cluster_name`, `task_arn` which are added with FireLens+Fluentbit, but not with the Lamdbda forwarder.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
