### PR TITLE
Fix the code owners for logs assets

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -214,13 +214,13 @@ datadog_checks_base/datadog_checks/base/checks/windows/              @DataDog/wi
 /adyen/                                                              @DataDog/saas-integrations
 /adyen/*.md                                                          @DataDog/saas-integrations @DataDog/documentation
 /adyen/manifest.json                                                 @DataDog/saas-integrations @DataDog/documentation
-/adyen/assets/logs/                                                  @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/adyen/assets/logs/                                                  @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /authorize_net/                                                      @DataDog/saas-integrations
 /authorize_net/*.md                                                  @DataDog/saas-integrations @DataDog/documentation
 /authorize_net/manifest.json                                         @DataDog/saas-integrations @DataDog/documentation
 /authorize_net/metadata.csv                                          @DataDog/saas-integrations @DataDog/documentation
-/authorize_net/assets/logs/                                          @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/authorize_net/assets/logs/                                          @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /blazemeter/                                                        @DataDog/saas-integrations
 /blazemeter/*.md                                                    @DataDog/saas-integrations @DataDog/documentation
@@ -230,12 +230,12 @@ datadog_checks_base/datadog_checks/base/checks/windows/              @DataDog/wi
 /brevo/                                                              @DataDog/saas-integrations
 /brevo/*.md                                                          @DataDog/saas-integrations @DataDog/documentation
 /brevo/manifest.json                                                 @DataDog/saas-integrations @DataDog/documentation
-/brevo/assets/logs/                                                  @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/brevo/assets/logs/                                                  @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /checkpoint_harmony_email_and_collaboration/                         @DataDog/saas-integrations
 /checkpoint_harmony_email_and_collaboration/*.md                     @DataDog/saas-integrations @DataDog/documentation
 /checkpoint_harmony_email_and_collaboration/manifest.json            @DataDog/saas-integrations @DataDog/documentation
-/checkpoint_harmony_email_and_collaboration/assets/logs/             @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/checkpoint_harmony_email_and_collaboration/assets/logs/             @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /cisco_umbrella_dns/                                                 @DataDog/saas-integrations
 /cisco_umbrella_dns/*.md                                             @DataDog/saas-integrations @DataDog/documentation
@@ -248,38 +248,38 @@ datadog_checks_base/datadog_checks/base/checks/windows/              @DataDog/wi
 /cisco_secure_endpoint/                                              @DataDog/saas-integrations
 /cisco_secure_endpoint/*.md                                          @DataDog/saas-integrations @DataDog/documentation
 /cisco_secure_endpoint/manifest.json                                 @DataDog/saas-integrations @DataDog/documentation
-/cisco_secure_endpoint/assets/logs/                                  @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/cisco_secure_endpoint/assets/logs/                                  @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /contentful/                                                         @DataDog/saas-integrations
 /contentful/*.md                                                     @DataDog/saas-integrations @DataDog/documentation
 /contentful/manifest.json                                            @DataDog/saas-integrations @DataDog/documentation
-/contentful/assets/logs/                                             @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/contentful/assets/logs/                                             @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /eset_protect/                                                       @DataDog/agent-integrations
 /eset_protect/*.md                                                   @DataDog/agent-integrations @DataDog/documentation
 /eset_protect/manifest.json                                          @DataDog/agent-integrations @DataDog/documentation
-/eset_protect/assets/logs/                                           @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/eset_protect/assets/logs/                                           @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /extrahop/                                                          @DataDog/saas-integrations
 /extrahop/*.md                                                      @DataDog/saas-integrations @DataDog/documentation
 /extrahop/manifest.json                                             @DataDog/saas-integrations @DataDog/documentation
-/extrahop/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/extrahop/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /falco/                                                             @DataDog/agent-integrations @DataDog/saas-integrations
 /falco/*.md                                                         @DataDog/agent-integrations @DataDog/saas-integrations @DataDog/documentation
 /falco/manifest.json                                                @DataDog/agent-integrations @DataDog/saas-integrations @DataDog/documentation
-/falco/assets/logs/                                                 @DataDog/agent-integrations @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/falco/assets/logs/                                                 @DataDog/agent-integrations @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /freshservice/                                                          @DataDog/saas-integrations
 /freshservice/*.md                                                      @DataDog/saas-integrations @DataDog/documentation
 /freshservice/manifest.json                                             @DataDog/saas-integrations @DataDog/documentation
-/freshservice/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/freshservice/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /genesys/                                                           @DataDog/saas-integrations
 /genesys/*.md                                                       @DataDog/saas-integrations @DataDog/documentation
 /genesys/manifest.json                                              @DataDog/saas-integrations @DataDog/documentation
 /genesys/metadata.csv                                               @DataDog/saas-integrations @DataDog/documentation
-/genesys/assets/logs/                                               @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/genesys/assets/logs/                                               @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /godaddy/                                                           @DataDog/saas-integrations
 /godaddy/*.md                                                       @DataDog/saas-integrations @DataDog/documentation
@@ -289,17 +289,17 @@ datadog_checks_base/datadog_checks/base/checks/windows/              @DataDog/wi
 /greenhouse/                                                          @DataDog/saas-integrations
 /greenhouse/*.md                                                      @DataDog/saas-integrations @DataDog/documentation
 /greenhouse/manifest.json                                             @DataDog/saas-integrations @DataDog/documentation
-/greenhouse/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/greenhouse/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /iboss/                                                              @DataDog/saas-integrations @DataDog/agent-integrations
 /iboss/*.md                                                          @DataDog/saas-integrations @DataDog/agent-integrations @DataDog/documentation
 /iboss/manifest.json                                                 @DataDog/saas-integrations @DataDog/agent-integrations @DataDog/documentation
-/iboss/assets/logs/                                                  @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/iboss/assets/logs/                                                  @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /incident_io/                                                        @DataDog/saas-integrations
 /incident_io/*.md                                                    @DataDog/saas-integrations @DataDog/documentation
 /incident_io/manifest.json                                           @DataDog/saas-integrations @DataDog/documentation
-/incident_io/assets/logs/                                            @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/incident_io/assets/logs/                                            @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /keeper/                                                             @DataDog/saas-integrations
 /keeper/*.md                                                         @DataDog/saas-integrations @DataDog/documentation
@@ -309,7 +309,7 @@ datadog_checks_base/datadog_checks/base/checks/windows/              @DataDog/wi
 /lastpass/                                                          @DataDog/saas-integrations
 /lastpass/*.md                                                      @DataDog/saas-integrations @DataDog/documentation
 /lastpass/manifest.json                                             @DataDog/saas-integrations @DataDog/documentation
-/lastpass/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/lastpass/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /mailchimp/                                                          @DataDog/saas-integrations
 /mailchimp/*.md                                                      @DataDog/saas-integrations @DataDog/documentation
@@ -318,22 +318,22 @@ datadog_checks_base/datadog_checks/base/checks/windows/              @DataDog/wi
 /metabase/                                                          @DataDog/saas-integrations
 /metabase/*.md                                                      @DataDog/saas-integrations @DataDog/documentation
 /metabase/manifest.json                                             @DataDog/saas-integrations @DataDog/documentation
-/metabase/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/metabase/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /microsoft_dns/                                                     @DataDog/agent-integrations
 /microsoft_dns/*.md                                                 @DataDog/agent-integrations @DataDog/documentation
 /microsoft_dns/manifest.json                                        @DataDog/agent-integrations @DataDog/documentation
-/microsoft_dns/assets/logs/                                         @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/microsoft_dns/assets/logs/                                         @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /microsoft_sysmon/                                                  @DataDog/agent-integrations
 /microsoft_sysmon/*.md                                              @DataDog/agent-integrations @DataDog/documentation
 /microsoft_sysmon/manifest.json                                     @DataDog/agent-integrations @DataDog/documentation
-/microsoft_sysmon/assets/logs/                                      @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/microsoft_sysmon/assets/logs/                                      @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /mimecast/                                                          @DataDog/saas-integrations
 /mimecast/*.md                                                      @DataDog/saas-integrations @DataDog/documentation
 /mimecast/manifest.json                                             @DataDog/saas-integrations @DataDog/documentation
-/mimecast/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/mimecast/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /mux/                                                               @DataDog/saas-integrations
 /mux/*.md                                                           @DataDog/saas-integrations @DataDog/documentation
@@ -343,37 +343,37 @@ datadog_checks_base/datadog_checks/base/checks/windows/              @DataDog/wi
 /orca_security/                                                      @DataDog/saas-integrations
 /orca_security/*.md                                                  @DataDog/saas-integrations @DataDog/documentation
 /orca_security/manifest.json                                         @DataDog/saas-integrations @DataDog/documentation
-/orca_security/assets/logs/                                          @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/orca_security/assets/logs/                                          @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /okta_workflows/                                                     @DataDog/saas-integrations
 /okta_workflows/*.md                                                 @DataDog/saas-integrations @DataDog/documentation
 /okta_workflows/manifest.json                                        @DataDog/saas-integrations @DataDog/documentation
-/okta_workflows/assets/logs/                                         @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/okta_workflows/assets/logs/                                         @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /palo_alto_cortex_xdr/                                               @DataDog/saas-integrations
 /palo_alto_cortex_xdr/*.md                                           @DataDog/saas-integrations @DataDog/documentation
 /palo_alto_cortex_xdr/manifest.json                                  @DataDog/saas-integrations @DataDog/documentation
-/palo_alto_cortex_xdr/assets/logs/                                   @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/palo_alto_cortex_xdr/assets/logs/                                   @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /plivo/                                                              @DataDog/saas-integrations
 /plivo/*.md                                                          @DataDog/saas-integrations @DataDog/documentation
 /plivo/manifest.json                                                 @DataDog/saas-integrations @DataDog/documentation
-/plivo/assets/logs/                                                  @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/plivo/assets/logs/                                                  @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /postmark/                                                          @DataDog/saas-integrations
 /postmark/*.md                                                      @DataDog/saas-integrations @DataDog/documentation
 /postmark/manifest.json                                             @DataDog/saas-integrations @DataDog/documentation
-/postmark/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/postmark/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /proofpoint_on_demand/                                              @DataDog/saas-integrations
 /proofpoint_on_demand/*.md                                          @DataDog/saas-integrations @DataDog/documentation
 /proofpoint_on_demand/manifest.json                                 @DataDog/saas-integrations @DataDog/documentation
-/proofpoint_on_demand/assets/logs/                                  @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/proofpoint_on_demand/assets/logs/                                  @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /sanity/                                                            @DataDog/saas-integrations
 /sanity/*.md                                                        @DataDog/saas-integrations @DataDog/documentation
 /sanity/manifest.json                                               @DataDog/saas-integrations @DataDog/documentation
-/sanity/assets/logs/                                                @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/sanity/assets/logs/                                                @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /snowflake/                                                          @DataDog/saas-integrations
 /snowflake/*.md                                                      @DataDog/saas-integrations @DataDog/documentation @DataDog/agent-integrations
@@ -390,43 +390,43 @@ datadog_checks_base/datadog_checks/base/checks/windows/              @DataDog/wi
 /sonicwall_firewall/                                                  @DataDog/saas-integrations
 /sonicwall_firewall/*.md                                              @DataDog/saas-integrations @DataDog/documentation
 /sonicwall_firewall/manifest.json                                     @DataDog/saas-integrations @DataDog/documentation
-/sonicwall_firewall/assets/logs/                                      @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/sonicwall_firewall/assets/logs/                                      @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /sophos_central_cloud/                                               @DataDog/saas-integrations
 /sophos_central_cloud/*.md                                           @DataDog/saas-integrations @DataDog/documentation
 /sophos_central_cloud/manifest.json                                  @DataDog/saas-integrations @DataDog/documentation
-/sophos_central_cloud/assets/logs/                                   @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/sophos_central_cloud/assets/logs/                                   @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /squid/                                                              @DataDog/saas-integrations
 /squid/*.md                                                          @DataDog/saas-integrations @DataDog/documentation
 /squid/manifest.json                                                 @DataDog/saas-integrations @DataDog/documentation
-/squid/assets/logs/                                                  @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/squid/assets/logs/                                                  @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /ping_one/                                                           @DataDog/saas-integrations
 /ping_one/*.md                                                       @DataDog/saas-integrations @DataDog/documentation
 /ping_one/manifest.json                                              @DataDog/saas-integrations @DataDog/documentation
-/ping_one/assets/logs/                                               @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/ping_one/assets/logs/                                               @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /trend_micro_vision_one_xdr/                                         @DataDog/saas-integrations
 /trend_micro_vision_one_xdr/*.md                                     @DataDog/saas-integrations @DataDog/documentation
 /trend_micro_vision_one_xdr/manifest.json                            @DataDog/saas-integrations @DataDog/documentation
-/trend_micro_vision_one_xdr/assets/logs/                             @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/trend_micro_vision_one_xdr/assets/logs/                             @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /ping_federate/                                                      @DataDog/saas-integrations
 /ping_federate/*.md                                                  @DataDog/saas-integrations @DataDog/documentation
 /ping_federate/manifest.json                                         @DataDog/saas-integrations @DataDog/documentation
-/ping_federate/assets/logs/                                          @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/ping_federate/assets/logs/                                          @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /cisco_secure_email_threat_defense/                                 @DataDog/saas-integrations
 /cisco_secure_email_threat_defense/*.md                             @DataDog/saas-integrations @DataDog/documentation
 /cisco_secure_email_threat_defense/manifest.json                    @DataDog/saas-integrations @DataDog/documentation
-/cisco_secure_email_threat_defense/assets/logs/                     @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/cisco_secure_email_threat_defense/assets/logs/                     @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /ringcentral/                                                        @DataDog/saas-integrations
 /ringcentral/*.md                                                    @DataDog/saas-integrations @DataDog/documentation
 /ringcentral/manifest.json                                           @DataDog/saas-integrations @DataDog/documentation
 /ringcentral/metadata.csv                                            @DataDog/saas-integrations @DataDog/documentation
-/ringcentral/assets/logs/                                            @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/ringcentral/assets/logs/                                            @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /temporal_cloud/                                                    @DataDog/saas-integrations
 /temporal_cloud/*.md                                                @DataDog/saas-integrations @DataDog/documentation
@@ -436,132 +436,132 @@ datadog_checks_base/datadog_checks/base/checks/windows/              @DataDog/wi
 /trend_micro_email_security/                                        @DataDog/saas-integrations
 /trend_micro_email_security/*.md                                    @DataDog/saas-integrations @DataDog/documentation
 /trend_micro_email_security/manifest.json                           @DataDog/saas-integrations @DataDog/documentation
-/trend_micro_email_security/assets/logs/                            @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/trend_micro_email_security/assets/logs/                            @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /trellix_endpoint_security/                                         @DataDog/saas-integrations
 /trellix_endpoint_security/*.md                                     @DataDog/saas-integrations @DataDog/documentation
 /trellix_endpoint_security/manifest.json                            @DataDog/saas-integrations @DataDog/documentation
-/trellix_endpoint_security/assets/logs/                             @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/trellix_endpoint_security/assets/logs/                             @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /docusign/                                                          @DataDog/saas-integrations
 /docusign/*.md                                                      @DataDog/saas-integrations @DataDog/documentation
 /docusign/manifest.json                                             @DataDog/saas-integrations @DataDog/documentation
-/docusign/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/docusign/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /trend_micro_vision_one_endpoint_security/                          @DataDog/saas-integrations
 /trend_micro_vision_one_endpoint_security/*.md                      @DataDog/saas-integrations @DataDog/documentation
 /trend_micro_vision_one_endpoint_security/manifest.json             @DataDog/saas-integrations @DataDog/documentation
-/trend_micro_vision_one_endpoint_security/assets/logs/              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/trend_micro_vision_one_endpoint_security/assets/logs/              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /shopify/                                                           @DataDog/saas-integrations
 /shopify/*.md                                                       @DataDog/saas-integrations @DataDog/documentation
 /shopify/manifest.json                                              @DataDog/saas-integrations @DataDog/documentation
-/shopify/assets/logs/                                               @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/shopify/assets/logs/                                               @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /asana/                                                             @DataDog/saas-integrations
 /asana/*.md                                                         @DataDog/saas-integrations @DataDog/documentation
 /asana/manifest.json                                                @DataDog/saas-integrations @DataDog/documentation
-/asana/assets/logs/                                                 @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/asana/assets/logs/                                                 @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /hubspot_content_hub/                                               @DataDog/saas-integrations
 /hubspot_content_hub/*.md                                           @DataDog/saas-integrations @DataDog/documentation
 /hubspot_content_hub/manifest.json                                  @DataDog/saas-integrations @DataDog/documentation
-/hubspot_content_hub/assets/logs/                                   @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/hubspot_content_hub/assets/logs/                                   @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /forcepoint_secure_web_gateway/                                     @DataDog/saas-integrations
 /forcepoint_secure_web_gateway/*.md                                 @DataDog/saas-integrations @DataDog/documentation
 /forcepoint_secure_web_gateway/manifest.json                        @DataDog/saas-integrations @DataDog/documentation
-/forcepoint_secure_web_gateway/assets/logs/                         @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/forcepoint_secure_web_gateway/assets/logs/                         @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 vonage/                                                            @DataDog/saas-integrations
 vonage/*.md                                                        @DataDog/saas-integrations @DataDog/documentation
 vonage/manifest.json                                               @DataDog/saas-integrations @DataDog/documentation
-vonage/assets/logs/                                                @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+vonage/assets/logs/                                                @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /asana/                                                             @DataDog/saas-integrations
 /asana/*.md                                                         @DataDog/saas-integrations @DataDog/documentation
 /asana/manifest.json                                                @DataDog/saas-integrations @DataDog/documentation
-/asana/assets/logs/                                                 @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/asana/assets/logs/                                                 @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /tanium/                                                            @DataDog/saas-integrations
 /tanium/*.md                                                        @DataDog/saas-integrations @DataDog/documentation
 /tanium/manifest.json                                               @DataDog/saas-integrations @DataDog/documentation
-/tanium/assets/logs/                                                @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/tanium/assets/logs/                                                @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 plaid/                                                              @DataDog/saas-integrations
 plaid/*.md                                                          @DataDog/saas-integrations @DataDog/documentation
 plaid/manifest.json                                                 @DataDog/saas-integrations @DataDog/documentation
-plaid/assets/logs/                                                  @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+plaid/assets/logs/                                                  @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /streamnative/                                                      @DataDog/saas-integrations
 /streamnative/*.md                                                  @DataDog/saas-integrations @DataDog/documentation
 /streamnative/manifest.json                                         @DataDog/saas-integrations @DataDog/documentation
-/streamnative/assets/logs/                                          @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/streamnative/assets/logs/                                          @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /servicenow_performance/                                            @DataDog/saas-integrations
 /servicenow_performance/*.md                                        @DataDog/saas-integrations @DataDog/documentation
 /servicenow_performance/manifest.json                               @DataDog/saas-integrations @DataDog/documentation
-/servicenow_performance/assets/logs/                                @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/servicenow_performance/assets/logs/                                @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /silverstripe_cms/                                                  @DataDog/agent-integrations
 /silverstripe_cms/*.md                                              @DataDog/agent-integrations @DataDog/documentation
 /silverstripe_cms/manifest.json                                     @DataDog/agent-integrations @DataDog/documentation
-/silverstripe_cms/assets/logs/                                      @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/silverstripe_cms/assets/logs/                                      @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /avast/                                                             @DataDog/saas-integrations
 /avast/*.md                                                         @DataDog/saas-integrations @DataDog/documentation
 /avast/manifest.json                                                @DataDog/saas-integrations @DataDog/documentation
-/avast/assets/logs/                                                 @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/avast/assets/logs/                                                 @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /symantec_vip/                                                      @DataDog/saas-integrations
 /symantec_vip/*.md                                                  @DataDog/saas-integrations @DataDog/documentation
 /symantec_vip/manifest.json                                         @DataDog/saas-integrations @DataDog/documentation
-/symantec_vip/assets/logs/                                          @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/symantec_vip/assets/logs/                                          @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /tenable_io/                                                        @DataDog/saas-integrations
 /tenable_io/*.md                                                    @DataDog/saas-integrations @DataDog/documentation
 /tenable_io/manifest.json                                           @DataDog/saas-integrations @DataDog/documentation
-/tenable_io/assets/logs/                                            @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/tenable_io/assets/logs/                                            @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /zero_networks/                                                     @DataDog/saas-integrations
 /zero_networks/*.md                                                 @DataDog/saas-integrations @DataDog/documentation
 /zero_networks/manifest.json                                        @DataDog/saas-integrations @DataDog/documentation
-/zero_networks/assets/logs/                                         @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/zero_networks/assets/logs/                                         @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /bitdefender/                                                       @DataDog/saas-integrations
 /bitdefender/*.md                                                   @DataDog/saas-integrations @DataDog/documentation
 /bitdefender/manifest.json                                          @DataDog/saas-integrations @DataDog/documentation
-/bitdefender/assets/logs/                                           @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/bitdefender/assets/logs/                                           @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /ivanti_nzta/                                                       @DataDog/saas-integrations
 /ivanti_nzta/*.md                                                   @DataDog/saas-integrations @DataDog/documentation
 /ivanti_nzta/manifest.json                                          @DataDog/saas-integrations @DataDog/documentation
-/ivanti_nzta/assets/logs/                                           @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/ivanti_nzta/assets/logs/                                           @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /box/                                                               @DataDog/saas-integrations
 /box/*.md                                                           @DataDog/saas-integrations @DataDog/documentation
 /box/manifest.json                                                  @DataDog/saas-integrations @DataDog/documentation
-/box/assets/logs/                                                   @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/box/assets/logs/                                                   @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /proofpoint_tap/                                                    @DataDog/saas-integrations
 /proofpoint_tap/*.md                                                @DataDog/saas-integrations @DataDog/documentation
 /proofpoint_tap/manifest.json                                       @DataDog/saas-integrations @DataDog/documentation
-/proofpoint_tap/assets/logs/                                        @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/proofpoint_tap/assets/logs/                                        @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /carbon_black_cloud/                                                               @DataDog/saas-integrations
 /carbon_black_cloud/*.md                                                           @DataDog/saas-integrations @DataDog/documentation
 /carbon_black_cloud/manifest.json                                                  @DataDog/saas-integrations @DataDog/documentation
-/carbon_black_cloud/assets/logs/                                                   @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/carbon_black_cloud/assets/logs/                                                   @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /forcepoint_security_service_edge/                                   @DataDog/saas-integrations
 /forcepoint_security_service_edge/*.md                               @DataDog/saas-integrations @DataDog/documentation
 /forcepoint_security_service_edge/manifest.json                      @DataDog/saas-integrations @DataDog/documentation
-/forcepoint_security_service_edge/assets/logs/                       @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/forcepoint_security_service_edge/assets/logs/                       @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /mac_audit_logs/                                                     @DataDog/agent-integrations
 /mac_audit_logs/*.md                                                 @DataDog/agent-integrations @DataDog/documentation
 /mac_audit_logs/manifest.json                                        @DataDog/agent-integrations @DataDog/documentation
-/mac_audit_logs/assets/logs/                                         @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/mac_audit_logs/assets/logs/                                         @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /gpu/                                                                @DataDog/ebpf-platform
 /gpu/*.md                                                            @DataDog/ebpf-platform @DataDog/documentation
@@ -570,42 +570,42 @@ plaid/assets/logs/                                                  @DataDog/saa
 /linux_audit_logs/                                                  @DataDog/agent-integrations
 /linux_audit_logs/*.md                                              @DataDog/agent-integrations @DataDog/documentation
 /linux_audit_logs/manifest.json                                     @DataDog/agent-integrations @DataDog/documentation
-/linux_audit_logs/assets/logs/                                      @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/linux_audit_logs/assets/logs/                                      @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /openvpn/                                                           @DataDog/agent-integrations
 /openvpn/*.md                                                       @DataDog/agent-integrations @DataDog/documentation
 /openvpn/manifest.json                                              @DataDog/agent-integrations @DataDog/documentation
-/openvpn/assets/logs/                                               @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/openvpn/assets/logs/                                               @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /watchguard_firebox/                                                  @DataDog/agent-integrations
 /watchguard_firebox/*.md                                              @DataDog/agent-integrations @DataDog/documentation
 /watchguard_firebox/manifest.json                                     @DataDog/agent-integrations @DataDog/documentation
-/watchguard_firebox/assets/logs/                                      @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-integrations-reviews @DataDog/logs-core
+/watchguard_firebox/assets/logs/                                      @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /dnsfilter/                                                          @DataDog/saas-integrations
 /dnsfilter/*.md                                                      @DataDog/saas-integrations @DataDog/documentation
 /dnsfilter/manifest.json                                             @DataDog/saas-integrations @DataDog/documentation
-/dnsfilter/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/dnsfilter/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /workato/                                                            @DataDog/saas-integrations
 /workato/*.md                                                        @DataDog/saas-integrations @DataDog/documentation
 /workato/manifest.json                                               @DataDog/saas-integrations @DataDog/documentation
-/workato/assets/logs/                                                @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/workato/assets/logs/                                                @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /bitwarden/                                                          @DataDog/saas-integrations
 /bitwarden/*.md                                                      @DataDog/saas-integrations @DataDog/documentation
 /bitwarden/manifest.json                                             @DataDog/saas-integrations @DataDog/documentation
-/bitwarden/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/bitwarden/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /klaviyo/                                                            @DataDog/saas-integrations
 /klaviyo/*.md                                                        @DataDog/saas-integrations @DataDog/documentation
 /klaviyo/manifest.json                                               @DataDog/saas-integrations @DataDog/documentation
-/klaviyo/assets/logs/                                                @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/klaviyo/assets/logs/                                                @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /beyondtrust_password_safe/                                          @DataDog/saas-integrations @DataDog/agent-integrations
 /beyondtrust_password_safe/*.md                                      @DataDog/saas-integrations @DataDog/agent-integrations @DataDog/documentation
 /beyondtrust_password_safe/manifest.json                             @DataDog/saas-integrations @DataDog/agent-integrations @DataDog/documentation
-/beyondtrust_password_safe/assets/logs/                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviews
+/beyondtrust_password_safe/assets/logs/                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 # To keep Security up-to-date with changes to the signing tool.
 /datadog_checks_dev/datadog_checks/dev/tooling/signing.py             @DataDog/agent-integrations
@@ -624,4 +624,4 @@ docs/developer/process/integration-release.md                         @DataDog/a
 
 # LEAVE THE FOLLOWING LOG OWNERSHIP LAST IN THE FILE
 # Make sure logs team is the full owner for all logs related files
-**/assets/logs/                                                       @DataDog/logs-integrations-reviewers @DataDog/logs-integrations-reviews
+**/assets/logs/                                                       @DataDog/logs-integrations-reviewers


### PR DESCRIPTION
### What does this PR do?
The codeowners was incorrectly assigned to @DataDog/logs-integrations-reviews instead of @DataDog/logs-integrations-reviewers