### PR TITLE
[AI-6164] Skip Vertica docker tests

### DIFF
--- a/vertica/tests/conftest.py
+++ b/vertica/tests/conftest.py
@@ -36,6 +36,7 @@ class InitializeDB(LazyFunction):
 
 @pytest.fixture(scope='session')
 def dd_environment():
+    pytest.skip("Skipping Vertica integration tests: the Vertica Docker image is no longer available.")
     compose_file = os.path.join(common.HERE, 'docker', 'docker-compose.yaml')
 
     with docker_run(compose_file, log_patterns=['Vertica is now running'], conditions=[InitializeDB(common.CONFIG)]):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Skips all Vertica tests that require a docker environment.
This is a temporary fix to stop the failing check in all PRs.

### Motivation
<!-- What inspired you to submit this pull request? -->
Vertica docker images are no longer available and this is causing Vertica tests to fail on CI every time.
https://datadoghq.atlassian.net/browse/AI-6164

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
