### PR TITLE
Drop test environment for confluent 5.4 since the docker image has been removed

### DIFF
--- a/confluent_platform/hatch.toml
+++ b/confluent_platform/hatch.toml
@@ -2,14 +2,10 @@
 
 [[envs.default.matrix]]
 python = ["3.12"]
-version = ["5.4", "6.2"]
+version = ["6.2"]
 
 [envs.default.overrides]
 matrix.version.env-vars = [
-  { key = "CONFLUENT_VERSION", value = "5.4.0", if = ["5.4"] },
-  { key = "CONFLUENT_VERSION_CONNECT", value = "0.2.0-5.4.0", if = ["5.4"] },
-  { key = "CONFLUENT_KSQLDB_NAME", value = "ksql", if = ["5.4"] },
-
   { key = "CONFLUENT_VERSION", value = "6.2.0", if = ["6.2"] },
   { key = "CONFLUENT_VERSION_CONNECT", value = "0.5.0-6.2.0", if = ["6.2"] },
   { key = "CONFLUENT_KSQLDB_NAME", value = "ksqldb", if = ["6.2"] },


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Removes test environment for `confluent_platform` for version 5.4.
### Motivation
<!-- What inspired you to submit this pull request? -->
This version reached the end-of-life in 2023 and the docker image [is not available anymore](https://hub.docker.com/layers/confluentinc/ksql-examples).

We have started failing tests because the image could not be pulled. See [here](https://github.com/DataDog/integrations-core/actions/runs/16800733542/job/47581348673?pr=20967)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
