### PR TITLE
Add debug logs to ddev size to investigate metric duplication

### DIFF
--- a/ddev/src/ddev/cli/size/status.py
+++ b/ddev/src/ddev/cli/size/status.py
@@ -79,6 +79,8 @@ def status(
                 from ddev.cli.size.utils.common_funcs import get_last_dependency_sizes_artifact
 
                 dependency_sizes = get_last_dependency_sizes_artifact(app, commit, plat, ver, compressed)
+                if not dependency_sizes:
+                    app.display_error("Looking for dependency sizes in the local lockfiles")
 
             parameters: CLIParameters = {
                 "app": app,

--- a/ddev/src/ddev/cli/size/utils/common_funcs.py
+++ b/ddev/src/ddev/cli/size/utils/common_funcs.py
@@ -862,6 +862,8 @@ def send_metrics_to_dd(
     n_integrations: dict[tuple[str, str], int] = {}
     n_dependencies: dict[tuple[str, str], int] = {}
 
+    sizes: dict[str, dict[str, int]] = {}
+
     for item in modules:
         metrics.append(
             {
@@ -884,6 +886,15 @@ def send_metrics_to_dd(
                 ],
             }
         )
+
+        # Creating variables for debugging
+        if item['Platform'] not in sizes:
+            sizes[item['Platform']] = {}
+        if item['Python_Version'] not in sizes[item['Platform']]:
+            sizes[item['Platform']][item['Python_Version']] = 0
+
+        sizes[item['Platform']][item['Python_Version']] += item['Size_Bytes']
+
         key_count = (item['Platform'], item['Python_Version'])
         if key_count not in n_integrations:
             n_integrations[key_count] = 0
@@ -928,8 +939,27 @@ def send_metrics_to_dd(
         api_host=f"https://api.{config_file_info['site']}",
     )
 
+    app.display("Sending metrics to Datadog")
+
+    # Format the sizes dictionary into a human-readable summary
+    summary_lines = []
+    for platform, py_versions in sizes.items():
+        for py_version, size_bytes in py_versions.items():
+            summary_lines.append(
+                f"Platform: {platform}, Python: {py_version}, Size: "
+                f"{convert_to_human_readable_size(size_bytes)} ({size_bytes} bytes)"
+            )
+    summary = "\n".join(summary_lines)
+
+    app.display("Metric summary:\n" + summary + "\n")
+
+    app.display_debug(f"Metrics: {metrics}")
     api.Metric.send(metrics=metrics)
+
+    app.display_debug(f"N integrations metrics: {n_integrations_metrics}")
     api.Metric.send(metrics=n_integrations_metrics)
+
+    app.display_debug(f"N dependencies metrics: {n_dependencies_metrics}")
     api.Metric.send(metrics=n_dependencies_metrics)
 
 
@@ -962,7 +992,12 @@ def get_last_dependency_sizes_artifact(
     So in each commit, there is an artifact with the sizes of the wheels that were built to get the actual
     size of that commit.
     '''
-    dep_sizes_json = get_dep_sizes_json(commit, platform, py_version)
+    app.display(
+        "Getting last dependency sizes artifact for commit: "
+        f"{commit}, platform: {platform}, Python version: {py_version}, compressed: {compressed}"
+    )
+
+    dep_sizes_json = get_dep_sizes_json(app, commit, platform, py_version)
     if not dep_sizes_json:
         base_commit = app.repo.git.merge_base(commit, "origin/master")
         if base_commit != commit:
@@ -970,27 +1005,30 @@ def get_last_dependency_sizes_artifact(
         else:
             previous_commit = app.repo.git.log(["hash:%H"], n=2, source=commit)[1]["hash"]
 
-        dep_sizes_json = get_previous_dep_sizes(previous_commit, platform, py_version, compressed)
+        app.display(f"\n -> Looking for previous dependency sizes json in commit: {previous_commit}")
+
+        dep_sizes_json = get_previous_dep_sizes(app, previous_commit, platform, py_version, compressed)
     return Path(dep_sizes_json) if dep_sizes_json else None
 
 
 @cache
-def get_dep_sizes_json(current_commit: str, platform: str, py_version: str) -> Path | None:
+def get_dep_sizes_json(app: Application, current_commit: str, platform: str, py_version: str) -> Path | None:
     '''
     Gets the dependency sizes json for a given commit and platform when dependencies were resolved.
     '''
-    print(f"Getting dependency sizes json for commit: {current_commit}, platform: {platform}")
-    run_id = get_run_id(current_commit, RESOLVE_BUILD_DEPS_WORKFLOW)
+    app.display(f"\n -> Looking if dependency sizes were resolved in the commit {current_commit}")
+
+    run_id = get_run_id(app, current_commit, RESOLVE_BUILD_DEPS_WORKFLOW)
     if run_id:
-        dep_sizes_json = get_current_sizes_json(run_id, platform, py_version)
+        dep_sizes_json = get_current_sizes_json(app, run_id, platform, py_version)
         return dep_sizes_json
     else:
         return None
 
 
 @cache
-def get_run_id(commit: str, workflow: str) -> str | None:
-    print(f"Getting run id for commit: {commit}, workflow: {workflow}")
+def get_run_id(app: Application, commit: str, workflow: str) -> str | None:
+    app.display(f"Getting run id for commit: {commit}, workflow: {workflow}")
 
     result = subprocess.run(
         [
@@ -1012,21 +1050,21 @@ def get_run_id(commit: str, workflow: str) -> str | None:
 
     run_id = result.stdout.strip() if result.stdout else None
     if run_id:
-        print(f"Run id: {run_id}")
+        app.display(f"Found run id: {run_id}")
     else:
-        print(f"No run id found for commit: {commit}, workflow: {workflow}")
+        app.display_warning(f"No run id found for commit: {commit}, workflow: {workflow}")
 
     return run_id
 
 
 @cache
-def get_current_sizes_json(run_id: str, platform: str, py_version: str) -> Path | None:
+def get_current_sizes_json(app: Application, run_id: str, platform: str, py_version: str) -> Path | None:
     '''
     Downloads the dependency sizes json for a given run id and platform when dependencies were resolved.
     '''
-    print(f"Getting current sizes json for run_id={run_id}, platform={platform}")
+    app.display(f"Looking for resolved dependency sizes json for run_id={run_id}, platform={platform}")
     with tempfile.TemporaryDirectory() as tmpdir:
-        print(f"Downloading artifacts to {tmpdir}")
+        app.display(f"Downloading artifacts to {tmpdir}")
         try:
             subprocess.run(
                 [
@@ -1044,29 +1082,28 @@ def get_current_sizes_json(run_id: str, platform: str, py_version: str) -> Path 
                 text=True,
             )
         except subprocess.CalledProcessError as e:
-            if e.stderr and "no artifact matches any of the names or patterns provided" in e.stderr:
-                print(f"No artifact found for run_id={run_id}, platform={platform}")
+            if e.stderr and "no valid artifacts found" in e.stderr:
+                app.display_warning(f"No dependencies resolved for run_id={run_id}, platform={platform}")
             else:
-                print(f"Failed to download current sizes json: {e}")
+                app.display_error(f"Failed to download current sizes json: {e}")
 
-            print("Comparing to merge base commit")
             return None
 
-        print(f"Downloaded artifacts to {tmpdir}")
+        app.display(f"Downloaded artifacts to {tmpdir}")
         sizes_file = Path(tmpdir) / platform / 'py3' / 'sizes.json'
 
         if not sizes_file.is_file():
-            print(f"Sizes artifact not found at {sizes_file}")
+            app.display_warning(f"Sizes artifact not found at {sizes_file}")
             return None
 
-        print(f"Found sizes artifact at {sizes_file}")
+        app.display(f"Found sizes artifact at {sizes_file}")
         dest_path = sizes_file.rename(f"{platform}_{py_version}.json")
         return dest_path
 
 
 @cache
-def get_artifact(run_id: str, artifact_name: str, target_dir: str | None = None) -> Path | None:
-    print(f"Downloading artifact: {artifact_name} from run_id={run_id}")
+def get_artifact(app: Application, run_id: str, artifact_name: str, target_dir: str | None = None) -> Path | None:
+    app.display(f"Downloading artifact: {artifact_name} from run_id={run_id}")
     try:
         cmd = [
             'gh',
@@ -1081,34 +1118,31 @@ def get_artifact(run_id: str, artifact_name: str, target_dir: str | None = None)
 
         subprocess.run(cmd, check=True, text=True)
     except subprocess.CalledProcessError as e:
-        print(f"Failed to download artifact: {artifact_name} from run_id={run_id}: {e}")
+        app.display_warning(f"Failed to download artifact: {artifact_name} from run_id={run_id}: {e}")
         return None
 
     artifact_path = Path(target_dir) / artifact_name if target_dir else Path(artifact_name)
-    print(f"Artifact downloaded to: {artifact_path}")
+    app.display(f"Artifact downloaded to: {artifact_path}")
     return artifact_path
 
 
 @cache
-def get_previous_dep_sizes(base_commit: str, platform: str, py_version: str, compressed: bool) -> Path | None:
+def get_previous_dep_sizes(
+    app: Application, base_commit: str, platform: str, py_version: str, compressed: bool
+) -> Path | None:
     '''
     Gets the dependency sizes for a given commit when dependencies were not resolved.
     '''
     with tempfile.TemporaryDirectory() as tmpdir:
-        print(f"Getting previous dependency sizes json for {base_commit=}")
-
-        if (run_id := get_run_id(base_commit, MEASURE_DISK_USAGE_WORKFLOW)) is None:
+        if (run_id := get_run_id(app, base_commit, MEASURE_DISK_USAGE_WORKFLOW)) is None:
             return None
-
-        print(f"Previous run_id: {run_id}")
 
         artifact_name = 'status_compressed.json' if compressed else 'status_uncompressed.json'
-        sizes_json = get_artifact(run_id, artifact_name, tmpdir)
+        sizes_json = get_artifact(app, run_id, artifact_name, tmpdir)
 
         if not sizes_json:
+            app.display_error("No previous dependency sizes json found")
             return None
-
-        print(f"Sizes json: {sizes_json}")
 
         sizes = parse_sizes_json(sizes_json, platform, py_version, compressed)
 


### PR DESCRIPTION
### What does this PR do?
Adds detailed debug logs to the ddev size command. These logs provide better visibility into the command’s internal behavior, including how metrics are collected and sent to Datadog.

### Motivation
Some metrics appear to be duplicated in Datadog. These additional logs will make it easier to trace the execution flow of the ddev size command, understand when and how metrics are sent, and identify the root cause of the duplication issue.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
