### PR TITLE
Fix missed collection event to use collection interval

### DIFF
--- a/datadog_checks_base/changelog.d/21766.fixed
+++ b/datadog_checks_base/changelog.d/21766.fixed
@@ -1,0 +1,1 @@
+Fix missed collection event to use correct collection interval.

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -307,7 +307,7 @@ class DBMAsyncJob(object):
         self._config_host = config_host
         # The min_collection_interval is the expected collection interval for the main check
         self._min_collection_interval = min_collection_interval
-        self._expected_collection_interval = 1/rate_limit if rate_limit > 0 else 0
+        self._expected_collection_interval = 1 / rate_limit if rate_limit > 0 else 0
         # map[dbname -> psycopg connection]
         self._log = get_check_logger()
         self._job_loop_future = None
@@ -381,7 +381,7 @@ class DBMAsyncJob(object):
                                 "job_name": self._job_name,
                                 # send in ms for consistency with other metrics
                                 "last_run_start": self._last_run_start * 1000,
-                                "elapsed_time": elapsed_time * 1000, 
+                                "elapsed_time": elapsed_time * 1000,
                                 "expected_collection_interval": self._expected_collection_interval * 1000,
                                 "feature": feature,
                             },

--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -128,7 +128,7 @@ def test_dbm_async_job_missed_collection_interval(aggregator):
     check = AgentCheck()
     health = Health(check)
     check.health = health
-    job = JobForTesting(check, job_execution_time=3, rate_limit=1/1)
+    job = JobForTesting(check, job_execution_time=3, rate_limit=1 / 1)
     job.run_job_loop([])
     # Sleep longer than the target collection interval
     time.sleep(1.5)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes the interval that's used to calculate missed collections for DBM async jobs.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
