### PR TITLE
Run hash validation on prs to release branches and master

### DIFF
--- a/.github/workflows/release-hash-check.yml
+++ b/.github/workflows/release-hash-check.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - master
-      - '[0-9]+.[0-9]+.x'
+      - '7.[0-9]+.x'
     paths:
       - .in-toto/*.link
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Ensure we are running the hash validation in PRs done to release branches and master

### Motivation
<!-- What inspired you to submit this pull request? -->
We release most of the integrations to release branches and we need to run this validation.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
