### PR TITLE
Add dummy workflow to test workflow_run trigger

### DIFF
--- a/.github/workflows/testing-run-on-wf-run.yml
+++ b/.github/workflows/testing-run-on-wf-run.yml
@@ -1,10 +1,11 @@
 name: Run on PR Check
 
 on:
-  workflow_run:
-    workflows: ['Check PR']
-    types:
-      - completed
+  # workflow_run:
+  #   workflows: ['Check PR']
+  #   types:
+  #     - completed
+  pull_request:
 
 jobs:
   run-on-pr-check:
@@ -18,22 +19,28 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
+      - name: Wait
+        run: |
+          sleep 100
       - name: Define SHA
+        id: define_sha
         run: |
           # Determine if the triggering event was a push or a pull request
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            echo "Triggered by push"
-            sha=${{ github.sha }}
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "Triggered by pull_request"
-            sha=${{ github.event.pull_request.head.sha }}
-          else
-            echo "Triggered by unknown event: ${{ github.event_name }}"
-            sha=${{ github.sha }}
-          fi
+          # if [[ "${{ github.event.workflow_run.event }}" == "push" ]]; then
+          #   echo "Triggered by push"
+          #   sha=${{ github.sha }}
+          # elif [[ "${{ github.event.workflow_run.event }}" == "pull_request" ]]; then
+          #   echo "Triggered by pull_request"
+          #   sha=${{ github.event.pull_request.head.sha }}
+          # else
+          #   echo "Triggered by unknown event: ${{ github.event.workflow_run.event }}"
+          #   sha=${{ github.sha }}
+          # fi
+          sha = ${{ github.event.pull_request.head.sha }}
           echo "sha=$sha" >> $GITHUB_OUTPUT
- 
-          run_id=$(gh run list --workflow "Check PR" -c $sha --json databaseId --jq '.[-1].databaseId')
-          echo "Run ID: $run_id"
+      - name: Get run ID
+        run: |
+          run_id=$(gh run list --workflow "Check PR" -c ${{ steps.define_sha.outputs.sha }} --json databaseId --jq '.[-1].databaseId')
+          echo "run_id=$run_id"          
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What does this PR do?
This PR creates a dummy GitHub Actions workflow that runs once the PR check has finished and prints the workflow PR check run ID.

### Motivation
The `on: workflow_run` trigger cannot be tested within a branch, it only works once the workflow exists in the master branch. This dummy workflow provides a way to validate and test the trigger behavior.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
