### PR TITLE
Add owner field to ml-observability integrations

### DIFF
--- a/anthropic/manifest.json
+++ b/anthropic/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "53fe7c3e-57eb-42ca-8e43-ec92c04b6160",
   "app_id": "anthropic",
+  "owner": "ml-observability",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/crewai/manifest.json
+++ b/crewai/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "19af2d5a-74cc-42db-98e4-e49a9e6c1de4",
   "app_id": "crewai",
+  "owner": "ml-observability",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION

## Summary
Adding owner field to 2 integrations for the ml-observability team:

- anthropic
- crewai

## Changes
- Set `owner` field to `ml-observability` in manifest.json for both integrations

Related to IDP-592 initiative to add owner fields to integration manifests.
