### PR TITLE
Fix Codecov by having a single job uploading results (#20940)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -51,6 +51,35 @@ jobs:
     uses: ./.github/workflows/test-results-master.yml
     secrets: inherit
 
+  upload-coverage:
+    needs:
+    - test
+    if: >
+      !github.event.repository.private &&
+      (success() || failure())
+    runs-on: ubuntu-latest
+    permissions:
+      # needed for codecov, allows the action to get a JWT signed by Github
+      id-token: write
+      contents: read
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Download all coverage artifacts
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      with:
+        pattern: coverage-*
+        path: coverage-reports
+        merge-multiple: false
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@15559ed290fa727036809b67ab0f646ffa6c5158
+      with:
+        use_oidc: true
+        directory: coverage-reports
+        fail_ci_if_error: false
+
   submit-traces:
     needs:
     - test

--- a/.github/workflows/pr-all.yml
+++ b/.github/workflows/pr-all.yml
@@ -37,6 +37,35 @@ jobs:
 
     uses: ./.github/workflows/save-event.yml
 
+  upload-coverage:
+    needs:
+    - test
+    if: >
+      !github.event.repository.private &&
+      (success() || failure())
+    runs-on: ubuntu-latest
+    permissions:
+      # needed for codecov, allows the action to get a JWT signed by Github
+      id-token: write
+      contents: read
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Download all coverage artifacts
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      with:
+        pattern: coverage-*
+        path: coverage-reports
+        merge-multiple: false
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@15559ed290fa727036809b67ab0f646ffa6c5158
+      with:
+        use_oidc: true
+        directory: coverage-reports
+        fail_ci_if_error: false
+
   submit-traces:
     needs:
     - test

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -76,6 +76,36 @@ jobs:
     uses: ./.github/workflows/submit-traces.yml
     secrets: inherit
 
+  upload-coverage:
+    needs:
+    - test
+    if: >
+      !github.event.repository.private &&
+      (success() || failure()) &&
+      inputs.pytest-args != '-m flaky'
+    runs-on: ubuntu-latest
+    permissions:
+      # needed for codecov, allows the action to get a JWT signed by Github
+      id-token: write
+      contents: read
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Download all coverage artifacts
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      with:
+        pattern: coverage-*
+        path: coverage-reports
+        merge-multiple: false
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@15559ed290fa727036809b67ab0f646ffa6c5158
+      with:
+        use_oidc: true
+        directory: coverage-reports
+        fail_ci_if_error: false
+
   check:
     needs:
     - test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
     secrets: inherit
 
     permissions:
-       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
+       # needed for codecov in pr-test.yml, allows the action to get a JWT signed by Github
        id-token: write
        # needed for compute-matrix in test-target.yml
        contents: read

--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -413,15 +413,14 @@ jobs:
         name: "test-results-${{ inputs.target }}-${{ inputs.platform }}"
         path: "${{ env.TEST_RESULTS_BASE_DIR }}"
 
-    - name: Upload coverage data
+    - name: Upload coverage data as artifact
       if: >
-        inputs.standard &&
         !github.event.repository.private &&
         always() &&
         inputs.pytest-args != '-m flaky'
-      # Flaky tests will have low coverage, don't upload it to avoid pipeline failure
-      uses: codecov/codecov-action@15559ed290fa727036809b67ab0f646ffa6c5158
+      # Flaky tests will have low coverage, don't include in artifacts to avoid pipeline issues
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        use_oidc: true
-        files: "${{ inputs.target }}/coverage.xml"
-        flags: "${{ inputs.target }}"
+        name: "coverage-${{ inputs.target }}${{ inputs.target-env && format('-{0}', inputs.target-env) || '' }}-${{ inputs.platform }}"
+        path: "${{ inputs.target }}/coverage.xml"
+        if-no-files-found: ignore


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Backport of #20940 to 7.69.x

Remove flakes in CI related with codecov failing to get the token to push results.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
