### PR TITLE
Leave single image to select in test agent target

### DIFF
--- a/.github/workflows/test-agent-target.yml
+++ b/.github/workflows/test-agent-target.yml
@@ -22,11 +22,6 @@ on:
         description: Agent 7 image
         default: "datadog/agent:7-rc"
         type: string
-      agent-image-windows:
-        required: false
-        description: Agent 7 image on Windows
-        default: "datadog/agent:7-rc-servercore"
-        type: string
       test-py2:
         required: false
         description: Run Python 2 tests
@@ -36,11 +31,6 @@ on:
         required: false
         description: Agent 6 image
         default: "datadog/agent:6-rc"
-        type: string
-      agent-image-windows-py2:
-        required: false
-        description: Agent 6 image on Windows
-        default: "datadog/agent-dev:master-py2-win-servercore"
         type: string
       platform:
         required: true


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Remove the windows image selection from the workflow.

### Motivation
Since we are selecting which platform to run the tests for in the workflow there is no point on having an image for windows and another for linux. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
