### PR TITLE
Remove top() causing "Invalid Formula"

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_daemonsets.json
+++ b/kubernetes/assets/dashboards/kubernetes_daemonsets.json
@@ -309,7 +309,7 @@
                             {
                                 "name": "query1",
                                 "data_source": "metrics",
-                                "query": "top(avg:kubernetes_state.daemonset.ready{$scope,$kube_namespace,$kube_cluster_name,$kube_daemon_set} by {kube_cluster_name,kube_namespace,kube_replica_set}, 10, 'mean', 'desc')",
+                                "query": "avg:kubernetes_state.daemonset.ready{$scope,$kube_namespace,$kube_cluster_name,$kube_daemon_set} by {kube_cluster_name,kube_namespace,kube_replica_set}",
                                 "aggregator": "avg"
                             }
                         ]


### PR DESCRIPTION



### What does this PR do?
The OOTB Kubernetes DaemonSets Overview page displays a "Replicas Changes" change widget with the following `Invalid Formula in Query Object` error for all users: [Demo Org Kubernetes DaemonSets Overview Dashboard](https://app.datadoghq.com/screen/integration/30537/kubernetes-daemonsets-overview?fromUser=false&refresh_mode=sliding&from_ts=1756327085534&to_ts=1756330685534&live=true)

<img width="1308" height="490" alt="image" src="https://github.com/user-attachments/assets/c44b4d33-3b7d-41a3-9feb-51399d991b06" />

This is being caused by a conflict between a `top()` function with the Change widget, and this PR removes the `top()` function in the query. Here's the same dashboard with this update:
<img width="1303" height="489" alt="image" src="https://github.com/user-attachments/assets/3514628f-b62d-4b81-b1c8-6a2b482389ea" />

### Motivation
https://datadog.zendesk.com/agent/tickets/2226887

### Review checklist (to be filled by reviewers)
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
