### PR TITLE
Reword message to upgrade to ddev 12.0.0 on linting actions

### DIFF
--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -187,10 +187,10 @@ jobs:
         ddev config set repo ${{ inputs.repo }}
 
     - name: Lint
-      run: |
+      run: |-
         ddev test --lint ${{ inputs.target }} || {
-          echo "::error::Lint failed! ddev has been updated to version 12.0.0."
-          echo "::error::Please update to the latest version of ddev and then run 'ddev test --fmt ${{ inputs.target }}' to fix formatting issues."
+          echo "::error::Lint failed!"
+          echo "::error::Please update to the latest version of ddev to ensure you are using the latest linting rules and then run 'ddev test --fmt ${{ inputs.target }}' to fix formatting issues."
           exit 1
         }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Removes the warning we added to the linting job after releasing ddev 12.0.0.

### Motivation
<!-- What inspired you to submit this pull request? -->
This warning was added as a temporary instruction for anyone opening PRs. On 12.0.0 we moved to ruff from black which could cause users not linting their projects properly. We wanted to make it clear in CI that an upgrade on ddev would fix it.

We wanted it to be a explicity enough message that people would realize that 12.0.0 was a big change. However, enough time has passed now and 13.0.0 has been released. This message is misleading.

We are keeping the message to point out that the latest linting rules need to be used to be consistent with CI but removed the version bump information.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
