### PR TITLE
[IDP-592] Add owner field to AWS Integrations Integrations

### DIFF
--- a/amazon_eks/manifest.json
+++ b/amazon_eks/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "abb8b86b-eeb7-4e38-b436-f4cbb09b4398",
   "app_id": "amazon-eks",
+  "owner": "aws-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/amazon_eks_blueprints/manifest.json
+++ b/amazon_eks_blueprints/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "4c0828d6-0c41-47d0-aa20-c174773e2bda",
   "app_id": "amazon-eks-blueprints",
+  "owner": "aws-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/amazon_msk/manifest.json
+++ b/amazon_msk/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "e6dc171a-911d-4440-a409-7951eaadf69f",
   "app_id": "amazon-kafka",
+  "owner": "aws-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/aws_neuron/manifest.json
+++ b/aws_neuron/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "fff4d15b-0953-41c9-8139-ef0a8d718d93",
   "app_id": "aws-neuron",
+  "owner": "aws-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/ecs_fargate/manifest.json
+++ b/ecs_fargate/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "4c298061-c7d2-4ce6-ab3e-5378039de65a",
   "app_id": "aws-fargate",
+  "owner": "aws-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/eks_anywhere/manifest.json
+++ b/eks_anywhere/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "21bd91d8-7594-4c2f-bbd8-11595e4511d1",
   "app_id": "eks-anywhere",
+  "owner": "aws-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add `owner` field set to `aws-integrations` to manifest.json files for AWS Integrations Integrations (6 integrations):
amazon_eks, amazon_eks_blueprints, amazon_msk, aws_neuron, ecs_fargate, eks_anywhere

**Note:** These integrations are our best guesses for the AWS Integrations team. If you don't own these integrations, or if you also own other integrations that should be included, please let us know.

This provides clear ownership tracking for these aws integrations as part of the initiative to add owner fields to all integration manifest.json files.

**For reviewer:** Please confirm:
1. Is `aws-integrations` the correct Datadog team slug in org 2 for tracking ownership?
2. For the display-tile feature flags in SDP, what workday team should we use as the `team` tag? We believe it should be "AWS Integrations" - could you confirm this is the correct workday team name?

Thank you for your review\!