### PR TITLE
Changelog update for cluster agent check release from 7.71.2

### DIFF
--- a/datadog_cluster_agent/CHANGELOG.md
+++ b/datadog_cluster_agent/CHANGELOG.md
@@ -9,6 +9,12 @@
 * Bump Python to 3.13 ([#21161](https://github.com/DataDog/integrations-core/pull/21161))
 * Bump datadog-checks-base to 37.21.0 ([#21477](https://github.com/DataDog/integrations-core/pull/21477))
 
+## 6.0.2 / 2025-10-10
+
+***Added***:
+
+* Add new metric for SSI gradual rollout ([#21599](https://github.com/DataDog/integrations-core/pull/21599))
+
 ## 6.0.1 / 2025-08-07 / Agent 7.70.0
 
 ***Fixed***:


### PR DESCRIPTION
### What does this PR do?
Changelog port
