### PR TITLE
[LOGSC-2395] add bypasse for new linter rule on grok parsers for cloudgen

### DIFF
--- a/cloudgen_firewall/assets/logs/cloudgen_firewall.yaml
+++ b/cloudgen_firewall/assets/logs/cloudgen_firewall.yaml
@@ -1,6 +1,5 @@
 # bypass-global-grok-parser-rules-checks
 # bypass-global-grok-parser-count-per-pipeline-checks
-
 id: cloudgen_firewall
 metric_id: cloudgen-firewall
 backend_only: false


### PR DESCRIPTION
This integration was forgotten in the first pass of bypass, however it has more than 5 grok parser in a subpipeline