### PR TITLE
Make new 7.72.0 integrations docs public

### DIFF
--- a/cloudgen_firewall/manifest.json
+++ b/cloudgen_firewall/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "fec157b4-467e-4faa-8db6-b80baea69b00",
   "app_id": "cloudgen-firewall",
-  "display_on_public_website": true,
+  "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?
Makes documentation for integrations to be released in 7.72.0 public, so that they are visible when 7.72.0 is released.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
