### PR TITLE
[IDP-592] Add owner field to Azure Integrations Integrations

### DIFF
--- a/azure_active_directory/manifest.json
+++ b/azure_active_directory/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "8c4717a8-93f0-4de6-b79b-1e7f52c94895",
   "app_id": "azure-active-directory",
+  "owner": "azureintegrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/azure_iot_edge/manifest.json
+++ b/azure_iot_edge/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "9c4d7121-eed1-429c-bd86-18952b11d3f5",
   "app_id": "azure-iot-edge",
+  "owner": "azureintegrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add `owner` field set to `azureintegrations` to manifest.json files for Azure Integrations Integrations (2 integrations):
azure_active_directory, azure_iot_edge

**Note:** These integrations are our best guesses for the Azure Integrations team. If you don't own these integrations, or if you also own other integrations that should be included, please let us know.

This provides clear ownership tracking for these azure integrations as part of the initiative to add owner fields to all integration manifest.json files.

**For reviewer:** Please confirm:
1. Is `azureintegrations` the correct Datadog team slug in org 2 for tracking ownership?
2. For the display-tile feature flags in SDP, what workday team should we use as the `team` tag? We believe it should be "Azure Integrations" - could you confirm this is the correct workday team name?

Thank you for your review\!