### PR TITLE
[NDMII-3524] Direct users to profile onboarding docs from ddev SNMP profiles docs

### DIFF
--- a/docs/developer/tutorials/snmp/profiles.md
+++ b/docs/developer/tutorials/snmp/profiles.md
@@ -3,7 +3,7 @@
 SNMP profiles are our way of providing out-of-the-box monitoring for certain makes and models of network devices.
 
 !!! warning
-    This page describes an old workflow for building SNMP profiles. The recommended way to create and manage profiles is now through the **SNMP Profile Manager**, which provides a guided, GUI-based experience.
+    This page describes the manual workflow for building SNMP profiles manually. The recommended way to create and manage profiles is now through the **SNMP Profile Manager**, which provides a guided, GUI-based experience.
 
     See the updated guide: [Getting Started with Device Profiles](https://docs.datadoghq.com/network_monitoring/devices/guide/device_profiles/?tab=devicescanrecommended).
 

--- a/docs/developer/tutorials/snmp/profiles.md
+++ b/docs/developer/tutorials/snmp/profiles.md
@@ -2,6 +2,11 @@
 
 SNMP profiles are our way of providing out-of-the-box monitoring for certain makes and models of network devices.
 
+!!! warning
+    This page describes an old workflow for building SNMP profiles. The recommended way to create and manage profiles is now through the **SNMP Profile Manager**, which provides a guided, GUI-based experience.
+
+    See the updated guide: [Getting Started with Device Profiles](https://docs.datadoghq.com/network_monitoring/devices/guide/device_profiles/?tab=devicescanrecommended).
+
 This tutorial will walk you through the steps of building a basic SNMP profile that collects OID metrics from HP iLO4 devices.
 
 Feel free to read the [Introduction to SNMP](./introduction.md) if you need a refresher on SNMP concepts such as OIDs and MIBs.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR adds a warning in the ddev SNMP profiles docs to redirect users to the new SNMP Profile Manager docs.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
