### PR TITLE
Lift `pyodbc` dependency exclusion for macOS on AArch64/ARM64 (ABLD-28 follow-up)

### DIFF
--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -40,7 +40,7 @@ pyjwt==2.10.1
 pymongo[srv]==4.8.0; python_version >= '3.9'
 pymqi==1.12.11
 pymysql==1.1.1
-pyodbc==5.2.0; sys_platform != 'darwin' or platform_machine != 'arm64'
+pyodbc==5.2.0
 pyopenssl==25.1.0
 pysmi==1.2.1
 pysnmp-mibs==0.1.6

--- a/ibm_i/changelog.d/20812.fixed
+++ b/ibm_i/changelog.d/20812.fixed
@@ -1,0 +1,1 @@
+Lift `pyodbc` dependency exclusion for macOS on AArch64/ARM64

--- a/ibm_i/pyproject.toml
+++ b/ibm_i/pyproject.toml
@@ -37,7 +37,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "pyodbc==5.2.0; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    "pyodbc==5.2.0",
 ]
 
 [project.urls]

--- a/sqlserver/changelog.d/20812.fixed
+++ b/sqlserver/changelog.d/20812.fixed
@@ -1,0 +1,1 @@
+Lift `pyodbc` dependency exclusion for macOS on AArch64/ARM64

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -39,7 +39,7 @@ license = "BSD-3-Clause"
 deps = [
     "azure-identity==1.23.0",
     "lxml==5.1.1",
-    "pyodbc==5.2.0; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    "pyodbc==5.2.0",
     "pywin32==310; sys_platform == 'win32'",
 ]
 


### PR DESCRIPTION
### What does this PR do?
This removes a special case where `pyodbc` was depended on by all target platforms (including macOS on x86_64/AMD64) **except macOS on AArch64/ARM64**.

### Motivation
There's no reason to keep the exclusion since `pyodbc` 5.2.0 is available for `macosx_11_0_arm64`, see: https://pypi.org/project/pyodbc/5.2.0/#files

### Review checklist (to be filled by reviewers)
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged