### PR TITLE
[DBM][Postgres] Debug log if extension is not in loader map

### DIFF
--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -70,7 +70,6 @@ PG_EXTENSION_LOADER_QUERY = {
     'plpgsql': "DO $$ BEGIN PERFORM 1; END$$;",
     'pgcrypto': "SELECT armor('foo');",
     'hstore': "SELECT 'a=>1'::hstore;",
-    'pg_stat_statements': "SELECT 1 FROM pg_stat_statements LIMIT 1;",
 }
 
 DATABASE_INFORMATION_QUERY = """
@@ -813,13 +812,13 @@ class PostgresMetadata(DBMAsyncJob):
                         if row['schemaname'] in ['pg_catalog', 'public']:
                             query = PG_EXTENSION_LOADER_QUERY[extension] + "\n" + query
                         else:
-                            self._log.warning(
+                            self._log.debug(
                                 "unable to collect settings for extension %s in schema %s",
                                 extension,
                                 row['schemaname'],
                             )
                     else:
-                        self._log.warning("unable to collect settings for unknown extension %s", extension)
+                        self._log.debug("unable to collect settings for unknown extension %s", extension)
 
                 if self.pg_settings_ignored_patterns:
                     query = query + " WHERE name NOT LIKE ALL(%s)"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR will lower the logging severity for [this log](https://github.com/DataDog/integrations-core/blob/dd9946e98c591a1b08fd56be4b27918edbab9566/postgres/datadog_checks/postgres/metadata.py#L821) as it should not be a warning.

### Motivation
<!-- What inspired you to submit this pull request? -->

Customer in [this case](https://datadoghq.atlassian.net/browse/SDBM-2132) reached out about  they kept seeing [this log](https://github.com/DataDog/integrations-core/blob/dd9946e98c591a1b08fd56be4b27918edbab9566/postgres/datadog_checks/postgres/metadata.py#L821) for unknown extension `pg_stat_statements`. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
