### PR TITLE
support Avro & Protobuf messages with schema registry

### DIFF
--- a/kafka_consumer/changelog.d/21632.fixed
+++ b/kafka_consumer/changelog.d/21632.fixed
@@ -1,0 +1,1 @@
+Correctly support schema registry bytes in Avro & Protobuf messages

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -415,8 +415,10 @@ class KafkaCheck(AgentCheck):
             config_id = cfg["id"]
             value_format = kafka["value_format"]
             value_schema_str = kafka.get("value_schema", "")
+            value_uses_schema_registry = kafka.get("value_uses_schema_registry", False)
             key_format = kafka["key_format"]
             key_schema_str = kafka.get("key_schema", "")
+            key_uses_schema_registry = kafka.get("key_uses_schema_registry", False)
             if self._messages_have_been_retrieved(config_id):
                 continue
             if not cluster or not cluster_id or cluster.lower() != cluster_id.lower():
@@ -497,7 +499,13 @@ class KafkaCheck(AgentCheck):
                         'feature': 'data_streams_messages',
                     }
                     decoded_value, value_schema_id, decoded_key, key_schema_id = deserialize_message(
-                        message, value_format, value_schema, key_format, key_schema
+                        message,
+                        value_format,
+                        value_schema,
+                        value_uses_schema_registry,
+                        key_format,
+                        key_schema,
+                        key_uses_schema_registry,
                     )
                     if decoded_value:
                         data['message_value'] = decoded_value
@@ -570,31 +578,56 @@ def resolve_start_offsets(highwater_offsets, target_topic, target_partition, sta
     return [TopicPartition(target_topic, target_partition, start_offset)]
 
 
-def deserialize_message(message, value_format, value_schema, key_format, key_schema):
+def deserialize_message(
+    message,
+    value_format,
+    value_schema,
+    value_uses_schema_registry,
+    key_format,
+    key_schema,
+    key_uses_schema_registry,
+):
     try:
         decoded_value, value_schema_id = _deserialize_bytes_maybe_schema_registry(
-            message.value(), value_format, value_schema
+            message.value(), value_format, value_schema, value_uses_schema_registry
         )
     except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
         return None, None, None, None
     try:
-        decoded_key, key_schema_id = _deserialize_bytes_maybe_schema_registry(message.key(), key_format, key_schema)
+        decoded_key, key_schema_id = _deserialize_bytes_maybe_schema_registry(
+            message.key(), key_format, key_schema, key_uses_schema_registry
+        )
         return decoded_value, value_schema_id, decoded_key, key_schema_id
     except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
         return decoded_value, value_schema_id, None, None
 
 
-def _deserialize_bytes_maybe_schema_registry(message, message_format, schema):
-    try:
-        return _deserialize_bytes(message, message_format, schema), None
-    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as e:
-        # If the message is not a valid JSON, it might be a schema registry message, that is prefixed
-        # with a magic byte and a schema ID.
+def _deserialize_bytes_maybe_schema_registry(message, message_format, schema, uses_schema_registry):
+    if not message:
+        return "", None
+    if uses_schema_registry:
+        # When explicitly configured, go straight to schema registry format
         if len(message) < 5 or message[0] != SCHEMA_REGISTRY_MAGIC_BYTE:
-            raise e
+            msg_hex = message[:5].hex() if len(message) >= 5 else message.hex()
+            raise ValueError(
+                f"Expected schema registry format (magic byte 0x00 + 4-byte schema ID), "
+                f"but message is too short or has wrong magic byte: {msg_hex}"
+            )
         schema_id = int.from_bytes(message[1:5], 'big')
-        message = message[5:]  # Skip the schema ID bytes
+        message = message[5:]  # Skip the magic byte and schema ID bytes
         return _deserialize_bytes(message, message_format, schema), schema_id
+    else:
+        # Fallback behavior: try without schema registry format first, then with it
+        try:
+            return _deserialize_bytes(message, message_format, schema), None
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as e:
+            # If the message is not valid, it might be a schema registry message, that is prefixed
+            # with a magic byte and a schema ID.
+            if len(message) < 5 or message[0] != SCHEMA_REGISTRY_MAGIC_BYTE:
+                raise e
+            schema_id = int.from_bytes(message[1:5], 'big')
+            message = message[5:]  # Skip the magic byte and schema ID bytes
+            return _deserialize_bytes(message, message_format, schema), schema_id
 
 
 def _deserialize_bytes(message, message_format, schema):
@@ -621,18 +654,40 @@ def _deserialize_json(message):
 
 
 def _deserialize_protobuf(message, schema):
-    """Deserialize a Protobuf message using google.protobuf."""
+    """Deserialize a Protobuf message using google.protobuf with strict validation."""
     try:
-        schema.ParseFromString(message)
+        bytes_consumed = schema.ParseFromString(message)
+
+        # Check if all bytes were consumed (strict validation)
+        if bytes_consumed != len(message):
+            raise ValueError(
+                f"Not all bytes were consumed during Protobuf decoding! "
+                f"Read {bytes_consumed} bytes, but message has {len(message)} bytes. "
+            )
+
         return MessageToJson(schema)
     except Exception as e:
         raise ValueError(f"Failed to deserialize Protobuf message: {e}")
 
 
 def _deserialize_avro(message, schema):
-    """Deserialize an Avro message using fastavro."""
+    """Deserialize an Avro message using fastavro with strict validation."""
     try:
-        data = schemaless_reader(BytesIO(message), schema)
+        bio = BytesIO(message)
+        initial_position = bio.tell()
+        data = schemaless_reader(bio, schema)
+        final_position = bio.tell()
+
+        # Check if all bytes were consumed (strict validation)
+        bytes_read = final_position - initial_position
+        total_bytes = len(message)
+
+        if bytes_read != total_bytes:
+            raise ValueError(
+                f"Not all bytes were consumed during Avro decoding! "
+                f"Read {bytes_read} bytes, but message has {total_bytes} bytes. "
+            )
+
         return json.dumps(data)
     except Exception as e:
         raise ValueError(f"Failed to deserialize Avro message: {e}")

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -536,23 +536,33 @@ def test_deserialize_message():
         b'\x00\x00\x00\x01\x5e{"name": "Peter Parker", "age": 18, "transaction_amount": 123, "currency": "dollar"}'
     )
     key = b'{"name": "Peter Parker"}'
-    assert deserialize_message(MockedMessage(message, key), 'json', '', 'json', '') == (
+    assert deserialize_message(MockedMessage(message, key), 'json', '', False, 'json', '', False) == (
         '{"name": "Peter Parker", "age": 18, "transaction_amount": 123, "currency": "dollar"}',
         None,
         '{"name": "Peter Parker"}',
         None,
     )
-    assert deserialize_message(MockedMessage(message_with_schema), 'json', '', 'json', '') == (
+    assert deserialize_message(MockedMessage(message_with_schema), 'json', '', False, 'json', '', False) == (
         '{"name": "Peter Parker", "age": 18, "transaction_amount": 123, "currency": "dollar"}',
         350,
         '',
         None,
     )
     invalid_json = b'{"name": "Peter Parker", "age": 18, "transaction_amount": 123, "currency": "dollar"'
-    assert deserialize_message(MockedMessage(invalid_json, key), 'json', '', 'json', '') == (None, None, None, None)
+    assert deserialize_message(MockedMessage(invalid_json, key), 'json', '', False, 'json', '', False) == (
+        None,
+        None,
+        None,
+        None,
+    )
 
     invalid_utf8 = b'{"name": "Peter Parker", "age": 18, "transaction_amount": 123, "currency": "dollar"\xff'
-    assert deserialize_message(MockedMessage(invalid_utf8, key), 'json', '', 'json', '') == (None, None, None, None)
+    assert deserialize_message(MockedMessage(invalid_utf8, key), 'json', '', False, 'json', '', False) == (
+        None,
+        None,
+        None,
+        None,
+    )
 
     # Test Avro deserialization
     avro_schema = (
@@ -562,7 +572,9 @@ def test_deserialize_message():
     )
     avro_message = b'\xd0\xf5\xe4\xd6\xa3\xb9\x046The Go Programming Language\x18Alan Donovan'
     parsed_avro_schema = build_schema('avro', avro_schema)
-    assert deserialize_message(MockedMessage(avro_message, key), 'avro', parsed_avro_schema, 'json', '') == (
+    assert deserialize_message(
+        MockedMessage(avro_message, key), 'avro', parsed_avro_schema, False, 'json', '', False
+    ) == (
         '{"isbn": 9780134190440, "title": "The Go Programming Language", "author": "Alan Donovan"}',
         None,
         '{"name": "Peter Parker"}',
@@ -580,7 +592,7 @@ def test_deserialize_message():
     )
     parsed_protobuf_schema = build_schema('protobuf', protobuf_schema)
     assert deserialize_message(
-        MockedMessage(protobuf_message, key), 'protobuf', parsed_protobuf_schema, 'json', ''
+        MockedMessage(protobuf_message, key), 'protobuf', parsed_protobuf_schema, False, 'json', '', False
     ) == (
         '{\n  "isbn": "9780134190440",\n  "title": "The Go Programming Language",\n  "author": "Alan Donovan"\n}',
         None,
@@ -590,7 +602,7 @@ def test_deserialize_message():
 
     # Test invalid Avro messages
     # Empty message (returns empty string, not None)
-    assert deserialize_message(MockedMessage(b'', key), 'avro', parsed_avro_schema, 'json', '') == (
+    assert deserialize_message(MockedMessage(b'', key), 'avro', parsed_avro_schema, False, 'json', '', False) == (
         '',
         None,
         '{"name": "Peter Parker"}',
@@ -599,7 +611,9 @@ def test_deserialize_message():
 
     # Corrupted message (truncated)
     corrupted_avro = b'\xd0\xf5\xe4\xd6\xa3\xb9\x046The Go Programming Language'  # Missing author field
-    assert deserialize_message(MockedMessage(corrupted_avro, key), 'avro', parsed_avro_schema, 'json', '') == (
+    assert deserialize_message(
+        MockedMessage(corrupted_avro, key), 'avro', parsed_avro_schema, False, 'json', '', False
+    ) == (
         None,
         None,
         None,
@@ -608,7 +622,9 @@ def test_deserialize_message():
 
     # Wrong data type (string instead of long for isbn)
     wrong_type_avro = b'\x02\x12\x1bThe Go Programming Language\x18Alan Donovan'  # Wrong encoding for isbn
-    assert deserialize_message(MockedMessage(wrong_type_avro, key), 'avro', parsed_avro_schema, 'json', '') == (
+    assert deserialize_message(
+        MockedMessage(wrong_type_avro, key), 'avro', parsed_avro_schema, False, 'json', '', False
+    ) == (
         None,
         None,
         None,
@@ -617,7 +633,9 @@ def test_deserialize_message():
 
     # Random bytes
     random_avro = b'\xff\xfe\xfd\xfc\xfb\xfa\xf9\xf8\xf7\xf6\xf5\xf4\xf3\xf2\xf1\xf0'
-    assert deserialize_message(MockedMessage(random_avro, key), 'avro', parsed_avro_schema, 'json', '') == (
+    assert deserialize_message(
+        MockedMessage(random_avro, key), 'avro', parsed_avro_schema, False, 'json', '', False
+    ) == (
         None,
         None,
         None,
@@ -626,7 +644,9 @@ def test_deserialize_message():
 
     # Completely invalid Avro message (random bytes)
     invalid_avro = b'\xff\xfe\xfd\xfc\xfb\xfa\xf9\xf8\xf7\xf6\xf5\xf4\xf3\xf2\xf1\xf0'
-    assert deserialize_message(MockedMessage(invalid_avro, key), 'avro', parsed_avro_schema, 'json', '') == (
+    assert deserialize_message(
+        MockedMessage(invalid_avro, key), 'avro', parsed_avro_schema, False, 'json', '', False
+    ) == (
         None,
         None,
         None,
@@ -635,7 +655,9 @@ def test_deserialize_message():
 
     # Avro message with wrong data types (string where long expected)
     wrong_type_avro = b'\x02\x12\x1bThe Go Programming Language\x18Alan Donovan'  # Wrong encoding for isbn
-    assert deserialize_message(MockedMessage(wrong_type_avro, key), 'avro', parsed_avro_schema, 'json', '') == (
+    assert deserialize_message(
+        MockedMessage(wrong_type_avro, key), 'avro', parsed_avro_schema, False, 'json', '', False
+    ) == (
         None,
         None,
         None,
@@ -644,7 +666,9 @@ def test_deserialize_message():
 
     # Test invalid Protobuf messages
     # Empty message (returns empty string, not None)
-    assert deserialize_message(MockedMessage(b'', key), 'protobuf', parsed_protobuf_schema, 'json', '') == (
+    assert deserialize_message(
+        MockedMessage(b'', key), 'protobuf', parsed_protobuf_schema, False, 'json', '', False
+    ) == (
         '',
         None,
         '{"name": "Peter Parker"}',
@@ -653,7 +677,9 @@ def test_deserialize_message():
 
     # Random bytes
     random_protobuf = b'\xff\xfe\xfd\xfc\xfb\xfa\xf9\xf8\xf7\xf6\xf5\xf4\xf3\xf2\xf1\xf0'
-    assert deserialize_message(MockedMessage(random_protobuf, key), 'protobuf', parsed_protobuf_schema, 'json', '') == (
+    assert deserialize_message(
+        MockedMessage(random_protobuf, key), 'protobuf', parsed_protobuf_schema, False, 'json', '', False
+    ) == (
         None,
         None,
         None,
@@ -663,7 +689,7 @@ def test_deserialize_message():
     # Completely invalid Protobuf message (random bytes)
     invalid_protobuf = b'\xff\xfe\xfd\xfc\xfb\xfa\xf9\xf8\xf7\xf6\xf5\xf4\xf3\xf2\xf1\xf0'
     assert deserialize_message(
-        MockedMessage(invalid_protobuf, key), 'protobuf', parsed_protobuf_schema, 'json', ''
+        MockedMessage(invalid_protobuf, key), 'protobuf', parsed_protobuf_schema, False, 'json', '', False
     ) == (None, None, None, None)
 
     # Protobuf message with wrong field number (field 99 instead of 1)
@@ -671,14 +697,241 @@ def test_deserialize_message():
         b'\x99\x01\xe8\xba\xb2\xeb\xd1\x9c\x02\x12\x1bThe Go Programming Language\x1a\x0cAlan Donovan'
     )
     assert deserialize_message(
-        MockedMessage(wrong_field_protobuf, key), 'protobuf', parsed_protobuf_schema, 'json', ''
+        MockedMessage(wrong_field_protobuf, key), 'protobuf', parsed_protobuf_schema, False, 'json', '', False
     ) == (None, None, None, None)
 
     # Protobuf message with truncated varint
     truncated_varint_protobuf = b'\x08\xff\xff\xff\xff\xff\xff\xff\xff\xff'  # Incomplete varint
     assert deserialize_message(
-        MockedMessage(truncated_varint_protobuf, key), 'protobuf', parsed_protobuf_schema, 'json', ''
+        MockedMessage(truncated_varint_protobuf, key), 'protobuf', parsed_protobuf_schema, False, 'json', '', False
     ) == (None, None, None, None)
+
+
+def test_strict_avro_validation():
+    """Test that Avro deserialization fails when not all bytes are consumed."""
+    key = b'{"name": "Peter Parker"}'
+
+    # Test case 1: Simple primitive string schema with extra bytes
+    # A primitive string in Avro is encoded as: varint length + UTF-8 bytes
+    # An empty string is just: 0x00 (zero length)
+    # If we have 0x00 followed by extra bytes (e.g., magic byte + 4 bytes + stuff),
+    # the string decoder will read the empty string but leave bytes unconsumed
+    string_schema = '"string"'
+    parsed_string_schema = build_schema('avro', string_schema)
+
+    # Message: 0x00 (empty string) + 0x00 (magic byte) + 4 bytes + some random data
+    # The Avro string decoder will only consume the first 0x00, leaving the rest
+    message_with_extra_bytes = b'\x00\x00\x00\x00\x01\x5e\x12\x34\x56\x78'
+
+    # This should now fail because not all bytes are consumed
+    result = deserialize_message(
+        MockedMessage(message_with_extra_bytes, key), 'avro', parsed_string_schema, False, 'json', '', False
+    )
+    assert result == (None, None, None, None), "Expected deserialization to fail due to unconsumed bytes"
+
+    # Test case 2: Avro message with trailing garbage bytes after valid data
+    avro_schema = (
+        '{"type": "record", "name": "Book", "namespace": "com.book", '
+        '"fields": [{"name": "isbn", "type": "long"}, {"name": "title", "type": "string"}, '
+        '{"name": "author", "type": "string"}]}'
+    )
+    parsed_avro_schema = build_schema('avro', avro_schema)
+
+    # Valid Avro message + trailing garbage
+    valid_avro_message = b'\xd0\xf5\xe4\xd6\xa3\xb9\x046The Go Programming Language\x18Alan Donovan'
+    message_with_trailing_bytes = valid_avro_message + b'\xff\xfe\xfd\xfc'
+
+    # This should now fail because of the trailing bytes
+    result = deserialize_message(
+        MockedMessage(message_with_trailing_bytes, key), 'avro', parsed_avro_schema, False, 'json', '', False
+    )
+    assert result == (None, None, None, None), "Expected deserialization to fail due to trailing bytes"
+
+    # Test case 3: Simple int schema with extra bytes
+    int_schema = '"int"'
+    parsed_int_schema = build_schema('avro', int_schema)
+
+    # Message: 0x02 (int value 1) + extra bytes
+    message_int_with_extra = b'\x02\xde\xad\xbe\xef'
+
+    result = deserialize_message(
+        MockedMessage(message_int_with_extra, key), 'avro', parsed_int_schema, False, 'json', '', False
+    )
+    assert result == (None, None, None, None), "Expected deserialization to fail due to unconsumed bytes"
+
+    # Test case 4: Verify that valid messages still work
+    valid_string_message = b'\x0aHello'  # Length 5 (encoded as 0x0a = 10/2 = 5) + "Hello"
+    result = deserialize_message(
+        MockedMessage(valid_string_message, key), 'avro', parsed_string_schema, False, 'json', '', False
+    )
+    assert result[0] == '"Hello"', "Expected valid string message to deserialize correctly"
+    assert result[1] is None
+
+    valid_int_message = b'\x02'  # int value 1
+    result = deserialize_message(
+        MockedMessage(valid_int_message, key), 'avro', parsed_int_schema, False, 'json', '', False
+    )
+    assert result[0] == '1', "Expected valid int message to deserialize correctly"
+
+
+def test_strict_protobuf_validation():
+    """Test that Protobuf deserialization fails when not all bytes are consumed."""
+    key = b'{"name": "Peter Parker"}'
+
+    # Build the same Book schema used in other tests
+    protobuf_schema = (
+        'CmoKDHNjaGVtYS5wcm90bxIIY29tLmJvb2siSAoEQm9vaxISCgRpc2JuGAEgASgDUgRpc2Ju'
+        'EhQKBXRpdGxlGAIgASgJUgV0aXRsZRIWCgZhdXRob3IYAyABKAlSBmF1dGhvcmIGcHJvdG8z'
+    )
+    parsed_protobuf_schema = build_schema('protobuf', protobuf_schema)
+
+    # Test case 1: Valid Protobuf message with trailing garbage bytes
+    valid_protobuf_message = (
+        b'\x08\xe8\xba\xb2\xeb\xd1\x9c\x02\x12\x1b\x54\x68\x65\x20\x47\x6f\x20\x50\x72\x6f\x67\x72\x61\x6d\x6d\x69\x6e\x67\x20\x4c\x61\x6e\x67\x75\x61\x67\x65'
+        b'\x1a\x0c\x41\x6c\x61\x6e\x20\x44\x6f\x6e\x6f\x76\x61\x6e'
+    )
+    message_with_trailing_bytes = valid_protobuf_message + b'\xff\xfe\xfd\xfc'
+
+    # This should now fail because of the trailing bytes
+    result = deserialize_message(
+        MockedMessage(message_with_trailing_bytes, key), 'protobuf', parsed_protobuf_schema, False, 'json', '', False
+    )
+    assert result == (None, None, None, None), "Expected deserialization to fail due to trailing bytes"
+
+    # Test case 2: Message with extra fields that aren't in the schema
+    # Protobuf will parse this but leave bytes unconsumed if there are truly extra bytes beyond valid fields
+    # Adding a completely invalid trailing byte sequence
+    message_with_invalid_trailer = valid_protobuf_message + b'\x00\x00\x00\x01\x5e'
+
+    result = deserialize_message(
+        MockedMessage(message_with_invalid_trailer, key),
+        'protobuf',
+        parsed_protobuf_schema,
+        False,
+        'json',
+        '',
+        False,
+    )
+    assert result == (None, None, None, None), "Expected deserialization to fail due to unconsumed bytes"
+
+    # Test case 3: Verify that valid messages still work
+    result = deserialize_message(
+        MockedMessage(valid_protobuf_message, key), 'protobuf', parsed_protobuf_schema, False, 'json', '', False
+    )
+    assert result[0] is not None, "Expected valid protobuf message to deserialize correctly"
+    assert 'The Go Programming Language' in result[0]
+
+
+def test_schema_registry_explicit_configuration():
+    """Test that explicit schema registry configuration is enforced."""
+    key = b'{"name": "Peter Parker"}'
+
+    # Test Avro with value_uses_schema_registry=True
+    avro_schema = (
+        '{"type": "record", "name": "Book", "namespace": "com.book", '
+        '"fields": [{"name": "isbn", "type": "long"}, {"name": "title", "type": "string"}, '
+        '{"name": "author", "type": "string"}]}'
+    )
+    parsed_avro_schema = build_schema('avro', avro_schema)
+
+    # Valid Avro message WITHOUT schema registry format
+    avro_message_no_sr = b'\xd0\xf5\xe4\xd6\xa3\xb9\x046The Go Programming Language\x18Alan Donovan'
+
+    # When uses_schema_registry=False, this should work
+    result = deserialize_message(
+        MockedMessage(avro_message_no_sr, key), 'avro', parsed_avro_schema, False, 'json', '', False
+    )
+    assert result[0] is not None, "Should succeed when uses_schema_registry=False"
+    assert result[1] is None, "Should have no schema ID"
+
+    # When uses_schema_registry=True, this should fail (missing magic byte and schema ID)
+    result = deserialize_message(
+        MockedMessage(avro_message_no_sr, key), 'avro', parsed_avro_schema, True, 'json', '', False
+    )
+    assert result == (None, None, None, None), "Should fail when uses_schema_registry=True"
+
+    # Valid Avro message WITH schema registry format (schema ID 350 = 0x015E)
+    avro_message_with_sr = (
+        b'\x00\x00\x00\x01\x5e\xd0\xf5\xe4\xd6\xa3\xb9\x046The Go Programming Language\x18Alan Donovan'
+    )
+
+    # When uses_schema_registry=True, this should work
+    result = deserialize_message(
+        MockedMessage(avro_message_with_sr, key), 'avro', parsed_avro_schema, True, 'json', '', False
+    )
+    assert result[0] is not None, "Should succeed when uses_schema_registry=True"
+    assert result[1] == 350, "Should extract schema ID 350"
+    assert 'The Go Programming Language' in result[0]
+
+    # Test with wrong magic byte
+    wrong_magic_byte = b'\x01\x00\x00\x01\x5e\xd0\xf5\xe4\xd6\xa3\xb9\x046The Go Programming Language\x18Alan Donovan'
+    result = deserialize_message(
+        MockedMessage(wrong_magic_byte, key), 'avro', parsed_avro_schema, True, 'json', '', False
+    )
+    assert result == (None, None, None, None), "Should fail with wrong magic byte"
+
+    # Test with message too short (less than 5 bytes)
+    too_short = b'\x00\x00\x01'
+    result = deserialize_message(MockedMessage(too_short, key), 'avro', parsed_avro_schema, True, 'json', '', False)
+    assert result == (None, None, None, None), "Should fail when message too short for SR format"
+
+    # Test Protobuf with value_uses_schema_registry=True
+    protobuf_schema = (
+        'CmoKDHNjaGVtYS5wcm90bxIIY29tLmJvb2siSAoEQm9vaxISCgRpc2JuGAEgASgDUgRpc2Ju'
+        'EhQKBXRpdGxlGAIgASgJUgV0aXRsZRIWCgZhdXRob3IYAyABKAlSBmF1dGhvcmIGcHJvdG8z'
+    )
+    parsed_protobuf_schema = build_schema('protobuf', protobuf_schema)
+
+    # Valid Protobuf message WITHOUT schema registry format
+    protobuf_message_no_sr = (
+        b'\x08\xe8\xba\xb2\xeb\xd1\x9c\x02\x12\x1b\x54\x68\x65\x20\x47\x6f\x20\x50\x72\x6f\x67\x72\x61\x6d\x6d\x69\x6e\x67\x20\x4c\x61\x6e\x67\x75\x61\x67\x65'
+        b'\x1a\x0c\x41\x6c\x61\x6e\x20\x44\x6f\x6e\x6f\x76\x61\x6e'
+    )
+
+    # When uses_schema_registry=False, this should work
+    result = deserialize_message(
+        MockedMessage(protobuf_message_no_sr, key), 'protobuf', parsed_protobuf_schema, False, 'json', '', False
+    )
+    assert result[0] is not None, "Protobuf should succeed when uses_schema_registry=False"
+    assert result[1] is None, "Should have no schema ID"
+
+    # When uses_schema_registry=True, this should fail
+    result = deserialize_message(
+        MockedMessage(protobuf_message_no_sr, key), 'protobuf', parsed_protobuf_schema, True, 'json', '', False
+    )
+    assert result == (None, None, None, None), "Protobuf should fail when uses_schema_registry=True but no SR format"
+
+    # Valid Protobuf message WITH schema registry format
+    protobuf_message_with_sr = (
+        b'\x00\x00\x00\x01\x5e'
+        b'\x08\xe8\xba\xb2\xeb\xd1\x9c\x02\x12\x1b\x54\x68\x65\x20\x47\x6f\x20\x50\x72\x6f\x67\x72\x61\x6d\x6d\x69\x6e\x67\x20\x4c\x61\x6e\x67\x75\x61\x67\x65'
+        b'\x1a\x0c\x41\x6c\x61\x6e\x20\x44\x6f\x6e\x6f\x76\x61\x6e'
+    )
+
+    # When uses_schema_registry=True, this should work
+    result = deserialize_message(
+        MockedMessage(protobuf_message_with_sr, key),
+        'protobuf',
+        parsed_protobuf_schema,
+        True,
+        'json',
+        '',
+        False,
+    )
+    assert result[0] is not None, "Protobuf should succeed when uses_schema_registry=True with SR format"
+    assert result[1] == 350, "Should extract schema ID 350"
+    assert 'The Go Programming Language' in result[0]
+
+    # Test key_uses_schema_registry=True
+    # When key has no schema registry format but key_uses_schema_registry=True, key decoding should fail
+    # but value should still succeed
+    result = deserialize_message(
+        MockedMessage(avro_message_no_sr, key), 'avro', parsed_avro_schema, False, 'json', '', True
+    )
+    # Value should succeed, but key should fail (returning None for key fields)
+    assert result[0] is not None, "Value should succeed"
+    assert result[2] is None, "Key should fail when key_uses_schema_registry=True but no SR format"
+    assert result[3] is None, "Key schema ID should be None when key fails"
 
 
 def mocked_time():


### PR DESCRIPTION
### What does this PR do?

This PR adds strict validation to Avro and Protobuf message deserialization in the Kafka Consumer integration. The deserialization functions now verify that all bytes in a message are consumed during decoding, and raise an error if trailing bytes are detected.

### Motivation

Previously, both Avro and Protobuf deserializers could silently accept malformed messages with extra trailing bytes. For example, a primitive Avro string schema would successfully decode an empty string (0x00) and ignore any additional bytes that followed (like a schema registry magic byte + schema ID + garbage data). This could incorrectly interpret magic byte + schema ID + avro bytes as just "avro bytes" and decode an incorrect message.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
