### PR TITLE
Upgrade tested version to `2.10.6` to not rely on bitnami images

### DIFF
--- a/kuma/hatch.toml
+++ b/kuma/hatch.toml
@@ -2,7 +2,7 @@
 
 [[envs.default.matrix]]
 python = ["3.12"]
-kuma_version = ["2.10.1"]
+kuma_version = ["2.10.6"]
 
 [envs.default.overrides]
 matrix.kuma_version.env-vars = "KUMA_VERSION"

--- a/kuma/tests/conftest.py
+++ b/kuma/tests/conftest.py
@@ -14,7 +14,7 @@ from datadog_checks.dev.subprocess import run_command
 
 
 def setup_kuma():
-    kuma_version = os.environ.get("KUMA_VERSION", "2.10.1")
+    kuma_version = os.environ.get("KUMA_VERSION", "2.10.6")
     run_command(["kubectl", "create", "namespace", "kuma-system"])
     run_command(["helm", "repo", "add", "kuma", "https://kumahq.github.io/charts"])
     run_command(["helm", "repo", "update"])


### PR DESCRIPTION
### What does this PR do?
Upgrades kuma e2e version to `2.10.1` that doesn't depend on bitnami. 2.10.1


### Motivation
Bitnami images are being removed: https://github.com/bitnami/charts/issues/35164

And kuma used to rely on them: https://github.com/kumahq/kuma/releases/tag/2.10.6

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
