### PR TITLE
Fix flaky Postgres cursor test

### DIFF
--- a/postgres/tests/test_cursor.py
+++ b/postgres/tests/test_cursor.py
@@ -7,10 +7,10 @@ from .utils import _get_superconn
 
 
 @pytest.mark.integration
-@pytest.mark.flaky
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize('ignore', [True, False])
 def test_integration_connection_with_commenter_cursor(integration_check, pg_instance, ignore):
+    pg_instance['application_name'] = 'test_integration_connection_with_commenter_cursor_{}'.format(ignore)
     check = integration_check(pg_instance)
 
     with check.db() as conn:
@@ -44,14 +44,19 @@ def __check_prepand_sql_comment(pg_instance, ignore):
     with super_conn.cursor() as cursor:
         cursor.execute(
             (
-                "SELECT query FROM pg_stat_activity where query like '%generate_series%' "
+                "SELECT query FROM pg_stat_activity where application_name = %s and query like '%%generate_series%%' "
                 "and query not like '%%pg_stat_activity%%'"
-            )
+            ),
+            (pg_instance['application_name'],),
         )
         result = cursor.fetchall()
         assert len(result) > 0
         comment = '/* service=\'datadog-agent\' */'
         if ignore:
             comment = '{} {}'.format('/* DDIGNORE */', comment)
-        assert result[0][0].startswith(comment)
+        assert result[0][0].startswith(comment), (
+            "Expected to filter by application_name {} for comment {} but got {}".format(
+                pg_instance['application_name'], comment, result[0][0]
+            )
+        )
     super_conn.close()


### PR DESCRIPTION
### What does this PR do?
Fixes a flaky test by scoping the queries we're filtering for to the specific test that's running. Previously this test could flake due to previously ran queries from other tests still existing in `pg_stat_activity` table as this cleanup happens on Postgres container async. This became more frequent of an issue after #21173 due to a new test `test_commenter_cursor_functionality` which has similar functionality goals of  `test_integration_connection_with_commenter_cursor` but scoped to our connection_pool classes connections. Depending on the order that these tests ran we could see incorrect count of queries returning so the first result that we check against would be incorrect. Now we're only looking for queries specifically from this test execution run

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
