### PR TITLE
[DBMON-5566] Sqlserver remove duplicate microsoft apt index / keys

### DIFF
--- a/.ddev/ci/scripts/sqlserver/linux/55_install_odbc.sh
+++ b/.ddev/ci/scripts/sqlserver/linux/55_install_odbc.sh
@@ -6,9 +6,6 @@ sudo apt-get update
 sudo apt-get install -y --no-install-recommends tdsodbc unixodbc-dev
 
 # Install the Microsoft ODBC driver for SQL Server (Linux)
-curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
-curl https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
-sudo apt-get update
 sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18=18.3.3.1-1
 
 set +ex


### PR DESCRIPTION
### What does this PR do?
SqlServer CI tests began failing on Linux CI. We run these on Azure linux. It looks like Azure has added these microsoft repos by default now so we're currently adding duplicates which is leading to apt errors.

Previously failing [CI link](https://github.com/DataDog/integrations-core/actions/runs/16905142568/job/47893103962#step:21:27)

The output of our first `apt-get update` shows we have `https://packages.microsoft.com/ubuntu/22.04/prod jammy/main amd64` already in our source list
```
sudo apt-get update
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Get:6 https://packages.microsoft.com/repos/azure-cli jammy InRelease [3596 B]
Hit:2 http://azure.archive.ubuntu.com/ubuntu jammy InRelease
Get:7 https://packages.microsoft.com/ubuntu/22.04/prod jammy InRelease [3632 B]
Get:3 http://azure.archive.ubuntu.com/ubuntu jammy-updates InRelease [128 kB]
Get:4 http://azure.archive.ubuntu.com/ubuntu jammy-backports InRelease [127 kB]
Get:5 http://azure.archive.ubuntu.com/ubuntu jammy-security InRelease [129 kB]
Get:8 https://packages.microsoft.com/repos/azure-cli jammy/main amd64 Packages [2575 B]
Get:9 https://packages.microsoft.com/ubuntu/22.04/prod jammy/main amd64 Packages [240 kB]
Get:10 https://packages.microsoft.com/ubuntu/22.04/prod jammy/main arm64 Packages [75.4 kB]
Get:11 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages [2803 kB]
Get:12 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main Translation-en [443 kB]
Get:13 http://azure.archive.ubuntu.com/ubuntu jammy-updates/restricted amd64 Packages [4163 kB]
Get:14 http://azure.archive.ubuntu.com/ubuntu jammy-updates/restricted Translation-en [756 kB]
Get:15 http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 Packages [1226 kB]
Get:16 http://azure.archive.ubuntu.com/ubuntu jammy-security/main amd64 Packages [2558 kB]
Get:17 http://azure.archive.ubuntu.com/ubuntu jammy-security/main Translation-en [379 kB]
Get:18 http://azure.archive.ubuntu.com/ubuntu jammy-security/restricted amd64 Packages [4018 kB]
Get:19 http://azure.archive.ubuntu.com/ubuntu jammy-security/restricted Translation-en [732 kB]
Get:20 http://azure.archive.ubuntu.com/ubuntu jammy-security/universe amd64 Packages [993 kB]
```

We then explicitly add this source and our second update fails with
```
deb [arch=amd64,arm64,armhf] https://packages.microsoft.com/ubuntu/22.04/prod jammy main
+ sudo apt-get update
E: Conflicting values set for option Signed-By regarding source https://packages.microsoft.com/ubuntu/22.04/prod/ jammy: /usr/share/keyrings/microsoft-prod.gpg != 
E: The list of sources could not be read.
```

The fix is removing our manually added MS source. Here's a link to a separate branch with these changes that ran SqlServer tests and all Linux tests pass
https://github.com/DataDog/integrations-core/actions/runs/16912916849/job/47919247940?pr=21024


### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
