### PR TITLE
Test with last 7.71.1 rc to avoid issues with python mismatch

### DIFF
--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -55,7 +55,7 @@ on:
         type: boolean
       agent-image:
         required: false
-        default: ""
+        default: "datadog/agent:7.71.1-rc.1"
         type: string
       agent-image-py2:
         required: false
@@ -63,7 +63,7 @@ on:
         type: string
       agent-image-windows:
         required: false
-        default: ""
+        default: "datadog/agent:7.71.1-rc.1-servercore"
         type: string
       agent-image-windows-py2:
         required: false


### PR DESCRIPTION
### What does this PR do?
Makes the CI use 7.71.1-rc.1 for tests. We upgraded python in 7.72 and the default dev image. This has caused some tests to fail. Testing on 7.71.1 agent is more accurate also.