### PR TITLE
Add dummy workflow to test workflow_run trigger

### DIFF
--- a/.github/workflows/testing-run-on-wf-run.yml
+++ b/.github/workflows/testing-run-on-wf-run.yml
@@ -33,7 +33,7 @@ jobs:
           echo "run_id_variable=${{ github.event.workflow_run.id }}"         
           run_id=$(gh run list --workflow ".github/workflows/resolve-build-deps.yaml" -c ${{ steps.define_sha.outputs.sha }} --json databaseId --jq '.[-1].databaseId')
           echo "run_id_list=$run_id" 
-          if [ ${#VAR_VALUE} -gt 2 ]; then echo "accessible!"; else echo "not accessible"; fi
+          if [ ${#DD_API_KEY} -gt 2 ]; then echo "accessible!"; else echo "not accessible"; fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/testing-run-on-wf-run.yml
+++ b/.github/workflows/testing-run-on-wf-run.yml
@@ -26,7 +26,7 @@ jobs:
           echo "event=${{ github.event.workflow_run.event }}" >> $GITHUB_OUTPUT
           echo "ref_name=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           echo "branch=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
-          echo "default_branch=${{ github.event.workflow_run.repository.default_branch }}" >> $GITHUB_OUTPUT
+          echo "pr_number=${{ github.event.workflow_run.pull_requests.number }}" >> $GITHUB_OUTPUT
 
       - name: Get run ID
         run: |
@@ -35,3 +35,4 @@ jobs:
           echo "run_id_list=$run_id" 
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/testing-run-on-wf-run.yml
+++ b/.github/workflows/testing-run-on-wf-run.yml
@@ -33,6 +33,7 @@ jobs:
           echo "run_id_variable=${{ github.event.workflow_run.id }}"         
           run_id=$(gh run list --workflow ".github/workflows/resolve-build-deps.yaml" -c ${{ steps.define_sha.outputs.sha }} --json databaseId --jq '.[-1].databaseId')
           echo "run_id_list=$run_id" 
+          if [ ${#VAR_VALUE} -gt 2 ]; then echo "accessible!"; else echo "not accessible"; fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}


### PR DESCRIPTION
### What does this PR do?
This PR creates a dummy GitHub Actions workflow that runs once the Resolve Build Deps has finished and prints the workflow run ID.

### Motivation
The on: workflow_run trigger cannot be tested within a branch, it only works once the workflow exists in the master branch. This dummy workflow provides a way to validate and test the trigger behavior.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
