### PR TITLE
Test using large runner for sqlserver tests

### DIFF
--- a/.ddev/config.toml
+++ b/.ddev/config.toml
@@ -42,7 +42,7 @@ platforms = ["linux", "windows"]
 
 [overrides.ci.sqlserver]
 platforms = ["windows", "linux"]
-runners = { windows = ["windows-2025"] }
+runners = { windows = ["windows-2022"] }
 
 [overrides.ci.tcp_check]
 platforms = ["linux", "windows"]

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -3626,7 +3626,7 @@ jobs:
       job-name: SQL Server on Windows
       target: sqlserver
       platform: windows
-      runner: '["windows-2025"]'
+      runner: '["windows-2022"]'
       repo: "${{ inputs.repo }}"
       python-version: "${{ inputs.python-version }}"
       standard: ${{ inputs.standard }}

--- a/sqlserver/hatch.toml
+++ b/sqlserver/hatch.toml
@@ -23,7 +23,7 @@ tz = ["newyork", "tokyo"]
 python = ["3.12"]
 os = ["windows"]
 driver = ["SQLOLEDB", "MSOLEDBSQL", "odbc"]
-version = ["2019", "2022"]
+version = ["2022"]
 setup = ["single"]
 
 # The high cardinality environment is meant to be used for local dev/testing


### PR DESCRIPTION
- **Remove 2019 tests for windows**
- **Rollback to windows 2022**
- **Update matrix overrides**
