### PR TITLE
[DOCS-12028] Add how to find account ID in Azure Databricks

### DIFF
--- a/databricks/README.md
+++ b/databricks/README.md
@@ -31,7 +31,7 @@ First, [connect a new Databricks workspace](#connect-to-a-new-databricks-workspa
 <div class="alert alert-warning">New workspaces must authenticate using OAuth. Workspaces integrated with a Personal Access Token continue to function and can switch to OAuth at any time. After a workspace starts using OAuth, it cannot revert to a Personal Access Token.</div>
 
 1. In your Databricks account, click on **User Management** in the left menu. Then, under the **Service principals** tab, click **Add service principal**.
-2. Under the **Credentials & secrets** tab, click **Generate secret**. Set **Lifetime (days)** to the maximum value allowed (730), then click **Generate**. Take note of your client ID and client secret. Also take note of your account ID, which can be found by clicking on your profile in the upper-right corner.
+2. Under the **Credentials & secrets** tab, click **Generate secret**. Set **Lifetime (days)** to the maximum value allowed (730), then click **Generate**. Take note of your client ID and client secret. Also take note of your account ID, which can be found by clicking on your profile in the upper-right corner (or, if you're using Azure Databricks, by going to https://accounts.azuredatabricks.net/login).
 3. Click **Workspaces** in the left menu, then select the name of your workspace.
 4. Go to the **Permissions** tab and click **Add permissions**.
 5. Search for the service principal you created and assign it the **Admin** permission.


### PR DESCRIPTION
### What does this PR do?
Customer support reported that some customers can't find their Databricks account ID via the method specified in the docs. From investigating, it looks like the difference is when a customer is using Azure Databricks. I added a parenthetical specifying where to look for the account ID instead if you're on that version.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
