### PR TITLE
Add owner field to Network Device Monitoring Integrations manifest files

### DIFF
--- a/cisco_aci/manifest.json
+++ b/cisco_aci/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "fab40264-45aa-434b-9f9f-dc0ab609dd49",
   "app_id": "cisco-aci",
+  "owner": "network-device-monitoring-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add \`owner\` field set to \`"network-device-monitoring-integrations"\` to manifest.json files for Network Device Monitoring Integrations.

This provides clear ownership tracking for network device monitoring integration (cisco_aci) as part of the initiative to add owner fields to all integration manifest.json files.

**Note:** These integrations are our best guesses for the team. If you don't own these integrations or if we're missing any integrations owned by this team, please let us know.

**For reviewer:** Please confirm:
1. Is \`network-device-monitoring-integrations\` the correct datadog team slug in org 2?
2. Is \`Network Device Monitoring Integrations\` the correct workday team name to use as the team tag in SDP?

This PR includes 1 integration in integrations-core.