### PR TITLE
Get previous commit when push on master

### DIFF
--- a/ddev/changelog.d/21536.fixed
+++ b/ddev/changelog.d/21536.fixed
@@ -1,0 +1,1 @@
+Fixed retrieval of previous dependency size calculations so they can be used in CI runs on pushes to master.

--- a/ddev/src/ddev/cli/size/utils/common_funcs.py
+++ b/ddev/src/ddev/cli/size/utils/common_funcs.py
@@ -964,9 +964,13 @@ def get_last_dependency_sizes_artifact(
     '''
     dep_sizes_json = get_dep_sizes_json(commit, platform, py_version)
     if not dep_sizes_json:
-        dep_sizes_json = get_previous_dep_sizes(
-            app.repo.git.merge_base(commit, "origin/master"), platform, py_version, compressed
-        )
+        base_commit = app.repo.git.merge_base(commit, "origin/master")
+        if base_commit != commit:
+            previous_commit = base_commit
+        else:
+            previous_commit = app.repo.git.log(["hash:%H"], n=2, source=commit)[1]["hash"]
+
+        dep_sizes_json = get_previous_dep_sizes(previous_commit, platform, py_version, compressed)
     return Path(dep_sizes_json) if dep_sizes_json else None
 
 


### PR DESCRIPTION
### What does this PR do?
Adds logic in `get_last_dependency_sizes_artifact` to retrieve the previous commit when the `merge base` with master equals the current commit (the commit is already on master).

### Motivation
In the `measure disk usage` workflow, when it runs on a `push` to master, the current commit is on master, so the `merge base` is the commit itself. In this case we couldn’t determine the previous sizes.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
