### PR TITLE
Update README.md

### DIFF
--- a/redisdb/README.md
+++ b/redisdb/README.md
@@ -212,7 +212,7 @@ spec:
         - containerPort: 6379
 ```
 
-**Notes**: 
+**Note**: 
 - If no user is specified in the configuration, the Redis integration authenticates with the `default` user. The password specified in the configuration therefore applies to `default` user.
 - The `"%%env_<ENV_VAR>%%"` template variable logic is used to avoid storing the password in plain text, hence the `REDIS_PASSWORD` environment variable must be set on the Agent container. See the [Autodiscovery Template Variable][9] documentation. Alternatively, the Agent can leverage the `secrets` package to work with any [secrets management][10] backend (such as HashiCorp Vault or AWS Secrets Manager).
 

--- a/redisdb/README.md
+++ b/redisdb/README.md
@@ -212,7 +212,7 @@ spec:
         - containerPort: 6379
 ```
 
-**Note**: The `"%%env_<ENV_VAR>%%"` template variable logic is used to avoid storing the password in plain text, hence the `REDIS_PASSWORD` environment variable must be set on the Agent container. See the [Autodiscovery Template Variable][9] documentation. Alternatively, the Agent can leverage the `secrets` package to work with any [secrets management][10] backend (such as HashiCorp Vault or AWS Secrets Manager).
+**Note**: By default, Redis integration authenticates with the `default` user, so the password specified in the configuration applies to `default` user. The `"%%env_<ENV_VAR>%%"` template variable logic is used to avoid storing the password in plain text, hence the `REDIS_PASSWORD` environment variable must be set on the Agent container. See the [Autodiscovery Template Variable][9] documentation. Alternatively, the Agent can leverage the `secrets` package to work with any [secrets management][10] backend (such as HashiCorp Vault or AWS Secrets Manager).
 
 ##### Log collection
 

--- a/redisdb/README.md
+++ b/redisdb/README.md
@@ -212,7 +212,9 @@ spec:
         - containerPort: 6379
 ```
 
-**Note**: By default, Redis integration authenticates with the `default` user, so the password specified in the configuration applies to `default` user. The `"%%env_<ENV_VAR>%%"` template variable logic is used to avoid storing the password in plain text, hence the `REDIS_PASSWORD` environment variable must be set on the Agent container. See the [Autodiscovery Template Variable][9] documentation. Alternatively, the Agent can leverage the `secrets` package to work with any [secrets management][10] backend (such as HashiCorp Vault or AWS Secrets Manager).
+**Notes**: 
+- If no user is specified in the configuration, the Redis integration authenticates with the `default` user. The password specified in the configuration therefore applies to `default` user.
+- The `"%%env_<ENV_VAR>%%"` template variable logic is used to avoid storing the password in plain text, hence the `REDIS_PASSWORD` environment variable must be set on the Agent container. See the [Autodiscovery Template Variable][9] documentation. Alternatively, the Agent can leverage the `secrets` package to work with any [secrets management][10] backend (such as HashiCorp Vault or AWS Secrets Manager).
 
 ##### Log collection
 


### PR DESCRIPTION
Update password note as per feedback from customer. I'd like to inform you that we were finally able to setup the Redis integration using the annotation with Redis support. The structure of the annotation, the endpoint and port were correct but the password apparently was supposed to be the password for the 'default' user. We use in our application (the Pod running in EKS where we place the annotation) different credentials, specific user with access to the DB, but apparently for this integration, the 'default' is needed.

### What does this PR do?
Update do Redis integration doc regarding password. The password in the configuration refers to `default` user

### Motivation
https://datadog.zendesk.com/agent/tickets/2200140

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
