### PR TITLE
Run the Agent build on release branches instead of main from release …

### DIFF
--- a/.gitlab/build_agent.yaml
+++ b/.gitlab/build_agent.yaml
@@ -2,6 +2,7 @@
 .build-agent-tpl:
   variables:
     # Pass these to triggered agent build job.
+    AGENT_BRANCH: "main"
     RELEASE_VERSION_6: "nightly"
     RELEASE_VERSION_7: "nightly-a7"
     BUCKET_BRANCH: "dev"
@@ -10,10 +11,15 @@
     # disable kitchen and e2e tests
     RUN_KITCHEN_TESTS: "false"
     RUN_E2E_TESTS: "off"
+  # Override AGENT_BRANCH for release branches
+  rules:
+    - if: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^7\.\d+\.x$/
+      variables:
+        AGENT_BRANCH: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
   stage: build
   trigger:
     project: DataDog/datadog-agent
-    branch: main
+    branch: $AGENT_BRANCH
     # It's more convenient to directly show if downstream pipeline succeeded.
     strategy: depend
 

--- a/.gitlab/build_agent.yaml
+++ b/.gitlab/build_agent.yaml
@@ -13,7 +13,7 @@
     RUN_E2E_TESTS: "off"
   # Override AGENT_BRANCH for release branches
   rules:
-    - if: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^7\.\d+\.x$/
+    - if: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^[0-9]+\.[0-9]+\.x$/
       variables:
         AGENT_BRANCH: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
   stage: build
@@ -27,7 +27,7 @@ build-agent-auto:
   extends: .build-agent-tpl
   rules:
     # Do not run on release branches
-    - if: $CI_COMMIT_BRANCH =~ /^7\.\d+\.x$/
+    - if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+\.x$/
       when: never
     # Only run if the branch is not a Github Merge Queue one.
     - if: $CI_COMMIT_BRANCH !~ /^gh-readonly-queue.*/
@@ -45,7 +45,7 @@ build-agent-manual-release:
   trigger:
     branch: $CI_COMMIT_BRANCH
   rules:
-    - if: $CI_COMMIT_BRANCH =~ /^7\.\d+\.x$/
+    - if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+\.x$/
       when: manual
 
 # Always have the option to run manually the agent build manually against the agent's main


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This change ensures we're targeting the correct branch when running the Agent build.

### Motivation
<!-- What inspired you to submit this pull request? -->
The Agent build that is triggered on dependency resolution PRs in integrations-core are always running against the main branch of the Agent instead of using the corresponding release branch when running on a specific release branch.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
