### PR TITLE
Remove autoinstall from Barracuda integrations until they are released

### DIFF
--- a/barracuda_secure_edge/manifest.json
+++ b/barracuda_secure_edge/manifest.json
@@ -20,7 +20,7 @@
         "media_type": "image",
         "caption": "Barracuda SecureEdge Overview Dark Mode",
         "image_url": "images/secure_edge_overview_dark.png"
-      }      
+      }
     ],
     "classifier_tags": [
       "Supported OS::Linux",
@@ -35,7 +35,7 @@
   },
   "assets": {
     "integration": {
-      "auto_install": true,
+      "auto_install": false,
       "source_type_id": 48860633,
       "source_type_name": "barracuda_secure_edge",
       "configuration": {

--- a/cloudgen_firewall/manifest.json
+++ b/cloudgen_firewall/manifest.json
@@ -40,7 +40,7 @@
   },
   "assets": {
     "integration": {
-      "auto_install": true,
+      "auto_install": false,
       "source_type_id": 47743103,
       "source_type_name": "cloudgen_firewall",
       "configuration": {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Makes the new Barracuda integrations not auto-installable until we release them.

### Motivation
<!-- What inspired you to submit this pull request? -->
Even if the integration is not released, the log pipeline gets install in prod once they are merged. This means that any customer that emits logs with a source that can trigger the pipeline auto-installation will see fields being parsed by it.

While the source is not used by any customers, they have visibility over this repo and can trigger unexpected behavior for an integration that is not yet visible in the tiles.

Once the integrations are ready for release we will change this to `true` again.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
