### PR TITLE
IDP-800: Add owner field to saas-integrations manifest files

### DIFF
--- a/beyondtrust_identity_security_insights/manifest.json
+++ b/beyondtrust_identity_security_insights/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "1ea8fd4a-c95e-460f-a2ec-703d8dccef5e",
   "app_id": "beyondtrust-identity-security-insights",
+  "owner": "saas-integrations",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/keeper/manifest.json
+++ b/keeper/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "8db87454-e15d-4f8b-bf70-a8229a2b6eba",
   "app_id": "keeper",
+  "owner": "saas-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/supply_chain_firewall/manifest.json
+++ b/supply_chain_firewall/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a86f7f3f-148b-4a66-838b-fb4c8678be59",
   "app_id": "supply-chain-firewall",
+  "owner": "saas-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add `owner` field set to `saas-integrations` to manifest.json files for saas-integrations team integrations (3 integrations):
- supply_chain_firewall
- keeper
- beyondtrust_identity_security_insights

This provides clear ownership tracking for these SaaS integrations as part of the initiative to add owner fields to all integration manifest.json files.