### PR TITLE
Fix Ray tests by replacing the ray-ml image with ray.

### DIFF
--- a/ray/tests/docker/docker-compose.yaml
+++ b/ray/tests/docker/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   ray-head:
     container_name: ray-head
     hostname: ray-head
-    image: rayproject/ray-ml:${RAY_VERSION}-cpu
+    image: rayproject/ray:${RAY_VERSION}-cpu
     command:
       - /bin/bash
       - -c
@@ -33,7 +33,7 @@ services:
   ray-worker-1:
     container_name: ray-worker-1
     hostname: ray-worker-1
-    image: rayproject/ray-ml:${RAY_VERSION}-cpu
+    image: rayproject/ray:${RAY_VERSION}-cpu
     command: bash -c "ray start --address=ray-head:6379 --num-cpus=2 --metrics-export-port=8080 --block"
     ports:
       - "${WORKER1_METRICS_PORT}:8080"
@@ -51,7 +51,7 @@ services:
   ray-worker-2:
     container_name: ray-worker-2
     hostname: ray-worker-2
-    image: rayproject/ray-ml:${RAY_VERSION}-cpu
+    image: rayproject/ray:${RAY_VERSION}-cpu
     command: bash -c "ray start --address=ray-head:6379 --num-cpus=2 --metrics-export-port=8080 --block"
     ports:
       - "${WORKER2_METRICS_PORT}:8080"
@@ -69,7 +69,7 @@ services:
   ray-worker-3:
     container_name: ray-worker-3
     hostname: ray-worker-3
-    image: rayproject/ray-ml:${RAY_VERSION}-cpu
+    image: rayproject/ray:${RAY_VERSION}-cpu
     command: bash -c "ray start --address=ray-head:6379 --num-cpus=2 --metrics-export-port=8080 --block"
     ports:
       - "${WORKER3_METRICS_PORT}:8080"
@@ -87,7 +87,7 @@ services:
   ray-echo-task:
     container_name: ray-echo-task
     hostname: ray-echo-task
-    image: rayproject/ray-ml:${RAY_VERSION}-cpu
+    image: rayproject/ray:${RAY_VERSION}-cpu
     command: bash -c "python /home/ray/echo.py"
     healthcheck:
       test: bash -c "[ -f /tmp/running ]"
@@ -109,7 +109,7 @@ services:
   ray-call-apis:
     container_name: ray-call-apis
     hostname: ray-call-apis
-    image: rayproject/ray-ml:${RAY_VERSION}-cpu
+    image: rayproject/ray:${RAY_VERSION}-cpu
     command: bash -c "python /home/ray/call_apis.py"
     depends_on:
       ray-head:


### PR DESCRIPTION
### What does this PR do?

Pulling the [rayproject/ray-ml ](https://hub.docker.com/r/rayproject/ray-ml) image transfers >4.8GB before we run out of disk space on the CI runners. This PR swaps that image for [rayproject/ray](https://hub.docker.com/r/rayproject/ray-ml) which is smaller. 

Also, the ray-ml image is deprecated.

### Motivation
Fix CI.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
