### PR TITLE
IDP-800: Add owner field to Windows Products manifest files

### DIFF
--- a/winkmem/manifest.json
+++ b/winkmem/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "70d34855-e504-4716-be0a-cc9d7d82e5ab",
   "app_id": "winkmem",
+  "owner": "windows-products",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/wlan/manifest.json
+++ b/wlan/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "dbf0f387-cef7-4694-9001-b7bb5c1c1274",
   "app_id": "wlan",
+  "owner": "windows-products",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add `owner` field set to `"windows-products"` to manifest.json files for Windows Products team.

This provides clear ownership tracking for Windows-focused integrations as part of IDP-800 to add owner fields to integration manifest.json files.

**Integrations updated (2 files changed):**
- winkmem, wlan

Since `windows-products` is an existing owner team, no team confirmation needed.

🤖 Generated with [Claude Code](https://claude.ai/code)