### PR TITLE
[LOGSC-2385] Add bypass annotations for new linter checks

### DIFF
--- a/airflow/assets/logs/airflow.yaml
+++ b/airflow/assets/logs/airflow.yaml
@@ -1,3 +1,5 @@
+# bypass-global-grok-parser-rules-checks
+# bypass-global-facets-path-checks
 id: airflow
 metric_id: airflow
 backend_only: false

--- a/ambari/assets/logs/ambari.yaml
+++ b/ambari/assets/logs/ambari.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-rules-checks
 id: ambari
 metric_id: ambari
 backend_only: false

--- a/aws_neuron/assets/logs/aws_neuron.yaml
+++ b/aws_neuron/assets/logs/aws_neuron.yaml
@@ -1,3 +1,4 @@
+# bypass-global-missing-date-remapper-checks
 id: aws_neuron
 metric_id: aws-neuron
 backend_only: false

--- a/azure_active_directory/assets/logs/azure.activedirectory.yaml
+++ b/azure_active_directory/assets/logs/azure.activedirectory.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: azure.activedirectory
 metric_id: azure-active-directory
 backend_only: false

--- a/azure_iot_edge/assets/logs/azure.iot_edge.yaml
+++ b/azure_iot_edge/assets/logs/azure.iot_edge.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: azure.iot_edge
 metric_id: azure-iot-edge
 backend_only: false

--- a/carbon_black_cloud/assets/logs/carbon-black-cloud.yaml
+++ b/carbon_black_cloud/assets/logs/carbon-black-cloud.yaml
@@ -1,3 +1,4 @@
+# bypass-global-missing-date-remapper-checks
 id: carbon-black-cloud
 metric_id: carbon-black-cloud
 backend_only: false

--- a/cassandra/assets/logs/cassandra.yaml
+++ b/cassandra/assets/logs/cassandra.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-rules-checks
 id: cassandra
 metric_id: cassandra
 backend_only: false

--- a/celery/assets/logs/celery.yaml
+++ b/celery/assets/logs/celery.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-rules-checks
 id: celery
 metric_id: celery
 backend_only: false

--- a/cockroachdb/assets/logs/cockroachdb.yaml
+++ b/cockroachdb/assets/logs/cockroachdb.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-rules-checks
 id: cockroachdb
 metric_id: cockroachdb
 backend_only: false

--- a/contentful/assets/logs/contentful.yaml
+++ b/contentful/assets/logs/contentful.yaml
@@ -1,3 +1,4 @@
+# bypass-global-missing-date-remapper-checks
 id: contentful
 metric_id: contentful
 backend_only: false

--- a/delinea_privilege_manager/assets/logs/delinea-privilege-manager.yaml
+++ b/delinea_privilege_manager/assets/logs/delinea-privilege-manager.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-rules-checks
 id: delinea-privilege-manager
 metric_id: delinea-privilege-manager
 backend_only: false

--- a/delinea_secret_server/assets/logs/delinea-secret-server.yaml
+++ b/delinea_secret_server/assets/logs/delinea-secret-server.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-rules-checks
 id: delinea-secret-server
 metric_id: delinea-secret-server
 backend_only: false

--- a/envoy/assets/logs/envoy.yaml
+++ b/envoy/assets/logs/envoy.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-rules-checks
 id: envoy
 metric_id: envoy
 backend_only: false

--- a/etcd/assets/logs/etcd.yaml
+++ b/etcd/assets/logs/etcd.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: etcd
 metric_id: etcd
 backend_only: false

--- a/exchange_server/assets/logs/exchange-server.yaml
+++ b/exchange_server/assets/logs/exchange-server.yaml
@@ -1,3 +1,5 @@
+# bypass-global-facets-path-checks
+# bypass-global-missing-date-remapper-checks
 id: exchange-server
 metric_id: exchange-server
 backend_only: false

--- a/fluxcd/assets/logs/fluxcd.yaml
+++ b/fluxcd/assets/logs/fluxcd.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: fluxcd
 backend_only: false
 facets:

--- a/fly_io/assets/logs/fly_io.yaml
+++ b/fly_io/assets/logs/fly_io.yaml
@@ -1,3 +1,4 @@
+# bypass-global-missing-date-remapper-checks
 id: fly_io
 metric_id: fly-io
 backend_only: false

--- a/foundationdb/assets/logs/foundationdb.yaml
+++ b/foundationdb/assets/logs/foundationdb.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: foundationdb
 backend_only: false
 facets:

--- a/gitlab/assets/logs/gitlab.yaml
+++ b/gitlab/assets/logs/gitlab.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: gitlab
 metric_id: gitlab
 backend_only: false

--- a/glusterfs/assets/logs/glusterfs.yaml
+++ b/glusterfs/assets/logs/glusterfs.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: glusterfs
 metric_id: glusterfs
 backend_only: false

--- a/haproxy/assets/logs/haproxy.yaml
+++ b/haproxy/assets/logs/haproxy.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-rules-checks
 id: haproxy
 metric_id: haproxy
 backend_only: false

--- a/harbor/assets/logs/harbor.yaml
+++ b/harbor/assets/logs/harbor.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: harbor
 metric_id: harbor
 backend_only: false

--- a/ibm_ace/assets/logs/ibm_ace.yaml
+++ b/ibm_ace/assets/logs/ibm_ace.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: ibm_ace
 metric_id: ibm-ace
 backend_only: false

--- a/ibm_db2/assets/logs/ibm_db2.yaml
+++ b/ibm_db2/assets/logs/ibm_db2.yaml
@@ -1,3 +1,5 @@
+# bypass-global-grok-parser-rules-checks
+# bypass-global-missing-date-remapper-checks
 id: ibm_db2
 metric_id: ibm-db2
 backend_only: false

--- a/ibm_mq/assets/logs/ibm_mq.yaml
+++ b/ibm_mq/assets/logs/ibm_mq.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-rules-checks
 id: ibm_mq
 metric_id: ibm-mq
 backend_only: false

--- a/ibm_was/assets/logs/ibm_was.yaml
+++ b/ibm_was/assets/logs/ibm_was.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: ibm_was
 metric_id: ibm-was
 backend_only: false

--- a/ignite/assets/logs/ignite.yaml
+++ b/ignite/assets/logs/ignite.yaml
@@ -1,3 +1,4 @@
+# bypass-global-missing-date-remapper-checks
 id: ignite
 metric_id: ignite
 backend_only: false

--- a/incident_io/assets/logs/incident-io.yaml
+++ b/incident_io/assets/logs/incident-io.yaml
@@ -1,3 +1,4 @@
+# bypass-global-missing-date-remapper-checks
 id: incident-io
 metric_id: incident-io
 backend_only: false

--- a/ivanti_nzta/assets/logs/ivanti-nzta.yaml
+++ b/ivanti_nzta/assets/logs/ivanti-nzta.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-rules-checks
 id: ivanti-nzta
 metric_id: ivanti-nzta
 backend_only: false

--- a/jmeter/assets/logs/jmeter.yaml
+++ b/jmeter/assets/logs/jmeter.yaml
@@ -1,3 +1,4 @@
+# bypass-global-missing-date-remapper-checks
 id: jmeter
 metric_id: jmeter
 backend_only: false

--- a/keycloak/assets/logs/keycloak.yaml
+++ b/keycloak/assets/logs/keycloak.yaml
@@ -1,3 +1,5 @@
+# bypass-global-grok-parser-rules-checks
+# bypass-global-missing-date-remapper-checks
 id: keycloak
 metric_id: keycloak
 backend_only: false

--- a/lastpass/assets/logs/lastpass.yaml
+++ b/lastpass/assets/logs/lastpass.yaml
@@ -1,3 +1,5 @@
+# bypass-global-grok-parser-rules-checks
+# bypass-global-missing-date-remapper-checks
 id: lastpass
 metric_id: lastpass
 backend_only: false

--- a/lighttpd/assets/logs/lighttpd.yaml
+++ b/lighttpd/assets/logs/lighttpd.yaml
@@ -1,3 +1,4 @@
+# bypass-global-missing-date-remapper-checks
 id: lighttpd
 metric_id: lighttpd
 backend_only: false

--- a/mcache/assets/logs/memcached.yaml
+++ b/mcache/assets/logs/memcached.yaml
@@ -1,3 +1,5 @@
+# bypass-global-facets-path-checks
+# bypass-global-missing-date-remapper-checks
 id: memcached
 metric_id: memcached
 backend_only: false

--- a/metabase/assets/logs/metabase.yaml
+++ b/metabase/assets/logs/metabase.yaml
@@ -1,3 +1,4 @@
+# bypass-global-missing-date-remapper-checks
 id: metabase
 metric_id: metabase
 backend_only: false

--- a/mongo/assets/logs/mongodb.yaml
+++ b/mongo/assets/logs/mongodb.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-rules-checks
 id: mongodb
 metric_id: mongodb
 backend_only: false

--- a/nagios/assets/logs/nagios.yaml
+++ b/nagios/assets/logs/nagios.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-rules-checks
 id: nagios
 metric_id: nagios
 backend_only: false

--- a/openvpn/assets/logs/openvpn.yaml
+++ b/openvpn/assets/logs/openvpn.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-rules-checks
 id: openvpn
 metric_id: openvpn
 backend_only: false

--- a/pan_firewall/assets/logs/pan.firewall.yaml
+++ b/pan_firewall/assets/logs/pan.firewall.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: pan.firewall
 metric_id: pan-firewall
 backend_only: false

--- a/plaid/assets/logs/plaid.yaml
+++ b/plaid/assets/logs/plaid.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: plaid
 # See app_id in your integration's manifest.json file to learn more:
 # https://docs.datadoghq.com/developers/integrations/check_references/#manifest-file

--- a/ray/assets/logs/ray.yaml
+++ b/ray/assets/logs/ray.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: ray
 backend_only: false
 facets:

--- a/redisdb/assets/logs/redis.yaml
+++ b/redisdb/assets/logs/redis.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: redis
 metric_id: redis
 backend_only: false

--- a/rethinkdb/assets/logs/rethinkdb.yaml
+++ b/rethinkdb/assets/logs/rethinkdb.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: rethinkdb
 metric_id: rethinkdb
 backend_only: false

--- a/ssh_check/assets/logs/sshd.yaml
+++ b/ssh_check/assets/logs/sshd.yaml
@@ -1,3 +1,4 @@
+# bypass-global-missing-date-remapper-checks
 id: sshd
 metric_id: ssh
 backend_only: false

--- a/temporal/assets/logs/temporal.yaml
+++ b/temporal/assets/logs/temporal.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: temporal
 metric_id: temporal
 backend_only: false

--- a/tenable/assets/logs/tenable.yaml
+++ b/tenable/assets/logs/tenable.yaml
@@ -1,3 +1,5 @@
+# bypass-global-grok-parser-rules-checks
+# bypass-global-facets-path-checks
 id: tenable
 metric_id: tenable
 backend_only: false

--- a/twemproxy/assets/logs/twemproxy.yaml
+++ b/twemproxy/assets/logs/twemproxy.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: twemproxy
 metric_id: twemproxy
 backend_only: false

--- a/vault/assets/logs/vault.yaml
+++ b/vault/assets/logs/vault.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: vault
 metric_id: vault
 backend_only: false

--- a/velero/assets/logs/velero.yaml
+++ b/velero/assets/logs/velero.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: velero
 metric_id: velero
 backend_only: false

--- a/vonage/assets/logs/vonage.yaml
+++ b/vonage/assets/logs/vonage.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: vonage
 # See app_id in your integration's manifest.json file to learn more:
 # https://docs.datadoghq.com/developers/integrations/check_references/#manifest-file

--- a/watchguard_firebox/assets/logs/watchguard-firebox.yaml
+++ b/watchguard_firebox/assets/logs/watchguard-firebox.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-rules-checks
 id: watchguard-firebox
 metric_id: watchguard-firebox
 backend_only: false

--- a/weblogic/assets/logs/weblogic.yaml
+++ b/weblogic/assets/logs/weblogic.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-rules-checks
 id: weblogic
 metric_id: weblogic
 backend_only: false

--- a/zeek/assets/logs/zeek.yaml
+++ b/zeek/assets/logs/zeek.yaml
@@ -1,3 +1,4 @@
+# bypass-global-missing-date-remapper-checks
 id: zeek
 metric_id: zeek
 backend_only: false


### PR DESCRIPTION
We’re enabling new linter rules and some integrations are expected to remain non‑compliant.
Add permanent bypass annotations so CI stays green and not fail for new PRs.