### PR TITLE
[EBPF-827] [GPUM] update(gpu): add xid errors metric metadata

### DIFF
--- a/gpu/CHANGELOG.md
+++ b/gpu/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - GPU
 
+## 0.5.0
+
+***Added***:
+
+* Added Xid errors count metric: `gpu.errors.xid.total`.
+
 ## 0.4.1
 
 ***Added***:

--- a/gpu/metadata.csv
+++ b/gpu/metadata.csv
@@ -19,6 +19,7 @@ gpu.decoder_utilization,gauge,,percent,,Percentage of time the decoder was activ
 gpu.device.total,gauge,15,,,Number of GPU devices found in the host,0,gpu,device.total,,
 gpu.dram_active,gauge,,percent,,Percentage of time the DRAM was active,0,gpu,dram_active,,
 gpu.encoder_utilization,gauge,,percent,,Percentage of time the encoder was active,0,gpu,encoder_utilization,,
+gpu.errors.xid.total,count,,,,Total count of Xid errors,0,gpu,errors.xid.total,,
 gpu.fan_speed,gauge,,percent,,Configured fan speed as a percentage of its maximum,0,gpu,fan_speed,,
 gpu.fp16_active,gauge,,percent,,Percentage of the time that the 16-bit floating point calculation engine was active. Only for Hopper and newer GPUs,0,gpu,fp16_active,,
 gpu.fp32_active,gauge,,percent,,Percentage of the time that the 32-bit floating point calculation engine was active. Only for Hopper and newer GPUs,0,gpu,fp32_active,,


### PR DESCRIPTION
### What does this PR do?

Add the new `gpu.errors.xid.total` metric to the metadata csv.

### Motivation

https://datadoghq.atlassian.net/browse/EBPF-827

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
