### PR TITLE
[DOCS-12068] Correct command for giving dd-agent permissions

### DIFF
--- a/linux_audit_logs/README.md
+++ b/linux_audit_logs/README.md
@@ -73,7 +73,7 @@ For Linux, run:
 
 1. Give the `dd-agent` user read permission for rotated audit log files:
     ```shell
-    sudo grep -q "^log_group=" /etc/audit/auditd.conf && sudo sed -i 's/^log_group=.*/log_group=dd-agent/' /etc/audit/auditd.conf || echo "log_group=dd-agent" | sudo tee -a /etc/audit/auditd.conf
+    sudo grep -q "^log_group=" /etc/audit/auditd.conf && sudo sed -i 's/^log_group=.*/log_group=dd-agent/' /etc/audit/auditd.conf || echo "log_group = dd-agent" | sudo tee -a /etc/audit/auditd.conf
     ```
 
 2. Restart Audit Daemon:


### PR DESCRIPTION
### What does this PR do?
We received customer feedback that the command in the instructions for configuring the audit daemon on this page was incorrect: this PR adds the correct spacing for the line added to the conf file (`log_group = dd-agent` instead of `log_group=dd-agent`).