### PR TITLE
[Release] Bumped ddev version to 12.2.0

### DIFF
--- a/ddev/CHANGELOG.md
+++ b/ddev/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 12.2.0 / 2025-07-31
+
+***Added***:
+
+* Run integration tests in parallel for single integrations ([#20816](https://github.com/DataDog/integrations-core/pull/20816))
+
 ## 12.1.0 / 2025-07-15
 
 ***Added***:

--- a/ddev/changelog.d/20816.added
+++ b/ddev/changelog.d/20816.added
@@ -1,1 +1,0 @@
-Run integration tests in parallel for single integrations


### PR DESCRIPTION
### What does this PR do?
Release ddev. The changes to CI is causing ci validation to now fail for extras and marketplace