### PR TITLE
Add run-name to Measure Disk Usage workflow

### DIFF
--- a/.github/workflows/dummy-wf.yml
+++ b/.github/workflows/dummy-wf.yml
@@ -1,11 +1,9 @@
 name: Dummy workflow
 
-run-name: "[${{ github.event.pull_request.head.sha }}] Dummy workflow"
-
 on:
-  pull_request:
-    branches:
-      - master
+  workflow_run:
+    workflows:
+      - 'Resolve Dependencies and Build Wheels'
 
 jobs:
   dummy:
@@ -13,6 +11,7 @@ jobs:
     steps:
       - run: |
             echo "Head branch: "
+            echo ${{ github.event.workflow_run.head_branch }}
             echo "Ref: "
             echo ${{ github.ref_name }}
            

--- a/.github/workflows/measure-disk-usage.yml
+++ b/.github/workflows/measure-disk-usage.yml
@@ -1,5 +1,5 @@
 name: Measure Disk Usage
-run-name: Measure Disk Usage (${{ github.event.workflow_run.head_sha }})
+run-name: "Measure Disk Usage [${{ github.event.workflow_run.head_sha }}]"
 
 on:
   workflow_run:


### PR DESCRIPTION
### What does this PR do?
Adds the commit hash to the run name of the Measure Disk Usage workflow.

### Motivation
Workflows triggered by workflow_run always run on the master branch, making it impossible to filter them by the commit that triggered them. Including the commit hash in the run name allows filtering workflows by the specific commit they correspond to.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
