### PR TITLE
Update README.md - Fixed some inconsistencies with source naming

### DIFF
--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -259,7 +259,7 @@ Here is an example regex pattern to only collect Windows Events Logs from a cert
 logs:
   - type: windows_event
     channel_path: Security
-    source: windows.event
+    source: windows.events
     service: Windows
     log_processing_rules:
       - type: include_at_match
@@ -284,7 +284,7 @@ The following regex must be used to match these EventIDs:
 logs:
   - type: windows_event
     channel_path: Security
-    source: windows.event
+    source: windows.events
     service: Windows
     log_processing_rules:
       - type: include_at_match
@@ -298,7 +298,7 @@ Agent versions 7.41 or later normalize the EventID field. This removes the need 
 logs:
   - type: windows_event
     channel_path: Security
-    source: windows.event
+    source: windows.events
     service: Windows
     log_processing_rules:
       - type: include_at_match


### PR DESCRIPTION
Some sources were names source: event instead of source: events.  Fixed all occurrences of the inconsistency

### What does this PR do?
Fixes a mistake in some parts of the doc where the wrong source was provided. This created issues when customers were using these examples in the configuration, as default SIEM rules are based on the source name.
The fix changes all occurrences of `source: event` into `source:events`

### Motivation
Meeting with a customer where we tried to understand why their SIEM rules were not applied despite the fact that they followed the documentation

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
