### PR TITLE
Lift `pymqi` dependency exclusion for macOS on AArch64/ARM64 (ABLD-28 follow-up)

### DIFF
--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -38,7 +38,7 @@ pycryptodomex==3.23.0
 pydantic==2.11.7
 pyjwt==2.10.1
 pymongo[srv]==4.8.0; python_version >= '3.9'
-pymqi==1.12.11; sys_platform != 'darwin' or platform_machine != 'arm64'
+pymqi==1.12.11
 pymysql==1.1.1
 pyodbc==5.2.0; sys_platform != 'darwin' or platform_machine != 'arm64'
 pyopenssl==25.1.0

--- a/ibm_ace/changelog.d/20815.fixed
+++ b/ibm_ace/changelog.d/20815.fixed
@@ -1,0 +1,1 @@
+Lift `pymqi` dependency exclusion for macOS on AArch64/ARM64

--- a/ibm_ace/pyproject.toml
+++ b/ibm_ace/pyproject.toml
@@ -37,7 +37,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "pymqi==1.12.11; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    "pymqi==1.12.11",
 ]
 
 [project.urls]

--- a/ibm_mq/changelog.d/20815.fixed
+++ b/ibm_mq/changelog.d/20815.fixed
@@ -1,0 +1,1 @@
+Lift `pymqi` dependency exclusion for macOS on AArch64/ARM64

--- a/ibm_mq/pyproject.toml
+++ b/ibm_mq/pyproject.toml
@@ -38,7 +38,7 @@ requires-python = ">=3.9"
 [project.optional-dependencies]
 deps = [
     "psutil==6.0.0",
-    "pymqi==1.12.11; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    "pymqi==1.12.11",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?
This removes a special case where `pymqi` was depended on by all target platforms (including macOS on x86_64/AMD64) **except macOS on AArch64/ARM64**.

### Motivation
There doesn't seem to be a compelling reason for keeping such an ad hoc exclusion since `pymqi` 1.12.11 basically consists in an installer that extracts a source tarball (https://pypi.org/project/pymqi/#files) and compiles it for the _effective_ platform, in place.

In other words, what works for `macosx_10_12_x86_64` should also work for `macosx_11_0_arm64`.

Moreover, `pymqi` is declared as an **optional** project dependency for both "IBM ACE" and "IBM MQ", which already offers some leverage since the dependency is _not installed unless explicitly qualified_:
- https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#optional-dependencies
- https://pydevtools.com/handbook/explanation/what-are-optional-dependencies-and-dependency-groups/#optional-dependencies-end-user-features

Should unforeseen consequences happen despite above cautions, then further actions may be considered (alternatively to a trivial rollback):
1. either drop the dependency at all for macOS if not needed (that is on all macOS architectures),
2. and/or bump IBM MQ deliverables to a version that better accomodates the AArch64/ARM64 architecture on macOS: #20645.

### Review checklist (to be filled by reviewers)
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged