### PR TITLE
Disable E2E on SQL Sever Windows

### DIFF
--- a/sqlserver/tests/test_e2e.py
+++ b/sqlserver/tests/test_e2e.py
@@ -21,7 +21,7 @@ from .common import (
     UNEXPECTED_QUERY_EXECUTOR_AO_METRICS,
     inc_perf_counter_metrics,
 )
-from .utils import always_on, not_windows_ado, not_windows_ci
+from .utils import always_on, not_windows_ci
 
 try:
     import pyodbc
@@ -99,7 +99,7 @@ def test_ao_secondary_replica(dd_agent_check, init_config, instance_ao_docker_se
     )
 
 
-@not_windows_ado
+@not_windows_ci
 def test_check_docker(dd_agent_check, init_config, instance_e2e):
     # run sync to ensure only a single run of both
     # set a very small collection interval so the tests go fast


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Disables the E2E test on Windows for SQL Server.

### Motivation
<!-- What inspired you to submit this pull request? -->
This test is currently broken for unknown reasons an provides minimal value.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
