### PR TITLE
Add log to ddev git

### DIFF
--- a/ddev/changelog.d/21512.added
+++ b/ddev/changelog.d/21512.added
@@ -1,0 +1,1 @@
+Adds a new method `log` in the `GitRepository` class. 

--- a/ddev/tests/utils/test_git.py
+++ b/ddev/tests/utils/test_git.py
@@ -44,6 +44,23 @@ def test_get_latest_commit(repository):
     assert short_sha2 not in commit_status1
 
 
+def test_get_log(repository):
+    repo = Repository(repository.path.name, str(repository.path))
+
+    repo.git.capture("config", "user.name", "test_user")
+    (repo.path / "test1.txt").touch()
+    repo.git.capture("add", ".")
+    repo.git.capture("commit", "-m", "test1")
+    (repo.path / "test2.txt").touch()
+    repo.git.capture("add", ".")
+    repo.git.capture("commit", "-m", "test2")
+
+    assert repo.git.log(["author:%an", "message:%f"], n=2) == [
+        {"author": "test_user", "message": "test2"},
+        {"author": "test_user", "message": "test1"},
+    ]
+
+
 def test_tags(repository):
     repo = Repository(repository.path.name, str(repository.path))
 


### PR DESCRIPTION
### What does this PR do?
Adds a new method `log` in the `GitRepository` class in `ddev`. It returns a dictionary with the log for the last `n` commits, including only the fields requested via the method arguments.

### Motivation
The `ddev size` command needs to retrieve the hash of the previous commit.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
