### PR TITLE
DOCS-11532: add rabbitmq_user and rabbitmq_pass to rabbitmq conf.yaml.example

### DIFF
--- a/rabbitmq/assets/configuration/spec.yaml
+++ b/rabbitmq/assets/configuration/spec.yaml
@@ -73,6 +73,16 @@ files:
         value:
           type: string
           example: http://localhost:15672/api/
+      - name: rabbitmq_user
+        description: The username to use for the RabbitMQ Management Plugin
+        value:
+          type: string
+          example: guest
+      - name: rabbitmq_pass
+        description: The password to use for the RabbitMQ Management Plugin
+        value:
+          type: string
+          example: guest
       - name: tag_families
         description: To tag queue "families" based off of regex matching.
         value:

--- a/rabbitmq/changelog.d/21120.added
+++ b/rabbitmq/changelog.d/21120.added
@@ -1,0 +1,1 @@
+Add rabbitmq_user and rabbitmq_pass to rabbitmq conf.yaml.example

--- a/rabbitmq/datadog_checks/rabbitmq/config_models/defaults.py
+++ b/rabbitmq/datadog_checks/rabbitmq/config_models/defaults.py
@@ -96,6 +96,14 @@ def instance_rabbitmq_api_url():
     return 'http://localhost:15672/api/'
 
 
+def instance_rabbitmq_pass():
+    return 'guest'
+
+
+def instance_rabbitmq_user():
+    return 'guest'
+
+
 def instance_request_size():
     return 16
 

--- a/rabbitmq/datadog_checks/rabbitmq/config_models/instance.py
+++ b/rabbitmq/datadog_checks/rabbitmq/config_models/instance.py
@@ -146,6 +146,8 @@ class InstanceConfig(BaseModel):
     queues: Optional[tuple[str, ...]] = None
     queues_regexes: Optional[tuple[str, ...]] = None
     rabbitmq_api_url: Optional[str] = None
+    rabbitmq_pass: Optional[str] = None
+    rabbitmq_user: Optional[str] = None
     raw_line_filters: Optional[tuple[str, ...]] = None
     raw_metric_prefix: Optional[str] = None
     read_timeout: Optional[float] = None

--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -684,6 +684,16 @@ instances:
     #
     # rabbitmq_api_url: http://localhost:15672/api/
 
+    ## @param rabbitmq_user - string - optional - default: guest
+    ## The username to use for the RabbitMQ Management Plugin
+    #
+    # rabbitmq_user: guest
+
+    ## @param rabbitmq_pass - string - optional - default: guest
+    ## The password to use for the RabbitMQ Management Plugin
+    #
+    # rabbitmq_pass: guest
+
     ## @param tag_families - boolean - optional - default: false
     ## To tag queue "families" based off of regex matching.
     #


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds `rabbitmq_user` and `rabbitmq_pass` to RabbitMQ example conf. These params are used for the management plugin. Reference: https://www.datadoghq.com/blog/openstack-monitoring-datadog/#integrating-rabbitmq-with-datadog

### Motivation
reported by Kelly Wiese

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
