### PR TITLE
Override `azure-identify` license

### DIFF
--- a/.ddev/config.toml
+++ b/.ddev/config.toml
@@ -53,6 +53,8 @@ exclude = true
 [overrides.dependencies.licenses]
 # https://github.com/aerospike/aerospike-client-python/blob/master/LICENSE
 aerospike = ['Apache-2.0']
+# https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/identity/azure-identity/LICENSE
+azure-identity = ['MIT']
 # https://github.com/pyca/cryptography/blob/main/LICENSE
 cryptography = ['Apache-2.0', 'BSD-3-Clause', 'PSF']
 # https://github.com/confluentinc/confluent-kafka-python/blob/master/LICENSE


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Update the dependencies GH Action is failing due to missing license for `azure-identity`. We override the license since it's missing in PYPI project metadata: https://pypi.org/project/azure-identity/
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
