### PR TITLE
Bump minimum supported macOS ABI as advertised (ABLD-28 follow-up)

### DIFF
--- a/.github/workflows/resolve-build-deps.yaml
+++ b/.github/workflows/resolve-build-deps.yaml
@@ -218,10 +218,8 @@ jobs:
         job:
         - arch: x86_64
           os: macos-13
-          macosx_version_min: "10.12"
         - arch: aarch64
           os: macos-13-xlarge # "macOS 13 Arm64" as per https://github.com/actions/runner-images/blob/main/README.md
-          macosx_version_min: "11.0"
     env:
       TARGET_NAME: macos-${{ matrix.job.arch }}
       OUT_DIR: output/macos-${{ matrix.job.arch }}
@@ -265,7 +263,7 @@ jobs:
     - name: Run the build
       env:
         # This sets the minimum macOS version compatible for all built artifacts
-        MACOSX_DEPLOYMENT_TARGET: ${{ matrix.job.macosx_version_min }}
+        MACOSX_DEPLOYMENT_TARGET: "11.0" # https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
         CACHE_HIT: ${{ steps.cache-builder-root.outputs.cache-hit }}
       run: |-
         # If we hit the cache, we can skip the builder setup


### PR DESCRIPTION
### What does this PR do?
This aligns (up) the minimum supported macOS ABI to 11.0, as otherwise [documented](https://docs.datadoghq.com/agent/supported_platforms/?tab=macos).

### Motivation
1. establish a baseline for binary sizes (static quality gates) with a single ABI version so that we'd get the same with Bazel builds,
2. macOS ABI 10.x is no longer officially supported since Agent [7.62.0](https://github.com/DataDog/datadog-agent/releases/tag/7.62.0) (Jan 29, 2025) according to:
<img width="621" height="471" alt="image" src="https://github.com/user-attachments/assets/1affd02f-bdf0-478d-8a1b-0e66d7ddbd57" />

Some bundled dependencies are anyway already depending on a greater ABI, for instance:
- 11.0: https://github.com/DataDog/integrations-core/blob/d3f7387a09725bd2e30b7466c0edfc34b2fb6f45/.deps/resolved/macos-x86_64_3.12.txt#L111
- **12.0**: https://github.com/DataDog/integrations-core/blob/d3f7387a09725bd2e30b7466c0edfc34b2fb6f45/.deps/resolved/macos-x86_64_3.12.txt#L21

### Additional Notes
There are multiple points of maintenance we'll centralize in the frame of the ongoing migration to Bazel.
See also:
- DataDog/datadog-agent#41945