### PR TITLE
[DBMON-5797] Avoid explain plan collection for queries that failed to execute

### DIFF
--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -111,6 +111,7 @@ EVENTS_STATEMENTS_CURRENT_QUERY = re.sub(
         AND event_name like 'statement/%%'
         AND digest_text is NOT NULL
         AND digest_text NOT LIKE 'EXPLAIN %%'
+        AND errors = 0
         ORDER BY timer_wait DESC
 """,
 ).strip()


### PR DESCRIPTION
### What does this PR do?
This change updates our explain plan collection query to filter out recently executed queries that have errors. This is done to avoid attempting to explain an unexplainable query and will stop emitting back an explain plan event that's marked as `unsupported`. We already avoid collection of these in Query samples and Query metrics. 

### Motivation
Will prevent explain plan event entries that look like this
<img width="757" height="89" alt="Screenshot 2025-10-20 at 4 32 00 PM" src="https://github.com/user-attachments/assets/b049c1e0-4a5c-4e29-af3a-a0975fa374fd" />


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
