### PR TITLE
Fix health event tags in Postgres

### DIFF
--- a/postgres/changelog.d/21764.fixed
+++ b/postgres/changelog.d/21764.fixed
@@ -1,0 +1,1 @@
+Fix handling health event tags in Postgres to allow for additional tags as an argument.

--- a/postgres/datadog_checks/postgres/health.py
+++ b/postgres/datadog_checks/postgres/health.py
@@ -37,7 +37,7 @@ class PostgresHealth(Health):
         self,
         name: HealthEvent | PostgresHealthEvent,
         status: HealthStatus,
-        tags: list[str]=None,
+        tags: list[str] = None,
         data: dict = None,
         **kwargs,
     ):
@@ -54,7 +54,7 @@ class PostgresHealth(Health):
             name=name,
             status=status,
             # If we have an error parsing the config we may not have tags yet
-            tags=(self.check.tags if hasattr(self.check, 'tags') else [])+(tags or []),
+            tags=(self.check.tags if hasattr(self.check, 'tags') else []) + (tags or []),
             data={
                 "database_instance": self.check.database_identifier,
                 "ddagenthostname": self.check.agent_hostname,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes the handling of the `tags` argument in Postgres health events to allow for additional tags to be passed in.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
