### PR TITLE
Disable flaky tests for nightly workflows

### DIFF
--- a/.github/workflows/nightly-base-package-windows.yml
+++ b/.github/workflows/nightly-base-package-windows.yml
@@ -28,6 +28,7 @@ jobs:
       # Options
       minimum-base-package: true
       test-py2: true
+      pytest-args: '-m "not flaky"'
     secrets: inherit
 
   submit-traces:

--- a/.github/workflows/nightly-base-package.yml
+++ b/.github/workflows/nightly-base-package.yml
@@ -26,6 +26,7 @@ jobs:
       # Options
       minimum-base-package: true
       test-py2: true
+      pytest-args: '-m "not flaky"'
     secrets: inherit
 
   submit-traces:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds the marker selection to nightly jobs to avoid running flaky tests.

### Motivation
<!-- What inspired you to submit this pull request? -->
We should not be validating flaky tests on nightlies for minimum base checks as we know they can fail. This adds noise to CI and it was agreed before to avoid these.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
