### PR TITLE
accept a list for skip all metrics matching a label

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper/base_scraper.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper/base_scraper.py
@@ -159,6 +159,9 @@ class OpenMetricsScraper:
                 if values is True:
                     self.exclude_metrics_by_labels[label] = return_true
                 elif isinstance(values, list):
+                    if len(values) == 1 and values[0] is True:
+                        self.exclude_metrics_by_labels[label] = return_true
+                        continue
                     for i, value in enumerate(values, 1):
                         if not isinstance(value, str):
                             raise ConfigurationError(

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
@@ -186,7 +186,8 @@
     a label `worker` or a label `pid` with the value of either `23` or `42`.
 
       exclude_metrics_by_labels:
-        worker: true
+        worker: 
+        - true
         pid:
         - '23'
         - '42'
@@ -195,6 +196,9 @@
     additionalProperties:
       anyOf:
       - type: boolean
+      - type: array
+        items:
+          type: boolean
       - type: array
         items:
           type: string

--- a/openmetrics/datadog_checks/openmetrics/config_models/instance.py
+++ b/openmetrics/datadog_checks/openmetrics/config_models/instance.py
@@ -128,7 +128,7 @@ class InstanceConfig(BaseModel):
     enable_health_service_check: Optional[bool] = None
     exclude_labels: Optional[tuple[str, ...]] = None
     exclude_metrics: Optional[tuple[str, ...]] = None
-    exclude_metrics_by_labels: Optional[MappingProxyType[str, Union[bool, tuple[str, ...]]]] = None
+    exclude_metrics_by_labels: Optional[MappingProxyType[str, Union[bool, tuple[bool, ...], tuple[str, ...]]]] = None
     extra_headers: Optional[MappingProxyType[str, Any]] = None
     extra_metrics: Optional[tuple[Union[str, MappingProxyType[str, Union[str, ExtraMetrics]]], ...]] = None
     headers: Optional[MappingProxyType[str, Any]] = None


### PR DESCRIPTION
### What does this PR do?
This PR is in conjunction with a PR to change the config model for the `exclude_metrics_by_label`. Currently this params accepts both a dict and a list:

```
{
  "target_label_key": true,
  "target_label_value_list": ["bar", "baz"]
}
```

But this change allows for the below to keep the same behavior of existing configs.
```
{ 
  "target_label_key": "true",
  "target_label_key": ["true"],
  "target_label_value_list": ["bar", "baz"]
}
```
I think it aligns it more to the below:
https://github.com/DataDog/integrations-core/pull/21583

I think the config example will change from:
```
   exclude_metrics_by_labels:
     worker: true
     pid:
     - '23'
     - '42'
```

to 

```
   exclude_metrics_by_labels:
     worker: 
     - true
     pid:
     - '23'
     - '42'
```    