### PR TITLE
Update test-target to set the service per test target

### DIFF
--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -106,7 +106,7 @@ jobs:
       TEST_RESULTS_BASE_DIR: "test-results"
       # Tracing to monitor our test suite
       DD_ENV: "ci"
-      DD_SERVICE: "ddev-integrations-${{ inputs.repo }}"
+      DD_SERVICE: "ddev-integrations-${{ inputs.repo }}-${{ inputs.target }}"
       DD_TAGS: "team:agent-integrations,platform:${{ inputs.platform }},integration:${{ inputs.target }}"
       DD_TRACE_ANALYTICS_ENABLED: "true"
       # Capture traces for a separate job to do the submission


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Changes the service reported to Datadog to have a different service per test target.

### Motivation
<!-- What inspired you to submit this pull request? -->
This should allow us to better monitor our CI health by service, i.e. by integration. At the moment we do not have any metadata being sent that tag CI jobs/tests by integration.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
