### PR TITLE
[DOCS-12573] Move iboss integration metrics table to right place

### DIFF
--- a/iboss/README.md
+++ b/iboss/README.md
@@ -207,8 +207,6 @@ sudo -u dd-agent -- datadog-agent integration install datadog-iboss==1.0.0
 
 See [metadata.csv][7] for a list of metrics provided by this integration.
 
-<!-- {{< get-metrics-from-git "iboss" >}} -->
-
 ### Events
 
 The iboss integration does not include any events.


### PR DESCRIPTION
### What does this PR do?
Because of how the "magic sentence" works, the metrics table in this integration was appearing too early in the doc ([beneath a different `Metrics` heading](https://docs.datadoghq.com/integrations/iboss/#metrics)). I manually added the sentence under the correct heading and removed the other method that we were using to pull in the metrics table, and confirmed via a local build that the table now appears only once, under the `Data Collected` section:

<img width="874" height="637" alt="image" src="https://github.com/user-attachments/assets/51cae8e5-6c1f-4f86-a188-89a97183b1cc" />


Also confirmed that the earlier `Metrics` section has only the content that the author added:

<img width="710" height="287" alt="image" src="https://github.com/user-attachments/assets/87fa7c63-a685-495e-a5be-00c04b085c67" />


### Motivation
Issue was reported via a DOCS ticket

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
