### PR TITLE
[DBMON-5730] Fix disable_innodb_metrics config

### DIFF
--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -25,8 +25,8 @@ class MySQLConfig(object):
             custom_tags=instance.get('tags', []),
             propagate_agent_tags=self._should_propagate_agent_tags(instance, init_config),
         )
-        self.disable_innodb_metrics = is_affirmative(instance.get('disable_innodb_metrics', False))
         self.options = instance.get('options', {}) or {}  # options could be None if empty in the YAML
+        self.disable_innodb_metrics = is_affirmative(self.options.get('disable_innodb_metrics', False))
         self.replication_channel = self.options.get('replication_channel')
         if self.replication_channel:
             self.tags.append("channel:{0}".format(self.replication_channel))


### PR DESCRIPTION
### What does this PR do?
The fix in https://github.com/DataDog/integrations-core/pull/21421 accidentally changed the config level where `disable_innodb_metrics` was loaded from. This pull request moves loading of that back to `instance.options.disable_innodb_metrics` where it's expected to be in order to preserve existing functionality. A test was added around this functionality to ensure it isn't missed again

### Motivation
Regression caught in QA while reviewing 7.72.0 release 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
