### PR TITLE
Port changelog changes from 7.71.0

### DIFF
--- a/pgbouncer/CHANGELOG.md
+++ b/pgbouncer/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 8.5.1 / 2025-09-24
+
+***Fixed***:
+
+* Updated to build psycopg from source to fix a problem with FIPS compatibility ([#21074](https://github.com/DataDog/integrations-core/pull/21074))
+
 ## 8.5.0 / 2025-09-04 / Agent 7.70.1
 
 ***Added***:

--- a/pgbouncer/changelog.d/21074.fixed
+++ b/pgbouncer/changelog.d/21074.fixed
@@ -1,1 +1,0 @@
-Updated to build psycopg from source to fix a problem with FIPS compatibility

--- a/pgbouncer/datadog_checks/pgbouncer/__about__.py
+++ b/pgbouncer/datadog_checks/pgbouncer/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = "8.5.0"
+__version__ = "8.5.1"

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 23.0.1 / 2025-09-24
+
+***Fixed***:
+
+* Updated to build psycopg from source to fix a problem with FIPS compatibility ([#21074](https://github.com/DataDog/integrations-core/pull/21074))
+
 ## 23.0.0 / 2025-09-05
 
 ***Changed***:

--- a/postgres/changelog.d/21074.fixed
+++ b/postgres/changelog.d/21074.fixed
@@ -1,1 +1,0 @@
-Updated to build psycopg from source to fix a problem with FIPS compatibility

--- a/postgres/datadog_checks/postgres/__about__.py
+++ b/postgres/datadog_checks/postgres/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "23.0.0"
+__version__ = "23.0.1"

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -166,11 +166,11 @@ datadog-ossec-security==2.0.0
 datadog-palo-alto-panorama==1.0.0
 datadog-pan-firewall==3.0.0
 datadog-pdh-check==4.3.0; sys_platform == 'win32'
-datadog-pgbouncer==8.5.0; sys_platform != 'win32'
+datadog-pgbouncer==8.5.1; sys_platform != 'win32'
 datadog-php-fpm==6.0.1
 datadog-ping-federate==2.0.0
 datadog-postfix==3.0.0; sys_platform != 'win32'
-datadog-postgres==23.0.0
+datadog-postgres==23.0.1
 datadog-powerdns-recursor==5.0.1
 datadog-presto==3.1.0
 datadog-process==5.1.0
@@ -189,7 +189,7 @@ datadog-sap-hana==5.1.1
 datadog-scylla==5.0.1
 datadog-sidekiq==3.0.0
 datadog-silk==4.1.1
-datadog-silverstripe-cms==1.4.0
+datadog-silverstripe-cms==1.4.1
 datadog-singlestore==4.2.0
 datadog-slurm==2.0.2; sys_platform == 'linux2'
 datadog-snmp==11.0.0

--- a/silverstripe_cms/CHANGELOG.md
+++ b/silverstripe_cms/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 1.4.1 / 2025-09-24
+
+***Fixed***:
+
+* Updated to build psycopg from source to fix a problem with FIPS compatibility ([#21074](https://github.com/DataDog/integrations-core/pull/21074))
+
 ## 1.4.0 / 2025-09-05
 
 ***Added***:

--- a/silverstripe_cms/changelog.d/21074.fixed
+++ b/silverstripe_cms/changelog.d/21074.fixed
@@ -1,1 +1,0 @@
-Updated to build psycopg from source to fix a problem with FIPS compatibility

--- a/silverstripe_cms/datadog_checks/silverstripe_cms/__about__.py
+++ b/silverstripe_cms/datadog_checks/silverstripe_cms/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2025-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = "1.4.0"
+__version__ = "1.4.1"


### PR DESCRIPTION
### What does this PR do?
Port the release and changelogs from 7.71.0 after release of patches.
