### PR TITLE
Set Saas-integrations as owner of Databricks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -655,6 +655,11 @@ plaid/assets/logs/                                                  @DataDog/saa
 /crowdstrike_fdr/manifest.json                                       @DataDog/saas-integrations @DataDog/documentation
 /crowdstrike_fdr/assets/logs/                                        @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
+/databricks/                                                         @DataDog/saas-integrations
+/databricks/*.md                                                     @DataDog/saas-integrations @DataDog/documentation
+/databricks/manifest.json                                            @DataDog/saas-integrations @DataDog/documentation
+/databricks/metadata.csv                                             @DataDog/saas-integrations @DataDog/documentation
+
 /trend_micro_cloud_one/                                              @DataDog/saas-integrations
 /trend_micro_cloud_one/*.md                                          @DataDog/saas-integrations @DataDog/documentation
 /trend_micro_cloud_one/manifest.json                                 @DataDog/saas-integrations @DataDog/documentation

--- a/databricks/manifest.json
+++ b/databricks/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "f99b6e79-f50a-479d-b916-955a577e4f41",
   "app_id": "databricks",
-  "owner": "agent-integrations",
+  "owner": "saas-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
### What does this PR do?
Sets saas-integrations as the Databricks integration owner.

### Motivation
Now that we're no longer mentioning the Spark integration in the Databricks README, the Databricks integration is a pure SaaS integration.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
