### PR TITLE
Add `certifi` fallback for missing default CA certificates

### DIFF
--- a/datadog_checks_base/changelog.d/21609.fixed
+++ b/datadog_checks_base/changelog.d/21609.fixed
@@ -1,0 +1,1 @@
+Add `certifi` fallback for missing default CA certificates

--- a/datadog_checks_base/datadog_checks/base/utils/tls.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tls.py
@@ -69,6 +69,18 @@ def _load_ca_certs(context, config):
                 context.load_verify_locations(cafile=ca_cert, capath=None, cadata=None)
         else:
             context.load_default_certs(ssl.Purpose.SERVER_AUTH)
+            if not context.get_ca_certs():
+                LOGGER.warning(
+                    'No CA certificates loaded from system default paths. '
+                    'This may indicate misconfigured SSL_CERT_FILE or SSL_CERT_DIR environment variables. '
+                    'Falling back to certifi certificate bundle.'
+                )
+                try:
+                    import certifi
+
+                    context.load_verify_locations(cafile=certifi.where())
+                except (ImportError, FileNotFoundError) as e:
+                    LOGGER.error('Failed to load fallback certificates from certifi: %s', e)
     except FileNotFoundError:
         LOGGER.warning(
             'TLS CA certificate file not found: %s. Please check the `tls_ca_cert` configuration option.',

--- a/datadog_checks_base/tests/base/utils/http/test_tls_and_certs.py
+++ b/datadog_checks_base/tests/base/utils/http/test_tls_and_certs.py
@@ -10,6 +10,7 @@ from requests.exceptions import SSLError
 
 from datadog_checks.base.utils.http import RequestsWrapper
 from datadog_checks.base.utils.tls import TlsConfig
+from datadog_checks.dev.utils import ON_WINDOWS
 
 pytestmark = [pytest.mark.unit]
 
@@ -66,6 +67,30 @@ class TestCert:
 
             mock_load_cert_chain.assert_called_once()
             mock_load_cert_chain.assert_called_with(expected_cert, keyfile=expected_key, password=None)
+
+    @pytest.mark.skipif(ON_WINDOWS, reason="Windows uses the default store locations.")
+    def test_bad_default_verify_paths(self, monkeypatch, caplog):
+        '''The SSL default verify paths can be set incorrectly.'''
+        bad_cert_file = "/nonexistent/path/to/ssl/cert.pem"
+        bad_cert_dir = "/nonexistent/path/to/ssl/certs"
+        monkeypatch.setenv("SSL_CERT_FILE", bad_cert_file)
+        monkeypatch.setenv("SSL_CERT_DIR", bad_cert_dir)
+        bad_ssl_paths = ssl.DefaultVerifyPaths(
+            cafile="None",
+            capath="None",
+            openssl_cafile_env="SSL_CERT_FILE",
+            openssl_capath_env="SSL_CERT_DIR",
+            openssl_cafile=bad_cert_file,
+            openssl_capath=bad_cert_dir,
+        )
+        with mock.patch("ssl.get_default_verify_paths", return_value=bad_ssl_paths):
+            with mock.patch("requests.Session.get"):
+                with caplog.at_level(logging.WARNING):
+                    http = RequestsWrapper({"tls_verify": True}, {})
+                    assert ssl.get_default_verify_paths() == bad_ssl_paths
+                    assert http.session.adapters["https://"].ssl_context.get_ca_certs() != []
+                    http.get("https://example.com")
+            assert 'Falling back to certifi certificate bundle.' in caplog.text
 
 
 class TestIgnoreTLSWarning:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds a fallback to `certifi` when the no CA certificates have been found during SSL context creation.

The fallback is tested only on Linux as on Windows the [system certificate stores](https://learn.microsoft.com/en-us/windows/win32/seccrypto/system-store-locations?redirectedfrom=MSDN) are loaded by default. ([source](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_default_certs))

### Motivation
<!-- What inspired you to submit this pull request? -->
On MacOS, some hosts were experiencing the following SSL Error:
```
SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1010)'))
```
This could have multiple root causes, originating at OpenSSL build time or from environment variables.
`certifi.where()` is [used by the `requests` library](https://github.com/psf/requests/blob/420d16bc7ef326f7b65f90e4644adc0f6a0e1d44/src/requests/utils.py#L64) and fixes this issue, therefore we can use it as a fallback.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
