### PR TITLE
gpu: add metadata for ECC error metrics

### DIFF
--- a/gpu/metadata.csv
+++ b/gpu/metadata.csv
@@ -19,6 +19,8 @@ gpu.decoder_utilization,gauge,,percent,,Percentage of time the decoder was activ
 gpu.device.total,gauge,15,,,Number of GPU devices found in the host,0,gpu,device.total,,
 gpu.dram_active,gauge,,percent,,Percentage of time the DRAM was active,0,gpu,dram_active,,
 gpu.encoder_utilization,gauge,,percent,,Percentage of time the encoder was active,0,gpu,encoder_utilization,,
+gpu.errors.ecc.corrected.total,count,,,,Total count of corrected ECC errors,0,gpu,errors.ecc.corrected.total,,
+gpu.errors.ecc.uncorrected.total,count,,,,Total count of uncorrected ECC errors,0,gpu,errors.ecc.uncorrected.total,,
 gpu.errors.xid.total,count,,,,Total count of Xid errors,0,gpu,errors.xid.total,,
 gpu.fan_speed,gauge,,percent,,Configured fan speed as a percentage of its maximum,0,gpu,fan_speed,,
 gpu.fp16_active,gauge,,percent,,Percentage of the time that the 16-bit floating point calculation engine was active. Only for Hopper and newer GPUs,0,gpu,fp16_active,,


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Adds metadata for two new metrics in GPU monitoring

### Motivation

<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged