### PR TITLE
Prevent leak of tags across check runs

### DIFF
--- a/tibco_ems/datadog_checks/tibco_ems/tibco_ems.py
+++ b/tibco_ems/datadog_checks/tibco_ems/tibco_ems.py
@@ -31,7 +31,6 @@ class TibcoEMSCheck(AgentCheck):
         script_path = self.instance.get('script_path')
         server_string = CONNECTION_STRING.format(host, port)
         self.tags = self.instance.get('tags', [])
-        self.parsed_data = {}
 
         self.cmd = tibemsadmin_cmd + [
             '-server',
@@ -55,18 +54,20 @@ class TibcoEMSCheck(AgentCheck):
         sections = self._section_output(cleaned_data)
 
         # Parse the output
+        parsed_data = {}
         for command, section in sections.items():
             pattern = SHOW_METRIC_DATA[command]['regex']
             if command == 'show server':
-                self.parsed_data[command] = self._parse_show_server(section, pattern)
+                parsed_data[command] = self._parse_show_server(section, pattern)
             else:
                 try:
-                    self.parsed_data[command] = self._parse_factory(section, pattern)
+                    parsed_data[command] = self._parse_factory(section, pattern)
                 except Exception as e:
                     self.log.error('Error parsing command %s: %s', command, e)
                     continue
 
-        for command, metric_info in self.parsed_data.items():
+        for command, metric_info in parsed_data.items():
+            self.log.debug("Processing output from %s command", command)
             metric_keys = SHOW_METRIC_DATA[command]['metric_keys']
             tag_keys = SHOW_METRIC_DATA[command]['tags']
             metric_prefix = SHOW_METRIC_DATA[command]['metric_prefix']
@@ -205,11 +206,14 @@ class TibcoEMSCheck(AgentCheck):
         return data
 
     def _submit_metrics_factory(self, prefix, metric_data, metric_names, tag_keys):
+        self.log.debug("Submitting %s metrics (%s tags) for %s", len(metric_names), len(tag_keys), prefix)
         tags = []
         for key in tag_keys:
             if prefix == 'server':
                 # Add server tags to all metrics
-                self.tags.append(f"server_{key}:{metric_data[key]}")
+                server_tag = f"server_{key}:{metric_data[key]}"
+                if server_tag not in self.tags:
+                    self.tags.append(server_tag)
             else:
                 if metric_data.get(key):
                     tags.append(f"{key}:{metric_data[key]}")

--- a/tibco_ems/tests/test_unit.py
+++ b/tibco_ems/tests/test_unit.py
@@ -149,3 +149,17 @@ def test_parse_factory(data, regex, expected_result):
     result = check._parse_factory(data.decode('utf-8'), regex)
 
     assert result == expected_result
+
+
+def test_base_tags(dd_run_check, instance):
+    check = TibcoEMSCheck('tibco_ems', {}, [instance])
+    check.run_tibco_command = MagicMock(return_value=mock_output('show_all'))
+    dd_run_check(check)
+    assert len(check.tags) == 3
+
+    dd_run_check(check)
+    dd_run_check(check)
+    dd_run_check(check)
+
+    # assert the lenght of tags does not grow indefinitely
+    assert len(check.tags) == 3

--- a/tibco_ems/tests/test_unit.py
+++ b/tibco_ems/tests/test_unit.py
@@ -2,13 +2,10 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from typing import Any, Callable, Dict  # noqa: F401
 from unittest.mock import MagicMock
 
 import pytest
 
-from datadog_checks.base import AgentCheck  # noqa: F401
-from datadog_checks.base.stubs.aggregator import AggregatorStub  # noqa: F401
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.tibco_ems import TibcoEMSCheck
 


### PR DESCRIPTION
### What does this PR do?
- Prevents self.tags from increasing every check run 
- Also stop storing parsed_data across check runs
- Additionally adds some debug log lines
### Motivation
customer was seeing increasing resource usage when running the tibco_ems integration. 
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
