### PR TITLE
Add dummy workflow to test workflow_run trigger

### DIFF
--- a/.github/workflows/testing-run-on-wf-run.yml
+++ b/.github/workflows/testing-run-on-wf-run.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
@@ -22,17 +23,7 @@ jobs:
       - name: Define SHA
         id: define_sha
         run: |
-          # Determine if the triggering event was a push or a pull request
-          if [[ "${{ github.event.workflow_run.event }}" == "push" ]]; then
-            echo "Triggered by push"
-            echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event.workflow_run.event }}" == "pull_request" ]]; then
-            echo "Triggered by pull_request"
-            echo "sha=${{ github.event.workflow_run.event.head.sha }}" >> $GITHUB_OUTPUT
-          else
-            echo "Triggered by unknown event: ${{ github.event.workflow_run.event }}"
-            echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
-          fi
+          echo "sha=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_OUTPUT
       - name: Get run ID
         run: |
           echo "run_id_variable=${{ github.event.workflow_run.id }}"         

--- a/.github/workflows/testing-run-on-wf-run.yml
+++ b/.github/workflows/testing-run-on-wf-run.yml
@@ -28,15 +28,15 @@ jobs:
             echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event.workflow_run.event }}" == "pull_request" ]]; then
             echo "Triggered by pull_request"
-            echo "sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+            echo "sha=${{ github.event.workflow_run.event.head.sha }}" >> $GITHUB_OUTPUT
           else
             echo "Triggered by unknown event: ${{ github.event.workflow_run.event }}"
             echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
           fi
       - name: Get run ID
         run: |
+          echo "run_id_variable=${{ github.event.workflow_run.id }}"         
           run_id=$(gh run list --workflow ".github/workflows/resolve-build-deps.yaml" -c ${{ steps.define_sha.outputs.sha }} --json databaseId --jq '.[-1].databaseId')
           echo "run_id_list=$run_id" 
-          echo "run_id_variable=${{ github.event.workflow_run.id }}"         
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testing-run-on-wf-run.yml
+++ b/.github/workflows/testing-run-on-wf-run.yml
@@ -1,10 +1,11 @@
 name: Run on PR Check
 
 on:
-  workflow_run:
-    workflows: ['Check PR']
-    types:
-      - completed
+  # workflow_run:
+  #   workflows: ['Check PR']
+  #   types:
+  #     - completed
+  pull_request:
 
 jobs:
   run-on-pr-check:
@@ -18,22 +19,28 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
+      - name: Wait
+        run: |
+          sleep 100
       - name: Define SHA
+        id: define_sha
         run: |
           # Determine if the triggering event was a push or a pull request
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            echo "Triggered by push"
-            sha=${{ github.sha }}
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "Triggered by pull_request"
-            sha=${{ github.event.pull_request.head.sha }}
-          else
-            echo "Triggered by unknown event: ${{ github.event_name }}"
-            sha=${{ github.sha }}
-          fi
+          # if [[ "${{ github.event.workflow_run.event }}" == "push" ]]; then
+          #   echo "Triggered by push"
+          #   sha=${{ github.sha }}
+          # elif [[ "${{ github.event.workflow_run.event }}" == "pull_request" ]]; then
+          #   echo "Triggered by pull_request"
+          #   sha=${{ github.event.pull_request.head.sha }}
+          # else
+          #   echo "Triggered by unknown event: ${{ github.event.workflow_run.event }}"
+          #   sha=${{ github.sha }}
+          # fi
+          sha = ${{ github.event.pull_request.head.sha }}
           echo "sha=$sha" >> $GITHUB_OUTPUT
- 
-          run_id=$(gh run list --workflow "Check PR" -c $sha --json databaseId --jq '.[-1].databaseId')
-          echo "Run ID: $run_id"
+      - name: Get run ID
+        run: |
+          run_id=$(gh run list --workflow "Check PR" -c ${{ steps.define_sha.outputs.sha }} --json databaseId --jq '.[-1].databaseId')
+          echo "run_id=$run_id"          
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testing-run-on-wf-run.yml
+++ b/.github/workflows/testing-run-on-wf-run.yml
@@ -36,8 +36,7 @@ jobs:
           #   echo "Triggered by unknown event: ${{ github.event.workflow_run.event }}"
           #   sha=${{ github.sha }}
           # fi
-          sha = ${{ github.event.pull_request.head.sha }}
-          echo "sha=$sha" >> $GITHUB_OUTPUT
+          echo "sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
       - name: Get run ID
         run: |
           run_id=$(gh run list --workflow "Check PR" -c ${{ steps.define_sha.outputs.sha }} --json databaseId --jq '.[-1].databaseId')

--- a/.github/workflows/testing-run-on-wf-run.yml
+++ b/.github/workflows/testing-run-on-wf-run.yml
@@ -2,7 +2,7 @@ name: Run on PR Check
 
 on:
   workflow_run:
-    workflows: ['Check PR']
+    workflows: ['Resolve Dependencies and Build Wheels']
     types:
       - completed
 

--- a/.github/workflows/testing-run-on-wf-run.yml
+++ b/.github/workflows/testing-run-on-wf-run.yml
@@ -35,7 +35,7 @@ jobs:
           fi
       - name: Get run ID
         run: |
-          run_id=$(gh run list --workflow "Check PR" -c ${{ steps.define_sha.outputs.sha }} --json databaseId --jq '.[-1].databaseId')
+          run_id=$(gh run list --workflow ".github/workflows/resolve-build-deps.yaml" -c ${{ steps.define_sha.outputs.sha }} --json databaseId --jq '.[-1].databaseId')
           echo "run_id_list=$run_id" 
           echo "run_id_variable=${{ github.event.workflow_run.id }}"         
         env:

--- a/.github/workflows/testing-run-on-wf-run.yml
+++ b/.github/workflows/testing-run-on-wf-run.yml
@@ -1,11 +1,10 @@
 name: Run on PR Check
 
 on:
-  # workflow_run:
-  #   workflows: ['Check PR']
-  #   types:
-  #     - completed
-  pull_request:
+  workflow_run:
+    workflows: ['Check PR']
+    types:
+      - completed
 
 jobs:
   run-on-pr-check:
@@ -19,27 +18,25 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
-      - name: Wait
-        run: |
-          sleep 100
+
       - name: Define SHA
         id: define_sha
         run: |
-          # Determine if the triggering event was a push or a pull request
-          # if [[ "${{ github.event.workflow_run.event }}" == "push" ]]; then
-          #   echo "Triggered by push"
-          #   sha=${{ github.sha }}
-          # elif [[ "${{ github.event.workflow_run.event }}" == "pull_request" ]]; then
-          #   echo "Triggered by pull_request"
-          #   sha=${{ github.event.pull_request.head.sha }}
-          # else
-          #   echo "Triggered by unknown event: ${{ github.event.workflow_run.event }}"
-          #   sha=${{ github.sha }}
-          # fi
-          echo "sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          Determine if the triggering event was a push or a pull request
+          if [[ "${{ github.event.workflow_run.event }}" == "push" ]]; then
+            echo "Triggered by push"
+            echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event.workflow_run.event }}" == "pull_request" ]]; then
+            echo "Triggered by pull_request"
+            echo "sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          else
+            echo "Triggered by unknown event: ${{ github.event.workflow_run.event }}"
+            echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+          fi
       - name: Get run ID
         run: |
           run_id=$(gh run list --workflow "Check PR" -c ${{ steps.define_sha.outputs.sha }} --json databaseId --jq '.[-1].databaseId')
-          echo "run_id=$run_id"          
+          echo "run_id_list=$run_id" 
+          echo "run_id_variable=${{ github.event.workflow_run.id }}"         
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testing-run-on-wf-run.yml
+++ b/.github/workflows/testing-run-on-wf-run.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Define SHA
         id: define_sha
         run: |
-          Determine if the triggering event was a push or a pull request
+          # Determine if the triggering event was a push or a pull request
           if [[ "${{ github.event.workflow_run.event }}" == "push" ]]; then
             echo "Triggered by push"
             echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/testing-run-on-wf-run.yml
+++ b/.github/workflows/testing-run-on-wf-run.yml
@@ -14,7 +14,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha }}
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:


### PR DESCRIPTION
### What does this PR do?
This PR creates a dummy GitHub Actions workflow that runs once the Resolve Build Deps has finished and prints the workflow run ID.

### Motivation
The `on: workflow_run` trigger cannot be tested within a branch, it only works once the workflow exists in the master branch. This dummy workflow provides a way to validate and test the trigger behavior.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
