### PR TITLE
Switch to `Python Build Standalone` for macOS wheels

### DIFF
--- a/.builders/build.py
+++ b/.builders/build.py
@@ -124,9 +124,6 @@ def build_macos():
             'LDFLAGS': f'-L{prefix_path}/lib',
             'CFLAGS': f'-I{prefix_path}/include -O2',
             'CXXFLAGS': f'-I{prefix_path}/include -O2',
-            # Use single-arch builds to avoid bundling extraneous binary payload and enable `require_archs` verification
-            'ARCHFLAGS': f'-arch {os.uname().machine}',
-            '_PYTHON_HOST_PLATFORM': f'macosx-{os.environ["MACOSX_DEPLOYMENT_TARGET"]}-{os.uname().machine}',
             # Build command for extra platform-specific build steps
             'DD_BUILD_COMMAND': f'bash {build_context_dir}/extra_build.sh'
         }

--- a/.github/workflows/resolve-build-deps.yaml
+++ b/.github/workflows/resolve-build-deps.yaml
@@ -206,12 +206,21 @@ jobs:
         brew install coreutils
 
     - name: Set up Python
+      # Use PBS as suggested by: https://github.com/DataDog/integrations-core/pull/21692#pullrequestreview-3358660684
+      # PBS stands for "Python Build Standalone": https://astral.sh/blog/python-build-standalone
       env:
-        # Despite the name, this is built for the macOS 11 SDK on arm64 and 10.9+ on intel
-        PYTHON3_DOWNLOAD_URL: "https://www.python.org/ftp/python/3.13.10/python-3.13.10-macos11.pkg"
+        PYTHON_PATCH: 10
+        PBS_RELEASE: 20251202
+        PBS_SHA256__aarch64: 799a3b76240496e4472dd60ed0cd5197e04637bea7fa16af68caeb989fadcb3a
+        PBS_SHA256__x86_64: 705b39dd74490c3e9b4beb1c4f40bf802b50ba40fe085bdca635506a944d5e74
       run: |
-        curl "$PYTHON3_DOWNLOAD_URL" -o python3.pkg
-        sudo installer -pkg python3.pkg -target /
+        set -u
+        curl -fsSL -o pbs.tgz "https://github.com/astral-sh/python-build-standalone/releases/download/$PBS_RELEASE/cpython-$PYTHON_VERSION.$PYTHON_PATCH+$PBS_RELEASE-${{ matrix.job.arch }}-apple-darwin-install_only_stripped.tar.gz"
+        echo "$PBS_SHA256__${{ matrix.job.arch }} *pbs.tgz" | shasum -a 256 -c -
+        prefix=$(dirname "$(dirname "$DD_PYTHON3")")
+        sudo mkdir -p "$prefix"
+        sudo tar -xzf pbs.tgz -C "$prefix" --strip-components=1
+        rm pbs.tgz
 
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
### Motivation
This is a direct follow-up of:
- #21692

... where a review [comment](https://github.com/DataDog/integrations-core/pull/21692#pullrequestreview-3358660684) rightfully suggested that:
> Instead, we should run a normal single-arch Python distribution where everything will just work by default and we can remove the renaming logic. The source of distributions should be the [python-build-standalone](https://github.com/astral-sh/python-build-standalone) project which the makers of UV recently adopted. They are used by everyone nowadays, even [rules_python](https://github.com/bazel-contrib/rules_python/blob/cf594f780c91f13d48e77faad34df48ac57398da/python/versions.bzl#L29).

### What does this PR do?
The present change aims at embracing the above-recommended approach, which indeed looks simpler because the need for bundling targeted architectures is then addressed without additional environment variables, while still allowing `delocate_wheel` to verify architecture requirements.

Also, the PBS distribution happens to be pretty lightweight (16MB vs 71MB).