### PR TITLE
Bump minimum base check version

### DIFF
--- a/active_directory/changelog.d/21945.added
+++ b/active_directory/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/active_directory/pyproject.toml
+++ b/active_directory/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/activemq/changelog.d/21945.added
+++ b/activemq/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/activemq/pyproject.toml
+++ b/activemq/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/activemq_xml/changelog.d/21945.added
+++ b/activemq_xml/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/activemq_xml/pyproject.toml
+++ b/activemq_xml/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/aerospike/changelog.d/21945.added
+++ b/aerospike/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/aerospike/pyproject.toml
+++ b/aerospike/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/airflow/changelog.d/21945.added
+++ b/airflow/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/airflow/pyproject.toml
+++ b/airflow/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/amazon_msk/changelog.d/21945.added
+++ b/amazon_msk/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/amazon_msk/pyproject.toml
+++ b/amazon_msk/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/ambari/changelog.d/21945.added
+++ b/ambari/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/ambari/pyproject.toml
+++ b/ambari/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/apache/changelog.d/21945.added
+++ b/apache/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/apache/pyproject.toml
+++ b/apache/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/appgate_sdp/changelog.d/21945.added
+++ b/appgate_sdp/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/appgate_sdp/pyproject.toml
+++ b/appgate_sdp/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/arangodb/changelog.d/21945.added
+++ b/arangodb/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/arangodb/pyproject.toml
+++ b/arangodb/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/argo_rollouts/changelog.d/21945.added
+++ b/argo_rollouts/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/argo_rollouts/pyproject.toml
+++ b/argo_rollouts/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/argo_workflows/changelog.d/21945.added
+++ b/argo_workflows/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/argo_workflows/pyproject.toml
+++ b/argo_workflows/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/argocd/changelog.d/21945.added
+++ b/argocd/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/argocd/pyproject.toml
+++ b/argocd/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/aspdotnet/changelog.d/21945.added
+++ b/aspdotnet/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/aspdotnet/pyproject.toml
+++ b/aspdotnet/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/avi_vantage/changelog.d/21945.added
+++ b/avi_vantage/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/avi_vantage/pyproject.toml
+++ b/avi_vantage/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/aws_neuron/changelog.d/21945.added
+++ b/aws_neuron/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/aws_neuron/pyproject.toml
+++ b/aws_neuron/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/azure_iot_edge/changelog.d/21945.added
+++ b/azure_iot_edge/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/azure_iot_edge/pyproject.toml
+++ b/azure_iot_edge/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/barracuda_secure_edge/changelog.d/21945.added
+++ b/barracuda_secure_edge/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/barracuda_secure_edge/pyproject.toml
+++ b/barracuda_secure_edge/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=4.2.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/bentoml/changelog.d/21945.added
+++ b/bentoml/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/bentoml/pyproject.toml
+++ b/bentoml/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/beyondtrust_password_safe/changelog.d/21945.added
+++ b/beyondtrust_password_safe/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/beyondtrust_password_safe/pyproject.toml
+++ b/beyondtrust_password_safe/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/boundary/changelog.d/21945.added
+++ b/boundary/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/boundary/pyproject.toml
+++ b/boundary/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/btrfs/changelog.d/21945.added
+++ b/btrfs/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/btrfs/pyproject.toml
+++ b/btrfs/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/cacti/changelog.d/21945.added
+++ b/cacti/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/cacti/pyproject.toml
+++ b/cacti/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/calico/changelog.d/21945.added
+++ b/calico/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/calico/pyproject.toml
+++ b/calico/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/cassandra/changelog.d/21945.added
+++ b/cassandra/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/cassandra/pyproject.toml
+++ b/cassandra/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/cassandra_nodetool/changelog.d/21945.added
+++ b/cassandra_nodetool/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/cassandra_nodetool/pyproject.toml
+++ b/cassandra_nodetool/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/celery/changelog.d/21945.added
+++ b/celery/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/celery/pyproject.toml
+++ b/celery/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/ceph/changelog.d/21945.added
+++ b/ceph/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/ceph/pyproject.toml
+++ b/ceph/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/cert_manager/changelog.d/21945.added
+++ b/cert_manager/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/cert_manager/pyproject.toml
+++ b/cert_manager/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/checkpoint_harmony_endpoint/changelog.d/21945.added
+++ b/checkpoint_harmony_endpoint/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/checkpoint_harmony_endpoint/pyproject.toml
+++ b/checkpoint_harmony_endpoint/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/checkpoint_quantum_firewall/changelog.d/21945.added
+++ b/checkpoint_quantum_firewall/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/checkpoint_quantum_firewall/pyproject.toml
+++ b/checkpoint_quantum_firewall/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/cilium/changelog.d/21945.added
+++ b/cilium/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/cilium/pyproject.toml
+++ b/cilium/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/cisco_aci/changelog.d/21945.added
+++ b/cisco_aci/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/cisco_aci/pyproject.toml
+++ b/cisco_aci/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/cisco_secure_firewall/changelog.d/21945.added
+++ b/cisco_secure_firewall/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/cisco_secure_firewall/pyproject.toml
+++ b/cisco_secure_firewall/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/cisco_secure_web_appliance/changelog.d/21945.added
+++ b/cisco_secure_web_appliance/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/cisco_secure_web_appliance/pyproject.toml
+++ b/cisco_secure_web_appliance/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/citrix_hypervisor/changelog.d/21945.added
+++ b/citrix_hypervisor/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/citrix_hypervisor/pyproject.toml
+++ b/citrix_hypervisor/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/clickhouse/changelog.d/21945.added
+++ b/clickhouse/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/clickhouse/pyproject.toml
+++ b/clickhouse/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/cloud_foundry_api/changelog.d/21945.added
+++ b/cloud_foundry_api/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/cloud_foundry_api/pyproject.toml
+++ b/cloud_foundry_api/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/cloudera/changelog.d/21945.added
+++ b/cloudera/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/cloudera/pyproject.toml
+++ b/cloudera/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/cloudgen_firewall/changelog.d/21945.added
+++ b/cloudgen_firewall/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/cloudgen_firewall/pyproject.toml
+++ b/cloudgen_firewall/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/cockroachdb/changelog.d/21945.added
+++ b/cockroachdb/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/cockroachdb/pyproject.toml
+++ b/cockroachdb/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/confluent_platform/changelog.d/21945.added
+++ b/confluent_platform/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/confluent_platform/pyproject.toml
+++ b/confluent_platform/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/consul/changelog.d/21945.added
+++ b/consul/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/consul/pyproject.toml
+++ b/consul/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/coredns/changelog.d/21945.added
+++ b/coredns/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/coredns/pyproject.toml
+++ b/coredns/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/couch/changelog.d/21945.added
+++ b/couch/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/couch/pyproject.toml
+++ b/couch/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/couchbase/changelog.d/21945.added
+++ b/couchbase/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/couchbase/pyproject.toml
+++ b/couchbase/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/crio/changelog.d/21945.added
+++ b/crio/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/crio/pyproject.toml
+++ b/crio/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/datadog_checks_dependency_provider/changelog.d/21945.added
+++ b/datadog_checks_dependency_provider/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/datadog_checks_dependency_provider/pyproject.toml
+++ b/datadog_checks_dependency_provider/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/datadog_checks_dev/changelog.d/21945.added
+++ b/datadog_checks_dev/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check_only/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check_only/{check_name}/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/datadog_cluster_agent/changelog.d/21945.added
+++ b/datadog_cluster_agent/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/datadog_cluster_agent/pyproject.toml
+++ b/datadog_cluster_agent/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/datadog_csi_driver/changelog.d/21945.added
+++ b/datadog_csi_driver/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/datadog_csi_driver/pyproject.toml
+++ b/datadog_csi_driver/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/dcgm/changelog.d/21945.added
+++ b/dcgm/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/dcgm/pyproject.toml
+++ b/dcgm/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/delinea_privilege_manager/changelog.d/21945.added
+++ b/delinea_privilege_manager/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/delinea_privilege_manager/pyproject.toml
+++ b/delinea_privilege_manager/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/delinea_secret_server/changelog.d/21945.added
+++ b/delinea_secret_server/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/delinea_secret_server/pyproject.toml
+++ b/delinea_secret_server/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/directory/changelog.d/21945.added
+++ b/directory/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/directory/pyproject.toml
+++ b/directory/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/disk/changelog.d/21945.added
+++ b/disk/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/disk/pyproject.toml
+++ b/disk/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/dns_check/changelog.d/21945.added
+++ b/dns_check/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/dns_check/pyproject.toml
+++ b/dns_check/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/dotnetclr/changelog.d/21945.added
+++ b/dotnetclr/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/dotnetclr/pyproject.toml
+++ b/dotnetclr/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/druid/changelog.d/21945.added
+++ b/druid/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/druid/pyproject.toml
+++ b/druid/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/duckdb/changelog.d/21945.added
+++ b/duckdb/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/duckdb/pyproject.toml
+++ b/duckdb/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/ecs_fargate/changelog.d/21945.added
+++ b/ecs_fargate/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/ecs_fargate/pyproject.toml
+++ b/ecs_fargate/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/eks_fargate/changelog.d/21945.added
+++ b/eks_fargate/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/eks_fargate/pyproject.toml
+++ b/eks_fargate/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/elastic/changelog.d/21945.added
+++ b/elastic/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/elastic/pyproject.toml
+++ b/elastic/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/envoy/changelog.d/21945.added
+++ b/envoy/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/envoy/pyproject.toml
+++ b/envoy/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/eset_protect/changelog.d/21945.added
+++ b/eset_protect/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/eset_protect/pyproject.toml
+++ b/eset_protect/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/esxi/changelog.d/21945.added
+++ b/esxi/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/esxi/pyproject.toml
+++ b/esxi/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/etcd/changelog.d/21945.added
+++ b/etcd/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/etcd/pyproject.toml
+++ b/etcd/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/exchange_server/changelog.d/21945.added
+++ b/exchange_server/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/exchange_server/pyproject.toml
+++ b/exchange_server/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/external_dns/changelog.d/21945.added
+++ b/external_dns/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/external_dns/pyproject.toml
+++ b/external_dns/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/falco/changelog.d/21945.added
+++ b/falco/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/falco/pyproject.toml
+++ b/falco/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/flink/changelog.d/21945.added
+++ b/flink/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/flink/pyproject.toml
+++ b/flink/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/fluentd/changelog.d/21945.added
+++ b/fluentd/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/fluentd/pyproject.toml
+++ b/fluentd/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/fluxcd/changelog.d/21945.added
+++ b/fluxcd/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/fluxcd/pyproject.toml
+++ b/fluxcd/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/fly_io/changelog.d/21945.added
+++ b/fly_io/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/fly_io/pyproject.toml
+++ b/fly_io/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/forescout/changelog.d/21945.added
+++ b/forescout/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/forescout/pyproject.toml
+++ b/forescout/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=4.2.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/foundationdb/changelog.d/21945.added
+++ b/foundationdb/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/foundationdb/pyproject.toml
+++ b/foundationdb/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/gearmand/changelog.d/21945.added
+++ b/gearmand/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/gearmand/pyproject.toml
+++ b/gearmand/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/gitlab/changelog.d/21945.added
+++ b/gitlab/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/gitlab/pyproject.toml
+++ b/gitlab/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/gitlab_runner/changelog.d/21945.added
+++ b/gitlab_runner/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/gitlab_runner/pyproject.toml
+++ b/gitlab_runner/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/glusterfs/changelog.d/21945.added
+++ b/glusterfs/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/glusterfs/pyproject.toml
+++ b/glusterfs/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/go_expvar/changelog.d/21945.added
+++ b/go_expvar/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/go_expvar/pyproject.toml
+++ b/go_expvar/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/gunicorn/changelog.d/21945.added
+++ b/gunicorn/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/gunicorn/pyproject.toml
+++ b/gunicorn/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/haproxy/changelog.d/21945.added
+++ b/haproxy/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/haproxy/pyproject.toml
+++ b/haproxy/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/harbor/changelog.d/21945.added
+++ b/harbor/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/harbor/pyproject.toml
+++ b/harbor/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/hazelcast/changelog.d/21945.added
+++ b/hazelcast/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/hazelcast/pyproject.toml
+++ b/hazelcast/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/hdfs_datanode/changelog.d/21945.added
+++ b/hdfs_datanode/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/hdfs_datanode/pyproject.toml
+++ b/hdfs_datanode/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/hdfs_namenode/changelog.d/21945.added
+++ b/hdfs_namenode/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/hdfs_namenode/pyproject.toml
+++ b/hdfs_namenode/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/hive/changelog.d/21945.added
+++ b/hive/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/hive/pyproject.toml
+++ b/hive/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/hivemq/changelog.d/21945.added
+++ b/hivemq/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/hivemq/pyproject.toml
+++ b/hivemq/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/http_check/changelog.d/21945.added
+++ b/http_check/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/http_check/pyproject.toml
+++ b/http_check/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/hudi/changelog.d/21945.added
+++ b/hudi/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/hudi/pyproject.toml
+++ b/hudi/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/hugging_face_tgi/changelog.d/21945.added
+++ b/hugging_face_tgi/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/hugging_face_tgi/pyproject.toml
+++ b/hugging_face_tgi/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/hyperv/changelog.d/21945.added
+++ b/hyperv/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/hyperv/pyproject.toml
+++ b/hyperv/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/ibm_ace/changelog.d/21945.added
+++ b/ibm_ace/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/ibm_ace/pyproject.toml
+++ b/ibm_ace/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/ibm_db2/changelog.d/21945.added
+++ b/ibm_db2/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/ibm_db2/pyproject.toml
+++ b/ibm_db2/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/ibm_i/changelog.d/21945.added
+++ b/ibm_i/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/ibm_i/pyproject.toml
+++ b/ibm_i/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/ibm_mq/changelog.d/21945.added
+++ b/ibm_mq/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/ibm_mq/pyproject.toml
+++ b/ibm_mq/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/ibm_was/changelog.d/21945.added
+++ b/ibm_was/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/ibm_was/pyproject.toml
+++ b/ibm_was/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/iboss/changelog.d/21945.added
+++ b/iboss/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/iboss/pyproject.toml
+++ b/iboss/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/ignite/changelog.d/21945.added
+++ b/ignite/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/ignite/pyproject.toml
+++ b/ignite/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/iis/changelog.d/21945.added
+++ b/iis/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/iis/pyproject.toml
+++ b/iis/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/impala/changelog.d/21945.added
+++ b/impala/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/impala/pyproject.toml
+++ b/impala/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/infiniband/changelog.d/21945.added
+++ b/infiniband/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/infiniband/pyproject.toml
+++ b/infiniband/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/istio/changelog.d/21945.added
+++ b/istio/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/istio/pyproject.toml
+++ b/istio/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/ivanti_connect_secure/changelog.d/21945.added
+++ b/ivanti_connect_secure/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/ivanti_connect_secure/pyproject.toml
+++ b/ivanti_connect_secure/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/jboss_wildfly/changelog.d/21945.added
+++ b/jboss_wildfly/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/jboss_wildfly/pyproject.toml
+++ b/jboss_wildfly/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/journald/changelog.d/21945.added
+++ b/journald/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/journald/pyproject.toml
+++ b/journald/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/juniper_srx_firewall/changelog.d/21945.added
+++ b/juniper_srx_firewall/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/juniper_srx_firewall/pyproject.toml
+++ b/juniper_srx_firewall/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/kafka/changelog.d/21945.added
+++ b/kafka/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/kafka/pyproject.toml
+++ b/kafka/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/kafka_consumer/changelog.d/21945.added
+++ b/kafka_consumer/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/kafka_consumer/pyproject.toml
+++ b/kafka_consumer/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/karpenter/changelog.d/21945.added
+++ b/karpenter/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/karpenter/pyproject.toml
+++ b/karpenter/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/keda/changelog.d/21945.added
+++ b/keda/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/keda/pyproject.toml
+++ b/keda/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/keycloak/changelog.d/21945.added
+++ b/keycloak/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/keycloak/pyproject.toml
+++ b/keycloak/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/kong/changelog.d/21945.added
+++ b/kong/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/kong/pyproject.toml
+++ b/kong/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/krakend/changelog.d/21945.added
+++ b/krakend/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/krakend/pyproject.toml
+++ b/krakend/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: System :: Monitoring",
 ]
-dependencies = ["datadog-checks-base>=37.21.0"]
+dependencies = ["datadog-checks-base>=37.24.0"]
 dynamic = ["version"]
 
 [project.optional-dependencies]

--- a/kube_apiserver_metrics/changelog.d/21945.added
+++ b/kube_apiserver_metrics/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/kube_apiserver_metrics/pyproject.toml
+++ b/kube_apiserver_metrics/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/kube_controller_manager/changelog.d/21945.added
+++ b/kube_controller_manager/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/kube_controller_manager/pyproject.toml
+++ b/kube_controller_manager/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/kube_dns/changelog.d/21945.added
+++ b/kube_dns/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/kube_dns/pyproject.toml
+++ b/kube_dns/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/kube_metrics_server/changelog.d/21945.added
+++ b/kube_metrics_server/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/kube_metrics_server/pyproject.toml
+++ b/kube_metrics_server/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/kube_proxy/changelog.d/21945.added
+++ b/kube_proxy/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/kube_proxy/pyproject.toml
+++ b/kube_proxy/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/kube_scheduler/changelog.d/21945.added
+++ b/kube_scheduler/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/kube_scheduler/pyproject.toml
+++ b/kube_scheduler/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/kubeflow/changelog.d/21945.added
+++ b/kubeflow/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/kubeflow/pyproject.toml
+++ b/kubeflow/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/kubelet/changelog.d/21945.added
+++ b/kubelet/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/kubelet/pyproject.toml
+++ b/kubelet/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/kubernetes_cluster_autoscaler/changelog.d/21945.added
+++ b/kubernetes_cluster_autoscaler/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/kubernetes_cluster_autoscaler/pyproject.toml
+++ b/kubernetes_cluster_autoscaler/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/kubernetes_state/changelog.d/21945.added
+++ b/kubernetes_state/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/kubernetes_state/pyproject.toml
+++ b/kubernetes_state/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/kubevirt_api/changelog.d/21945.added
+++ b/kubevirt_api/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/kubevirt_api/pyproject.toml
+++ b/kubevirt_api/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/kubevirt_controller/changelog.d/21945.added
+++ b/kubevirt_controller/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/kubevirt_controller/pyproject.toml
+++ b/kubevirt_controller/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/kubevirt_handler/changelog.d/21945.added
+++ b/kubevirt_handler/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/kubevirt_handler/pyproject.toml
+++ b/kubevirt_handler/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/kuma/changelog.d/21945.added
+++ b/kuma/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/kuma/pyproject.toml
+++ b/kuma/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/kyototycoon/changelog.d/21945.added
+++ b/kyototycoon/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/kyototycoon/pyproject.toml
+++ b/kyototycoon/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/kyverno/changelog.d/21945.added
+++ b/kyverno/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/kyverno/pyproject.toml
+++ b/kyverno/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/lighttpd/changelog.d/21945.added
+++ b/lighttpd/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/lighttpd/pyproject.toml
+++ b/lighttpd/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/linkerd/changelog.d/21945.added
+++ b/linkerd/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/linkerd/pyproject.toml
+++ b/linkerd/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/linux_audit_logs/changelog.d/21945.added
+++ b/linux_audit_logs/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/linux_audit_logs/pyproject.toml
+++ b/linux_audit_logs/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/linux_proc_extras/changelog.d/21945.added
+++ b/linux_proc_extras/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/linux_proc_extras/pyproject.toml
+++ b/linux_proc_extras/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/litellm/changelog.d/21945.added
+++ b/litellm/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/litellm/pyproject.toml
+++ b/litellm/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/lustre/changelog.d/21945.added
+++ b/lustre/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/lustre/pyproject.toml
+++ b/lustre/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/mac_audit_logs/changelog.d/21945.added
+++ b/mac_audit_logs/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/mac_audit_logs/pyproject.toml
+++ b/mac_audit_logs/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/mapr/changelog.d/21945.added
+++ b/mapr/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/mapr/pyproject.toml
+++ b/mapr/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/mapreduce/changelog.d/21945.added
+++ b/mapreduce/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/mapreduce/pyproject.toml
+++ b/mapreduce/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/marathon/changelog.d/21945.added
+++ b/marathon/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/marathon/pyproject.toml
+++ b/marathon/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/marklogic/changelog.d/21945.added
+++ b/marklogic/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/marklogic/pyproject.toml
+++ b/marklogic/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/mcache/changelog.d/21945.added
+++ b/mcache/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/mcache/pyproject.toml
+++ b/mcache/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/mesos_master/changelog.d/21945.added
+++ b/mesos_master/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/mesos_master/pyproject.toml
+++ b/mesos_master/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/mesos_slave/changelog.d/21945.added
+++ b/mesos_slave/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/mesos_slave/pyproject.toml
+++ b/mesos_slave/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/microsoft_dns/changelog.d/21945.added
+++ b/microsoft_dns/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/microsoft_dns/pyproject.toml
+++ b/microsoft_dns/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/microsoft_sysmon/changelog.d/21945.added
+++ b/microsoft_sysmon/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/microsoft_sysmon/pyproject.toml
+++ b/microsoft_sysmon/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/milvus/changelog.d/21945.added
+++ b/milvus/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/milvus/pyproject.toml
+++ b/milvus/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/mongo/changelog.d/21945.added
+++ b/mongo/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/mongo/pyproject.toml
+++ b/mongo/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/nagios/changelog.d/21945.added
+++ b/nagios/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/nagios/pyproject.toml
+++ b/nagios/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/network/changelog.d/21945.added
+++ b/network/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/network/pyproject.toml
+++ b/network/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/nfsstat/changelog.d/21945.added
+++ b/nfsstat/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/nfsstat/pyproject.toml
+++ b/nfsstat/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/nginx/changelog.d/21945.added
+++ b/nginx/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/nginx/pyproject.toml
+++ b/nginx/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/nginx_ingress_controller/changelog.d/21945.added
+++ b/nginx_ingress_controller/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/nginx_ingress_controller/pyproject.toml
+++ b/nginx_ingress_controller/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/nvidia_nim/changelog.d/21945.added
+++ b/nvidia_nim/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/nvidia_nim/pyproject.toml
+++ b/nvidia_nim/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/nvidia_triton/changelog.d/21945.added
+++ b/nvidia_triton/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/nvidia_triton/pyproject.toml
+++ b/nvidia_triton/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/octopus_deploy/changelog.d/21945.added
+++ b/octopus_deploy/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/octopus_deploy/pyproject.toml
+++ b/octopus_deploy/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/openldap/changelog.d/21945.added
+++ b/openldap/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/openldap/pyproject.toml
+++ b/openldap/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/openmetrics/changelog.d/21945.added
+++ b/openmetrics/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/openmetrics/pyproject.toml
+++ b/openmetrics/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/openstack/changelog.d/21945.added
+++ b/openstack/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/openstack/pyproject.toml
+++ b/openstack/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/openstack_controller/changelog.d/21945.added
+++ b/openstack_controller/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/openstack_controller/pyproject.toml
+++ b/openstack_controller/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/openvpn/changelog.d/21945.added
+++ b/openvpn/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/openvpn/pyproject.toml
+++ b/openvpn/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/oracle/changelog.d/21945.added
+++ b/oracle/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/oracle/pyproject.toml
+++ b/oracle/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/ossec_security/changelog.d/21945.added
+++ b/ossec_security/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/ossec_security/pyproject.toml
+++ b/ossec_security/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/palo_alto_panorama/changelog.d/21945.added
+++ b/palo_alto_panorama/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/palo_alto_panorama/pyproject.toml
+++ b/palo_alto_panorama/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/pan_firewall/changelog.d/21945.added
+++ b/pan_firewall/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/pan_firewall/pyproject.toml
+++ b/pan_firewall/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/pdh_check/changelog.d/21945.added
+++ b/pdh_check/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/pdh_check/pyproject.toml
+++ b/pdh_check/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/pgbouncer/changelog.d/21945.added
+++ b/pgbouncer/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/pgbouncer/pyproject.toml
+++ b/pgbouncer/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/php_fpm/changelog.d/21945.added
+++ b/php_fpm/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/php_fpm/pyproject.toml
+++ b/php_fpm/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/ping_federate/changelog.d/21945.added
+++ b/ping_federate/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/ping_federate/pyproject.toml
+++ b/ping_federate/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/postfix/changelog.d/21945.added
+++ b/postfix/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/postfix/pyproject.toml
+++ b/postfix/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/powerdns_recursor/changelog.d/21945.added
+++ b/powerdns_recursor/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/powerdns_recursor/pyproject.toml
+++ b/powerdns_recursor/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/presto/changelog.d/21945.added
+++ b/presto/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/presto/pyproject.toml
+++ b/presto/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/process/changelog.d/21945.added
+++ b/process/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/process/pyproject.toml
+++ b/process/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/prometheus/changelog.d/21945.added
+++ b/prometheus/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/prometheus/pyproject.toml
+++ b/prometheus/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/proxmox/changelog.d/21945.added
+++ b/proxmox/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/proxmox/pyproject.toml
+++ b/proxmox/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/proxysql/changelog.d/21945.added
+++ b/proxysql/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/proxysql/pyproject.toml
+++ b/proxysql/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/pulsar/changelog.d/21945.added
+++ b/pulsar/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/pulsar/pyproject.toml
+++ b/pulsar/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/quarkus/changelog.d/21945.added
+++ b/quarkus/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/quarkus/pyproject.toml
+++ b/quarkus/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/rabbitmq/changelog.d/21945.added
+++ b/rabbitmq/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/rabbitmq/pyproject.toml
+++ b/rabbitmq/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/ray/changelog.d/21945.added
+++ b/ray/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/ray/pyproject.toml
+++ b/ray/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/redisdb/changelog.d/21945.added
+++ b/redisdb/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/redisdb/pyproject.toml
+++ b/redisdb/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/rethinkdb/changelog.d/21945.added
+++ b/rethinkdb/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/rethinkdb/pyproject.toml
+++ b/rethinkdb/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/riak/changelog.d/21945.added
+++ b/riak/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/riak/pyproject.toml
+++ b/riak/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/riakcs/changelog.d/21945.added
+++ b/riakcs/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/riakcs/pyproject.toml
+++ b/riakcs/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/sap_hana/changelog.d/21945.added
+++ b/sap_hana/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/sap_hana/pyproject.toml
+++ b/sap_hana/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/scylla/changelog.d/21945.added
+++ b/scylla/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/scylla/pyproject.toml
+++ b/scylla/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/sidekiq/changelog.d/21945.added
+++ b/sidekiq/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/sidekiq/pyproject.toml
+++ b/sidekiq/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/silk/changelog.d/21945.added
+++ b/silk/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/silk/pyproject.toml
+++ b/silk/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/silverstripe_cms/changelog.d/21945.added
+++ b/silverstripe_cms/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/silverstripe_cms/pyproject.toml
+++ b/silverstripe_cms/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/singlestore/changelog.d/21945.added
+++ b/singlestore/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/singlestore/pyproject.toml
+++ b/singlestore/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/slurm/changelog.d/21945.added
+++ b/slurm/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/slurm/pyproject.toml
+++ b/slurm/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/snmp/changelog.d/21945.added
+++ b/snmp/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/snmp/pyproject.toml
+++ b/snmp/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/snowflake/changelog.d/21945.added
+++ b/snowflake/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/snowflake/pyproject.toml
+++ b/snowflake/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/solr/changelog.d/21945.added
+++ b/solr/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/solr/pyproject.toml
+++ b/solr/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/sonarqube/changelog.d/21945.added
+++ b/sonarqube/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/sonarqube/pyproject.toml
+++ b/sonarqube/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/sonatype_nexus/changelog.d/21945.added
+++ b/sonatype_nexus/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/sonatype_nexus/pyproject.toml
+++ b/sonatype_nexus/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/sonicwall_firewall/changelog.d/21945.added
+++ b/sonicwall_firewall/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/sonicwall_firewall/pyproject.toml
+++ b/sonicwall_firewall/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/spark/changelog.d/21945.added
+++ b/spark/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/spark/pyproject.toml
+++ b/spark/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/squid/changelog.d/21945.added
+++ b/squid/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/squid/pyproject.toml
+++ b/squid/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/ssh_check/changelog.d/21945.added
+++ b/ssh_check/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/ssh_check/pyproject.toml
+++ b/ssh_check/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/statsd/changelog.d/21945.added
+++ b/statsd/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/statsd/pyproject.toml
+++ b/statsd/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/strimzi/changelog.d/21945.added
+++ b/strimzi/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/strimzi/pyproject.toml
+++ b/strimzi/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/supabase/changelog.d/21945.added
+++ b/supabase/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/supabase/pyproject.toml
+++ b/supabase/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/supervisord/changelog.d/21945.added
+++ b/supervisord/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/supervisord/pyproject.toml
+++ b/supervisord/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/suricata/changelog.d/21945.added
+++ b/suricata/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/suricata/pyproject.toml
+++ b/suricata/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/symantec_endpoint_protection/changelog.d/21945.added
+++ b/symantec_endpoint_protection/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/symantec_endpoint_protection/pyproject.toml
+++ b/symantec_endpoint_protection/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/system_core/changelog.d/21945.added
+++ b/system_core/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/system_core/pyproject.toml
+++ b/system_core/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/system_swap/changelog.d/21945.added
+++ b/system_swap/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/system_swap/pyproject.toml
+++ b/system_swap/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/tcp_check/changelog.d/21945.added
+++ b/tcp_check/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/tcp_check/pyproject.toml
+++ b/tcp_check/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/teamcity/changelog.d/21945.added
+++ b/teamcity/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/teamcity/pyproject.toml
+++ b/teamcity/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/tekton/changelog.d/21945.added
+++ b/tekton/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/tekton/pyproject.toml
+++ b/tekton/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/teleport/changelog.d/21945.added
+++ b/teleport/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/teleport/pyproject.toml
+++ b/teleport/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/temporal/changelog.d/21945.added
+++ b/temporal/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/temporal/pyproject.toml
+++ b/temporal/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/tenable/changelog.d/21945.added
+++ b/tenable/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/tenable/pyproject.toml
+++ b/tenable/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/teradata/changelog.d/21945.added
+++ b/teradata/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/teradata/pyproject.toml
+++ b/teradata/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/tibco_ems/changelog.d/21945.added
+++ b/tibco_ems/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/tibco_ems/pyproject.toml
+++ b/tibco_ems/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/tls/changelog.d/21945.added
+++ b/tls/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/tls/pyproject.toml
+++ b/tls/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/tokumx/changelog.d/21945.added
+++ b/tokumx/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/tokumx/pyproject.toml
+++ b/tokumx/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/tomcat/changelog.d/21945.added
+++ b/tomcat/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/tomcat/pyproject.toml
+++ b/tomcat/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/torchserve/changelog.d/21945.added
+++ b/torchserve/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/torchserve/pyproject.toml
+++ b/torchserve/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/traefik_mesh/changelog.d/21945.added
+++ b/traefik_mesh/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/traefik_mesh/pyproject.toml
+++ b/traefik_mesh/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/traffic_server/changelog.d/21945.added
+++ b/traffic_server/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/traffic_server/pyproject.toml
+++ b/traffic_server/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/twemproxy/changelog.d/21945.added
+++ b/twemproxy/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/twemproxy/pyproject.toml
+++ b/twemproxy/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/twistlock/changelog.d/21945.added
+++ b/twistlock/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/twistlock/pyproject.toml
+++ b/twistlock/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/varnish/changelog.d/21945.added
+++ b/varnish/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/varnish/pyproject.toml
+++ b/varnish/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/vault/changelog.d/21945.added
+++ b/vault/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/vault/pyproject.toml
+++ b/vault/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/velero/changelog.d/21945.added
+++ b/velero/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/velero/pyproject.toml
+++ b/velero/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/vertica/changelog.d/21945.added
+++ b/vertica/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/vertica/pyproject.toml
+++ b/vertica/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/vllm/changelog.d/21945.added
+++ b/vllm/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/vllm/pyproject.toml
+++ b/vllm/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/voltdb/changelog.d/21945.added
+++ b/voltdb/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/voltdb/pyproject.toml
+++ b/voltdb/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/vsphere/changelog.d/21945.added
+++ b/vsphere/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/vsphere/pyproject.toml
+++ b/vsphere/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/watchguard_firebox/changelog.d/21945.added
+++ b/watchguard_firebox/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/watchguard_firebox/pyproject.toml
+++ b/watchguard_firebox/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/wazuh/changelog.d/21945.added
+++ b/wazuh/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/wazuh/pyproject.toml
+++ b/wazuh/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/weaviate/changelog.d/21945.added
+++ b/weaviate/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/weaviate/pyproject.toml
+++ b/weaviate/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/weblogic/changelog.d/21945.added
+++ b/weblogic/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/weblogic/pyproject.toml
+++ b/weblogic/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/win32_event_log/changelog.d/21945.added
+++ b/win32_event_log/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/win32_event_log/pyproject.toml
+++ b/win32_event_log/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/windows_performance_counters/changelog.d/21945.added
+++ b/windows_performance_counters/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/windows_performance_counters/pyproject.toml
+++ b/windows_performance_counters/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/windows_service/changelog.d/21945.added
+++ b/windows_service/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/windows_service/pyproject.toml
+++ b/windows_service/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/wmi_check/changelog.d/21945.added
+++ b/wmi_check/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/wmi_check/pyproject.toml
+++ b/wmi_check/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/yarn/changelog.d/21945.added
+++ b/yarn/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/yarn/pyproject.toml
+++ b/yarn/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/zeek/changelog.d/21945.added
+++ b/zeek/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/zeek/pyproject.toml
+++ b/zeek/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/zk/changelog.d/21945.added
+++ b/zk/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/zk/pyproject.toml
+++ b/zk/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.21.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",

--- a/zscaler_private_access/changelog.d/21945.added
+++ b/zscaler_private_access/changelog.d/21945.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.24.0

--- a/zscaler_private_access/pyproject.toml
+++ b/zscaler_private_access/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=4.2.0",
+    "datadog-checks-base>=37.24.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This bumps the minimum version of datadog-checks-base to include fixes from https://github.com/DataDog/integrations-core/pull/21852.

### Motivation
<!-- What inspired you to submit this pull request? -->
https://datadoghq.atlassian.net/browse/AGENT-14999

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
