### PR TITLE
Scope Postgres test container state to module

### DIFF
--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -125,7 +125,7 @@ def metrics_cache_replica(pg_replica_instance):
     return PostgresMetricsCache(config)
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='module')
 def e2e_instance():
     instance = copy.deepcopy(INSTANCE)
     instance['dbm'] = True


### PR DESCRIPTION
### What does this PR do?
Many of the flaky test failures we see from Postgres integration today are due to state leak within the Postgres test container we query. This changes the life cycle of the DB from the full test suite to the individual modules to help avoid test state leak between modules

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
