### PR TITLE
Downgrade paramiko back to 3.5.1

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -42,7 +42,7 @@ orjson,PyPI,Apache-2.0,
 orjson,PyPI,MIT,
 packaging,PyPI,Apache-2.0,Copyright (c) Donald Stufft and individual contributors.
 packaging,PyPI,BSD-3-Clause,Copyright (c) Donald Stufft and individual contributors.
-paramiko,PyPI,LGPL-2.1-only,Copyright (C) 2009 Jeff Forcier <jeff@bitprophet.org>
+paramiko,PyPI,LGPL-2.1-only,Copyright (C) 2009 Jeff Forcier
 ply,PyPI,BSD-3-Clause,Copyright (C) 2001-2018
 prometheus-client,PyPI,Apache-2.0,Copyright 2015 The Prometheus Authors
 protobuf,PyPI,BSD-3-Clause,Copyright 2008 Google Inc.  All rights reserved.

--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -28,7 +28,7 @@ oauthlib==3.3.1
 openstacksdk==4.7.0
 orjson==3.11.3
 packaging==25.0
-paramiko==4.0.0
+paramiko==3.5.1
 ply==3.11
 prometheus-client==0.22.1
 protobuf==6.32.0

--- a/ssh_check/changelog.d/21266.fixed
+++ b/ssh_check/changelog.d/21266.fixed
@@ -1,0 +1,1 @@
+Downgrade paramiko dependency

--- a/ssh_check/pyproject.toml
+++ b/ssh_check/pyproject.toml
@@ -36,7 +36,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "paramiko==4.0.0",
+    "paramiko==3.5.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?
Paramiko upgrade came with Invoke that breaks the dependency resolution pipeline.
