### PR TITLE
Revert "Adapt MySQL integration dashboards for OTel"

### DIFF
--- a/mysql/assets/dashboards/overview-screenboard.json
+++ b/mysql/assets/dashboards/overview-screenboard.json
@@ -7,9 +7,9 @@
       "definition": {
         "title": "About MySQL",
         "title_align": "center",
+        "type": "group",
         "banner_img": "/static/images/integration_dashboard/mysql_hero_1.jpeg",
         "show_title": false,
-        "type": "group",
         "layout_type": "ordered",
         "widgets": [
           {
@@ -68,8 +68,8 @@
       "definition": {
         "title": "Basic Activity Monitor",
         "title_align": "center",
-        "background_color": "white",
         "type": "group",
+        "background_color": "white",
         "layout_type": "ordered",
         "widgets": [
           {
@@ -81,6 +81,8 @@
               "type": "query_value",
               "requests": [
                 {
+                  "q": "avg:mysql.net.aborted_connects{$scope}",
+                  "aggregator": "avg",
                   "conditional_formats": [
                     {
                       "comparator": "<=",
@@ -91,15 +93,6 @@
                       "comparator": ">",
                       "palette": "white_on_red",
                       "value": 0
-                    }
-                  ],
-                  "response_format": "scalar",
-                  "queries": [
-                    {
-                      "data_source": "metrics",
-                      "name": "query1",
-                      "query": "avg:mysql.net.aborted_connects{$scope}",
-                      "semantic_mode": "combined"
                     }
                   ]
                 }
@@ -122,15 +115,8 @@
               "type": "query_value",
               "requests": [
                 {
-                  "response_format": "scalar",
-                  "queries": [
-                    {
-                      "data_source": "metrics",
-                      "name": "query1",
-                      "query": "avg:mysql.net.connections{$scope}",
-                      "semantic_mode": "combined"
-                    }
-                  ]
+                  "q": "avg:mysql.net.connections{$scope}",
+                  "aggregator": "avg"
                 }
               ],
               "precision": 2
@@ -151,16 +137,8 @@
               "type": "query_value",
               "requests": [
                 {
-                  "response_format": "scalar",
-                  "queries": [
-                    {
-                      "data_source": "metrics",
-                      "name": "query1",
-                      "query": "avg:mysql.net.max_connections{$scope}",
-                      "aggregator": "avg",
-                      "semantic_mode": "combined"
-                    }
-                  ]
+                  "q": "avg:mysql.net.max_connections{$scope}",
+                  "aggregator": "avg"
                 }
               ],
               "autoscale": true,
@@ -187,8 +165,8 @@
       "definition": {
         "title": "Performance",
         "title_align": "center",
-        "background_color": "vivid_blue",
         "type": "group",
+        "background_color": "vivid_blue",
         "layout_type": "ordered",
         "widgets": [
           {
@@ -198,6 +176,7 @@
               "title_size": "16",
               "title_align": "left",
               "show_legend": false,
+              "legend_size": "0",
               "legend_layout": "auto",
               "legend_columns": [
                 "avg",
@@ -215,12 +194,12 @@
                     }
                   ],
                   "response_format": "timeseries",
+                  "on_right_yaxis": false,
                   "queries": [
                     {
                       "query": "avg:mysql.performance.slow_queries{$scope}",
                       "data_source": "metrics",
-                      "name": "query1",
-                      "semantic_mode": "combined"
+                      "name": "query1"
                     }
                   ],
                   "style": {
@@ -318,8 +297,8 @@
       "definition": {
         "title": "Throughput",
         "title_align": "center",
-        "background_color": "blue",
         "type": "group",
+        "background_color": "blue",
         "layout_type": "ordered",
         "widgets": [
           {
@@ -329,6 +308,7 @@
               "title_size": "16",
               "title_align": "left",
               "show_legend": false,
+              "legend_size": "0",
               "legend_layout": "auto",
               "legend_columns": [
                 "avg",
@@ -340,18 +320,13 @@
               "type": "timeseries",
               "requests": [
                 {
+                  "on_right_yaxis": false,
                   "response_format": "timeseries",
                   "queries": [
                     {
                       "query": "avg:mysql.performance.com_select{$scope}",
                       "data_source": "metrics",
-                      "name": "query1",
-                      "semantic_mode": "combined"
-                    }
-                  ],
-                  "formulas": [
-                    {
-                      "formula": "query1"
+                      "name": "query1"
                     }
                   ],
                   "style": {
@@ -396,18 +371,13 @@
               "type": "timeseries",
               "requests": [
                 {
+                  "on_right_yaxis": false,
                   "response_format": "timeseries",
                   "queries": [
                     {
                       "query": "avg:mysql.performance.com_insert{$scope}",
                       "data_source": "metrics",
-                      "name": "query1",
-                      "semantic_mode": "combined"
-                    }
-                  ],
-                  "formulas": [
-                    {
-                      "formula": "query1"
+                      "name": "query1"
                     }
                   ],
                   "style": {
@@ -458,12 +428,12 @@
                     }
                   ],
                   "response_format": "timeseries",
+                  "on_right_yaxis": false,
                   "queries": [
                     {
                       "query": "avg:mysql.performance.com_update{$scope}",
                       "data_source": "metrics",
-                      "name": "query1",
-                      "semantic_mode": "combined"
+                      "name": "query1"
                     }
                   ],
                   "style": {
@@ -508,18 +478,13 @@
               "type": "timeseries",
               "requests": [
                 {
+                  "on_right_yaxis": false,
                   "response_format": "timeseries",
                   "queries": [
                     {
                       "query": "avg:mysql.performance.com_delete{$scope}",
                       "data_source": "metrics",
-                      "name": "query1",
-                      "semantic_mode": "combined"
-                    }
-                  ],
-                  "formulas": [
-                    {
-                      "formula": "query1"
+                      "name": "query1"
                     }
                   ],
                   "style": {
@@ -581,8 +546,8 @@
       "definition": {
         "title": "MySQL Resource Utilization",
         "title_align": "center",
-        "background_color": "vivid_green",
         "type": "group",
+        "background_color": "vivid_green",
         "layout_type": "ordered",
         "widgets": [
           {
@@ -603,13 +568,18 @@
               "type": "timeseries",
               "requests": [
                 {
+                  "formulas": [
+                    {
+                      "formula": "query1"
+                    }
+                  ],
                   "response_format": "timeseries",
+                  "on_right_yaxis": false,
                   "queries": [
                     {
                       "query": "avg:mysql.performance.threads_running{$scope}",
                       "data_source": "metrics",
-                      "name": "query1",
-                      "semantic_mode": "combined"
+                      "name": "query1"
                     }
                   ],
                   "style": {
@@ -654,13 +624,18 @@
               "type": "timeseries",
               "requests": [
                 {
+                  "formulas": [
+                    {
+                      "formula": "query1"
+                    }
+                  ],
                   "response_format": "timeseries",
+                  "on_right_yaxis": false,
                   "queries": [
                     {
                       "query": "avg:mysql.performance.threads_connected{$scope}",
                       "data_source": "metrics",
-                      "name": "query1",
-                      "semantic_mode": "combined"
+                      "name": "query1"
                     }
                   ],
                   "style": {
@@ -726,13 +701,19 @@
               "type": "timeseries",
               "requests": [
                 {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "alias": "Cache Utilization"
+                    }
+                  ],
                   "response_format": "timeseries",
+                  "on_right_yaxis": false,
                   "queries": [
                     {
                       "query": "avg:mysql.performance.key_cache_utilization{$scope} by {service}",
                       "data_source": "metrics",
-                      "name": "query1",
-                      "semantic_mode": "combined"
+                      "name": "query1"
                     }
                   ],
                   "style": {
@@ -777,19 +758,28 @@
               "type": "timeseries",
               "requests": [
                 {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "alias": "Data Reads"
+                    },
+                    {
+                      "formula": "query2",
+                      "alias": "Data Writes"
+                    }
+                  ],
                   "response_format": "timeseries",
+                  "on_right_yaxis": false,
                   "queries": [
                     {
                       "query": "avg:mysql.innodb.data_reads{$scope}",
                       "data_source": "metrics",
-                      "name": "query1",
-                      "semantic_mode": "combined"
+                      "name": "query1"
                     },
                     {
                       "query": "avg:mysql.innodb.data_writes{$scope}",
                       "data_source": "metrics",
-                      "name": "query2",
-                      "semantic_mode": "combined"
+                      "name": "query2"
                     }
                   ],
                   "style": {
@@ -834,25 +824,37 @@
               "type": "timeseries",
               "requests": [
                 {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "alias": "Available Buffer Pool"
+                    },
+                    {
+                      "formula": "query2",
+                      "alias": "Used Buffer Pool"
+                    },
+                    {
+                      "formula": "query3",
+                      "alias": "Total Buffer Pool"
+                    }
+                  ],
                   "response_format": "timeseries",
+                  "on_right_yaxis": false,
                   "queries": [
                     {
                       "query": "avg:mysql.innodb.buffer_pool_free{$scope}",
                       "data_source": "metrics",
-                      "name": "query1",
-                      "semantic_mode": "combined"
+                      "name": "query1"
                     },
                     {
                       "query": "avg:mysql.innodb.buffer_pool_used{$scope}",
                       "data_source": "metrics",
-                      "name": "query2",
-                      "semantic_mode": "combined"
+                      "name": "query2"
                     },
                     {
                       "query": "avg:mysql.innodb.buffer_pool_total{$scope}",
                       "data_source": "metrics",
-                      "name": "query3",
-                      "semantic_mode": "combined"
+                      "name": "query3"
                     }
                   ],
                   "style": {
@@ -897,25 +899,37 @@
               "type": "timeseries",
               "requests": [
                 {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "alias": "Total Pages"
+                    },
+                    {
+                      "formula": "query2",
+                      "alias": "Free Pages"
+                    },
+                    {
+                      "formula": "query3",
+                      "alias": "Pages Data"
+                    }
+                  ],
                   "response_format": "timeseries",
+                  "on_right_yaxis": false,
                   "queries": [
                     {
                       "query": "avg:mysql.innodb.buffer_pool_pages_total{$scope}",
                       "data_source": "metrics",
-                      "name": "query1",
-                      "semantic_mode": "combined"
+                      "name": "query1"
                     },
                     {
                       "query": "avg:mysql.innodb.buffer_pool_pages_free{$scope}",
                       "data_source": "metrics",
-                      "name": "query2",
-                      "semantic_mode": "combined"
+                      "name": "query2"
                     },
                     {
                       "query": "avg:mysql.innodb.buffer_pool_pages_data{$scope}",
                       "data_source": "metrics",
-                      "name": "query3",
-                      "semantic_mode": "combined"
+                      "name": "query3"
                     }
                   ],
                   "style": {
@@ -978,8 +992,8 @@
       "definition": {
         "title": "System Resource Utilization",
         "title_align": "center",
-        "background_color": "vivid_orange",
         "type": "group",
+        "background_color": "vivid_orange",
         "layout_type": "ordered",
         "widgets": [
           {
@@ -1041,8 +1055,7 @@
                     {
                       "query": "avg:system.cpu.iowait{$scope}",
                       "data_source": "metrics",
-                      "name": "query3",
-                      "semantic_mode": "combined"
+                      "name": "query3"
                     },
                     {
                       "query": "avg:system.cpu.user{$scope}",
@@ -1121,8 +1134,7 @@
                     {
                       "query": "avg:system.load.1{$scope}",
                       "data_source": "metrics",
-                      "name": "query1",
-                      "semantic_mode": "combined"
+                      "name": "query1"
                     },
                     {
                       "query": "avg:system.load.5{$scope}",
@@ -1197,8 +1209,7 @@
                     {
                       "query": "sum:system.mem.total{$scope}",
                       "data_source": "metrics",
-                      "name": "query2",
-                      "semantic_mode": "combined"
+                      "name": "query2"
                     }
                   ],
                   "style": {
@@ -1347,12 +1358,6 @@
             }
           }
         ]
-      },
-      "layout": {
-        "x": 0,
-        "y": 20,
-        "width": 12,
-        "height": 6
       }
     },
     {
@@ -1360,8 +1365,8 @@
       "definition": {
         "title": "Logs",
         "title_align": "center",
-        "background_color": "white",
         "type": "group",
+        "background_color": "white",
         "layout_type": "ordered",
         "widgets": [
           {
@@ -1370,44 +1375,20 @@
               "title": "Error Logs",
               "title_size": "16",
               "title_align": "left",
-              "requests": [
-                {
-                  "response_format": "event_list",
-                  "query": {
-                    "data_source": "logs_stream",
-                    "query_string": "source:mysql $scope status:error",
-                    "indexes": [],
-                    "storage": "hot",
-                    "sort": {
-                      "order": "desc",
-                      "column": "timestamp"
-                    }
-                  },
-                  "columns": [
-                    {
-                      "field": "status_line",
-                      "width": "auto"
-                    },
-                    {
-                      "field": "timestamp",
-                      "width": "auto"
-                    },
-                    {
-                      "field": "host",
-                      "width": "auto"
-                    },
-                    {
-                      "field": "service",
-                      "width": "auto"
-                    },
-                    {
-                      "field": "content",
-                      "width": "compact"
-                    }
-                  ]
-                }
+              "type": "log_stream",
+              "indexes": [],
+              "query": "source:mysql  $scope status:error",
+              "sort": {
+                "column": "time",
+                "order": "desc"
+              },
+              "columns": [
+                "core_host",
+                "core_service"
               ],
-              "type": "list_stream"
+              "show_date_column": true,
+              "show_message_column": true,
+              "message_display": "expanded-md"
             },
             "layout": {
               "x": 0,
@@ -1422,44 +1403,20 @@
               "title": "All Logs",
               "title_size": "16",
               "title_align": "left",
-              "requests": [
-                {
-                  "response_format": "event_list",
-                  "query": {
-                    "data_source": "logs_stream",
-                    "query_string": "source:mysql $scope",
-                    "indexes": [],
-                    "storage": "hot",
-                    "sort": {
-                      "order": "desc",
-                      "column": "timestamp"
-                    }
-                  },
-                  "columns": [
-                    {
-                      "field": "status_line",
-                      "width": "auto"
-                    },
-                    {
-                      "field": "timestamp",
-                      "width": "auto"
-                    },
-                    {
-                      "field": "host",
-                      "width": "auto"
-                    },
-                    {
-                      "field": "service",
-                      "width": "auto"
-                    },
-                    {
-                      "field": "content",
-                      "width": "compact"
-                    }
-                  ]
-                }
+              "type": "log_stream",
+              "indexes": [],
+              "query": "source:mysql $scope",
+              "sort": {
+                "column": "time",
+                "order": "desc"
+              },
+              "columns": [
+                "core_host",
+                "core_service"
               ],
-              "type": "list_stream"
+              "show_date_column": true,
+              "show_message_column": true,
+              "message_display": "expanded-md"
             },
             "layout": {
               "x": 6,
@@ -1469,23 +1426,17 @@
             }
           }
         ]
-      },
-      "layout": {
-        "x": 0,
-        "y": 26,
-        "width": 12,
-        "height": 5
       }
     }
   ],
   "template_variables": [
     {
       "name": "scope",
-      "available_values": [],
       "default": "*"
     }
   ],
   "layout_type": "ordered",
+  "is_read_only": false,
   "notify_list": [],
   "reflow_type": "fixed"
 }

--- a/mysql/assets/dashboards/overview.json
+++ b/mysql/assets/dashboards/overview.json
@@ -1,589 +1,150 @@
 {
     "title": "MySQL - Overview",
     "description": "This dashboard brings together key metrics from your MySQL servers so you can spot excessive numbers of [slow queries](https://www.datadoghq.com/blog/monitoring-mysql-performance-metrics/#query-performance) and quickly identify any resource constraints that may be impacting performance. Further reading on MySQL monitoring:\n\n- [Datadog's guide to key metrics for MySQL](https://www.datadoghq.com/blog/monitoring-mysql-performance-metrics/)\n\n- [How to collect MySQL metrics using built-in tools](https://www.datadoghq.com/blog/collecting-mysql-statistics-and-metrics/)\n\n- [How to monitor MySQL using Datadog](https://www.datadoghq.com/blog/mysql-monitoring-with-datadog/)\n\n- [Datadog's MySQL integration docs](https://docs.datadoghq.com/integrations/mysql/)\n\nClone this template dashboard to make changes and add your own graph widgets.",
-    "widgets": [
-      {
-        "id": 6275378000844597,
-        "definition": {
-          "title": "MySQL connections",
-          "show_legend": true,
-          "legend_layout": "auto",
-          "legend_columns": [
-            "avg",
-            "min",
-            "max",
-            "value",
-            "sum"
-          ],
-          "type": "timeseries",
-          "requests": [
-            {
-              "response_format": "timeseries",
-              "queries": [
-                {
-                  "data_source": "metrics",
-                  "name": "query1",
-                  "query": "sum:mysql.net.connections{$scope}",
-                  "semantic_mode": "combined"
-                }
-              ],
-              "style": {
-                "palette": "dog_classic",
-                "line_type": "solid",
-                "line_width": "normal"
-              }
-            },
-            {
-              "response_format": "timeseries",
-              "queries": [
-                {
-                  "data_source": "metrics",
-                  "name": "query1",
-                  "query": "sum:mysql.net.max_connections{$scope}",
-                  "semantic_mode": "combined"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "id": 7019698073009104,
-        "definition": {
-          "title": "MySQL reads and writes (per sec)",
-          "show_legend": true,
-          "legend_layout": "auto",
-          "legend_columns": [
-            "avg",
-            "min",
-            "max",
-            "value",
-            "sum"
-          ],
-          "type": "timeseries",
-          "requests": [
-            {
-              "response_format": "timeseries",
-              "queries": [
-                {
-                  "data_source": "metrics",
-                  "name": "query1",
-                  "query": "sum:mysql.innodb.data_reads{$scope}",
-                  "semantic_mode": "combined"
-                }
-              ],
-              "formulas": [
-                {
-                  "formula": "query1"
-                }
-              ],
-              "style": {
-                "palette": "dog_classic",
-                "line_type": "solid",
-                "line_width": "normal"
-              }
-            },
-            {
-              "response_format": "timeseries",
-              "queries": [
-                {
-                  "data_source": "metrics",
-                  "name": "query1",
-                  "query": "avg:mysql.innodb.data_writes{$scope}",
-                  "semantic_mode": "combined"
-                }
-              ],
-              "formulas": [
-                {
-                  "formula": "query1"
-                }
-              ],
-              "style": {
-                "palette": "dog_classic",
-                "line_type": "solid",
-                "line_width": "normal"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "id": 5054243947202682,
-        "definition": {
-          "title": "MySQL fsync op count (per sec)",
-          "show_legend": true,
-          "legend_layout": "auto",
-          "legend_columns": [
-            "avg",
-            "min",
-            "max",
-            "value",
-            "sum"
-          ],
-          "type": "timeseries",
-          "requests": [
-            {
-              "response_format": "timeseries",
-              "queries": [
-                {
-                  "data_source": "metrics",
-                  "name": "query1",
-                  "query": "sum:mysql.innodb.os_log_fsyncs{$scope}",
-                  "semantic_mode": "combined"
-                }
-              ],
-              "formulas": [
-                {
-                  "formula": "query1"
-                }
-              ],
-              "style": {
-                "palette": "dog_classic",
-                "line_type": "solid",
-                "line_width": "normal"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "id": 8679042482146834,
-        "definition": {
-          "title": "MySQL slow queries",
-          "show_legend": true,
-          "legend_layout": "auto",
-          "legend_columns": [
-            "avg",
-            "min",
-            "max",
-            "value",
-            "sum"
-          ],
-          "type": "timeseries",
-          "requests": [
-            {
-              "response_format": "timeseries",
-              "queries": [
-                {
-                  "data_source": "metrics",
-                  "name": "query1",
-                  "query": "sum:mysql.performance.slow_queries{$scope}",
-                  "semantic_mode": "combined"
-                }
-              ],
-              "formulas": [
-                {
-                  "formula": "query1"
-                }
-              ],
-              "style": {
-                "palette": "dog_classic",
-                "line_type": "solid",
-                "line_width": "normal"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "id": 8940192157313818,
-        "definition": {
-          "title": "MySQL locking rate (per sec)",
-          "show_legend": true,
-          "legend_layout": "auto",
-          "legend_columns": [
-            "avg",
-            "min",
-            "max",
-            "value",
-            "sum"
-          ],
-          "type": "timeseries",
-          "requests": [
-            {
-              "response_format": "timeseries",
-              "queries": [
-                {
-                  "data_source": "metrics",
-                  "name": "query1",
-                  "query": "sum:mysql.performance.table_locks_waited{$scope}",
-                  "semantic_mode": "combined"
-                }
-              ],
-              "formulas": [
-                {
-                  "formula": "rate(query1)"
-                }
-              ],
-              "style": {
-                "palette": "dog_classic",
-                "line_type": "solid",
-                "line_width": "normal"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "id": 7211572018463595,
-        "definition": {
-          "title": "MySQL CPU time (per sec)",
-          "show_legend": true,
-          "legend_layout": "auto",
-          "legend_columns": [
-            "avg",
-            "min",
-            "max",
-            "value",
-            "sum"
-          ],
-          "type": "timeseries",
-          "requests": [
-            {
-              "response_format": "timeseries",
-              "queries": [
-                {
-                  "data_source": "metrics",
-                  "name": "query1",
-                  "query": "mysql.performance.user_time{$scope}",
-                  "semantic_mode": "native"
-                }
-              ],
-              "formulas": [
-                {
-                  "formula": "query1"
-                }
-              ],
-              "style": {
-                "palette": "dog_classic",
-                "line_type": "solid",
-                "line_width": "normal"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "id": 3387110261451077,
-        "definition": {
-          "title": "System load",
-          "show_legend": true,
-          "legend_layout": "auto",
-          "legend_columns": [
-            "avg",
-            "min",
-            "max",
-            "value",
-            "sum"
-          ],
-          "type": "timeseries",
-          "requests": [
-            {
-              "response_format": "timeseries",
-              "queries": [
-                {
-                  "data_source": "metrics",
-                  "name": "query1",
-                  "query": "system.load.1{$scope}",
-                  "semantic_mode": "combined"
-                }
-              ],
-              "formulas": [
-                {
-                  "formula": "query1"
-                }
-              ],
-              "style": {
-                "palette": "dog_classic",
-                "line_type": "solid",
-                "line_width": "normal"
-              }
-            },
-            {
-              "response_format": "timeseries",
-              "queries": [
-                {
-                  "data_source": "metrics",
-                  "name": "query1",
-                  "query": "system.load.5{$scope}",
-                  "semantic_mode": "combined"
-                }
-              ],
-              "formulas": [
-                {
-                  "formula": "query1"
-                }
-              ],
-              "style": {
-                "palette": "dog_classic",
-                "line_type": "solid",
-                "line_width": "normal"
-              }
-            },
-            {
-              "response_format": "timeseries",
-              "queries": [
-                {
-                  "data_source": "metrics",
-                  "name": "query1",
-                  "query": "system.load.15{$scope}",
-                  "semantic_mode": "combined"
-                }
-              ],
-              "formulas": [
-                {
-                  "formula": "query1"
-                }
-              ],
-              "style": {
-                "palette": "dog_classic",
-                "line_type": "solid",
-                "line_width": "normal"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "id": 5930995066864482,
-        "definition": {
-          "title": "CPU usage (%)",
-          "show_legend": true,
-          "legend_layout": "auto",
-          "legend_columns": [
-            "avg",
-            "min",
-            "max",
-            "value",
-            "sum"
-          ],
-          "type": "timeseries",
-          "requests": [
-            {
-              "response_format": "timeseries",
-              "queries": [
-                {
-                  "data_source": "metrics",
-                  "name": "query1",
-                  "query": "system.cpu.idle{$scope}",
-                  "semantic_mode": "combined"
-                },
-                {
-                  "data_source": "metrics",
-                  "name": "query2",
-                  "query": "system.cpu.system{$scope}",
-                  "semantic_mode": "combined"
-                },
-                {
-                  "data_source": "metrics",
-                  "name": "query3",
-                  "query": "system.cpu.iowait{$scope}",
-                  "semantic_mode": "combined"
-                },
-                {
-                  "data_source": "metrics",
-                  "name": "query4",
-                  "query": "system.cpu.user{$scope}",
-                  "semantic_mode": "combined"
-                },
-                {
-                  "data_source": "metrics",
-                  "name": "query5",
-                  "query": "system.cpu.stolen{$scope}",
-                  "semantic_mode": "combined"
-                },
-                {
-                  "data_source": "metrics",
-                  "name": "query6",
-                  "query": "system.cpu.guest{$scope}",
-                  "semantic_mode": "combined"
-                }
-              ],
-              "formulas": [
-                {
-                  "formula": "query1"
-                },
-                {
-                  "formula": "query2"
-                },
-                {
-                  "formula": "query3"
-                },
-                {
-                  "formula": "query4"
-                },
-                {
-                  "formula": "query5"
-                },
-                {
-                  "formula": "query6"
-                }
-              ],
-              "style": {
-                "palette": "dog_classic",
-                "line_type": "solid",
-                "line_width": "normal"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "id": 354700245646769,
-        "definition": {
-          "title": "I/O wait (%)",
-          "show_legend": true,
-          "legend_layout": "auto",
-          "legend_columns": [
-            "avg",
-            "min",
-            "max",
-            "value",
-            "sum"
-          ],
-          "type": "timeseries",
-          "requests": [
-            {
-              "response_format": "timeseries",
-              "queries": [
-                {
-                  "data_source": "metrics",
-                  "name": "query1",
-                  "query": "max:system.cpu.iowait{$scope}",
-                  "semantic_mode": "combined"
-                }
-              ],
-              "formulas": [
-                {
-                  "formula": "query1"
-                }
-              ],
-              "style": {
-                "palette": "dog_classic",
-                "line_type": "solid",
-                "line_width": "normal"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "id": 1786796664554390,
-        "definition": {
-          "title": "System memory",
-          "show_legend": true,
-          "legend_layout": "auto",
-          "legend_columns": [
-            "avg",
-            "min",
-            "max",
-            "value",
-            "sum"
-          ],
-          "type": "timeseries",
-          "requests": [
-            {
-              "response_format": "timeseries",
-              "queries": [
-                {
-                  "data_source": "metrics",
-                  "name": "query1",
-                  "query": "sum:system.mem.usable{$scope}",
-                  "semantic_mode": "combined"
-                },
-                {
-                  "data_source": "metrics",
-                  "name": "query2",
-                  "query": "sum:system.mem.total{$scope}",
-                  "semantic_mode": "combined"
-                }
-              ],
-              "formulas": [
-                {
-                  "formula": "query1"
-                },
-                {
-                  "formula": "query2 - query1"
-                }
-              ],
-              "style": {
-                "palette": "dog_classic",
-                "line_type": "solid",
-                "line_width": "normal"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "id": 6896116482972023,
-        "definition": {
-          "title": "Network traffic (per sec)",
-          "show_legend": true,
-          "legend_layout": "auto",
-          "legend_columns": [
-            "avg",
-            "min",
-            "max",
-            "value",
-            "sum"
-          ],
-          "type": "timeseries",
-          "requests": [
-            {
-              "response_format": "timeseries",
-              "queries": [
-                {
-                  "data_source": "metrics",
-                  "name": "query1",
-                  "query": "sum:system.net.bytes_rcvd{$scope}",
-                  "semantic_mode": "combined"
-                }
-              ],
-              "formulas": [
-                {
-                  "formula": "query1"
-                }
-              ],
-              "style": {
-                "palette": "dog_classic",
-                "line_type": "solid",
-                "line_width": "normal"
-              }
-            },
-            {
-              "response_format": "timeseries",
-              "queries": [
-                {
-                  "data_source": "metrics",
-                  "name": "query1",
-                  "query": "sum:system.net.bytes_sent{$scope}",
-                  "semantic_mode": "combined"
-                }
-              ],
-              "formulas": [
-                {
-                  "formula": "query1"
-                }
-              ],
-              "style": {
-                "palette": "dog_classic",
-                "line_type": "solid",
-                "line_width": "normal"
-              }
-            }
-          ]
-        }
-      }
-    ],
-    "template_variables": [
-      {
-        "name": "scope",
-        "available_values": [],
-        "default": "*"
-      }
-    ],
     "layout_type": "ordered",
-    "notify_list": [],
-    "reflow_type": "auto"
-  }
+    "template_variables": [
+        {
+            "default": "*",
+            "prefix": null,
+            "name": "scope"
+        }
+    ],
+    "widgets": [
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:mysql.net.connections{$scope}"
+                    },
+                    {
+                        "q": "sum:mysql.net.max_connections{$scope}"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "MySQL connections"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:mysql.innodb.data_reads{$scope}"
+                    },
+                    {
+                        "q": "sum:mysql.innodb.data_writes{$scope}"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "MySQL reads and writes (per sec)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:mysql.innodb.os_log_fsyncs{$scope}"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "MySQL fsync op count (per sec)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:mysql.performance.slow_queries{$scope}"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "MySQL slow queries"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "rate(sum:mysql.performance.table_locks_waited{$scope})"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "MySQL locking rate (per sec)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "mysql.performance.user_time{$scope}"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "MySQL CPU time (per sec)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "system.load.1{$scope}"
+                    },
+                    {
+                        "q": "system.load.5{$scope}"
+                    },
+                    {
+                        "q": "system.load.15{$scope}"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "System load"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "system.cpu.idle{$scope}, system.cpu.system{$scope}, system.cpu.iowait{$scope}, system.cpu.user{$scope}, system.cpu.stolen{$scope}, system.cpu.guest{$scope}"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "CPU usage (%)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "max:system.cpu.iowait{$scope}"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "I/O wait (%)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:system.mem.usable{$scope},sum:system.mem.total{$scope}-sum:system.mem.usable{$scope}"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "System memory"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:system.net.bytes_rcvd{$scope}"
+                    },
+                    {
+                        "q": "sum:system.net.bytes_sent{$scope}"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Network traffic (per sec)"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Reverts DataDog/integrations-core#20460

mysql aren't working properly with semantic_mode, [traces](https://app.datadoghq.com/apm/traces?agg_m_a=count&agg_m_b=count&agg_m_source_a=base&agg_m_source_b=base&agg_q_a=%40view.url_path_group&agg_q_source_a=base&agg_t_a=count&agg_t_b=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&colsTraces=service%2Cresource_name%2C%40duration%2C%40_span.count%2C%40_duration.by_service&fromUser=false&graphType=waterfall&historicalData=true&messageDisplay=inline&panel=%7B%22queryString%22%3A%22%40http.path_group%3A%2Fapi%2Fui%2Fquery%2Ftimeseries%20%40view.url_path_group%3A%5C%22%2Fdash%2Fintegration%2F%3F%2Fmysql%5C%22%22%2C%22filters%22%3A%5B%7B%22isClicked%22%3Atrue%2C%22source%22%3A%22log%22%2C%22path%22%3A%22view.url_path_group%22%2C%22value%22%3A%22%2Fdash%2Fintegration%2F%3F%2Fmysql%22%7D%5D%2C%22queryId%22%3A%22tlq_graph_query_timeseries%22%2C%22timeRange%22%3A%7B%22from%22%3A1753967580000%2C%22to%22%3A1753967640000%2C%22live%22%3Afalse%7D%7D&query_a=%40http.path_group%3A%2Fapi%2Fui%2Fquery%2Ftimeseries&query_b=%40query_expr.incoming_query_expr%3A%2Aequiv_otel%2A%20%40error.message%3A%2Amismatched%5C%20metric%5C%20type%2A&shouldShowLegend=true&sort=time&spanID=8133925570977560011&spanType=all&spanViewType=metadata&storage=hot&target-span=a&timeHint=1753967631798&top_n_a=25&top_o_a=top&trace=2148149831712299149&trace_group_by_from=b&trace_group_by_metrics=b&traceID=2148149831712299149&traceQuery=a%20-%3E%20b&traceWhere=&view=traces&viz=timeseries&x_missing_a=true&start=1753973579007&end=1753977179007&paused=false)  