### PR TITLE
IDP-800: Add owner field to ebpf-platform manifest file

### DIFF
--- a/gpu/manifest.json
+++ b/gpu/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "1f730d2a-144d-43bc-aec3-9cf274ba8d73",
   "app_id": "gpu",
-  "owner": "new-workloads",
+  "owner": "ebpf-platform",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add `owner` field set to `ebpf-platform` to manifest.json files for eBPF Platform team integrations (1 integration):
- gpu

**Note:** These integrations are our best guesses for the eBPF Platform team. If you don't own these integrations, or if you also own other integrations that should be included, please let us know.

This provides clear ownership tracking for these system performance integrations as part of the initiative to add owner fields to all integration manifest.json files.

**For reviewer:** Please confirm:
1. Is `ebpf-platform` the correct Datadog team slug in org 2 for tracking ownership?
2. For the display-tile feature flags in SDP, what workday team should we use as the `team` tag? We believe it should be "eBPF Platform" - could you confirm this is the correct workday team name?

Thank you for your review\!