### PR TITLE
(docs) Edit link to metrics in overview.

### DIFF
--- a/activemq/README.md
+++ b/activemq/README.md
@@ -4,7 +4,7 @@
 
 The ActiveMQ check collects metrics for brokers, queues, producers, consumers, and more.
 
-**Note:** This check also supports ActiveMQ Artemis (future ActiveMQ version `6`) and reports metrics under the `activemq.artemis` namespace. See [metadata.csv][1] for a list of metrics provided by this integration.
+**Note:** This check also supports ActiveMQ Artemis (future ActiveMQ version `6`) and reports metrics under the `activemq.artemis` namespace. See the [Metrics section](#metrics) for a list of available metrics.
 
 **Note**: If you are running an ActiveMQ version older than 5.8.0, see the [Agent 5.10.x released sample files][2].
 


### PR DESCRIPTION
The docs build currently relies on a "Magic sentence" to generate metrics tables. I'm editing the sentence in the overview of this page to avoid the table being generated here.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
