### PR TITLE
[DBMON-5640] Postgres - Compile and reuse regex patterns

### DIFF
--- a/postgres/datadog_checks/postgres/explain_parameterized_queries.py
+++ b/postgres/datadog_checks/postgres/explain_parameterized_queries.py
@@ -12,6 +12,9 @@ from datadog_checks.base.utils.tracking import tracked_method
 from .util import DBExplainError
 from .version_utils import V12
 
+# Pre-compiled regex patterns for performance optimization
+PARAMETERIZED_QUERY_PATTERN = re.compile(r"(?<!')\$(?!'\$')[\d]+(?!')")
+
 logger = logging.getLogger(__name__)
 
 PREPARE_STATEMENT_QUERY = 'PREPARE dd_{query_signature} AS {statement}'
@@ -197,5 +200,4 @@ class ExplainParameterizedQueries:
         # BUT single quoted string '$1' should not be considered as a parameter
         # e.g. SELECT * FROM products WHERE id = $1; -- $1 is a parameter
         # e.g. SELECT * FROM products WHERE id = '$1'; -- '$1' is not a parameter
-        parameterized_query_pattern = r"(?<!')\$(?!'\$')[\d]+(?!')"
-        return re.search(parameterized_query_pattern, statement) is not None
+        return PARAMETERIZED_QUERY_PATTERN.search(statement) is not None

--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -7,6 +7,10 @@ from semver import VersionInfo
 
 from datadog_checks.base.log import get_check_logger
 
+DEV_VERSION_PATTERN = re.compile(r'(\d+)([a-zA-Z]+)(\d+)')
+RDS_VERSION_PATTERN = re.compile(r'(\d+\.\d+)-rds\.(\d+)')
+VERSION_SPLIT_PATTERN = re.compile(r'[ _]')
+
 V8_3 = VersionInfo.parse("8.3.0")
 V9 = VersionInfo.parse("9.0.0")
 V9_1 = VersionInfo.parse("9.1.0")
@@ -70,7 +74,7 @@ class VersionUtils(object):
             pass
         try:
             # Version may be missing minor eg: 10.0 and it might have an edition suffix (e.g. 12.3_TDE_1.0)
-            version = re.split('[ _]', raw_version)[0].split('.')
+            version = VERSION_SPLIT_PATTERN.split(raw_version)[0].split('.')
             version = [int(part) for part in version]
             while len(version) < 3:
                 version.append(0)
@@ -79,7 +83,7 @@ class VersionUtils(object):
             pass
         try:
             # Postgres might be in development, with format \d+[beta|rc]\d+
-            match = re.match(r'(\d+)([a-zA-Z]+)(\d+)', raw_version)
+            match = DEV_VERSION_PATTERN.match(raw_version)
             if match:
                 version = list(match.groups())
                 return VersionInfo.parse('{}.0.0-{}.{}'.format(*version))
@@ -88,7 +92,7 @@ class VersionUtils(object):
         except ValueError:
             # RDS changes the version format when the version switches to EOL.
             # Example: 11.22-rds.20241121.
-            match = re.match(r'(\d+\.\d+)-rds\.(\d+)', raw_version)
+            match = RDS_VERSION_PATTERN.match(raw_version)
             if match:
                 version = list(match.groups())
                 return VersionInfo.parse('{}.{}'.format(*version))


### PR DESCRIPTION
### What does this PR do?
This PR compiles and reuses regex patterns in the Postgres integration to avoid rebuilding the pattern frequently

### Motivation

- `PARAMETERIZED_QUERY_PATTERN` - This is a fairly expensive regex pattern that does lookaheads and lookbacks of capture groups. We run this static regex pattern in a tight loop for each query sampled that is explained vis parameterized query. This should have the most benefit seen
- Metadata Schema include/exclude patterns - We're currently recompiling the patterns loaded from user configs multiple times each schema collection. This will typically be a small number of includes or exclude patterns. Now we'll compile them on first access and cache it for later use.
- Version parsing patterns - These are called up to once per check run. Minor anticipated benefit from compiling these.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
