### PR TITLE
Test removal of loadText description in mib test

### DIFF
--- a/snmp/tests/mibs/DUMMY-MIB.py
+++ b/snmp/tests/mibs/DUMMY-MIB.py
@@ -72,20 +72,14 @@ dummy = MibIdentifier((1, 3, 6, 1, 4, 1, 123456789))
 scalar = MibScalar(
     (1, 3, 6, 1, 4, 1, 123456789, 1), Integer32().subtype(subtypeSpec=ValueRangeConstraint(1, 65535))
 ).setMaxAccess("readonly")
-if mibBuilder.loadTexts:
-    scalar.setStatus('mandatory')
 
 dummyCounterGauge = MibScalar(
     (1, 3, 6, 1, 4, 1, 123456789, 2), CounterBasedGauge64().subtype(subtypeSpec=ValueRangeConstraint(1, 65535))
 ).setMaxAccess("readonly")
-if mibBuilder.loadTexts:
-    dummyCounterGauge.setStatus('mandatory')
 
 dummyZeroCounter = MibScalar(
     (1, 3, 6, 1, 4, 1, 123456789, 3), ZeroBasedCounter64().subtype(subtypeSpec=ValueRangeConstraint(1, 65535))
 ).setMaxAccess("readonly")
-if mibBuilder.loadTexts:
-    dummyZeroCounter.setStatus('mandatory')
 
 mibBuilder.exportSymbols(
     "DUMMY-MIB", scalar=scalar, dummy=dummy, dummyCounterGauge=dummyCounterGauge, dummyZeroCounter=dummyZeroCounter


### PR DESCRIPTION
### What does this PR do?
The pysnmp_mibs directory is used by the MibBuilder to resolve MIB definitions into their corresponding OIDs. These MIB files include descriptive text meant to help users understand what each MIB/OID represents when loadTexts is enabled. Since the SNMP check does not enable loadTexts, these descriptions are never used. This PR explores removing them from the agent to reclaim disk space.

The main change in this PR is the deletion of the loadTexts in the DUMMY-MIB.py files that are loaded using MIB only in the test. 