### PR TITLE
Trend micro cloud - remove html notation from readme

### DIFF
--- a/trend_micro_cloud_one/README.md
+++ b/trend_micro_cloud_one/README.md
@@ -17,11 +17,11 @@ Integrate Trend Micro Cloud One with Datadog to gain insights into endpoint and 
 The following table shows the log collection methods, the logs collected, and the dashboards populated for each method.
 | Log Collection Method | Logs Collected | Dashboards Populated |
 |-----------------------------------------|---------------------------------------------------------------------------|------------------------------|
-| [Agent and Event Forwarder Configuration][8] | <li> Workload Security <ul> <li> System Events <li> Anti-Malware Events <li> Application Control Events <li> Firewall Events <li> Integrity Monitoring Events <li> Intrusion Prevention Events <li> Log Inspection Events <li> Device Control Events </ul> <li> Network Security <ul> <li> Reputation Events <li> IPS Events </ul> | <li> Trend Micro Cloud One - Workload Security Insights <li> Trend Micro Cloud One - System Events <li> Trend Micro Cloud One - Anti-Malware Events <li> Trend Micro Cloud One - Application Control and Device Control Events <li> Trend Micro Cloud One - Firewall Events <li> Trend Micro Cloud One - Integrity Monitoring Log Events <li> Trend Micro Cloud One - Intrusion Prevention Events <li> Trend Micro Cloud One - Log Inspection and Web Reputation Events <li> Trend Micro Cloud One - Network Security Insights |
-| [File Storage Security API Configuration][9] | <li> File Storage Security Events | <li> Trend Micro Cloud One - File Storage Security Insights |
+| [Agent and Event Forwarder Configuration][8] | **Workload Security** <br>- System Events <br>- Anti-Malware Events <br>- Application Control Events <br>- Firewall Events <br>- Integrity Monitoring Events <br>- Intrusion Prevention Events <br>- Log Inspection Events <br>- Device Control Events <br><br>**Network Security** <br>- Reputation Events <br>- IPS Events | - Trend Micro Cloud One - Workload Security Insights <br>- Trend Micro Cloud One - System Events <br>- Trend Micro Cloud One - Anti-Malware Events <br>- Trend Micro Cloud One - Application Control and Device Control Events <br>- Trend Micro Cloud One - Firewall Events <br>- Trend Micro Cloud One - Integrity Monitoring Log Events <br>- Trend Micro Cloud One - Intrusion Prevention Events <br>- Trend Micro Cloud One - Log Inspection and Web Reputation Events <br>- Trend Micro Cloud One - Network Security Insights |
+| [File Storage Security API Configuration][9] | - File Storage Security Events | - Trend Micro Cloud One - File Storage Security Insights |
 
 ### Agent and Event Forwarder Configuration
-
+****
 #### Installation
 
 To install the Trend Micro Cloud One integration, run the following Agent installation command in your terminal, then complete the configuration steps. For more information, see the [Integration Management][3] documentation.
@@ -77,22 +77,18 @@ sudo -u dd-agent -- datadog-agent integration install datadog-trend_micro_cloud_
    - Enable Include time zone in events.
    - **Facility**: Select `Local 0`.
 4. Click **OK**.
-5. Forward System events:
-   <ol type="i">
-      <li>Go to <strong>Administration</strong> > <strong>System Settings</strong> > <strong>Event Forwarding</strong>.</li>
-      <li>From Forward System Events to a remote computer (via Syslog) using configuration, select an existing configuration from dropdown.</li>
-      <li>Click <strong>Save</strong>.</li>
-   </ol>
-6. Forward Security events:
-   <ol type="i">
-      <li>Go to <strong>Policies</strong>.</li>
-      <li>Double-click the policy whose events you want to push to Datadog.</li>
-      <li>Go to <strong>Settings</strong> > <strong>Event Forwarding</strong>.</li>
-      <li>Under Event Forwarding Frequency (from the Agent/Appliance), use Period between sending of events to select how often the security events are forwarded.</li>
-      <li>Under Event Forwarding Configuration (from the Agent/Appliance), use Anti-Malware Syslog Configuration and other protection modules' lists and select an existing Syslog configuration.</li>
-      <li>Click <strong>Save</strong>.</li>
-      <li>Repeat steps <strong>ii</strong> to <strong>vi</strong> for each base policy you want to push to Datadog.</li>
-   </ol>
+5. Forward System events:<br>
+   i. Go to **Administration** > **System Settings** > **Event Forwarding**.<br>
+   ii. From Forward System Events to a remote computer (via Syslog) using configuration, select an existing configuration from dropdown.<br>
+   iii. Click **Save**.
+6. Forward Security events:<br>
+   i. Go to **Policies**.<br>
+   ii. Double-click the policy whose events you want to push to Datadog.<br>
+   iii. Go to **Settings** > **Event Forwarding**.<br>
+   iv. Under Event Forwarding Frequency (from the Agent/Appliance), use Period between sending of events to select how often the security events are forwarded.<br>
+   v. Under Event Forwarding Configuration (from the Agent/Appliance), use Anti-Malware Syslog Configuration and other protection modules' lists and select an existing Syslog configuration.<br>
+   vi. Click **Save**.<br>
+   vii. Repeat steps **ii** to **vi** for each base policy you want to push to Datadog.
 
 #### Configure syslog message forwarding from Network Security
 


### PR DESCRIPTION
### What does this PR do?
There seems to be an issue when rendering the integration README on the tile. And I suspect the issue is related to html tags.  On this PR, I replace the html tags with pure markdown notation to confirm if this is the issue. I also have noticed the same issue with another integration - https://github.com/DataDog/integrations-core/blob/master/beyondtrust_password_safe/README.md


 
<img width="2676" height="915" alt="image" src="https://github.com/user-attachments/assets/296ec5a5-b947-4993-bb66-6341072df9e2" />
<img width="2637" height="908" alt="image" src="https://github.com/user-attachments/assets/d32863b5-e782-4737-8a6e-a75b08d12e4f" />


### Motivation
README is incorrectly rendered on the integration tile.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
