### PR TITLE
Fix hash-check workflow to check and merge against target branch of the PR

### DIFF
--- a/.github/workflows/release-hash-check.yml
+++ b/.github/workflows/release-hash-check.yml
@@ -17,21 +17,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.13'
 
-    - id: files
-      env:
-        BASE_BRANCH: ${{ github.base_ref }}
-      run: |
-        git fetch origin $BASE_BRANCH
-        LAST_COMMON_COMMIT=$(git merge-base HEAD origin/$BASE_BRANCH)
-        FILES=$(git --no-pager diff --name-only $LAST_COMMON_COMMIT -- .in-toto | xargs echo)
-        echo "all=$FILES" >> "$GITHUB_OUTPUT"
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
+      with:
+        files: .in-toto/*.link
 
-    - run: python .github/workflows/release-hash-check.py ${{ steps.files.outputs.all }}
+    - run: python .github/workflows/release-hash-check.py ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We recently updated the workflow to run on release branches but forgot to update the logic which actually checks out master instead of the target branch.

This PR updates the workflow with the following changes:
- Avoid depth 0 checkout. This was done to be able to do `merge-base` but we can now get the files changed int he PR through the `changed-files` action.
- Remove write permissions, not needed
- In `pull_request` the workflow runs already in a merge commit between the head of the Pr and the head of the target branch we are going to merge into. I have been checking the original PR the logic for a manual merge was introduced but I am unsure about any possible reason this should be needed. The merging action is literally the merge commit where the workflow runs.

### Motivation
<!-- What inspired you to submit this pull request? -->
Make the workflow simpler and safer.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
