### PR TITLE
feat(SAASINT-4380): Making Jamf Pro docs public

### DIFF
--- a/jamf_pro/manifest.json
+++ b/jamf_pro/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "02ca0a87-f9e7-46e3-989d-9ac8b3654ac4",
   "app_id": "jamf-pro",
-  "display_on_public_website": false,
+  "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?
Making Jamf Pro documentation public on website

### Motivation
Jira ticket: [SAASINT-4380](https://datadoghq.atlassian.net/browse/SAASINT-4380)


[SAASINT-4380]: https://datadoghq.atlassian.net/browse/SAASINT-4380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ