### PR TITLE
SAASINT-4900 Fix Genesys logos

### DIFF
--- a/genesys/assets/dashboards/genesys_audit.json
+++ b/genesys/assets/dashboards/genesys_audit.json
@@ -6,7 +6,7 @@
       "id": 9001282409665398,
       "definition": {
         "type": "image",
-        "url": "https://www.logo.wine/a/logo/Genesys_(company)/Genesys_(company)-Logo.wine.svg",
+        "url": "/static/images/logos/genesys_large.svg",
         "sizing": "cover",
         "has_background": false,
         "has_border": false,

--- a/genesys/assets/dashboards/genesys_callback.json
+++ b/genesys/assets/dashboards/genesys_callback.json
@@ -6,7 +6,7 @@
       "id": 1087031255759440,
       "definition": {
         "type": "image",
-        "url": "https://www.logo.wine/a/logo/Genesys_(company)/Genesys_(company)-Logo.wine.svg",
+        "url": "/static/images/logos/genesys_large.svg",
         "sizing": "cover",
         "has_background": false,
         "has_border": false,

--- a/genesys/assets/dashboards/genesys_chat.json
+++ b/genesys/assets/dashboards/genesys_chat.json
@@ -6,7 +6,7 @@
       "id": 6289012271406585,
       "definition": {
         "type": "image",
-        "url": "https://www.logo.wine/a/logo/Genesys_(company)/Genesys_(company)-Logo.wine.svg",
+        "url": "/static/images/logos/genesys_large.svg",
         "sizing": "cover",
         "has_background": false,
         "has_border": false,

--- a/genesys/assets/dashboards/genesys_conversation_overview.json
+++ b/genesys/assets/dashboards/genesys_conversation_overview.json
@@ -6,7 +6,7 @@
       "id": 5088819716215640,
       "definition": {
         "type": "image",
-        "url": "https://www.logo.wine/a/logo/Genesys_(company)/Genesys_(company)-Logo.wine.svg",
+        "url": "/static/images/logos/genesys_large.svg",
         "sizing": "cover",
         "has_background": false,
         "has_border": false,

--- a/genesys/assets/dashboards/genesys_email.json
+++ b/genesys/assets/dashboards/genesys_email.json
@@ -6,7 +6,7 @@
       "id": 5000349741342400,
       "definition": {
         "type": "image",
-        "url": "https://www.logo.wine/a/logo/Genesys_(company)/Genesys_(company)-Logo.wine.svg",
+        "url": "/static/images/logos/genesys_large.svg",
         "sizing": "cover",
         "has_background": false,
         "has_border": false,

--- a/genesys/assets/dashboards/genesys_message.json
+++ b/genesys/assets/dashboards/genesys_message.json
@@ -6,7 +6,7 @@
       "id": 6686255836399149,
       "definition": {
         "type": "image",
-        "url": "https://www.logo.wine/a/logo/Genesys_(company)/Genesys_(company)-Logo.wine.svg",
+        "url": "/static/images/logos/genesys_large.svg",
         "sizing": "cover",
         "has_background": false,
         "has_border": false,

--- a/genesys/assets/dashboards/genesys_voice.json
+++ b/genesys/assets/dashboards/genesys_voice.json
@@ -6,7 +6,7 @@
       "id": 4921638547489418,
       "definition": {
         "type": "image",
-        "url": "https://www.logo.wine/a/logo/Genesys_(company)/Genesys_(company)-Logo.wine.svg",
+        "url": "/static/images/logos/genesys_large.svg",
         "sizing": "cover",
         "has_background": false,
         "has_border": false,


### PR DESCRIPTION
### What does this PR do?
The Genesys dashboards were created with the logo as a link to https://www.logo.wine/a/logo/Genesys_(company)/Genesys_(company)-Logo.wine.svg which is a 404.  This changes the link to a logo on our servers, which we control at https://github.com/DataDog/web-ui/blob/preprod/public/static/images/logos/genesys_large.svg.  

Before:
<img width="638" height="404" alt="image" src="https://github.com/user-attachments/assets/b0936bd1-d280-4ac5-b118-aa761e608701" />


After:
<img width="693" height="404" alt="image" src="https://github.com/user-attachments/assets/9234bae7-2148-40d5-8d85-54f0ff8dd307" />

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
