### PR TITLE
[DBMON-5640] SqlServer - compile and reuse connection error regex

### DIFF
--- a/sqlserver/changelog.d/21319.fixed
+++ b/sqlserver/changelog.d/21319.fixed
@@ -1,0 +1,1 @@
+Compile and reuse connection error regex patterns


### PR DESCRIPTION
### What does this PR do?
This PR compiles and reuses regex patterns in the SqlServer integration to avoid rebuilding the pattern frequently

### Motivation
For each connection error we currently loop through a static list of connection error regex patterns that we're dynamically searching for each time. We can pre compile all these regex patterns to avoid recomputing

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
