### PR TITLE
[IXP-656] Add dataflow definitions for some NDM integrations

### DIFF
--- a/cisco_aci/assets/dataflows.yaml
+++ b/cisco_aci/assets/dataflows.yaml
@@ -1,0 +1,5 @@
+provides:
+  - id: cisco-aci-network-device-metrics
+    always_on: false
+  - id: cisco-aci-network-event-logs
+    always_on: false

--- a/cisco_sdwan/assets/dataflows.yaml
+++ b/cisco_sdwan/assets/dataflows.yaml
@@ -1,0 +1,3 @@
+provides:
+  - id: cisco-sdwan-network-device-metrics
+    always_on: false

--- a/versa/assets/dataflows.yaml
+++ b/versa/assets/dataflows.yaml
@@ -1,0 +1,3 @@
+provides:
+  - id: versa-network-device-metrics
+    always_on: false


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds dataflow definitions for integrations that connect to NDM
Note: This is not an exhaustive list
* cisco_aci
* cisco_sdwan
* versa

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
