### PR TITLE
Allow manually running the release pipeline from master

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -113,16 +113,20 @@ release-manual:
     - if: $CI_COMMIT_BRANCH == 'master'
       when: manual
   script:
-    # Get tagger info
-    - tagger=$(git for-each-ref refs/tags/$CI_COMMIT_TAG  --format='%(taggername) %(taggeremail)')
-    # The automatic release builder will trigger this job as a side-effect of
-    # tagging releases. To prevent multiple redundant builds we don't trigger
-    # the pipeline unless the tag was applied manually.
     - |
-      if [[ "$tagger" =~ "$TAGGER_NAME <$TAGGER_EMAIL>" ]]; then
-          echo "Skipping, packages have already been built"
-      else
+      if [[ -z "$CI_COMMIT_TAG" ]]; then
           ./.gitlab/tagger/build-packages.sh
+      else
+          # Get tagger info
+          tagger=$(git for-each-ref refs/tags/$CI_COMMIT_TAG  --format='%(taggername) %(taggeremail)')
+          # The automatic release builder will trigger this job as a side-effect of
+          # tagging releases. To prevent multiple redundant builds we don't trigger
+          # the pipeline unless the tag was applied manually.
+          if [[ "$tagger" =~ "$TAGGER_NAME <$TAGGER_EMAIL>" ]]; then
+              echo "Skipping, packages have already been built"
+          else
+              ./.gitlab/tagger/build-packages.sh
+          fi
       fi
   tags: [ "arch:amd64" ]
   needs: []


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Allows running the release pipeline by clicking on it from master. This prevents the need of having to create a bootstrapping tag every time we want to rerun for some reason.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
