### PR TITLE
IDP-800: Add owner field to SaaS Integrations manifest files

### DIFF
--- a/anthropic_usage_and_costs/manifest.json
+++ b/anthropic_usage_and_costs/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "96f960de-2b87-41ec-8d9a-88fe75e93dc9",
   "app_id": "anthropic-usage-and-costs",
+  "owner": "saas-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/jamf_pro/manifest.json
+++ b/jamf_pro/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "02ca0a87-f9e7-46e3-989d-9ac8b3654ac4",
   "app_id": "jamf-pro",
+  "owner": "saas-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/trend_micro_cloud_one/manifest.json
+++ b/trend_micro_cloud_one/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "06b13f44-cba3-48f1-8c73-338f22b9ad18",
   "app_id": "trend-micro-cloud-one",
+  "owner": "saas-integrations",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add `owner` field set to `"saas-integrations"` to manifest.json files for SaaS Integrations team.

This provides clear ownership tracking for SaaS-focused integrations as part of IDP-800 to add owner fields to integration manifest.json files.

**Integrations updated (3 files changed):**
- trend_micro_cloud_one, anthropic_usage_and_costs, jamf_pro

Since `saas-integrations` is an existing owner team, no team confirmation needed.

🤖 Generated with [Claude Code](https://claude.ai/code)