### PR TITLE
[7.71.x] Release integrations for RC5 (#21374)

### DIFF
--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- towncrier release notes start -->
 
+## 37.20.0 / 2025-09-17
+
+***Added***:
+
+* Add support for customizable cache keys to be used by the agent persistent cache. This allows integrations developers to define when the cache will be invalidated for each integration. ([#21316](https://github.com/DataDog/integrations-core/pull/21316))
+* Upgrade ddtrace to 3.12.5 ([#21360](https://github.com/DataDog/integrations-core/pull/21360))
+
 ## 37.19.0 / 2025-09-05
 
 ***Added***:

--- a/datadog_checks_base/changelog.d/21316.added
+++ b/datadog_checks_base/changelog.d/21316.added
@@ -1,1 +1,0 @@
-Add support for customizable cache keys to be used by the agent persistent cache. This allows integrations developers to define when the cache will be invalidated for each integration.

--- a/datadog_checks_base/changelog.d/21360.added
+++ b/datadog_checks_base/changelog.d/21360.added
@@ -1,1 +1,0 @@
-Upgrade ddtrace to 3.12.5

--- a/datadog_checks_base/datadog_checks/base/__about__.py
+++ b/datadog_checks_base/datadog_checks/base/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = "37.19.0"
+__version__ = "37.20.0"

--- a/redisdb/CHANGELOG.md
+++ b/redisdb/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 8.1.1 / 2025-09-17
+
+***Fixed***:
+
+* Downgrade redis module ([#21366](https://github.com/DataDog/integrations-core/pull/21366))
+
 ## 8.1.0 / 2025-09-05
 
 ***Added***:

--- a/redisdb/changelog.d/21366.fixed
+++ b/redisdb/changelog.d/21366.fixed
@@ -1,1 +1,0 @@
-Downgrade redis module

--- a/redisdb/datadog_checks/redisdb/__about__.py
+++ b/redisdb/datadog_checks/redisdb/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "8.1.0"
+__version__ = "8.1.1"

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -30,7 +30,7 @@ datadog-celery==2.0.1
 datadog-ceph==4.1.0; sys_platform != 'win32'
 datadog-cert-manager==6.0.1
 datadog-checkpoint-quantum-firewall==1.0.0
-datadog-checks-base==37.19.0
+datadog-checks-base==37.20.0
 datadog-checks-dependency-provider==3.0.0
 datadog-checks-downloader==8.0.0
 datadog-cilium==6.0.1
@@ -181,7 +181,7 @@ datadog-pulsar==3.2.1
 datadog-quarkus==2.0.1
 datadog-rabbitmq==8.1.0
 datadog-ray==3.0.1
-datadog-redisdb==8.1.0
+datadog-redisdb==8.1.1
 datadog-rethinkdb==5.1.0
 datadog-riak==5.1.1
 datadog-riakcs==4.8.0
@@ -228,7 +228,7 @@ datadog-twemproxy==3.0.0
 datadog-twistlock==6.0.1
 datadog-varnish==4.0.0
 datadog-vault==7.0.1
-datadog-velero==3.0.1
+datadog-velero==3.0.2
 datadog-vertica==6.1.1
 datadog-vllm==3.0.1
 datadog-voltdb==6.0.1

--- a/velero/CHANGELOG.md
+++ b/velero/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 3.0.2 / 2025-09-17
+
+***Fixed***:
+
+* Remove usage of bitnami images for testing and add ruff rules from parent directory ([#21274](https://github.com/DataDog/integrations-core/pull/21274))
+
 ## 3.0.1 / 2025-08-07 / Agent 7.70.0
 
 ***Fixed***:

--- a/velero/changelog.d/21274.fixed
+++ b/velero/changelog.d/21274.fixed
@@ -1,1 +1,0 @@
-Remove usage of bitnami images for testing and add ruff rules from parent directory

--- a/velero/datadog_checks/velero/__about__.py
+++ b/velero/datadog_checks/velero/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2025-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '3.0.1'
+__version__ = '3.0.2'


### PR DESCRIPTION
* [Release] Bumped datadog_checks_base version to 37.20.0

* [Release] Bumped redisdb version to 8.1.1

* [Release] Bumped velero version to 3.0.2

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
