### PR TITLE
SAASINT-4951 Fix metric display in public docs

### DIFF
--- a/blazemeter/README.md
+++ b/blazemeter/README.md
@@ -32,7 +32,7 @@ Integrate BlazeMeter with Datadog to gain insights into performance and function
 
 ### Metrics
 
-The BlazeMeter integration collects and forwards **Performance** and **Functional** test results metrics to Datadog. See [metadata.csv][3] for a list of metrics provided by this integration.
+See [metadata.csv][3] for a list of metrics provided by this integration.
 
 ### Service Checks
 

--- a/genesys/README.md
+++ b/genesys/README.md
@@ -57,7 +57,7 @@ The Genesys integration collects and forwards audit logs to Datadog.
 
 ### Metrics
 
-The Genesys integration collects and forwards conversation analytics metrics to Datadog. See [metadata.csv][5] for a list of metrics provided by this integration.
+See [metadata.csv][5] for a list of metrics provided by this integration.
 
 ### Events
 

--- a/mux/README.md
+++ b/mux/README.md
@@ -41,7 +41,7 @@ The Mux integration does not include any logs.
 
 ### Metrics
 
-The Mux integration collects and forwards mux metrics data to Datadog. See [metadata.csv][4] for a list of metrics provided by this integration.
+See [metadata.csv][4] for a list of metrics provided by this integration.
 
 ### Service Checks
 


### PR DESCRIPTION
### What does this PR do?
From APW investigation with Brian Deutsch: 


problem here is not metadata.csv but in how we are parsing the readme.   there is a legacy workflow we support where we inject the metrics table by searching for and replacing a "magic sentence":
See [metadata.csv][5] for a list of metrics provided by this integration
however in [genesys](https://github.com/DataDog/integrations-core/blob/94ed10f2504e632a75f199c124e40792eb381426/genesys/README.md?plain=1#L60) and [blazemeter](https://github.com/DataDog/integrations-core/blob/master/blazemeter/README.md?plain=1#L35), there is another sentence before the magic sentence.   we don't expect that, so the parser replaces the magic sentence with the metrics table markdown, and it ends up on the same line as the first sentence.   thus making markdown that is no longer a valid table.

So the metrics table currently looks like this: 
<img width="758" height="583" alt="image" src="https://github.com/user-attachments/assets/f45d597f-a066-453f-86ea-6a209e89d109" />


### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
