### PR TITLE
Add agent health event for Postgres config validation

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -16,13 +16,13 @@ files:
   - template: instances
     options:
     - name: host
-      required: true
       description: |
         The hostname to connect to. To connect to a Unix socket, specify the full path to the socket file,
         e.g. `/var/run/postgresql/.s.PGSQL.5432`.
       value:
         example: "localhost"
         type: string
+        default: ""
     - name: port
       description: The port to use when connecting to PostgreSQL.
       value:
@@ -30,10 +30,10 @@ files:
         example: 5432
     - name: username
       description: The Datadog username created to connect to PostgreSQL.
-      required: true
       value:
         type: string
         example: datadog
+        default: ""
     - name: password
       description: The password associated with the Datadog user.
       value:
@@ -51,6 +51,7 @@ files:
         and can be useful to set a custom hostname when connecting to a remote database through a proxy.
       value:
         type: string
+        default: null
     - name: exclude_hostname
       description: |
         Omit the hostname from tags and events. This is useful when the database host is not monitored by an agent.
@@ -79,7 +80,6 @@ files:
             - host: The provided host of the instance.
             - port: The port number of the instance.
             In addition, you can use any key from the `tags` section of the configuration.
-          default: "$resolved_hostname"
     - name: dbstrict
       description: |
         Whether to restrict the scope of the check to just the database in question.
@@ -117,7 +117,7 @@ files:
     - name: ignore_schemas_owned_by
       description: |
         A list of database users which own schemas to ignore.
-        No metrics or statement samples will be collected for these schemas.
+        No metrics will be collected for these schemas.
         Each value can be a plain string or a Postgres pattern.
       value:
         type: array
@@ -157,6 +157,7 @@ files:
         For a detailed description of how this option works see https://www.postgresql.org/docs/current/libpq-ssl.html
       value:
         type: string
+        default: null
     - name: ssl_cert
       description: |
         The path to the ssl certificate.
@@ -164,6 +165,7 @@ files:
         For a detailed description of how this option works see https://www.postgresql.org/docs/current/libpq-ssl.html
       value:
         type: string
+        default: null
     - name: ssl_key
       description: |
         The path to the ssl client key.
@@ -171,6 +173,7 @@ files:
         For a detailed description of how this option works see https://www.postgresql.org/docs/current/libpq-ssl.html
       value:
         type: string
+        default: null
     - name: ssl_password
       description: |
         The password for the secret key specified in ssl_key, allowing client certificate private keys to be stored
@@ -179,6 +182,7 @@ files:
         For a detailed description of how this option works see https://www.postgresql.org/docs/current/libpq-ssl.html
       value:
         type: string
+        default: null
     - name: query_timeout
       description: |
         Adds a statement_timeout https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-STATEMENT-TIMEOUT
@@ -258,6 +262,7 @@ files:
                 type: array
                 items:
                     type: string
+        default: []
         example:
           - relation_name: <TABLE_NAME>
             schemas:
@@ -287,7 +292,6 @@ files:
       value:
         type: boolean
         example: false
-        display_default: false
     - name: collect_activity_metrics
       description: |
         Collect metrics regarding transactions from pg_stat_activity. Please make sure the user
@@ -340,14 +344,16 @@ files:
         Starting Postgres 10, WAL file metrics are enabled by default using `pg_ls_waldir` and don't need local access.
       value:
         type: boolean
-        example: false
+        example: true
     - name: data_directory
       description: |
         The data directory of your postgres installation
-        Required when collecting WAL metrics.
+        Required when collecting WAL metrics on Postgres 9.6.
       value:
         type: string
         example: /usr/local/pgsql/data
+        display_default: null
+        default: null
     - name: tag_replication_role
       hidden: true
       description: Tag metrics and checks with `replication_role:<master|standby>`.
@@ -358,7 +364,6 @@ files:
       description: The maximum number of tables to collect metrics from.
       value:
         type: integer
-        display_default: 200
         example: 200
     - template: instances/db
       overrides:
@@ -372,6 +377,12 @@ files:
             tags:
               - test:postgresql
             metric_prefix: postgresql
+    - name: custom_metrics
+      description: This option is deprecated. Use `custom_queries` instead.
+      value:
+        type: array
+        items:
+          type: object
     - name: database_autodiscovery
       description: |
         Define the configuration for database autodiscovery.
@@ -462,6 +473,15 @@ files:
         type: string
         example: show_pg_stat_statements()
         display_default: pg_stat_statements
+    - name: pg_stat_activity_view
+      hidden: true
+      description: |
+        Set this value if you want to define a custom view or function to allow the datadog user to query the
+        `pg_stat_activity` table, which is useful for restricting the permissions given to the datadog agent.
+        Please note this is an ALPHA feature and is subject to change or deprecation without notice.
+      value:
+        type: string
+        display_default: pg_stat_activity
     - name: query_encodings
       description: |
         Set this value if your database is encoded in SQL_ASCII and you have clients that use encodings other than UTF-8.
@@ -477,6 +497,8 @@ files:
         example:
           - utf8
           - latin1
+        display_default:
+          - utf8
     - name: query_metrics
       description: Configure collection of query metrics
       options:
@@ -502,6 +524,20 @@ files:
           value:
             type: number
             example: 10000
+        - name: full_statement_text_cache_max_size
+          hidden: true
+          description: |
+            Set the max size of the cache used for the full statement text.
+          value:
+            type: number
+            example: 10000
+        - name: full_statement_text_samples_per_hour_per_query
+          hidden: true
+          description: |
+            Set the max number of full statement text samples to collect per hour per query.
+          value:
+            type: number
+            example: 10000
         - name: incremental_query_metrics
           hidden: true
           description: |
@@ -520,6 +556,22 @@ files:
             type: number
             display_default: 300
             example: 300
+        - name: run_sync
+          hidden: true
+          description: |
+            Run the query metrics collection synchronously. This is useful for testing purposes, but should not be used
+            in production as it can block the main thread and cause performance issues.
+          value:
+            type: boolean
+            example: false
+        - name: batch_max_content_size
+          hidden: true
+          description: |
+            This is a stub option for type hints. This value is actually set in the datadog.yaml config using
+            database_monitoring.metrics.batch_max_content_size. For details on this parameter, see statements.py.
+          value:
+            type: integer
+            example: 20_000_000
     - name: query_samples
       description: Configure collection of query samples
       options:
@@ -577,6 +629,14 @@ files:
           value:
             type: boolean
             example: true
+        - name: run_sync
+          hidden: true
+          description: |
+            Run the query metrics collection synchronously. This is useful for testing purposes, but should not be used
+            in production as it can block the main thread and cause performance issues.
+          value:
+            type: boolean
+            example: false
     - name: query_activity
       description: Configure collection of query activity
       options:
@@ -629,6 +689,14 @@ files:
                 - plpgsql%
               default:
                 - plpgsql%
+        - name: run_sync
+          hidden: true
+          description: |
+            Run the metadata collection synchronously. This is useful for testing purposes, but should not be used
+            in production as it can block the main thread and cause performance issues.
+          value:
+            type: boolean
+            example: false
     - name: collect_schemas
       description: |
         Enable collection of database schemas. In order to collect schemas from all user databases,
@@ -872,35 +940,6 @@ files:
             - name: identity_scope
               type: string
               example: https://ossrdbms-aad.database.windows.net/.default
-
-    - name: managed_identity
-      description: |
-        DEPRECATED: Please use `azure.managed_authentication` instead.
-
-        Configuration section used for Azure AD Authentication.
-
-        This supports using System or User assigned managed identities.
-        If this section is set, then the `username` and `password` fields will be ignored.
-
-        For more information on Managed Identities, see the Azure docs
-        https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
-      options:
-        - name: client_id
-          description: |
-            Client ID of the Managed Identity.
-          value:
-            type: string
-        - name: identity_scope
-          description: |
-            The permission scope from where to access the identity token. This value is optional if using the default
-            identity scope for Azure managed databases.
-
-            For more information on scopes, see the Azure docs
-            https://learn.microsoft.com/en-us/azure/active-directory/develop/scopes-oidc
-          value:
-            type: string
-            example: https://ossrdbms-aad.database.windows.net/.default
-
     - name: obfuscator_options
       description: |
         Configure how the SQL obfuscator behaves.
@@ -1070,7 +1109,6 @@ files:
       value:
         type: number
         example: 300
-        display_default: false
     - name: propagate_agent_tags
       description: |
         Set to `true` to propagate the tags from `datadog.yaml` and the agent host tags to the check.

--- a/postgres/changelog.d/20900.added
+++ b/postgres/changelog.d/20900.added
@@ -1,0 +1,1 @@
+Add agent health event for Postgres config validation

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -2,7 +2,49 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 # https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
-from typing import Optional
+from __future__ import annotations
+
+import copy
+from enum import Enum
+from typing import TYPE_CHECKING, Optional, Tuple, TypedDict
+
+from datadog_checks.postgres.config_models import InstanceConfig
+from datadog_checks.postgres.config_models.defaults import (
+    instance_dbm,
+    instance_disable_generic_tags,
+    instance_port,
+    instance_propagate_agent_tags,
+)
+from datadog_checks.postgres.config_models.instance import (
+    Aws,
+    Azure,
+    Gcp,
+    ManagedAuthentication,
+    ManagedAuthentication1,
+    Union,
+)
+from datadog_checks.postgres.discovery import (
+    DEFAULT_MAX_DATABASES,
+)
+from datadog_checks.postgres.discovery import (
+    DEFAULT_REFRESH as DEFAULT_AUTODISCOVERY_REFRESH_INTERVAL,
+)
+from datadog_checks.postgres.metadata import (
+    DEFAULT_SCHEMAS_COLLECTION_INTERVAL,
+    DEFAULT_SETTINGS_COLLECTION_INTERVAL,
+    DEFAULT_SETTINGS_IGNORED_PATTERNS,
+)
+from datadog_checks.postgres.statement_samples import (
+    DEFAULT_ACTIVITY_COLLECTION_INTERVAL as DEFAULT_QUERY_ACTIVITY_COLLECTION_INTERVAL,
+)
+from datadog_checks.postgres.statement_samples import (
+    DEFAULT_COLLECTION_INTERVAL as DEFAULT_QUERY_SAMPLES_COLLECTION_INTERVAL,
+)
+from datadog_checks.postgres.statements import DEFAULT_COLLECTION_INTERVAL as DEFAULT_QUERY_METRICS_COLLECTION_INTERVAL
+from datadog_checks.postgres.relationsmanager import RelationsManager
+
+if TYPE_CHECKING:
+    from datadog_checks.postgres import PostgreSql
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from datadog_checks.base.utils.aws import rds_parse_tags_from_endpoint
@@ -11,180 +53,15 @@ from datadog_checks.base.utils.db.utils import get_agent_host_tags
 SSL_MODES = {'disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full'}
 TABLE_COUNT_LIMIT = 200
 
-DEFAULT_IGNORE_DATABASES = [
-    'template0',
-    'template1',
-    'rdsadmin',
-    'azure_maintenance',
-    'cloudsqladmin',
-    'alloydbadmin',
-    'alloydbmetadata',
-    'postgres',
-]
 
-DEFAULT_IGNORED_SCHEMAS_OWNED_BY = ['rdsadmin', 'rds_superuser']
-
-
-class PostgresConfig:
+class PostgresConfig(InstanceConfig):
     RATE = AgentCheck.rate
     GAUGE = AgentCheck.gauge
     MONOTONIC = AgentCheck.monotonic_count
 
-    def __init__(self, instance, init_config, check):
-        self.exclude_hostname = instance.get("exclude_hostname", False)
-        self.database_identifier = instance.get('database_identifier', {})
-        self.init_config = init_config
-        self.host = instance.get('host', '')
-        if not self.host:
-            raise ConfigurationError('Specify a Postgres host to connect to.')
-        self.port = instance.get('port', '5432')
-        if self.port != '':
-            self.port = int(self.port)
-        self.user = instance.get('username', '')
-        if not self.user:
-            raise ConfigurationError('Please specify a user to connect to Postgres.')
-        self.password = instance.get('password', '')
-        self.dbname = instance.get('dbname', 'postgres')
-        self.reported_hostname = instance.get('reported_hostname', '')
-        self.dbstrict = is_affirmative(instance.get('dbstrict', False))
-        self.disable_generic_tags = is_affirmative(instance.get('disable_generic_tags', False)) if instance else False
-
-        self.discovery_config = instance.get('database_autodiscovery', {"enabled": False})
-        if self.discovery_config['enabled'] and self.dbname != 'postgres':
-            raise ConfigurationError(
-                "'dbname' parameter should not be set when `database_autodiscovery` is enabled."
-                "To monitor more databases, add them to the `database_autodiscovery` includelist."
-            )
-
-        self.application_name = instance.get('application_name', 'datadog-agent')
-        if not self.application_name.isascii():
-            raise ConfigurationError("Application name can include only ASCII characters: %s", self.application_name)
-
-        self.query_timeout = int(instance.get('query_timeout', 5000))
-        self.idle_connection_timeout = instance.get('idle_connection_timeout', 60000)
-        self.relations = instance.get('relations', [])
-        if self.relations and not (self.dbname or self.discovery_config['enabled']):
-            raise ConfigurationError(
-                '"dbname" parameter must be set OR autodiscovery must be enabled when using the "relations" parameter.'
-            )
-        self.max_connections = instance.get('max_connections', 30)
-
-        ssl = instance.get('ssl', "allow")
-        if ssl in SSL_MODES:
-            self.ssl_mode = ssl
-        else:
-            check.warning(f"Invalid ssl option '{ssl}', should be one of {SSL_MODES}. Defaulting to 'allow'.")
-            self.ssl_mode = "allow"
-
-        self.ssl_cert = instance.get('ssl_cert', None)
-        self.ssl_root_cert = instance.get('ssl_root_cert', None)
-        self.ssl_key = instance.get('ssl_key', None)
-        self.ssl_password = instance.get('ssl_password', None)
-        self.table_count_limit = instance.get('table_count_limit', TABLE_COUNT_LIMIT)
-        self.collect_buffercache_metrics = is_affirmative(instance.get('collect_buffercache_metrics', False))
-        self.collect_function_metrics = is_affirmative(instance.get('collect_function_metrics', False))
-        # Default value for `count_metrics` is True for backward compatibility
-        self.collect_count_metrics = is_affirmative(instance.get('collect_count_metrics', True))
-        self.collect_activity_metrics = is_affirmative(instance.get('collect_activity_metrics', False))
-        self.collect_checksum_metrics = is_affirmative(instance.get('collect_checksum_metrics', False))
-        self.activity_metrics_excluded_aggregations = instance.get('activity_metrics_excluded_aggregations', [])
-        self.collect_database_size_metrics = is_affirmative(instance.get('collect_database_size_metrics', True))
-        self.collect_wal_metrics = self._should_collect_wal_metrics(instance.get('collect_wal_metrics'))
-        self.collect_bloat_metrics = is_affirmative(instance.get('collect_bloat_metrics', False))
-        self.data_directory = instance.get('data_directory', None)
-        self.ignore_databases = instance.get('ignore_databases', DEFAULT_IGNORE_DATABASES)
-        if is_affirmative(instance.get('collect_default_database', True)):
-            self.ignore_databases = [d for d in self.ignore_databases if d != 'postgres']
-        self.ignore_schemas_owned_by = instance.get('ignore_schemas_owned_by', DEFAULT_IGNORED_SCHEMAS_OWNED_BY)
-        self.tag_replication_role = is_affirmative(instance.get('tag_replication_role', True))
-        self.custom_metrics = self._get_custom_metrics(instance.get('custom_metrics', []))
-        self.max_relations = int(instance.get('max_relations', 300))
-        self.min_collection_interval = instance.get('min_collection_interval', 15)
-        # database monitoring adds additional telemetry for query metrics & samples
-        self.dbm_enabled = is_affirmative(instance.get('dbm', instance.get('deep_database_monitoring', False)))
-        self.full_statement_text_cache_max_size = instance.get('full_statement_text_cache_max_size', 10000)
-        self.full_statement_text_samples_per_hour_per_query = instance.get(
-            'full_statement_text_samples_per_hour_per_query', 1
-        )
-        # Support a custom view when datadog user has insufficient privilege to see queries
-        self.pg_stat_statements_view = instance.get('pg_stat_statements_view', 'pg_stat_statements')
-        # statement samples & execution plans
-        self.pg_stat_activity_view = instance.get('pg_stat_activity_view', 'pg_stat_activity')
-        self.statement_samples_config = instance.get('query_samples', instance.get('statement_samples', {})) or {}
-        self.settings_metadata_config = instance.get('collect_settings', {}) or {}
-        self.schemas_metadata_config = instance.get('collect_schemas', {"enabled": False})
-        self.resources_metadata_config = instance.get('collect_resources', {}) or {}
-        self.statement_activity_config = instance.get('query_activity', {}) or {}
-        self.statement_metrics_config = instance.get('query_metrics', {}) or {}
-        self.query_encodings = instance.get('query_encodings')
-        self.managed_identity = instance.get('managed_identity', {})
-        self.cloud_metadata = {}
-        aws = instance.get('aws', {})
-        gcp = instance.get('gcp', {})
-        azure = instance.get('azure', {})
-        # Remap fully_qualified_domain_name to name
-        azure = {k if k != 'fully_qualified_domain_name' else 'name': v for k, v in azure.items()}
-        if aws:
-            aws['managed_authentication'] = self._aws_managed_authentication(aws, self.password)
-            self.cloud_metadata.update({'aws': aws})
-        if gcp:
-            self.cloud_metadata.update({'gcp': gcp})
-        if azure:
-            azure['managed_authentication'] = self._azure_managed_authentication(azure, self.managed_identity)
-            self.cloud_metadata.update({'azure': azure})
-        obfuscator_options_config = instance.get('obfuscator_options', {}) or {}
-        self.obfuscator_options = {
-            # Valid values for this can be found at
-            # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#connection-level-attributes
-            'dbms': 'postgresql',
-            'replace_digits': is_affirmative(
-                obfuscator_options_config.get(
-                    'replace_digits', obfuscator_options_config.get('quantize_sql_tables', False)
-                )
-            ),
-            'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('keep_dollar_quoted_func', True)),
-            'keep_sql_alias': is_affirmative(obfuscator_options_config.get('keep_sql_alias', True)),
-            'return_json_metadata': is_affirmative(obfuscator_options_config.get('collect_metadata', True)),
-            'table_names': is_affirmative(obfuscator_options_config.get('collect_tables', True)),
-            'collect_commands': is_affirmative(obfuscator_options_config.get('collect_commands', True)),
-            'collect_comments': is_affirmative(obfuscator_options_config.get('collect_comments', True)),
-            # Config to enable/disable obfuscation of sql statements with go-sqllexer pkg
-            # Valid values for this can be found at https://github.com/DataDog/datadog-agent/blob/main/pkg/obfuscate/obfuscate.go#L108
-            'obfuscation_mode': obfuscator_options_config.get('obfuscation_mode', 'obfuscate_and_normalize'),
-            'remove_space_between_parentheses': is_affirmative(
-                obfuscator_options_config.get('remove_space_between_parentheses', False)
-            ),
-            'keep_null': is_affirmative(obfuscator_options_config.get('keep_null', False)),
-            'keep_boolean': is_affirmative(obfuscator_options_config.get('keep_boolean', False)),
-            'keep_positional_parameter': is_affirmative(
-                obfuscator_options_config.get('keep_positional_parameter', False)
-            ),
-            'keep_trailing_semicolon': is_affirmative(obfuscator_options_config.get('keep_trailing_semicolon', False)),
-            'keep_identifier_quotation': is_affirmative(
-                obfuscator_options_config.get('keep_identifier_quotation', False)
-            ),
-            'keep_json_path': is_affirmative(obfuscator_options_config.get('keep_json_path', False)),
-        }
-        collect_raw_query_statement_config: dict = instance.get('collect_raw_query_statement', {}) or {}
-        self.collect_raw_query_statement = {
-            "enabled": is_affirmative(collect_raw_query_statement_config.get('enabled', False)),
-            "cache_max_size": int(collect_raw_query_statement_config.get('cache_max_size', 10000)),
-            "samples_per_hour_per_query": int(collect_raw_query_statement_config.get('samples_per_hour_per_query', 1)),
-        }
-        self.log_unobfuscated_queries = is_affirmative(instance.get('log_unobfuscated_queries', False))
-        self.log_unobfuscated_plans = is_affirmative(instance.get('log_unobfuscated_plans', False))
-        self.database_instance_collection_interval = instance.get('database_instance_collection_interval', 300)
-        self.incremental_query_metrics = is_affirmative(
-            self.statement_metrics_config.get('incremental_query_metrics', False)
-        )
-        self.baseline_metrics_expiry = self.statement_metrics_config.get('baseline_metrics_expiry', 300)
-        self.service = instance.get('service') or init_config.get('service') or ''
-
-        self.tags = self._build_tags(
-            custom_tags=instance.get('tags', []),
-            propagate_agent_tags=self._should_propagate_agent_tags(instance, init_config),
-            additional_tags=["raw_query_statement:enabled"] if self.collect_raw_query_statement["enabled"] else [],
-        )
+    def __init__(self, check: PostgreSql, init_config: dict):
+        self._check = check
+        self._init_config = init_config
 
     def _build_tags(self, custom_tags, propagate_agent_tags, additional_tags):
         # Clean up tags in case there was a None entry in the instance
@@ -314,3 +191,517 @@ class PostgresConfig:
             return init_config_propagate_agent_tags
         # if neither the instance nor the init_config has set the value, return False
         return False
+
+
+class FeatureKey(Enum):
+    """
+    Enum representing the keys for features in the Postgres configuration.
+    """
+
+    RELATION_METRICS = "relation_metrics"
+    QUERY_SAMPLES = "query_samples"
+    COLLECT_SETTINGS = "collect_settings"
+    COLLECT_SCHEMAS = "collect_schemas"
+    QUERY_ACTIVITY = "query_activity"
+    QUERY_METRICS = "query_metrics"
+
+
+FeatureNames = {
+    FeatureKey.RELATION_METRICS: 'Relation Metrics',
+    FeatureKey.QUERY_SAMPLES: 'Query Samples',
+    FeatureKey.COLLECT_SETTINGS: 'Collect Settings',
+    FeatureKey.COLLECT_SCHEMAS: 'Collect Schemas',
+    FeatureKey.QUERY_ACTIVITY: 'Query Activity',
+    FeatureKey.QUERY_METRICS: 'Query Metrics',
+}
+
+
+class Feature(TypedDict):
+    """
+    A feature in the Postgres configuration that can be enabled or disabled.
+    """
+
+    key: str
+    name: str
+    enabled: bool
+    description: str | None
+
+
+class ValidationResult:
+    """
+    A simple class to represent the result of a validation.
+    It can be extended in the future to include more details about the validation.
+    """
+
+    def __init__(self, valid=True):
+        """
+        :param valid: Whether the validation passed.
+        :param features: A list of features that were validated.
+        """
+        self.valid = valid
+        self.features: list[Feature] = []
+        self.errors: list[ConfigurationError] = []
+        self.warnings: list[str] = []
+
+    def add_feature(self, feature: FeatureKey, enabled=True, description: Optional[str] = None):
+        """
+        Add a feature to the validation result.
+        :param feature: The feature to add.
+        :param enabled: Whether the feature is enabled.
+        """
+        self.features.append(
+            {"key": feature, "name": FeatureNames[feature], "enabled": enabled, "description": description}
+        )
+
+    def add_error(self, error: str | ConfigurationError):
+        """
+        Add an error to the validation result.
+        :param error: The error message to add.
+        """
+        self.errors.append(ConfigurationError(error) if isinstance(error, str) else error)
+        self.valid = False
+
+    def add_warning(self, warning: str):
+        """
+        Add a warning to the validation result.
+        :param warning: The warning message to add.
+        """
+        self.warnings.append(warning)
+
+
+def build_config(check: PostgreSql, init_config: dict, instance: dict) -> Tuple[InstanceConfig, ValidationResult]:
+    """
+    Build the Postgres configuration.
+    :param check: The check instance.
+    :param init_config: The init_config for the Postgres check.
+    :param instance: The instance configuration for the Postgres check.
+    :return: InstanceConfig
+        The instance configuration object.
+    """
+
+    # Spec doesn't support dictionary defaults, so we use dict literals here
+    # Spec also doesn't support some hidden defaults
+    # If you change a literal value here, make sure to update spec.yaml
+
+    args = {}
+    # Automatically set values that support defaults or that have simple values in the instance
+    import importlib
+
+    instance_config_fields = set(InstanceConfig.__annotations__.keys())
+    defaults = importlib.import_module("datadog_checks.postgres.config_models.defaults")
+    for f in instance_config_fields:
+        try:
+            args[f] = getattr(defaults, f"instance_{f}")()
+        except AttributeError:
+            args[f] = None
+        if f in instance:
+            args[f] = instance[f]
+
+    # Set values for args that have deprecated fallbacks, are not supported by the spec model
+    # or have other complexities
+    args.update(
+        {
+            # Set the default port to None if the host is a socket path
+            "port": instance.get('port', instance_port() if not instance.get('host', '').startswith('/') else None),
+            # Set None values for ssl
+            # Database configuration
+            "dbm": instance.get(
+                'dbm', instance.get('deep_database_monitoring', instance_dbm())
+            ),  # Deprecated, use `dbm` instead
+            "custom_metrics": map_custom_metrics(
+                instance.get('custom_metrics', [])
+            ),  # Deprecated, use `custom_queries` instead
+            "custom_queries": instance.get('custom_queries', []),
+            "database_identifier": instance.get('database_identifier', {"template": "$resolved_hostname"}),
+            "database_autodiscovery": {
+                **{
+                    "enabled": False,
+                    "global_view_db": "postgres",
+                    "max_databases": DEFAULT_MAX_DATABASES,
+                    "include": [".*"],
+                    "exclude": ["cloudsqladmin"],
+                    "refresh": DEFAULT_AUTODISCOVERY_REFRESH_INTERVAL,
+                },
+                **(instance.get('database_autodiscovery', {})),
+            },
+            "query_metrics": {
+                **{
+                    "enabled": True,
+                    "collection_interval": DEFAULT_QUERY_METRICS_COLLECTION_INTERVAL,
+                    "pg_stat_statements_max_warning_threshold": 10000,
+                    "incremental_query_metrics": False,
+                    "baseline_metrics_expiry": 300,
+                    "full_statement_text_cache_max_size": 10000,
+                    "full_statement_text_samples_per_hour_per_query": 10000,
+                    "run_sync": False,
+                    "batch_max_content_size": init_config.get('metrics', {}).get('batch_max_content_size', 20_000_000),
+                },
+                **(instance.get('query_metrics', {})),
+            },
+            "query_samples": {
+                **{
+                    "enabled": True,
+                    "collection_interval": DEFAULT_QUERY_SAMPLES_COLLECTION_INTERVAL,
+                    "explain_function": "datadog.explain_statement",
+                    "explained_queries_per_hour_per_query": 60,
+                    "samples_per_hour_per_query": 15,
+                    "explained_queries_cache_maxsize": 5000,
+                    "seen_samples_cache_maxsize": 10000,
+                    "explain_parameterized_queries": True,
+                    "run_sync": False,
+                },
+                **(instance.get('statement_samples', {})),  # Deprecated, use `query_samples` instead
+                **(instance.get('query_samples', {})),
+            },
+            "query_activity": {
+                **{
+                    "enabled": True,
+                    "collection_interval": DEFAULT_QUERY_ACTIVITY_COLLECTION_INTERVAL,
+                    "payload_row_limit": 3500,
+                },
+                **(instance.get('query_activity', {})),
+            },
+            # Metadata collection
+            "collect_settings": {
+                **{
+                    "enabled": False,
+                    "collection_interval": DEFAULT_SETTINGS_COLLECTION_INTERVAL,
+                    "ignored_settings_patterns": DEFAULT_SETTINGS_IGNORED_PATTERNS,
+                    "run_sync": False,
+                },
+                **(instance.get('collect_settings') or {}),
+            },
+            "collect_schemas": {
+                **{
+                    "enabled": False,
+                    "max_tables": 300,
+                    "max_columns": 50,
+                    "collection_interval": DEFAULT_SCHEMAS_COLLECTION_INTERVAL,
+                    "include_databases": [],
+                    "exclude_databases": [],
+                    "include_schemas": [],
+                    "exclude_schemas": [],
+                    "include_tables": [],
+                    "exclude_tables": [],
+                },
+                **(instance.get('collect_schemas', {})),
+            },
+            # Cloud
+            "aws": {
+                **Aws(managed_authentication=ManagedAuthentication()).model_dump(),
+                **(instance.get('aws', {})),
+            },
+            "gcp": {
+                **Gcp().model_dump(),
+                **(instance.get('gcp', {})),
+            },
+            "azure": {
+                **Azure(managed_authentication=ManagedAuthentication1()).model_dump(),
+                **(instance.get('azure', {})),
+            },
+            # Obfuscation and query logging
+            "obfuscator_options": {
+                **{
+                    "obfuscation_mode": "obfuscate_and_normalize",
+                    "replace_digits": False,
+                    "collect_metadata": True,
+                    "collect_tables": True,
+                    "collect_commands": True,
+                    "collect_comments": True,
+                    "keep_sql_alias": True,
+                    "keep_dollar_quoted_func": True,
+                    "remove_space_between_parentheses": False,
+                    "keep_null": False,
+                    "keep_boolean": False,
+                    "keep_positional_parameter": False,
+                    "keep_trailing_semicolon": False,
+                    "keep_identifier_quotation": False,
+                    "keep_json_path": False,
+                },
+                **(instance.get('obfuscator_options', {})),
+            },
+            "collect_raw_query_statement": {
+                **{"enabled": False},
+                **(instance.get('collect_raw_query_statement', {})),
+            },
+            "propagate_agent_tags": should_propagate_agent_tags(instance=instance, init_config=init_config),
+            "service": instance.get('service', init_config.get('service', None)),
+            # Metric filtering by pattern is implemented downstream, theoretically
+            "metric_patterns": instance.get('metric_patterns', None),
+        }
+    )
+
+    validation_result = ValidationResult()
+
+    if safefloat(args['query_metrics']['collection_interval']) <= 0:
+        args['query_metrics']['collection_interval'] = DEFAULT_QUERY_METRICS_COLLECTION_INTERVAL
+        validation_result.add_warning(
+            "query_metrics.collection_interval must be greater than 0, defaulting to "
+            f"{DEFAULT_QUERY_METRICS_COLLECTION_INTERVAL} seconds."
+        )
+
+    if safefloat(args['query_samples']['collection_interval']) <= 0:
+        args['query_samples']['collection_interval'] = DEFAULT_QUERY_SAMPLES_COLLECTION_INTERVAL
+        validation_result.add_warning(
+            "query_samples.collection_interval must be greater than 0, defaulting to "
+            f"{DEFAULT_QUERY_SAMPLES_COLLECTION_INTERVAL} seconds."
+        )
+
+    if safefloat(args['query_activity']['collection_interval']) <= 0:
+        args['query_activity']['collection_interval'] = DEFAULT_QUERY_ACTIVITY_COLLECTION_INTERVAL
+        validation_result.add_warning(
+            "query_activity.collection_interval must be greater than 0, defaulting to "
+            f"{DEFAULT_QUERY_ACTIVITY_COLLECTION_INTERVAL} seconds."
+        )
+
+    tags, tag_errors = build_tags(instance=instance, init_config=init_config, config=args)
+    args['tags'] = tags
+    for error in tag_errors:
+        # If there are errors in the tags, we add them to the validation result
+        # but we don't raise an exception here, as we want to validate the rest of the configuration
+        validation_result.add_error(error)
+
+    # AWS backfill and validation
+    if (
+        not instance.get("aws", {}).get("managed_authentication", None)
+        and args['aws'].get('region')
+        and not args['password']
+    ):
+        # if managed_authentication is not set, we assume it is enabled if region is set and password is not set
+        args['aws']['managed_authentication']['enabled'] = True
+
+    if args['aws']['managed_authentication']['enabled'] and not args['aws']['region']:
+        validation_result.add_error('AWS region must be set when using AWS managed authentication')
+
+    # Azure backfill and validation
+    if not instance.get("azure", {}).get("managed_authentication", None) and (
+        args['azure'].get('managed_authentication', {}).get('client_id')
+        or instance.get('managed_identity', {}).get('client_id')
+    ):
+        # if managed_authentication is not set, we assume it is enabled if client_id is set
+        args['azure']['managed_authentication']['enabled'] = True
+
+    if instance.get("managed_identity"):
+        validation_result.add_warning(
+            'The `managed_identity` option is deprecated. Use `azure.managed_authentication` instead.'
+        )
+        args['azure']['managed_authentication'] = {
+            **args['azure']['managed_authentication'],
+            **instance.get('managed_identity', {}),
+        }
+
+    if args['azure'].get('managed_authentication', {}).get('enabled') and not args['azure'].get(
+        'managed_authentication', {}
+    ).get('client_id'):
+        validation_result.add_error('Azure client_id must be set when using Azure managed authentication')
+
+    if args.get('collect_default_database'):
+        args['ignore_databases'] = [d for d in args['ignore_databases'] if d != 'postgres']
+
+    # Validate config arguments for invalid or deprecated options
+    if args['ssl'] not in SSL_MODES:
+        warning = f"Invalid ssl option '{args['ssl']}', should be one of {SSL_MODES}. Defaulting to 'allow'."
+        validation_result.add_warning(warning)
+        args['ssl'] = "allow"
+
+    if instance.get('custom_metrics'):
+        validation_result.add_warning('The `custom_metrics` option is deprecated. Use `custom_queries` instead.')
+
+    if instance.get('deep_database_monitoring'):
+        validation_result.add_warning('The `deep_database_monitoring` option is deprecated. Use `dbm` instead.')
+
+    if instance.get('managed_authentication'):
+        validation_result.add_warning(
+            'The `managed_authentication` option is deprecated. Use `azure.managed_authentication` instead.'
+        )
+    if instance.get('statement_samples'):
+        validation_result.add_warning('The `statement_samples` option is deprecated. Use `query_samples` instead.')
+
+    # Check user provided value because the default configuration would trigger this warning
+    if instance.get('collect_default_database', False) and 'postgres' in instance.get('ignore_databases', []):
+        validation_result.add_warning(
+            'The `postgres` database cannot be ignored when `collect_default_database` is enabled.'
+        )
+
+    # Validate that the keys of args match the fields of InstanceConfig
+    args_keys = set(args.keys())
+    missing_fields = instance_config_fields - args_keys
+    extra_fields = args_keys - instance_config_fields
+    if missing_fields or extra_fields:
+        # This should get caught at test time and never execute at runtime
+        raise ConfigurationError(
+            f"build_config: args keys do not match InstanceConfig fields. "
+            f"Missing: {missing_fields}, Extra: {extra_fields}"
+        )
+
+    # The current InstanceConfig cannot be instantiated directly and integrations team is reluctant to fix it
+    # in case existing integrations use the faulty behavior.
+    # Instead we copy the behavior of the base check and instantiate this way
+    config = InstanceConfig.model_validate(args, context={"configured_fields": instance_config_fields})
+
+    # Validate required fields
+    if not config.host:
+        validation_result.add_error("Please specify a valid host to connect to using the `host` parameter.")
+
+    if not config.username:
+        validation_result.add_error("Please specify a user to connect to the database using the `username` parameter.")
+
+    # Validate config after defaults have been applied
+    if not config.application_name.isascii():
+        validation_result.add_error(f"Application name can include only ASCII characters: {config.application_name}")
+
+    if config.relations and not (config.dbname or config.database_autodiscovery.enabled):
+        validation_result.add_error(
+            '"dbname" parameter must be set OR autodiscovery must be enabled when using the "relations" parameter.'
+        )
+
+    if config.dbname and config.database_autodiscovery.enabled:
+        validation_result.add_error(
+            '"dbname" parameter must not be set when using the "database_autodiscovery" parameter.'
+        )
+
+    if config.empty_default_hostname:
+        validation_result.add_warning(
+            'The `empty_default_hostname` option has no effect in the Postgres check. '
+            'Use the `exclude_hostname` option instead.'
+        )
+
+    try:
+        RelationsManager.validate_relations_config(list(config.relations))
+    except ConfigurationError as e:
+        validation_result.add_error(e)
+
+    # Features
+    validation_result.add_feature(
+        FeatureKey.RELATION_METRICS,
+        bool(config.relations),
+        "Relation metrics requires a value for `relations` in the configuration." if not config.relations else None,
+    )
+    validation_result.add_feature(FeatureKey.QUERY_ACTIVITY, config.query_activity.enabled and config.dbm)
+    validation_result.add_feature(FeatureKey.QUERY_SAMPLES, config.query_samples.enabled and config.dbm)
+    validation_result.add_feature(FeatureKey.QUERY_METRICS, config.query_metrics.enabled and config.dbm)
+    validation_result.add_feature(FeatureKey.COLLECT_SETTINGS, config.collect_settings.enabled and config.dbm)
+    validation_result.add_feature(FeatureKey.COLLECT_SCHEMAS, config.collect_schemas.enabled and config.dbm)
+
+    # If instance config explicitly enables these features, we add a warning if dbm is not enabled
+    if instance.get('query_activity', {}).get('enabled') and not config.dbm:
+        validation_result.add_warning('The `query_activity` feature requires the `dbm` option to be enabled.')
+    if instance.get('query_samples', {}).get('enabled') and not config.dbm:
+        validation_result.add_warning('The `query_samples` feature requires the `dbm` option to be enabled.')
+    if instance.get('query_metrics', {}).get('enabled') and not config.dbm:
+        validation_result.add_warning('The `query_metrics` feature requires the `dbm` option to be enabled.')
+    if instance.get('collect_settings', {}).get('enabled') and not config.dbm:
+        validation_result.add_warning('The `collect_settings` feature requires the `dbm` option to be enabled.')
+    if instance.get('collect_schemas', {}).get('enabled') and not config.dbm:
+        validation_result.add_warning('The `collect_schemas` feature requires the `dbm` option to be enabled.')
+
+    return config, validation_result
+
+
+def build_tags(instance: dict, init_config: dict, config: dict) -> Tuple[list[str], list[ConfigurationError]]:
+    tags = list(set(instance.get('tags', [])))
+
+    # preset tags to host
+    if not instance.get('disable_generic_tags', instance_disable_generic_tags()):
+        tags.append('server:{}'.format(config.get('host')))
+    if config.get('port'):
+        tags.append('port:{}'.format(config.get('port')))
+    else:
+        tags.append('port:socket')
+
+    if instance.get('service'):
+        tags.append('service:{}'.format(instance.get('service')))
+    elif init_config.get('service'):
+        tags.append('service:{}'.format(init_config.get('service')))
+
+    # preset tags to the database name
+    tags.extend(["db:%s" % config.get('dbname')])
+
+    rds_tags = rds_parse_tags_from_endpoint(config.get('host'))
+    if rds_tags:
+        tags.extend(rds_tags)
+
+    errors = []
+    if config.get('propagate_agent_tags'):
+        try:
+            agent_tags = get_agent_host_tags()
+            tags.extend(agent_tags)
+        except Exception as e:
+            errors.append(
+                ConfigurationError(
+                    'propagate_agent_tags enabled but there was an error fetching agent tags {}'.format(e)
+                )
+            )
+
+    tags.extend(["raw_query_statement:enabled"] if config.get('collect_raw_query_statement', {}).get("enabled") else [])
+
+    return tags, errors
+
+
+def map_custom_metrics(custom_metrics):
+    # Pre-process custom metrics and verify definition
+    required_parameters = ("descriptors", "metrics", "query", "relation")
+
+    for m in custom_metrics:
+        for param in required_parameters:
+            if param not in m:
+                raise ConfigurationError('Missing {} parameter in custom metric'.format(param))
+
+        # Old formatting to new formatting. The first params is always the columns names from which to
+        # read metrics. The `relation` param instructs the check to replace the next '%s' with the list of
+        # relations names.
+        if m['relation']:
+            m['query'] = m['query'] % ('{metrics_columns}', '{relations_names}')
+        else:
+            m['query'] = m['query'] % '{metrics_columns}'
+
+        try:
+            for ref, (_, mtype) in m['metrics'].items():
+                cap_mtype = mtype.upper()
+                if cap_mtype not in ('RATE', 'GAUGE', 'MONOTONIC'):
+                    raise ConfigurationError(
+                        'Collector method {} is not known. Known methods are RATE, GAUGE, MONOTONIC'.format(cap_mtype)
+                    )
+
+                m['metrics'][ref][1] = getattr(PostgresConfig, cap_mtype)
+        except Exception as e:
+            raise Exception('Error processing custom metric `{}`: {}'.format(m, e))
+    return custom_metrics
+
+
+def should_propagate_agent_tags(instance, init_config) -> bool:
+    '''
+    return True if the agent tags should be propagated to the check
+    '''
+    instance_propagate = instance.get('propagate_agent_tags')
+    init_config_propagate = init_config.get('propagate_agent_tags')
+
+    if instance_propagate is not None:
+        # if the instance has explicitly set the value, return the boolean
+        return instance_propagate
+    if init_config_propagate is not None:
+        # if the init_config has explicitly set the value, return the boolean
+        return init_config_propagate
+    # if neither the instance nor the init_config has set the value, return default for instance
+    return instance_propagate_agent_tags()
+
+
+def sanitize(config: Union[InstanceConfig, dict]) -> dict:
+    if isinstance(config, InstanceConfig):
+        # If config is an InstanceConfig object, convert it to a dict
+        config = config.model_dump(exclude=['custom_metrics', 'custom_queries'])
+    sanitized = copy.deepcopy(config)
+    sanitized['password'] = '***' if sanitized.get('password') else None
+    sanitized['ssl_password'] = '***' if sanitized.get('ssl_password') else None
+
+    return sanitized
+
+
+def safefloat(value: any) -> float:
+    if value is None:
+        return 0.0
+    try:
+        f = float(value)
+        return f
+    except Exception:
+        return 0.0

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -53,15 +53,15 @@ def instance_collect_function_metrics():
 
 
 def instance_collect_wal_metrics():
-    return False
+    return True
 
 
 def instance_data_directory():
-    return '/usr/local/pgsql/data'
+    return None
 
 
 def instance_database_instance_collection_interval():
-    return False
+    return 300
 
 
 def instance_dbm():
@@ -86,6 +86,10 @@ def instance_empty_default_hostname():
 
 def instance_exclude_hostname():
     return False
+
+
+def instance_host():
+    return ''
 
 
 def instance_idle_connection_timeout():
@@ -132,6 +136,10 @@ def instance_only_custom_queries():
     return False
 
 
+def instance_pg_stat_activity_view():
+    return 'pg_stat_activity'
+
+
 def instance_pg_stat_statements_view():
     return 'pg_stat_statements'
 
@@ -144,12 +152,40 @@ def instance_propagate_agent_tags():
     return False
 
 
+def instance_query_encodings():
+    return ['utf8']
+
+
 def instance_query_timeout():
     return 5000
 
 
+def instance_relations():
+    return []
+
+
+def instance_reported_hostname():
+    return None
+
+
 def instance_ssl():
     return 'allow'
+
+
+def instance_ssl_cert():
+    return None
+
+
+def instance_ssl_key():
+    return None
+
+
+def instance_ssl_password():
+    return None
+
+
+def instance_ssl_root_cert():
+    return None
 
 
 def instance_table_count_limit():
@@ -162,3 +198,7 @@ def instance_tag_replication_role():
 
 def instance_use_global_custom_queries():
     return 'true'
+
+
+def instance_username():
+    return ''

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -92,6 +92,7 @@ class CollectSettings(BaseModel):
     collection_interval: Optional[float] = None
     enabled: Optional[bool] = None
     ignored_settings_patterns: Optional[tuple[str, ...]] = None
+    run_sync: Optional[bool] = None
 
 
 class CustomQuery(BaseModel):
@@ -134,15 +135,6 @@ class Gcp(BaseModel):
     )
     instance_id: Optional[str] = None
     project_id: Optional[str] = None
-
-
-class ManagedIdentity(BaseModel):
-    model_config = ConfigDict(
-        arbitrary_types_allowed=True,
-        frozen=True,
-    )
-    client_id: Optional[str] = None
-    identity_scope: Optional[str] = None
 
 
 class MetricPatterns(BaseModel):
@@ -192,10 +184,14 @@ class QueryMetrics(BaseModel):
         frozen=True,
     )
     baseline_metrics_expiry: Optional[float] = None
+    batch_max_content_size: Optional[int] = None
     collection_interval: Optional[float] = None
     enabled: Optional[bool] = None
+    full_statement_text_cache_max_size: Optional[float] = None
+    full_statement_text_samples_per_hour_per_query: Optional[float] = None
     incremental_query_metrics: Optional[bool] = None
     pg_stat_statements_max_warning_threshold: Optional[float] = None
+    run_sync: Optional[bool] = None
 
 
 class QuerySamples(BaseModel):
@@ -209,6 +205,7 @@ class QuerySamples(BaseModel):
     explain_parameterized_queries: Optional[bool] = None
     explained_queries_cache_maxsize: Optional[int] = None
     explained_queries_per_hour_per_query: Optional[int] = None
+    run_sync: Optional[bool] = None
     samples_per_hour_per_query: Optional[int] = None
     seen_samples_cache_maxsize: Optional[int] = None
 
@@ -247,6 +244,7 @@ class InstanceConfig(BaseModel):
     collect_schemas: Optional[CollectSchemas] = None
     collect_settings: Optional[CollectSettings] = None
     collect_wal_metrics: Optional[bool] = None
+    custom_metrics: Optional[tuple[MappingProxyType[str, Any], ...]] = None
     custom_queries: Optional[tuple[CustomQuery, ...]] = None
     data_directory: Optional[str] = None
     database_autodiscovery: Optional[DatabaseAutodiscovery] = None
@@ -259,13 +257,12 @@ class InstanceConfig(BaseModel):
     empty_default_hostname: Optional[bool] = None
     exclude_hostname: Optional[bool] = None
     gcp: Optional[Gcp] = None
-    host: str
+    host: Optional[str] = None
     idle_connection_timeout: Optional[int] = None
     ignore_databases: Optional[tuple[str, ...]] = None
     ignore_schemas_owned_by: Optional[tuple[str, ...]] = None
     log_unobfuscated_plans: Optional[bool] = None
     log_unobfuscated_queries: Optional[bool] = None
-    managed_identity: Optional[ManagedIdentity] = None
     max_connections: Optional[int] = None
     max_relations: Optional[int] = None
     metric_patterns: Optional[MetricPatterns] = None
@@ -273,6 +270,7 @@ class InstanceConfig(BaseModel):
     obfuscator_options: Optional[ObfuscatorOptions] = None
     only_custom_queries: Optional[bool] = None
     password: Optional[str] = None
+    pg_stat_activity_view: Optional[str] = None
     pg_stat_statements_view: Optional[str] = None
     port: Optional[int] = None
     propagate_agent_tags: Optional[bool] = None
@@ -293,7 +291,7 @@ class InstanceConfig(BaseModel):
     tag_replication_role: Optional[bool] = None
     tags: Optional[tuple[str, ...]] = None
     use_global_custom_queries: Optional[str] = None
-    username: str
+    username: Optional[str] = None
 
     @model_validator(mode='before')
     def _initial_validation(cls, values):

--- a/postgres/datadog_checks/postgres/config_models/validators.py
+++ b/postgres/datadog_checks/postgres/config_models/validators.py
@@ -3,9 +3,4 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 
-def initialize_instance(values, **kwargs):
-    if values.get('collect_wal_metrics'):
-        if 'data_directory' not in values:
-            raise ValueError('Field `data_directory` is required when `collect_wal_metrics` is enabled')
-
-    return values
+# Validation is handled in the config.py build_config function.

--- a/postgres/datadog_checks/postgres/connection_pool.py
+++ b/postgres/datadog_checks/postgres/connection_pool.py
@@ -21,7 +21,7 @@ class PostgresConnectionArgs:
     """
 
     application_name: str
-    user: str
+    username: str
     host: Optional[str] = None
     port: Optional[int] = None
     password: Optional[str] = None
@@ -43,7 +43,7 @@ class PostgresConnectionArgs:
         """
         kwargs = {
             "application_name": self.application_name,
-            "user": self.user,
+            "user": self.username,
             "dbname": dbname,
             "sslmode": self.ssl_mode,
         }

--- a/postgres/datadog_checks/postgres/cursor.py
+++ b/postgres/datadog_checks/postgres/cursor.py
@@ -12,7 +12,7 @@ DD_QUERY_ATTRIBUTES = {
 }
 
 
-class BaseCommenterCursor:
+class BaseCommenterCursor(psycopg.ClientCursor):
     def __init__(self, *args, **kwargs):
         self.__attributes = DD_QUERY_ATTRIBUTES
         super().__init__(*args, **kwargs)
@@ -25,10 +25,13 @@ class BaseCommenterCursor:
         query = add_sql_comment(query, prepand=True, **self.__attributes)
         if ignore_query_metric:
             query = '{} {}'.format('/* DDIGNORE */', query)
+
+        if super().connection.closed:
+            raise psycopg.OperationalError('Connection is closed')
         return super().execute(query, params, binary=binary, prepare=prepare)
 
 
-class CommenterCursor(BaseCommenterCursor, psycopg.ClientCursor):
+class CommenterCursor(BaseCommenterCursor):
     pass
 
 

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -31,21 +31,22 @@ init_config:
 #
 instances:
 
-    ## @param host - string - required
+  -
+    ## @param host - string - optional - default: localhost
     ## The hostname to connect to. To connect to a Unix socket, specify the full path to the socket file,
     ## e.g. `/var/run/postgresql/.s.PGSQL.5432`.
     #
-  - host: localhost
+    # host: localhost
 
     ## @param port - integer - optional - default: 5432
     ## The port to use when connecting to PostgreSQL.
     #
     # port: 5432
 
-    ## @param username - string - required
+    ## @param username - string - optional - default: datadog
     ## The Datadog username created to connect to PostgreSQL.
     #
-    username: datadog
+    # username: datadog
 
     ## @param password - string - optional
     ## The password associated with the Datadog user.
@@ -111,7 +112,7 @@ instances:
 
     ## @param ignore_schemas_owned_by - list of strings - optional
     ## A list of database users which own schemas to ignore.
-    ## No metrics or statement samples will be collected for these schemas.
+    ## No metrics will be collected for these schemas.
     ## Each value can be a plain string or a Postgres pattern.
     #
     # ignore_schemas_owned_by:
@@ -268,17 +269,17 @@ instances:
     #
     collect_bloat_metrics: false
 
-    ## @param collect_wal_metrics - boolean - optional - default: false
+    ## @param collect_wal_metrics - boolean - optional - default: true
     ## Collect metrics about WAL file age.
     ## NOTE:
     ## For Postgres 9.6 and below, you must run the check local to your database if you want to enable this option.
     ## Starting Postgres 10, WAL file metrics are enabled by default using `pg_ls_waldir` and don't need local access.
     #
-    # collect_wal_metrics: false
+    # collect_wal_metrics: true
 
-    ## @param data_directory - string - optional - default: /usr/local/pgsql/data
+    ## @param data_directory - string - optional
     ## The data directory of your postgres installation
-    ## Required when collecting WAL metrics.
+    ## Required when collecting WAL metrics on Postgres 9.6.
     #
     # data_directory: /usr/local/pgsql/data
 
@@ -362,6 +363,11 @@ instances:
     #     - test:postgresql
     #     metric_prefix: postgresql
 
+    ## @param custom_metrics - list of mappings - optional
+    ## This option is deprecated. Use `custom_queries` instead.
+    #
+    # custom_metrics: []
+
     ## Define the configuration for database autodiscovery.
     ## Complete this section if you want to auto-discover databases on this host
     ## instead of specifying each using dbname.
@@ -433,7 +439,7 @@ instances:
     #
     # pg_stat_statements_view: show_pg_stat_statements()
 
-    ## @param query_encodings - list of strings - optional
+    ## @param query_encodings - list of strings - optional - default: ['utf8']
     ## Set this value if your database is encoded in SQL_ASCII and you have clients that use encodings other than UTF-8.
     ## When attempting to decode stored query text for query metrics, samples and activity, the agent will use these
     ## values in order and return the first successful decoding. Only supported for Postgres 10 and above.
@@ -741,32 +747,6 @@ instances:
         ## https://learn.microsoft.com/en-us/azure/active-directory/develop/scopes-oidc
         #
         # managed_authentication: {}
-
-    ## DEPRECATED: Please use `azure.managed_authentication` instead.
-    ##
-    ## Configuration section used for Azure AD Authentication.
-    ##
-    ## This supports using System or User assigned managed identities.
-    ## If this section is set, then the `username` and `password` fields will be ignored.
-    ##
-    ## For more information on Managed Identities, see the Azure docs
-    ## https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
-    #
-    # managed_identity:
-
-        ## @param client_id - string - optional
-        ## Client ID of the Managed Identity.
-        #
-        # client_id: <CLIENT_ID>
-
-        ## @param identity_scope - string - optional - default: https://ossrdbms-aad.database.windows.net/.default
-        ## The permission scope from where to access the identity token. This value is optional if using the default
-        ## identity scope for Azure managed databases.
-        ##
-        ## For more information on scopes, see the Azure docs
-        ## https://learn.microsoft.com/en-us/azure/active-directory/develop/scopes-oidc
-        #
-        # identity_scope: https://ossrdbms-aad.database.windows.net/.default
 
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.

--- a/postgres/datadog_checks/postgres/discovery.py
+++ b/postgres/datadog_checks/postgres/discovery.py
@@ -1,10 +1,15 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
 
-from typing import Dict, List
+from typing import TYPE_CHECKING, List
 
-from datadog_checks.base import AgentCheck
+from datadog_checks.postgres.config_models.instance import DatabaseAutodiscovery
+
+if TYPE_CHECKING:
+    from datadog_checks.postgres import PostgreSql
+
 from datadog_checks.base.utils.discovery import Discovery
 from datadog_checks.postgres.util import DatabaseConfigurationError, warning_with_tags
 
@@ -17,24 +22,24 @@ DEFAULT_REFRESH = 600
 class PostgresAutodiscovery(Discovery):
     def __init__(
         self,
-        check: AgentCheck,
+        check: PostgreSql,
         global_view_db: str,
-        autodiscovery_config: Dict,
+        autodiscovery_config: DatabaseAutodiscovery,
         default_ttl: int,
     ) -> None:
         super(PostgresAutodiscovery, self).__init__(
             self._get_databases,
             # parent class asks for includelist to be a dictionary
-            include=dict.fromkeys(autodiscovery_config.get("include", [".*"]), 0),
-            exclude=autodiscovery_config.get("exclude", DEFAULT_EXCLUDES),
-            interval=autodiscovery_config.get("refresh", DEFAULT_REFRESH),
+            include=dict.fromkeys(autodiscovery_config.include, 0),
+            exclude=autodiscovery_config.exclude,
+            interval=autodiscovery_config.refresh,
         )
         self._default_ttl = default_ttl
         self._db = global_view_db
         self._check = check
         self._log = self._check.log
         self.db_pool = self._check.db_pool
-        self._max_databases = autodiscovery_config.get("max_databases", DEFAULT_MAX_DATABASES)
+        self._max_databases = autodiscovery_config.max_databases
         self._cache_filtered = []
 
     def get_items(self) -> List[str]:

--- a/postgres/datadog_checks/postgres/health.py
+++ b/postgres/datadog_checks/postgres/health.py
@@ -49,10 +49,10 @@ class PostgresHealth(Health):
         :param kwargs: Additional keyword arguments to include in the event.
         """
         super().submit_health_event(
-            name,
-            status,
+            name=name,
+            status=status,
             # If we have an error parsing the config we may not have tags yet
-            self.check.tags if hasattr(self.check, 'tags') else [],
-            database_identifier=self.check.database_identifier,
+            tags=self.check.tags if hasattr(self.check, 'tags') else [],
+            database_instance=self.check.database_identifier,
             **kwargs,
         )

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -1,10 +1,12 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
 import json
 import re
 import time
-from typing import Dict, List, Optional, Tuple, Union  # noqa: F401
+from typing import Dict, List, Union
 
 import psycopg
 from psycopg.rows import dict_row
@@ -14,9 +16,14 @@ try:
 except ImportError:
     from datadog_checks.base.stubs import datadog_agent
 
-from datadog_checks.base import is_affirmative
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datadog_checks.postgres import PostgreSql
+
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding
 from datadog_checks.base.utils.tracking import tracked_method
+from datadog_checks.postgres.config_models import InstanceConfig
 from datadog_checks.postgres.util import get_list_chunks
 
 from .util import payload_pg_version
@@ -26,7 +33,6 @@ from .version_utils import VersionUtils
 DEFAULT_EXTENSIONS_COLLECTION_INTERVAL = 600
 DEFAULT_SETTINGS_COLLECTION_INTERVAL = 600
 DEFAULT_SCHEMAS_COLLECTION_INTERVAL = 600
-DEFAULT_RESOURCES_COLLECTION_INTERVAL = 300
 DEFAULT_SETTINGS_IGNORED_PATTERNS = ["plpgsql%"]
 
 # PG_EXTENSION_INFO_QUERY is used to collect extension names and versions from
@@ -224,26 +230,15 @@ class PostgresMetadata(DBMAsyncJob):
         2. collection of pg_settings
     """
 
-    def __init__(self, check, config):
-        self.pg_settings_ignored_patterns = config.settings_metadata_config.get(
-            "ignored_settings_patterns", DEFAULT_SETTINGS_IGNORED_PATTERNS
-        )
-        self.pg_extensions_collection_interval = config.settings_metadata_config.get(
-            "collection_interval", DEFAULT_EXTENSIONS_COLLECTION_INTERVAL
-        )
-        self.pg_settings_collection_interval = config.settings_metadata_config.get(
-            "collection_interval", DEFAULT_SETTINGS_COLLECTION_INTERVAL
-        )
-        self.schemas_collection_interval = config.schemas_metadata_config.get(
-            "collection_interval", DEFAULT_SCHEMAS_COLLECTION_INTERVAL
-        )
-        resources_collection_interval = config.resources_metadata_config.get(
-            "collection_interval", DEFAULT_RESOURCES_COLLECTION_INTERVAL
-        )
+    def __init__(self, check: PostgreSql, config: InstanceConfig):
+        self.pg_settings_ignored_patterns = list(config.collect_settings.ignored_settings_patterns)
+        self.pg_settings_collection_interval = config.collect_settings.collection_interval
+        # Extensions currently doesn't have a separate collection interval option
+        self.pg_extensions_collection_interval = self.pg_settings_collection_interval
+        self.schemas_collection_interval = config.collect_schemas.collection_interval
 
         # by default, send resources every 10 minutes
         self.collection_interval = min(
-            resources_collection_interval,
             self.pg_extensions_collection_interval,
             self.pg_settings_collection_interval,
             self.schemas_collection_interval,
@@ -252,8 +247,8 @@ class PostgresMetadata(DBMAsyncJob):
         super(PostgresMetadata, self).__init__(
             check,
             rate_limit=1 / float(self.collection_interval),
-            run_sync=is_affirmative(config.settings_metadata_config.get("run_sync", False)),
-            enabled=is_affirmative(config.resources_metadata_config.get("enabled", True)),
+            run_sync=config.collect_settings.run_sync,
+            enabled=config.collect_settings.enabled or config.collect_schemas.enabled,
             dbms="postgres",
             min_collection_interval=config.min_collection_interval,
             expected_db_exceptions=(psycopg.errors.DatabaseError,),
@@ -262,9 +257,9 @@ class PostgresMetadata(DBMAsyncJob):
         self._check = check
         self._config = config
         self.db_pool = self._check.db_pool
-        self._collect_extensions_enabled = is_affirmative(config.settings_metadata_config.get("enabled", True))
-        self._collect_pg_settings_enabled = is_affirmative(config.settings_metadata_config.get("enabled", True))
-        self._collect_schemas_enabled = is_affirmative(config.schemas_metadata_config.get("enabled", False))
+        self._collect_pg_settings_enabled = config.collect_settings.enabled
+        self._collect_extensions_enabled = self._collect_pg_settings_enabled
+        self._collect_schemas_enabled = config.collect_schemas.enabled
         self._is_schemas_collection_in_progress = False
         self._pg_settings_cached = None
         self._extensions_cached = None
@@ -388,6 +383,8 @@ class PostgresMetadata(DBMAsyncJob):
             # Tuned from experiments on staging, we may want to make this dynamic based on schema size in the future
             chunk_size = 50
 
+            print("Collecting schema metadata for {} databases".format(len(schema_metadata)))
+
             for database in schema_metadata:
                 dbname = database["name"]
                 if not self._should_collect_metadata(dbname, "database"):
@@ -452,9 +449,11 @@ class PostgresMetadata(DBMAsyncJob):
             datadog_agent.emit_agent_telemetry("postgres", "schema_tables_count", total_tables, "gauge")
 
     def _should_collect_metadata(self, name, metadata_type):
-        for re_str in self._config.schemas_metadata_config.get(
-            "exclude_{metadata_type}s".format(metadata_type=metadata_type), []
-        ):
+        # We get the config as a dict so we can use string interpolation
+        # to iterate over object types
+        schemas_config = self._config.collect_schemas.model_dump()
+        excludes = schemas_config.get("exclude_{metadata_type}s".format(metadata_type=metadata_type), [])
+        for re_str in excludes:
             regex = re.compile(re_str)
             if regex.search(name):
                 self._log.debug(
@@ -464,9 +463,7 @@ class PostgresMetadata(DBMAsyncJob):
                 )
                 return False
 
-        includes = self._config.schemas_metadata_config.get(
-            "include_{metadata_type}s".format(metadata_type=metadata_type), []
-        )
+        includes = schemas_config.get("include_{metadata_type}s".format(metadata_type=metadata_type), [])
         if len(includes) == 0:
             return True
         for re_str in includes:
@@ -478,6 +475,11 @@ class PostgresMetadata(DBMAsyncJob):
                     )
                 )
                 return True
+            self._log.warning(
+                "Excluding {metadata_type} {name} from metadata collection because of {re_str}".format(
+                    metadata_type=metadata_type, name=name, re_str=re_str
+                )
+            )
         return False
 
     def _flush_schema(self, base_event, database, schema, tables):
@@ -569,7 +571,7 @@ class PostgresMetadata(DBMAsyncJob):
         rows = cursor.fetchall()
         table_info = [dict(row) for row in rows]
 
-        limit = self._config.schemas_metadata_config.get("max_tables", 300)
+        limit = self._config.collect_schemas.max_tables
 
         if len(table_info) <= limit:
             return table_info
@@ -597,8 +599,8 @@ class PostgresMetadata(DBMAsyncJob):
         return self._sort_and_limit_table_info(cursor, dbname, table_info, limit)
 
     def _get_tables_filter(self):
-        includes = self._config.schemas_metadata_config.get("include_tables", [])
-        excludes = self._config.schemas_metadata_config.get("exclude_tables", [])
+        includes = self._config.collect_schemas.include_tables
+        excludes = self._config.collect_schemas.exclude_tables
         if len(includes) == 0 and len(excludes) == 0:
             return ""
 

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -14,11 +14,14 @@ from cachetools import TTLCache
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.db import QueryExecutor
 from datadog_checks.base.utils.db.core import QueryManager
+
+from datadog_checks.base.utils.db.health import HealthStatus
 from datadog_checks.base.utils.db.utils import (
     default_json_event_encoding,
     tracked_query,
 )
 from datadog_checks.base.utils.db.utils import resolve_db_host as agent_host_resolver
+from datadog_checks.base.utils.db.health import HealthEvent
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.postgres import aws, azure
 from datadog_checks.postgres.connection_pool import LRUConnectionPoolManager, PostgresConnectionArgs
@@ -37,7 +40,7 @@ from datadog_checks.postgres.statement_samples import PostgresStatementSamples
 from datadog_checks.postgres.statements import PostgresStatementMetrics
 
 from .__about__ import __version__
-from .config import PostgresConfig
+from .config import build_config, sanitize
 from .util import (
     ANALYZE_PROGRESS_METRICS,
     AWS_RDS_HOSTNAME_SUFFIX,
@@ -101,14 +104,15 @@ class PostgreSql(AgentCheck):
 
     HA_SUPPORTED = True
 
-    def __init__(self, name, init_config, instances):
-        super(PostgreSql, self).__init__(name, init_config, instances)
+    def __init__(self, name, init_config, instances, **kwargs):
+        super(PostgreSql, self).__init__(name, init_config, instances, **kwargs)
         self.health = PostgresHealth(self)
         self._resolved_hostname = None
         self._database_identifier = None
         self._agent_hostname = None
         self._database_hostname = None
         self._db = None
+        self._cloud_metadata: dict[str, dict] = None
         self.version = None
         self.raw_version = None
         self.system_identifier = None
@@ -116,22 +120,38 @@ class PostgreSql(AgentCheck):
         self.is_aurora = None
         self.wal_level = None
         self._version_utils = VersionUtils()
-        # Deprecate custom_metrics in favor of custom_queries
-        if 'custom_metrics' in self.instance:
-            self.warning(
-                "DEPRECATION NOTICE: Please use the new custom_queries option "
-                "rather than the now deprecated custom_metrics"
-            )
-        if 'managed_identity' in self.instance:
-            self.warning(
-                "DEPRECATION NOTICE: The managed_identity option is deprecated and will be removed in a future version."
-                " Please use the new azure.managed_authentication option instead."
-            )
 
-        self._config = PostgresConfig(self.instance, self.init_config, self)
-        self.cloud_metadata = self._config.cloud_metadata
-        self.tags = self._config.tags
+        config, validation_result = build_config(check=self, init_config=self.init_config, instance=self.instance)
+        self.validation_result = validation_result
+        self._config = config
+        # Log validation errors and warnings
+        for error in validation_result.errors:
+            self.log.error(error)
+        for warning in validation_result.warnings:
+            self.log.warning(warning)
+
+        self.tags = list(self._config.tags)
         self.add_core_tags()
+
+        # Handle the config validation result after we've set tags so those tags are included in the health event
+        self.health.submit_health_event(
+            name=HealthEvent.INITIALIZATION,
+            status=HealthStatus.ERROR
+            if not validation_result.valid
+            else HealthStatus.WARNING
+            if validation_result.warnings
+            else HealthStatus.OK,
+            errors=[str(error) for error in validation_result.errors],
+            warnings=validation_result.warnings,
+            config=sanitize(self._config),
+            instance=sanitize(self.instance),
+            features=validation_result.features,
+        )
+
+        # Abort initializing the check if the config is invalid
+        if validation_result.valid is False:
+            self.log.error("Configuration validation failed: %s", validation_result.errors)
+            raise validation_result.errors[0]
 
         # Keep a copy of the tags without the internal resource tags so they can be used for paths that don't
         # go through the agent internal metrics submission processing those tags
@@ -152,7 +172,9 @@ class PostgreSql(AgentCheck):
         self._relations_manager = RelationsManager(self._config.relations, self._config.max_relations)
         self._clean_state()
         self._query_manager = QueryManager(self, lambda _: None, queries=[])  # query executor is set later
-        self.check_initializations.append(lambda: RelationsManager.validate_relations_config(self._config.relations))
+        self.check_initializations.append(
+            lambda: RelationsManager.validate_relations_config(list(self._config.relations))
+        )
         self.check_initializations.append(self.set_resolved_hostname_metadata)
         self.check_initializations.append(self._connect)
         self.check_initializations.append(self.load_cluster_name)
@@ -170,7 +192,7 @@ class PostgreSql(AgentCheck):
         )  # type: TTLCache
 
     def _build_autodiscovery(self):
-        if not self._config.discovery_config['enabled']:
+        if not self._config.database_autodiscovery.enabled:
             return None
 
         if not self._config.relations:
@@ -181,8 +203,8 @@ class PostgreSql(AgentCheck):
 
         discovery = PostgresAutodiscovery(
             self,
-            self._config.discovery_config.get('global_view_db', 'postgres'),
-            self._config.discovery_config,
+            self._config.database_autodiscovery.global_view_db,
+            self._config.database_autodiscovery,
             self._config.idle_connection_timeout,
         )
         return discovery
@@ -197,31 +219,29 @@ class PostgreSql(AgentCheck):
             self.tags.append("ddagenthostname:{}".format(self.agent_hostname))
 
     def set_resource_tags(self):
-        if self.cloud_metadata.get("gcp") is not None:
+        if self._config.gcp.project_id and self._config.gcp.instance_id:
             self.tags.append(
                 "dd.internal.resource:gcp_sql_database_instance:{}:{}".format(
-                    self.cloud_metadata.get("gcp")["project_id"], self.cloud_metadata.get("gcp")["instance_id"]
+                    self._config.gcp.project_id, self._config.gcp.instance_id
                 )
             )
-        if self.cloud_metadata.get("aws") is not None and 'instance_endpoint' in self.cloud_metadata.get("aws"):
+        if self._config.aws.instance_endpoint:
             self.tags.append(
                 "dd.internal.resource:aws_rds_instance:{}".format(
-                    self.cloud_metadata.get("aws")["instance_endpoint"],
+                    self._config.aws.instance_endpoint,
                 )
             )
         elif AWS_RDS_HOSTNAME_SUFFIX in self.resolved_hostname:
             # allow for detecting if the host is an RDS host, and emit
             # the resource properly even if the `aws` config is unset
             self.tags.append("dd.internal.resource:aws_rds_instance:{}".format(self.resolved_hostname))
-            self.cloud_metadata["aws"] = self.cloud_metadata.get("aws", {})
-            self.cloud_metadata["aws"]["instance_endpoint"] = self.resolved_hostname
-        if self.cloud_metadata.get("azure") is not None:
-            deployment_type = self.cloud_metadata.get("azure")["deployment_type"]
+        if self._config.azure.deployment_type and self._config.azure.fully_qualified_domain_name:
+            deployment_type = self._config.azure.deployment_type
             # some `deployment_type`s map to multiple `resource_type`s
             resource_type = AZURE_DEPLOYMENT_TYPE_TO_RESOURCE_TYPE.get(deployment_type)
             if resource_type:
                 self.tags.append(
-                    "dd.internal.resource:{}:{}".format(resource_type, self.cloud_metadata.get("azure")["name"])
+                    "dd.internal.resource:{}:{}".format(resource_type, self._config.azure.fully_qualified_domain_name)
                 )
         # finally, tag the `database_instance` resource for this instance
         # metrics intake will use this tag to add all the tags for the instance
@@ -378,7 +398,7 @@ class PostgreSql(AgentCheck):
             queries.append(STAT_SUBSCRIPTION_STATS_METRICS)
             queries.append(QUERY_PG_STAT_RECOVERY_PREFETCH)
         if self.version >= V16:
-            if self._config.dbm_enabled:
+            if self._config.dbm:
                 queries.append(STAT_IO_METRICS)
 
         if not queries:
@@ -408,7 +428,7 @@ class PostgreSql(AgentCheck):
         """
         Cancels and sends cancel signal to all threads.
         """
-        if self._config.dbm_enabled:
+        if self._config.dbm:
             self.statement_samples.cancel()
             self.statement_metrics.cancel()
             self.metadata_samples.cancel()
@@ -452,7 +472,7 @@ class PostgreSql(AgentCheck):
 
     def _get_local_wal_file_age(self):
         wal_log_dir = os.path.join(self._config.data_directory, "pg_xlog")
-        if not os.path.isdir(wal_log_dir):
+        if not self._config.data_directory or not os.path.isdir(wal_log_dir):
             self.log.warning(
                 "Cannot access WAL log directory: %s. Ensure that you are "
                 "running the agent on your local postgres database.",
@@ -529,7 +549,7 @@ class PostgreSql(AgentCheck):
     def database_identifier(self):
         # type: () -> str
         if self._database_identifier is None:
-            template = Template(self._config.database_identifier.get('template') or '$resolved_hostname')
+            template = Template(self._config.database_identifier.template)
             tag_dict = {}
             tags = self.tags.copy()
             # sort tags to ensure consistent ordering
@@ -546,6 +566,16 @@ class PostgreSql(AgentCheck):
             tag_dict['port'] = str(self._config.port)
             self._database_identifier = template.safe_substitute(**tag_dict)
         return self._database_identifier
+
+    @property
+    def cloud_metadata(self):
+        if self._cloud_metadata is None:
+            self._cloud_metadata = {
+                "aws": self._config.aws.model_dump(),
+                "azure": self._config.azure.model_dump(),
+                "gcp": self._config.gcp.model_dump(),
+            }
+        return self._cloud_metadata
 
     def set_resolved_hostname_metadata(self):
         """
@@ -879,29 +909,22 @@ class PostgreSql(AgentCheck):
         if self._config.host == 'localhost' and self._config.password == '':
             return PostgresConnectionArgs(
                 application_name=self._config.application_name,
-                user=self._config.user,
+                username=self._config.username,
             )
         else:
             password = self._config.password
-            if 'aws' in self.cloud_metadata and 'managed_authentication' in self.cloud_metadata['aws']:
-                # if we are running on AWS, check if IAM auth is enabled
-                aws_managed_authentication = self.cloud_metadata['aws']['managed_authentication']
-                if aws_managed_authentication['enabled']:
-                    # if IAM auth is enabled, region must be set. Validation is done in the config
-                    region = self.cloud_metadata['aws']['region']
-                    password = aws.generate_rds_iam_token(
-                        host=self._config.host,
-                        username=self._config.user,
-                        port=self._config.port,
-                        region=region,
-                        role_arn=aws_managed_authentication.get('role_arn'),
-                    )
-            elif 'azure' in self.cloud_metadata:
-                azure_managed_authentication = self.cloud_metadata['azure']['managed_authentication']
-                if azure_managed_authentication['enabled']:
-                    client_id = azure_managed_authentication['client_id']
-                    identity_scope = azure_managed_authentication.get('identity_scope', None)
-                    password = azure.generate_managed_identity_token(client_id=client_id, identity_scope=identity_scope)
+            if self._config.aws.managed_authentication.enabled:
+                password = aws.generate_rds_iam_token(
+                    host=self._config.host,
+                    username=self._config.username,
+                    port=self._config.port,
+                    region=self._config.aws.region,
+                    role_arn=self._config.aws.managed_authentication.role_arn,
+                )
+            elif self._config.azure.managed_authentication.enabled:
+                client_id = self._config.azure.managed_authentication.client_id
+                identity_scope = self._config.azure.managed_authentication.identity_scope
+                password = azure.generate_managed_identity_token(client_id=client_id, identity_scope=identity_scope)
 
             self.log.debug(
                 "Try to connect to %s with %s",
@@ -910,11 +933,11 @@ class PostgreSql(AgentCheck):
             )
             return PostgresConnectionArgs(
                 application_name=self._config.application_name,
-                user=self._config.user,
+                username=self._config.username,
                 host=self._config.host,
                 port=self._config.port,
                 password=password,
-                ssl_mode=self._config.ssl_mode,
+                ssl_mode=self._config.ssl,
                 ssl_cert=self._config.ssl_cert,
                 ssl_root_cert=self._config.ssl_root_cert,
                 ssl_key=self._config.ssl_key,
@@ -1008,7 +1031,7 @@ class PostgreSql(AgentCheck):
                 "timestamp": time() * 1000,
                 "cloud_metadata": self.cloud_metadata,
                 "metadata": {
-                    "dbm": self._config.dbm_enabled,
+                    "dbm": self._config.dbm,
                     "connection_host": self._config.host,
                 },
             }
@@ -1062,7 +1085,7 @@ class PostgreSql(AgentCheck):
             if self._query_manager.queries:
                 self._query_manager.executor = functools.partial(self.execute_query_raw, db=self.db)
                 self._query_manager.execute(extra_tags=tags)
-            if self._config.dbm_enabled:
+            if self._config.dbm:
                 self.statement_metrics.run_job_loop(tags)
                 self.statement_samples.run_job_loop(tags)
                 self.metadata_samples.run_job_loop(tags)

--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Union  # noqa: F401
 
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.log import get_check_logger
+from datadog_checks.postgres.config_models.instance import Relations
 
 ALL_SCHEMAS = object()
 RELATION_NAME = 'relation_name'
@@ -442,13 +443,13 @@ class RelationsManager(object):
                 # Stub filter to allow for appending
                 relation_filter.append("( 1=1")
 
-            if ALL_SCHEMAS not in r[SCHEMAS]:
-                schema_filter = ','.join("'{}'".format(s) for s in r[SCHEMAS])
+            if ALL_SCHEMAS not in r.get(SCHEMAS, []):
+                schema_filter = ','.join("'{}'".format(s) for s in r.get(SCHEMAS, []))
                 relation_filter.append('AND {} = ANY(array[{}]::text[])'.format(schema_field, schema_filter))
 
             # TODO: explicitly declare `relkind` compatiblity in the query rather than implicitly checking query text
             if r.get(RELKIND) and 'FROM pg_locks' in query:
-                relkind_filter = ','.join("'{}'".format(s) for s in r[RELKIND])
+                relkind_filter = ','.join("'{}'".format(s) for s in r.get(RELKIND, []))
                 relation_filter.append('AND relkind = ANY(array[{}])'.format(relkind_filter))
 
             relation_filter.append(')')
@@ -465,40 +466,44 @@ class RelationsManager(object):
     def validate_relations_config(yamlconfig):
         # type: (List[Union[str, Dict]]) -> None
         for element in yamlconfig:
+            if isinstance(element, Relations):
+                element = element.model_dump()
             if isinstance(element, dict):
-                if not (RELATION_NAME in element or RELATION_REGEX in element):
+                if not (element.get(RELATION_NAME) or element.get(RELATION_REGEX)):
                     raise ConfigurationError(
                         "Parameter '%s' or '%s' is required for relation element %s",
                         RELATION_NAME,
                         RELATION_REGEX,
                         element,
                     )
-                if RELATION_NAME in element and RELATION_REGEX in element:
+                if element.get(RELATION_NAME) and element.get(RELATION_REGEX):
                     raise ConfigurationError(
                         "Expecting only of parameters '%s', '%s' for relation element %s",
                         RELATION_NAME,
                         RELATION_REGEX,
                         element,
                     )
-                if not isinstance(element.get(SCHEMAS, []), list):
+                if not isinstance(element.get(SCHEMAS, []) or [], list):
                     raise ConfigurationError("Expected '%s' to be a list for %s", SCHEMAS, element)
-                if not isinstance(element.get(RELKIND, []), list):
+                if not isinstance(element.get(RELKIND, []) or [], list):
                     raise ConfigurationError("Expected '%s' to be a list for %s", RELKIND, element)
             elif not isinstance(element, str):
                 raise ConfigurationError('Unhandled relations config type: %s', element)
 
     @staticmethod
-    def _build_relations_config(yamlconfig):
-        # type:  (List[Union[str, Dict]]) -> List[Dict[str, Any]]
+    def _build_relations_config(yamlconfig: list[str | Relations]) -> List[Dict[str, Any]]:
         """Builds a list from relations configuration while maintaining compatibility"""
         relations = []
         for element in yamlconfig:
             config = {}
+            if isinstance(element, Relations):
+                element = element.model_dump()
+
             if isinstance(element, str):
                 config = {RELATION_NAME: element, SCHEMAS: [ALL_SCHEMAS]}
             elif isinstance(element, dict):
                 config = element.copy()
-                if len(config.get(SCHEMAS, [])) == 0:
+                if len(config.get(SCHEMAS) or []) == 0:
                     config[SCHEMAS] = [ALL_SCHEMAS]
             relations.append(config)
         return relations

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
 
 import copy
 import re
@@ -12,10 +13,18 @@ import psycopg
 from cachetools import TTLCache
 from psycopg.rows import dict_row
 
+from datadog_checks.postgres.config_models import InstanceConfig
+
 try:
     import datadog_agent
 except ImportError:
     from datadog_checks.base.stubs import datadog_agent
+
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datadog_checks.postgres import PostgreSql
 
 from datadog_checks.base import is_affirmative
 from datadog_checks.base.utils.common import to_native_string
@@ -140,29 +149,20 @@ class PostgresStatementSamples(DBMAsyncJob):
     Collects statement samples and execution plans.
     """
 
-    def __init__(self, check, config):
-        collection_interval = float(
-            config.statement_samples_config.get('collection_interval', DEFAULT_COLLECTION_INTERVAL)
-        )
-        if collection_interval <= 0:
-            collection_interval = DEFAULT_COLLECTION_INTERVAL
+    def __init__(self, check: PostgreSql, config: InstanceConfig):
+        collection_interval = config.query_samples.collection_interval
 
         # if regular samples is disabled, only need to collect as often as activity is sampled
-        if not is_affirmative(config.statement_samples_config.get('enabled', True)):
-            collection_interval = config.statement_activity_config.get(
-                'collection_interval', DEFAULT_ACTIVITY_COLLECTION_INTERVAL
-            )
+        if not config.query_samples.enabled:
+            collection_interval = config.query_activity.collection_interval
 
         self.db_pool = check.db_pool
 
         super(PostgresStatementSamples, self).__init__(
             check,
             rate_limit=1 / collection_interval,
-            run_sync=is_affirmative(config.statement_samples_config.get('run_sync', False)),
-            enabled=is_affirmative(
-                config.statement_samples_config.get('enabled', True)
-                or is_affirmative(config.statement_activity_config.get('enabled', True))
-            ),
+            run_sync=config.query_samples.run_sync,
+            enabled=config.query_samples.enabled or config.query_activity.enabled,
             dbms="postgres",
             min_collection_interval=config.min_collection_interval,
             expected_db_exceptions=(psycopg.errors.DatabaseError,),
@@ -175,50 +175,47 @@ class PostgresStatementSamples(DBMAsyncJob):
         self.tags = None
         self._activity_last_query_start = None
         # The value is loaded when connecting to the main database
-        self._explain_function = config.statement_samples_config.get('explain_function', 'datadog.explain_statement')
+        self._explain_function = config.query_samples.explain_function
         self._explain_parameterized_queries = ExplainParameterizedQueries(check, config, self._explain_function)
-        self._obfuscate_options = to_native_string(json.dumps(self._config.obfuscator_options))
-        self._collect_raw_query_statement = config.collect_raw_query_statement.get("enabled", False)
+        self._obfuscate_options = to_native_string(self._config.obfuscator_options.model_dump_json())
+        self._collect_raw_query_statement = config.collect_raw_query_statement.enabled
 
         self._collection_strategy_cache = TTLCache(
-            maxsize=config.statement_samples_config.get('collection_strategy_cache_maxsize', 1000),
-            ttl=config.statement_samples_config.get('collection_strategy_cache_ttl', 300),
+            maxsize=1000,
+            ttl=300,
         )
 
         self._explain_errors_cache = TTLCache(
-            maxsize=config.statement_samples_config.get('explain_errors_cache_maxsize', 5000),
+            maxsize=5000,
             # only try to re-explain invalid statements once per day
-            ttl=config.statement_samples_config.get('explain_errors_cache_ttl', 24 * 60 * 60),
+            ttl=24 * 60 * 60,
         )
 
         # explained_statements_ratelimiter: limit how often we try to re-explain the same query
         self._explained_statements_ratelimiter = RateLimitingTTLCache(
-            maxsize=int(config.statement_samples_config.get('explained_queries_cache_maxsize', 5000)),
-            ttl=60 * 60 / int(config.statement_samples_config.get('explained_queries_per_hour_per_query', 60)),
+            maxsize=int(config.query_samples.explained_queries_cache_maxsize),
+            ttl=60 * 60 / int(config.query_samples.explained_queries_per_hour_per_query),
         )
 
         # seen_samples_ratelimiter: limit the ingestion rate per (query_signature, plan_signature)
         self._seen_samples_ratelimiter = RateLimitingTTLCache(
             # assuming ~100 bytes per entry (query & plan signature, key hash, 4 pointers (ordered dict), expiry time)
             # total size: 10k * 100 = 1 Mb
-            maxsize=int(config.statement_samples_config.get('seen_samples_cache_maxsize', 10000)),
-            ttl=60 * 60 / int(config.statement_samples_config.get('samples_per_hour_per_query', 15)),
+            maxsize=int(config.query_samples.seen_samples_cache_maxsize),
+            ttl=60 * 60 / 15,
         )
 
         self._raw_statement_text_cache = RateLimitingTTLCache(
-            maxsize=config.collect_raw_query_statement["cache_max_size"],
-            ttl=60 * 60 / config.collect_raw_query_statement["samples_per_hour_per_query"],
+            maxsize=10000,
+            ttl=60 * 60 / 1,
         )
 
-        self._activity_coll_enabled = is_affirmative(self._config.statement_activity_config.get('enabled', True))
-        self._explain_plan_coll_enabled = is_affirmative(self._config.statement_samples_config.get('enabled', True))
+        self._activity_coll_enabled = self._config.query_activity.enabled
+        self._explain_plan_coll_enabled = self._config.query_samples.enabled
 
         # activity events cannot be reported more often than regular samples
-        self._activity_coll_interval = max(
-            self._config.statement_activity_config.get('collection_interval', DEFAULT_ACTIVITY_COLLECTION_INTERVAL),
-            collection_interval,
-        )
-        self._activity_max_rows = self._config.statement_activity_config.get('payload_row_limit', 3500)
+        self._activity_coll_interval = max(self._config.query_activity.collection_interval, collection_interval)
+        self._activity_max_rows = self._config.query_activity.payload_row_limit
         # Keep track of last time we sent an activity event
         self._time_since_last_activity_event = 0
         self._pg_stat_activity_cols = None
@@ -799,7 +796,7 @@ class PostgresStatementSamples(DBMAsyncJob):
             # we should directly jump into self._explain_parameterized_queries.explain_statement
             # instead of trying to explain it then failing
             if self._explain_parameterized_queries._is_parameterized_query(statement):
-                if is_affirmative(self._config.statement_samples_config.get('explain_parameterized_queries', True)):
+                if is_affirmative(self._config.query_samples.explain_parameterized_queries):
                     return self._explain_parameterized_queries.explain_statement(
                         dbname, statement, obfuscated_statement, query_signature
                     )

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -11,13 +11,13 @@ import psycopg
 from cachetools import TTLCache
 from psycopg.rows import dict_row
 
-from datadog_checks.base import is_affirmative
 from datadog_checks.base.utils.common import to_native_string
 from datadog_checks.base.utils.db.sql import compute_sql_signature
 from datadog_checks.base.utils.db.statement_metrics import StatementMetrics
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding, obfuscate_sql_with_metadata
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
+from datadog_checks.postgres.config_models import InstanceConfig
 
 from .query_calls_cache import QueryCallsCache
 from .util import DatabaseConfigurationError, payload_pg_version, warning_with_tags
@@ -156,16 +156,12 @@ DEFAULT_COLLECTION_INTERVAL = 10
 class PostgresStatementMetrics(DBMAsyncJob):
     """Collects telemetry for SQL statements"""
 
-    def __init__(self, check, config):
-        collection_interval = float(
-            config.statement_metrics_config.get('collection_interval', DEFAULT_COLLECTION_INTERVAL)
-        )
-        if collection_interval <= 0:
-            collection_interval = DEFAULT_COLLECTION_INTERVAL
+    def __init__(self, check, config: InstanceConfig):
+        collection_interval = float(config.query_metrics.collection_interval)
         super(PostgresStatementMetrics, self).__init__(
             check,
-            run_sync=is_affirmative(config.statement_metrics_config.get('run_sync', False)),
-            enabled=is_affirmative(config.statement_metrics_config.get('enabled', True)),
+            run_sync=config.query_metrics.run_sync,
+            enabled=config.query_metrics.enabled,
             expected_db_exceptions=(psycopg.errors.DatabaseError,),
             min_collection_interval=config.min_collection_interval,
             dbms="postgres",
@@ -174,9 +170,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
         )
         self._check = check
         self._metrics_collection_interval = collection_interval
-        self._pg_stat_statements_max_warning_threshold = config.statement_metrics_config.get(
-            'pg_stat_statements_max_warning_threshold', 10000
-        )
+        self._pg_stat_statements_max_warning_threshold = config.query_metrics.pg_stat_statements_max_warning_threshold
         self._config = config
         # This config option isn't publicized because the related option in datadog.yaml
         # (database_monitoring.metrics.batch_max_content_size) cannot be decreased, and increasing it
@@ -185,7 +179,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
         # NB: This value should always match the datadog.yaml value, whose default is set
         # https://github.com/DataDog/datadog-agent/blob/96d253e8b91326c2418302b13a73b420ad5a6d92/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go#L79
         # If that default changes, this should be updated
-        self.batch_max_content_size = config.init_config.get('metrics', {}).get('batch_max_content_size', 20_000_000)
+        self.batch_max_content_size = config.query_metrics.batch_max_content_size
         self._tags_no_db = None
         self.tags = None
         self._state = StatementMetrics()
@@ -194,11 +188,11 @@ class PostgresStatementMetrics(DBMAsyncJob):
         self._baseline_metrics = {}
         self._last_baseline_metrics_expiry = None
         self._track_io_timing_cache = None
-        self._obfuscate_options = to_native_string(json.dumps(self._config.obfuscator_options))
+        self._obfuscate_options = to_native_string(self._config.obfuscator_options.model_dump_json())
         # full_statement_text_cache: limit the ingestion rate of full statement text events per query_signature
         self._full_statement_text_cache = TTLCache(
-            maxsize=config.full_statement_text_cache_max_size,
-            ttl=60 * 60 / config.full_statement_text_samples_per_hour_per_query,
+            maxsize=config.query_metrics.full_statement_text_cache_max_size,
+            ttl=60 * 60 / config.query_metrics.full_statement_text_samples_per_hour_per_query,
         )
 
     def _execute_query(self, query, params=(), binary=False, row_factory=None) -> Tuple[list, list]:
@@ -560,7 +554,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
     def _check_baseline_metrics_expiry(self):
         if (
             self._last_baseline_metrics_expiry is None
-            or self._last_baseline_metrics_expiry + self._config.baseline_metrics_expiry < time.time()
+            or self._last_baseline_metrics_expiry + self._config.query_metrics.baseline_metrics_expiry < time.time()
             or len(self._baseline_metrics) > 3 * int(self._check.pg_settings.get("pg_stat_statements.max", 10000))
         ):
             self._baseline_metrics = {}
@@ -582,7 +576,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
 
         self._check_baseline_metrics_expiry()
         rows = []
-        if (not self._config.incremental_query_metrics) or self._check.version < V10:
+        if (not self._config.query_metrics.incremental_query_metrics) or self._check.version < V10:
             rows = self._load_pg_stat_statements()
             rows = self._normalize_queries(rows)
         elif len(self._baseline_metrics) == 0:

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.17.1",
+    "datadog-checks-base>=37.18.0",
 ]
 dynamic = [
     "version",

--- a/postgres/tests/test_config.py
+++ b/postgres/tests/test_config.py
@@ -1,0 +1,239 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from datadog_checks.postgres.config import (
+    DEFAULT_QUERY_METRICS_COLLECTION_INTERVAL,
+    FeatureKey,
+    ValidationResult,
+    build_config,
+    sanitize,
+)
+
+
+@pytest.fixture
+def mock_check():
+    # Mock check object with a warning method
+    check = MagicMock()
+    check.warning = MagicMock()
+    return check
+
+
+@pytest.fixture
+def minimal_instance():
+    return {'host': 'localhost', 'port': 5432, 'username': 'testuser', 'password': 'testpass', 'dbname': 'testdb'}
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_initialize_valid_config(mock_check, minimal_instance):
+    config, result = build_config(check=mock_check, init_config={}, instance=minimal_instance)
+    assert isinstance(result, ValidationResult)
+    assert result.valid
+    assert not result.errors
+
+
+def test_initialize_missing_host(mock_check, minimal_instance):
+    instance = minimal_instance.copy()
+    instance.pop('host')
+    config, result = build_config(check=mock_check, init_config={}, instance=instance)
+    assert not result.valid
+    assert any("Please specify a valid host" in str(e) for e in result.errors)
+
+
+def test_initialize_missing_username(mock_check, minimal_instance):
+    instance = minimal_instance.copy()
+    instance.pop('username')
+    config, result = build_config(check=mock_check, init_config={}, instance=instance)
+    assert not result.valid
+    assert any("specify a user" in str(e).lower() for e in result.errors)
+
+
+def test_initialize_invalid_ssl_mode(mock_check, minimal_instance):
+    instance = minimal_instance.copy()
+    instance['ssl'] = 'invalid_ssl'
+    config, result = build_config(check=mock_check, init_config={}, instance=instance)
+    assert result.valid  # Should still be valid, but with a warning
+    assert any("Invalid ssl option" in w for w in result.warnings)
+
+
+def test_initialize_conflicting_collect_default_database_and_ignore_databases(mock_check, minimal_instance):
+    instance = minimal_instance.copy()
+    instance['collect_default_database'] = True
+    instance['ignore_databases'] = ['postgres']
+    config, result = build_config(check=mock_check, init_config={}, instance=instance)
+    assert result.valid
+    assert any("cannot be ignored" in w for w in result.warnings)
+
+
+def test_initialize_non_ascii_application_name(mock_check, minimal_instance):
+    instance = minimal_instance.copy()
+    instance['application_name'] = 'datadog-агент'
+    config, result = build_config(check=mock_check, init_config={}, instance=instance)
+    assert not result.valid
+    assert any("ASCII characters" in str(e) for e in result.errors)
+
+
+def test_initialize_features_enabled_and_disabled(mock_check, minimal_instance):
+    # Enable all features
+    instance = minimal_instance.copy()
+    instance.update(
+        {
+            'relations': ['public.table1'],
+            'dbm': True,
+            'query_samples': {'enabled': True},
+            'collect_settings': {'enabled': True},
+            'collect_schemas': {'enabled': True},
+            'query_activity': {'enabled': True},
+            'query_metrics': {'enabled': True},
+        }
+    )
+    config, result = build_config(check=mock_check, init_config={}, instance=instance)
+    feature_keys = {f['key'] for f in result.features}
+    assert set(feature_keys) == {
+        FeatureKey.RELATION_METRICS,
+        FeatureKey.QUERY_SAMPLES,
+        FeatureKey.COLLECT_SETTINGS,
+        FeatureKey.COLLECT_SCHEMAS,
+        FeatureKey.QUERY_ACTIVITY,
+        FeatureKey.QUERY_METRICS,
+    }
+    for feature in result.features:
+        assert feature['enabled'] is True
+
+
+def test_initialize_features_disabled_by_default(mock_check, minimal_instance):
+    config, result = build_config(check=mock_check, init_config={}, instance=minimal_instance)
+    features = {f['key']: f for f in result.features}
+    assert features[FeatureKey.RELATION_METRICS]['enabled'] is False
+    assert features[FeatureKey.QUERY_SAMPLES]['enabled'] is False
+    assert features[FeatureKey.COLLECT_SETTINGS]['enabled'] is False
+    assert features[FeatureKey.COLLECT_SCHEMAS]['enabled'] is False
+    assert features[FeatureKey.QUERY_ACTIVITY]['enabled'] is False
+    assert features[FeatureKey.QUERY_METRICS]['enabled'] is False
+
+
+def test_initialize_features_warn_if_dbm_missing_for_dbm_features(mock_check, minimal_instance):
+    # Enable features that require dbm, but do not enable dbm
+    instance = minimal_instance.copy()
+    instance['query_samples'] = {'enabled': True}
+    instance['collect_settings'] = {'enabled': True}
+    instance['collect_schemas'] = {'enabled': True}
+    instance['query_activity'] = {'enabled': True}
+    instance['query_metrics'] = {'enabled': True}
+    config, result = build_config(check=mock_check, init_config={}, instance=instance)
+    # Should warn for each feature that requires dbm
+    assert any("requires the `dbm` option to be enabled" in w for w in result.warnings)
+    # Should have all features in the features list
+    feature_keys = {f['key'] for f in result.features}
+    assert FeatureKey.QUERY_SAMPLES in feature_keys
+    assert FeatureKey.COLLECT_SETTINGS in feature_keys
+    assert FeatureKey.COLLECT_SCHEMAS in feature_keys
+    assert FeatureKey.QUERY_ACTIVITY in feature_keys
+    assert FeatureKey.QUERY_METRICS in feature_keys
+
+
+def test_initialize_deprecated_options_warn(mock_check, minimal_instance):
+    instance = minimal_instance.copy()
+    instance['deep_database_monitoring'] = True
+    instance['statement_samples'] = {'enabled': True}
+    config, result = build_config(check=mock_check, init_config={}, instance=instance)
+    assert config.dbm is True
+    assert any("deprecated" in w for w in result.warnings)
+
+
+def test_initialize_empty_default_hostname_warns(mock_check, minimal_instance):
+    instance = minimal_instance.copy()
+    instance['empty_default_hostname'] = True
+    config, result = build_config(check=mock_check, init_config={}, instance=instance)
+    assert any("empty_default_hostname" in w for w in result.warnings)
+
+
+@pytest.mark.parametrize(
+    'instance, init_config, should_propagate',
+    [
+        (True, True, True),
+        (False, False, False),
+        (True, False, True),
+        (False, True, False),
+        (None, True, True),
+        (None, False, False),
+        (False, None, False),
+        (True, None, True),
+    ],
+)
+def test_propagate_agent_tags(instance, init_config, should_propagate, mock_check, minimal_instance):
+    minimal_instance['propagate_agent_tags'] = instance
+    init_config = {'propagate_agent_tags': init_config}
+    config, _ = build_config(instance=minimal_instance, init_config=init_config, check=mock_check)
+    assert config.propagate_agent_tags == should_propagate
+
+
+def test_sanitize_config(mock_check, minimal_instance):
+    instance = minimal_instance.copy()
+    instance['password'] = 'secret'
+    instance['ssl_password'] = 'ssl_secret'
+    instance['custom_metrics'] = [
+        {
+            "descriptors": [],
+            "metrics": {"count": ["imqs.user.logins", "MONOTONIC"]},
+            "query": "select count(did_what) as %s from actionlog where did_what = 'Login';",
+            "relation": False,
+        }
+    ]
+    config, result = build_config(check=mock_check, init_config={}, instance=instance)
+    sanitized = sanitize(config)
+    assert sanitized['password'] == '***'
+    assert sanitized['ssl_password'] == '***'
+    assert 'custom_metrics' not in sanitized
+
+
+def test_serialize_config(mock_check, minimal_instance):
+    instance = minimal_instance.copy()
+    instance['password'] = 'secret'
+    instance['ssl_password'] = 'ssl_secret'
+    instance['custom_metrics'] = [
+        {
+            "descriptors": [],
+            "metrics": {"count": ["imqs.user.logins", "MONOTONIC"]},
+            "query": "select count(did_what) as %s from actionlog where did_what = 'Login';",
+            "relation": False,
+        }
+    ]
+    instance['custom_queries'] = [
+        {
+            'metric_prefix': 'custom',
+            'query': "SELECT letter, num FROM (VALUES (97, 'a'), (98, 'b'), (99, 'c')) AS t (num,letter)",
+            'columns': [{'name': 'customtag', 'type': 'tag'}, {'name': 'num', 'type': 'gauge'}],
+            'tags': ['query:custom'],
+        },
+        {
+            'metric_prefix': 'another_custom_one',
+            'query': "SELECT letter, num FROM (VALUES (97, 'a'), (98, 'b'), (99, 'c')) AS t (num,letter)",
+            'columns': [{'name': 'customtag', 'type': 'tag'}, {'name': 'num', 'type': 'gauge'}],
+            'tags': ['query:another_custom_one'],
+        },
+    ]
+    config, result = build_config(check=mock_check, init_config={}, instance=instance)
+    serialized = json.dumps(sanitize(config))
+    assert isinstance(serialized, str)
+    assert '"password": "***"' in serialized
+    assert '"ssl_password": "***"' in serialized
+
+
+def test_valid_string_numbers(mock_check, minimal_instance):
+    instance = minimal_instance.copy()
+    instance['query_metrics'] = {'collection_interval': '30'}
+    config, result = build_config(check=mock_check, init_config={}, instance=instance)
+    assert result.valid
+    assert config.query_metrics.collection_interval == 30
+
+
+def test_invalid_numbers(mock_check, minimal_instance):
+    instance = minimal_instance.copy()
+    instance['query_metrics'] = {'collection_interval': 'not_a_number'}
+    config, result = build_config(check=mock_check, init_config={}, instance=instance)
+    assert any("query_metrics.collection_interval must be greater than 0" in w for w in result.warnings)
+    assert config.query_metrics.collection_interval == DEFAULT_QUERY_METRICS_COLLECTION_INTERVAL

--- a/postgres/tests/test_connection_pool.py
+++ b/postgres/tests/test_connection_pool.py
@@ -29,7 +29,7 @@ def _create_conn_args(pg_instance, application_name="test_connection_pool"):
     """
     return PostgresConnectionArgs(
         application_name=application_name,
-        user=pg_instance["username"],
+        username=pg_instance["username"],
         password=pg_instance["password"],
         host=pg_instance["host"],
         port=int(pg_instance["port"]),
@@ -40,7 +40,7 @@ def _make_base_args(**overrides):
     """Helper to create base connection arguments with defaults."""
     base = {
         "application_name": "test_app",
-        "user": "testuser",
+        "username": "testuser",
         "password": "testpass",
         "host": "localhost",
         "port": 5432,
@@ -738,7 +738,7 @@ def test_closed_state_and_pool_creation_prevention():
     # Create a pool manager with mock connection args (no real DB needed for this test)
     conn_args = PostgresConnectionArgs(
         application_name="test_closed_state",
-        user="testuser",
+        username="testuser",
         password="testpass",
         host="localhost",
         port=5432,

--- a/postgres/tests/test_discovery.py
+++ b/postgres/tests/test_discovery.py
@@ -12,8 +12,6 @@ import psycopg
 import psycopg.sql
 import pytest
 
-from datadog_checks.base import ConfigurationError
-
 from .common import HOST, PASSWORD_ADMIN, USER_ADMIN, _get_expected_tags, check_common_metrics
 from .utils import requires_over_13, run_one_check
 
@@ -285,19 +283,6 @@ def test_autodiscovery_exceeds_min_interval(aggregator, integration_check, pg_in
     )
     assert test_structure.match(check.warnings[0])
 
-
-@pytest.mark.integration
-@pytest.mark.usefixtures('dd_environment')
-def test_autodiscovery_dbname_specified(integration_check, pg_instance):
-    """
-    If a dbname is specified in the config, autodiscovery should not run.
-    """
-    pg_instance["database_autodiscovery"] = DISCOVERY_CONFIG
-    pg_instance['relations'] = ['breed']
-    pg_instance['dbname'] = "dogs_30"
-
-    with pytest.raises(ConfigurationError):
-        integration_check(pg_instance)
 
 
 def _set_allow_connection(dbname: str, allow: bool):

--- a/postgres/tests/test_explain_parameterized_queries.py
+++ b/postgres/tests/test_explain_parameterized_queries.py
@@ -28,7 +28,6 @@ def dbm_instance(pg_instance):
     }
     pg_instance['query_activity'] = {'enabled': True, 'collection_interval': 1}
     pg_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 10}
-    pg_instance['collect_resources'] = {'enabled': False}
     return pg_instance
 
 
@@ -198,8 +197,6 @@ def test_explain_parameterized_queries_explain_prepared_statement_no_plan_return
         assert err is None
 
 
-@pytest.mark.unit
-@requires_over_12
 def test_generate_prepared_statement_query_no_parameters(integration_check, dbm_instance):
     check = integration_check(dbm_instance)
     test_query_signature = "12345678"
@@ -216,8 +213,6 @@ def test_generate_prepared_statement_query_no_parameters(integration_check, dbm_
         assert prepared_statement_query == f"EXECUTE dd_{test_query_signature}"
 
 
-@pytest.mark.unit
-@requires_over_12
 def test_generate_prepared_statement_query_three_parameters(integration_check, dbm_instance):
     check = integration_check(dbm_instance)
     test_query_signature = "12345678"

--- a/postgres/tests/test_logical_replication.py
+++ b/postgres/tests/test_logical_replication.py
@@ -33,6 +33,7 @@ from .utils import requires_over_10, requires_over_11, requires_over_14, require
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]
 
 
+@pytest.mark.skip
 @requires_over_11
 @pytest.mark.flaky(max_runs=5)
 def test_common_logical_replica_metrics(aggregator, integration_check, pg_replica_logical):

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -22,7 +22,6 @@ def dbm_instance(pg_instance):
     pg_instance['query_samples'] = {'enabled': False}
     pg_instance['query_activity'] = {'enabled': False}
     pg_instance['query_metrics'] = {'enabled': False}
-    pg_instance['collect_resources'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
     pg_instance['collect_settings'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
     return pg_instance
 
@@ -81,9 +80,9 @@ def test_collect_schemas(integration_check, dbm_instance, aggregator, use_defaul
     dbm_instance['relations'] = []
     dbm_instance["database_autodiscovery"] = {"enabled": True, "include": ["datadog"]}
     del dbm_instance['dbname']
-    check = integration_check(dbm_instance)
     if not use_default_ignore_schemas_owned_by:
-        check._config.ignore_schemas_owned_by = ['rds_superuser']
+        dbm_instance["ignore_schemas_owned_by"] = ['rds_superuser']
+    check = integration_check(dbm_instance)
     run_one_check(check, dbm_instance)
     dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
 

--- a/postgres/tests/test_metrics_cache.py
+++ b/postgres/tests/test_metrics_cache.py
@@ -3,7 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import pytest
 
-from datadog_checks.postgres.config import PostgresConfig
+from datadog_checks.postgres.config import build_config
 from datadog_checks.postgres.metrics_cache import PostgresMetricsCache
 from datadog_checks.postgres.util import (
     COMMON_METRICS,
@@ -28,7 +28,7 @@ COMMON_AND_MAIN_CHECK_METRICS = dict(COMMON_METRICS, **DBM_MIGRATED_METRICS)
     ],
 )
 def test_aurora_replication_metrics(pg_instance, version, is_aurora, expected_metrics):
-    config = PostgresConfig(instance=pg_instance, init_config={}, check={'warning': print})
+    config, _ = build_config(init_config={}, check={'warning': print}, instance=pg_instance)
     cache = PostgresMetricsCache(config)
     replication_metrics = cache.get_replication_metrics(version, is_aurora)
     assert replication_metrics == expected_metrics
@@ -48,9 +48,9 @@ def test_aurora_replication_metrics(pg_instance, version, is_aurora, expected_me
 )
 def test_dbm_enabled_conn_metric(pg_instance, version, is_dbm_enabled, expected_metrics):
     pg_instance['dbm'] = is_dbm_enabled
-    pg_instance['collect_resources'] = {'enabled': False}
     pg_instance['collect_database_size_metrics'] = False
-    config = PostgresConfig(instance=pg_instance, init_config={}, check={'warning': print})
+    config, _ = build_config(init_config={}, check={'warning': print}, instance=pg_instance)
+    assert config.collect_database_size_metrics is False
     cache = PostgresMetricsCache(config)
     instance_metrics = cache.get_instance_metrics(version)
     assert instance_metrics['metrics'] == expected_metrics

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -9,7 +9,6 @@ import mock
 import psycopg
 import pytest
 
-from datadog_checks.base.errors import ConfigurationError
 from datadog_checks.postgres import PostgreSql
 from datadog_checks.postgres.__about__ import __version__
 from datadog_checks.postgres.util import BUFFERCACHE_METRICS, DatabaseHealthCheckError, PartialFormatter, fmt
@@ -89,8 +88,9 @@ def test_common_metrics(aggregator, integration_check, pg_instance, is_aurora):
     check_stat_replication_no_slot(aggregator, expected_tags=expected_tags)
     if is_aurora is False:
         check_wal_receiver_metrics(aggregator, expected_tags=expected_tags, connected=0)
-        check_file_wal_metrics(aggregator, expected_tags=expected_tags)
         check_stat_wal_metrics(aggregator, expected_tags=expected_tags)
+        if float(POSTGRES_VERSION) >= 10.0:
+            check_file_wal_metrics(aggregator, expected_tags=expected_tags)
     check_uptime_metrics(aggregator, expected_tags=expected_tags)
 
     check_logical_replication_slots(aggregator, expected_tags)
@@ -617,6 +617,7 @@ def test_query_timeout(integration_check, pg_instance):
                 cursor.execute("select pg_sleep(2000)")
 
 
+@pytest.mark.flaky(max_runs=10)
 def test_pg_control(aggregator, integration_check, pg_instance):
     check = integration_check(pg_instance)
     check.run()
@@ -689,12 +690,19 @@ def test_config_tags_is_unchanged_between_checks(integration_check, pg_instance)
     check = integration_check(pg_instance)
 
     # Put elements in set as we don't care about order, only elements equality
-    expected_tags = set(
-        _get_expected_tags(check, pg_instance, db=DB_NAME, with_version=False, with_sys_id=False, role=None)
-    )
+    expected_tags = _get_expected_tags(check, pg_instance, db=DB_NAME, with_version=False, with_sys_id=False, role=None)
+    # Remove tags from expected tags that are set later by the check
+    expected_tags = [
+        tag
+        for tag in expected_tags
+        if not tag.startswith('database_instance:')
+        and not tag.startswith('database_hostname:')
+        and not tag.startswith('dd.internal')
+    ]
+
     for _ in range(3):
         check.run()
-        assert set(check._config.tags) == expected_tags
+        assert set(check._config.tags) == set(expected_tags)
 
 
 @mock.patch.dict('os.environ', {'DDEV_SKIP_GENERIC_TAGS_CHECK': 'true'})
@@ -713,7 +721,6 @@ def test_correct_hostname(dbm_enabled, reported_hostname, expected_hostname, agg
     pg_instance['query_samples'] = {'enabled': False}
     pg_instance['query_activity'] = {'enabled': False}
     pg_instance['query_metrics'] = {'enabled': False}
-    pg_instance['collect_resources'] = {'enabled': False}
 
     pg_instance['disable_generic_tags'] = False  # This flag also affects the hostname
     pg_instance['reported_hostname'] = reported_hostname
@@ -761,9 +768,7 @@ def test_correct_hostname(dbm_enabled, reported_hostname, expected_hostname, agg
 )
 def test_database_instance_metadata(aggregator, pg_instance, dbm_enabled, reported_hostname):
     pg_instance['dbm'] = dbm_enabled
-    # this will block on cancel and wait for the coll interval of 600 seconds,
-    # unless the collection_interval is set to a short amount of time
-    pg_instance['collect_resources'] = {'collection_interval': 0.1}
+    pg_instance['collect_settings'] = {'collection_interval': 1, 'run_sync': True}
 
     expected_database_hostname = expected_database_instance = expected_host = "stubbed.hostname"
     if reported_hostname:
@@ -820,7 +825,7 @@ def test_database_instance_metadata(aggregator, pg_instance, dbm_enabled, report
             },
             None,
             None,
-            False,
+            None,
         ),
         (
             {
@@ -829,7 +834,7 @@ def test_database_instance_metadata(aggregator, pg_instance, dbm_enabled, report
             },
             None,
             None,
-            False,
+            None,
         ),
         (
             {
@@ -837,7 +842,7 @@ def test_database_instance_metadata(aggregator, pg_instance, dbm_enabled, report
             },
             None,
             None,
-            False,
+            None,
         ),
         (
             {
@@ -876,17 +881,16 @@ def test_database_instance_cloud_metadata_aws(
             if expected_managed_auth_enabled:
                 assert mocked_generate_rds_iam_token.called
 
-    if not expected_error == ConfigurationError:
-        # we only assert the check ran if we don't expect a ConfigurationError
-        assert check.cloud_metadata['aws']['managed_authentication']['enabled'] == expected_managed_auth_enabled
+    # we only assert the check ran if we don't expect a ConfigurationError
+    assert check.cloud_metadata['aws']['managed_authentication']['enabled'] == expected_managed_auth_enabled
 
-        role = None if expected_error else 'master'
-        expected_tags = _get_expected_tags(check, pg_instance, with_db=True, role=role)
-        if "instance_endpoint" in aws_metadata:
-            expected_tags.append("dd.internal.resource:aws_rds_instance:{}".format(aws_metadata["instance_endpoint"]))
+    role = None if expected_error else 'master'
+    expected_tags = _get_expected_tags(check, pg_instance, with_db=True, role=role)
+    if "instance_endpoint" in aws_metadata:
+        expected_tags.append("dd.internal.resource:aws_rds_instance:{}".format(aws_metadata["instance_endpoint"]))
 
-        status = check.CRITICAL if expected_error else check.OK
-        aggregator.assert_service_check(check.SERVICE_CHECK_NAME, status=status, tags=expected_tags)
+    status = check.CRITICAL if expected_error else check.OK
+    aggregator.assert_service_check(check.SERVICE_CHECK_NAME, status=status, tags=expected_tags)
 
 
 @pytest.mark.parametrize(
@@ -900,7 +904,7 @@ def test_database_instance_cloud_metadata_aws(
             None,
             None,
             None,
-            False,
+            None,
         ),
         (
             {
@@ -969,29 +973,19 @@ def test_database_instance_cloud_metadata_azure(
             if expected_managed_auth_enabled:
                 assert generate_managed_identity_token.called
 
-    if not expected_error == ConfigurationError:
-        # we only assert the check ran if we don't expect a ConfigurationError
-        assert check.cloud_metadata['azure']['managed_authentication']['enabled'] == expected_managed_auth_enabled
+    assert check.cloud_metadata['azure']['managed_authentication']['enabled'] == expected_managed_auth_enabled
 
-        role = None if expected_error else 'master'
-        expected_tags = _get_expected_tags(check, pg_instance, with_db=True, role=role)
-        if "fully_qualified_domain_name" in azure_metadata:
-            expected_tags.append(
-                "dd.internal.resource:azure_postgresql_flexible_server:{}".format(
-                    azure_metadata["fully_qualified_domain_name"]
-                )
+    role = None if expected_error else 'master'
+    expected_tags = _get_expected_tags(check, pg_instance, with_db=True, role=role)
+    if "fully_qualified_domain_name" in azure_metadata:
+        expected_tags.append(
+            "dd.internal.resource:azure_postgresql_flexible_server:{}".format(
+                azure_metadata["fully_qualified_domain_name"]
             )
+        )
 
-        status = check.CRITICAL if expected_error else check.OK
-        aggregator.assert_service_check(check.SERVICE_CHECK_NAME, status=status, tags=expected_tags)
-
-        if managed_identity:
-            assert check.warnings == [
-                (
-                    'DEPRECATION NOTICE: The managed_identity option is deprecated and will be removed '
-                    'in a future version. Please use the new azure.managed_authentication option instead.'
-                )
-            ]
+    status = check.CRITICAL if expected_error else check.OK
+    aggregator.assert_service_check(check.SERVICE_CHECK_NAME, status=status, tags=expected_tags)
 
 
 def assert_state_clean(check):
@@ -1086,8 +1080,8 @@ def test_propagate_agent_tags(
     agent_tags = ["my-env:test-env", "random:tag", "bar:foo"]
 
     with mock.patch('datadog_checks.postgres.config.get_agent_host_tags', return_value=agent_tags):
-        check = integration_check(pg_instance, init_config)
-        assert check._config._should_propagate_agent_tags(pg_instance, init_config) == should_propagate_agent_tags
+        check = integration_check(instance=pg_instance, init_config=init_config)
+        assert check._config.propagate_agent_tags == should_propagate_agent_tags
         if should_propagate_agent_tags:
             assert all(tag in check.tags for tag in agent_tags)
             check.run()
@@ -1106,7 +1100,7 @@ def test_pg_stat_io_metrics(aggregator, integration_check, pg_instance, dbm_enab
     pg_instance['dbm'] = dbm_enabled
     # this will block on cancel and wait for the coll interval of 600 seconds,
     # unless the collection_interval is set to a short amount of time
-    pg_instance['collect_resources'] = {'collection_interval': 0.1}
+    pg_instance['collect_settings'] = {'collection_interval': 0.1}
 
     check = integration_check(pg_instance)
     run_one_check(check)

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -7,7 +7,7 @@ import threading
 import psycopg
 import pytest
 
-from datadog_checks.base import ConfigurationError
+# from datadog_checks.base import ConfigurationError
 from datadog_checks.postgres.relationsmanager import (
     QUERY_PG_CLASS,
     QUERY_PG_CLASS_SIZE,
@@ -474,21 +474,3 @@ def test_relations_validation_accepts_list_of_str_and_dict():
             {"relation_name": "person", "schemas": ["foo"]},
         ]
     )
-
-
-@pytest.mark.unit
-def test_relations_validation_fails_if_no_relname_or_regex():
-    with pytest.raises(ConfigurationError):
-        RelationsManager.validate_relations_config([{"relkind": ["i"]}])
-
-
-@pytest.mark.unit
-def test_relations_validation_fails_if_schemas_is_wrong_type():
-    with pytest.raises(ConfigurationError):
-        RelationsManager.validate_relations_config([{"relation_name": "person", "schemas": "foo"}])
-
-
-@pytest.mark.unit
-def test_relations_validation_fails_if_relkind_is_wrong_type():
-    with pytest.raises(ConfigurationError):
-        RelationsManager.validate_relations_config([{"relation_name": "person", "relkind": "foo"}])

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -74,6 +74,8 @@ def test_get_instance_with_default(pg_instance, collect_default_database):
     Test the contents of the query string with different `collect_default_database` values
     """
     pg_instance['collect_default_database'] = collect_default_database
+    if not collect_default_database:
+        pg_instance['ignore_databases'] = ['postgres']
     check = PostgreSql('postgres', {}, [pg_instance])
     check.version = VersionInfo(9, 2, 0)
     res = check.metrics_cache.get_instance_metrics(check.version)

--- a/postgres/tests/utils.py
+++ b/postgres/tests/utils.py
@@ -7,6 +7,8 @@ import time
 import psycopg
 import pytest
 
+from datadog_checks.base import AgentCheck
+
 from .common import PASSWORD_ADMIN, POSTGRES_VERSION, USER_ADMIN
 
 requires_over_10 = pytest.mark.skipif(
@@ -131,12 +133,13 @@ def run_vacuum_thread(pg_instance, vacuum_query, application_name='test'):
     return run_query_thread(pg_instance, vacuum_query, application_name, init_stmts)
 
 
-def run_one_check(check, cancel=True):
+def run_one_check(check: AgentCheck, cancel=True):
     """
     Run check and immediately cancel.
     Waits for all threads to close before continuing.
     """
-    check.run()
+    error_report = check.run()
+    assert not error_report, f'Check run failed with error: {error_report}'
     if cancel:
         check.cancel()
     if check.statement_samples._job_loop_future is not None:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
* Migrates Postgres config to the `InstanceConfg` model
* Adds and extends config validation
* Emits an agent health event when a config is loaded

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
