### PR TITLE
[Release] Bumped lustre version to 1.2.1 [port from 7.73.x]

### DIFF
--- a/lustre/CHANGELOG.md
+++ b/lustre/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 1.2.1 / 2025-11-19
+
+***Fixed***:
+
+* Fix device discovery for older versions of Lustre (<2.15.5) ([#21901](https://github.com/DataDog/integrations-core/pull/21901))
+
 ## 1.2.0 / 2025-10-31
 
 ***Security***:

--- a/lustre/changelog.d/21901.fixed
+++ b/lustre/changelog.d/21901.fixed
@@ -1,1 +1,0 @@
-Fix device discovery for older versions of Lustre (<2.15.5)

--- a/lustre/datadog_checks/lustre/__about__.py
+++ b/lustre/datadog_checks/lustre/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2025-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '1.2.0'
+__version__ = '1.2.1'

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -137,7 +137,7 @@ datadog-linkerd==7.1.1
 datadog-linux-audit-logs==1.1.0; sys_platform == 'linux2'
 datadog-linux-proc-extras==4.1.0; sys_platform == 'linux2'
 datadog-litellm==2.1.1
-datadog-lustre==1.2.0
+datadog-lustre==1.2.1
 datadog-mac-audit-logs==1.1.0; sys_platform == 'darwin'
 datadog-mapr==3.1.0; sys_platform == 'linux2'
 datadog-mapreduce==7.1.1


### PR DESCRIPTION
### What does this PR do?
Ports release of lustre from the release branch to main
### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
