### PR TITLE
Add nimimum-bnase-package tests to PR workflow

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -95,6 +95,7 @@ jobs:
   save-event:
     needs:
     - test
+    - test-minimum-base-package
     if: success() || failure()
 
     uses: ./.github/workflows/save-event.yml
@@ -102,6 +103,7 @@ jobs:
   submit-traces:
     needs:
     - test
+    - test-minimum-base-package
     if: inputs.repo == 'core' && (success() || failure()) && github.event.pull_request.head.repo.full_name == github.repository
 
     uses: ./.github/workflows/submit-traces.yml
@@ -110,6 +112,7 @@ jobs:
   upload-coverage:
     needs:
     - test
+    - test-minimum-base-package
     if: >
       !github.event.repository.private &&
       (success() || failure()) &&
@@ -140,6 +143,7 @@ jobs:
   check:
     needs:
     - test
+    - test-minimum-base-package
     # In integrations-core and integrations-extras repos the tests are flaky enough that
     # it would be a pain to merge PRs with the Merge Queue enabled.
     # While we work on the tests, we skip the job if it's triggered by Merge Queue.
@@ -152,4 +156,4 @@ jobs:
       uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
       with:
         jobs: ${{ toJSON(needs) }}
-        allowed-skips: test
+        allowed-skips: test, test-minimum-base-package


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Runs the minimum base check tests in PR workflows.

### Motivation
<!-- What inspired you to submit this pull request? -->
We have had many cases already in which we update an integration that requires the latest version of the `datadog_checks_base` package but only notice one day later when we see the dialy job failing. This can be caught in the PR that updates the integration if we just run the minimum base check job as well.

While we could argue that this would only cause master to be faulty for one day but it is rather simple to ensure that master is not failing because of this. This could happen the day before release and cause a release schedule delay. The intention of this chagne is to ensure that PRs without the proper base check dependency are not merged until they are ready.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
