### PR TITLE
Revert "Add pytest-timeout to ddev tests"

### DIFF
--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -124,8 +124,6 @@ jobs:
       TRACE_CAPTURE_LOG: "trace-captures/output.log"
       # Prefix for artifact names when using minimum base package
       MINIMUM_BASE_PACKAGE_PREFIX: "${{ inputs.minimum-base-package && 'minimum-base-package-' || '' }}"
-      # Add timeout to pytest to force stop hanging integrations.
-      PYTEST_TIMEOUT: "1800"
 
     permissions:
        # needed for compute-matrix in test-target.yml

--- a/datadog_checks_dev/changelog.d/21596.added
+++ b/datadog_checks_dev/changelog.d/21596.added
@@ -1,1 +1,0 @@
-Add pytest-timeout to ddev

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
     "pytest-cov>=2.6.1",
     "pytest-memray>=1.4.0; platform_system=='Linux' or platform_system=='Darwin'",
     "pytest-mock",
-    "pytest-timeout==2.4.0",
     "pyyaml>=5.4.1",
     "requests>=2.22.0",
     "tenacity",


### PR DESCRIPTION
Timeouts via pytest don't seem to work. The running theory is the hang also hangs the process that checks the timeout.