### PR TITLE
[Backport 7.74.x] Bump cython version in builders and unpin krb5 (#21991)

### DIFF
--- a/.builders/deps/build_dependencies.txt
+++ b/.builders/deps/build_dependencies.txt
@@ -6,5 +6,5 @@ setuptools-scm
 setuptools-rust>=1.7.0
 maturin
 cffi>=1.12
-cython==3.0.11
+cython==3.2.1
 tomli>=2.0.1

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -29,7 +29,6 @@ hazelcast-python-client,PyPI,Apache-2.0,"Copyright (c) 2008-2023, Hazelcast, Inc
 in-toto,PyPI,Apache-2.0,Copyright 2018 New York University
 jellyfish,PyPI,MIT,Copyright (c) 2015 James Turk
 kentik-snmp-profiles,"https://github.com/kentik/snmp-profiles",Apache-2.0,
-krb5,PyPI,MIT,"Copyright (c) 2021 Jordan Borean, Red Hat"
 kubernetes,PyPI,Apache-2.0,Copyright 2014 The Kubernetes Authors.
 lazy-loader,PyPI,BSD-3-Clause,"Copyright (c) 2022--2023, Scientific Python project"
 ldap3,PyPI,LGPL-3.0-only,Copyright 2013 - 2020 Giovanni Cannata

--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -17,7 +17,6 @@ foundationdb==6.3.25
 hazelcast-python-client==5.5.0
 in-toto==2.0.0
 jellyfish==1.2.0
-krb5==0.8.0; sys_platform != 'win32'
 kubernetes==33.1.0
 lazy-loader==0.4
 ldap3==2.9.1

--- a/datadog_checks_base/changelog.d/21991.fixed
+++ b/datadog_checks_base/changelog.d/21991.fixed
@@ -1,0 +1,1 @@
+Unpin krb5 after having updated cython in our build system

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -61,10 +61,6 @@ http = [
     "pyopenssl==25.1.0",
     "pysocks==1.7.1",
     "requests-kerberos==0.15.0",
-    # Pinned because 0.9.0 does not build in py3.13.9
-    # Should remove when the build is fixed.
-    # https://github.com/jborean93/pykrb5/issues/71
-    "krb5==0.8.0; sys_platform != 'win32'",
     "requests-ntlm==1.3.0",
     "requests-oauthlib==2.0.0",
 ]


### PR DESCRIPTION
Backport 66149e46990270939e75ab297be7ec9068612be4 from #21991.

___

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This pr bumps cython to `3.2.1` as this is the new cython requirement to build `krb5 0.9.0`. We pinned `krb5` in #21987 as an emergency measurement and now we want to be able to build `0.9.0` properly to keep updating it.

### Motivation
<!-- What inspired you to submit this pull request? -->
As discussed with the maintainers of `krb5` in https://github.com/jborean93/pykrb5/issues/71 we need to either enable isolated builds or bump cython. Since we want to avoid isolated builds, bumping cython is the only way to try and build it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
