### PR TITLE
IDP - set agent-integrations as squid owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -405,10 +405,10 @@ datadog_checks_base/datadog_checks/base/checks/windows/              @DataDog/wi
 /sophos_central_cloud/manifest.json                                  @DataDog/saas-integrations @DataDog/documentation
 /sophos_central_cloud/assets/logs/                                   @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
-/squid/                                                              @DataDog/saas-integrations
-/squid/*.md                                                          @DataDog/saas-integrations @DataDog/documentation
-/squid/manifest.json                                                 @DataDog/saas-integrations @DataDog/documentation
-/squid/assets/logs/                                                  @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
+/squid/                                                              @DataDog/agent-integrations
+/squid/*.md                                                          @DataDog/agent-integrations @DataDog/documentation
+/squid/manifest.json                                                 @DataDog/agent-integrations @DataDog/documentation
+/squid/assets/logs/                                                  @DataDog/agent-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
 /ping_one/                                                           @DataDog/saas-integrations
 /ping_one/*.md                                                       @DataDog/saas-integrations @DataDog/documentation

--- a/squid/manifest.json
+++ b/squid/manifest.json
@@ -2,6 +2,7 @@
     "manifest_version": "2.0.0",
     "app_uuid": "de18c581-69ee-48cf-ba23-7794bfb7a4bd",
     "app_id": "squid",
+    "owner": "agent-integrations",
     "display_on_public_website": true,
     "tile": {
         "overview": "README.md#Overview",


### PR DESCRIPTION
### What does this PR do?
Set the `owner` field of `squid` to `agent-integrations`.
Also correct the CODEOWNERS.

Ref: 
- [How to setupa proxy server for the agent (Squid)]

Share


How to setup a proxy server for the Agent (Squid)]https://datadoghq.atlassian.net/wiki/spaces/TS/pages/2271380268/How+to+setup+a+proxy+server+for+the+Agent+Squid

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
