### PR TITLE
Avoid relying on the manifest to validate 3rd party licenses

### DIFF
--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -145,15 +145,7 @@ jobs:
         # Enable disk performance counters
         diskperf -y
 
-    - name: Checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        # Get all commits in the current branch to ensure that we can find a merge base
-        # for those tests where we need it
-        fetch-depth: ${{ github.event.pull_request.commits + 1 }}
-
-    - name: Fetch base commit
-      run: git fetch origin ${{ github.event.pull_request.base.sha }}
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set up Python 2.7
       if: inputs.test-py2

--- a/ddev/src/ddev/cli/validate/licenses.py
+++ b/ddev/src/ddev/cli/validate/licenses.py
@@ -103,7 +103,7 @@ def find_cpy(data):
 
 
 def get_extra_license_files(app: Application):
-    for integration in app.repo.integrations.iter():
+    for integration in app.repo.integrations.iter('all'):
         extra_license_file = integration.path / '3rdparty-extra-LICENSE.csv'
         if extra_license_file.is_file():
             yield extra_license_file

--- a/ddev/tests/cli/validate/test_licenses.py
+++ b/ddev/tests/cli/validate/test_licenses.py
@@ -1,8 +1,6 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
-
 import os
 
 import pytest


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PRs modifies the way we validate third party licenses by avoiding relying on the existence of a `manifest.json` file to identify integrations.

### Motivation
<!-- What inspired you to submit this pull request? -->
Starting in November 2025, integrations whose assets are going to be built through Publishing Platform won't include the `manifest.json` file in them as Publishing Platform will be the one that handles it.

Instead of relying on this file to identify a folder in the repo as an integration, we will rely on the logic of the Integration object to iterate over integrations. This has been updated in #21772 to recognize them without having to include the `manifest.json`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
