### PR TITLE
kubernetes dashboard - add cluster dashboard for event widget

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_dashboard.json
+++ b/kubernetes/assets/dashboards/kubernetes_dashboard.json
@@ -424,7 +424,7 @@
                                             "data_source": "events",
                                             "name": "query1",
                                             "search": {
-                                                "query": "source:kubernetes $node"
+                                                "query": "source:kubernetes $node $cluster"
                                             },
                                             "indexes": [
                                                 "*"
@@ -466,7 +466,7 @@
                             "requests": [
                                 {
                                     "query": {
-                                        "query_string": "source:kubernetes $node",
+                                        "query_string": "source:kubernetes $node $cluster",
                                         "data_source": "event_stream",
                                         "event_size": "s"
                                     },


### PR DESCRIPTION


### What does this PR do?

All widgets on the dashboard use the $cluster variable to filter events by cluster when the user inputs a cluster name.

Add that filter for the event list widget.

### Motivation

make the widget user friendly by displaying only the data filtered by the user

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
