### PR TITLE
[DBMON-5583] SqlServer remove unnecessary flaky assertion

### DIFF
--- a/sqlserver/tests/test_stored_procedures.py
+++ b/sqlserver/tests/test_stored_procedures.py
@@ -285,7 +285,6 @@ def test_procedure_metrics(
             expected_objects, payload['sqlserver_rows']
         )
 
-    assert len(payload['sqlserver_rows']) == len(expected_objects), 'should have as many emitted rows as expected'
     assert set(payload['tags']) == expected_instance_tags
     assert payload['ddagenthostname'] == datadog_agent.get_hostname()
 


### PR DESCRIPTION
### What does this PR do?
We're regularly seeing SqlServer test failures from `test_procedure_metrics` due to this assertion line. We should remove this as it's not a stable assertion or necessary in this case. We already ensure all of our expected procedures are captured properly and asserted on in a loop before this line. When we see query counts higher than our expected manually called procedures they are due to procedures ran internally by the SQL Server Agent. Since we don't control when these occur, that is why this passes sometimes, but other times it fails with additional procedure queries.

Attached is an example of a previous flaky failure. We can see that the procedure names are from SqlServer internal operations and can safely be ignored
```
E       AssertionError: should have as many emitted rows as expected
E       assert 7 == 1
E        +  where 7 = len([{'database_name': 'msdb', 'execution_count': 1, 'procedure_name': 'sp_sqlagent_update_jobactivity_requested_date', 'schema_name': 'dbo', ...}, {'database_name': 'msdb', 'execution_count': 1, 'procedure_name': 'sp_agent_get_jobstep', 'schema_name': 'dbo', ...}, {'database_name': 'msdb', 'execution_count': 1, 'procedure_name': 'sp_help_jobstep', 'schema_name': 'dbo', ...}, {'database_name': 'msdb', 'execution_count': 1, 'procedure_name': 'sp_sqlagent_has_server_access', 'schema_name': 'dbo', ...}, {'database_name': 'msdb', 'execution_count': 1, 'procedure_name': 'sp_sqlagent_update_jobactivity_start_execution_date', 'schema_name': 'dbo', ...}, {'database_name': 'msdb', 'execution_count': 1, 'procedure_name': 'sp_verify_job_identifiers', 'schema_name': 'dbo', ...}, ...])
E        +  and   1 = len([{'database_name': 'datadog_test-1', 'execution_count': 2, 'procedure_name': 'bobProcParams', 'schema_name': 'dbo'}])

tests/test_stored_procedures.py:288: AssertionError
``` 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
