### PR TITLE
Add `trend_micro_cloud_one` to removed integrations

### DIFF
--- a/ddev/src/ddev/cli/release/agent/changelog.py
+++ b/ddev/src/ddev/cli/release/agent/changelog.py
@@ -25,8 +25,8 @@ DISPLAY_NAME_MAPPING = {
 
 REMOVED_INTEGRATIONS = {
     # name --> display name
-    'kaspersky': 'Kaspersky'
-    'trend_micro_cloud_one': 'Trend Micro Cloud One'
+    'kaspersky': 'Kaspersky',
+    'trend_micro_cloud_one': 'Trend Micro Cloud One',
 }
 
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds `trend_micro_cloud_one` to removed integrations

### Motivation
<!-- What inspired you to submit this pull request? -->
https://github.com/DataDog/integrations-core/pull/21863/files

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
