### PR TITLE
[DBM][Postgres] Updated config to show excluded databases

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -461,10 +461,10 @@ files:
             items:
               type: string
             example:
+              - "model"
+              - "msdb"
               - "cloudsqladmin"
-              - "rdsadmin" 
-              - "alloydbadmin"
-              - "alloydbmetadata"
+              - "rdsadmin"
             display_default:
               - "cloudsqladmin"
               - "rdsadmin" 

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -407,10 +407,10 @@ instances:
         ## those found via `include`
         #
         # exclude:
+        #   - model
+        #   - msdb
         #   - cloudsqladmin
         #   - rdsadmin
-        #   - alloydbadmin
-        #   - alloydbmetadata
 
         ## @param refresh - integer - optional - default: 600
         ## Frequency in seconds of scans for new databases. Defaults to 10 minutes.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Updates the postgres configuration to show what databases we exclude from database autodiscovery 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
