### PR TITLE
Avoid running agent build auto on tags

### DIFF
--- a/.gitlab/build_agent.yaml
+++ b/.gitlab/build_agent.yaml
@@ -20,6 +20,9 @@
 build-agent-auto:
   extends: .build-agent-tpl
   rules:
+    # Do not run on tags
+    - if: $CI_COMMIT_TAG
+      when: never
     # Do not run on release branches
     - if: $CI_COMMIT_BRANCH =~ /^7\.\d+\.x$/
       when: never


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Modifies the `agent-build-auto` job to not trigger on tags.

### Motivation
<!-- What inspired you to submit this pull request? -->
 This can cause an execution storm on agent pipelines for every tag we create during the release process. Seems that in recent updates to the pipelines we have regressed this and broad updates on all integrations can trigger thousand of jobs that are not necessary.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
