### PR TITLE
kafka_consumer: lowercase Kafka cluster in data streams messages feature

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -418,7 +418,7 @@ class KafkaCheck(AgentCheck):
             config_id = cfg["id"]
             if self._messages_have_been_retrieved(config_id):
                 continue
-            if cluster != cluster_id:
+            if not cluster or not cluster_id or cluster.lower() != cluster_id.lower():
                 continue
             start_offsets = resolve_start_offsets(highwater_offsets, topic, partition, start_offset, n_messages)
 

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -26,7 +26,7 @@ def fake_consumer_offsets_for_times(partitions):
     return [(t, p, 80) for t, p in partitions]
 
 
-def seed_mock_client():
+def seed_mock_client(cluster_id="cluster_id"):
     """Set some common defaults for the mock client to kafka."""
     client = mock.create_autospec(KafkaClient)
     client.list_consumer_groups.return_value = ["consumer_group1"]
@@ -34,7 +34,7 @@ def seed_mock_client():
     client.list_consumer_group_offsets.return_value = [("consumer_group1", [("topic1", "partition1", 2)])]
     client.describe_consumer_group.return_value = 'STABLE'
     client.consumer_get_cluster_id_and_list_topics.return_value = (
-        "cluster_id",
+        cluster_id,
         # topics
         [
             # Used in unit tets
@@ -618,7 +618,7 @@ def test_data_streams_messages(
             }
         ),
     )
-    mock_client = seed_mock_client()
+    mock_client = seed_mock_client(cluster_id="Cluster_id")
     mock_client.get_next_message.side_effect = [
         MockedMessage(
             b'{"name": "Peter Parker", "age": 18, "transaction_amount": 123, "currency": "dollar"}',


### PR DESCRIPTION
### What does this PR do?

Datadog gets the Kafka cluster from metric tags. However, metric tags are normalized (lowercased). So when targeting a specific Kafka cluster, Datadog can only target a lowercased cluster name.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
