### PR TITLE
Add dummy workflow to test workflow_run variables

### DIFF
--- a/.github/workflows/dummy-wf.yml
+++ b/.github/workflows/dummy-wf.yml
@@ -10,5 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
+            echo "Head branch: "
             echo ${{ github.event.workflow_run.head_branch }}
+            echo "Ref: "
+            echo ${{ github.ref_name }}
            


### PR DESCRIPTION
### What does this PR do?
This PR creates a dummy GitHub Actions workflow that runs once the Resolve Build Deps has finished and prints the head_branch.

### Motivation
The on: workflow_run trigger cannot be tested within a branch, it only works once the workflow exists in the master branch. This dummy workflow provides a way to validate and test the trigger behavior.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
