### PR TITLE
[DBMON-5558] Fix deprecation warnings on isSet()

### DIFF
--- a/datadog_checks_base/changelog.d/20947.fixed
+++ b/datadog_checks_base/changelog.d/20947.fixed
@@ -1,0 +1,1 @@
+Fixes deprecation warnings on isSet() usage in DBMAsyncJob

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -334,7 +334,7 @@ class DBMAsyncJob(object):
         try:
             self._log.info("[%s] Starting job loop", self._job_tags_str)
             while True:
-                if self._cancel_event.isSet():
+                if self._cancel_event.is_set():
                     self._log.info("[%s] Job loop cancelled", self._job_tags_str)
                     self._check.count("dd.{}.async_job.cancel".format(self._dbms), 1, tags=self._job_tags, raw=True)
                     break
@@ -353,7 +353,7 @@ class DBMAsyncJob(object):
                 else:
                     self._run_job_rate_limited()
         except Exception as e:
-            if self._cancel_event.isSet():
+            if self._cancel_event.is_set():
                 # canceling can cause exceptions if the connection is closed the middle of the check run
                 # in this case we still want to report it as a cancellation instead of a crash
                 self._log.debug("[%s] Job loop error after cancel: %s", self._job_tags_str, e)
@@ -400,7 +400,7 @@ class DBMAsyncJob(object):
         except:
             raise
         finally:
-            if not self._cancel_event.isSet():
+            if not self._cancel_event.is_set():
                 self._rate_limiter.update_last_time_and_sleep()
             else:
                 self._rate_limiter.update_last_time()


### PR DESCRIPTION
### What does this PR do?
Fixes deprecation warnings on DBMAsyncJob class

### Motivation
Cleans up these warnings all over DBM related tests
```
=============================== warnings summary ===============================
tests/test_statements.py::test_async_job_cancel_cancel
  integrations-core/datadog_checks_base/datadog_checks/base/utils/db/utils.py:337: DeprecationWarning: isSet() is deprecated, use is_set() instead
    if self._cancel_event.isSet():
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
