### PR TITLE
Add agent version to the job name for test agent target

### DIFF
--- a/.github/workflows/test-agent-target.yml
+++ b/.github/workflows/test-agent-target.yml
@@ -48,7 +48,7 @@ jobs:
     with:
       repo: core
 
-      job-name: ${{ inputs.platform }}-${{ inputs.integration }}
+      job-name: "[${{ inputs.integration }} - ${{inputs.agent-image}}] ${{ inputs.platform }}"
       platform: ${{ inputs.platform }}
       runner: ${{ inputs.platform == 'linux' && '["ubuntu-22.04"]' || inputs.platform == 'windows' && '["windows-2022"]' || '["macos-13"]' }}
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Ad the agent image to the job name to ensure we know without having to dig into the logs of the integration tests.

### Motivation
<!-- What inspired you to submit this pull request? -->
Make it clear what is it that we are running

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
