### PR TITLE
Use `ddev` to target Agent branch in `build_agent.yaml`

### DIFF
--- a/ddev/changelog.d/21136.added
+++ b/ddev/changelog.d/21136.added
@@ -1,0 +1,1 @@
+Use ddev to target Agent branch in build_agent.yaml

--- a/ddev/src/ddev/cli/release/branch/create.py
+++ b/ddev/src/ddev/cli/release/branch/create.py
@@ -3,8 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import annotations
 
-from pathlib import Path
-
 import re
 from typing import TYPE_CHECKING
 
@@ -47,51 +45,58 @@ def create(app: Application, branch_name):
     app.display_success("Done.")
 
     app.display_waiting("Updating the .gitlab/build_agent.yaml file...")
-    update_build_agent_yaml(branch_name)
+    update_build_agent_yaml(app, branch_name)
     app.display_success("Done.")
 
-    # app.display_waiting(f"Pushing the release branch `{branch_name}`...")
-    # app.repo.git.run('push', 'origin', branch_name)
-    # app.display_success("Done.")
+    app.display_waiting("Adding and committing the changes...")
+    app.repo.git.run('add', '.gitlab/build_agent.yaml')
+    app.repo.git.run('commit', '-m', f"Update build_agent.yaml to use agent branch: {branch_name}")
+    app.display_success("Done.")
 
-    # app.display_waiting(f"Creating the `backport/{branch_name}` label on GitHub...")
-    # app.github.create_label(f'backport/{branch_name}', GITHUB_LABEL_COLOR)
-    # app.display_success("Done.")
+    app.display_waiting(f"Pushing the release branch `{branch_name}`...")
+    app.repo.git.run('push', 'origin', branch_name)
+    app.display_success("Done.")
+
+    app.display_waiting(f"Creating the `backport/{branch_name}` label on GitHub...")
+    app.github.create_label(f'backport/{branch_name}', GITHUB_LABEL_COLOR)
+    app.display_success("Done.")
 
     app.display_success("All done.")
 
 
-def update_build_agent_yaml(branch_name: str) -> None:
+def update_build_agent_yaml(app: Application, branch_name: str) -> None:
     """
     Update the .gitlab/build_agent.yaml file to use the correct agent branch for release builds.
-    
+
     Args:
         branch_name: The release branch name (e.g., '7.45.x')
     """
+    from ddev.utils.fs import Path
+
     build_agent_yaml = Path('.gitlab/build_agent.yaml')
-    
+
     if not build_agent_yaml.exists():
-        click.secho(f'Warning: {build_agent_yaml} not found, skipping update', fg='yellow')
+        app.display_warning(f'Warning: {build_agent_yaml} not found')
         return
-    
+
     # Read the current content
     with open(build_agent_yaml, 'r') as f:
         content = f.read()
-    
+
     # Update the build-agent-manual-release job to use the correct agent branch
     # Find the line with 'branch: main' and replace it
     old_pattern = r'(\s+branch:\s+)main'
-    new_replacement = lambda match: match.group(1) + branch_name
-    
+
+    def replacement(match):
+        return match.group(1) + branch_name
+
     if re.search(old_pattern, content):
-        updated_content = re.sub(old_pattern, new_replacement, content)
-        breakpoint()
-        
+        updated_content = re.sub(old_pattern, replacement, content)
+
         # Write the updated content back
         with open(build_agent_yaml, 'w') as f:
             f.write(updated_content)
-        
-        click.secho(f'Updated {build_agent_yaml} to use agent branch: {branch_name}', fg='green')
-    else:
-        click.secho(f'Warning: Could not find branch pattern to update in {build_agent_yaml}', fg='yellow')
 
+        app.display_success(f'Updated {build_agent_yaml} to use agent branch: {branch_name}')
+    else:
+        app.display_warning(f'Warning: Could not find branch pattern to update in {build_agent_yaml}')

--- a/ddev/src/ddev/cli/release/branch/create.py
+++ b/ddev/src/ddev/cli/release/branch/create.py
@@ -97,6 +97,6 @@ def update_build_agent_yaml(app: Application, branch_name: str) -> None:
         with open(build_agent_yaml, 'w') as f:
             f.write(updated_content)
 
-        app.display_success(f'Updated {build_agent_yaml} to use agent branch: {branch_name}')
+        app.display_success(f'Updated build_agent.yaml file to use Agent branch: {branch_name}')
     else:
         app.display_warning(f'Warning: Could not find branch pattern to update in {build_agent_yaml}')

--- a/ddev/src/ddev/cli/release/branch/create.py
+++ b/ddev/src/ddev/cli/release/branch/create.py
@@ -3,6 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import annotations
 
+from pathlib import Path
+
 import re
 from typing import TYPE_CHECKING
 
@@ -44,12 +46,52 @@ def create(app: Application, branch_name):
     app.repo.git.run('checkout', '-B', branch_name)
     app.display_success("Done.")
 
-    app.display_waiting(f"Pushing the release branch `{branch_name}`...")
-    app.repo.git.run('push', 'origin', branch_name)
+    app.display_waiting("Updating the .gitlab/build_agent.yaml file...")
+    update_build_agent_yaml(branch_name)
     app.display_success("Done.")
 
-    app.display_waiting(f"Creating the `backport/{branch_name}` label on GitHub...")
-    app.github.create_label(f'backport/{branch_name}', GITHUB_LABEL_COLOR)
-    app.display_success("Done.")
+    # app.display_waiting(f"Pushing the release branch `{branch_name}`...")
+    # app.repo.git.run('push', 'origin', branch_name)
+    # app.display_success("Done.")
+
+    # app.display_waiting(f"Creating the `backport/{branch_name}` label on GitHub...")
+    # app.github.create_label(f'backport/{branch_name}', GITHUB_LABEL_COLOR)
+    # app.display_success("Done.")
 
     app.display_success("All done.")
+
+
+def update_build_agent_yaml(branch_name: str) -> None:
+    """
+    Update the .gitlab/build_agent.yaml file to use the correct agent branch for release builds.
+    
+    Args:
+        branch_name: The release branch name (e.g., '7.45.x')
+    """
+    build_agent_yaml = Path('.gitlab/build_agent.yaml')
+    
+    if not build_agent_yaml.exists():
+        click.secho(f'Warning: {build_agent_yaml} not found, skipping update', fg='yellow')
+        return
+    
+    # Read the current content
+    with open(build_agent_yaml, 'r') as f:
+        content = f.read()
+    
+    # Update the build-agent-manual-release job to use the correct agent branch
+    # Find the line with 'branch: main' and replace it
+    old_pattern = r'(\s+branch:\s+)main'
+    new_replacement = r'\1' + branch_name
+    
+    if re.search(old_pattern, content):
+        updated_content = re.sub(old_pattern, new_replacement, content)
+        breakpoint()
+        
+        # Write the updated content back
+        with open(build_agent_yaml, 'w') as f:
+            f.write(updated_content)
+        
+        click.secho(f'Updated {build_agent_yaml} to use agent branch: {branch_name}', fg='green')
+    else:
+        click.secho(f'Warning: Could not find branch pattern to update in {build_agent_yaml}', fg='yellow')
+

--- a/ddev/src/ddev/cli/release/branch/create.py
+++ b/ddev/src/ddev/cli/release/branch/create.py
@@ -81,7 +81,7 @@ def update_build_agent_yaml(branch_name: str) -> None:
     # Update the build-agent-manual-release job to use the correct agent branch
     # Find the line with 'branch: main' and replace it
     old_pattern = r'(\s+branch:\s+)main'
-    new_replacement = r'\1' + branch_name
+    new_replacement = lambda match: match.group(1) + branch_name
     
     if re.search(old_pattern, content):
         updated_content = re.sub(old_pattern, new_replacement, content)

--- a/ddev/src/ddev/cli/release/branch/tag.py
+++ b/ddev/src/ddev/cli/release/branch/tag.py
@@ -1,6 +1,4 @@
 import re
-import os
-from pathlib import Path
 
 import click
 from packaging.version import Version
@@ -26,9 +24,6 @@ def tag(app, final):
         app.abort(
             f'Invalid branch name: {branch_name}. Branch name must match the pattern {BRANCH_NAME_REGEX.pattern}.'
         )
-    
-    # Update the build_agent.yaml file with the correct agent branch
-    
     click.echo(app.repo.git.pull(branch_name))
     click.echo(app.repo.git.fetch_tags())
     major_minor_version = branch_name.replace('.x', '')

--- a/ddev/src/ddev/cli/release/branch/tag.py
+++ b/ddev/src/ddev/cli/release/branch/tag.py
@@ -1,4 +1,6 @@
 import re
+import os
+from pathlib import Path
 
 import click
 from packaging.version import Version
@@ -24,6 +26,9 @@ def tag(app, final):
         app.abort(
             f'Invalid branch name: {branch_name}. Branch name must match the pattern {BRANCH_NAME_REGEX.pattern}.'
         )
+    
+    # Update the build_agent.yaml file with the correct agent branch
+    
     click.echo(app.repo.git.pull(branch_name))
     click.echo(app.repo.git.fetch_tags())
     major_minor_version = branch_name.replace('.x', '')

--- a/ddev/tests/cli/release/branch/test_create.py
+++ b/ddev/tests/cli/release/branch/test_create.py
@@ -3,6 +3,9 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
+from ddev.cli.release.branch.create import update_build_agent_yaml
+from ddev.utils.fs import Path
+
 
 @pytest.mark.parametrize(
     'name',
@@ -42,8 +45,6 @@ def test_create_branch(ddev, mocker):
 
 def test_update_build_agent_yaml_success(mocker, tmp_path):
     """Test successful update of build_agent.yaml"""
-    from ddev.cli.release.branch.create import update_build_agent_yaml
-    from ddev.utils.fs import Path
 
     # Create a temporary build_agent.yaml file
     build_agent_path = Path(tmp_path / '.gitlab' / 'build_agent.yaml')
@@ -77,4 +78,3 @@ build-agent-auto:
 
     assert 'branch: 7.99.x' in updated_content
     assert 'branch: main' not in updated_content
-    app_mock.display_success.assert_called_once_with('Updated build_agent.yaml file to use Agent branch: 7.99.x')

--- a/ddev/tests/cli/release/branch/test_create.py
+++ b/ddev/tests/cli/release/branch/test_create.py
@@ -38,3 +38,43 @@ def test_create_branch(ddev, mocker):
     assert create_label_mock.call_args_list == [
         mocker.call('backport/5.5.x', '5319e7'),
     ]
+
+
+def test_update_build_agent_yaml_success(mocker, tmp_path):
+    """Test successful update of build_agent.yaml"""
+    from ddev.cli.release.branch.create import update_build_agent_yaml
+    from ddev.utils.fs import Path
+
+    # Create a temporary build_agent.yaml file
+    build_agent_path = Path(tmp_path / '.gitlab' / 'build_agent.yaml')
+    build_agent_path.parent.ensure_dir_exists()
+
+    original_content = """---
+.build-agent-tpl:
+  variables:
+    RELEASE_VERSION_6: "nightly"
+    RELEASE_VERSION_7: "nightly-a7"
+  trigger:
+    project: DataDog/datadog-agent
+    branch: main
+    strategy: depend
+
+build-agent-auto:
+  extends: .build-agent-tpl
+  rules:
+    - if: $CI_COMMIT_BRANCH =~ /^7\\.\\d+\\.x$/
+      when: never
+"""
+
+    build_agent_path.write_text(original_content)
+
+    app_mock = mocker.MagicMock()
+
+    with Path(tmp_path).as_cwd():
+        update_build_agent_yaml(app_mock, '7.99.x')
+
+    updated_content = build_agent_path.read_text()
+
+    assert 'branch: 7.99.x' in updated_content
+    assert 'branch: main' not in updated_content
+    app_mock.display_success.assert_called_once_with('Updated .gitlab/build_agent.yaml to use agent branch: 7.99.x')

--- a/ddev/tests/cli/release/branch/test_create.py
+++ b/ddev/tests/cli/release/branch/test_create.py
@@ -77,4 +77,4 @@ build-agent-auto:
 
     assert 'branch: 7.99.x' in updated_content
     assert 'branch: main' not in updated_content
-    app_mock.display_success.assert_called_once_with('Updated .gitlab/build_agent.yaml to use agent branch: 7.99.x')
+    app_mock.display_success.assert_called_once_with('Updated build_agent.yaml file to use Agent branch: 7.99.x')

--- a/ddev/tests/cli/release/branch/test_create.py
+++ b/ddev/tests/cli/release/branch/test_create.py
@@ -30,6 +30,8 @@ def test_create_branch(ddev, mocker):
         mocker.call('checkout', 'master'),
         mocker.call('pull', 'origin', 'master'),
         mocker.call('checkout', '-B', '5.5.x'),
+        mocker.call('add', '.gitlab/build_agent.yaml'),
+        mocker.call('commit', '-m', 'Update build_agent.yaml to use agent branch: 5.5.x'),
         mocker.call('push', 'origin', '5.5.x'),
     ]
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This allows us to target the right Agent branch as part of our release process workflow.

### Motivation
<!-- What inspired you to submit this pull request? -->
https://datadoghq.atlassian.net/browse/AI-5682

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
