### PR TITLE
Add docs to AD for service check recommendation

### DIFF
--- a/active_directory/README.md
+++ b/active_directory/README.md
@@ -86,10 +86,6 @@ The Netlogon and Security metrics help address several monitoring scenarios:
 
 The Active Directory check does not include any events.
 
-### Service Checks
-
-The Active Directory check does not include any service checks.
-
 ## Troubleshooting
 
 Need help? Contact [Datadog support][9].


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We want to add a widget in the AD OOTB dashboard that monitors the AD services statuses, which requires configuring the Windows Services integration. We should include this in the docs for customers to see. 

### Motivation
<!-- What inspired you to submit this pull request? -->
https://datadoghq.atlassian.net/browse/WINA-1797

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
