### PR TITLE
[IDP-592] Add owner field to OpenTelemetry Integrations

### DIFF
--- a/otel/manifest.json
+++ b/otel/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "ca08ac68-f4a4-4d84-9c21-8f645733d62c",
   "app_id": "otel",
+  "owner": "team-opentelemetry",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add `owner` field set to `team-opentelemetry` to manifest.json files for OpenTelemetry Integrations (1 integration):
otel

**Note:** These integrations are our best guesses for the OpenTelemetry team. If you don't own these integrations, or if you also own other integrations that should be included, please let us know.

This provides clear ownership tracking for these opentelemetry integrations as part of the initiative to add owner fields to all integration manifest.json files.

**Please note:** You may encounter validation errors such as `Error in manifests: {'owner': ['Unknown field']}` during CI checks. These can be safely ignored as we're working to update the manifest schema validation in parallel. We're seeking team approval on ownership assignments while addressing the technical validation separately.

**For reviewer:** Please confirm:
1. Is `team-opentelemetry` the correct Datadog team slug in org 2 for tracking ownership?
2. For the display-tile feature flags in SDP, what workday team should we use as the `team` tag? We believe it should be "OpenTelemetry" - could you confirm this is the correct workday team name?

Thank you for your review\!