### PR TITLE
Add dummy workflow to test workflow_run trigger

### DIFF
--- a/.github/workflows/testing-run-on-wf-run.yml
+++ b/.github/workflows/testing-run-on-wf-run.yml
@@ -1,13 +1,10 @@
 name: Run on PR Check
 
 on:
-  # workflow_run:
-  #   workflows: ['Check PR']
-  #   types:
-  #     - completed
-  pull_request:
-    branches:
-      - master
+  workflow_run:
+    workflows: ['Check PR']
+    types:
+      - completed
 
 jobs:
   run-on-pr-check:


### PR DESCRIPTION
### What does this PR do?
This PR creates a dummy GitHub Actions workflow that runs once the PR check has finished and prints the workflow PR check run ID.

### Motivation
The `on: workflow_run` trigger cannot be tested within a branch, it only works once the workflow exists in the master branch. This dummy workflow provides a way to validate and test the trigger behavior.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
