### PR TITLE
Revert "Set ZScaler Private Access auto_install setting to false"

### DIFF
--- a/zscaler_private_access/manifest.json
+++ b/zscaler_private_access/manifest.json
@@ -65,7 +65,7 @@
   },
   "assets": {
     "integration": {
-      "auto_install": false,
+      "auto_install": true,
       "source_type_id": 56444351,
       "source_type_name": "Zscaler Private Access",
       "configuration": {


### PR DESCRIPTION
Reverts DataDog/integrations-core#21644 - we have greenlight to release ZPA with the next Agent.