### PR TITLE
[DOCS-12665] Fix typo in metric name

### DIFF
--- a/ibm_was/metadata.csv
+++ b/ibm_was/metadata.csv
@@ -47,7 +47,7 @@ ibm_was.thread_pools.active_time,gauge,,millisecond,,The average time in millise
 ibm_was.thread_pools.cleared_thread_hang_count,gauge,,thread,,The number of thread hangs cleared,0,ibm_was,thread pools cleared,
 ibm_was.thread_pools.concurrent_hung_thread_count,gauge,,thread,,The number of concurrently hung threads,0,ibm_was,thread pools concurrent hung,
 ibm_was.thread_pools.create_count,gauge,,thread,,The total number of threads created,0,ibm_was,thread pools create count,
-ibm_was.thread_pools.declaredthread_hung_count,gauge,,thread,,The number of threads declared hung,0,ibm_was,thread pools declared count,
+ibm_was.thread_pools.declared_thread_hung_count,gauge,,thread,,The number of threads declared hung,0,ibm_was,thread pools declared count,
 ibm_was.thread_pools.destroy_count,gauge,,thread,,The total number of threads destroyed,0,ibm_was,thread pools destroy count,
 ibm_was.thread_pools.percent_maxed,gauge,,percent,,The average percent of the time that all threads are in use,0,ibm_was,thread pools percent max,
 ibm_was.thread_pools.percent_used,gauge,,percent,,The average percent of the pool that is in use. The value is based on the total number of configured threads in the ThreadPool and not the current pool size.,0,ibm_was,thread pools percent used,


### PR DESCRIPTION
### What does this PR do?
This PR fixes a typo reported to us in the name of a metric for the IBM WAS integration.

`ibm_was.thread_pools.declaredthread_hung_count` -> `ibm_was.thread_pools.declared_thread_hung_count` (added the missing underscore).

Let me know if updating the name in the metadata.csv file is sufficient or if there's anything additional I need to do to get the new name to populate to the docs!