### PR TITLE
[Backport 7.71.x] Upgrade ddtrace to 3.12.5

### DIFF
--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -11,7 +11,7 @@ clickhouse-driver==0.2.9
 cm-client==45.0.4
 confluent-kafka==2.8.0
 cryptography==45.0.6
-ddtrace==3.9.3
+ddtrace==3.12.5
 dnspython==2.7.0
 fastavro==1.12.0
 foundationdb==6.3.25

--- a/datadog_checks_base/changelog.d/21360.added
+++ b/datadog_checks_base/changelog.d/21360.added
@@ -1,0 +1,1 @@
+Upgrade ddtrace to 3.12.5

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -37,7 +37,7 @@ deps = [
     "binary==1.0.2",
     "cachetools==6.2.0",
     "cryptography==45.0.6",
-    "ddtrace==3.9.3",
+    "ddtrace==3.12.5",
     "jellyfish==1.2.0",
     "lazy-loader==0.4",
     "prometheus-client==0.22.1",


### PR DESCRIPTION
### What does this PR do?
Back port of https://github.com/DataDog/integrations-core/pull/21360.

3.12.3 was shown to cause an increase of CPU usage during QA. 
