### PR TITLE
Disable Vertica tests that use the missing docker image.

### DIFF
--- a/vertica/hatch.toml
+++ b/vertica/hatch.toml
@@ -4,6 +4,10 @@
 python = ["3.13"]
 version = ["10.1", "11.1", "12.0", "23.3"]
 
+[envs.default]
+# E2E tests disabled because Vertica Docker image is no longer available
+e2e-env = false
+
 [envs.default.overrides]
 matrix.version.env-vars = [
   { key = "VERTICA_VERSION", value = "10.1.1-0", if = ["10.1"] },

--- a/vertica/tests/test_queries.py
+++ b/vertica/tests/test_queries.py
@@ -12,6 +12,8 @@ from datadog_checks.vertica.vertica import VerticaClient
 from . import common
 from .db import BASE_DB_OPTIONS
 
+skip_integration = pytest.mark.skip(reason="Vertica Docker image is no longer available")
+
 
 @pytest.mark.parametrize(
     'version, expected_per_projection_query',
@@ -125,6 +127,7 @@ def approx_a_day_in_seconds(t, margin=60):
     return 86400 - margin <= t <= 86400 + margin
 
 
+@skip_integration
 @pytest.mark.usefixtures('dd_environment')
 def test_licenses_query(client, builder, setup_db_tables):
     setup_db_tables(
@@ -149,6 +152,7 @@ def test_licenses_query(client, builder, setup_db_tables):
     assert approx_a_day_in_seconds(results[2][1])
 
 
+@skip_integration
 @pytest.mark.usefixtures('dd_environment')
 def test_license_audits_query(client, builder, setup_db_tables):
     setup_db_tables(
@@ -179,6 +183,7 @@ def test_license_audits_query(client, builder, setup_db_tables):
     assert results[0][1:] == [1000, 100, 900, 10]
 
 
+@skip_integration
 @pytest.mark.usefixtures('dd_environment')
 def test_system_query(client, builder, setup_db_tables):
     setup_db_tables(
@@ -227,6 +232,7 @@ def test_system_query(client, builder, setup_db_tables):
     assert results == [[40, 5, 1, 2, 20, 30, 10, None, None]]
 
 
+@skip_integration
 @pytest.mark.usefixtures('dd_environment')
 def test_projections_query(client, builder, setup_db_tables):
     setup_db_tables(
@@ -254,6 +260,7 @@ def test_projections_query(client, builder, setup_db_tables):
     assert results == [[5, 2, 3, 40, 60]]
 
 
+@skip_integration
 @pytest.mark.usefixtures('dd_environment')
 def test_projections_query_handles_zeros(client, builder, setup_db_tables):
     setup_db_tables(
@@ -274,6 +281,7 @@ def test_projections_query_handles_zeros(client, builder, setup_db_tables):
 
 
 @pytest.mark.skipif(common.VERTICA_MAJOR_VERSION >= 11, reason='Requires Vertica < 11')
+@skip_integration
 @pytest.mark.usefixtures('dd_environment')
 def test_projection_storage_queries_pre_11(client, builder, setup_db_tables):
     setup_db_tables(
@@ -333,6 +341,7 @@ def test_projection_storage_queries_pre_11(client, builder, setup_db_tables):
 
 
 @pytest.mark.skipif(common.VERTICA_MAJOR_VERSION < 11, reason='Requires Vertica >= 11')
+@skip_integration
 @pytest.mark.usefixtures('dd_environment')
 def test_projection_storage_queries_11_plus(client, builder, setup_db_tables):
     setup_db_tables(
@@ -388,6 +397,7 @@ def test_projection_storage_queries_11_plus(client, builder, setup_db_tables):
 
 
 @pytest.mark.skipif(common.VERTICA_MAJOR_VERSION >= 11, reason='Requires Vertica < 11')
+@skip_integration
 @pytest.mark.usefixtures('dd_environment')
 def test_storage_containers_queries_pre_11(client, builder, setup_db_tables):
     setup_db_tables(
@@ -433,6 +443,7 @@ def test_storage_containers_queries_pre_11(client, builder, setup_db_tables):
 
 
 @pytest.mark.skipif(common.VERTICA_MAJOR_VERSION < 11, reason='Requires Vertica >= 11')
+@skip_integration
 @pytest.mark.usefixtures('dd_environment')
 def test_storage_containers_queries_11_plus(client, builder, setup_db_tables):
     setup_db_tables(
@@ -470,6 +481,7 @@ def test_storage_containers_queries_11_plus(client, builder, setup_db_tables):
     assert total == [[9]]
 
 
+@skip_integration
 @pytest.mark.usefixtures('dd_environment')
 def test_host_resources_query(client, builder, setup_db_tables):
     setup_db_tables(
@@ -506,6 +518,7 @@ def test_host_resources_query(client, builder, setup_db_tables):
     ]
 
 
+@skip_integration
 @pytest.mark.usefixtures('dd_environment')
 def test_disk_storage_query(client, builder, setup_db_tables):
     setup_db_tables(

--- a/vertica/tests/test_vertica.py
+++ b/vertica/tests/test_vertica.py
@@ -11,7 +11,10 @@ from datadog_checks.vertica.vertica import VerticaClient
 from . import common
 from .metrics import ALL_METRICS
 
+skip_integration = pytest.mark.skip(reason="Vertica Docker image is no longer available")
 
+
+# E2E tests are disabled in hatch.toml (e2e-env = false)
 @pytest.mark.e2e
 @pytest.mark.parametrize('connection_load_balance', [False, True])
 def test_check_e2e(dd_agent_check, instance, connection_load_balance):
@@ -25,6 +28,7 @@ def test_check_e2e(dd_agent_check, instance, connection_load_balance):
     aggregator.assert_all_metrics_covered()
 
 
+@skip_integration
 @pytest.mark.usefixtures('dd_environment')
 def test_check(aggregator, datadog_agent, instance, dd_run_check):
     check = VerticaCheck('vertica', {}, [instance])
@@ -43,6 +47,7 @@ def test_check(aggregator, datadog_agent, instance, dd_run_check):
     datadog_agent.assert_metadata_count(len(version_metadata) + 4)
 
 
+@skip_integration
 @pytest.mark.usefixtures('dd_environment')
 def test_vertica_log_file_not_created(aggregator, instance, dd_run_check):
     instance['client_lib_log_level'] = 'DEBUG'
@@ -56,6 +61,7 @@ def test_vertica_log_file_not_created(aggregator, instance, dd_run_check):
     assert not os.path.exists(vertica_default_log)
 
 
+@skip_integration
 @pytest.mark.usefixtures('dd_environment')
 def test_check_connection_load_balance(monkeypatch):
     options = common.connection_options_from_config(common.CONFIG)
@@ -69,6 +75,7 @@ def test_check_connection_load_balance(monkeypatch):
     assert client.connection != old_connection
 
 
+@skip_integration
 @pytest.mark.usefixtures('dd_environment')
 def test_connect_resets_connection_when_connection_closed():
     options = common.connection_options_from_config(common.CONFIG)
@@ -83,6 +90,7 @@ def test_connect_resets_connection_when_connection_closed():
     assert client.connection != old_connection
 
 
+@skip_integration
 @pytest.mark.usefixtures('dd_environment')
 def test_connect_when_connection_is_open_reuses_connection():
     options = common.connection_options_from_config(common.CONFIG)
@@ -92,6 +100,7 @@ def test_connect_when_connection_is_open_reuses_connection():
     assert client.connect() == conn
 
 
+@skip_integration
 @pytest.mark.usefixtures('dd_environment')
 def test_custom_queries(aggregator, instance, dd_run_check):
     instance['custom_queries'] = [
@@ -110,6 +119,7 @@ def test_custom_queries(aggregator, instance, dd_run_check):
     )
 
 
+@skip_integration
 @pytest.mark.usefixtures('dd_environment')
 def test_include_all_metric_groups(aggregator, instance, dd_run_check):
     check = VerticaCheck('vertica', {}, [instance])
@@ -128,6 +138,7 @@ def test_include_all_metric_groups(aggregator, instance, dd_run_check):
     aggregator.assert_metric('vertica.node.resource_requests', metric_type=aggregator.GAUGE)
 
 
+@skip_integration
 @pytest.mark.usefixtures('dd_environment')
 def test_include_system_metric_group(aggregator, instance, dd_run_check):
     instance['metric_groups'] = ['system']


### PR DESCRIPTION
### What does this PR do?
Disable Vertica tests that use the missing docker image (integration and E2E). 
There might be less repetitive ways to disable them, but this hopefully minimizes reader surprise.

### Motivation
Reduce failed test noise in our CI.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
