### PR TITLE
[NDM] Introduce NCM integration + default device profile for Cisco IOS devices

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -123,6 +123,7 @@ manifest.json         @DataDog/documentation @DataDog/agent-integrations
 /snmp/*.md                                                         @DataDog/ndm-core @DataDog/agent-integrations @DataDog/documentation
 /snmp_*/                                                           @DataDog/ndm-core @DataDog/agent-integrations @DataDog/documentation
 /snmp_*/*.md                                                       @DataDog/ndm-core @DataDog/agent-integrations @DataDog/documentation
+/network_config_management/                                        @Datadog/network-device-monitoring
 /network_path/                                                     @DataDog/network-device-monitoring @DataDog/Networks @DataDog/agent-integrations
 /network_path/*.md                                                 @DataDog/network-device-monitoring @DataDog/Networks @DataDog/agent-integrations @DataDog/documentation
 /versa/                                                            @DataDog/ndm-integrations @DataDog/agent-integrations @DataDog/documentation

--- a/network_config_management/datadog_checks/network_config_management/data/default_profiles/cisco_ios.json
+++ b/network_config_management/datadog_checks/network_config_management/data/default_profiles/cisco_ios.json
@@ -1,0 +1,72 @@
+{
+  "commands": [
+    {
+      "type": "running",
+      "values": [
+        "show running-config"
+      ],
+      "processing_rules": {
+        "metadata": [
+          {
+            "type": "timestamp",
+            "regex": "! Last configuration change at ([^\r\n]+)",
+            "format": "15:04:05 MST Mon Jan 2 2006"
+          },
+          {
+            "type": "config_size",
+            "regex": "Current configuration : (?P<Size>\\d+)"
+          }
+        ],
+        "validation": [
+          {
+            "type": "valid_output",
+            "pattern": "Building configuration..."
+          }
+        ],
+        "redaction": [
+          {
+            "regex": "(username .+ (password|secret) \\d) .+",
+            "replacement": "<redacted secret>"
+          }
+        ]
+      }
+    },
+    {
+      "type": "startup",
+      "values": [
+        "show startup-config"
+      ],
+      "processing_rules": {
+        "metadata": [
+          {
+            "type": "timestamp",
+            "regex": "! Last configuration change at ([^\r\n]+)",
+            "format": "15:04:05 MST Mon Jan 2 2006"
+          },
+          {
+            "type": "config_size",
+            "regex": "Current configuration : (?P<Size>\\d+)"
+          }
+        ],
+        "validation": [
+          {
+            "type": "valid_output",
+            "pattern": "Building configuration..."
+          }
+        ],
+        "redaction": [
+          {
+            "regex": "(username .+ (password|secret) \\d) .+",
+            "replacement": "<redacted secret>"
+          }
+        ]
+      }
+    },
+    {
+      "type": "version",
+      "values": [
+        "show version"
+      ]
+    }
+  ]
+}

--- a/network_config_management/datadog_checks/network_config_management/data/default_profiles/cisco_ios.json
+++ b/network_config_management/datadog_checks/network_config_management/data/default_profiles/cisco_ios.json
@@ -25,8 +25,104 @@
         ],
         "redaction": [
           {
-            "regex": "(username .+ (password|secret) \\d) .+",
-            "replacement": "<redacted secret>"
+            "regex": "(?m)^(snmp-server community).*",
+            "replacement": "$1 <configuration removed>"
+          },
+          {
+            "regex": "(?m)^(snmp-server host \\S+( vrf \\S+)?( informs?)?( version (1|2c))?) +\\S+( .*)?$",
+            "replacement": "$1 <secret hidden>$6"
+          },
+          {
+            "regex": "(?m)^(username .+ (password|secret) \\d) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^(enable (password|secret)( level \\d+)? \\d) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +(?:password|secret)) (?:\\d )?\\S+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^(.*wpa-psk ascii \\d) (\\S+)",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^(.*key 7) (\\d.+)",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^(tacacs-server (.+ )?key) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^(crypto isakmp key) (\\S+) (.*)",
+            "replacement": "$1 <secret hidden> $3"
+          },
+          {
+            "regex": "(?m)^( +ip ospf message-digest-key \\d+ md5) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +ip ospf authentication-key) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +neighbor \\S+ password) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +vrrp \\d+ authentication text) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +standby \\d+ authentication) .{1,8}$",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +standby \\d+ authentication md5 key-string) .+?( timeout \\d+)?$",
+            "replacement": "$1 <secret hidden> $2"
+          },
+          {
+            "regex": "(?m)^( +key-string) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^((tacacs|radius) server [^\\n]+\\n( +[^\\n]+\\n)* +key) [^\\n]+$",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +ppp (chap|pap) password \\d) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +security wpa psk set-key (?:ascii|hex) \\d) (.*)$",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +dot1x username \\S+ password \\d) (.*)$",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +mgmtuser username \\S+ password \\d) (.*) (secret \\d) (.*)$",
+            "replacement": "$1 <secret hidden> $3 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +client \\S+ server-key \\d) (.*)$",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +domain-password) \\S+ ?(.*)",
+            "replacement": "$1 <secret hidden> $2"
+          },
+          {
+            "regex": "(?m)^( +pre-shared-key).*",
+            "replacement": "$1 <configuration removed>"
+          },
+          {
+            "regex": "(?m)^(.*server-key(?: \\d)?) \\S+",
+            "replacement": "$1 <secret hidden>"
           }
         ]
       }
@@ -56,8 +152,104 @@
         ],
         "redaction": [
           {
-            "regex": "(username .+ (password|secret) \\d) .+",
-            "replacement": "<redacted secret>"
+            "regex": "(?m)^(snmp-server community).*",
+            "replacement": "$1 <configuration removed>"
+          },
+          {
+            "regex": "(?m)^(snmp-server host \\S+( vrf \\S+)?( informs?)?( version (1|2c))?) +\\S+( .*)?$",
+            "replacement": "$1 <secret hidden>$6"
+          },
+          {
+            "regex": "(?m)^(username .+ (password|secret) \\d) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^(enable (password|secret)( level \\d+)? \\d) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +(?:password|secret)) (?:\\d )?\\S+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^(.*wpa-psk ascii \\d) (\\S+)",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^(.*key 7) (\\d.+)",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^(tacacs-server (.+ )?key) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^(crypto isakmp key) (\\S+) (.*)",
+            "replacement": "$1 <secret hidden> $3"
+          },
+          {
+            "regex": "(?m)^( +ip ospf message-digest-key \\d+ md5) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +ip ospf authentication-key) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +neighbor \\S+ password) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +vrrp \\d+ authentication text) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +standby \\d+ authentication) .{1,8}$",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +standby \\d+ authentication md5 key-string) .+?( timeout \\d+)?$",
+            "replacement": "$1 <secret hidden> $2"
+          },
+          {
+            "regex": "(?m)^( +key-string) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^((tacacs|radius) server [^\\n]+\\n( +[^\\n]+\\n)* +key) [^\\n]+$",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +ppp (chap|pap) password \\d) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +security wpa psk set-key (?:ascii|hex) \\d) (.*)$",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +dot1x username \\S+ password \\d) (.*)$",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +mgmtuser username \\S+ password \\d) (.*) (secret \\d) (.*)$",
+            "replacement": "$1 <secret hidden> $3 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +client \\S+ server-key \\d) (.*)$",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +domain-password) \\S+ ?(.*)",
+            "replacement": "$1 <secret hidden> $2"
+          },
+          {
+            "regex": "(?m)^( +pre-shared-key).*",
+            "replacement": "$1 <configuration removed>"
+          },
+          {
+            "regex": "(?m)^(.*server-key(?: \\d)?) \\S+",
+            "replacement": "$1 <secret hidden>"
           }
         ]
       }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
* Adding directory for new integration `network_config_management` (see [this doc ](https://datadoghq.atlassian.net/wiki/spaces/II/pages/5182783901/RFC+s+Network+Configuration+Management?focusedCommentId=5187731849)for details about the project)
* Specifically, adding a new directory for default profiles representing commands and their processing details per vendor/model/etc. ([doc on device profiles](https://datadoghq.atlassian.net/wiki/spaces/II/pages/5314904489/Sub-RFC+Ingestion+Generic+retrieval+of+configs#:Vending_Machine:-Multi-vendor/device-support))
* Introduction of one profile for Cisco IOS devices, reference from the open source project `oxidized` ([link](https://github.com/ytti/oxidized/blob/master/lib/oxidized/model/ios.rb))

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
