### PR TITLE
Migrate Datadog/integrations-core off of legacy runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ validate-log-integrations:
     - $CI_PROJECT_DIR/errors.txt
     expire_in: 1 day
     when: always
-  tags: [ "runner:main" ]
+  tags: [ "arch:amd64" ]
 
 notify-slack:
   needs:
@@ -83,7 +83,7 @@ notify-failed-pipeline:
     - |
       MESSAGE="The pipeline encountered an unexpected error in job $CI_JOB_NAME. Please investigate $CI_JOB_URL for errors."
       postmessage "$NOTIFICATIONS_SLACK_CHANNEL" "$MESSAGE" alert
-  tags: [ "runner:main" ]
+  tags: [ "arch:amd64" ]
 
 
 release-auto:
@@ -99,7 +99,7 @@ release-auto:
     - ddev config override
     # Prefix every line with a timestamp
     - ./.gitlab/tagger/tag-release.sh 2>&1 | ts "[%H:%M:%S %Z]  "
-  tags: [ "runner:main" ]
+  tags: [ "arch:amd64" ]
   needs: []
 
 release-manual:
@@ -122,7 +122,7 @@ release-manual:
       else
           ./.gitlab/tagger/build-packages.sh
       fi
-  tags: [ "runner:main" ]
+  tags: [ "arch:amd64" ]
   needs: []
 
 tagger-image-builder:


### PR DESCRIPTION
<details open><summary>

# Problem
</summary>

This repo is still using `runner:main`
which are legacy runners that will be decommissioned soon
due to running on EOL OS.

</details>

<details open><summary>

# Solution
</summary>

Migrate the jobs to the kubernetes runners since
we can do docker builds in K8s via buildkit and the other
jobs don't access docker at all.

Relevant docs:

- [CI Legacy Runner Deprecation](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/5471568252/CI+Legacy+Runner+Deprecation#User-Guides)

> [!NOTE]
> For any questions, contact us on [#ci-runner-docker-deprecation](https://dd.enterprise.slack.com/archives/C069CKY4NQ6)

</details>