### PR TITLE
[DSM] Move the DSM callout above the JMX notice in Kafka Broker configuration

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -23,11 +23,11 @@ To collect Kafka consumer metrics, see the [kafka_consumer check][3].
 
 The Agent's Kafka check is included in the [Datadog Agent][4] package, no additional installation is needed on your Kafka nodes.
 
+Add [Data Streams Monitoring][24] to your producers and consumers to visualize the application topology, root cause issues across services, and measure end to end latency, throughput and lag.
+
 The check collects metrics from JMX with [JMXFetch][5]. A JVM is needed on each kafka node so the Agent can run JMXFetch. The same JVM that Kafka uses can be used for this.
 
 **Note**: The Kafka check cannot be used with Managed Streaming for Apache Kafka (Amazon MSK). Use the [Amazon MSK integration][6] instead.
-
-Add [Data Streams Monitoring][24] to your producers and consumers to visualize the application topology, root cause issues across services, and measure end to end latency, throughput and lag.
 
 ### Configuration
 


### PR DESCRIPTION

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Updates the configuration section of the kafka broker integration too highlight DSM earlier

### Motivation
<!-- What inspired you to submit this pull request? -->

From feedback in slack: 
<img width="858" height="293" alt="image" src="https://github.com/user-attachments/assets/3468b325-68a3-4f1f-96e3-45a4ab5a31c4" />

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
