### PR TITLE
run auditreduce subprocess using TZ=UTC due to issue translating daylight savings hours

### DIFF
--- a/mac_audit_logs/CHANGELOG.md
+++ b/mac_audit_logs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 1.0.1 / 2025-08-29
+
+***Fixed***:
+
+* Run `auditreduce` subprocess with `TZ=UTC` in the environment to ensure the timestamps queried match within the window of the audit file
+
 ## 1.0.0 / 2025-07-10 / Agent 7.69.0
 
 ***Added***:

--- a/mac_audit_logs/README.md
+++ b/mac_audit_logs/README.md
@@ -24,7 +24,7 @@ To install the Mac Audit Logs integration, run the following Agent installation 
 
 For Mac, run:
   ```shell
-  sudo datadog-agent integration install datadog-mac-audit-logs==1.0.0
+  sudo datadog-agent integration install datadog-mac-audit-logs==1.0.1
   ```
 
 


### PR DESCRIPTION
### What does this PR do?
This pull request adds a bugfix for auditreduce not properly translating daylight savings hours to UTC. The timestamp provided always translates based on standard time, even if the local timezone is of daylight savings time. Running the subprocess using timezone of UTC ensures a consistent query regardless of what timezone the Mac system is in. 

This was causing the integration to only submit logs on initial start when the timestamp provided is 18 hours in the past, and then once an hour after that when the last_record_time was used rather than the filename start time.

For other info, see the following support case: https://help.datadoghq.com/hc/en-us/requests/2225393

### Motivation
The integration does not function properly otherwise.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
