### PR TITLE
Revert build_agent.yaml to use agent branch 7.73.x

### DIFF
--- a/.gitlab/build_agent.yaml
+++ b/.gitlab/build_agent.yaml
@@ -13,7 +13,7 @@
   stage: build
   trigger:
     project: DataDog/datadog-agent
-    branch: main 
+    branch: 7.73.x 
     # It's more convenient to directly show if downstream pipeline succeeded.
     strategy: depend
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We had to do this workaround last week when the datadog-agent branch 7.73.x was not created yet.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
