### PR TITLE
IDP-800: Add owner field to agent-integrations manifest files

### DIFF
--- a/barracuda_secure_edge/manifest.json
+++ b/barracuda_secure_edge/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "c0acbaef-4769-4ea9-aa77-b208440f9303",
   "app_id": "barracuda-secure-edge",
+  "owner": "agent-integrations",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/cloudgen_firewall/manifest.json
+++ b/cloudgen_firewall/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "fec157b4-467e-4faa-8db6-b80baea69b00",
   "app_id": "cloudgen-firewall",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/zscaler_private_access/manifest.json
+++ b/zscaler_private_access/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "316cf13a-3c12-4014-9cb1-e3fa6ad8dd5e",
   "app_id": "zscaler-private-access",
+  "owner": "agent-integrations",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add `owner` field set to `agent-integrations` to manifest.json files for agent-integrations team integrations (3 integrations):
- barracuda_secure_edge
- cloudgen_firewall  
- zscaler_private_access

This provides clear ownership tracking for these security and networking integrations as part of the initiative to add owner fields to all integration manifest.json files.