### PR TITLE
Remove Trend Micro Cloud One from requirements-agent-release.txt

### DIFF
--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -230,7 +230,6 @@ datadog-tomcat==4.1.0
 datadog-torchserve==4.1.1
 datadog-traefik-mesh==3.1.1
 datadog-traffic-server==3.3.1
-datadog-trend-micro-cloud-one==1.0.0
 datadog-twemproxy==3.1.0
 datadog-twistlock==6.1.1
 datadog-varnish==4.1.0


### PR DESCRIPTION
### What does this PR do?
Manually removes the datadog-trend-micro-cloud-one==1.0.0 entry from requirements-agent-release.txt because the trend_micro_cloud_one integration was deleted.

Manual removal is required because `ddev release make` updates or adds entries, but doesn't delete them.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
