### PR TITLE
[DBMON-5685] Ensure innodb lock queries respect disable_innodb_metrics config option

### DIFF
--- a/mysql/changelog.d/21421.fixed
+++ b/mysql/changelog.d/21421.fixed
@@ -1,0 +1,1 @@
+Setting `disable_innodb_metrics` config option to `true` will now properly disable `mysql.innodb.deadlocks` metric collection

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -25,6 +25,7 @@ class MySQLConfig(object):
             custom_tags=instance.get('tags', []),
             propagate_agent_tags=self._should_propagate_agent_tags(instance, init_config),
         )
+        self.disable_innodb_metrics = is_affirmative(instance.get('disable_innodb_metrics', False))
         self.options = instance.get('options', {}) or {}  # options could be None if empty in the YAML
         self.replication_channel = self.options.get('replication_channel')
         if self.replication_channel:


### PR DESCRIPTION
### What does this PR do?
Originally we checked for `disable_innodb_metrics` before our innodb query to `SHOW INNODB STATUS` but we've since extended support for querying for deadlocks from `information_schema.INNODB_METRICS`. This second query isn't currently excluded when disabling innodb metrics which leads to a consistent query exception when using a different mysql engine or very old Mysql versions that don't have `information_schema.INNODB_METRICS` table. 

We already check if InnoDB engine is in use before issuing these queries, but if `INNODB_METRICS` table doesn't exist it will crash. This change moves evaluation of the `disable_innodb_metrics` config value into our `_check_innodb_engine_enabled` function so that it's respected everywhere we query innodb allowing customers to disable them if desired.

### Motivation
This issue was raised in https://datadoghq.atlassian.net/browse/SDBM-2053

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
