### PR TITLE
Fix title and inputs for test-agent-target

### DIFF
--- a/.github/workflows/test-agent-target.yml
+++ b/.github/workflows/test-agent-target.yml
@@ -48,7 +48,7 @@ jobs:
     with:
       repo: core
 
-      job-name: "[${{ inputs.integration }} - ${{inputs.agent-image}}] ${{ inputs.platform }}"
+      job-name: "${{ inputs.integration }}-${{ inputs.platform }}-${{ inputs.environment }}"
       platform: ${{ inputs.platform }}
       runner: ${{ inputs.platform == 'linux' && '["ubuntu-22.04"]' || inputs.platform == 'windows' && '["windows-2022"]' || '["macos-13"]' }}
 
@@ -59,8 +59,6 @@ jobs:
       test-py3: ${{ inputs.test-py3 }}
       agent-image: "${{ inputs.agent-image }}"
       agent-image-py2: "${{ inputs.agent-image-py2 }}"
-      agent-image-windows: "${{ inputs.agent-image-windows }}"
-      agent-image-windows-py2: "${{ inputs.agent-image-windows-py2 }}"
       target-env: ${{ inputs.environment }}
     secrets: inherit
     permissions:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This fixes the title of the jobs launched on test during the `test-agent-target` workflow.

### Motivation
<!-- What inspired you to submit this pull request? -->
The other job name, while useful, is not valid to upload artifacts because the agent image has a colon which is a forbidden character. See [this job](https://github.com/DataDog/integrations-core/actions/runs/16967475658/job/48095163004#step:24:34)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
