### PR TITLE
Bump `freezegun` to 1.5.5 for Python 3.13

### DIFF
--- a/cisco_aci/hatch.toml
+++ b/cisco_aci/hatch.toml
@@ -5,5 +5,5 @@ python = ["3.12"]
 
 [envs.default]
 dependencies = [
-  "freezegun==1.2.2",
+  "freezegun==1.5.5",
 ]

--- a/datadog_checks_downloader/hatch.toml
+++ b/datadog_checks_downloader/hatch.toml
@@ -6,7 +6,7 @@ python = ["3.12"]
 [envs.default]
 e2e-env = false
 dependencies = [
-  "freezegun==1.2.2",
+  "freezegun==1.5.5",
 ]
 
 [envs.test-data]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR bumps the version of freezegun use for python 3.13 support

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
