### PR TITLE
Workato: Add new monitor; update svg for better dark mode support

### DIFF
--- a/workato/assets/dashboards/workato_overview.json
+++ b/workato/assets/dashboards/workato_overview.json
@@ -6,7 +6,7 @@
       "id": 1515816601282997,
       "definition": {
         "title": "New group",
-        "banner_img": "/api/v2/images/fa344656-5eeb-4f3d-a726-87359e0d14d7",
+        "banner_img": "/api/v2/images/c869acac-c00b-45f8-ad84-a8576def226f",
         "show_title": false,
         "type": "group",
         "layout_type": "ordered",

--- a/workato/assets/monitors/high_percentage_of_recipe_job_failures.json
+++ b/workato/assets/monitors/high_percentage_of_recipe_job_failures.json
@@ -1,0 +1,86 @@
+{
+  "version": 2,
+  "created_at": "2025-08-20",
+  "last_updated_at": "2025-08-20",
+  "title": "High percentage of job failures for recipe",
+  "description": "The number of recent job failures for a recipe exceeds the threshold.",
+  "definition": {
+    "id": 181800008,
+    "name": "High percentage of job failures for recipe",
+    "type": "log alert",
+    "query": "formula(\"(query / query1) * 100\").last(\"1h\") > 50",
+    "message": "{{#is_alert}}The percentage of failures for {{[@workato.recipe_name].name}} has exceeded threshold.{{/is_alert}}\n{{#is_alert_recovery}}The job failure percentage for {{[@workato.recipe_name].name}} has recovered {{/is_alert_recovery}}\n\n@email@example.com",
+    "tags": [
+        "source:workato"
+    ],
+    "options": {
+        "thresholds": {
+            "critical": 50
+        },
+        "enable_logs_sample": false,
+        "notify_audit": false,
+        "on_missing_data": "default",
+        "include_tags": false,
+        "new_group_delay": 60,
+        "variables": [
+            {
+                "name": "query",
+                "data_source": "logs",
+                "search": {
+                    "query": "source:workato service:jobs status:error"
+                },
+                "indexes": [
+                    "*"
+                ],
+                "group_by": [
+                    {
+                        "facet": "@workato.recipe_name",
+                        "limit": 10,
+                        "sort": {
+                            "aggregation": "count",
+                            "order": "desc",
+                            "metric": "count"
+                        },
+                        "should_exclude_missing": true
+                    }
+                ],
+                "compute": {
+                    "aggregation": "count"
+                },
+                "storage": "hot"
+            },
+            {
+                "name": "query1",
+                "data_source": "logs",
+                "search": {
+                    "query": "source:workato service:jobs"
+                },
+                "indexes": [
+                    "*"
+                ],
+                "group_by": [
+                    {
+                        "facet": "@workato.recipe_name",
+                        "limit": 10,
+                        "sort": {
+                            "aggregation": "count",
+                            "order": "desc",
+                            "metric": "count"
+                        },
+                        "should_exclude_missing": true
+                    }
+                ],
+                "compute": {
+                    "aggregation": "count"
+                },
+                "storage": "hot"
+            }
+        ],
+        "groupby_simple_monitor": false
+    },
+    "priority": null
+  },
+  "tags": [
+    "integration:workato"
+  ]
+}

--- a/workato/manifest.json
+++ b/workato/manifest.json
@@ -58,6 +58,7 @@
       "Connection with active recipes is down" : "assets/monitors/connection_with_active_recipes.json",
       "Connection is lost" : "assets/monitors/connection_lost.json",
       "Connection auth failure" : "assets/monitors/connection_auth_failure.json",
+      "High percentage of recipe job failures" : "assets/monitors/high_percentage_of_recipe_job_failures.json",
       "Recipe exceeds quota" : "assets/monitors/recipe_exceeds_quota.json"
     }
   },


### PR DESCRIPTION
- Add new monitor for notifying on recent high recipe job failure
- Update dashboard svg image reference for better display in dark mode

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
