### PR TITLE
Prevent command injection in Measure Disk Usage

### DIFF
--- a/.github/workflows/measure-disk-usage.yml
+++ b/.github/workflows/measure-disk-usage.yml
@@ -42,11 +42,6 @@ jobs:
         EVENT_NAME: ${{ github.event.workflow_run.event }}
         HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
       run: |
-        if ! [[ $HEAD_BRANCH =~ ^[A-Za-z0-9._/-]+$ ]]; then
-            echo "Branch name contains invalid characters. Exiting."
-            exit 1
-        fi
-
         cmd="ddev -v size status --commit \"$HEAD_SHA\" --format json"
 
         if [ "$EVENT_NAME" = "push" ] && [ "$HEAD_BRANCH" = "master" ]; then 


### PR DESCRIPTION
### What does this PR do?
This PR adds input sanitization to the “Measure Disk Usage” GitHub Actions workflow to prevent potential command injection attacks.
Untrusted values from the workflow_run trigger (head_sha, head_branch, event) are now passed through environment variables instead of being directly interpolated into shell commands. In addition, branch names are validated against a safe character pattern before use.

### Motivation
Previously, the workflow interpolated data from `github.event.workflow_run` directly into shell commands, allowing an attacker to inject malicious head_branch values.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[VULN-935]: https://datadoghq.atlassian.net/browse/VULN-935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ