### PR TITLE
[AI-6103] Use bitnamilegacy for pgbouncer E2E

### DIFF
--- a/pgbouncer/tests/compose/docker-compose-v3.yml
+++ b/pgbouncer/tests/compose/docker-compose-v3.yml
@@ -9,7 +9,8 @@ services:
       - "5432:5432"
 
   pgbouncer:
-    image: "bitnami/pgbouncer:${PGBOUNCER_IMAGE_TAG}"
+    # TODO: use a different source than bitnamilegacy as it will no longer be updated
+    image: "bitnamilegacy/pgbouncer:${PGBOUNCER_IMAGE_TAG}"
     environment:
       POSTGRESQL_USERNAME: postgres
       POSTGRESQL_PASSWORD: d@tadog


### PR DESCRIPTION
### What does this PR do?
Use `bitnamilegacy` image for pgbouncer E2E env

### Motivation
bitnami images are being removed and there is a brownout now: https://github.com/bitnami/charts/issues/35164
the images are available from bitnamilegacy but they won't be updated, so we will need to migrate to a different source soon/ 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
