### PR TITLE
Remove version 1.0 of the test that uses an unavailable gearmand Docker image

### DIFF
--- a/gearmand/hatch.toml
+++ b/gearmand/hatch.toml
@@ -6,7 +6,6 @@ version = ["1.1"]
 
 [envs.default.overrides]
 matrix.version.env-vars = [
-  { key = "GEARMAND_VERSION", value = "1.1.18", if = ["1.1"] },
-  { key = "DOCKER_IMAGE", value = "artefactual/gearmand", if = ["1.1"] },
-  { key = "DOCKER_TAG", value = "1.1.18-alpine", if = ["1.1"] },
+  { key = "GEARMAND_VERSION", value = "1.1.18" },
+  { key = "DOCKER_TAG", value = "1.1.18-alpine" },
 ]

--- a/gearmand/tests/compose/docker-compose.yaml
+++ b/gearmand/tests/compose/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   gearman:
-    image: ${DOCKER_IMAGE}:${DOCKER_TAG}
+    image: artefactual/gearmand:${DOCKER_TAG}
     ports:
       - 15440:4730
     command: ["--log-file", "/var/log/gearmand.log"]


### PR DESCRIPTION
### What does this PR do?
The image we look at is no longer available on Docker hub. That version is pretty old, I think we can safely remove it.
