### PR TITLE
[LOGSC-2395] add bypasse for new linter rule on grok parsers

### DIFF
--- a/forcepoint_secure_web_gateway/assets/logs/forcepoint-secure-web-gateway.yaml
+++ b/forcepoint_secure_web_gateway/assets/logs/forcepoint-secure-web-gateway.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-count-per-pipeline-checks
 id: forcepoint-secure-web-gateway
 metric_id: forcepoint-secure-web-gateway
 backend_only: false

--- a/forcepoint_security_service_edge/assets/logs/forcepoint-security-service-edge.yaml
+++ b/forcepoint_security_service_edge/assets/logs/forcepoint-security-service-edge.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-count-per-pipeline-checks
 id: forcepoint-security-service-edge
 metric_id: forcepoint-security-service-edge
 backend_only: false

--- a/harbor/assets/logs/harbor.yaml
+++ b/harbor/assets/logs/harbor.yaml
@@ -1,4 +1,5 @@
 # bypass-global-facets-path-checks
+# bypass-global-grok-parser-count-per-pipeline-checks
 id: harbor
 metric_id: harbor
 backend_only: false

--- a/ivanti_connect_secure/assets/logs/ivanti-connect-secure.yaml
+++ b/ivanti_connect_secure/assets/logs/ivanti-connect-secure.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-match-rules-checks
 id: ivanti-connect-secure
 metric_id: ivanti-connect-secure
 backend_only: false

--- a/linux_audit_logs/assets/logs/linux-audit-logs.yaml
+++ b/linux_audit_logs/assets/logs/linux-audit-logs.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-count-per-pipeline-checks
 id: linux-audit-logs
 metric_id: linux-audit-logs
 backend_only: false

--- a/openvpn/assets/logs/openvpn.yaml
+++ b/openvpn/assets/logs/openvpn.yaml
@@ -1,4 +1,5 @@
 # bypass-global-grok-parser-rules-checks
+# bypass-global-grok-parser-count-per-pipeline-checks
 id: openvpn
 metric_id: openvpn
 backend_only: false

--- a/proxysql/assets/logs/proxysql.yaml
+++ b/proxysql/assets/logs/proxysql.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-count-per-pipeline-checks
 id: proxysql
 metric_id: proxysql
 backend_only: false

--- a/sonicwall_firewall/assets/logs/sonicwall-firewall.yaml
+++ b/sonicwall_firewall/assets/logs/sonicwall-firewall.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-count-per-pipeline-checks
 id: sonicwall-firewall
 metric_id: sonicwall-firewall
 backend_only: false


### PR DESCRIPTION
Those integrations doesn't respect the new linter rules on maximum count of parser per pipeline or max matchRules per parser, so they need to bypass the check.