### PR TITLE
Remove broken `test_submit_is_called_if_too_many_columns` test

### DIFF
--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -867,21 +867,6 @@ def test_fetch_throws(instance_docker):
             schemas._fetch_schema_data("dummy_cursor", time.time(), "my_db")
 
 
-def test_submit_is_called_if_too_many_columns(instance_docker):
-    check = SQLServer(CHECK_NAME, {}, [instance_docker])
-    schemas = Schemas(check, check._config)
-    with (
-        mock.patch('time.time', side_effect=[0, 0]),
-        mock.patch('datadog_checks.sqlserver.schemas.Schemas._query_schema_information', return_value={"id": 1}),
-        mock.patch('datadog_checks.sqlserver.schemas.Schemas._get_tables', return_value=[1, 2]),
-        mock.patch('datadog_checks.sqlserver.schemas.SubmitData.submit') as mocked_submit,
-        mock.patch('datadog_checks.sqlserver.schemas.Schemas._get_tables_data', return_value=(1000_000, {"id": 1})),
-    ):
-        with pytest.raises(StopIteration):
-            schemas._fetch_schema_data("dummy_cursor", time.time(), "my_db")
-            mocked_submit.called_once()
-
-
 def test_exception_handling_by_do_for_dbs(instance_docker):
     check = SQLServer(CHECK_NAME, {}, [instance_docker])
     check.initialize_connection()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Remove broken `test_submit_is_called_if_too_many_columns` test

### Motivation
<!-- What inspired you to submit this pull request? -->
This test has multiple issues:
1. Mocks `_query_schema_information` to return wrong data structure
2. Uses non-existent `called_once()` method instead of `assert_called_once()`
3. Expects `StopIteration` but tests "too many columns" logic which doesn't raise it
4. Doesn't actually test the timeout condition that would raise `StopIteration`

The test is fundamentally broken and doesn't test what it claims to test.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
