### PR TITLE
[DOCS-11706] Remove extra whitespace from yaml codeblock

### DIFF
--- a/wincrashdetect/README.md
+++ b/wincrashdetect/README.md
@@ -19,9 +19,9 @@ The Windows Crash Detection integration is included in the [Datadog Agent][1] pa
 2. Enable the Windows Crash Detection module in `C:\ProgramData\Datadog\system-probe.yaml` by setting the enabled flag to 'true':
 
    ```yaml
-    windows_crash_detection:
-        enabled: true
-    ```
+   windows_crash_detection:
+       enabled: true
+   ```
 3. [Restart the Agent][4].
 
 ### Validation


### PR DESCRIPTION
### Motivation & What does this PR do?
A support engineer wrote in that the [validation step](https://docs.datadoghq.com/integrations/wincrashdetect/#validation) for the Windows Crash Detection integration was not working for their customer. I verified with the #windows-product team that the validation _should_ work as written, but we also noticed that the yaml code block under Configuration for this integration had some extra whitespace in it that [could cause issues](https://dd.slack.com/archives/C03NWEP4R0B/p1755110606635349?thread_ts=1754680407.013869&cid=C03NWEP4R0B) if copied directly.

This PR removes the extra whitespace.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
