### PR TITLE
Fix proxy tests in datadog_checks_base avoiding calling external endpoints

### DIFF
--- a/datadog_checks_base/tests/base/utils/http/test_proxy.py
+++ b/datadog_checks_base/tests/base/utils/http/test_proxy.py
@@ -134,7 +134,7 @@ def test_proxy_env_vars_override_skip_fail(mock_requests_get: mock.MagicMock, ur
     http = RequestsWrapper(instance, init_config)
 
     with EnvVars({env_var: 'http://1.2.3.4:567'}):
-        http.get('http://www.google.com', timeout=1, proxies=None)
+        http.get(url, timeout=1, proxies=None)
         actual_proxies = mock_requests_get.call_args[1]['proxies']
 
         # Even with skip true, we ignore it to call get with the proxies supplied to the get method


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR removes the need of the `test_proxy` module of reaching out to any real endpoit for unit testing by mocking the request method and testing that we actually call `Session.get` as we expect to. 

### Motivation
<!-- What inspired you to submit this pull request? -->
Tests have been failing from time to time because there were delays connecting with `google.com`. Since we rely on the `request` library, running real tests mean we are actually testing how the `requests` library deals with proxies. The current modification avoids testing third party libraries and instead ensure we are testing the features we implement and call `request` as we expect to.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
