### PR TITLE
Make the validate-skip-qa action trigger on pull_request_target

### DIFF
--- a/.github/workflows/validate-skip-qa.yml
+++ b/.github/workflows/validate-skip-qa.yml
@@ -1,7 +1,7 @@
 name: 'Validate skip QA label'
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
     branches:
       - master


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Modifies the `validate-skip-qa` action to run on `pull_request_target` to allow comments to be added from forked repos.


### Motivation
<!-- What inspired you to submit this pull request? -->
Since we have partners opening PRs from forked repos, `pull_request` gives read-only permissions which forbid the action from adding comments to the PRs. An example is #20344 where a Sacumen PR would have the action failing.

Moving it to `pull_request_target` allows permissions to add comments using the base branch as context of the action.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
