### PR TITLE
Fix path in ddev size command

### DIFF
--- a/ddev/changelog.d/21234.fixed
+++ b/ddev/changelog.d/21234.fixed
@@ -1,0 +1,2 @@
+Removes duplicated os.path.join when defining the path for the resolved folder.
+

--- a/ddev/src/ddev/cli/size/utils/common_funcs.py
+++ b/ddev/src/ddev/cli/size/utils/common_funcs.py
@@ -95,7 +95,7 @@ def get_valid_platforms(repo_path: Path | str, versions: set[str]) -> set[str]:
     """
     Extracts the platforms we support from the .deps/resolved file names.
     """
-    resolved_path = os.path.join(repo_path, os.path.join(repo_path, ".deps", "resolved"))
+    resolved_path = os.path.join(repo_path, ".deps", "resolved")
     platforms = []
     for file in os.listdir(resolved_path):
         if any(version in file for version in versions):
@@ -107,7 +107,7 @@ def get_valid_versions(repo_path: Path | str) -> set[str]:
     """
     Extracts the Python versions we support from the .deps/resolved file names.
     """
-    resolved_path = os.path.join(repo_path, os.path.join(repo_path, ".deps", "resolved"))
+    resolved_path = os.path.join(repo_path, ".deps", "resolved")
     versions = []
     pattern = re.compile(r"\d+\.\d+")
     for file in os.listdir(resolved_path):
@@ -282,7 +282,7 @@ def get_dependencies(repo_path: str | Path, platform: str, version: str, compres
     Gets the list of dependencies for a given platform and Python version and returns a FileDataEntry that includes:
     Name, Version, Size_Bytes, Size, and Type.
     """
-    resolved_path = os.path.join(repo_path, os.path.join(repo_path, ".deps", "resolved"))
+    resolved_path = os.path.join(repo_path, ".deps", "resolved")
 
     for filename in os.listdir(resolved_path):
         file_path = os.path.join(resolved_path, filename)


### PR DESCRIPTION
### What does this PR do?
Removes duplicated `os.path.join` when defining the path for the resolved folder.

### Motivation
`os.path.join` was duplicated.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
