### PR TITLE
Update Fly.io to recommend using readonly auth token

### DIFF
--- a/fly_io/README.md
+++ b/fly_io/README.md
@@ -27,18 +27,20 @@ The Fly.io check is included in the [Datadog Agent][2] package. We recommend dep
 
 2. Set a [secret][17] for your Datadog API key called `DD_API_KEY`, and optionally your [site][14] as `DD_SITE`.
 
-3. In your app's directory, create a `conf.yaml` file for the Fly.io integration, [configure](#Configuration) the integration, and mount it in the Agent's `conf.d/fly_io.d/` directory as `conf.yaml`:
+3. Create a [read-only][23] authentication token.
+
+4. In your app's directory, create a `conf.yaml` file for the Fly.io integration, [configure](#Configuration) the integration, and mount it in the Agent's `conf.d/fly_io.d/` directory as `conf.yaml`:
 
     ```
     instances:
     - empty_default_hostname: true
       headers:
-          Authorization: Bearer <YOUR_FLY_TOKEN>
+          Authorization: FlyV1 <YOUR_FLY_TOKEN>
       machines_api_endpoint: http://_api.internal:4280
       org_slug: <YOUR_ORG_SLUG>
     ```
 
-4. [Deploy][16] your app.
+5. [Deploy][16] your app.
 
 **Note**: To collect traces and custom metrics from your applications, see [Application traces](#Application-traces).
 
@@ -166,3 +168,4 @@ Need help? Contact [Datadog support][9].
 [20]: https://fly.io/docs/machines/api/
 [21]: https://docs.datadoghq.com/logs/log_configuration/pipelines/?tab=source#integration-pipeline-library
 [22]: https://vector.dev/docs/reference/configuration/transforms/lua/
+[23]: https://fly.io/docs/flyctl/tokens-create-readonly/

--- a/fly_io/assets/configuration/spec.yaml
+++ b/fly_io/assets/configuration/spec.yaml
@@ -18,10 +18,14 @@ files:
           for authentication for both the OpenMetrics endpoint and REST API.
           You can alternatively use the `auth_token` option.
 
-          You can create an access token with this command:
-            `TOKEN=$(flyctl auth token)`
+          You can create a read-only token with this command:
+            `fly tokens create readonly`
+
+          Alternatively, you can use the `flyctl auth token` command to create a token. If using this
+          type of token, the header value should be: `Authorization: "Bearer <FLY_ACCESS_TOKEN>"`. Note this
+          option is no longer recommended: https://fly.io/docs/security/tokens/.
         headers.value.example:
-          Authorization: "Bearer <FLY_ACCESS_TOKEN>"
+          Authorization: "FlyV1 <FLY_ACCESS_TOKEN>"
         auth_token.display_priority: 2
         empty_default_hostname.display_priority: 1
         empty_default_hostname.required: true

--- a/fly_io/datadog_checks/fly_io/data/conf.yaml.example
+++ b/fly_io/datadog_checks/fly_io/data/conf.yaml.example
@@ -56,11 +56,15 @@ instances:
     ## for authentication for both the OpenMetrics endpoint and REST API.
     ## You can alternatively use the `auth_token` option.
     ##
-    ## You can create an access token with this command:
-    ##   `TOKEN=$(flyctl auth token)`
+    ## You can create a read-only token with this command:
+    ##   `fly tokens create readonly`
+    ##
+    ## Alternatively, you can use the `flyctl auth token` command to create a token. If using this
+    ## type of token, the header value should be: `Authorization: "Bearer <FLY_ACCESS_TOKEN>"`. Note this
+    ## option is no longer recommended: https://fly.io/docs/security/tokens/.
     #
     headers:
-      Authorization: Bearer <FLY_ACCESS_TOKEN>
+      Authorization: FlyV1 <FLY_ACCESS_TOKEN>
 
     ## @param machines_api_endpoint - string - optional
     ## Endpoint of the Fly.io Machines Restful API.


### PR DESCRIPTION
### What does this PR do?
Updates Fly.io docs with recommendation to use the new readonly auth token  https://fly.io/docs/security/tokens/
### Motivation
There is a new type of auth token recommended by Fly.io, it's more secure, and it is used differently in headers
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
