### PR TITLE
fix(json-specs): fix incorrect schema for ignore_metrics_by_labels field

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics_legacy_base.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics_legacy_base.yaml
@@ -185,13 +185,10 @@
     Use the "*" wildcard to match all label values.
   value:
     type: object
-    properties:
-      - name: target_label_key
+    additionalProperties:
+      type: array
+      items:
         type: string
-      - name: target_label_value_list
-        type: array
-        items:
-          type: string
     example:
       <KEY_1>: [<LABEL_1>, <LABEL_2>]
       <KEY_2>: ['*']


### PR DESCRIPTION
### What does this PR do?

Fix minor issues in spec files:
- 69f44e29ae Incorrect schema for `ignore_metrics_by_labels`
- ??  add changelogs
- ?? regenerate instances

<hr/>

`ignore_metrics_by_labels` was defined to accept:

```json
{
  "target_label_key": "foo",
  "target_label_value_list": ["bar", "baz"]
}
```

instead of 

```json
{
  "foo1" :  ["bar", "baz"],
  "foo2" :  ["bar", "baz"],
}
```

### Motivation
https://datadoghq.atlassian.net/browse/FA-1028

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
