### PR TITLE
Fix macOS SSL certificate verification by conditionally mounting TLS adapters

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -490,7 +490,11 @@ class RequestsWrapper(object):
             if url.startswith('https'):
                 # Only mount custom adapter if we have non-default TLS config
                 tls_config = ChainMap(get_tls_config_from_options(new_options), self.tls_config)
-                if tls_config.get('tls_ca_cert') or tls_config.get('tls_cert') or not tls_config.get('tls_verify', True):
+                if (
+                    tls_config.get('tls_ca_cert')
+                    or tls_config.get('tls_cert')
+                    or not tls_config.get('tls_verify', True)
+                ):
                     self._mount_https_adapter(session, tls_config)
             request_method = getattr(session, method)
 
@@ -522,7 +526,11 @@ class RequestsWrapper(object):
             if parsed_url.scheme == "https":
                 # Only mount custom adapter if we have non-default TLS config
                 tls_config_with_certs = ChainMap({'tls_intermediate_ca_certs': certs}, self.tls_config)
-                if tls_config_with_certs.get('tls_ca_cert') or tls_config_with_certs.get('tls_cert') or not tls_config_with_certs.get('tls_verify', True):
+                if (
+                    tls_config_with_certs.get('tls_ca_cert')
+                    or tls_config_with_certs.get('tls_cert')
+                    or not tls_config_with_certs.get('tls_verify', True)
+                ):
                     self._mount_https_adapter(session, tls_config_with_certs)
             request_method = getattr(session, method)
             response = request_method(url, **new_options)
@@ -622,7 +630,11 @@ class RequestsWrapper(object):
             # Create a new session if it doesn't exist and mount HTTPS adapter if needed.
             self._session = self._create_session()
             # Only mount custom adapter if we have non-default TLS config
-            if self.tls_config.get('tls_ca_cert') or self.tls_config.get('tls_cert') or not self.tls_config.get('tls_verify', True):
+            if (
+                self.tls_config.get('tls_ca_cert')
+                or self.tls_config.get('tls_cert')
+                or not self.tls_config.get('tls_verify', True)
+            ):
                 self._mount_https_adapter(self._session, self.tls_config)
         return self._session
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes SSL certificate verification failures on macOS by only mounting custom TLS adapters when non-default TLS configuration is present. Previously, the Agent mounted custom adapters for all HTTPS requests, bypassing requests' built-in SSL handling that works correctly on macOS. This change improves performance by avoiding unnecessary adapter creation.

### Motivation
<!-- What inspired you to submit this pull request? -->
Resolves issues where integrations like GitLab Runner failed with "unable to get local issuer certificate" errors on macOS systems with embedded Python environments. Also resolves build-time vs runtime path mismatch in the embedded Python environment.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
