### PR TITLE
Add verbosity flag to measure disk size workflow 

### DIFF
--- a/.github/workflows/measure-disk-usage.yml
+++ b/.github/workflows/measure-disk-usage.yml
@@ -44,7 +44,7 @@ jobs:
         if [ "${{ github.event.workflow_run.event }}" = "push" ] && [ "${{ github.ref_name }}" = "master" ]; then 
           cmd="$cmd --to-dd-key ${{ secrets.DD_API_KEY }}"
         fi
- 
+
         echo "cmd=$cmd" >> $GITHUB_OUTPUT
 
     - name: Measure disk usage (Uncompressed)


### PR DESCRIPTION
### What does this PR do?
Adds a `-v` flag to the `ddev size status` command to enable verbose debug logs in CI runs.

### Motivation
Most relevant logs are at the debug level, so this flag allows inspecting the measure disk size workflow in more detail when needed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
