### PR TITLE
Add get_merge_base to ddev git 

### DIFF
--- a/ddev/changelog.d/21340.added
+++ b/ddev/changelog.d/21340.added
@@ -1,1 +1,1 @@
-Adds a new helper method `get_merge_base` in the `GitRepository` class. 
+Adds a new method `get_merge_base` in the `GitRepository` class. 

--- a/ddev/changelog.d/21340.added
+++ b/ddev/changelog.d/21340.added
@@ -1,1 +1,1 @@
-Adds a new method `get_merge_base` in the `GitRepository` class. 
+Adds a new method `merge_base` in the `GitRepository` class. 

--- a/ddev/changelog.d/21340.added
+++ b/ddev/changelog.d/21340.added
@@ -1,1 +1,1 @@
-Adds a new helper method `get_merge_base` in the `GitRepository` class. It returns the commit hash of the common ancestor between HEAD and the given reference.
+Adds a new helper method `get_merge_base` in the `GitRepository` class. 

--- a/ddev/changelog.d/21340.added
+++ b/ddev/changelog.d/21340.added
@@ -1,0 +1,1 @@
+Adds a new helper method `get_merge_base` in the `GitRepository` class. It returns the commit hash of the common ancestor between HEAD and the given reference.

--- a/ddev/src/ddev/utils/git.py
+++ b/ddev/src/ddev/utils/git.py
@@ -125,6 +125,9 @@ class GitRepository:
 
         return process.stdout
 
+    def get_merge_base(self, ref: str) -> str:
+        return self.capture('merge-base', 'HEAD', ref).splitlines()[0]
+
     @staticmethod
     def __is_warning_line(line):
         return line.startswith('warning: ') or 'original line endings' in line

--- a/ddev/src/ddev/utils/git.py
+++ b/ddev/src/ddev/utils/git.py
@@ -125,8 +125,8 @@ class GitRepository:
 
         return process.stdout
 
-    def merge_base(self, refA: str, refB: str | None = "HEAD") -> str:
-        return self.capture('merge-base', refA, refB).splitlines()[0]
+    def merge_base(self, ref_a: str, ref_b: str | None = "HEAD") -> str:
+        return self.capture('merge-base', ref_a, ref_b).splitlines()[0]
 
     @staticmethod
     def __is_warning_line(line):

--- a/ddev/src/ddev/utils/git.py
+++ b/ddev/src/ddev/utils/git.py
@@ -125,8 +125,8 @@ class GitRepository:
 
         return process.stdout
 
-    def get_merge_base(self, ref: str) -> str:
-        return self.capture('merge-base', 'HEAD', ref).splitlines()[0]
+    def merge_base(self, refA: str, refB: str | None = "HEAD") -> str:
+        return self.capture('merge-base', refA, refB).splitlines()[0]
 
     @staticmethod
     def __is_warning_line(line):

--- a/ddev/tests/utils/test_git.py
+++ b/ddev/tests/utils/test_git.py
@@ -108,8 +108,8 @@ def test_fetch_tags(repository, mocker):
 def test_get_merge_base(repository):
     repo = Repository(repository.path.name, str(repository.path))
     commit = repo.git.latest_commit()
-    repo.git.capture('branch', 'test')
-    repo.git.capture('checkout', 'test')
+    repo.git.capture('branch', 'test_merge_base')
+    repo.git.capture('checkout', 'test_merge_base')
     (repo.path / 'test1.txt').touch()
     repo.git.capture('add', '.')
     repo.git.capture('commit', '-m', 'test1')
@@ -121,20 +121,20 @@ def test_get_merge_base_two_branches(repository):
     repo = Repository(repository.path.name, str(repository.path))
     commit = repo.git.latest_commit()
 
-    repo.git.capture('branch', 'test')
-    repo.git.capture('checkout', 'test')
+    repo.git.capture('branch', 'test1_merge_base')
+    repo.git.capture('checkout', 'test1_merge_base')
 
     (repo.path / 'test1.txt').touch()
     repo.git.capture('add', '.')
     repo.git.capture('commit', '-m', 'test1')
 
-    repo.git.capture('branch', 'test2')
+    repo.git.capture('branch', 'test2_merge_base')
 
     (repo.path / 'test1_1.txt').touch()
     repo.git.capture('add', '.')
     repo.git.capture('commit', '-m', 'test1_1')
 
-    repo.git.capture('checkout', 'test2')
+    repo.git.capture('checkout', 'test2_merge_base')
     (repo.path / 'test2_1.txt').touch()
     repo.git.capture('add', '.')
     repo.git.capture('commit', '-m', 'test2')

--- a/ddev/tests/utils/test_git.py
+++ b/ddev/tests/utils/test_git.py
@@ -107,22 +107,23 @@ def test_fetch_tags(repository, mocker):
 
 def test_get_merge_base(repository):
     repo = Repository(repository.path.name, str(repository.path))
-    commit = repo.git.latest_commit()
-    repo.git.capture('branch', 'test_merge_base')
-    repo.git.capture('checkout', 'test_merge_base')
+    base_commit = repo.git.latest_commit()
+    repo.git.capture('checkout', '-b', 'test_merge_base')
+
     (repo.path / 'test1.txt').touch()
     repo.git.capture('add', '.')
     repo.git.capture('commit', '-m', 'test1')
-    base = repo.git.get_merge_base('origin/master')
-    assert base == commit.sha
+
+    base = repo.git.merge_base('origin/master')
+
+    assert base == base_commit.sha
 
 
 def test_get_merge_base_two_branches(repository):
     repo = Repository(repository.path.name, str(repository.path))
-    commit = repo.git.latest_commit()
+    base_commit = repo.git.latest_commit()
 
-    repo.git.capture('branch', 'test1_merge_base')
-    repo.git.capture('checkout', 'test1_merge_base')
+    repo.git.capture('checkout', '-b', 'test1_merge_base')
 
     (repo.path / 'test1.txt').touch()
     repo.git.capture('add', '.')
@@ -138,5 +139,5 @@ def test_get_merge_base_two_branches(repository):
     (repo.path / 'test2_1.txt').touch()
     repo.git.capture('add', '.')
     repo.git.capture('commit', '-m', 'test2')
-    base = repo.git.get_merge_base('origin/master')
-    assert base == commit.sha
+    base = repo.git.merge_base('origin/master')
+    assert base == base_commit.sha

--- a/ddev/tests/utils/test_git.py
+++ b/ddev/tests/utils/test_git.py
@@ -103,3 +103,40 @@ def test_fetch_tags(repository, mocker):
             check=True,
         ),
     ]
+
+
+def test_get_merge_base(repository):
+    repo = Repository(repository.path.name, str(repository.path))
+    commit = repo.git.latest_commit()
+    repo.git.capture('branch', 'test')
+    repo.git.capture('checkout', 'test')
+    (repo.path / 'test1.txt').touch()
+    repo.git.capture('add', '.')
+    repo.git.capture('commit', '-m', 'test1')
+    base = repo.git.get_merge_base('origin/master')
+    assert base == commit.sha
+
+
+def test_get_merge_base_two_branches(repository):
+    repo = Repository(repository.path.name, str(repository.path))
+    commit = repo.git.latest_commit()
+
+    repo.git.capture('branch', 'test')
+    repo.git.capture('checkout', 'test')
+
+    (repo.path / 'test1.txt').touch()
+    repo.git.capture('add', '.')
+    repo.git.capture('commit', '-m', 'test1')
+
+    repo.git.capture('branch', 'test2')
+
+    (repo.path / 'test1_1.txt').touch()
+    repo.git.capture('add', '.')
+    repo.git.capture('commit', '-m', 'test1_1')
+
+    repo.git.capture('checkout', 'test2')
+    (repo.path / 'test2_1.txt').touch()
+    repo.git.capture('add', '.')
+    repo.git.capture('commit', '-m', 'test2')
+    base = repo.git.get_merge_base('origin/master')
+    assert base == commit.sha


### PR DESCRIPTION
### What does this PR do?
Adds a new helper method `get_merge_base` in the `GitRepository` class in `ddev`. It returns the commit hash of the common ancestor between HEAD and the given reference. 

### Motivation
The quality gates need to get the merge base in order to compare sizes in PRs.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
