### PR TITLE
Force check log conditions in tests for specific service in VoltDB

### DIFF
--- a/voltdb/hatch.toml
+++ b/voltdb/hatch.toml
@@ -11,7 +11,7 @@ DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
 [[envs.default.matrix]]
 python = ["3.12"]
 version = ["8.4", "10.0"]
-tls = ["false", "true"]
+tls = ["with-tls", "without-tls"]
 
 [envs.default.overrides]
 matrix.version.env-vars = [
@@ -20,4 +20,7 @@ matrix.version.env-vars = [
     { key = "VOLTDB_VERSION", value = "10.0.0", if = ["10.0"] },
     { key = "VOLTDB_IMAGE", value = "datadog/docker-library:voltdb_10_0", if = ["10.0"] }
 ]
-matrix.tls.env-vars = "TLS_ENABLED"
+matrix.tls.env-vars = [
+    { key = "TLS_ENABLED", value = "true", if = ["with-tls"] },
+    { key = "TLS_ENABLED", value = "false", if = ["without-tls"] }
+]

--- a/voltdb/tests/conftest.py
+++ b/voltdb/tests/conftest.py
@@ -26,7 +26,9 @@ def dd_environment(instance):
         schema = f.read()
 
     conditions = [
-        CheckDockerLogs(compose_file, patterns=['Server completed initialization']),
+        CheckDockerLogs(compose_file, patterns=['Server completed initialization'], service='voltdb0'),
+        CheckDockerLogs(compose_file, patterns=['Server completed initialization'], service='voltdb1'),
+        CheckDockerLogs(compose_file, patterns=['Server completed initialization'], service='voltdb2'),
         CreateSchema(compose_file, schema, container_name='voltdb0'),
         EnsureExpectedMetricsShowUp(instance),
     ]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
- Modifies the check log conditions to check for the specific service and validate all of them
- Modifies the environment name so we can understand what we are doing in the environment. True and False do not convey what the environment is

### Motivation
<!-- What inspired you to submit this pull request? -->
We have started to get the [tests flaking](https://github.com/DataDog/integrations-core/actions/runs/17395859706/job/49377608857) when running a command before things were ready. We were checking the logs of the three services at the same time which can cause a race condition in which one of the dbs is ready but not the one we are doing to run the command to create the schema on.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
