### PR TITLE
Add option to specify container to check logs from and to wait for health when running docker compose up

### DIFF
--- a/datadog_checks_dev/changelog.d/21104.added
+++ b/datadog_checks_dev/changelog.d/21104.added
@@ -1,0 +1,1 @@
+Add option to specify container to check logs from and to wait for health when running docker compose up

--- a/datadog_checks_dev/datadog_checks/dev/conditions.py
+++ b/datadog_checks_dev/datadog_checks/dev/conditions.py
@@ -5,7 +5,7 @@ import re
 import socket
 import time
 from contextlib import closing
-from typing import Callable, Dict, List, Tuple, Union  # noqa: F401
+from typing import Any, Callable, Dict, List, Tuple, Union  # noqa: F401
 from urllib.request import urlopen
 
 from .errors import RetryError
@@ -17,11 +17,11 @@ from .utils import file_exists
 class WaitFor(LazyFunction):
     def __init__(
         self,
-        func,  # type: Callable
-        attempts=60,  # type: int
-        wait=1,  # type: int
-        args=(),  # type: Tuple
-        kwargs=None,  # type: Dict
+        func: Callable,
+        attempts: int = 60,
+        wait: int = 1,
+        args: Tuple = (),
+        kwargs: Dict[str, Any] | None = None,
     ):
         if kwargs is None:
             kwargs = {}
@@ -61,10 +61,10 @@ class WaitFor(LazyFunction):
 class CheckEndpoints(LazyFunction):
     def __init__(
         self,
-        endpoints,  # type: Union[str, List[str]]
-        timeout=1,  # type: int
-        attempts=60,  # type: int
-        wait=1,  # type: int
+        endpoints: Union[str, List[str]],
+        timeout: int = 1,
+        attempts: int = 60,
+        wait: int = 1,
         send_request=None,
     ):
         self.endpoints = [endpoints] if isinstance(endpoints, str) else endpoints
@@ -101,13 +101,13 @@ class CheckEndpoints(LazyFunction):
 class CheckCommandOutput(LazyFunction):
     def __init__(
         self,
-        command,  # type: Union[str, List[str]]
-        patterns,  # type: Union[str, List[str]]
-        matches=1,  # type: Union[str, int]  #Either 'all' or a number
-        stdout=True,  # type: bool
-        stderr=True,  # type: bool
-        attempts=60,  # type: int
-        wait=1,  # type: int
+        command: Union[str, List[str]],
+        patterns: Union[str, List[str]],
+        matches: Union[str, int] = 1,  # Either 'all' or a number
+        stdout: bool = True,
+        stderr: bool = True,
+        attempts: int = 60,
+        wait: int = 1,
     ):
         """
         Checks if the provided patterns are present in the output of a command
@@ -182,13 +182,14 @@ class CheckCommandOutput(LazyFunction):
 class CheckDockerLogs(CheckCommandOutput):
     def __init__(
         self,
-        identifier,  # type: str
-        patterns,  # type: Union[str, List[str]]
-        matches=1,  # type: Union[str, int]
-        stdout=True,  # type: bool
-        stderr=True,  # type: bool
-        attempts=60,  # type: int
-        wait=1,  # type: int
+        identifier: str,
+        patterns: Union[str, List[str]],
+        matches: Union[str, int] = 1,
+        stdout: bool = True,
+        stderr: bool = True,
+        attempts: int = 60,
+        wait: int = 1,
+        service: str | None = None,
     ):
         """
         Checks if the provided patterns are present in docker logs
@@ -200,9 +201,10 @@ class CheckDockerLogs(CheckCommandOutput):
         :param stderr: Whether to search for the provided patterns in stderr
         :param attempts: How many times to try searching for the patterns
         :param wait: How long, in seconds, to wait between attempts
+        :param service: The service name to check the logs for when using docker compose
         """
         if file_exists(identifier):
-            command = ['docker', 'compose', '-f', identifier, 'logs']
+            command = ['docker', 'compose', '-f', identifier, 'logs', service or '']
         else:
             command = ['docker', 'logs', identifier]
 

--- a/datadog_checks_dev/datadog_checks/dev/conditions.py
+++ b/datadog_checks_dev/datadog_checks/dev/conditions.py
@@ -204,7 +204,9 @@ class CheckDockerLogs(CheckCommandOutput):
         :param service: The service name to check the logs for when using docker compose
         """
         if file_exists(identifier):
-            command = ['docker', 'compose', '-f', identifier, 'logs', service or '']
+            command = ['docker', 'compose', '-f', identifier, 'logs']
+            if service:
+                command.append(service)
         else:
             command = ['docker', 'logs', identifier]
 

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -107,6 +107,7 @@ def shared_logs(example_log_configs, mount_whitelist=None):
 @contextmanager
 def docker_run(
     compose_file=None,
+    waith_for_health=False,
     build=False,
     service_name=None,
     up=None,
@@ -131,6 +132,8 @@ def docker_run(
         compose_file (str):
             A path to a Docker compose file. A custom tear
             down is not required when using this.
+        waith_for_health (bool):
+            Whether or not to wait for the health of the service to be healthy before yielding.
         build (bool):
             Whether or not to build images for when `compose_file` is provided
         service_name (str):
@@ -233,12 +236,23 @@ def docker_run(
 
 
 class ComposeFileUp(LazyFunction):
-    def __init__(self, compose_file, build=False, service_name=None, capture=None):
+    def __init__(
+        self,
+        compose_file: str,
+        build: bool = False,
+        service_name: str | None = None,
+        capture: str | None = None,
+        waith_for_health: bool = False,
+    ):
         self.compose_file = compose_file
         self.build = build
         self.service_name = service_name
         self.capture = capture
+        self.waith_for_health = waith_for_health
         self.command = ['docker', 'compose', '-f', self.compose_file, 'up', '-d', '--force-recreate']
+
+        if waith_for_health:
+            self.command.append('--wait')
 
         if self.build:
             self.command.append('--build')

--- a/datadog_checks_dev/tests/docker/test_default.yaml
+++ b/datadog_checks_dev/tests/docker/test_default.yaml
@@ -12,3 +12,8 @@ services:
       - VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
     ports:
       - "8200:8200"
+
+  logging-service:
+    image: alpine
+    container_name: ddev_logging_service
+    command: sh -c 'while true; do echo "I am a logging service"; sleep 1; done'

--- a/datadog_checks_dev/tests/test_conditions.py
+++ b/datadog_checks_dev/tests/test_conditions.py
@@ -94,6 +94,20 @@ class TestCheckDockerLogs:
         finally:
             run_command(['docker', 'compose', '-f', compose_file, 'down'], capture=True)
 
+    def test_matches_service(self):
+        compose_file = os.path.join(DOCKER_DIR, 'test_default.yaml')
+        check_logging_service = CheckDockerLogs(compose_file, 'I am a logging service', service='logging-service')
+        check_vault = CheckDockerLogs(compose_file, 'Vault server started', service='logging-service')
+        try:
+            run_command(['docker', 'compose', '-f', compose_file, 'up', '-d'], check=True)
+            check_logging_service()
+
+            # Only the logs for the specified service should be matched
+            with pytest.raises(RetryError):
+                check_vault()
+        finally:
+            run_command(['docker', 'compose', '-f', compose_file, 'down'], capture=True)
+
 
 class TestCheckEndpoints:
     def test_fail(self):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds two options to improve docker compose reliability:

- Option to provice the service we want to check the logs from when running docker compose.
- Option to make the `docker compose up` command to wait for health before finishing.

### Motivation
<!-- What inspired you to submit this pull request? -->
When running docker compose we can define health checks to ensure that service that depend on each other only start once the dependency is healthy. Passing `--wait` to `docker compose up` ensures the command does not finish until the healthy state has been achieved.

The improvement on logs check is specially important when running multi service setups. `docker compose logs` can take some time to include logs from service that took longer to start. This can cause timeouts that are not real. By being able to provide the service we want to check the logs from we target that specific service without relying on the global log buffering from docker compose.

This makes log checking faster and reliable to slow startups.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
