### PR TITLE
Fail config validation if templates are missing.

### DIFF
--- a/datadog_checks_dev/changelog.d/20832.fixed
+++ b/datadog_checks_dev/changelog.d/20832.fixed
@@ -1,0 +1,1 @@
+Fail config validation if templates are missing.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
#### Before
The whole validation would pass, but we would annotate on `spec.yaml` that we are missing the default templates.

#### After
The whole validation now fails if `spec.yaml` is missing the default templates.


Along the way refactor how we search for the templates.

### Motivation
<!-- What inspired you to submit this pull request? -->
Follow-up to https://github.com/DataDog/integrations-core/pull/20801. I noticed that I did break the logic a bit and we're getting annotations about failed files, but the validation passes.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
