### PR TITLE
ECS Fargate Terraform Source Docs Update

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -201,7 +201,7 @@ partial -->
 
 ```hcl
 module "ecs_fargate_task" {
-  source  = "https://registry.terraform.io/modules/DataDog/ecs-datadog/aws/latest"
+  source  = "DataDog/ecs-datadog/aws//modules/ecs_fargate"
   version = "1.0.0"
 
   # Configure Datadog
@@ -1038,7 +1038,7 @@ To enable logging through the [Datadog ECS Fargate Terraform][71] module, config
 
 ```hcl
 module "ecs_fargate_task" {
-  source  = "https://registry.terraform.io/modules/DataDog/ecs-datadog/aws/latest"
+  source  = "DataDog/ecs-datadog/aws//modules/ecs_fargate"
   version = "1.0.0"
 
   # Configure Datadog


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update public docs for the Datadog ECS Fargate Terraform module to properly reference the registry source as expected in the in the [module](https://registry.terraform.io/modules/DataDog/ecs-datadog/aws/latest/submodules/ecs_fargate?tab=dependencies) 

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [x] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
