### PR TITLE
(DOCS-11888) Added Agent support info for container health service check

### DIFF
--- a/docker_daemon/assets/service_checks.json
+++ b/docker_daemon/assets/service_checks.json
@@ -15,7 +15,7 @@
         "statuses": ["ok", "critical", "unknown"],
         "groups": ["host"],
         "name": "Container Health",
-        "description": "Returns `CRITICAL` if a container is unhealthy. Returns `OK` otherwise or `UNKNOWN` if the health is unknown. **Note**: Only available for Agent v6 and below"
+        "description": "Returns `CRITICAL` if a container is unhealthy. Returns `OK` otherwise or `UNKNOWN` if the health is unknown. **Note**: Only available for Agent v6 and below."
     },
     {
         "agent_version": "5.1.0",

--- a/docker_daemon/assets/service_checks.json
+++ b/docker_daemon/assets/service_checks.json
@@ -15,7 +15,7 @@
         "statuses": ["ok", "critical", "unknown"],
         "groups": ["host"],
         "name": "Container Health",
-        "description": "Returns `CRITICAL` if a container is unhealthy. Returns `OK` otherwise or `UNKNOWN` if the health is unknown."
+        "description": "Returns `CRITICAL` if a container is unhealthy. Returns `OK` otherwise or `UNKNOWN` if the health is unknown. **Note**: Only available for Agent v6 and below"
     },
     {
         "agent_version": "5.1.0",


### PR DESCRIPTION
### What does this PR do?
Adds Agent support info for the docker.container_health service check. This check is not supported in Agent v7 and above.


### Motivation
A request from Support captured in https://datadoghq.atlassian.net/browse/DOCS-11888?atlOrigin=eyJpIjoiMjcxY2Y4MGY2ZjQyNDNlODgwZWY0OTcxODY1MjUyYTgiLCJwIjoiaiJ9

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
