### PR TITLE
Auto cancel Postgres checks after tests

### DIFF
--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 import psycopg
 import pytest
+from semver import VersionInfo
 
 from datadog_checks.dev import WaitFor, docker_run
 from datadog_checks.postgres import PostgreSql
@@ -72,6 +73,13 @@ def dd_environment(e2e_instance):
         capture=True,
     ):
         yield e2e_instance, E2E_METADATA
+
+
+@pytest.fixture
+def check():
+    c = PostgreSql('postgres', {}, [{'dbname': 'dbname', 'host': 'localhost', 'port': '5432', 'username': USER}])
+    c._version = VersionInfo(9, 2, 0)
+    return c
 
 
 @pytest.fixture(scope="function")

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -85,6 +85,7 @@ def check():
 @pytest.fixture(scope="function")
 def integration_check() -> Callable[[dict, Optional[dict]], PostgreSql]:
     c = None
+
     def _check(instance: dict, init_config: dict = None):
         nonlocal c
         c = PostgreSql('postgres', init_config or {}, [instance])
@@ -95,7 +96,6 @@ def integration_check() -> Callable[[dict, Optional[dict]], PostgreSql]:
     if not c:
         raise Exception("integration_check fixture called but no check created")
     c.cancel()
-    
 
 
 @pytest.fixture

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -8,7 +8,6 @@ from typing import Optional
 
 import psycopg
 import pytest
-from semver import VersionInfo
 
 from datadog_checks.dev import WaitFor, docker_run
 from datadog_checks.postgres import PostgreSql
@@ -75,7 +74,6 @@ def dd_environment(e2e_instance):
         yield e2e_instance, E2E_METADATA
 
 
-
 @pytest.fixture(scope="function")
 def integration_check() -> Callable[[dict, Optional[dict]], PostgreSql]:
     c = None
@@ -87,7 +85,7 @@ def integration_check() -> Callable[[dict, Optional[dict]], PostgreSql]:
 
     yield _check
 
-    if c:        
+    if c:
         c.cancel()
 
 

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -75,12 +75,6 @@ def dd_environment(e2e_instance):
         yield e2e_instance, E2E_METADATA
 
 
-@pytest.fixture
-def check():
-    c = PostgreSql('postgres', {}, [{'dbname': 'dbname', 'host': 'localhost', 'port': '5432', 'username': USER}])
-    c._version = VersionInfo(9, 2, 0)
-    return c
-
 
 @pytest.fixture(scope="function")
 def integration_check() -> Callable[[dict, Optional[dict]], PostgreSql]:
@@ -93,9 +87,8 @@ def integration_check() -> Callable[[dict, Optional[dict]], PostgreSql]:
 
     yield _check
 
-    if not c:
-        raise Exception("integration_check fixture called but no check created")
-    c.cancel()
+    if c:        
+        c.cancel()
 
 
 @pytest.fixture

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -82,13 +82,20 @@ def check():
     return c
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def integration_check() -> Callable[[dict, Optional[dict]], PostgreSql]:
+    c = None
     def _check(instance: dict, init_config: dict = None):
+        nonlocal c
         c = PostgreSql('postgres', init_config or {}, [instance])
         return c
 
-    return _check
+    yield _check
+
+    if not c:
+        raise Exception("integration_check fixture called but no check created")
+    c.cancel()
+    
 
 
 @pytest.fixture


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Automatically cancels Postgres checks created during tests.

### Motivation
<!-- What inspired you to submit this pull request? -->
This is necessary to clean up threads used by the connection pool.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
