### PR TITLE
Add python version to mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ mypy_path = "../.stubs"
 # Exclude generated files
 # TODO Remove when we drop python 2
 exclude = '.*/config_models/.*\.py$'
+python_version = 3.13
 
 [tool.ruff]
 exclude = [


### PR DESCRIPTION
### What does this PR do?
Adds Python version 3.13 to mypy configuration.

### Motivation
Some type annotations caused errors when running ddev test --lint because they relied on features introduced in Python 3.11. Updating the configuration ensures compatibility with Python 3.13

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
