### PR TITLE
Backfill old keys used in SQL obfuscator

### DIFF
--- a/postgres/changelog.d/21557.fixed
+++ b/postgres/changelog.d/21557.fixed
@@ -1,0 +1,1 @@
+Backill old keys in options passed from Postgres integration to SQL obfuscator 

--- a/postgres/changelog.d/21557.fixed
+++ b/postgres/changelog.d/21557.fixed
@@ -1,1 +1,1 @@
-Backill old keys in options passed from Postgres integration to SQL obfuscator 
+Backfill old keys in options passed from Postgres integration to SQL obfuscator 

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -178,6 +178,10 @@ def build_config(check: PostgreSql) -> Tuple[InstanceConfig, ValidationResult]:
         }
     )
 
+    # Backfill old key to new key
+    if instance.get('obfuscator_options', {}).get('quantize_sql_tables'):
+        args['obfuscator_options']['replace_digits'] = True
+
     validation_result = ValidationResult()
 
     # Generate and validate tags

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -173,7 +173,13 @@ class PostgresStatementSamples(DBMAsyncJob):
         # The value is loaded when connecting to the main database
         self._explain_function = config.query_samples.explain_function
         self._explain_parameterized_queries = ExplainParameterizedQueries(check, config, self._explain_function)
-        self._obfuscate_options = to_native_string(self._config.obfuscator_options.model_dump_json())
+        obfuscate_options = self._config.obfuscator_options.model_dump()
+        # Backfill old keys used in the agent obfuscator
+        obfuscate_options['table_names'] = self._config.obfuscator_options.collect_tables
+        obfuscate_options['dollar_quoted_func'] = self._config.obfuscator_options.keep_dollar_quoted_func
+        obfuscate_options['return_json_metadata'] = self._config.obfuscator_options.collect_metadata
+        self._obfuscate_options = to_native_string(json.dumps(obfuscate_options))
+
         self._collect_raw_query_statement = config.collect_raw_query_statement.enabled
 
         self._collection_strategy_cache = TTLCache(

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -185,7 +185,12 @@ class PostgresStatementMetrics(DBMAsyncJob):
         self._baseline_metrics = {}
         self._last_baseline_metrics_expiry = None
         self._track_io_timing_cache = None
-        self._obfuscate_options = to_native_string(self._config.obfuscator_options.model_dump_json())
+        obfuscate_options = self._config.obfuscator_options.model_dump()
+        # Backfill old keys used in the agent obfuscator
+        obfuscate_options['table_names'] = self._config.obfuscator_options.collect_tables
+        obfuscate_options['dollar_quoted_func'] = self._config.obfuscator_options.keep_dollar_quoted_func
+        obfuscate_options['return_json_metadata'] = self._config.obfuscator_options.collect_metadata
+        self._obfuscate_options = to_native_string(json.dumps(obfuscate_options))
         # full_statement_text_cache: limit the ingestion rate of full statement text events per query_signature
         self._full_statement_text_cache = TTLCache(
             maxsize=config.query_metrics.full_statement_text_cache_max_size,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Backfills keys for obfuscator settings passed from Postgres to the agent SQL obfuscator.

### Motivation
<!-- What inspired you to submit this pull request? -->
The obfuscator expects certain legacy keys for its configuration that no longer match the options documented in the Postgres integration.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
