### PR TITLE
Temporary fix for releasing integrations with no manifest

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/release.py
@@ -96,7 +96,10 @@ def get_agent_requirement_line(check, version):
         return f'{package_name}=={version}'
 
     m = load_manifest(check)
-    if 'tile' in m:
+    # Temporary patch to avoid relying on the manifest when releasing Krakend and Lustre
+    if not m:
+        platforms = ALL_PLATFORMS
+    elif 'tile' in m:
         platforms = []
         for classifier_tag in m['tile']['classifier_tags']:
             key, value = classifier_tag.split('::', 1)


### PR DESCRIPTION
### What does this PR do?
Assigns all platforms to integrations that don’t have a manifest in the `ddev release make` command.
### Motivation
The manifests for Krakend and Lustre were removed from their integrations, but `ddev release make` still relies on those manifests to determine which platforms an integration supports. Since both integrations support all platforms, the command now defaults to assigning all platforms whenever an integration has no manifest.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
