### PR TITLE
Update gitlab-ci syntax to use rules instead of the only keyword

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,8 +28,8 @@ validate-log-integrations:
   stage: validate
   needs: []
   image: $VALIDATE_LOG_INTGS
-  only:
-  - schedules
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
   variables:
     INTEGRATIONS_CORE_ROOT: $CI_PROJECT_DIR
   script:
@@ -52,8 +52,8 @@ notify-slack:
     - validate-log-integrations
   stage: notify
   image: $NOTIFIER_IMAGE
-  only:
-  - schedules
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
   cache:
     <<: *slack-cache
   script:
@@ -73,9 +73,9 @@ notify-slack:
 notify-failed-pipeline:
   stage: notify
   image: $NOTIFIER_IMAGE
-  only:
-  - master
-  when: on_failure
+  rules:
+    - if: $CI_COMMIT_BRANCH == "master"
+      when: on_failure
   cache:
     <<: *slack-cache
   script:
@@ -89,11 +89,11 @@ notify-failed-pipeline:
 release-auto:
   stage: release
   image: $TAGGER_IMAGE
-  only:
-    - master
-    - /^\d+\.\d+\.x$/
-  except:
-    - schedules
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
+    - if: $CI_COMMIT_BRANCH == "master"
+    - if: $CI_COMMIT_BRANCH =~ /^\d+\.\d+\.x$/
   script:
     - ddev --version
     - ddev config override
@@ -105,11 +105,11 @@ release-auto:
 release-manual:
   stage: release
   image: $TAGGER_IMAGE
-  only:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
     # Integration release tags e.g. any_check-X.Y.Z-rc.N
-    - /.*-\d+\.\d+\.\d+(-(rc|pre|alpha|beta)\.\d+)?$/
-  except:
-  - schedules
+    - if: $CI_COMMIT_TAG =~ /.*-\d+\.\d+\.\d+(-(rc|pre|alpha|beta)\.\d+)?$/
   script:
     # Get tagger info
     - tagger=$(git for-each-ref refs/tags/$CI_COMMIT_TAG  --format='%(taggername) %(taggeremail)')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Remove the usage of `only`/`except` in our GitLab pipeline which was deprecate some time ago in favor of `rules`.

### Motivation
<!-- What inspired you to submit this pull request? -->
The `only`/`except` keywords can be removed at any time. [Docs](https://docs.gitlab.com/ci/yaml/deprecated_keywords/#only--except).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
