### PR TITLE
[IDP-592] Add owner field to Event Management Integrations

### DIFF
--- a/solarwinds/manifest.json
+++ b/solarwinds/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "b9c52007-5909-44c7-b4a2-624f0efffa9e",
   "app_id": "solarwinds",
+  "owner": "event-management",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add `owner` field set to `event-management` to manifest.json files for Event Management Integrations (1 integration):
solarwinds

**Note:** These integrations are our best guesses for the Event Management team. If you don't own these integrations, or if you also own other integrations that should be included, please let us know.

This provides clear ownership tracking for these event management integrations as part of the initiative to add owner fields to all integration manifest.json files.

**Please note:** You may encounter validation errors such as `Error in manifests: {'owner': ['Unknown field']}` during CI checks. These can be safely ignored as we're working to update the manifest schema validation in parallel. We're seeking team approval on ownership assignments while addressing the technical validation separately.

**For reviewer:** Please confirm:
1. Is `event-management` the correct Datadog team slug in org 2 for tracking ownership?
2. For the display-tile feature flags in SDP, what workday team should we use as the `team` tag? We believe it should be "Event Management" - could you confirm this is the correct workday team name?

Thank you for your review\!