### PR TITLE
Fix duplicated size metrics in Datadog

### DIFF
--- a/.github/workflows/measure-disk-usage.yml
+++ b/.github/workflows/measure-disk-usage.yml
@@ -41,7 +41,7 @@ jobs:
         --commit ${{ github.event.workflow_run.head_sha }} \
         --format json"
 
-        if [ "${{ github.event.workflow_run.event }}" = "push" ] && [ "${{ github.ref_name }}" = "master" ]; then 
+        if [ "${{ github.event.workflow_run.event }}" = "push" ] && [ "${{ github.event.workflow_run.head_branch }}" = "master" ]; then 
           cmd="$cmd --to-dd-key ${{ secrets.DD_API_KEY }}"
         fi
 


### PR DESCRIPTION
### What does this PR do?
Updates the `measure_disk_size` workflow to determine the branch from `github.event.workflow_run.head_branch` instead of `github.ref`.

### Motivation
Metrics were being duplicated in Datadog because all workflow runs were reported under `master`.
This happened because `github.ref` refers to the branch where the workflow itself runs — and for `workflow_run` triggers, that’s always master. By switching to `github.event.workflow_run.head_branch`, the workflow now correctly compares the branch that actually triggered the run, avoiding duplicated metrics.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
