### PR TITLE
Improve Postgres autodiscovery test performance

### DIFF
--- a/postgres/tests/test_discovery.py
+++ b/postgres/tests/test_discovery.py
@@ -87,10 +87,6 @@ def test_autodiscovery_simple(integration_check, pg_instance):
     Test simple autodiscovery.
     """
     pg_instance["database_autodiscovery"] = DISCOVERY_CONFIG
-    pg_instance['collect_settings'] = {'enabled': False}
-    pg_instance['query_metrics'] = {'enabled': False}
-    pg_instance['query_samples'] = {'enabled': False}
-    pg_instance['query_activity'] = {'enabled': False}
     del pg_instance['dbname']
     check = integration_check(pg_instance)
     run_one_check(check, pg_instance)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Removes per-database relation metrics collection from the Postgres autodiscovery tests where it is not needed.

### Motivation
<!-- What inspired you to submit this pull request? -->
The test includes many databases, which makes per-database collection slow and it is not needed on all tests.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
