### PR TITLE
[kafka_consumer] Improve efficiency of collecting consumer group state.

### DIFF
--- a/kafka_consumer/changelog.d/21221.fixed
+++ b/kafka_consumer/changelog.d/21221.fixed
@@ -1,0 +1,1 @@
+Improve check efficiency with many topics or partitions per consumer group when `collect_consumer_group_state` is enabled.

--- a/kafka_consumer/changelog.d/9999.fixed
+++ b/kafka_consumer/changelog.d/9999.fixed
@@ -1,1 +1,0 @@
-Improve check efficiency with many topics or partitions per consumer group when `collect_consumer_group_state` is enabledheck

--- a/kafka_consumer/changelog.d/9999.fixed
+++ b/kafka_consumer/changelog.d/9999.fixed
@@ -1,0 +1,1 @@
+Improve check efficiency with many topics or partitions per consumer group when `collect_consumer_group_state` is enabledheck

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -243,6 +243,7 @@ class KafkaCheck(AgentCheck):
         reported_contexts = 0
         self.log.debug("Reporting consumer offsets and lag metrics")
         for consumer_group, offsets in consumer_offsets.items():
+            consumer_group_state = None
             for (topic, partition), consumer_offset in offsets.items():
                 if reported_contexts >= contexts_limit:
                     self.log.debug(
@@ -259,7 +260,8 @@ class KafkaCheck(AgentCheck):
                     'kafka_cluster_id:%s' % cluster_id,
                 ]
                 if self.config._collect_consumer_group_state:
-                    consumer_group_state = self.get_consumer_group_state(consumer_group)
+                    if consumer_group_state is None:
+                        consumer_group_state = self.get_consumer_group_state(consumer_group)
                     consumer_group_tags.append(f'consumer_group_state:{consumer_group_state}')
                 consumer_group_tags.extend(self.config._custom_tags)
 


### PR DESCRIPTION
### What does this PR do?
Improve check efficiency with many topics or partitions per consumer group when `collect_consumer_group_state` is enabled. This is done by only getting the consumer group state once per consumer group.

### Motivation
Make the kafka_consumer check faster.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
