### PR TITLE
IDP-592: set pdh_check owner to windows-products

### DIFF
--- a/pdh_check/manifest.json
+++ b/pdh_check/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "75f6813c-934c-4f1a-b8f4-71f9f1911165",
   "app_id": "pdh",
+  "owner": "windows-products",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
### What does this PR do?
Set the `owner` field to `windows-products` for `pdh_check`.

This info is from CODEOWNERS.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
