### PR TITLE
IDP-800: Add owner field to network-device-monitoring-integrations manifest file

### DIFF
--- a/versa/manifest.json
+++ b/versa/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "3bd4335c-19ec-46dc-8c15-0192d6206ebf",
   "app_id": "versa",
+  "owner": "network-device-monitoring-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add `owner` field set to `network-device-monitoring-integrations` to manifest.json files for network-device-monitoring-integrations team integrations (1 integration):
- versa

This provides clear ownership tracking for these network device monitoring integrations as part of the initiative to add owner fields to all integration manifest.json files.