### PR TITLE
Revert Redis module upgrade

### DIFF
--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -52,7 +52,7 @@ python3-gearman==0.1.0; sys_platform != 'win32'
 pyvmomi==8.0.3.0.1
 pywin32==311; sys_platform == 'win32'
 pyyaml==6.0.2
-redis==6.4.0
+redis==6.2.0
 requests-kerberos==0.15.0
 requests-ntlm==1.3.0
 requests-oauthlib==2.0.0

--- a/redisdb/changelog.d/21366.fixed
+++ b/redisdb/changelog.d/21366.fixed
@@ -1,0 +1,1 @@
+Downgrade redis module

--- a/redisdb/pyproject.toml
+++ b/redisdb/pyproject.toml
@@ -36,7 +36,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "redis==6.4.0",
+    "redis==6.2.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?
Revert the redis dependency back to 6.2.0. The 6.4.0 is causing issues with auth error in the internal redis sentinel check. 
