### PR TITLE
Fixes a race condition during pool close

### DIFF
--- a/postgres/tests/test_connection_pool.py
+++ b/postgres/tests/test_connection_pool.py
@@ -755,18 +755,14 @@ def test_closed_state_and_pool_creation_prevention():
     # Should now be closed
     assert manager.is_closed()
 
-    # Attempting to get a new pool should raise RuntimeError
-    with pytest.raises(RuntimeError, match="Pool manager is closed and cannot get connection pool"):
-        manager.get_pool("testdb")
-
-    # Attempting to get a connection should also raise RuntimeError
-    with pytest.raises(RuntimeError, match="Pool manager is closed and cannot get connection pool"):
+    # Attempting to get a connection should raise RuntimeError
+    with pytest.raises(RuntimeError, match="Pool manager is closed and cannot get connection"):
         manager.get_connection("testdb")
 
     # Calling close_all() again should not cause issues (idempotent)
     manager.close_all()
     assert manager.is_closed()
 
-    # Still should not be able to create new pools
-    with pytest.raises(RuntimeError, match="Pool manager is closed and cannot get connection pool"):
-        manager.get_pool("testdb")
+    # Still should not be able to create new connections
+    with pytest.raises(RuntimeError, match="Pool manager is closed and cannot get connection"):
+        manager.get_connection("testdb")


### PR DESCRIPTION
### What does this PR do?
Fixes a race condition that exists when calling `get_connection()`. Currently we have locks around access to our multi-pool dict and closing our pool safe from concurrent access. When calling `get_connection()` it was previously calling `get_pool` and then within ConnectionProxy we'd call `pool.get_connection()`. There existed a case where between getting a psycopg ConnectionPool, and grabbing a connection from it, the main thread could call `close_all_pools()` which would then lead to our thread calling `pool.get_connection()` to throw a psycopg pool closed exception. 

The changes here are aimed to fix this race condition and simplify our overall interface. We're only ever making use of individual connections and want the concept of multiple ConnectionPools to be hidden away anyway, so I've removed `get_pool()` call in favor of dealing with it all within `get_connection()` which will now return back a psycopg3 connection context manager directly and we no longer leak ConnectionPool outside of immediate usage. This means that we no longer need the ConnectionProxy class, further simplifying things.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
