### PR TITLE
Upgrade ddtrace to 3.12.5

### DIFF
--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -11,7 +11,7 @@ clickhouse-driver==0.2.9
 cm-client==45.0.4
 confluent-kafka==2.11.1
 cryptography==45.0.6
-ddtrace==3.12.3
+ddtrace==3.12.5
 dnspython==2.7.0
 fastavro==1.12.0
 foundationdb==6.3.25

--- a/datadog_checks_base/changelog.d/21360.added
+++ b/datadog_checks_base/changelog.d/21360.added
@@ -1,0 +1,1 @@
+Upgrade ddtrace to 3.12.5

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -37,7 +37,7 @@ deps = [
     "binary==1.0.2",
     "cachetools==6.2.0",
     "cryptography==45.0.6",
-    "ddtrace==3.12.3",
+    "ddtrace==3.12.5",
     "jellyfish==1.2.0",
     "lazy-loader==0.4",
     "prometheus-client==0.22.1",


### PR DESCRIPTION
### What does this PR do?
Upgrade ddtrace to 3.12.5. 3.12.3 had an issue that cause increase CPU usage.

https://github.com/DataDog/dd-trace-py/releases#:~:text=profiling%3A%20This%20fixes%20a%20performance%20regression%20where%20the%20memory%20profiler%27s%20collector%20thread%20would%20spin%20in%20a%20tight%20loop%2C%20consuming%20nearly%20a%20full%20CPU%20core.