### PR TITLE
Replace PROTOCOL_TLS by PROTOCOL_TLS_CLIENT in the tls module

### DIFF
--- a/datadog_checks_base/changelog.d/21739.fixed
+++ b/datadog_checks_base/changelog.d/21739.fixed
@@ -1,0 +1,1 @@
+Replace PROTOCOL_TLS by PROTOCOL_TLS_CLIENT when creating the SSLContext

--- a/datadog_checks_base/datadog_checks/base/utils/tls.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tls.py
@@ -120,7 +120,7 @@ def _load_ca_certs(context, config):
 def create_ssl_context(config):
     # https://docs.python.org/3/library/ssl.html#ssl.SSLContext
     # https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS_CLIENT
-    context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS)
+    context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
 
     LOGGER.debug('Creating SSL context with config: %s', config)
     # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.check_hostname


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR replaces the deprecated `PROTOCOL_TLS` by `TLS_PROTOCOL_CLIENT`. The `PROTOCOL_TLS` has been deprecated since 3.10 and will eventually be removed:

https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS

The code actually includes a comment to the `PROTOCOL_TLS_CLIENT` documentation which seems to imply this was a leftover.


### Motivation
<!-- What inspired you to submit this pull request? -->
Keeping deprecated parts can cause issues when upgrading to new versions of python and generate lots of warnings when running logs that can obscure CI validation.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
