### PR TITLE
Update the artifact names to include a prefix when running the minimum base package tests

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -72,7 +72,7 @@ jobs:
 
     uses: ./.github/workflows/test-target.yml
     with:
-      job-name: "${{ matrix.name }}"
+      job-name: "minimum-base-package-${{ matrix.name }}"
       target: "${{ matrix.target }}"
       target-env: "${{ matrix.target-env }}"
       platform: "${{ matrix.platform }}"

--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -112,6 +112,8 @@ jobs:
       # Capture traces for a separate job to do the submission
       TRACE_CAPTURE_BASE_DIR: "trace-captures"
       TRACE_CAPTURE_LOG: "trace-captures/output.log"
+      # Prefix for artifact names when using minimum base package
+      MINIMUM_BASE_PACKAGE_PREFIX: "${{ inputs.minimum-base-package && 'minimum-base-package-' || '' }}"
 
     permissions:
        # needed for compute-matrix in test-target.yml
@@ -374,7 +376,7 @@ jobs:
       if: inputs.repo == 'core' && always()
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: "${{ inputs.traces-artifact-name }}-${{ inputs.target }}${{ inputs.target-env && format('-{0}', inputs.target-env) || '' }}-${{ inputs.platform }}"
+        name: "${{ env.MINIMUM_BASE_PACKAGE_PREFIX }}${{ inputs.traces-artifact-name }}-${{ inputs.target }}${{ inputs.target-env && format('-{0}', inputs.target-env) || '' }}-${{ inputs.platform }}"
         path: "${{ env.TRACE_CAPTURE_FILE }}"
 
     - name: Finalize test results
@@ -389,7 +391,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: "test-results-${{ inputs.target }}${{ inputs.target-env && format('-{0}', inputs.target-env) || '' }}-${{ inputs.platform }}"
+        name: "${{ env.MINIMUM_BASE_PACKAGE_PREFIX }}test-results-${{ inputs.target }}${{ inputs.target-env && format('-{0}', inputs.target-env) || '' }}-${{ inputs.platform }}"
         path: "${{ env.TEST_RESULTS_BASE_DIR }}"
 
     - name: Upload coverage data as artifact
@@ -400,6 +402,6 @@ jobs:
       # Flaky tests will have low coverage, don't include in artifacts to avoid pipeline issues
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: "coverage-${{ inputs.target }}${{ inputs.target-env && format('-{0}', inputs.target-env) || '' }}-${{ inputs.platform }}"
+        name: "${{ env.MINIMUM_BASE_PACKAGE_PREFIX }}coverage-${{ inputs.target }}${{ inputs.target-env && format('-{0}', inputs.target-env) || '' }}-${{ inputs.platform }}"
         path: "${{ inputs.target }}/coverage.xml"
         if-no-files-found: ignore


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds a preffix (`minimum-base-package-`) to the artifacts generated by the `test-target` job.

### Motivation
<!-- What inspired you to submit this pull request? -->
We want to ro run the minimum base tests in PRs to ensure they work properly before merging them to master. However, having the same artifact names means we cannot push both artifacts.

This allows both sets of tests to run at the same time.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
