### PR TITLE
Statement metrics collection respect global_view_db

### DIFF
--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -306,6 +306,10 @@ def apply_validated_defaults(args: dict, instance: dict, validation_result: Vali
     if args.get('collect_default_database'):
         args['ignore_databases'] = [d for d in args['ignore_databases'] if d != 'postgres']
 
+    # When autodiscovery is enabled, use global_view_db as the main database for DBM jobs
+    if args.get('database_autodiscovery', {}).get('enabled'):
+        args['dbname'] = args.get('database_autodiscovery', {}).get('global_view_db', 'postgres')
+
     apply_cloud_defaults(args, instance, validation_result)
 
 

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -185,6 +185,11 @@ def build_config(check: PostgreSql) -> Tuple[InstanceConfig, ValidationResult]:
     if instance.get('obfuscator_options', {}).get('quantize_sql_tables'):
         args['obfuscator_options']['replace_digits'] = True
 
+    # When autodiscovery is enabled, use global_view_db as the main database for DBM jobs
+    # This must happen before building tags so the db: tag reflects the correct database
+    if args.get('database_autodiscovery', {}).get('enabled'):
+        args['dbname'] = args.get('database_autodiscovery', {}).get('global_view_db', 'postgres')
+
     validation_result = ValidationResult()
 
     # Generate and validate tags
@@ -305,10 +310,6 @@ def apply_validated_defaults(args: dict, instance: dict, validation_result: Vali
 
     if args.get('collect_default_database'):
         args['ignore_databases'] = [d for d in args['ignore_databases'] if d != 'postgres']
-
-    # When autodiscovery is enabled, use global_view_db as the main database for DBM jobs
-    if args.get('database_autodiscovery', {}).get('enabled'):
-        args['dbname'] = args.get('database_autodiscovery', {}).get('global_view_db', 'postgres')
 
     apply_cloud_defaults(args, instance, validation_result)
 


### PR DESCRIPTION
### What does this PR do?

Fixes statement metrics collection to respect the `global_view_db` configuration when database autodiscovery is enabled. Previously, the agent would always connect to the 'postgres' database for DBM jobs, ignoring the `global_view_db` setting.

### Motivation

When using `database_autodiscovery` with a custom `global_view_db` (other than postgres), the agent was still attempting to collect statement metrics from the default 'postgres' database. 
This caused warnings like "Unable to collect statement metrics because pg_stat_statements is not created in database 'postgres'" even when:
- `global_view_db: other` was configured
- `pg_stat_statements` is setup in the global_view_db database
- `postgres` was in the `exclude` list

The root cause was that `self.dbname` was not being updated to use the `global_view_db` value, so `_get_main_db()` always connected to 'postgres' for DBM operations.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged