### PR TITLE
[IDP-592] Add owner field to Container Integrations Integrations

### DIFF
--- a/cert_manager/manifest.json
+++ b/cert_manager/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "d8bac6db-8cf7-49ca-a4b8-643714fbc7b9",
   "app_id": "cert-manager",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/container/manifest.json
+++ b/container/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "ac3cc203-5b28-457d-8737-bbe32fa7c3b9",
   "app_id": "container",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/containerd/manifest.json
+++ b/containerd/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "206cf95f-1d2a-4ad5-b027-0de15431833b",
   "app_id": "containerd",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/cri/manifest.json
+++ b/cri/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "81805522-0f55-45a4-95f6-23dd9ea46361",
   "app_id": "cri",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/crio/manifest.json
+++ b/crio/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a5f9ace1-19b5-4928-b98b-21f15d62cce2",
   "app_id": "cri-o",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/datadog_cluster_agent/manifest.json
+++ b/datadog_cluster_agent/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "b6c2b71b-38c9-4769-86ad-516953849236",
   "app_id": "datadog-cluster-agent",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/datadog_operator/manifest.json
+++ b/datadog_operator/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "8ea2f311-02dd-478b-9b3b-3fbef310d82c",
   "app_id": "datadog-operator",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "ca1a7870-7d95-40c7-9790-ef6c1e928967",
   "app_id": "docker",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/eks_fargate/manifest.json
+++ b/eks_fargate/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "f5919a4b-4142-4889-b9c0-6ecdab299ebb",
   "app_id": "eks-fargate",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/helm/manifest.json
+++ b/helm/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "754a061c-d896-4f3c-b54e-87125bb66241",
   "app_id": "helm",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/kube_apiserver_metrics/manifest.json
+++ b/kube_apiserver_metrics/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "c5caf884-25c1-4a35-a72e-fa75e7cc10fc",
   "app_id": "kube-apiserver-metrics",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/kube_controller_manager/manifest.json
+++ b/kube_controller_manager/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "25d4ccd6-de50-4ef0-849f-b7ab1aea203e",
   "app_id": "kube-controller-manager",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/kube_dns/manifest.json
+++ b/kube_dns/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "41986c96-f53e-49fb-8892-cc6716238e48",
   "app_id": "kube-dns",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/kube_metrics_server/manifest.json
+++ b/kube_metrics_server/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "df9c9e3c-368a-4472-b0cb-b32f1066a2f5",
   "app_id": "kube-metrics-server",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/kube_proxy/manifest.json
+++ b/kube_proxy/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "0f9508bc-f260-4268-b94d-13c8da1525fb",
   "app_id": "kube-proxy",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/kube_scheduler/manifest.json
+++ b/kube_scheduler/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "1cf58691-ac6b-4f1d-b410-0132a4590378",
   "app_id": "kube-scheduler",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/kubelet/manifest.json
+++ b/kubelet/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "8afd5500-0b72-4574-95f9-81282e2bd535",
   "app_id": "kubelet",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "1b01568a-d25e-4e8d-98f6-c999f1d253c7",
   "app_id": "kubernetes",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/kubernetes_cluster_autoscaler/manifest.json
+++ b/kubernetes_cluster_autoscaler/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "3a3fc186-af02-48e5-8b68-ee9ef37ea566",
   "app_id": "kubernetes-cluster-autoscaler",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/kubernetes_state/manifest.json
+++ b/kubernetes_state/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "da79704f-b8b0-4a41-9ebe-a3772e939ae8",
   "app_id": "kubernetes-state",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/kubernetes_state_core/manifest.json
+++ b/kubernetes_state_core/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "6fbcfd6b-369d-4e69-8974-87b3fb5d4715",
   "app_id": "kubernetes-state-core",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/nginx_ingress_controller/manifest.json
+++ b/nginx_ingress_controller/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "f84e3ebf-848b-4894-a5b0-9abbd21d4189",
   "app_id": "nginx-ingress-controller",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/oom_kill/manifest.json
+++ b/oom_kill/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "7546b270-2efe-4a59-8f94-3447df2db801",
   "app_id": "oom-kill",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/openmetrics/manifest.json
+++ b/openmetrics/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "302b841e-8270-4ecd-948e-f16317a316bc",
   "app_id": "openmetrics",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/podman/manifest.json
+++ b/podman/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "ecc06845-18ac-448e-b352-1bbf31fdfcc3",
   "app_id": "podman",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/tcp_queue_length/manifest.json
+++ b/tcp_queue_length/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "2c48a360-9fbb-4cd6-9316-0e9afd9926c8",
   "app_id": "tcp-queue-length",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add `owner` field set to `container-integrations` to manifest.json files for Container Integrations Integrations (26 integrations):
cert_manager, container, containerd, cri, crio, datadog_cluster_agent, datadog_operator, docker_daemon, eks_fargate, helm, kube_apiserver_metrics, kube_controller_manager, kube_dns, kube_metrics_server, kube_proxy, kube_scheduler, kubelet, kubernetes, kubernetes_cluster_autoscaler, kubernetes_state, kubernetes_state_core, nginx_ingress_controller, oom_kill, openmetrics, podman, tcp_queue_length

**Note:** These integrations are our best guesses for the Container Integrations team. If you don't own these integrations, or if you also own other integrations that should be included, please let us know.

This provides clear ownership tracking for these container integrations as part of the initiative to add owner fields to all integration manifest.json files.

**For reviewer:** Please confirm:
1. Is `container-integrations` the correct Datadog team slug in org 2 for tracking ownership?
2. For the display-tile feature flags in SDP, what workday team should we use as the `team` tag? We believe it should be "Container Integrations" - could you confirm this is the correct workday team name?

Thank you for your review\!