### PR TITLE
Fix OpenLDAP custom queries to use search_scope parameter

### DIFF
--- a/openldap/datadog_checks/openldap/openldap.py
+++ b/openldap/datadog_checks/openldap/openldap.py
@@ -5,6 +5,7 @@ import os
 import ssl
 
 import ldap3
+
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 
 

--- a/openldap/tests/conftest.py
+++ b/openldap/tests/conftest.py
@@ -5,6 +5,7 @@ import os
 from copy import deepcopy
 
 import pytest
+
 from datadog_checks.dev import TempDir, docker_run
 from datadog_checks.dev.fs import create_file, path_exists
 from datadog_checks.openldap import OpenLDAP

--- a/openldap/tests/test_check.py
+++ b/openldap/tests/test_check.py
@@ -5,6 +5,7 @@ import os
 
 import ldap3
 import pytest
+
 from datadog_checks.base.utils.platform import Platform
 
 from .common import _check

--- a/openldap/tests/test_unit.py
+++ b/openldap/tests/test_unit.py
@@ -6,6 +6,7 @@ import os
 
 import ldap3
 import pytest
+
 from datadog_checks.base.errors import CheckException
 
 from .common import HERE


### PR DESCRIPTION
### What does this PR do?
Fixes the OpenLDAP integration to properly use the `search_scope` parameter in custom queries. The parameter was documented in the configuration but was being ignored during LDAP search operations.

### Motivation
Users reported in #20685 that the `search_scope` parameter in OpenLDAP custom queries was not working as expected. The parameter is documented in `conf.yaml.example` but the actual search implementation was not using this parameter, making it impossible to control LDAP search scope (base, level, or subtree).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged