### PR TITLE
add category for MicrosoftServicePrincipalSignInLogs

### DIFF
--- a/azure_active_directory/assets/logs/azure.activedirectory.yaml
+++ b/azure_active_directory/assets/logs/azure.activedirectory.yaml
@@ -881,7 +881,7 @@ pipeline:
                 query: "@ocsf.metadata.log_name:(SignInLogs OR NonInteractiveUserSignInLogs)"
               name: User
             - filter:
-                query: "@ocsf.metadata.log_name:(ManagedIdentitySignInLogs OR *ServicePrincipalSignInLogs*)"
+                query: "@ocsf.metadata.log_name:(ManagedIdentitySignInLogs OR MicrosoftServicePrincipalSignInLogs OR ServicePrincipalSignInLogs)"
               name: System
           target: ocsf.actor.user.type
         - type: category-processor
@@ -892,7 +892,7 @@ pipeline:
                 query: "@ocsf.metadata.log_name:(SignInLogs OR NonInteractiveUserSignInLogs)"
               name: "1"
             - filter:
-                query: "@ocsf.metadata.log_name:(ManagedIdentitySignInLogs OR *ServicePrincipalSignInLogs*)"
+                query: "@ocsf.metadata.log_name:(ManagedIdentitySignInLogs OR MicrosoftServicePrincipalSignInLogs OR ServicePrincipalSignInLogs)"
               name: "3"
             - filter:
                 query: "@ocsf.metadata.log_name:*"
@@ -948,7 +948,7 @@ pipeline:
                 query: "@ocsf.metadata.log_name:(SignInLogs OR NonInteractiveUserSignInLogs)"
               name: User
             - filter:
-                query: "@ocsf.metadata.log_name:(ManagedIdentitySignInLogs OR *ServicePrincipalSignInLogs*)"
+                query: "@ocsf.metadata.log_name:(ManagedIdentitySignInLogs OR MicrosoftServicePrincipalSignInLogs OR ServicePrincipalSignInLogs)"
               name: System
           target: ocsf.user.type
         - type: category-processor
@@ -959,7 +959,7 @@ pipeline:
                 query: "@ocsf.metadata.log_name:(SignInLogs OR NonInteractiveUserSignInLogs)"
               name: "1"
             - filter:
-                query: "@ocsf.metadata.log_name:(ManagedIdentitySignInLogs OR *ServicePrincipalSignInLogs*)"
+                query: "@ocsf.metadata.log_name:(ManagedIdentitySignInLogs OR MicrosoftServicePrincipalSignInLogs OR ServicePrincipalSignInLogs)"
               name: "3"
             - filter:
                 query: "@ocsf.metadata.log_name:*"


### PR DESCRIPTION
### What does this PR do?
Categorizes login events coming from the category `MicrosoftServicePrincipalSignInLogs` as `System` logins instead of leaving the user and actor type uncategorized

### Motivation
Triggered by this support ticket https://datadog.zendesk.com/agent/tickets/2267405. Customer was getting impossible travel false positives from non-human sign ons


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
