### PR TITLE
[REMED-230] Adding template for OOMKilled monitors

### DIFF
--- a/kubernetes/assets/monitors/monitor_pod_oomkilled.json
+++ b/kubernetes/assets/monitors/monitor_pod_oomkilled.json
@@ -1,0 +1,33 @@
+{
+  "version": 2,
+  "created_at": "2025-09-15",
+  "last_updated_at": "2025-09-15",
+  "title": "Pod is in an OOMKilled state",
+  "tags": [
+    "integration:kubernetes"
+  ],
+  "description": "The status OOMKilled means that a container was killed because it exceeded memory limits or the node ran out of available memory. This monitor tracks when a pod is in an OOMKilled state for your Kubernetes integration.",
+  "definition": {
+    "message": "pod {{pod_name.name}} is in OOMKilled on {{kube_namespace.name}} \n This could happen for several reasons, for example insufficient memory limits, memory leaks in the application, or the node running out of available memory.",
+    "name": "[Kubernetes] Pod {{pod_name.name}} is OOMKilled on namespace {{kube_namespace.name}}",
+    "options": {
+      "escalation_message": "",
+      "include_tags": true,
+      "locked": false,
+      "new_host_delay": 300,
+      "notify_audit": true,
+      "notify_no_data": false,
+      "renotify_interval": 0,
+      "require_full_window": false,
+      "thresholds": {
+        "critical": 1
+      },
+      "timeout_h": 0
+    },
+    "query": "max(last_10m):default_zero(max:kubernetes_state.container.status_report.count.waiting{reason:oomkilled} by {kube_cluster_name,kube_namespace,pod_name}) >= 1",
+    "tags": [
+      "integration:kubernetes"
+    ],
+    "type": "query alert"
+  }
+}

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -71,6 +71,7 @@
       "Nodes are unavailable": "assets/monitors/monitor_node_unavailable.json",
       "Pod is in a CrashloopBackOff state": "assets/monitors/monitor_pod_crashloopbackoff.json",
       "Pod is in an ImagePullBackOff state": "assets/monitors/monitor_pod_imagepullbackoff.json",
+      "Pod is in an OOMKilled state": "assets/monitors/monitor_pod_oomkilled.json",
       "Pods are failing": "assets/monitors/monitor_pods_failed_state.json",
       "Pods are restarting": "assets/monitors/monitor_pods_restarting.json",
       "Kubernetes Statefulset Replicas are failing": "assets/monitors/monitor_statefulset_replicas.json"


### PR DESCRIPTION
### What does this PR do?

This pull request extends the integration between Kubernetes Remediation and Datadog monitors by adding support for OOMKilled workloads. Specifically:

- Introduces a new JSON definition file for OOMKilled pods with the reason:oomkilled tag enabled.
- Updates the manifest.json file to include a new path for handling OOMKilled monitors.
- Ensures that users can now view Remediation Affected Workloads when a pod enters an OOMKilled state.
- Provides a new monitor template in staging for Pods in the OOMKilled state, allowing configuration and creation of corresponding monitors.
<img width="1901" height="1040" alt="Screenshot 2025-09-15 at 2 35 46 PM" src="https://github.com/user-attachments/assets/e540112a-9a5f-4129-be90-0afd6343e368" />



### Motivation

The motivation for this change is to expand existing remediation functionality to include Out-Of-Memory (OOM) killed scenarios. Previously, remediation only covered certain workload failure reasons; with this enhancement, users gain visibility into OOMKilled workloads and can act on them through monitors.

This update follows the steps outlined in the [Recommended Monitors v2 schema documentation](https://datadoghq.atlassian.net/wiki/spaces/AP/pages/2258307734/Recommended+Monitors#v2-schema).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [x] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
