### PR TITLE
Increate TTL in RateLimitingTTLCache cache test

### DIFF
--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -105,7 +105,7 @@ def test_constant_rate_limiter_shell_execute():
 
 
 def test_ratelimiting_ttl_cache():
-    ttl = 0.1
+    ttl = 2
     cache = RateLimitingTTLCache(maxsize=5, ttl=ttl)
 
     for i in range(5):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Increase the TTL of the cache on the RateLimitingTTLCache tests.

### Motivation
<!-- What inspired you to submit this pull request? -->
We have had some tests failing in Windows for checks base (see [here](https://github.com/DataDog/integrations-core/actions/runs/17552745392/job/49848986993?pr=21288)). The first element in the cache disappears by the time we want to validate we cannot add more, but we can, because the first one disappeared.

Increasing the TTL to 2 seconds is more than enough to avoid having elements removed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
