### PR TITLE
[IDP-592] Add owner field to cloud-network-monitoring Integrations

### DIFF
--- a/checkpoint_quantum_firewall/manifest.json
+++ b/checkpoint_quantum_firewall/manifest.json
@@ -2,7 +2,6 @@
   "manifest_version": "2.0.0",
   "app_uuid": "4b6b8ef9-e079-4ee4-877e-8f4aafbf8a1d",
   "app_id": "checkpoint-quantum-firewall",
-  "owner": "network-device-monitoring-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/checkpoint_quantum_firewall/manifest.json
+++ b/checkpoint_quantum_firewall/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "4b6b8ef9-e079-4ee4-877e-8f4aafbf8a1d",
   "app_id": "checkpoint-quantum-firewall",
+  "owner": "network-device-monitoring-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/network_path/manifest.json
+++ b/network_path/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "3913cf32-d869-4852-beda-9e3e9d9e2feb",
   "app_id": "network-path",
+  "owner": "network-device-monitoring-integrations",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/network_path/manifest.json
+++ b/network_path/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "3913cf32-d869-4852-beda-9e3e9d9e2feb",
   "app_id": "network-path",
-  "owner": "networks",
+  "owner": "cloud-network-monitoring",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/network_path/manifest.json
+++ b/network_path/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "3913cf32-d869-4852-beda-9e3e9d9e2feb",
   "app_id": "network-path",
-  "owner": "network-device-monitoring-integrations",
+  "owner": "networks",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add `owner` field set to `network-device-monitoring-integrations` to manifest.json files for Network Device Monitoring Integrations (network_path, checkpoint_quantum_firewall).

**Note:** These integrations are our best guesses for the Network Device Monitoring Integrations team. If you don't own these integrations, or if you also own other integrations that should be included, please let us know.

This provides clear ownership tracking for these non-SNMP network device monitoring integrations as part of the initiative to add owner fields to all integration manifest.json files.

**For reviewer:** Please confirm:
1. Is `network-device-monitoring-integrations` the correct Datadog team slug in org 2 for tracking ownership?
2. For the display-tile feature flags in SDP, what workday team should we use as the `team` tag? We believe it should be "Network Device Monitoring Integrations" - could you confirm this is the correct workday team name?

Thank you for your review\!

🤖 Generated with [Claude Code](https://claude.ai/code)