### PR TITLE
Fix Codecov by having a single job uploading results

### DIFF
--- a/.github/workflows/flaky-tests.yml
+++ b/.github/workflows/flaky-tests.yml
@@ -19,18 +19,16 @@ jobs:
       repo: core
 
       # Options
-      # Because -m starts with a dash, 
-      # click (the library used to build the CLI) will 
+      # Because -m starts with a dash,
+      # click (the library used to build the CLI) will
       # interpret it as an option, not as an argument.
-      # To avoid this, using -- syntax, 
-      # which tells the command that everything following it 
+      # To avoid this, using -- syntax,
+      # which tells the command that everything following it
       # should be treated as positional arguments, not options
       pytest-args: '-m flaky'
     secrets: inherit
 
     permissions:
-       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
-       id-token: write
        # needed for compute-matrix in test-target.yml
        contents: read
 
@@ -45,7 +43,7 @@ jobs:
       checks: write # Needed for test-results-master
       contents: write # Needed for test-results-master
       pull-requests: write # Needed for test-results-master
-      
+
     uses: ./.github/workflows/test-results-master.yml
     secrets: inherit
 

--- a/.github/workflows/flaky-tests.yml
+++ b/.github/workflows/flaky-tests.yml
@@ -19,16 +19,18 @@ jobs:
       repo: core
 
       # Options
-      # Because -m starts with a dash,
-      # click (the library used to build the CLI) will
+      # Because -m starts with a dash, 
+      # click (the library used to build the CLI) will 
       # interpret it as an option, not as an argument.
-      # To avoid this, using -- syntax,
-      # which tells the command that everything following it
+      # To avoid this, using -- syntax, 
+      # which tells the command that everything following it 
       # should be treated as positional arguments, not options
       pytest-args: '-m flaky'
     secrets: inherit
 
     permissions:
+       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
+       id-token: write
        # needed for compute-matrix in test-target.yml
        contents: read
 
@@ -43,7 +45,7 @@ jobs:
       checks: write # Needed for test-results-master
       contents: write # Needed for test-results-master
       pull-requests: write # Needed for test-results-master
-
+      
     uses: ./.github/workflows/test-results-master.yml
     secrets: inherit
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,23 +18,21 @@ jobs:
       repo: core
 
       # Options
-      # Because -m starts with a dash, 
-      # click (the library used to build the CLI) will 
+      # Because -m starts with a dash,
+      # click (the library used to build the CLI) will
       # interpret it as an option, not as an argument.
-      # To avoid this, using -- syntax, 
-      # which tells the command that everything following it 
+      # To avoid this, using -- syntax,
+      # which tells the command that everything following it
       # should be treated as positional arguments, not options
       pytest-args: '-m "not flaky"'
     secrets: inherit
 
     permissions:
-       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
-       id-token: write
        # needed for compute-matrix in test-target.yml
        contents: read
 
   publish-test-results:
-    
+
     needs:
     - test
 
@@ -49,6 +47,35 @@ jobs:
 
     uses: ./.github/workflows/test-results-master.yml
     secrets: inherit
+
+  upload-coverage:
+    needs:
+    - test
+    if: >
+      !github.event.repository.private &&
+      (success() || failure())
+    runs-on: ubuntu-latest
+    permissions:
+      # needed for codecov, allows the action to get a JWT signed by Github
+      id-token: write
+      contents: read
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Download all coverage artifacts
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      with:
+        pattern: coverage-*
+        path: coverage-reports
+        merge-multiple: false
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@15559ed290fa727036809b67ab0f646ffa6c5158
+      with:
+        use_oidc: true
+        directory: coverage-reports
+        fail_ci_if_error: false
 
   submit-traces:
     needs:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,21 +18,23 @@ jobs:
       repo: core
 
       # Options
-      # Because -m starts with a dash,
-      # click (the library used to build the CLI) will
+      # Because -m starts with a dash, 
+      # click (the library used to build the CLI) will 
       # interpret it as an option, not as an argument.
-      # To avoid this, using -- syntax,
-      # which tells the command that everything following it
+      # To avoid this, using -- syntax, 
+      # which tells the command that everything following it 
       # should be treated as positional arguments, not options
       pytest-args: '-m "not flaky"'
     secrets: inherit
 
     permissions:
+       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
+       id-token: write
        # needed for compute-matrix in test-target.yml
        contents: read
 
   publish-test-results:
-
+    
     needs:
     - test
 

--- a/.github/workflows/nightly-base-package.yml
+++ b/.github/workflows/nightly-base-package.yml
@@ -15,6 +15,8 @@ jobs:
     uses: ./.github/workflows/test-all.yml
 
     permissions:
+       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
+       id-token: write
        # needed for compute-matrix in test-target.yml
        contents: read
 

--- a/.github/workflows/pr-all.yml
+++ b/.github/workflows/pr-all.yml
@@ -17,8 +17,6 @@ jobs:
     uses: ./.github/workflows/test-all.yml
 
     permissions:
-       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
-       id-token: write
        # needed for compute-matrix in test-target.yml
        contents: read
 
@@ -35,6 +33,35 @@ jobs:
     if: success() || failure()
 
     uses: ./.github/workflows/save-event.yml
+
+  upload-coverage:
+    needs:
+    - test
+    if: >
+      !github.event.repository.private &&
+      (success() || failure())
+    runs-on: ubuntu-latest
+    permissions:
+      # needed for codecov, allows the action to get a JWT signed by Github
+      id-token: write
+      contents: read
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Download all coverage artifacts
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      with:
+        pattern: coverage-*
+        path: coverage-reports
+        merge-multiple: false
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@15559ed290fa727036809b67ab0f646ffa6c5158
+      with:
+        use_oidc: true
+        directory: coverage-reports
+        fail_ci_if_error: false
 
   submit-traces:
     needs:

--- a/.github/workflows/pr-all.yml
+++ b/.github/workflows/pr-all.yml
@@ -17,6 +17,8 @@ jobs:
     uses: ./.github/workflows/test-all.yml
 
     permissions:
+       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
+       id-token: write
        # needed for compute-matrix in test-target.yml
        contents: read
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -76,6 +76,36 @@ jobs:
     uses: ./.github/workflows/submit-traces.yml
     secrets: inherit
 
+  upload-coverage:
+    needs:
+    - test
+    if: >
+      !github.event.repository.private &&
+      (success() || failure()) &&
+      inputs.pytest-args != '-m flaky'
+    runs-on: ubuntu-latest
+    permissions:
+      # needed for codecov, allows the action to get a JWT signed by Github
+      id-token: write
+      contents: read
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Download all coverage artifacts
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      with:
+        pattern: coverage-*
+        path: coverage-reports
+        merge-multiple: false
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@15559ed290fa727036809b67ab0f646ffa6c5158
+      with:
+        use_oidc: true
+        directory: coverage-reports
+        fail_ci_if_error: false
+
   check:
     needs:
     - test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,5 +24,7 @@ jobs:
     secrets: inherit
 
     permissions:
+       # needed for codecov in pr-test.yml, allows the action to get a JWT signed by Github
+       id-token: write
        # needed for compute-matrix in test-target.yml
        contents: read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,5 @@ jobs:
     secrets: inherit
 
     permissions:
-       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
-       id-token: write
        # needed for compute-matrix in test-target.yml
        contents: read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,5 +24,7 @@ jobs:
     secrets: inherit
 
     permissions:
+       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
+       id-token: write
        # needed for compute-matrix in test-target.yml
        contents: read

--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -50,6 +50,8 @@ jobs:
       skip-ddev-tests: true
     secrets: inherit
     permissions:
+       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
+       id-token: write
        # needed for compute-matrix in test-target.yml
        contents: read
 

--- a/.github/workflows/test-fips-e2e.yml
+++ b/.github/workflows/test-fips-e2e.yml
@@ -46,6 +46,8 @@ jobs:
       TRACE_CAPTURE_LOG: "trace-captures/output.log"
 
     permissions:
+       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
+       id-token: write
        # needed for compute-matrix in test-target.yml
        contents: read
 
@@ -149,3 +151,12 @@ jobs:
         name: "test-results-${{ inputs.target || 'tls' }}"
         path: "${{ env.TEST_RESULTS_BASE_DIR }}"
 
+    - name: Upload coverage data
+      if: >
+        !github.event.repository.private &&
+        always()
+      uses: codecov/codecov-action@15559ed290fa727036809b67ab0f646ffa6c5158
+      with:
+        use_oidc: true
+        files: "${{ inputs.target || 'tls' }}/coverage.xml"
+        flags: "${{ inputs.target || 'tls' }}"

--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -114,8 +114,6 @@ jobs:
       TRACE_CAPTURE_LOG: "trace-captures/output.log"
 
     permissions:
-       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
-       id-token: write
        # needed for compute-matrix in test-target.yml
        contents: read
     steps:

--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -15,7 +15,7 @@ on:
         description: "Specific target env to run"
         required: false
         default: ""
-        type: string
+        type: string      
       platform:
         required: true
         type: string
@@ -114,6 +114,8 @@ jobs:
       TRACE_CAPTURE_LOG: "trace-captures/output.log"
 
     permissions:
+       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
+       id-token: write
        # needed for compute-matrix in test-target.yml
        contents: read
     steps:
@@ -411,3 +413,15 @@ jobs:
       with:
         name: "test-results-${{ inputs.target }}${{ inputs.target-env && format('-{0}', inputs.target-env) || '' }}-${{ inputs.platform }}"
         path: "${{ env.TEST_RESULTS_BASE_DIR }}"
+
+    - name: Upload coverage data
+      if: >
+        !github.event.repository.private &&
+        always() &&
+        inputs.pytest-args != '-m flaky'
+      # Flaky tests will have low coverage, don't upload it to avoid pipeline failure
+      uses: codecov/codecov-action@15559ed290fa727036809b67ab0f646ffa6c5158
+      with:
+        use_oidc: true
+        files: "${{ inputs.target }}/coverage.xml"
+        flags: "${{ inputs.target }}"

--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -15,7 +15,7 @@ on:
         description: "Specific target env to run"
         required: false
         default: ""
-        type: string      
+        type: string
       platform:
         required: true
         type: string
@@ -414,14 +414,14 @@ jobs:
         name: "test-results-${{ inputs.target }}${{ inputs.target-env && format('-{0}', inputs.target-env) || '' }}-${{ inputs.platform }}"
         path: "${{ env.TEST_RESULTS_BASE_DIR }}"
 
-    - name: Upload coverage data
+    - name: Upload coverage data as artifact
       if: >
         !github.event.repository.private &&
         always() &&
         inputs.pytest-args != '-m flaky'
-      # Flaky tests will have low coverage, don't upload it to avoid pipeline failure
-      uses: codecov/codecov-action@15559ed290fa727036809b67ab0f646ffa6c5158
+      # Flaky tests will have low coverage, don't include in artifacts to avoid pipeline issues
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        use_oidc: true
-        files: "${{ inputs.target }}/coverage.xml"
-        flags: "${{ inputs.target }}"
+        name: "coverage-${{ inputs.target }}${{ inputs.target-env && format('-{0}', inputs.target-env) || '' }}-${{ inputs.platform }}"
+        path: "${{ inputs.target }}/coverage.xml"
+        if-no-files-found: ignore

--- a/.github/workflows/weekly-latest.yml
+++ b/.github/workflows/weekly-latest.yml
@@ -15,6 +15,8 @@ jobs:
       latest: true
     secrets: inherit
     permissions:
+       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
+       id-token: write
        # needed for compute-matrix in test-target.yml
        contents: read
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This reverts commit a43fc0f8a890c395dccca676d96f1221fbc98be8.

We are bringing back Codecov having a single job that uploads coverage results from artifacts stored in each job run.

I created this PR on top of this branch to validate the execution: [Dummy commit](https://github.com/DataDog/integrations-core/pull/20941/checks)

### Motivation
<!-- What inspired you to submit this pull request? -->
Bring coverage report back.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
