### PR TITLE
Add owner field to Container-Platform manifest files

### DIFF
--- a/datadog_csi_driver/manifest.json
+++ b/datadog_csi_driver/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "30d84795-b413-411b-a64f-8baf1a8a7418",
   "app_id": "datadog-csi-driver",
+  "owner": "container-platform",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/kubernetes_admission/manifest.json
+++ b/kubernetes_admission/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "6d009536-3383-4071-b45e-7771e0970cf4",
   "app_id": "kubernetes-admission",
+  "owner": "container-platform",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add `owner` field set to `"container-platform"` to manifest.json files for Container-Platform.

This provides clear ownership tracking for container platform integrations as part of the initiative to add owner fields to all integration manifest.json files.

**Note:** These integrations are our best guesses for the team. If you don't own these integrations or if we're missing any integrations owned by this team, please let us know.

**For reviewer:** Please confirm:
1. Is `container-platform` the correct datadog team slug in org 2?
2. Is `Container-Platform` the correct workday team name to use as the team tag in SDP?

Thank you for your review\!

🤖 Generated with [Claude Code](https://claude.ai/code)