### PR TITLE
Remove Agent mentions from Databricks README

### DIFF
--- a/databricks/README.md
+++ b/databricks/README.md
@@ -1,4 +1,4 @@
-# Agent Check: Databricks
+# Databricks Integration
 
 ![Databricks default dashboard][21]
 
@@ -105,12 +105,10 @@ For Datadog to access your Databricks cost data in Data Jobs Monitoring or [Clou
 ### Metrics
 #### Model Serving Metrics
 See [metadata.csv][29] for a list of metrics provided by this integration.
-#### Spark Metrics
-See the [Spark integration documentation][8] for a list of Spark metrics collected.
 
 ### Service Checks
 
-See the [Spark integration documentation][9] for the list of service checks collected.
+The Databricks integration does not include any service checks.
  
 ### Events
 
@@ -118,14 +116,11 @@ The Databricks integration does not include any events.
 
 ## Troubleshooting
 
-You can troubleshoot issues yourself by enabling the [Databricks web terminal][18] or by using a [Databricks Notebook][19]. Consult the [Agent Troubleshooting][20] documentation for information on useful troubleshooting steps. 
-
-Need help? Contact [Datadog support][10].
+You can troubleshoot issues yourself by enabling the [Databricks web terminal][18] or by using a [Databricks Notebook][19]. Need help? Contact [Datadog support][10].
 
 [10]: https://docs.datadoghq.com/help/
 [18]: https://docs.databricks.com/en/clusters/web-terminal.html
 [19]: https://docs.databricks.com/en/notebooks/index.html
-[20]: https://docs.datadoghq.com/agent/troubleshooting/
 [21]: https://raw.githubusercontent.com/DataDog/integrations-core/master/databricks/images/databricks_dashboard.png
 [25]: https://www.datadoghq.com/product/data-jobs-monitoring/
 [26]: https://www.datadoghq.com/product/cloud-cost-management/


### PR DESCRIPTION
Updated the README to remove residual mentions of Agent checks in the Databricks readme.

### What does this PR do?
Following the [README update](https://github.com/DataDog/integrations-core/pull/21380) that removed Spark Agent integration instructions, this PR removes remaining references to Spark and the Agent.

### Motivation
Remove confusion on whether this is an Agent integration or not.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
