### PR TITLE
Attempt fixing capture traces by making the traces file unique among multi-environment tests

### DIFF
--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -121,10 +121,10 @@ jobs:
     - name: Set environment variables with sanitized paths
       run: |
         # We want to replace leading dots as they will make directories hidden, which will cause them to be ignored by upload-artifact and EnricoMi/publish-unit-test-result-action
-        JOB_NAME=$(echo "${{ inputs.job-name }}" | sed 's/^\./Dot/')
+        JOB_NAME=$(echo "${{ inputs.job-name }}${{ inputs.target-env && format('-{0}', inputs.target-env) || '' }}" | sed 's/^\./Dot/')
 
         echo "TEST_RESULTS_DIR=$TEST_RESULTS_BASE_DIR/$JOB_NAME" >> $GITHUB_ENV
-        echo "TRACE_CAPTURE_FILE=${{ inputs.job-name }}${{ inputs.target-env && format('-{0}', inputs.target-env) || '' }}" >> $GITHUB_ENV
+        echo "TRACE_CAPTURE_FILE=$TRACE_CAPTURE_BASE_DIR/$JOB_NAME" >> $GITHUB_ENV
 
     - name: Set up Windows
       if: runner.os == 'Windows'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR is an attempt on fixing the submit traces job that has been failing for the last weeks (see [here](https://github.com/DataDog/integrations-core/actions/runs/17037702460/job/48295852537) as an example).

It modifies the traces file that is stored in each tests to ensure that when artifacts are downloaded they do not clash and potentially corrupt the trace files. This seems to be what is happening as the submit traces always fails in MongoDB tests.

### Motivation
<!-- What inspired you to submit this pull request? -->
Try and get our CI clean.

PR for validation: https://github.com/DataDog/integrations-core/pull/21095

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
