### PR TITLE
[DBMON-5587] Always clear out state between schema collections

### DIFF
--- a/mysql/changelog.d/21198.fixed
+++ b/mysql/changelog.d/21198.fixed
@@ -1,0 +1,1 @@
+Properly cleanup schema metadata memory references after all collection cycles

--- a/mysql/datadog_checks/mysql/databases_data.py
+++ b/mysql/datadog_checks/mysql/databases_data.py
@@ -54,6 +54,7 @@ class SubmitData:
         self._total_columns_sent = 0
         self._columns_count = 0
         self.db_info.clear()
+        self.db_to_tables.clear()
         self.any_tables_found = False
 
     def store_db_infos(self, db_infos):
@@ -183,7 +184,7 @@ class DatabasesData:
         self._data_submitter.submit()
 
     @tracked_method(agent_check_getter=agent_check_getter)
-    def _collect_databases_data(self, tags):
+    def collect_databases_data(self, tags):
         """
         Collects database information and schemas and submits them to the agent's queue as dictionaries.
 
@@ -247,22 +248,25 @@ class DatabasesData:
                             - data_length (int): The data length of the partition in bytes. If partition has
                                                  subpartitions, this is the sum of all subpartitions data_length.
         """
-        self._data_submitter.reset()
+        self._data_submitter.reset() # Ensure we start fresh
         self._tags = tags
-        with closing(self._metadata.get_db_connection().cursor(CommenterDictCursor)) as cursor:
-            self._data_submitter.set_base_event_data(
-                self._check.reported_hostname,
-                self._check.database_identifier,
-                self._tags,
-                self._check._config.cloud_metadata,
-                self._check.version.version,
-                self._check.version.flavor,
-            )
-            db_infos = self._query_db_information(cursor)
-            self._data_submitter.store_db_infos(db_infos)
-            self._fetch_for_databases(db_infos, cursor)
-            self._data_submitter.submit()
-            self._log.debug("Finished collect_schemas_data")
+        self._data_submitter.set_base_event_data(
+            self._check.reported_hostname,
+            self._check.database_identifier,
+            self._tags,
+            self._check._config.cloud_metadata,
+            self._check.version.version,
+            self._check.version.flavor,
+        )
+        try:
+            with closing(self._metadata.get_db_connection().cursor(CommenterDictCursor)) as cursor:
+                db_infos = self._query_db_information(cursor)
+                self._data_submitter.store_db_infos(db_infos)
+                self._fetch_for_databases(db_infos, cursor)
+                self._data_submitter.submit()
+        finally:
+            self._data_submitter.reset() # Ensure we reset in case of errors
+        self._log.debug("Finished collect_databases_data")
 
     def _fetch_for_databases(self, db_infos, cursor):
         start_time = time.time()

--- a/mysql/datadog_checks/mysql/databases_data.py
+++ b/mysql/datadog_checks/mysql/databases_data.py
@@ -248,7 +248,7 @@ class DatabasesData:
                             - data_length (int): The data length of the partition in bytes. If partition has
                                                  subpartitions, this is the sum of all subpartitions data_length.
         """
-        self._data_submitter.reset() # Ensure we start fresh
+        self._data_submitter.reset()  # Ensure we start fresh
         self._tags = tags
         self._data_submitter.set_base_event_data(
             self._check.reported_hostname,
@@ -265,7 +265,7 @@ class DatabasesData:
                 self._fetch_for_databases(db_infos, cursor)
                 self._data_submitter.submit()
         finally:
-            self._data_submitter.reset() # Ensure we reset in case of errors
+            self._data_submitter.reset()  # Ensure we reset in case of errors
         self._log.debug("Finished collect_databases_data")
 
     def _fetch_for_databases(self, db_infos, cursor):

--- a/mysql/datadog_checks/mysql/metadata.py
+++ b/mysql/datadog_checks/mysql/metadata.py
@@ -145,7 +145,7 @@ class MySQLMetadata(DBMAsyncJob):
         if self._databases_data_enabled and elapsed_time_databases >= self._databases_data_collection_interval:
             self._last_databases_collection_time = time.time()
             try:
-                self._databases_data._collect_databases_data(self._tags)
+                self._databases_data.collect_databases_data(self._tags)
             except Exception as e:
                 self._log.error(
                     """An error occurred while collecting schema data.


### PR DESCRIPTION
### What does this PR do?
Fixes a memory leak where errors during schema collection could lead to table metadata being held onto between check runs. Previously `db_to_tables` metadata dict was only cleared on successful submission. Now we're also cleaning it up when we reset.

We're now more aggressively clearing schema collection state before and after check runs to ensure we're not holding references in memory between the long collection intervals as well. This should decrease overall memory consumption from schema collection

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
