### PR TITLE
[mongo] Fix system.profile naive timestamp parsing

### DIFF
--- a/mongo/changelog.d/20834.fixed
+++ b/mongo/changelog.d/20834.fixed
@@ -1,0 +1,1 @@
+Fix incorrect UTC timestamp parsing for system.profile slow queries when the agent runs in non-UTC timezones.

--- a/mongo/datadog_checks/mongo/dbm/slow_operations.py
+++ b/mongo/datadog_checks/mongo/dbm/slow_operations.py
@@ -5,7 +5,7 @@
 
 import binascii
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 from bson import json_util
 from cachetools import TTLCache
@@ -158,7 +158,7 @@ class MongoSlowOperations(DBMAsyncJob):
         for profile in profiling_data:
             if 'command' not in profile:
                 continue
-            profile["ts"] = profile["ts"].timestamp()  # convert datetime to timestamp
+            profile["ts"] = profile["ts"].replace(tzinfo=timezone.utc).timestamp()  # convert datetime to timestamp
             yield self._obfuscate_slow_operation(profile, db_name)
 
     def _collect_slow_operations_from_logs(self, db_names, last_ts):

--- a/mongo/hatch.toml
+++ b/mongo/hatch.toml
@@ -11,9 +11,20 @@ python = ["3.12"]
 version = ["4.4", "5.0", "6.0", "7.0", "8.0"]
 flavor = ["standalone", "shard", "auth", "tls"]
 
+# test the compatibility of mongo running on non-utc timezone
+[[envs.default.matrix]]
+python = ["3.12"]
+version = ["8.0"]
+flavor = ["standalone"]
+tz = ["newyork"]
+
 [envs.default.overrides]
 matrix.version.env-vars = "MONGO_VERSION"
+matrix.tz.env-vars = [
+  { key = "TZ", value = "America/New_York", if = ["newyork"] },
+]
 
 [envs.default.env-vars]
 COMPOSE_FILE = "mongo-{matrix:flavor}.yaml"
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
+TZ="UTC"

--- a/mongo/tests/compose/mongo-standalone.yaml
+++ b/mongo/tests/compose/mongo-standalone.yaml
@@ -4,6 +4,8 @@ services:
     networks:
       - mongo-standalone
     command: mongod --port 27017 --bind_ip=0.0.0.0
+    environment:
+      - TZ=${TZ}
     ports:
       - "27017:27017"
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes incorrect timestamp parsing for slow queries collected from the `system.profile` collection when database profiling is enabled.

The `ts` field in `system.profile` is a naive datetime object in UTC. It contains no timezone offset information. Previously, when parsing this field without explicitly specifying a timezone, it is defaulted to the agent's local system timezone. This led to timestamp mismatches when the agent was running in a non-UTC environment.

With this fix, we explicitly interpret the `ts` field as UTC, ensuring accurate and consistent timestamp parsing across all timezones.

This issue only affects slow queries collected from database profiling. Slow queries from logs is not affected because the `ts` field from logs include the timezone.

### Motivation
Correctly parse timestamp for slow queries from database profiling when agent runs on a non UTC timezone. 
https://datadoghq.atlassian.net/browse/SDBM-1851

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
