### PR TITLE
fix(json-specs): add secret flags on secret SNMP fields

### DIFF
--- a/snmp/assets/configuration/spec.yaml
+++ b/snmp/assets/configuration/spec.yaml
@@ -218,6 +218,7 @@ files:
           Only useful for SNMP v1 & v2.
           Enclose the community string with single quotes to avoid special characters being interpreted. For instance:
           community_string: 'public'
+        secret: true
         value:
           type: string
       - name: snmp_version
@@ -292,6 +293,7 @@ files:
         description: |
           Authentication key to use with your Authentication type.
           SNMP v3 specific configuration.
+        secret: true
         value:
           type: string
           example: <AUTHENTICATION_TYPE_KEY>
@@ -309,6 +311,7 @@ files:
         description: |
           Privacy type key to use with your Privacy type.
           SNMP v3 specific configuration.
+        secret: true
         value:
           type: string
           example: <PRIVACY_TYPE_KEY>


### PR DESCRIPTION
### What does this PR do?

Add `secret` flag on the following fields of the SNMP integration: `community_string`, `authKey` and `privKey` so that they can be treated as secrets by *Fleet Automation*.

### Motivation

https://datadoghq.atlassian.net/browse/FA-1028

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
