### PR TITLE
Skip Python 2 tests by default in Test Agent release

### DIFF
--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -21,7 +21,7 @@ on:
       test-py2:
         required: false
         description: Run Python 2 tests
-        default: true
+        default: false
         type: boolean
       agent-image-py2:
         required: false


### PR DESCRIPTION
### What does this PR do?
Unchecks the "Run Python 2 Tests" checkbox when displaying a "Test Agent release" dialog. This only changes the default, the checkbox can still be checked.

### Motivation
Saves a click.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
