### PR TITLE
Add owner field to ML Observability manifest files

### DIFF
--- a/langchain/manifest.json
+++ b/langchain/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "7993851f-d36b-40f3-8425-92080f3b9d61",
   "app_id": "langchain",
+  "owner": "ml-observability",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/openai/manifest.json
+++ b/openai/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "46e76528-8e93-4a7c-9299-387ce0a905c6",
   "app_id": "openai",
+  "owner": "ml-observability",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add \`owner\` field set to \`"ml-observability"\` to manifest.json files for ML Observability.

This provides clear ownership tracking for AI/ML observability integrations (langchain and openai) as part of the initiative to add owner fields to all integration manifest.json files.

**Note:** These integrations are our best guesses for the team. If you don't own these integrations or if we're missing any integrations owned by this team, please let us know.

**For reviewer:** Please confirm:
1. Is \`ml-observability\` the correct datadog team slug in org 2?
2. Is \`ML Observability\` the correct workday team name to use as the team tag in SDP?

This PR includes 2 integrations in integrations-core.