### PR TITLE
Switch from unmaintained mockbin to newer httpbin

### DIFF
--- a/http_check/tests/common.py
+++ b/http_check/tests/common.py
@@ -5,7 +5,7 @@ import os
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 
-MOCKBIN_URL = "http://localhost:8080/request"
+MOCKBIN_URL = "http://localhost:8080"
 
 CONFIG = {
     "instances": [
@@ -269,65 +269,73 @@ FAKE_CERT = (
     b"\xddB*\xb24r\x08\x82\x95"
 )
 
+
+def _infer_url(inst):
+    return {**inst, "url": f"{MOCKBIN_URL}/{inst['method']}"}
+
+
 CONFIG_DATA_METHOD = {
     "instances": [
-        {
-            "name": "post_json",
-            "url": MOCKBIN_URL,
-            "timeout": 1,
-            "method": "post",
-            "data": {"foo": "bar", "baz": ["qux", "quux"]},
-        },
-        {
-            "name": "post_str",
-            "url": MOCKBIN_URL,
-            "timeout": 1,
-            "method": "post",
-            "data": '<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"'
-            'xmlns:m="http://www.example.org/stocks"><soap:Header></soap:Header><soap:Body><m:GetStockPrice>'
-            "<m:StockName>EXAMPLE</m:StockName></m:GetStockPrice></soap:Body></soap:Envelope>",
-        },
-        {
-            "name": "put_json",
-            "url": MOCKBIN_URL,
-            "timeout": 1,
-            "method": "put",
-            "data": {"foo": "bar", "baz": ["qux", "quux"]},
-        },
-        {
-            "name": "put_str",
-            "url": MOCKBIN_URL,
-            "timeout": 1,
-            "method": "put",
-            "data": "Lorem ipsum",
-        },
-        {
-            "name": "patch_json",
-            "url": MOCKBIN_URL,
-            "timeout": 1,
-            "method": "patch",
-            "data": {"foo": "bar", "baz": ["qux", "quux"]},
-        },
-        {
-            "name": "patch_str",
-            "url": MOCKBIN_URL,
-            "timeout": 1,
-            "method": "patch",
-            "data": "Lorem ipsum",
-        },
-        {
-            "name": "delete_json",
-            "url": MOCKBIN_URL,
-            "timeout": 1,
-            "method": "delete",
-            "data": {"foo": "bar", "baz": ["qux", "quux"]},
-        },
-        {
-            "name": "delete_str",
-            "url": MOCKBIN_URL,
-            "timeout": 1,
-            "method": "delete",
-            "data": "Lorem ipsum",
-        },
+        _infer_url(inst)
+        for inst in [
+            {
+                "name": "post_json",
+                "url": MOCKBIN_URL,
+                "timeout": 1,
+                "method": "post",
+                "data": {"foo": "bar", "baz": ["qux", "quux"]},
+            },
+            {
+                "name": "post_str",
+                "url": MOCKBIN_URL,
+                "timeout": 1,
+                "method": "post",
+                "data": '<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"'
+                'xmlns:m="http://www.example.org/stocks"><soap:Header></soap:Header><soap:Body><m:GetStockPrice>'
+                "<m:StockName>EXAMPLE</m:StockName></m:GetStockPrice></soap:Body></soap:Envelope>",
+            },
+            {
+                "name": "put_json",
+                "url": MOCKBIN_URL,
+                "timeout": 1,
+                "method": "put",
+                "data": {"foo": "bar", "baz": ["qux", "quux"]},
+            },
+            {
+                "name": "put_str",
+                "url": MOCKBIN_URL,
+                "timeout": 1,
+                "method": "put",
+                "data": "Lorem ipsum",
+            },
+            {
+                "name": "patch_json",
+                "url": MOCKBIN_URL,
+                "timeout": 1,
+                "method": "patch",
+                "data": {"foo": "bar", "baz": ["qux", "quux"]},
+            },
+            {
+                "name": "patch_str",
+                "url": MOCKBIN_URL,
+                "timeout": 1,
+                "method": "patch",
+                "data": "Lorem ipsum",
+            },
+            {
+                "name": "delete_json",
+                "url": MOCKBIN_URL,
+                "timeout": 1,
+                "method": "delete",
+                "data": {"foo": "bar", "baz": ["qux", "quux"]},
+            },
+            {
+                "name": "delete_str",
+                "url": MOCKBIN_URL,
+                "timeout": 1,
+                "method": "delete",
+                "data": "Lorem ipsum",
+            },
+        ]
     ]
 }

--- a/http_check/tests/compose/docker-compose.yml
+++ b/http_check/tests/compose/docker-compose.yml
@@ -33,9 +33,9 @@ services:
 
   mockbin:
     container_name: mockbin
-    image: mashape/mockbin
+    image: kennethreitz/httpbin
     ports:
-      - "8080:8080"
+      - "8080:80"
 
   tinyproxy:
     container_name: tinyproxy

--- a/http_check/tests/conftest.py
+++ b/http_check/tests/conftest.py
@@ -29,7 +29,7 @@ def dd_environment(mock_local_http_dns):
     with docker_run(
         os.path.join(HERE, 'compose', 'docker-compose.yml'),
         build=True,
-        log_patterns=["starting server on port"],
+        log_patterns=["start worker process"],
         conditions=[WaitFor(call_endpoint, args=("https://127.0.0.1",))],
     ):
         yield CONFIG_E2E, e2e_metadata


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Kudos @JSGette and his Cursor for this work!

### Motivation
<!-- What inspired you to submit this pull request? -->
The mockbin docker image is 9 years old and stopped working on macos (our dev laptops).
httpbin is more maintained, should buy us some more time with this e2e setup.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
