### PR TITLE
Rename validation job to easily identify it when selecting required checks

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run:
+  validate-repo:
     uses: ./.github/workflows/run-validations.yml
     with:
       repo: core


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Renames the repository validation job to `validate-repo` to easily identify it when selecting required checks.

### Motivation
<!-- What inspired you to submit this pull request? -->
We want to make this a required check but with such a generic name we can have multiple jobs matching it. Required checks are selected by job name.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
