### PR TITLE
CAP-2761 Add recommended ecs_fargate monitors

### DIFF
--- a/ecs_fargate/assets/monitors/ecs_fargate_cpu_usage.json
+++ b/ecs_fargate/assets/monitors/ecs_fargate_cpu_usage.json
@@ -8,8 +8,8 @@
         "name": "[ECS Fargate] AWS ECS Task CPU utilization is high",
         "type": "query alert",
         "query": "avg(last_15m):sum:ecs.fargate.cpu.usage{*} by {ecs_cluster,task_arn,ecs_service} / sum:ecs.fargate.cpu.task.limit{*} by {ecs_cluster,task_arn,ecs_service} * 100 > 80",
-        "message": "{{#is_warning}}\nAWS ECS Task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}}) is approaching CPU Utilization threshold\n{{/is_warning}}\n\n{{#is_alert}}\nAWS ECS Task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}}) has crossed CPU Utilization threshold\n{{/is_alert}}",
-        "tags": [],
+        "message": "{{#is_warning}}\nAWS ECS Task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}}) is approaching CPU Utilization threshold\n{{/is_warning}}\n\n{{#is_alert}}\nAWS ECS Task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}}) has crossed CPU Utilization threshold\n{{/is_alert}}\n\nTo investigate further, view the affected task in the [ECS Explorer](/orchestration/explorer/ecsTask?inspect={{task_arn.name}})",
+        "tags": ["integration:ecs_fargate"],
         "options": {
             "thresholds": {
                 "critical": 80

--- a/ecs_fargate/assets/monitors/ecs_fargate_cpu_usage.json
+++ b/ecs_fargate/assets/monitors/ecs_fargate_cpu_usage.json
@@ -1,0 +1,26 @@
+{
+    "version": 2,
+    "created_at": "2025-08-08",
+    "last_updated_at": "2025-08-08",
+    "title": "ECS Fargate CPU utilization exceeds threshold",
+    "description": "CPU usage represents the percentage of CPU resources consumed by an ECS Fargate task relative to its allocated limit. This monitor tracks when CPU utilization exceeds the configured threshold for the specified duration to identify performance bottlenecks that could lead to increased response times, task throttling, and potential service disruptions.",
+    "definition": {
+        "name": "[ECS Fargate] AWS ECS Task CPU utilization is high",
+        "type": "query alert",
+        "query": "avg(last_15m):sum:ecs.fargate.cpu.usage{*} by {ecs_cluster,task_arn,ecs_service} / sum:ecs.fargate.cpu.task.limit{*} by {ecs_cluster,task_arn,ecs_service} * 100 > 80",
+        "message": "{{#is_warning}}\nAWS ECS Task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}}) is approaching CPU Utilization threshold\n{{/is_warning}}\n\n{{#is_alert}}\nAWS ECS Task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}}) has crossed CPU Utilization threshold\n{{/is_alert}}",
+        "tags": [],
+        "options": {
+            "thresholds": {
+                "critical": 80
+            },
+            "notify_audit": false,
+            "on_missing_data": "default",
+            "include_tags": true,
+            "new_group_delay": 300
+        }
+    },
+    "tags": [
+        "integration:ecs_fargate"
+    ]
+}

--- a/ecs_fargate/assets/monitors/ecs_fargate_cpu_usage.json
+++ b/ecs_fargate/assets/monitors/ecs_fargate_cpu_usage.json
@@ -3,7 +3,7 @@
     "created_at": "2025-08-08",
     "last_updated_at": "2025-08-08",
     "title": "ECS Fargate CPU utilization exceeds threshold",
-    "description": "CPU usage represents the percentage of CPU resources consumed by an ECS Fargate task relative to its allocated limit. This monitor tracks when CPU utilization exceeds the configured threshold for the specified duration to identify performance bottlenecks that could lead to increased response times, task throttling, and potential service disruptions.",
+    "description": "CPU usage represents the percentage of CPU resources consumed by an ECS Fargate task relative to its allocated limit. This monitor tracks when CPU utilization exceeds the configured threshold to identify performance bottlenecks that could lead to increased response times and service disruptions.",
     "definition": {
         "name": "[ECS Fargate] AWS ECS Task CPU utilization is high",
         "type": "query alert",
@@ -21,6 +21,6 @@
         }
     },
     "tags": [
-        "integration:ecs_fargate"
+        "integration:aws-fargate"
     ]
 }

--- a/ecs_fargate/assets/monitors/ecs_fargate_ephemeral_storage.json
+++ b/ecs_fargate/assets/monitors/ecs_fargate_ephemeral_storage.json
@@ -8,8 +8,8 @@
         "name": "[ECS Fargate] Ephemeral storage utilization is high for task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}})",
         "type": "query alert",
         "query": "avg(last_15m):sum:ecs.fargate.ephemeral_storage.utilized{*} by {ecs_cluster,task_arn,ecs_service} / sum:ecs.fargate.ephemeral_storage.reserved{*} by {ecs_cluster,task_arn,ecs_service} * 100 > 80",
-        "message": "{{#is_warning}}\nAWS ECS Fargate task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}}) is approaching ephemeral storage utilization threshold\n\nCurrent Usage: {{value}}%\n{{/is_warning}}\n\n{{#is_alert}}\nAWS ECS Fargate task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}}) has exceeded ephemeral storage utilization threshold\n\nCurrent Usage: {{value}}%\n{{/is_alert}}",
-        "tags": [],
+        "message": "{{#is_warning}}\nAWS ECS Fargate task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}}) is approaching ephemeral storage utilization threshold\n\nCurrent Usage: {{value}}%\n{{/is_warning}}\n\n{{#is_alert}}\nAWS ECS Fargate task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}}) has exceeded ephemeral storage utilization threshold\n\nCurrent Usage: {{value}}%\n{{/is_alert}}\n\nTo investigate further, view the affected task in the [ECS Explorer](/orchestration/explorer/ecsTask?inspect={{task_arn.name}})",
+        "tags": ["integration:ecs_fargate"],
         "options": {
             "thresholds": {
                 "critical": 80

--- a/ecs_fargate/assets/monitors/ecs_fargate_ephemeral_storage.json
+++ b/ecs_fargate/assets/monitors/ecs_fargate_ephemeral_storage.json
@@ -1,0 +1,26 @@
+{
+    "version": 2,
+    "created_at": "2025-08-08",
+    "last_updated_at": "2025-08-08",
+    "title": "ECS Fargate ephemeral storage utilization exceeds threshold",
+    "description": "Ephemeral storage utilization represents the percentage of temporary storage space consumed by an ECS Fargate task relative to its allocated limit. This monitor tracks when storage utilization exceeds the configured threshold for the specified duration to prevent storage exhaustion that could lead to task failures, application crashes, and potential data loss.",
+    "definition": {
+        "name": "[ECS Fargate] Ephemeral storage utilization is high for task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}})",
+        "type": "query alert",
+        "query": "avg(last_15m):sum:ecs.fargate.ephemeral_storage.utilized{*} by {ecs_cluster,task_arn,ecs_service} / sum:ecs.fargate.ephemeral_storage.reserved{*} by {ecs_cluster,task_arn,ecs_service} * 100 > 80",
+        "message": "{{#is_warning}}\nAWS ECS Fargate task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}}) is approaching ephemeral storage utilization threshold\n\nCurrent Usage: {{value}}%\n{{/is_warning}}\n\n{{#is_alert}}\nAWS ECS Fargate task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}}) has exceeded ephemeral storage utilization threshold\n\nCurrent Usage: {{value}}%\n{{/is_alert}}",
+        "tags": [],
+        "options": {
+            "thresholds": {
+                "critical": 80
+            },
+            "notify_audit": false,
+            "on_missing_data": "default",
+            "include_tags": true,
+            "new_group_delay": 300
+        }
+    },
+    "tags": [
+        "integration:ecs_fargate"
+    ]
+}

--- a/ecs_fargate/assets/monitors/ecs_fargate_ephemeral_storage.json
+++ b/ecs_fargate/assets/monitors/ecs_fargate_ephemeral_storage.json
@@ -3,7 +3,7 @@
     "created_at": "2025-08-08",
     "last_updated_at": "2025-08-08",
     "title": "ECS Fargate ephemeral storage utilization exceeds threshold",
-    "description": "Ephemeral storage utilization represents the percentage of temporary storage space consumed by an ECS Fargate task relative to its allocated limit. This monitor tracks when storage utilization exceeds the configured threshold to prevent storage exhaustion that could lead to task failures and data loss.",
+    "description": "Ephemeral storage utilization represents the percentage of temporary storage space consumed by an ECS Fargate task relative to its allocated limit. This monitor tracks when storage utilization exceeds the threshold to prevent storage exhaustion that could lead to task failures and data loss.",
     "definition": {
         "name": "[ECS Fargate] Ephemeral storage utilization is high for task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}})",
         "type": "query alert",

--- a/ecs_fargate/assets/monitors/ecs_fargate_ephemeral_storage.json
+++ b/ecs_fargate/assets/monitors/ecs_fargate_ephemeral_storage.json
@@ -3,7 +3,7 @@
     "created_at": "2025-08-08",
     "last_updated_at": "2025-08-08",
     "title": "ECS Fargate ephemeral storage utilization exceeds threshold",
-    "description": "Ephemeral storage utilization represents the percentage of temporary storage space consumed by an ECS Fargate task relative to its allocated limit. This monitor tracks when storage utilization exceeds the configured threshold for the specified duration to prevent storage exhaustion that could lead to task failures, application crashes, and potential data loss.",
+    "description": "Ephemeral storage utilization represents the percentage of temporary storage space consumed by an ECS Fargate task relative to its allocated limit. This monitor tracks when storage utilization exceeds the configured threshold to prevent storage exhaustion that could lead to task failures and data loss.",
     "definition": {
         "name": "[ECS Fargate] Ephemeral storage utilization is high for task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}})",
         "type": "query alert",
@@ -21,6 +21,6 @@
         }
     },
     "tags": [
-        "integration:ecs_fargate"
+        "integration:aws-fargate"
     ]
 }

--- a/ecs_fargate/assets/monitors/ecs_fargate_mem_usage.json
+++ b/ecs_fargate/assets/monitors/ecs_fargate_mem_usage.json
@@ -8,8 +8,8 @@
         "name": "[ECS Fargate] AWS ECS Task Memory utilization is high",
         "type": "query alert",
         "query": "avg(last_15m):sum:ecs.fargate.mem.usage{*} by {ecs_cluster,task_arn,ecs_service} / sum:ecs.fargate.mem.task.limit{*} by {ecs_cluster,task_arn,ecs_service} * 100 > 80",
-        "message": "{{#is_warning}}\nAWS ECS Task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}}) is approaching Memory Utilization threshold\n{{/is_warning}}\n\n{{#is_alert}}\nAWS ECS Task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}}) has crossed Memory Utilization threshold\n{{/is_alert}}",
-        "tags": [],
+        "message": "{{#is_warning}}\nAWS ECS Task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}}) is approaching Memory Utilization threshold\n{{/is_warning}}\n\n{{#is_alert}}\nAWS ECS Task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}}) has crossed Memory Utilization threshold\n{{/is_alert}}\n\nTo investigate further, view the affected task in the [ECS Explorer](/orchestration/explorer/ecsTask?inspect={{task_arn.name}})",
+        "tags": ["integration:ecs_fargate"],
         "options": {
             "thresholds": {
                 "critical": 80

--- a/ecs_fargate/assets/monitors/ecs_fargate_mem_usage.json
+++ b/ecs_fargate/assets/monitors/ecs_fargate_mem_usage.json
@@ -1,0 +1,26 @@
+{
+    "version": 2,
+    "created_at": "2025-08-08",
+    "last_updated_at": "2025-08-08",
+    "title": "ECS Fargate memory utilization exceeds threshold",
+    "description": "Memory usage represents the percentage of memory resources consumed by an ECS Fargate task relative to its allocated limit. This monitor tracks when memory utilization exceeds the configured threshold for the specified duration to prevent out-of-memory errors that could lead to task crashes, service unavailability, and increased operational costs.",
+    "definition": {
+        "name": "[ECS Fargate] AWS ECS Task Memory utilization is high",
+        "type": "query alert",
+        "query": "avg(last_15m):sum:ecs.fargate.mem.usage{*} by {ecs_cluster,task_arn,ecs_service} / sum:ecs.fargate.mem.task.limit{*} by {ecs_cluster,task_arn,ecs_service} * 100 > 80",
+        "message": "{{#is_warning}}\nAWS ECS Task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}}) is approaching Memory Utilization threshold\n{{/is_warning}}\n\n{{#is_alert}}\nAWS ECS Task {{task_arn.name}} in service {{ecs_service.name}} (cluster {{ecs_cluster.name}}) has crossed Memory Utilization threshold\n{{/is_alert}}",
+        "tags": [],
+        "options": {
+            "thresholds": {
+                "critical": 80
+            },
+            "notify_audit": false,
+            "on_missing_data": "default",
+            "include_tags": true,
+            "new_group_delay": 300
+        }
+    },
+    "tags": [
+        "integration:ecs_fargate"
+    ]
+}

--- a/ecs_fargate/assets/monitors/ecs_fargate_mem_usage.json
+++ b/ecs_fargate/assets/monitors/ecs_fargate_mem_usage.json
@@ -3,7 +3,7 @@
     "created_at": "2025-08-08",
     "last_updated_at": "2025-08-08",
     "title": "ECS Fargate memory utilization exceeds threshold",
-    "description": "Memory usage represents the percentage of memory resources consumed by an ECS Fargate task relative to its allocated limit. This monitor tracks when memory utilization exceeds the configured threshold for the specified duration to prevent out-of-memory errors that could lead to task crashes, service unavailability, and increased operational costs.",
+    "description": "Memory usage represents the percentage of memory resources consumed by an ECS Fargate task relative to its allocated limit. This monitor tracks when memory utilization exceeds the configured threshold to prevent out-of-memory errors that could lead to task crashes and service unavailability.",
     "definition": {
         "name": "[ECS Fargate] AWS ECS Task Memory utilization is high",
         "type": "query alert",
@@ -21,6 +21,6 @@
         }
     },
     "tags": [
-        "integration:ecs_fargate"
+        "integration:aws-fargate"
     ]
 }

--- a/ecs_fargate/assets/monitors/ecs_fargate_net_rcvd.json
+++ b/ecs_fargate/assets/monitors/ecs_fargate_net_rcvd.json
@@ -8,8 +8,8 @@
         "name": "[ECS Fargate] Network received error rate is high for service: {{ecs_service.name}} in cluster: {{ecs_cluster.name}}",
         "type": "query alert",
         "query": "sum(last_5m):sum:ecs.fargate.net.rcvd_errors{*} by {ecs_service,ecs_cluster} / sum:ecs.fargate.net.bytes_rcvd{*} by {ecs_service,ecs_cluster} * 100 > 5",
-        "message": "ECS Fargate service {{ecs_service.name}} in cluster {{ecs_cluster.name}} has a network received error rate of {{value}}%, which exceeds the 5% threshold.\n\nThis indicates potential network connectivity issues.\n",
-        "tags": [],
+        "message": "ECS Fargate service {{ecs_service.name}} in cluster {{ecs_cluster.name}} has a network received error rate of {{value}}%, which exceeds the 5% threshold.\n\nThis indicates potential network connectivity issues. To investigate further, view the affected service in the [ECS Explorer](/orchestration/explorer/ecsService?query=ecs_service:{{ecs_service.name}}+ecs_cluster:{{ecs_cluster.name}})",
+        "tags": ["integration:ecs_fargate"],
         "options": {
             "thresholds": {
                 "critical": 5

--- a/ecs_fargate/assets/monitors/ecs_fargate_net_rcvd.json
+++ b/ecs_fargate/assets/monitors/ecs_fargate_net_rcvd.json
@@ -1,0 +1,26 @@
+{
+    "version": 2,
+    "created_at": "2025-08-08",
+    "last_updated_at": "2025-08-08",
+    "title": "ECS Fargate network received error rate exceeds threshold",
+    "description": "Network received error rate represents the percentage of network packets that failed to be received successfully. This monitor tracks when the error rate exceeds the configured threshold of total bytes received to identify network connectivity issues that could lead to data transmission failures, application errors, and service degradation.",
+    "definition": {
+        "name": "[ECS Fargate] Network received error rate is high for service: {{ecs_service.name}} in cluster: {{ecs_cluster.name}}",
+        "type": "query alert",
+        "query": "sum(last_5m):sum:ecs.fargate.net.rcvd_errors{*} by {ecs_service,ecs_cluster} / sum:ecs.fargate.net.bytes_rcvd{*} by {ecs_service,ecs_cluster} * 100 > 5",
+        "message": "ECS Fargate service {{ecs_service.name}} in cluster {{ecs_cluster.name}} has a network received error rate of {{value}}%, which exceeds the 5% threshold.\n\nThis indicates potential network connectivity issues.\n",
+        "tags": [],
+        "options": {
+            "thresholds": {
+                "critical": 5
+            },
+            "notify_audit": false,
+            "on_missing_data": "default",
+            "include_tags": true,
+            "new_group_delay": 60
+        }
+    },
+    "tags": [
+        "integration:ecs_fargate"
+    ]
+}

--- a/ecs_fargate/assets/monitors/ecs_fargate_net_rcvd.json
+++ b/ecs_fargate/assets/monitors/ecs_fargate_net_rcvd.json
@@ -3,7 +3,7 @@
     "created_at": "2025-08-08",
     "last_updated_at": "2025-08-08",
     "title": "ECS Fargate network received error rate exceeds threshold",
-    "description": "Network received error rate represents the percentage of network packets that failed to be received successfully. This monitor tracks when the error rate exceeds the configured threshold of total bytes received to identify network connectivity issues that could lead to data transmission failures, application errors, and service degradation.",
+    "description": "Network received error rate represents the percentage of network packets that failed to be received successfully. This monitor tracks when the error rate exceeds the configured threshold to identify network connectivity issues that could lead to data transmission failures and service degradation.",
     "definition": {
         "name": "[ECS Fargate] Network received error rate is high for service: {{ecs_service.name}} in cluster: {{ecs_cluster.name}}",
         "type": "query alert",
@@ -21,6 +21,6 @@
         }
     },
     "tags": [
-        "integration:ecs_fargate"
+        "integration:aws-fargate"
     ]
 }

--- a/ecs_fargate/assets/monitors/ecs_fargate_net_sent.json
+++ b/ecs_fargate/assets/monitors/ecs_fargate_net_sent.json
@@ -8,8 +8,8 @@
         "name": "[ECS Fargate] Network sent error rate is high for service: {{ecs_service.name}} in cluster: {{ecs_cluster.name}}",
         "type": "query alert",
         "query": "sum(last_5m):sum:ecs.fargate.net.sent_errors{*} by {ecs_service,ecs_cluster} / sum:ecs.fargate.net.bytes_sent{*} by {ecs_service,ecs_cluster} * 100 > 5",
-        "message": "ECS Fargate service {{ecs_service.name}} in cluster {{ecs_cluster.name}} has a network sent error rate of {{value}}%, which exceeds the 5% threshold.\n\nThis indicates potential network connectivity issues.\n",
-        "tags": [],
+        "message": "ECS Fargate service {{ecs_service.name}} in cluster {{ecs_cluster.name}} has a network sent error rate of {{value}}%, which exceeds the 5% threshold.\n\nThis indicates potential network connectivity issues. To investigate further, view the affected service in the [ECS Explorer](/orchestration/explorer/ecsService?query=ecs_service:{{ecs_service.name}}+ecs_cluster:{{ecs_cluster.name}})",
+        "tags": ["integration:ecs_fargate"],
         "options": {
             "thresholds": {
                 "critical": 5

--- a/ecs_fargate/assets/monitors/ecs_fargate_net_sent.json
+++ b/ecs_fargate/assets/monitors/ecs_fargate_net_sent.json
@@ -3,7 +3,7 @@
     "created_at": "2025-08-08",
     "last_updated_at": "2025-08-08",
     "title": "ECS Fargate network sent error rate exceeds threshold",
-    "description": "Network sent error rate represents the percentage of network packets that failed to be transmitted successfully. This monitor tracks when the error rate exceeds the configured threshold of total bytes sent to identify network connectivity issues that could lead to data transmission failures, application errors, and service degradation.",
+    "description": "Network sent error rate represents the percentage of network packets that failed to be transmitted successfully. This monitor tracks when the error rate exceeds the configured threshold to identify network connectivity issues that could lead to data transmission failures and service degradation.",
     "definition": {
         "name": "[ECS Fargate] Network sent error rate is high for service: {{ecs_service.name}} in cluster: {{ecs_cluster.name}}",
         "type": "query alert",
@@ -21,6 +21,6 @@
         }
     },
     "tags": [
-        "integration:ecs_fargate"
+        "integration:aws-fargate"
     ]
 }

--- a/ecs_fargate/assets/monitors/ecs_fargate_net_sent.json
+++ b/ecs_fargate/assets/monitors/ecs_fargate_net_sent.json
@@ -1,0 +1,26 @@
+{
+    "version": 2,
+    "created_at": "2025-08-08",
+    "last_updated_at": "2025-08-08",
+    "title": "ECS Fargate network sent error rate exceeds threshold",
+    "description": "Network sent error rate represents the percentage of network packets that failed to be transmitted successfully. This monitor tracks when the error rate exceeds the configured threshold of total bytes sent to identify network connectivity issues that could lead to data transmission failures, application errors, and service degradation.",
+    "definition": {
+        "name": "[ECS Fargate] Network sent error rate is high for service: {{ecs_service.name}} in cluster: {{ecs_cluster.name}}",
+        "type": "query alert",
+        "query": "sum(last_5m):sum:ecs.fargate.net.sent_errors{*} by {ecs_service,ecs_cluster} / sum:ecs.fargate.net.bytes_sent{*} by {ecs_service,ecs_cluster} * 100 > 5",
+        "message": "ECS Fargate service {{ecs_service.name}} in cluster {{ecs_cluster.name}} has a network sent error rate of {{value}}%, which exceeds the 5% threshold.\n\nThis indicates potential network connectivity issues.\n",
+        "tags": [],
+        "options": {
+            "thresholds": {
+                "critical": 5
+            },
+            "notify_audit": false,
+            "on_missing_data": "default",
+            "include_tags": true,
+            "new_group_delay": 60
+        }
+    },
+    "tags": [
+        "integration:ecs_fargate"
+    ]
+}

--- a/ecs_fargate/manifest.json
+++ b/ecs_fargate/manifest.json
@@ -79,6 +79,13 @@
     },
     "dashboards": {
       "Amazon Fargate": "assets/dashboards/amazon_fargate_overview.json"
+    },
+    "monitors": {
+      "ECS Fargate CPU Usage": "assets/monitors/ecs_fargate_cpu_usage.json",
+      "ECS Fargate Memory Usage": "assets/monitors/ecs_fargate_mem_usage.json",
+      "ECS Fargate Ephemeral Storage Utilization": "assets/monitors/ecs_fargate_ephemeral_storage.json",
+      "ECS Fargate Network Received Error Rate": "assets/monitors/ecs_fargate_net_rcvd.json",
+      "ECS Fargate Network Sent Error Rate": "assets/monitors/ecs_fargate_net_sent.json"
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
Add recommended ECS Fargate monitors

### Motivation
CAP-2761 - part of OKR to improve the overall ECS alerting and troubleshooting experience in Datadog.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
