### PR TITLE
[Tibco EMS] Fix collection of queues with a `none` prefetch value

### DIFF
--- a/tibco_ems/changelog.d/21039.fixed
+++ b/tibco_ems/changelog.d/21039.fixed
@@ -1,0 +1,1 @@
+Fix collection of queues with a `none` prefetch value

--- a/tibco_ems/datadog_checks/tibco_ems/constants.py
+++ b/tibco_ems/datadog_checks/tibco_ems/constants.py
@@ -41,7 +41,7 @@ SHOW_METRIC_DATA = {
         'regex': re.compile(
             r'^\s*[*\s]*(?P<queue_name>\S+)\s+'
             r'(?P<snfgxibct>[-+*]*)\s+'
-            r'(?P<pre>\d+\*?)\s+'
+            r'(?P<pre>(?:\d+\*?|none))\s+'
             r'(?P<receivers>\d+)\s+'
             r'(?P<pending_messages>\d+)\s+'
             r'(?P<pending_messages_size>\d+\.?\d*\s*\S+)\s+'

--- a/tibco_ems/tests/common.py
+++ b/tibco_ems/tests/common.py
@@ -275,6 +275,22 @@ SHOW_MAP = {
                 'receivers': 0,
                 'snfgxibct': '',
             },
+            {
+                'pending_messages': 214,
+                'pending_messages_size': {
+                    'unit': 'Kb',
+                    'value': 214.1,
+                },
+                'pending_persistent_messages': 214,
+                'pending_persistent_messages_size': {
+                    'unit': 'Kb',
+                    'value': 214.1,
+                },
+                'pre': 'none',
+                'queue_name': 'none.prefetch.sample',
+                'receivers': 16,
+                'snfgxibct': '',
+            },
         ],
         'expected_metrics': [
             'tibco_ems.queue.pending_messages',

--- a/tibco_ems/tests/fixtures/show_queues
+++ b/tibco_ems/tests/fixtures/show_queues
@@ -10,3 +10,5 @@ Command: show queues
 * $TMP$.tibemsd.1669EC51B3.1        ---------    5      1        0     0.0 Kb        0     0.0 Kb
   queue.sample                      -------+-    5*     0        0     0.0 Kb        0     0.0 Kb
   sample                            -------+-    5*     0        0     0.0 Kb        0     0.0 Kb
+  none.prefetch.sample              --------- none     16      214   214.1 Kb      214   214.1 Kb
+


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Collects information about queues with a `none` prefetch value.

### Motivation
<!-- What inspired you to submit this pull request? -->
The previous regex matching the prefetch field did not catch all cases.
Namely, it did not include a case for a `none` value, which is documented [here](https://docs.tibco.com/pub/ems/8.6.0/doc/html/GUID-7687D8CC-02F9-4896-A0DC-80B1DFCA35B0.html).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
