### PR TITLE
Replace bitnami Kafka Docker image with confluent one

### DIFF
--- a/kafka/hatch.toml
+++ b/kafka/hatch.toml
@@ -2,13 +2,13 @@
 
 [[envs.default.matrix]]
 python = ["3.12"]
-version = ["2.8", "3.3"]
+kafka_version = ["3.3"]
 
 [envs.default.overrides]
-matrix.version.env-vars = [
-  { key = "KAFKA_VERSION", value = "2.8.1", if = ["2.8"] },
-  { key = "KAFKA_VERSION", value = "3.3.1", if = ["3.3"] },
+# See mappings between kafka version and confluent versions here: https://docs.confluent.io/platform/current/installation/versions-interoperability.html
+matrix.kafka_version.env-vars = [
+  { key = "CONFLUENT_VERSION", value = "7.3.0", if = ["3.3"] },
 ]
 
 [envs.latest.env-vars]
-KAFKA_VERSION = "latest"
+CONFLUENT_VERSION = "latest"

--- a/kafka/tests/compose/docker-compose.yml
+++ b/kafka/tests/compose/docker-compose.yml
@@ -1,23 +1,33 @@
 services:
   zookeeper:
-    image: bitnami/zookeeper:3.8.0
+    image: confluentinc/cp-zookeeper:7.2.0
     ports:
       - 2181:2181
     environment:
-      - ALLOW_ANONYMOUS_LOGIN=yes
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    healthcheck:
+      test: ["CMD", "bash", "-c", "echo 'srvr' | nc localhost 2181 | grep -q 'Mode:'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
   kafka:
-    image: bitnami/kafka:${KAFKA_VERSION}
+    image: confluentinc/cp-kafka:${CONFLUENT_VERSION}
+    platform: linux/arm64/v8
     ports:
       - 9092:9092
       - 9999:9999
     environment:
       KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_CREATE_TOPICS: "marvel:2:1,dc:2:1"
-      ALLOW_PLAINTEXT_LISTENER: yes
-      KAFKA_CFG_ADVERTISED_HOST_NAME: localhost
-      KAFKA_CFG_ADVERTISED_PORT: "9092"
-      KAFKA_CFG_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: "true"
-      JMX_PORT: "9999"
+      KAFKA_JMX_PORT: 9999
+      KAFKA_JMX_HOSTNAME: localhost
     depends_on:
-      - zookeeper
+      zookeeper:
+        condition: service_healthy
+

--- a/kafka/tests/conftest.py
+++ b/kafka/tests/conftest.py
@@ -17,6 +17,7 @@ def dd_environment():
     compose_file = os.path.join(HERE, 'compose', 'docker-compose.yml')
 
     with docker_run(
-        compose_file, conditions=[CheckDockerLogs(compose_file, [r'\[KafkaServer id=\d+\] started'], matches="all")]
+        compose_file,
+        conditions=[CheckDockerLogs(compose_file, [r'\[KafkaServer id=\d+\] started'], matches="all")],
     ):
         yield load_jmx_config(), {'use_jmx': True}

--- a/kafka_consumer/hatch.toml
+++ b/kafka_consumer/hatch.toml
@@ -8,25 +8,19 @@ post-install-commands = [
 ]
 
 [envs.default.env-vars]
-ZK_VERSION = "3.6.4"
 AUTHENTICATION = "noauth"
 
 [[envs.default.matrix]]
 python = ["3.12"]
-version = ["2.6", "3.3"]
-
-[[envs.default.matrix]]
-python = ["3.12"]
-version = ["3.3"]
+kafka_version = ["3.3"]
 auth = ["ssl", "kerberos"]
 
 [envs.default.overrides]
-matrix.version.env-vars = [
-  { key = "KAFKA_VERSION", value = "2.6.0", if = ["2.6"] },
-  { key = "KAFKA_VERSION", value = "3.3.2-debian-11-r175", if = ["3.3"] },
+# See mappings between kafka version and confluent versions here: https://docs.confluent.io/platform/current/installation/versions-interoperability.html
+matrix.kafka_version.env-vars = [
+  { key = "CONFLUENT_VERSION", value = "7.3.0", if = ["3.3"] },
 ]
 matrix.auth.env-vars = "AUTHENTICATION"
 
 [envs.latest.env-vars]
-KAFKA_VERSION = "latest"
-ZK_VERSION = "3.6.4"
+CONFLUENT_VERSION = "latest"

--- a/kafka_consumer/tests/docker/kerberos/docker-compose.yaml
+++ b/kafka_consumer/tests/docker/kerberos/docker-compose.yaml
@@ -44,7 +44,7 @@ services:
         -Dzookeeper.requireClientAuthScheme=sasl
 
   broker:
-    image: confluentinc/cp-server:7.3.0
+    image: confluentinc/cp-server:${CONFLUENT_VERSION}
     hostname: broker.kerberos-demo.local
     container_name: broker
     ports:
@@ -84,9 +84,12 @@ services:
       interval: 5s
       timeout: 10s
       retries: 10
+    depends_on:
+      zookeeper:
+        condition: service_healthy
 
   broker2:
-    image: confluentinc/cp-server:7.3.0
+    image: confluentinc/cp-server:${CONFLUENT_VERSION}
     hostname: broker2.kerberos-demo.local
     container_name: broker2
     ports:
@@ -125,6 +128,9 @@ services:
       interval: 5s
       timeout: 10s
       retries: 10
+    depends_on:
+      zookeeper:
+        condition: service_healthy
 
 networks:
   default:

--- a/kafka_consumer/tests/docker/kerberos/docker-compose.yaml
+++ b/kafka_consumer/tests/docker/kerberos/docker-compose.yaml
@@ -84,9 +84,6 @@ services:
       interval: 5s
       timeout: 10s
       retries: 10
-    depends_on:
-      zookeeper:
-        condition: service_healthy
 
   broker2:
     image: confluentinc/cp-server:${CONFLUENT_VERSION}
@@ -128,9 +125,6 @@ services:
       interval: 5s
       timeout: 10s
       retries: 10
-    depends_on:
-      zookeeper:
-        condition: service_healthy
 
 networks:
   default:

--- a/kafka_consumer/tests/docker/noauth/docker-compose.yaml
+++ b/kafka_consumer/tests/docker/noauth/docker-compose.yaml
@@ -1,52 +1,51 @@
 services:
   zookeeper:
-    image: docker.io/bitnami/zookeeper:${ZK_VERSION}
+    image: confluentinc/cp-zookeeper:7.3.0
     container_name: zookeeper
     hostname: zookeeper
     ports:
       - 2181:2181
     environment:
-      - ALLOW_ANONYMOUS_LOGIN=yes
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
     healthcheck:
-      test: nc -vz localhost 2181 || exit -1
-      start_period: 5s
-      interval: 5s
+      test: ["CMD", "bash", "-c", "echo 'srvr' | nc localhost 2181 | grep -q 'Mode:'"]
+      interval: 10s
       timeout: 5s
-      retries: 10
+      retries: 5
 
   kafka1:
-    image: docker.io/bitnami/kafka:${KAFKA_VERSION}
+    image: confluentinc/cp-kafka:${CONFLUENT_VERSION}
+    platform: linux/arm64/v8
     container_name: kafka1
     hostname: kafka1
     ports:
       - 9092:9092
     environment:
-      KAFKA_CFG_BROKER_ID: 1
-      KAFKA_CFG_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: INTERNAL
-      KAFKA_CFG_LISTENERS: INTERNAL://:19092,EXTERNAL://:9092
-      KAFKA_CFG_ADVERTISED_LISTENERS: INTERNAL://:19092,EXTERNAL://127.0.0.1:9092
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
-      ALLOW_PLAINTEXT_LISTENER: "true"
-      KAFKA_ENABLE_KRAFT: false
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
     depends_on:
       zookeeper:
         condition: service_healthy
 
   kafka2:
-    image: docker.io/bitnami/kafka:${KAFKA_VERSION}
+    image: confluentinc/cp-kafka:${CONFLUENT_VERSION}
+    platform: linux/arm64/v8
     ports:
       - 9093:9093
     container_name: kafka2
     hostname: kafka2
     environment:
-      KAFKA_CFG_BROKER_ID: 2
-      KAFKA_CFG_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: INTERNAL
-      KAFKA_CFG_LISTENERS: INTERNAL://:19093,EXTERNAL://:9093
-      KAFKA_CFG_ADVERTISED_LISTENERS: INTERNAL://:19093,EXTERNAL://127.0.0.1:9093
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
-      ALLOW_PLAINTEXT_LISTENER: "true"
+      KAFKA_BROKER_ID: 2
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka2:29093,PLAINTEXT_HOST://localhost:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
     depends_on:
       zookeeper:
         condition: service_healthy

--- a/kafka_consumer/tests/docker/ssl/docker-compose.yaml
+++ b/kafka_consumer/tests/docker/ssl/docker-compose.yaml
@@ -1,81 +1,75 @@
 services:
   zookeeper:
-    image: docker.io/bitnami/zookeeper:${ZK_VERSION}
+    image: confluentinc/cp-zookeeper:7.3.0
     ports:
       - 2181:2181
     container_name: zookeeper
     hostname: zookeeper
     environment:
-      - ALLOW_ANONYMOUS_LOGIN=yes
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
     healthcheck:
-      test: nc -vz localhost 2181 || exit -1
-      start_period: 5s
-      interval: 5s
+      test: ["CMD", "bash", "-c", "echo 'srvr' | nc localhost 2181 | grep -q 'Mode:'"]
+      interval: 10s
       timeout: 5s
-      retries: 10
+      retries: 5
 
   kafka1:
-    image: docker.io/bitnami/kafka:${KAFKA_VERSION}
+    image: confluentinc/cp-kafka:${CONFLUENT_VERSION}
+    platform: linux/arm64/v8
     container_name: kafka1
     hostname: kafka1
     ports:
       - "9092:9092"
     environment:
-      KAFKA_CFG_BROKER_ID: 1
-      KAFKA_CFG_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_CFG_LISTENERS: INTERNAL://:19092,EXTERNAL://:9092
-      KAFKA_CFG_ADVERTISED_LISTENERS: INTERNAL://:19092,EXTERNAL://localhost:9092
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:SSL
-      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: INTERNAL
-      KAFKA_CFG_SSL_TRUSTSTORE_TYPE: jks
-      KAFKA_CFG_SSL_TRUSTSTORE_PASSWORD: secret
-      KAFKA_CFG_SSL_KEYSTORE_PASSWORD: secret
-      KAFKA_CFG_SSL_KEY_PASSWORD: secret
-      KAFKA_CFG_SSL_CLIENT_AUTH: required
-      KAFKA_CFG_SSL_KEYSTORE_TYPE: jks
-      KAFKA_CFG_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM: HTTPS
-      KAFKA_CFG_SUPER_USERS: User:kafka
-      KAFKA_CFG_MESSAGE_MAX_BYTES:  1000000
-      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: false
-      KAFKA_CFG_SSL_PRINCIPAL_MAPPING_RULES: 'RULE:^CN=(.*?),OU=ServiceUsers.*$/$1/,RULE:^CN=(.*?),OU=(.*?),O=(.*?),L=(.*?),ST=(.*?),C=(.*?)$/$1@$2/L,RULE:^.*[Cc][Nn]=([a-zA-Z0-9.]*).*$/$1/L,DEFAULT'
-      ALLOW_PLAINTEXT_LISTENER: yes
-      KAFKA_ENABLE_KRAFT: false
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,SSL:SSL
+      KAFKA_LISTENERS: PLAINTEXT://kafka1:29092,SSL://kafka1:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:29092,SSL://localhost:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_SSL_TRUSTSTORE_FILENAME: kafka.truststore.jks
+      KAFKA_SSL_TRUSTSTORE_PASSWORD: secret
+      KAFKA_SSL_KEYSTORE_FILENAME: kafka1.server.keystore.jks
+      KAFKA_SSL_KEYSTORE_PASSWORD: secret
+      KAFKA_SSL_KEY_PASSWORD: secret
+      KAFKA_SSL_CLIENT_AUTH: required
+      KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM: https
+      KAFKA_SUPER_USERS: User:kafka
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
     volumes:
-      - ./truststore/kafka.truststore.jks:/bitnami/kafka/config/certs/kafka.truststore.jks
-      - ./keystore/kafka1.server.keystore.jks:/bitnami/kafka/config/certs/kafka.keystore.jks
+      - ./truststore/kafka.truststore.jks:/etc/kafka/secrets/kafka.truststore.jks
+      - ./keystore/kafka1.server.keystore.jks:/etc/kafka/secrets/kafka1.server.keystore.jks
     depends_on:
       zookeeper:
         condition: service_healthy
 
   kafka2:
-    image: docker.io/bitnami/kafka:${KAFKA_VERSION}
+    image: confluentinc/cp-kafka:${CONFLUENT_VERSION}
+    platform: linux/arm64/v8
     container_name: kafka2
     hostname: kafka2
     ports:
       - "9093:9093"
     environment:
-      KAFKA_CFG_BROKER_ID: 2
-      KAFKA_CFG_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_CFG_LISTENERS: INTERNAL://:19093,EXTERNAL://:9093
-      KAFKA_CFG_ADVERTISED_LISTENERS: INTERNAL://:19093,EXTERNAL://localhost:9093
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:SSL
-      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: INTERNAL
-      KAFKA_CFG_SSL_TRUSTSTORE_TYPE: jks
-      KAFKA_CFG_SSL_TRUSTSTORE_PASSWORD: secret
-      KAFKA_CFG_SSL_KEYSTORE_PASSWORD: secret
-      KAFKA_CFG_SSL_KEY_PASSWORD: secret
-      KAFKA_CFG_SSL_CLIENT_AUTH: required
-      KAFKA_CFG_SSL_KEYSTORE_TYPE: jks
-      KAFKA_CFG_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM: HTTPS
-      KAFKA_CFG_SUPER_USERS: User:kafka
-      KAFKA_CFG_MESSAGE_MAX_BYTES:  1000000
-      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: false
-      KAFKA_CFG_SSL_PRINCIPAL_MAPPING_RULES: 'RULE:^CN=(.*?),OU=ServiceUsers.*$/$1/,RULE:^CN=(.*?),OU=(.*?),O=(.*?),L=(.*?),ST=(.*?),C=(.*?)$/$1@$2/L,RULE:^.*[Cc][Nn]=([a-zA-Z0-9.]*).*$/$1/L,DEFAULT'
-      ALLOW_PLAINTEXT_LISTENER: yes
-      KAFKA_ENABLE_KRAFT: false
+      KAFKA_BROKER_ID: 2
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,SSL:SSL
+      KAFKA_LISTENERS: PLAINTEXT://kafka2:29093,SSL://kafka2:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka2:29093,SSL://localhost:9093
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_SSL_TRUSTSTORE_FILENAME: kafka.truststore.jks
+      KAFKA_SSL_TRUSTSTORE_PASSWORD: secret
+      KAFKA_SSL_KEYSTORE_FILENAME: kafka2.server.keystore.jks
+      KAFKA_SSL_KEYSTORE_PASSWORD: secret
+      KAFKA_SSL_KEY_PASSWORD: secret
+      KAFKA_SSL_CLIENT_AUTH: required
+      KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM: https
+      KAFKA_SUPER_USERS: User:kafka
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
     volumes:
-      - ./truststore/kafka.truststore.jks:/bitnami/kafka/config/certs/kafka.truststore.jks
-      - ./keystore/kafka2.server.keystore.jks:/bitnami/kafka/config/certs/kafka.keystore.jks
+      - ./truststore/kafka.truststore.jks:/etc/kafka/secrets/kafka.truststore.jks
+      - ./keystore/kafka2.server.keystore.jks:/etc/kafka/secrets/kafka2.server.keystore.jks
     depends_on:
       zookeeper:
         condition: service_healthy


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Replace bitnami docker images for Kafka and Kafka Consumer integrations with confluent images instead.

### Motivation
<!-- What inspired you to submit this pull request? -->
Bitnami has removed their open images from the public regsitry. They provided a legacy registry where they are keeping them but if we need to move we better move to a separate source. The legacy ones will be frozen and won't be updated anymore.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
