### PR TITLE
Add timeouts at the GitHub Actions step level for ddev tests.

### DIFF
--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -91,6 +91,11 @@ on:
         required: false
         default: "standard"
         type: string
+      step-timeout-minutes:
+        description: "Timeout in minutes for ddev test steps"
+        required: false
+        default: 60
+        type: number
 
 defaults:
   run:
@@ -197,6 +202,7 @@ jobs:
         ddev config set repo ${{ inputs.repo }}
 
     - name: Lint
+      timeout-minutes: ${{ inputs.step-timeout-minutes }}
       run: |-
         ddev test --lint ${{ inputs.target }} || {
           echo "::error::Lint failed!"
@@ -205,6 +211,7 @@ jobs:
         }
 
     - name: Prepare for testing
+      timeout-minutes: ${{ inputs.step-timeout-minutes }}
       env: >-
         ${{ fromJson(inputs.setup-env-vars || format(
           '{{
@@ -235,7 +242,7 @@ jobs:
 
     - name: Run Unit & Integration tests
       if: inputs.latest != true && inputs.minimum-base-package != true
-      timeout-minutes: 60
+      timeout-minutes: ${{ inputs.step-timeout-minutes }}
       env:
         # TODO: SQL Server on Windows crashes when tracing is enabled with error File Windows fatal exception: access violation
         DDEV_TEST_ENABLE_TRACING: "${{ inputs.repo == 'core' && (inputs.target != 'sqlserver' || inputs.platform != 'windows') && '1' || '0' }}"
@@ -257,7 +264,7 @@ jobs:
 
     - name: Run Unit & Integration tests with minimum version of base package
       if: inputs.minimum-base-package
-      timeout-minutes: 60
+      timeout-minutes: ${{ inputs.step-timeout-minutes }}
       run: |
         if [ '${{ inputs.pytest-args }}' = '-m flaky' ]; then
           set +e # Disable immediate exit
@@ -276,7 +283,7 @@ jobs:
 
     - name: Run E2E tests with latest base package
       if: inputs.repo == 'core' && !inputs.minimum-base-package
-      timeout-minutes: 60
+      timeout-minutes: ${{ inputs.step-timeout-minutes }}
       env:
         DD_API_KEY: "${{ secrets.DD_API_KEY }}"
       run: |
@@ -305,7 +312,7 @@ jobs:
 
     - name: Run E2E tests
       if: inputs.repo != 'core'
-      timeout-minutes: 60
+      timeout-minutes: ${{ inputs.step-timeout-minutes }}
       env:
         DD_API_KEY: "${{ secrets.DD_API_KEY }}"
       run: |
@@ -334,17 +341,17 @@ jobs:
 
     - name: Run benchmarks
       if: inputs.benchmark
-      timeout-minutes: 60
+      timeout-minutes: ${{ inputs.step-timeout-minutes }}
       run: ddev test --bench --junit ${{ inputs.target-env && format('{0}:{1}', inputs.target, inputs.target-env) || inputs.target }}
 
     - name: Run tests and verify support for the latest version
       if: inputs.latest
-      timeout-minutes: 60
+      timeout-minutes: ${{ inputs.step-timeout-minutes }}
       run: ddev test --latest --junit ${{ inputs.target-env && format('{0}:{1}', inputs.target, inputs.target-env) || inputs.target }}
 
     - name: Run E2E tests for the latest version
       if: inputs.latest
-      timeout-minutes: 60
+      timeout-minutes: ${{ inputs.step-timeout-minutes }}
       env:
         DD_API_KEY: "${{ secrets.DD_API_KEY }}"
         # TODO: SQL Server on Windows crashes when tracing is enabled with error File Windows fatal exception: access violation


### PR DESCRIPTION
### What does this PR do?
Add timeouts at the GitHub Actions step level for ddev tests.

### Motivation
* Have a faster timeout than the current 6h so that hangs are less disruptive.
* Stop hangs that are not caught by the the Python-level timeout.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
