### PR TITLE
fix(json-specs): ibm_i - fix invalid type on exclusiveMinimum prop

### DIFF
--- a/ibm_i/assets/configuration/spec.yaml
+++ b/ibm_i/assets/configuration/spec.yaml
@@ -53,24 +53,21 @@ files:
         The timeout (in seconds) applied to queries on job views (ACTIVE_JOB_INFO, JOB_INFO) made on the IBM i system.
       value:
         type: integer
-        minimum: 0
-        exclusiveMinimum: true
+        exclusiveMinimum: 0
         example: 240
     - name: system_mq_query_timeout
       description: |
         The timeout (in seconds) applied to queries on message queue views (MESSAGE_QUEUE_INFO) made on the IBM i system.
       value:
         type: integer
-        minimum: 0
-        exclusiveMinimum: true
+        exclusiveMinimum: 0
         example: 80
     - name: query_timeout
       description: |
         The timeout (in seconds) applied to queries made on the IBM i system.
       value:
         type: integer
-        minimum: 0
-        exclusiveMinimum: true
+        exclusiveMinimum: 0
         example: 30
     - name: queries
       description: |


### PR DESCRIPTION
### What does this PR do?

Fix invalid value of `exclusiveMinimum` in the spec file of `ibm_i` integration.

`exclusiveMinimum` is a number, not a boolean:
- https://spec.openapis.org/oas/v3.0.3#properties
- https://json-schema.org/understanding-json-schema/reference/numeric#range

### Motivation

https://datadoghq.atlassian.net/browse/FA-1028

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
