### PR TITLE
[NDMII-3565]enrich ndm interface metrics with redapl tags

### DIFF
--- a/cisco_aci/datadog_checks/cisco_aci/fabric.py
+++ b/cisco_aci/datadog_checks/cisco_aci/fabric.py
@@ -10,7 +10,7 @@ from . import aci_metrics, exceptions, helpers, ndm
 VENDOR_CISCO = 'cisco'
 PAYLOAD_METADATA_BATCH_SIZE = 100
 DEVICE_USER_TAGS_PREFIX = "dd.internal.resource:ndm_device_user_tags"
-INTERFACE_USER_TAGS_PREFIX = "dd.internal.resource:ndm_interface_user_tags"
+INTERFACE_USER_TAGS_PREFIX = "dd.internal.resource:ndm_interface"
 
 
 class Fabric:

--- a/cisco_aci/datadog_checks/cisco_aci/fabric.py
+++ b/cisco_aci/datadog_checks/cisco_aci/fabric.py
@@ -9,8 +9,8 @@ from . import aci_metrics, exceptions, helpers, ndm
 
 VENDOR_CISCO = 'cisco'
 PAYLOAD_METADATA_BATCH_SIZE = 100
-DEVICE_USER_TAGS_PREFIX = "dd.internal.resource:ndm_device_user_tags"
-INTERFACE_USER_TAGS_PREFIX = "dd.internal.resource:ndm_interface"
+DEVICE_TAGS_PREFIX = "dd.internal.resource:ndm_device"
+INTERFACE_TAGS_PREFIX = "dd.internal.resource:ndm_interface"
 
 
 class Fabric:
@@ -104,7 +104,7 @@ class Fabric:
                     device_metadata.append(ndm.create_node_metadata(node_attrs, tags, self.namespace))
 
                     device_id = '{}:{}'.format(self.namespace, node_attrs.get('address', ''))
-                    tags.append('{}:{}'.format(DEVICE_USER_TAGS_PREFIX, device_id))
+                    tags.append('{}:{}'.format(DEVICE_TAGS_PREFIX, device_id))
 
                 self.submit_process_metric(n, tags + self.check_tags + user_tags, hostname=hostname)
             except (exceptions.APIConnectionException, exceptions.APIParsingException):
@@ -140,10 +140,10 @@ class Fabric:
                 interface_metadata = ndm.create_interface_metadata(e, node.get('address', ''), self.namespace)
                 interfaces.append(interface_metadata)
                 device_id = '{}:{}'.format(self.namespace, node.get('address', ''))
-                tags.append('{}:{}'.format(DEVICE_USER_TAGS_PREFIX, device_id))
+                tags.append('{}:{}'.format(DEVICE_TAGS_PREFIX, device_id))
                 tags.append(
                     "{}:{}:{}".format(
-                        INTERFACE_USER_TAGS_PREFIX, interface_metadata.device_id, str(interface_metadata.index)
+                        INTERFACE_TAGS_PREFIX, interface_metadata.device_id, str(interface_metadata.index)
                     ),
                 )
                 self.submit_interface_status_metric(

--- a/cisco_aci/tests/test_fabric.py
+++ b/cisco_aci/tests/test_fabric.py
@@ -31,12 +31,12 @@ device_hn1 = 'apic1'
 
 namespace = 'default'
 
-node101_port1 = 'dd.internal.resource:ndm_interface_user_tags:default:10.0.200.0:1'
-node101_port2 = 'dd.internal.resource:ndm_interface_user_tags:default:10.0.200.0:2'
-node102_port1 = 'dd.internal.resource:ndm_interface_user_tags:default:10.0.200.1:1'
-node102_port2 = 'dd.internal.resource:ndm_interface_user_tags:default:10.0.200.1:2'
-node201_port1 = 'dd.internal.resource:ndm_interface_user_tags:default:10.0.200.5:1'
-node201_port2 = 'dd.internal.resource:ndm_interface_user_tags:default:10.0.200.5:2'
+node101_port1 = 'dd.internal.resource:ndm_interface:default:10.0.200.0:1'
+node101_port2 = 'dd.internal.resource:ndm_interface:default:10.0.200.0:2'
+node102_port1 = 'dd.internal.resource:ndm_interface:default:10.0.200.1:1'
+node102_port2 = 'dd.internal.resource:ndm_interface:default:10.0.200.1:2'
+node201_port1 = 'dd.internal.resource:ndm_interface:default:10.0.200.5:1'
+node201_port2 = 'dd.internal.resource:ndm_interface:default:10.0.200.5:2'
 
 device_tags_101 = [
     'device_hostname:{}'.format(device_hn101),
@@ -130,7 +130,7 @@ def test_fabric_mocked(aggregator):
                 'device_id:{}'.format(interface.device_id),
                 'status:{}'.format(interface.status),
                 'dd.internal.resource:ndm_device_user_tags:{}'.format(interface.device_id),
-                'dd.internal.resource:ndm_interface_user_tags:{}:{}'.format(interface.device_id, interface.index),
+                'dd.internal.resource:ndm_interface:{}:{}'.format(interface.device_id, interface.index),
             ]
             aggregator.assert_metric('cisco_aci.fabric.port.status', value=1.0, tags=interface_tags, hostname=device_hn)
 

--- a/cisco_aci/tests/test_fabric.py
+++ b/cisco_aci/tests/test_fabric.py
@@ -43,28 +43,28 @@ device_tags_101 = [
     'device_id:{}:{}'.format(namespace, node101),
     'device_ip:{}'.format(node101),
     'device_namespace:{}'.format(namespace),
-    'dd.internal.resource:ndm_device_user_tags:default:10.0.200.0',
+    'dd.internal.resource:ndm_device:default:10.0.200.0',
 ]
 device_tags_102 = [
     'device_hostname:{}'.format(device_hn102),
     'device_id:{}:{}'.format(namespace, node102),
     'device_ip:{}'.format(node102),
     'device_namespace:{}'.format(namespace),
-    'dd.internal.resource:ndm_device_user_tags:default:10.0.200.1',
+    'dd.internal.resource:ndm_device:default:10.0.200.1',
 ]
 device_tags_201 = [
     'device_hostname:{}'.format(device_hn201),
     'device_id:{}:{}'.format(namespace, node201),
     'device_ip:{}'.format(node201),
     'device_namespace:{}'.format(namespace),
-    'dd.internal.resource:ndm_device_user_tags:default:10.0.200.5',
+    'dd.internal.resource:ndm_device:default:10.0.200.5',
 ]
 device_tags_1 = [
     'device_hostname:{}'.format(device_hn1),
     'device_id:{}:{}'.format(namespace, node1),
     'device_ip:{}'.format(node1),
     'device_namespace:{}'.format(namespace),
-    'dd.internal.resource:ndm_device_user_tags:default:10.0.200.4',
+    'dd.internal.resource:ndm_device:default:10.0.200.4',
 ]
 
 tags000 = ['cisco', 'project:cisco_aci', 'medium:broadcast', 'snmpTrapSt:enable', 'fabric_pod_id:1']
@@ -129,7 +129,7 @@ def test_fabric_mocked(aggregator):
                 'device_hostname:{}'.format(device_hn),
                 'device_id:{}'.format(interface.device_id),
                 'status:{}'.format(interface.status),
-                'dd.internal.resource:ndm_device_user_tags:{}'.format(interface.device_id),
+                'dd.internal.resource:ndm_device:{}'.format(interface.device_id),
                 'dd.internal.resource:ndm_interface:{}:{}'.format(interface.device_id, interface.index),
             ]
             aggregator.assert_metric('cisco_aci.fabric.port.status', value=1.0, tags=interface_tags, hostname=device_hn)


### PR DESCRIPTION
### What does this PR do?
This PR udpates cisco aci integration to tag metrics by `ndm_interface` and `ndm_device`

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
