### PR TITLE
PG: Directly run ANALYZE for the test_analyze_progress

### DIFF
--- a/postgres/tests/test_progress_stats.py
+++ b/postgres/tests/test_progress_stats.py
@@ -31,7 +31,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')
 
 
 def _check_analyze_progress(check, pg_instance, table):
-    thread = run_vacuum_thread(pg_instance, f'VACUUM ANALYZE {table}')
+    thread = run_vacuum_thread(pg_instance, f'ANALYZE {table}')
 
     # Wait for vacuum to be reported
     _wait_for_value(


### PR DESCRIPTION
### What does this PR do?
To avoid flakiness, we skip the vacuum phase and directly run an analyze.

### Motivation
Tests are currently using `vacuum analyze` to check metrics reporting analyze progress. If the vacuum phase takes more than 1s, the test will fail as the wait_for_value will exit and only a running vacuum will be present when metrics are collected.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
