### PR TITLE
Include NTDS counters by default

### DIFF
--- a/active_directory/datadog_checks/active_directory/check.py
+++ b/active_directory/datadog_checks/active_directory/check.py
@@ -10,7 +10,6 @@ from datadog_checks.base.checks.windows.perf_counters.base import PerfCountersBa
 from .metrics import METRICS_CONFIG
 
 SERVICE_METRIC_MAP = {
-    'NTDS': ['NTDS'],
     'Netlogon': ['Netlogon', 'Security System-Wide Statistics'],
     'DHCPServer': ['DHCP Server'],
     'DFSR': ['DFS Replicated Folders'],
@@ -34,11 +33,13 @@ class ActiveDirectoryCheckV2(PerfCountersBaseCheckWithLegacySupport):
 
     def get_default_config(self):
         """Build metrics configuration based on service availability."""
-        filtered_metrics_config = {}
+        filtered_metrics_config = {
+            'NTDS': METRICS_CONFIG['NTDS'],  # Include NTDS metrics by default
+        }
         existing_services = _get_existing_services()
 
         for service in existing_services:
-            for metric in SERVICE_METRIC_MAP[service]:
-                filtered_metrics_config[metric] = METRICS_CONFIG[metric]
+            for service_metric_name in SERVICE_METRIC_MAP[service]:
+                filtered_metrics_config[service_metric_name] = METRICS_CONFIG[service_metric_name]
 
         return {'metrics': filtered_metrics_config}

--- a/active_directory/tests/test_unit.py
+++ b/active_directory/tests/test_unit.py
@@ -31,6 +31,10 @@ def mock_service_states(mocker):
 
 
 def assert_metrics(aggregator, global_tags, service_states):
+    # NTDS metrics are included by default
+    for metric in METRICS_CONFIG['NTDS']['counters'][0].values():
+        aggregator.assert_metric(f"active_directory.{metric['metric_name']}", 9000, global_tags, count=1)
+
     for service_name, exists in service_states.items():
         for service_display_name in SERVICE_METRIC_MAP[service_name]:
             service_metric_name = METRICS_CONFIG[service_display_name]['name']
@@ -46,16 +50,16 @@ def assert_metrics(aggregator, global_tags, service_states):
                 # Only assert metrics for services that exist
                 # If a service doesn't exist, its metrics shouldn't be collected at all
                 if exists:
-                    aggregator.assert_metric(metric_name, 9000, global_tags)
+                    aggregator.assert_metric(metric_name, 9000, global_tags, count=1)
 
 
 @pytest.mark.parametrize(
     'service_states',
     [
-        {'NTDS': True, 'Netlogon': True, 'DHCPServer': True, 'DFSR': True},
-        {'NTDS': True, 'Netlogon': False, 'DHCPServer': False, 'DFSR': False},
-        {'NTDS': True, 'Netlogon': True, 'DHCPServer': False, 'DFSR': False},
-        {'NTDS': False, 'Netlogon': False, 'DHCPServer': False, 'DFSR': False},
+        {'Netlogon': True, 'DHCPServer': True, 'DFSR': True},
+        {'Netlogon': False, 'DHCPServer': False, 'DFSR': False},
+        {'Netlogon': True, 'DHCPServer': False, 'DFSR': False},
+        {'Netlogon': False, 'DHCPServer': False, 'DFSR': False},
     ],
 )
 def test_all_services_existing(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The Agent cannot access the NTDS service by default. https://docs.datadoghq.com/integrations/windows-service/#service-permissions
We'll have to include the NTDS counters by default (like we did before this PR https://github.com/DataDog/integrations-core/pull/20894), instead of checking if the service exists.

### Motivation
<!-- What inspired you to submit this pull request? -->
https://datadoghq.atlassian.net/browse/WINA-1797

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
