### PR TITLE
[AI-6163] Fix skip-qa action to update comments for every case

### DIFF
--- a/.github/workflows/validate-skip-qa.yml
+++ b/.github/workflows/validate-skip-qa.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: "`qa/skip-qa` label"
+          comment-author: "github-actions[bot]"
 
       - name: Post message - Add skip qa label
         if: steps.changed_files.outputs.any_changed == 'false' && !contains(github.event.pull_request.labels.*.name, 'qa/skip-qa')


### PR DESCRIPTION
### What does this PR do?
Updates the validate-skip-qa workflow so that the PR comment is refreshed in both cases, when the skip-qa tag needs to be added and when it needs to be removed. Previously, the comment was only updated when the tag needed to be removed.

It also ensures that the comment is only posted once the PR is marked as ready for review.

### Motivation
When a PR is initially opened without agent shippable files and those files are later added, the comment becomes outdated, it keeps asking to add the skip-qa tag even though it’s no longer needed.
This change ensures the comment always stays accurate and reflects the current state of the PR.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
