### PR TITLE
Data Streams messages - support Avro & Protobuf formats

### DIFF
--- a/kafka_consumer/pyproject.toml
+++ b/kafka_consumer/pyproject.toml
@@ -37,6 +37,8 @@ license = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "confluent-kafka==2.8.0",
+    "fastavro>=1.11.0",
+    "protobuf>=4.25.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?

For users using Avro & Protobuf, this PR allows them to retrieve messages from Kafka via the Datadog UI:
<img width="1113" height="777" alt="image" src="https://github.com/user-attachments/assets/406752c9-e5f1-4cb2-b775-22f04e57d2d9" />

Avro support is pretty straight forward: The Avro schema is in Json format.
For Protobuf, the schema is the descriptor file, and in order to pass it via remote configuration & as a configuration to the Kafka Consumer integration, it is base64 encoded on top of it.
For Protobuf, it is assumed that the first object in the pool is the parent schema.


### Motivation

Most Kafka users are using Avro & Protobuf formats. With support for both of these, most users should be covered.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
