### PR TITLE
IDP-800: Add owner field to aws-integrations manifest file

### DIFF
--- a/amazon_app_mesh/manifest.json
+++ b/amazon_app_mesh/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "507d48b6-cfda-4f62-b95a-67de98a50cc6",
   "app_id": "amazon-app-mesh",
+  "owner": "aws-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add `owner` field set to `"aws-integrations"` to manifest.json file for aws-integrations team.

This provides clear ownership tracking for Amazon App Mesh integration as part of IDP-800 to add owner fields to integration manifest.json files.

**Integrations updated (1 file changed):**
- amazon_app_mesh

Since `aws-integrations` is an existing owner team, no team confirmation needed.

🤖 Generated with [Claude Code](https://claude.ai/code)