### PR TITLE
Reduce verbosity of validate skip qa label action

### DIFF
--- a/.github/workflows/validate-skip-qa.yml
+++ b/.github/workflows/validate-skip-qa.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Find comment - Remove skip qa label
         if: steps.changed_files.outputs.any_changed == 'true' && contains(github.event.pull_request.labels.*.name, 'qa/skip-qa')
-        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.0.0
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         id: find_comment_remove_label
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/validate-skip-qa.yml
+++ b/.github/workflows/validate-skip-qa.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize]
     branches:
       - master
+
 env:
   COMMENT_BODY_ADD_LABEL: |
     ⚠️ **Recommendation: Add `qa/skip-qa` Label**

--- a/.github/workflows/validate-skip-qa.yml
+++ b/.github/workflows/validate-skip-qa.yml
@@ -5,6 +5,13 @@ on:
     types: [opened, synchronize]
     branches:
       - master
+env:
+  COMMENT_BODY_ADD_LABEL: |
+    ⚠️ **Recommendation: Add `qa/skip-qa` Label**
+
+    This PR does not modify any files shipped with the agent.
+
+    To help streamline the release process, please consider adding the `qa/skip-qa` label if these changes do not require QA testing.
 
 jobs:
   validate-skip-qa:
@@ -31,8 +38,16 @@ jobs:
             datadog_checks_dev/**
             datadog_checks_tests_helper/**
 
-      - name: Post message - Add skip qa label
+      - name: Find comment - Add skip qa label
         if: steps.changed_files.outputs.any_changed == 'false' && !contains(github.event.pull_request.labels.*.name, 'qa/skip-qa')
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+        id: find_comment_add_label
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: ${{ env.COMMENT_BODY_ADD_LABEL }}
+
+      - name: Post message - Add skip qa label
+        if: steps.changed_files.outputs.any_changed == 'false' && !contains(github.event.pull_request.labels.*.name, 'qa/skip-qa') && steps.find_comment_add_label.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -52,24 +67,43 @@ jobs:
             echo "$formatted_list" >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Post comment - Remove skip qa label
+      - name: Construct "Remove skip qa label" comment body
+        id: construct_remove_label_comment
         if: steps.changed_files.outputs.any_changed == 'true' && contains(github.event.pull_request.labels.*.name, 'qa/skip-qa')
+        run: |
+          comment_body=$(cat <<EOF
+          ⚠️ **The \`qa/skip-qa\` label has been added with shippable changes**
+
+          The following files, which will be shipped with the agent, were modified in this PR and
+          the \`qa/skip-qa\` label has been added.
+
+          You can ignore this if you are sure the changes in this PR do not require QA. Otherwise, consider removing the label.
+
+          <details>
+          <summary>List of modified files that will be shipped with the agent</summary>
+
+          \`\`\`
+          ${{ steps.format_files.outputs.file_list }}
+          \`\`\`
+
+          </details>
+          EOF
+          )
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          echo "$comment_body" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Find comment - Remove skip qa label
+        if: steps.changed_files.outputs.any_changed == 'true' && contains(github.event.pull_request.labels.*.name, 'qa/skip-qa')
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.0.0
+        id: find_comment_remove_label
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: ${{ steps.construct_remove_label_comment.outputs.body }}
+
+      - name: Post comment - Remove skip qa label
+        if: steps.changed_files.outputs.any_changed == 'true' && contains(github.event.pull_request.labels.*.name, 'qa/skip-qa') && steps.find_comment_remove_label.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            ⚠️ **The `qa/skip-qa` label has been added with shippable changes**
-
-            The following files, which will be shipped with the agent, were modified in this PR and
-            the `qa/skip-qa` label has been added.
-
-            You can ignore this if you are sure the changes in this PR do not require QA. Otherwise, consider removing the label.
-
-            <details>
-            <summary>List of modified files that will be shipped with the agent</summary>
-
-            ```
-            ${{ steps.format_files.outputs.file_list }}
-            ```
-
-            </details>
+          body: ${{ steps.construct_remove_label_comment.outputs.body }}

--- a/.github/workflows/validate-skip-qa.yml
+++ b/.github/workflows/validate-skip-qa.yml
@@ -2,7 +2,7 @@ name: 'Validate skip QA label'
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize]
     branches:
       - master
 

--- a/argocd/pyproject.toml
+++ b/argocd/pyproject.toml
@@ -57,3 +57,4 @@ include = [
 dev-mode-dirs = [
     ".",
 ]
+

--- a/argocd/pyproject.toml
+++ b/argocd/pyproject.toml
@@ -57,4 +57,3 @@ include = [
 dev-mode-dirs = [
     ".",
 ]
-


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Avoid running the action when the PRs are labeled. Since the labeler adds a bunch of labels, each time it does a new message is posted.

Also post the message only if it has not yet been posted.

See #21015 as an example.
### Motivation
<!-- What inspired you to submit this pull request? -->
There is no need to bomb ard the PR author once the message has been posted once.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
