### PR TITLE
[Databricks cost overview] Fix cluster and job specific widgets 

### DIFF
--- a/databricks/assets/dashboards/databricks_cost_overview.json
+++ b/databricks/assets/dashboards/databricks_cost_overview.json
@@ -655,7 +655,7 @@
                     {
                       "data_source": "cloud_cost",
                       "name": "query1",
-                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id} by {cluster_id}",
+                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id,cluster_id:*} by {cluster_id}",
                       "aggregator": "sum"
                     }
                   ],
@@ -722,7 +722,7 @@
                     {
                       "data_source": "cloud_cost",
                       "name": "query1",
-                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id} by {cluster_id}.rollup(sum, daily)"
+                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id,cluster_id:*} by {cluster_id}.rollup(sum, daily)"
                     }
                   ],
                   "response_format": "timeseries",
@@ -759,7 +759,7 @@
                     {
                       "data_source": "cloud_cost",
                       "name": "query1",
-                      "query": "sum:all.cost{providername:Databricks,$workspace_id,$cluster_id,$job_id,$charge_description,$servicename} by {job_id}",
+                      "query": "sum:all.cost{providername:Databricks,$workspace_id,$cluster_id,$job_id,$charge_description,$servicename,job_id:*} by {job_id}",
                       "aggregator": "sum"
                     }
                   ],
@@ -826,7 +826,7 @@
                     {
                       "data_source": "cloud_cost",
                       "name": "query1",
-                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id} by {job_id}.rollup(sum, daily)"
+                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id,job_id:*} by {job_id}.rollup(sum, daily)"
                     }
                   ],
                   "response_format": "timeseries",
@@ -903,7 +903,7 @@
                     {
                       "data_source": "cloud_cost",
                       "name": "query1",
-                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id} by {cluster_id}",
+                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id,cluster_id:*} by {cluster_id}",
                       "aggregator": "sum"
                     },
                     {


### PR DESCRIPTION
### What does this PR do?

- scope the widgets to `cluster_id:*` or `job_id:*` to avoid having an `N/A` row at the top
- fix percentage memory utilized that was missing a 100 factor: previously was:
<img width="2346" height="252" alt="image" src="https://github.com/user-attachments/assets/acf3cc93-12d0-4753-ad93-08622a165491" />


### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
