### PR TITLE
Remove `DELETED_INTEGRATION` workaround from `ddev`

### DIFF
--- a/ddev/src/ddev/cli/release/agent/changelog.py
+++ b/ddev/src/ddev/cli/release/agent/changelog.py
@@ -23,11 +23,6 @@ DISPLAY_NAME_MAPPING = {
     'Mesos': 'Mesos Slave'
 }
 
-DELETED_INTEGRATIONS = [
-    'kaspersky',
-]
-
-
 @click.command(
     short_help="Provide a list of updated checks on a given Datadog Agent version, in changelog form",
 )
@@ -73,8 +68,6 @@ def changelog(app: Application, since: str, to: str, write: bool, force: bool):
             for entry in CHANGELOG_MANUAL_ENTRIES.get(agent, []):
                 changelog_contents.write(f'{entry}\n')
             for name, ver in version_changes.items():
-                if name in DELETED_INTEGRATIONS:
-                    continue
                 display_name = app.repo.integrations.get(name).display_name
                 display_name = DISPLAY_NAME_MAPPING.get(display_name, display_name)
 

--- a/ddev/src/ddev/cli/release/agent/changelog.py
+++ b/ddev/src/ddev/cli/release/agent/changelog.py
@@ -23,6 +23,7 @@ DISPLAY_NAME_MAPPING = {
     'Mesos': 'Mesos Slave'
 }
 
+
 @click.command(
     short_help="Provide a list of updated checks on a given Datadog Agent version, in changelog form",
 )


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
