### PR TITLE
Add workflow to run a test of a given integration and environment with a version of the agent

### DIFF
--- a/.github/workflows/test-agent-target.yml
+++ b/.github/workflows/test-agent-target.yml
@@ -1,0 +1,88 @@
+name: Test Agent with Target
+
+on:
+  workflow_dispatch:
+    inputs:
+      integration:
+        required: true
+        description: Integration (target) to test, e.g. "apache", "kafka_consumer"
+        type: string
+      environment:
+        required: false
+        description: Environment to test, e.g. "py3.12". By default runs all
+        default: ""
+        type: string
+      test-py3:
+        required: false
+        description: Run Python 3 tests
+        default: true
+        type: boolean
+      agent-image:
+        required: false
+        description: Agent 7 image
+        default: "datadog/agent:7-rc"
+        type: string
+      agent-image-windows:
+        required: false
+        description: Agent 7 image on Windows
+        default: "datadog/agent:7-rc-servercore"
+        type: string
+      test-py2:
+        required: false
+        description: Run Python 2 tests
+        default: true
+        type: boolean
+      agent-image-py2:
+        required: false
+        description: Agent 6 image
+        default: "datadog/agent:6-rc"
+        type: string
+      agent-image-windows-py2:
+        required: false
+        description: Agent 6 image on Windows
+        default: "datadog/agent-dev:master-py2-win-servercore"
+        type: string
+      platform:
+        required: true
+        description: Platform to run tests on
+        default: linux
+        type: choice
+        options:
+        - linux
+        - windows
+        - macos
+
+jobs:
+  test:
+    uses: ./.github/workflows/test-target.yml
+    with:
+      repo: core
+
+      job-name: ${{ inputs.platform }}-${{ inputs.integration }}
+      platform: ${{ inputs.platform }}
+      runner: ${{ inputs.platform == 'linux' && '["ubuntu-22.04"]' || inputs.platform == 'windows' && '["windows-2022"]' || '["macos-13"]' }}
+
+      target: ${{ inputs.integration }}
+
+      # Options
+      test-py2: ${{ inputs.test-py2 }}
+      test-py3: ${{ inputs.test-py3 }}
+      agent-image: "${{ inputs.agent-image }}"
+      agent-image-py2: "${{ inputs.agent-image-py2 }}"
+      agent-image-windows: "${{ inputs.agent-image-windows }}"
+      agent-image-windows-py2: "${{ inputs.agent-image-windows-py2 }}"
+      target-env: ${{ inputs.environment }}
+    secrets: inherit
+    permissions:
+       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
+       id-token: write
+       # needed for compute-matrix in test-target.yml
+       contents: read
+
+  submit-traces:
+    needs:
+    - test
+    if: success() || failure()
+
+    uses: ./.github/workflows/submit-traces.yml
+    secrets: inherit


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR ads a workflow to be able to run tests for a given integration and environment with a version of the agent of our choice.

### Motivation
<!-- What inspired you to submit this pull request? -->
The Test agent workflow runs all integrations and environments. This means that if we want to retry a failed job to validate flakes during the release process we need to wait for all jobs to finish.

Some integrations tests run in windows which is not easy to test while developing. We can leverage this workflow to test different versions of the agent as well.



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
