### PR TITLE
Remove `.files` null values

### DIFF
--- a/.github/workflows/resolve-build-deps.yaml
+++ b/.github/workflows/resolve-build-deps.yaml
@@ -64,7 +64,8 @@ jobs:
           REPO="${{ github.repository }}"
 
           CHANGED_FILES=$(gh api "repos/$REPO/compare/${{ steps.set_sha.outputs.prev_sha }}...${{ steps.set_sha.outputs.curr_sha }}" --paginate | \
-          jq -r '.files | map(.filename) | join(" ")')
+          # Remove null values from the files array
+          jq -r 'select(.files != null) | .files | map(.filename) | join(" ")')
 
           echo "files_changed=$CHANGED_FILES" >> $GITHUB_OUTPUT
           echo "files_changed=$CHANGED_FILES"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
`select(.files != null)` filters out JSON objects that don't have a "files" field

### Motivation
<!-- What inspired you to submit this pull request? -->
When using `--paginate`, the GitHub API returns multiple objects. The first object contains the "files" field with the file changes, but subsequent paginated objects (containing additional commits) don't have a "files" field, causing `jq` to try to iterate over null.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
