### PR TITLE
Fix model template for InstanceConfig

### DIFF
--- a/datadog_checks_dev/changelog.d/21189.fixed
+++ b/datadog_checks_dev/changelog.d/21189.fixed
@@ -1,0 +1,1 @@
+Fix model template generation for InstanceConfig

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/model/model_file.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/model/model_file.py
@@ -153,7 +153,7 @@ def _define_validator_functions(model_id, validator_data, need_defaults):
     model_file_lines.append('    def _validate(cls, value, info):')
     model_file_lines.append('        field = cls.model_fields[info.field_name]')
     model_file_lines.append('        field_name = field.alias or info.field_name')
-    model_file_lines.append("        if field_name in info.context['configured_fields']:")
+    model_file_lines.append("        if info.context and field_name in info.context['configured_fields']:")
     model_file_lines.append(
         f"            value = getattr(validators, f'{model_id}_{{info.field_name}}', identity)(value, field=field)"
     )
@@ -165,7 +165,7 @@ def _define_validator_functions(model_id, validator_data, need_defaults):
             model_file_lines.append(f'                value = validation.{import_path}(value, field=field)')
 
     if need_defaults:
-        model_file_lines.append('        else:')
+        model_file_lines.append('        elif value is None:')
         model_file_lines.append(
             f"            value = getattr(defaults, f'{model_id}_{{info.field_name}}', lambda: value)()"
         )

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}/config_models/instance.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}/config_models/instance.py
@@ -33,9 +33,9 @@ class InstanceConfig(BaseModel):
     def _validate(cls, value, info):
         field = cls.model_fields[info.field_name]
         field_name = field.alias or info.field_name
-        if field_name in info.context['configured_fields']:
+        if info.context and field_name in info.context['configured_fields']:
             value = getattr(validators, f'instance_{{info.field_name}}', identity)(value, field=field)
-        else:
+        elif value is None:
             value = getattr(defaults, f'instance_{{info.field_name}}', lambda: value)()
 
         return validation.utils.make_immutable(value)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}/config_models/shared.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}/config_models/shared.py
@@ -30,9 +30,9 @@ class SharedConfig(BaseModel):
     def _validate(cls, value, info):
         field = cls.model_fields[info.field_name]
         field_name = field.alias or info.field_name
-        if field_name in info.context['configured_fields']:
+        if info.context and field_name in info.context['configured_fields']:
             value = getattr(validators, f'shared_{{info.field_name}}', identity)(value, field=field)
-        else:
+        elif value is None:
             value = getattr(defaults, f'shared_{{info.field_name}}', lambda: value)()
 
         return validation.utils.make_immutable(value)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check_only/{check_name}/datadog_checks/{check_name}/config_models/instance.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check_only/{check_name}/datadog_checks/{check_name}/config_models/instance.py
@@ -33,9 +33,9 @@ class InstanceConfig(BaseModel):
     def _validate(cls, value, info):
         field = cls.model_fields[info.field_name]
         field_name = field.alias or info.field_name
-        if field_name in info.context['configured_fields']:
+        if info.context and field_name in info.context['configured_fields']:
             value = getattr(validators, f'instance_{{info.field_name}}', identity)(value, field=field)
-        else:
+        elif value is None:
             value = getattr(defaults, f'instance_{{info.field_name}}', lambda: value)()
 
         return validation.utils.make_immutable(value)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check_only/{check_name}/datadog_checks/{check_name}/config_models/shared.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check_only/{check_name}/datadog_checks/{check_name}/config_models/shared.py
@@ -30,9 +30,9 @@ class SharedConfig(BaseModel):
     def _validate(cls, value, info):
         field = cls.model_fields[info.field_name]
         field_name = field.alias or info.field_name
-        if field_name in info.context['configured_fields']:
+        if info.context and field_name in info.context['configured_fields']:
             value = getattr(validators, f'shared_{{info.field_name}}', identity)(value, field=field)
-        else:
+        elif value is None:
             value = getattr(defaults, f'shared_{{info.field_name}}', lambda: value)()
 
         return validation.utils.make_immutable(value)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/datadog_checks/{check_name}/config_models/instance.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/datadog_checks/{check_name}/config_models/instance.py
@@ -51,9 +51,9 @@ class InstanceConfig(BaseModel):
     def _validate(cls, value, info):
         field = cls.model_fields[info.field_name]
         field_name = field.alias or info.field_name
-        if field_name in info.context['configured_fields']:
+        if info.context and field_name in info.context['configured_fields']:
             value = getattr(validators, f'instance_{{info.field_name}}', identity)(value, field=field)
-        else:
+        elif value is None:
             value = getattr(defaults, f'instance_{{info.field_name}}', lambda: value)()
 
         return validation.utils.make_immutable(value)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/datadog_checks/{check_name}/config_models/shared.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/datadog_checks/{check_name}/config_models/shared.py
@@ -36,9 +36,9 @@ class SharedConfig(BaseModel):
     def _validate(cls, value, info):
         field = cls.model_fields[info.field_name]
         field_name = field.alias or info.field_name
-        if field_name in info.context['configured_fields']:
+        if info.context and field_name in info.context['configured_fields']:
             value = getattr(validators, f'shared_{{info.field_name}}', identity)(value, field=field)
-        else:
+        elif value is None:
             value = getattr(defaults, f'shared_{{info.field_name}}', lambda: value)()
 
         return validation.utils.make_immutable(value)

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_all_required.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_all_required.py
@@ -80,7 +80,7 @@ def test():
             def _validate(cls, value, info):
                 field = cls.model_fields[info.field_name]
                 field_name = field.alias or info.field_name
-                if field_name in info.context['configured_fields']:
+                if info.context and field_name in info.context['configured_fields']:
                     value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
 
                 return validation.utils.make_immutable(value)

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_array.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_array.py
@@ -89,7 +89,7 @@ def test():
             def _validate(cls, value, info):
                 field = cls.model_fields[info.field_name]
                 field_name = field.alias or info.field_name
-                if field_name in info.context['configured_fields']:
+                if info.context and field_name in info.context['configured_fields']:
                     value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
 
                 return validation.utils.make_immutable(value)

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_both_models_basic.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_both_models_basic.py
@@ -93,7 +93,7 @@ def test():
             def _validate(cls, value, info):
                 field = cls.model_fields[info.field_name]
                 field_name = field.alias or info.field_name
-                if field_name in info.context['configured_fields']:
+                if info.context and field_name in info.context['configured_fields']:
                     value = getattr(validators, f'shared_{info.field_name}', identity)(value, field=field)
 
                 return validation.utils.make_immutable(value)
@@ -136,7 +136,7 @@ def test():
             def _validate(cls, value, info):
                 field = cls.model_fields[info.field_name]
                 field_name = field.alias or info.field_name
-                if field_name in info.context['configured_fields']:
+                if info.context and field_name in info.context['configured_fields']:
                     value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
 
                 return validation.utils.make_immutable(value)

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_common_validators.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_common_validators.py
@@ -95,7 +95,7 @@ def test():
             def _validate(cls, value, info):
                 field = cls.model_fields[info.field_name]
                 field_name = field.alias or info.field_name
-                if field_name in info.context['configured_fields']:
+                if info.context and field_name in info.context['configured_fields']:
                     value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
 
                     if info.field_name == 'foo':

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_defaults.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_defaults.py
@@ -151,9 +151,9 @@ def test():
             def _validate(cls, value, info):
                 field = cls.model_fields[info.field_name]
                 field_name = field.alias or info.field_name
-                if field_name in info.context['configured_fields']:
+                if info.context and field_name in info.context['configured_fields']:
                     value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
-                else:
+                elif value is None:
                     value = getattr(defaults, f'instance_{info.field_name}', lambda: value)()
 
                 return validation.utils.make_immutable(value)

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_duplicate_hidden.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_duplicate_hidden.py
@@ -102,9 +102,9 @@ def test():
             def _validate(cls, value, info):
                 field = cls.model_fields[info.field_name]
                 field_name = field.alias or info.field_name
-                if field_name in info.context['configured_fields']:
+                if info.context and field_name in info.context['configured_fields']:
                     value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
-                else:
+                elif value is None:
                     value = getattr(defaults, f'instance_{info.field_name}', lambda: value)()
 
                 return validation.utils.make_immutable(value)

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_enum.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_enum.py
@@ -96,9 +96,9 @@ def test_enum_of_strings():
             def _validate(cls, value, info):
                 field = cls.model_fields[info.field_name]
                 field_name = field.alias or info.field_name
-                if field_name in info.context['configured_fields']:
+                if info.context and field_name in info.context['configured_fields']:
                     value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
-                else:
+                elif value is None:
                     value = getattr(defaults, f'instance_{info.field_name}', lambda: value)()
 
                 return validation.utils.make_immutable(value)
@@ -201,9 +201,9 @@ def test_enum_of_ints():
             def _validate(cls, value, info):
                 field = cls.model_fields[info.field_name]
                 field_name = field.alias or info.field_name
-                if field_name in info.context['configured_fields']:
+                if info.context and field_name in info.context['configured_fields']:
                     value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
-                else:
+                elif value is None:
                     value = getattr(defaults, f'instance_{info.field_name}', lambda: value)()
 
                 return validation.utils.make_immutable(value)

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_merge_instances.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_merge_instances.py
@@ -101,7 +101,7 @@ def test():
             def _validate(cls, value, info):
                 field = cls.model_fields[info.field_name]
                 field_name = field.alias or info.field_name
-                if field_name in info.context['configured_fields']:
+                if info.context and field_name in info.context['configured_fields']:
                     value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
 
                 return validation.utils.make_immutable(value)

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_nested_option.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_nested_option.py
@@ -121,7 +121,7 @@ def test():
             def _validate(cls, value, info):
                 field = cls.model_fields[info.field_name]
                 field_name = field.alias or info.field_name
-                if field_name in info.context['configured_fields']:
+                if info.context and field_name in info.context['configured_fields']:
                     value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
 
                 return validation.utils.make_immutable(value)

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_object_arbitrary_values.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_object_arbitrary_values.py
@@ -89,7 +89,7 @@ def test():
             def _validate(cls, value, info):
                 field = cls.model_fields[info.field_name]
                 field_name = field.alias or info.field_name
-                if field_name in info.context['configured_fields']:
+                if info.context and field_name in info.context['configured_fields']:
                     value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
 
                 return validation.utils.make_immutable(value)

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_object_model.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_object_model.py
@@ -105,7 +105,7 @@ def test():
             def _validate(cls, value, info):
                 field = cls.model_fields[info.field_name]
                 field_name = field.alias or info.field_name
-                if field_name in info.context['configured_fields']:
+                if info.context and field_name in info.context['configured_fields']:
                     value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
 
                 return validation.utils.make_immutable(value)

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_object_typed_values.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_object_typed_values.py
@@ -92,7 +92,7 @@ def test():
             def _validate(cls, value, info):
                 field = cls.model_fields[info.field_name]
                 field_name = field.alias or info.field_name
-                if field_name in info.context['configured_fields']:
+                if info.context and field_name in info.context['configured_fields']:
                     value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
 
                 return validation.utils.make_immutable(value)

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_only_shared.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_only_shared.py
@@ -81,7 +81,7 @@ def test():
             def _validate(cls, value, info):
                 field = cls.model_fields[info.field_name]
                 field_name = field.alias or info.field_name
-                if field_name in info.context['configured_fields']:
+                if info.context and field_name in info.context['configured_fields']:
                     value = getattr(validators, f'shared_{info.field_name}', identity)(value, field=field)
 
                 return validation.utils.make_immutable(value)

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_option_name_normalization.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_option_name_normalization.py
@@ -87,7 +87,7 @@ def test():
             def _validate(cls, value, info):
                 field = cls.model_fields[info.field_name]
                 field_name = field.alias or info.field_name
-                if field_name in info.context['configured_fields']:
+                if info.context and field_name in info.context['configured_fields']:
                     value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
 
                 return validation.utils.make_immutable(value)

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_union_types.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_union_types.py
@@ -91,7 +91,7 @@ def test():
             def _validate(cls, value, info):
                 field = cls.model_fields[info.field_name]
                 field_name = field.alias or info.field_name
-                if field_name in info.context['configured_fields']:
+                if info.context and field_name in info.context['configured_fields']:
                     value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
 
                 return validation.utils.make_immutable(value)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes the generating script for model instances to be directly instantiatable.

### Motivation
<!-- What inspired you to submit this pull request? -->
Currently trying to instantiate an `InstanceConfig()` will crash due to the lack of context.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
