### PR TITLE
Update test-target job to install the integration in the agent when running e2e tests

### DIFF
--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -306,10 +306,10 @@ jobs:
         #   by default
         set +e # Disable immediate exit
         if [ '${{ inputs.pytest-args }}' = '-m flaky' ] || [ '${{ inputs.pytest-args }}' = '-m "not flaky"' ]; then
-          ddev env test --new-env --junit ${{ inputs.target }} ${{ inputs.target-env || 'all' }} -- ${{ inputs.pytest-args }} -k "not fips"
+          ddev env test --dev --junit ${{ inputs.target }} ${{ inputs.target-env || 'all' }} -- ${{ inputs.pytest-args }} -k "not fips"
           exit_code=$?
         else
-          ddev env test --new-env --junit ${{ inputs.target }} ${{ inputs.target-env || 'all' }} ${{ inputs.pytest-args != '' && format('-- {0} -k "not fips"', inputs.pytest-args) || '-- -k "not fips"' }}
+          ddev env test --dev --junit ${{ inputs.target }} ${{ inputs.target-env || 'all' }} ${{ inputs.pytest-args != '' && format('-- {0} -k "not fips"', inputs.pytest-args) || '-- -k "not fips"' }}
           exit_code=$?
         fi
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates the `test-target` job when running outside the `core` repo to pass the `--dev` option.

### Motivation
<!-- What inspired you to submit this pull request? -->
It seems we were relying on the `new-env` flag to ensure the integrations get installed but this option is a noop in `ddev`. Integrations outside core are not built within the agent and unless we build them manually before launching the agent, e2e tests won't run.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
