### PR TITLE
Remove automatic fill option for default Wi-Fi Overview dashboard

### DIFF
--- a/wlan/assets/dashboards/wlan_overview.json
+++ b/wlan/assets/dashboards/wlan_overview.json
@@ -526,7 +526,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:system.wlan.rssi{$ssid,$bssid,$mac_address,$host} by {host,mac_address,bssid,ssid}"
+                      "query": "avg:system.wlan.rssi{$ssid,$bssid,$mac_address,$host} by {host,mac_address,bssid,ssid}.fill(null)"
                     }
                   ],
                   "formulas": [
@@ -586,7 +586,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:system.wlan.noise{$ssid,$bssid,$mac_address,$host} by {host,mac_address,bssid,ssid}"
+                      "query": "avg:system.wlan.noise{$ssid,$bssid,$mac_address,$host} by {host,mac_address,bssid,ssid}.fill(null)"
                     }
                   ],
                   "formulas": [
@@ -640,7 +640,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "sum:system.wlan.channel_swap_events{$ssid,$bssid,$mac_address,$host} by {host,mac_address,bssid,ssid}.as_count()"
+                      "query": "sum:system.wlan.channel_swap_events{$ssid,$bssid,$mac_address,$host} by {host,mac_address,bssid,ssid}.as_count().fill(null)"
                     }
                   ],
                   "formulas": [
@@ -688,7 +688,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "sum:system.wlan.roaming_events{$ssid,$bssid,$mac_address,$host} by {host,mac_address,bssid,ssid}.as_count()"
+                      "query": "sum:system.wlan.roaming_events{$ssid,$bssid,$mac_address,$host} by {host,mac_address,bssid,ssid}.as_count().fill(null)"
                     }
                   ],
                   "formulas": [
@@ -755,7 +755,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:system.wlan.txrate{$ssid,$bssid,$mac_address,$host} by {host,mac_address,bssid,ssid}"
+                      "query": "avg:system.wlan.txrate{$ssid,$bssid,$mac_address,$host} by {host,mac_address,bssid,ssid}.fill(null)"
                     }
                   ],
                   "formulas": [
@@ -809,7 +809,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:system.wlan.rxrate{$ssid,$bssid,$mac_address,$host} by {host,mac_address,bssid,ssid}"
+                      "query": "avg:system.wlan.rxrate{$ssid,$bssid,$mac_address,$host} by {host,mac_address,bssid,ssid}.fill(null)"
                     }
                   ],
                   "formulas": [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add `.fill(null)` to many widgets of the default Wi-Fi Overview dashboard

### Motivation
<!-- What inspired you to submit this pull request? -->
If fill option, which is default behavior, is not removed then Wi-Fi drop are not shown or visible or discernable in the graph, and it defeat the main goal of the dashboard - Wi-Fi troubleshooting which should report Wi-Fi drop.

### Review checklist (to be filled by reviewers)
* Add your own Windows machine to an org
* Disable Wi-Fi for a few minutes
* Reenable Wi-Fi
* Go to the org Wi-Fi Overview and see the drop in its widgets.

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
