### PR TITLE
Add additional proxmox_type tag to nodes

### DIFF
--- a/proxmox/changelog.d/21581.added
+++ b/proxmox/changelog.d/21581.added
@@ -1,0 +1,1 @@
+Add additional `proxmox_type` tag to nodes.

--- a/proxmox/datadog_checks/proxmox/check.py
+++ b/proxmox/datadog_checks/proxmox/check.py
@@ -298,6 +298,7 @@ class ProxmoxCheck(AgentCheck, ConfigMixin):
                 vm_id = resource.get('vmid')
                 hostname = self._get_vm_hostname(vm_id, resource_name, node)
             elif resource_type_remapped == NODE_RESOURCE:
+                resource_tags.add('proxmox_type:host')
                 hostname = node
 
             resource_val = {

--- a/proxmox/tests/test_unit.py
+++ b/proxmox/tests/test_unit.py
@@ -120,6 +120,7 @@ def test_resource_count_metrics(dd_run_check, aggregator, instance):
             'proxmox_server:http://localhost:8006/api2/json',
             'testing',
             'proxmox_type:node',
+            'proxmox_type:host',
             'proxmox_name:ip-122-82-3-112',
             'proxmox_id:node/ip-122-82-3-112',
         ],
@@ -328,6 +329,7 @@ def test_external_tags(dd_run_check, aggregator, instance, datadog_agent):
                 'proxmox_id:node/ip-122-82-3-112',
                 'proxmox_name:ip-122-82-3-112',
                 'proxmox_type:node',
+                'proxmox_type:host',
             ]
         },
     )


### PR DESCRIPTION
### What does this PR do?
Add additional proxmox_type tag to nodes
### Motivation
Standardize with other hypervisor integrations
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
