### PR TITLE
[IDP-592] Add owner field to Agent Integrations (Part 4/4: S-Z)

### DIFF
--- a/silk/manifest.json
+++ b/silk/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "1f436ae6-e063-408f-ad35-37ee37fa2183",
   "app_id": "silk",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/silverstripe_cms/manifest.json
+++ b/silverstripe_cms/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "acd6d383-dfe8-4e70-8c68-e5f3b6da84af",
   "app_id": "silverstripe-cms",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/singlestore/manifest.json
+++ b/singlestore/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "5e8c3b5f-278f-4423-90d9-969c06a478eb",
   "app_id": "singlestore",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/slurm/manifest.json
+++ b/slurm/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a1e88183-da10-4651-bac8-843bdb640af7",
   "app_id": "slurm",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/snowflake/manifest.json
+++ b/snowflake/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "23e9084d-5801-4a71-88fe-f62b7c1bb289",
   "app_id": "snowflake",
+  "owner": "agent-integrations",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/solr/manifest.json
+++ b/solr/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "3733c24e-8466-4f3b-8411-59ef85c28302",
   "app_id": "solr",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/sonarqube/manifest.json
+++ b/sonarqube/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "c6033e2f-8b3d-4b82-8d35-7c61ce7d0908",
   "app_id": "sonarqube",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/sonatype_nexus/manifest.json
+++ b/sonatype_nexus/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "6cec5ac3-a686-4408-936d-26f19fa6763a",
   "app_id": "sonatype-nexus",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/spark/manifest.json
+++ b/spark/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "5cb22455-9ae2-44ee-ae05-ec21c27b3292",
   "app_id": "spark",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/squid/manifest.json
+++ b/squid/manifest.json
@@ -2,6 +2,7 @@
     "manifest_version": "2.0.0",
     "app_uuid": "de18c581-69ee-48cf-ba23-7794bfb7a4bd",
     "app_id": "squid",
+  "owner": "agent-integrations",
     "display_on_public_website": true,
     "tile": {
         "overview": "README.md#Overview",

--- a/ssh_check/manifest.json
+++ b/ssh_check/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "66833cbe-1bfc-4104-9d77-7b828219470b",
   "app_id": "ssh",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/statsd/manifest.json
+++ b/statsd/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "847f92f2-77e2-4429-844f-50f4d9c8097f",
   "app_id": "statsd",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/strimzi/manifest.json
+++ b/strimzi/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "06a90da7-974a-489e-b9bf-9a2828a351fe",
   "app_id": "strimzi",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/supabase/manifest.json
+++ b/supabase/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "f22fec2a-ff0a-4380-8ddf-3348f1e7ff15",
   "app_id": "supabase",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/supervisord/manifest.json
+++ b/supervisord/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "c4ee3618-f4b4-48b8-9515-a4a2f4091c0d",
   "app_id": "supervisord",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/suricata/manifest.json
+++ b/suricata/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "d5d0689e-8684-4663-b31b-d1947b7ccefd",
   "app_id": "suricata",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/systemd/manifest.json
+++ b/systemd/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a18dccd2-35c0-40e2-9c0a-7a01a5daf5f3",
   "app_id": "systemd",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/teamcity/manifest.json
+++ b/teamcity/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "8dd65d36-9cb4-4295-bb0c-68d67c0cdd4b",
   "app_id": "teamcity",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/tekton/manifest.json
+++ b/tekton/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "4e8f129e-1c9b-4078-a966-f0099dbf9465",
   "app_id": "tekton",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/temporal/manifest.json
+++ b/temporal/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "6fbb6b85-e9f0-4d0e-af82-3c82871b857c",
   "app_id": "temporal",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/tenable/manifest.json
+++ b/tenable/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "09a46b1b-a940-4aba-8e9f-bde9e5ae2c3f",
   "app_id": "tenable",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/teradata/manifest.json
+++ b/teradata/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "8cac0599-64ca-4a46-8c68-1c5db6cc65ca",
   "app_id": "teradata",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/terraform/manifest.json
+++ b/terraform/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "05198ed5-6fe5-417b-8711-e124718e9715",
   "app_id": "terraform",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/tibco_ems/manifest.json
+++ b/tibco_ems/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "32445b00-582f-4e56-9c4d-87944d5c347b",
   "app_id": "tibco-ems",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/tls/manifest.json
+++ b/tls/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "347d6721-fe59-4215-a4f6-415feb4dda0c",
   "app_id": "tls",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/tokumx/manifest.json
+++ b/tokumx/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "8169c714-555c-4e00-9be0-c6604cf1e858",
   "app_id": "tokumx",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/tomcat/manifest.json
+++ b/tomcat/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "9497c2d8-63cb-4d90-b73c-f32065349fe1",
   "app_id": "tomcat",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/torchserve/manifest.json
+++ b/torchserve/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "d5400c22-0f0a-4ce4-894d-c3cda48140e9",
   "app_id": "torchserve",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/traefik_mesh/manifest.json
+++ b/traefik_mesh/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "8ace5f4d-ba92-4b68-acf0-20275c8c2a2a",
   "app_id": "traefik-mesh",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/traffic_server/manifest.json
+++ b/traffic_server/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "aaf78f60-10de-453c-b2d8-dc44818720c9",
   "app_id": "traffic-server",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/twemproxy/manifest.json
+++ b/twemproxy/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "34f4e81a-6fd2-48fd-a10c-5bffb75bbd0e",
   "app_id": "twemproxy",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/twistlock/manifest.json
+++ b/twistlock/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "b10f1447-4e25-4c76-ab05-911cde5df5c6",
   "app_id": "twistlock",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/varnish/manifest.json
+++ b/varnish/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "e342e5eb-71ce-4c5b-a9c9-2c33691e858f",
   "app_id": "varnish",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/vault/manifest.json
+++ b/vault/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "450e17a2-3ca0-4dc5-800c-99c5db736073",
   "app_id": "vault",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/velero/manifest.json
+++ b/velero/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "e4199d9b-74fe-4af2-9afb-bbcde0f729f6",
   "app_id": "velero",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/vertica/manifest.json
+++ b/vertica/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "c5946789-de76-4ec6-9485-db83dd66fd28",
   "app_id": "vertica",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/vllm/manifest.json
+++ b/vllm/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "355886f0-31ae-44a9-9638-6951ad0f3039",
   "app_id": "vllm",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/voltdb/manifest.json
+++ b/voltdb/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "4ea56824-28da-4beb-8937-c45ef32fdb7f",
   "app_id": "voltdb",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/watchguard_firebox/manifest.json
+++ b/watchguard_firebox/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "5e035b0b-faa2-4465-baab-6565046f6c1c",
   "app_id": "watchguard-firebox",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/weaviate/manifest.json
+++ b/weaviate/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "3bb2d803-0608-4da3-8987-e6f7feb4e481",
   "app_id": "weaviate",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/weblogic/manifest.json
+++ b/weblogic/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "80a8d9e2-48dd-4242-be78-0d929ea1a492",
   "app_id": "weblogic",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/yarn/manifest.json
+++ b/yarn/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "427f8f08-00a1-455a-a0e5-9b2ec7ffb0a5",
   "app_id": "yarn",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/zeek/manifest.json
+++ b/zeek/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "81ba5f4a-0e85-48c3-9ba3-2e5ea37b1ed2",
   "app_id": "zeek",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/zk/manifest.json
+++ b/zk/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "01aee33c-0c85-4800-ab79-c02a25da04fa",
   "app_id": "zookeeper",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add `owner` field set to `agent-integrations` to manifest.json files for Agent Integrations (Part 4/4: S-Z) (44 integrations):
silk, silverstripe_cms, singlestore, slurm, snowflake, solr, sonarqube, sonatype_nexus, spark, squid, ssh_check, statsd, strimzi, supabase, supervisord, suricata, systemd, teamcity, tekton, temporal, tenable, teradata, terraform, tibco_ems, tls, tokumx, tomcat, torchserve, traefik_mesh, traffic_server, twemproxy, twistlock, varnish, vault, velero, vertica, vllm, voltdb, watchguard_firebox, weaviate, weblogic, yarn, zeek, zk

**Note:** These integrations are our best guesses for the Agent Integrations team. If you don't own these integrations, or if you also own other integrations that should be included, please let us know.

This provides clear ownership tracking for these agent integrations as part of the initiative to add owner fields to all integration manifest.json files.

**Please note:** You may encounter validation errors such as `Error in manifests: {'owner': ['Unknown field']}` during CI checks. These can be safely ignored as we're working to update the manifest schema validation in parallel. We're seeking team approval on ownership assignments while addressing the technical validation separately.

**For reviewer:** Please confirm:
1. Is `agent-integrations` the correct Datadog team slug in org 2 for tracking ownership?
2. For the display-tile feature flags in SDP, what workday team should we use as the `team` tag? We believe it should be "Agent Integrations" - could you confirm this is the correct workday team name?

Thank you for your review\!