### PR TITLE
Update LiteLLM integration docs to use tabs

### DIFF
--- a/litellm/README.md
+++ b/litellm/README.md
@@ -16,9 +16,9 @@ Key metrics such as request/response counts, latency, error rates, token usage, 
 
 ## Setup
 
-You can configure this integration either as a standalone integration via LLM Observability, or as an agent check.
+You can configure this integration either as a standalone integration with LLM Observability, or as an agent check.
 
-Use it as an integration via LLM Observability to:
+Use it as an integration with LLM Observability to:
 
 - Monitor LLM agents and applications that use LiteLLM
 - Debug and troubleshoot every single operation, including calls to LiteLLM


### PR DESCRIPTION
### What does this PR do?
@mahipdeora25 suggested putting the two different setup options for this integration into a tabbed format:

<img width="694" height="662" alt="image" src="https://github.com/user-attachments/assets/029cdf7d-b6cc-445e-b615-a9144ac5edd2" />

@barieom, thank you for providing details on the two setup cases, and @cswatt, thank you for refactoring the Automatic Instrumentation for LLM Observability docs page to make linking to the LiteLLM entry easier.

In a review, I'm looking for:
* Are the technical details all still correct?
* Is there anything else you'd add?

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [x] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
