### PR TITLE
Modify the job name for test target to fix the artifact overriding

### DIFF
--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -92,7 +92,7 @@ defaults:
 
 jobs:
   run:
-    name: "${{ inputs.job-name }}"
+    name: "${{ inputs.job-name }}${{ inputs.target-env && format('-{0}', inputs.target-env) || '' }}"
     runs-on: ${{ fromJson(inputs.runner) }}
 
     env:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR modifies the job name for each test-target run to include the environment selected, if any.
### Motivation
<!-- What inspired you to submit this pull request? -->
There are 2 issues with the current approach:

- After parallelizing the tests with different environments, the name for all jobs of the same integration are the same which makes it hard to track which job is which.
- More importantly, the job name is used for the artifact names for traces and test results. When replying traces this can cause files to be corrupted of they are being overwritten in parallel. See [these failures](https://github.com/DataDog/integrations-core/actions/runs/16607430143/job/46985434754). By using a proper job name we should fix this issue and make the job name clear on the interface.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
