### PR TITLE
Bump prometheus client to improve performance

### DIFF
--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -28,7 +28,7 @@ openstacksdk==4.7.0
 orjson==3.11.3
 packaging==25.0
 paramiko==3.5.1
-prometheus-client==0.22.1
+prometheus-client==0.23.1
 protobuf==6.32.0
 psutil==6.0.0
 psycopg[c,pool]==3.2.10

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -40,7 +40,7 @@ deps = [
     "ddtrace==3.12.5",
     "jellyfish==1.2.0",
     "lazy-loader==0.4",
-    "prometheus-client==0.22.1",
+    "prometheus-client==0.23.1",
     "protobuf==6.32.0",
     "pydantic==2.11.7",
     "python-dateutil==2.9.0.post0",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
v0.22.1 seems to have introduced a performance regression. It uses exception-based control flow in a hot loop.
This [is supposed to be fixed](https://github.com/prometheus/client_python/commit/26da805153365c75c336aa89f96293b149143122) in v0.23.1.

### Motivation
<!-- What inspired you to submit this pull request? -->
Better CPU usage.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
