### PR TITLE
[DBMON-5538] MySQL version compatibility check: move get_check_logger() to except block

### DIFF
--- a/mysql/changelog.d/20833.fixed
+++ b/mysql/changelog.d/20833.fixed
@@ -1,0 +1,1 @@
+Moved logger instantiation in MySQL version compatibility check to the except block to only perform the costly call to `get_check_logger()` when outputting the warning log.

--- a/mysql/datadog_checks/mysql/version_utils.py
+++ b/mysql/datadog_checks/mysql/version_utils.py
@@ -51,13 +51,12 @@ class MySQLVersion(namedtuple('MySQLVersion', ['version', 'flavor', 'build'])):
     def version_compatible(self, compat_version):
         # some patch version numbers contain letters (e.g. 5.0.51a)
         # so let's be careful when we compute the version number
-        log = get_check_logger()
         try:
             mysql_version = self.version.split('.')
         except Exception as e:
-            log.warning("Cannot compute mysql version, assuming it's older.: %s", e)
+            log = get_check_logger()
+            log.warning("Cannot compute MySQL version, assuming it's older: %s", e)
             return False
-        log.debug("MySQL version %s", mysql_version)
 
         patchlevel = int(re.match(r"([0-9]+)", mysql_version[2]).group(1))
         version = (int(mysql_version[0]), int(mysql_version[1]), patchlevel)

--- a/mysql/tests/test_unit.py
+++ b/mysql/tests/test_unit.py
@@ -139,6 +139,8 @@ def test_parse_get_version():
         assert v.version == '5.5.12'
         assert v.flavor == 'MySQL'
         assert v.build == 'log'
+        assert v.version_compatible(compat_version=(5, 4, 3))
+        assert not v.version_compatible(compat_version=(8, 0, 43))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?
- Moved logger instantiation in MySQL version compatibility check to the except block to avoid costly call to `get_check_logger()` when there are no warning logs to output.
- Added test coverage for `MySQLVersion.version_compatible`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
