### PR TITLE
Ensure that E2E tests do not run for packages that won't contain any E2E

### DIFF
--- a/ddev/changelog.d/20967.fixed
+++ b/ddev/changelog.d/20967.fixed
@@ -1,1 +1,1 @@
-Avoid  to start if a package without E2E tests is selected
+Skip E2E test execution for packages that don’t define them.

--- a/ddev/changelog.d/20967.fixed
+++ b/ddev/changelog.d/20967.fixed
@@ -1,1 +1,1 @@
-Skip E2E test execution for packages that don’t define them.
+Skip E2E test execution for packages that do not define them.

--- a/ddev/changelog.d/20967.fixed
+++ b/ddev/changelog.d/20967.fixed
@@ -1,0 +1,1 @@
+Avoid  to start if a package without E2E tests is selected

--- a/ddev/src/ddev/cli/env/test.py
+++ b/ddev/src/ddev/cli/env/test.py
@@ -78,12 +78,18 @@ def test_command(
     from ddev.config.constants import AppEnvVars
     from ddev.e2e.config import EnvDataStorage
     from ddev.e2e.constants import E2EMetadata
+    from ddev.repo.constants import NOT_E2E_TESTABLE
     from ddev.utils.ci import running_in_ci
     from ddev.utils.structures import EnvVars
 
     app: Application = ctx.obj
-    storage = EnvDataStorage(app.data_dir)
     integration = app.repo.integrations.get(intg_name)
+
+    if integration.name in NOT_E2E_TESTABLE:
+        app.display_info(f"Selected target {integration.name!r} does not have E2E tests to run. Skipping.")
+        return
+
+    storage = EnvDataStorage(app.data_dir)
     active_envs = storage.get_environments(integration.name)
 
     if environment is None:
@@ -109,6 +115,8 @@ def test_command(
             and (not data.get('platforms') or app.platform.name in data['platforms'])
             and (python_filter is None or data.get('python') == python_filter)
         ]
+
+        print(env_names)
     elif environment == 'active':
         env_names = active_envs
     else:

--- a/ddev/src/ddev/cli/env/test.py
+++ b/ddev/src/ddev/cli/env/test.py
@@ -116,7 +116,6 @@ def test_command(
             and (python_filter is None or data.get('python') == python_filter)
         ]
 
-        print(env_names)
     elif environment == 'active':
         env_names = active_envs
     else:

--- a/ddev/src/ddev/repo/constants.py
+++ b/ddev/src/ddev/repo/constants.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 CONFIG_DIRECTORY = '.ddev'
 NOT_SHIPPABLE = frozenset(['datadog_checks_dev', 'datadog_checks_tests_helper', 'ddev'])
+NOT_E2E_TESTABLE = frozenset(['datadog_checks_dev', 'datadog_checks_base', 'datadog_checks_tests_helper', 'ddev'])
 FULL_NAMES = {
     'core': 'integrations-core',
     'extras': 'integrations-extras',

--- a/ddev/tests/cli/env/test_test.py
+++ b/ddev/tests/cli/env/test_test.py
@@ -26,6 +26,8 @@ def test_env_vars_repo(ddev, helpers, data_dir, write_result_file, mocker):
     with mock.patch('ddev.utils.structures.EnvVars', side_effect=MockEnvVars):
         result = ddev('env', 'test', 'postgres', 'py3.12')
         assert result.exit_code == 0, result.output
+        # Ensure test was not skipped
+        assert "does not have E2E tests to run" not in result.output
 
 
 @pytest.mark.parametrize(

--- a/ddev/tests/cli/env/test_test.py
+++ b/ddev/tests/cli/env/test_test.py
@@ -1,7 +1,10 @@
 # (C) Datadog, Inc. 2024-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from contextlib import nullcontext
+
 import mock
+import pytest
 
 from tests.helpers.mocks import MockPopen
 
@@ -23,3 +26,22 @@ def test_env_vars_repo(ddev, helpers, data_dir, write_result_file, mocker):
     with mock.patch('ddev.utils.structures.EnvVars', side_effect=MockEnvVars):
         result = ddev('env', 'test', 'postgres', 'py3.12')
         assert result.exit_code == 0, result.output
+
+
+@pytest.mark.parametrize(
+    'target, expectation',
+    [
+        ('datadog_checks_dev', nullcontext()),
+        ('datadog_checks_base', nullcontext()),
+        # This will raise an OSError because the package is not a valid integration
+        ('datadog_checks_tests_helper', pytest.raises(OSError)),
+        ('ddev', nullcontext()),
+    ],
+    ids=['datadog_checks_dev', 'datadog_checks_base', 'datadog_checks_tests_helper', 'ddev'],
+)
+@pytest.mark.parametrize('env', ['py3.12', 'all', ''], ids=['py3.12', 'all', 'no-env'])
+def test_env_test_not_e2e_testable(ddev, target: str, env: str, expectation):
+    with expectation:
+        result = ddev('env', 'test', target, env)
+        assert result.exit_code == 0, result.output
+        assert "does not have E2E tests to run" in result.output


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Makes sure that the and `ddev test` command does not run for packages in the repo that do not have any E2E environment to test.

### Motivation
Since we move to run tests parallelized, we are seeing issues when running tests in packages without E2E tests because the environment is provided.

This makes the E2E tests to actually trigger and a requriement to start the environment is to load the `dd_environmet` fixture. For packages without E2E tests this fixture does not exist and the command fails even before filtering `e2e` tests.

This update makes it explicit that some packages do not run E2E tests and skips them. I have followed the same approach that we have now in which we keep a list of packages that are not shippable but defined a new one which keeps track of packages that do not have E2E tests.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
