### PR TITLE
Add persistent cache information to the LogCrawlerCheck documentation

### DIFF
--- a/docs/developer/base/logs-crawlers.md
+++ b/docs/developer/base/logs-crawlers.md
@@ -5,6 +5,8 @@
 Some systems expose their logs from HTTP endpoints instead of files that the Logs Agent can tail.
 In such cases, you can create an Agent integration to crawl the endpoints and submit the logs.
 
+To avoid data loss and duplication, the `LogCrawlerCheck` uses the [persistent cache](./persistent-cache.md) to store the log cursor for each log stream. This allows the integration to resume crawling from its last known position after an Agent restart.
+
 The following diagram illustrates how crawling logs integrates into the Datadog Agent.
 
 <div align="center" markdown="1">
@@ -15,6 +17,7 @@ graph LR
     A[Log Stream] -->|Log Records| B(Log Crawler Check)
     end
     subgraph Agent
+    B <-->|Read/Write Cursor| F([Persistent Cache])
     B -->|Save Logs| C[(Log File)]
     D(Logs Agent) -->|Tail Logs| C
     end


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We have recently updated our docs to include information about persistent cache in the `AgentCheck` base class. This PR adds information about how the LogCrawlerCheck uses persistent cache to store the log cursor for each stream.

### Motivation
<!-- What inspired you to submit this pull request? -->
Keep the documentation complete after the recent updates.

#### Local validation

<img width="704" height="727" alt="image" src="https://github.com/user-attachments/assets/a0423c91-0cbf-4cad-8c49-c5be192fd5da" />


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
