### PR TITLE
Kafka Consumer check: estimated lag in seconds does not cause additio…

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -305,6 +305,6 @@ instances:
     #   - <EXCLUDE_REGEX>
 
     ## @param data_streams_enabled - boolean - optional - default: false
-    ## Collects consumer lag metric in seconds. It may result in additional billing charges.
+    ## Collects consumer lag metric in seconds.
     #
     # data_streams_enabled: false


### PR DESCRIPTION
…nal cost

### What does this PR do?

The metric does not cause any additional billing, and is useful for many customers (as it enables getting lag in seconds).

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
