### PR TITLE
Override wrapt license and exclude confluent-kafka in dependency overrides

### DIFF
--- a/.ddev/config.toml
+++ b/.ddev/config.toml
@@ -155,7 +155,7 @@ exclude = [
     'pyasn1',  # https://github.com/pyasn1/pyasn1/issues/52
     'pysnmp',  # Breaking snmp tests
     'aerospike',  # v8+ breaks agent build.
-    'confluent-kafka,
+    'confluent-kafka',
     # https://github.com/DataDog/integrations-core/pull/16080
     'lxml',
     'psutil',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update dependencies GH Action is failing so this pins the `wrapt` license. We also exclude `confluent-kafka` since updating this particular dependency requires additional steps.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
