### PR TITLE
Update Postgres function definition of datadog.explain_statement to use a read-only transaction

### DIFF
--- a/postgres/tests/compose/resources/02_setup.sh
+++ b/postgres/tests/compose/resources/02_setup.sh
@@ -45,6 +45,8 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" "$DBNAME" <<-'EOSQL'
     plan JSON;
 
     BEGIN
+      SET TRANSACTION READ ONLY;
+
       OPEN curs FOR EXECUTE pg_catalog.concat('EXPLAIN (FORMAT JSON) ', l_query);
       FETCH curs INTO plan;
       CLOSE curs;


### PR DESCRIPTION
### What does this PR do?

Ensures the datadog.explain_statement statement executes with read-only transaction state. While this change does not affect the behavior of the Agent (only the test data is changed), the function definition will be modified in the documentation to match this. 

### Motivation

There is no known vulnerability to execute the query passed to the function or escape the EXPLAIN command, however this mitigates the blast radius if such a vulnerability is discovered.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
