### PR TITLE
add replace_bind_parameter to sqlserver obfuscator option

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -890,6 +890,13 @@ files:
             type: boolean
             example: false
             display_default: false
+        - name: replace_bind_parameter
+          description: |
+            Set to `true` to replace bind parameters (e.g. `@p1`) with `?` in your obfuscated SQL statements.
+          value:
+            type: boolean
+            example: false
+            display_default: false
         - name: keep_trailing_semicolon
           description: |
             Set to `true` to keep trailing semicolons in your normalized SQL statements.

--- a/sqlserver/changelog.d/21481.added
+++ b/sqlserver/changelog.d/21481.added
@@ -1,0 +1,1 @@
+Add `replace_bind_parameter` to sqlserver obfuscator option to support obfuscate bind parameters like `@P1`.

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -104,6 +104,9 @@ class SQLServerConfig:
                     'keep_positional_parameter': is_affirmative(
                         obfuscator_options_config.get('keep_positional_parameter', False)
                     ),
+                    'replace_bind_parameter': is_affirmative(
+                        obfuscator_options_config.get('replace_bind_parameter', False)
+                    ),
                     'keep_trailing_semicolon': is_affirmative(
                         obfuscator_options_config.get('keep_trailing_semicolon', False)
                     ),

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -359,6 +359,7 @@ class ObfuscatorOptions(BaseModel):
     keep_trailing_semicolon: Optional[bool] = None
     obfuscation_mode: Optional[str] = None
     remove_space_between_parentheses: Optional[bool] = None
+    replace_bind_parameter: Optional[bool] = None
     replace_digits: Optional[bool] = None
 
 

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -646,6 +646,11 @@ instances:
         #
         # keep_positional_parameter: false
 
+        ## @param replace_bind_parameter - boolean - optional - default: false
+        ## Set to `true` to replace bind parameters (e.g. `@p1`) with `?` in your obfuscated SQL statements.
+        #
+        # replace_bind_parameter: false
+
         ## @param keep_trailing_semicolon - boolean - optional - default: false
         ## Set to `true` to keep trailing semicolons in your normalized SQL statements.
         #


### PR DESCRIPTION
### What does this PR do?
This PR adds `replace_bind_parameter` config option to sqlserver obfuscator options. 
Depends on https://github.com/DataDog/datadog-agent/pull/41408

### Motivation
https://datadoghq.atlassian.net/browse/SDBM-2069

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
