### PR TITLE
add RDSIAMTokenManager to support token generation with TTL

### DIFF
--- a/datadog_checks_base/changelog.d/21506.added
+++ b/datadog_checks_base/changelog.d/21506.added
@@ -1,0 +1,2 @@
+Add RDSIAMTokenManager for AWS RDS IAM token caching and refresh.
+

--- a/datadog_checks_base/datadog_checks/base/utils/db/cloud_auth.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/cloud_auth.py
@@ -1,0 +1,115 @@
+# (C) Datadog, Inc. 2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import threading
+import time
+
+import boto3
+
+
+class RDSIAMTokenManager:
+    """
+    Manages AWS RDS IAM token generation and automatic refresh based on TTL.
+
+    This class caches the generated token and automatically refreshes it when the TTL expires.
+    This is useful for long-running database connections that need to periodically refresh
+    their authentication tokens.
+
+    RDS IAM tokens are valid for 15 minutes, so the default TTL is set to 10 minutes (600 seconds)
+    to ensure tokens are refreshed before they expire.
+
+    Thread-safe: Multiple threads can safely call get_token() concurrently.
+    """
+
+    def __init__(self, token_ttl_seconds=600):
+        """
+        Initialize the RDS IAM token manager.
+
+        Args:
+            token_ttl_seconds (int, optional): Number of seconds before refreshing the token.
+                Defaults to 600 seconds (10 minutes), which provides a 5-minute safety buffer
+                before the 15-minute token expiration.
+        """
+        self._token_ttl_seconds = token_ttl_seconds
+        self._token = None
+        self._token_created_at = 0
+        self._lock = threading.Lock()
+
+    def _generate_token(self, host, port, username, region, role_arn=None):
+        """
+        Generate an AWS RDS IAM authentication token using boto3.
+
+        This token can be used as a password when connecting to RDS databases that have
+        IAM authentication enabled. The token is valid for 15 minutes from generation.
+
+        Args:
+            host (str): The hostname of the RDS instance (e.g., 'mydb.region.rds.amazonaws.com')
+            port (int): The port number of the database (e.g., 3306 for MySQL, 5432 for PostgreSQL)
+            username (str): The database username to authenticate as
+            region (str): The AWS region where the RDS instance is located (e.g., 'us-east-1')
+            role_arn (str, optional): The ARN of an IAM role to assume before generating the token.
+                This is useful for cross-account access. If not provided, uses the default
+                AWS credentials/role.
+
+        Returns:
+            str: A presigned URL that can be used as a password for database authentication.
+                This token expires after 15 minutes.
+
+        Raises:
+            boto3.exceptions.Boto3Error: If there are issues with AWS credentials or permissions
+            botocore.exceptions.ClientError: If the RDS instance doesn't exist or IAM auth is not enabled
+
+        Note:
+            The RDS instance must have IAM authentication enabled, and the IAM user/role
+            must have the 'rds-db:connect' permission for the specific database resource.
+        """
+        if role_arn:
+            # when role_arn is defined, assume the role to generate the token
+            # this can be used for cross-account access
+            sts_client = boto3.client("sts")
+            assumed_role = sts_client.assume_role(RoleArn=role_arn, RoleSessionName="datadog-rds-iam-auth-session")
+            credentials = assumed_role["Credentials"]
+            session = boto3.Session(
+                aws_access_key_id=credentials["AccessKeyId"],
+                aws_secret_access_key=credentials["SecretAccessKey"],
+                aws_session_token=credentials["SessionToken"],
+                region_name=region,
+            )
+        else:
+            session = boto3.Session(region_name=region)
+        client = session.client("rds")
+        token = client.generate_db_auth_token(DBHostname=host, Port=port, DBUsername=username)
+
+        return token
+
+    def get_token(self, host, port, username, region, role_arn=None):
+        """
+        Get a valid RDS IAM token, generating a new one if needed.
+
+        This method returns a cached token if:
+        1. A token has been previously generated
+        2. The token is still within its TTL
+
+        Otherwise, it generates a new token.
+
+        Args:
+            host (str): The hostname of the RDS instance
+            port (int): The port number of the database
+            username (str): The database username to authenticate as
+            region (str): The AWS region where the RDS instance is located
+            role_arn (str, optional): The ARN of an IAM role to assume
+
+        Returns:
+            str: A valid RDS IAM authentication token
+
+        Thread-safe: Can be called from multiple threads concurrently.
+        """
+        with self._lock:
+            now = time.time()
+
+            # Generate new token if no token exists or TTL expired
+            if self._token is None or (now - self._token_created_at) >= self._token_ttl_seconds:
+                self._token = self._generate_token(host, port, username, region, role_arn)
+                self._token_created_at = now
+
+            return self._token

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -35,6 +35,7 @@ db = [
 ]
 deps = [
     "binary==1.0.2",
+    "boto3==1.40.21",
     "cachetools==6.2.0",
     "cryptography==45.0.6",
     "ddtrace==3.12.5",

--- a/datadog_checks_base/tests/base/utils/db/test_cloud_auth.py
+++ b/datadog_checks_base/tests/base/utils/db/test_cloud_auth.py
@@ -1,0 +1,130 @@
+# (C) Datadog, Inc. 2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import time
+
+import mock
+
+from datadog_checks.base.utils.db.cloud_auth import RDSIAMTokenManager
+
+
+class TestRDSIAMTokenManager:
+    """Test the RDSIAMTokenManager class"""
+
+    @mock.patch.object(RDSIAMTokenManager, '_generate_token')
+    def test_first_call_generates_token(self, mock_generate):
+        """Test that the first call generates a new token"""
+        mock_generate.return_value = 'first-token'
+        manager = RDSIAMTokenManager(token_ttl_seconds=600)
+
+        token = manager.get_token(
+            host='mydb.us-east-1.rds.amazonaws.com', port=3306, username='dbuser', region='us-east-1'
+        )
+
+        assert token == 'first-token'
+        mock_generate.assert_called_once_with('mydb.us-east-1.rds.amazonaws.com', 3306, 'dbuser', 'us-east-1', None)
+
+    @mock.patch.object(RDSIAMTokenManager, '_generate_token')
+    def test_cached_token_reused_within_ttl(self, mock_generate):
+        """Test that cached token is reused within TTL"""
+        mock_generate.return_value = 'cached-token'
+        manager = RDSIAMTokenManager(token_ttl_seconds=600)
+
+        # First call
+        token1 = manager.get_token(
+            host='mydb.us-east-1.rds.amazonaws.com', port=3306, username='dbuser', region='us-east-1'
+        )
+
+        # Second call (should use cached token)
+        token2 = manager.get_token(
+            host='mydb.us-east-1.rds.amazonaws.com', port=3306, username='dbuser', region='us-east-1'
+        )
+
+        assert token1 == token2 == 'cached-token'
+        # generate_rds_iam_token should only be called once
+        assert mock_generate.call_count == 1
+
+    @mock.patch.object(RDSIAMTokenManager, '_generate_token')
+    @mock.patch('datadog_checks.base.utils.db.cloud_auth.time')
+    def test_token_refreshed_after_ttl(self, mock_time, mock_generate):
+        """Test that token is refreshed after TTL expires"""
+        mock_generate.side_effect = ['first-token', 'refreshed-token']
+
+        # Mock time progression
+        time_values = [0, 100, 700]  # 0s, 100s, 700s
+        mock_time.time.side_effect = time_values
+
+        manager = RDSIAMTokenManager(token_ttl_seconds=600)
+
+        # First call at t=0
+        token1 = manager.get_token(
+            host='mydb.us-east-1.rds.amazonaws.com', port=3306, username='dbuser', region='us-east-1'
+        )
+
+        # Second call at t=100 (within TTL)
+        token2 = manager.get_token(
+            host='mydb.us-east-1.rds.amazonaws.com', port=3306, username='dbuser', region='us-east-1'
+        )
+
+        # Third call at t=700 (past TTL)
+        token3 = manager.get_token(
+            host='mydb.us-east-1.rds.amazonaws.com', port=3306, username='dbuser', region='us-east-1'
+        )
+
+        assert token1 == token2 == 'first-token'
+        assert token3 == 'refreshed-token'
+        assert mock_generate.call_count == 2
+
+    @mock.patch.object(RDSIAMTokenManager, '_generate_token')
+    def test_thread_safety(self, mock_generate):
+        """Test that token manager is thread-safe"""
+        import threading
+
+        mock_generate.return_value = 'thread-safe-token'
+        manager = RDSIAMTokenManager(token_ttl_seconds=600)
+
+        tokens = []
+
+        def get_token():
+            token = manager.get_token(
+                host='mydb.us-east-1.rds.amazonaws.com', port=3306, username='dbuser', region='us-east-1'
+            )
+            tokens.append(token)
+
+        # Create multiple threads
+        threads = [threading.Thread(target=get_token) for _ in range(10)]
+
+        # Start all threads
+        for thread in threads:
+            thread.start()
+
+        # Wait for all threads
+        for thread in threads:
+            thread.join()
+
+        # All tokens should be the same
+        assert all(token == 'thread-safe-token' for token in tokens)
+        # generate_rds_iam_token should only be called once despite multiple threads
+        assert mock_generate.call_count == 1
+
+    @mock.patch.object(RDSIAMTokenManager, '_generate_token')
+    def test_custom_ttl(self, mock_generate):
+        """Test that custom TTL is respected"""
+        mock_generate.side_effect = ['first-token', 'refreshed-token']
+        manager = RDSIAMTokenManager(token_ttl_seconds=300)  # 5 minutes
+
+        # First call
+        token1 = manager.get_token(
+            host='mydb.us-east-1.rds.amazonaws.com', port=3306, username='dbuser', region='us-east-1'
+        )
+
+        # Simulate time passing (less than TTL)
+        time.sleep(0.1)
+
+        # Second call (should use cache)
+        token2 = manager.get_token(
+            host='mydb.us-east-1.rds.amazonaws.com', port=3306, username='dbuser', region='us-east-1'
+        )
+
+        assert token1 == token2
+        assert mock_generate.call_count == 1


### PR DESCRIPTION
### What does this PR do?
Adds a new `RDSIAMTokenManager` to datadog_checks_base for managing AWS RDS IAM authentication tokens with automatic caching and refresh logic.

Next step: use `RDSIAMTokenManager` in mysql and postgres integration to support IAM token refresh. 

### Motivation
https://datadoghq.atlassian.net/browse/SDBM-2067

AWS RDS IAM authentication tokens expire after 15 minutes. Database integrations (MySQL, PostgreSQL) that maintain long-lived connections need to periodically refresh these tokens to avoid authentication failures. This PR provides a reusable, thread-safe token manager that:
- Generates RDS IAM tokens using boto3
- Caches tokens to reduce AWS API calls
- Automatically refreshes tokens based on configurable TTL (default: 10 minutes)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
