### PR TITLE
[REMED-248] Updating the OOMKilled monitor template to measure a different metric

### DIFF
--- a/kubernetes/assets/monitors/monitor_pod_oomkilled.json
+++ b/kubernetes/assets/monitors/monitor_pod_oomkilled.json
@@ -24,7 +24,7 @@
       },
       "timeout_h": 0
     },
-    "query": "max(last_10m):default_zero(max:kubernetes_state.container.status_report.count.waiting{reason:oomkilled} by {kube_cluster_name,kube_namespace,pod_name}) >= 1",
+    "query": "max(last_10m):default_zero(max:kubernetes.containers.state.terminated{reason:oomkilled} by {kube_cluster_name,kube_namespace,pod_name}) >= 1",
     "tags": [
       "integration:kubernetes"
     ],


### PR DESCRIPTION
### What does this PR do?

This PR updates the monitor template for Pods in an OOMKilled state.
Previously, the template incorrectly relied on the metric kubernetes_state.container.status_report.count.waiting. While this metric is valid for other failure cases such as ImagePullBackOff and CrashLoopBackOff, it does not correctly represent Pods terminated due to OOMKilled events.

The template has been updated to use kubernetes.containers.state.terminated, which accurately reflects Pods that have been terminated because of OOMKilled.

### Motivation

- This change was driven by [REMED-248](https://datadoghq.atlassian.net/browse/REMED-248), which identified the incorrect metric usage for OOMKilled Pods. This mismatch in metric alignment caused no evaluation data to show up in the out of the box templates provided for OOMKilled Pods.
- It also aligns with the broader effort to create consistent monitor templates for common Pod failure conditions, as already done for other cases (see [REMED-230](https://datadoghq.atlassian.net/browse/REMED-230))


### Additional Notes

- The replacement metric, kubernetes.containers.state.terminated, was chosen because it correctly surfaces OOMKilled events. Its accuracy was confirmed by examining the [Kubernetes - Pods integration dashboard](https://app.datadoghq.com/dash/integration/Kubernetes%20-%20Pods?fromUser=false&fullscreen_end_ts=1758745963516&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1758742363516&fullscreen_widget=935123463493438&refresh_mode=sliding&storage=flex_tier&from_ts=1758742113854&to_ts=1758745713854&live=true), where OOMKilled Pods were clearly associated with this metric.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[REMED-248]: https://datadoghq.atlassian.net/browse/REMED-248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[REMED-230]: https://datadoghq.atlassian.net/browse/REMED-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ