### PR TITLE
[Backport 7.53.x] Fix redisdb check on Redis 8 (#20227)

### DIFF
--- a/redisdb/changelog.d/20227.added
+++ b/redisdb/changelog.d/20227.added
@@ -1,0 +1,1 @@
+Add support of Redis 8

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -24,7 +24,7 @@ DEFAULT_CLIENT_NAME = "unknown"
 
 
 class Redis(AgentCheck):
-    db_key_pattern = re.compile(r'^db\d+')
+    db_key_pattern = re.compile(r'^db\d+$')
     slave_key_pattern = re.compile(r'^slave\d+')
     subkeys = ['keys', 'expires']
 

--- a/redisdb/hatch.toml
+++ b/redisdb/hatch.toml
@@ -2,12 +2,12 @@
 
 [[envs.default.matrix]]
 python = ["2.7", "3.11"]
-version = ["5.0", "6.0", "7.0", "cloud"]
+version = ["5.0", "6.0", "7.0", "8.0", "cloud"]
 
 [envs.default.overrides]
 matrix.version.env-vars = [
-  { key = "REDIS_VERSION", if = ["5.0", "6.0", "7.0"] },
-  { key = "CLOUD_ENV", value = "false", if = ["5.0", "6.0", "7.0"] },
+  { key = "REDIS_VERSION", if = ["5.0", "6.0", "7.0", "8.0"] },
+  { key = "CLOUD_ENV", value = "false", if = ["5.0", "6.0", "7.0", "8.0"] },
   { key = "REDIS_VERSION", value="7.0", if = ["cloud"] },
   { key = "CLOUD_ENV", value = "true", if = ["cloud"] },
 ]


### PR DESCRIPTION
### Motivation
Fix the Agent6 branch of the `datadog-agent` repo

