### PR TITLE
Move short_help contents into docstrings

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/__init__.py
@@ -9,8 +9,9 @@ from .requirements import requirements
 ALL_COMMANDS = (requirements,)
 
 
-@click.group(context_settings=CONTEXT_SETTINGS, short_help='A collection of tasks related to the Datadog Agent')
+@click.group(context_settings=CONTEXT_SETTINGS)
 def agent():
+    """Tasks related to the Agent."""
     pass
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/config.py
@@ -23,8 +23,9 @@ from datadog_checks.dev.tooling.utils import string_to_toml_type
 from .console import CONTEXT_SETTINGS, echo_info, echo_success
 
 
-@click.group(context_settings=CONTEXT_SETTINGS, short_help='Manage the config file')
+@click.group(context_settings=CONTEXT_SETTINGS)
 def config():
+    """Manage configuration settings."""
     pass
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/create_commits.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/create_commits.py
@@ -25,11 +25,12 @@ will be committed to the repo on the feature branch in ascending order.
 """
 
 
-@click.command(context_settings=CONTEXT_SETTINGS, short_help='Create branch commits from example repo')
+@click.command(context_settings=CONTEXT_SETTINGS)
 @click.argument('source_dir')
 @click.option('--prefix', '-p', default='', help='Optional text to prefix each commit')
 @click.pass_context
 def create_example_commits(ctx, source_dir, prefix):
+    """Create sequential commits for integration examples."""
     repo_choice = ctx.obj['repo_choice']
     root = get_root()
     branch = get_current_branch()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/dashboard.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/dashboard.py
@@ -18,8 +18,9 @@ DASHBOARD_API = 'https://api.{site}/api/v1/dashboard/{board_id}'
 REQUIRED_FIELDS = ["layout_type", "title", "description", "template_variables", "widgets"]
 
 
-@click.group(context_settings=CONTEXT_SETTINGS, short_help='Dashboard utilities')
+@click.group(context_settings=CONTEXT_SETTINGS)
 def dash():
+    """Manage dashboards."""
     pass
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/jmx.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/jmx.py
@@ -7,8 +7,9 @@ import click
 from datadog_checks.dev.tooling.commands.console import CONTEXT_SETTINGS
 
 
-@click.group(context_settings=CONTEXT_SETTINGS, short_help='JMX utilities')
+@click.group(context_settings=CONTEXT_SETTINGS)
 def jmx():
+    """Manage JMX configurations."""
     pass
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/manifest.py
@@ -8,8 +8,9 @@ from datadog_checks.dev.tooling.manifest_validator.v2.migration import TODO_FILL
 from datadog_checks.dev.tooling.utils import get_valid_integrations
 
 
-@click.group(context_settings=CONTEXT_SETTINGS, short_help='Manifest utilities')
+@click.group(context_settings=CONTEXT_SETTINGS)
 def manifest():
+    """Manage integration manifests."""
     pass
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/prometheus.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/prometheus.py
@@ -70,8 +70,9 @@ def set_up_stream(ctx, endpoint, filehandle):
     ctx.fail("Please specify an endpoint or a file.")
 
 
-@click.group(context_settings=CONTEXT_SETTINGS, short_help='Prometheus utilities')
+@click.group(context_settings=CONTEXT_SETTINGS)
 def prom():
+    """Manage Prometheus metrics."""
     pass
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/__init__.py
@@ -11,8 +11,9 @@ from .remove_labels import remove_labels
 ALL_COMMANDS = (email2ghuser, metrics2md, remove_labels)
 
 
-@click.group(context_settings=CONTEXT_SETTINGS, short_help='Miscellaneous scripts that may be useful')
+@click.group(context_settings=CONTEXT_SETTINGS)
 def scripts():
+    """Run utility scripts."""
     pass
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/__init__.py
@@ -19,8 +19,9 @@ ALL_COMMANDS = [
 ]
 
 
-@click.group(context_settings=CONTEXT_SETTINGS, short_help='SNMP utilities')
+@click.group(context_settings=CONTEXT_SETTINGS)
 def snmp():
+    """Manage SNMP profiles and MIBs."""
     pass
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validate_snmp_profiles.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validate_snmp_profiles.py
@@ -19,11 +19,12 @@ from .validators.utils import (
 MESSAGE_METHODS = {'success': echo_success, 'warning': echo_warning, 'failure': echo_failure, 'info': echo_info}
 
 
-@click.command("validate-profile", short_help="Validate SNMP profiles", context_settings=CONTEXT_SETTINGS)
+@click.command("validate-profile", context_settings=CONTEXT_SETTINGS)
 @click.option('-f', '--file', help="Path to a profile file to validate")
 @click.option('-d', '--directory', 'directories', multiple=True, help="Path to a directory of profiles to validate")
 @click.option('-v', '--verbose', help="Increase verbosity of error messages", is_flag=True)
 def validate_profile(file, directories, verbose):
+    """Validate SNMP profiles."""
     path = initialize_path(directories)
 
     if file:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/windows/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/windows/__init__.py
@@ -9,8 +9,9 @@ from .pdh import pdh
 ALL_COMMANDS = [pdh]
 
 
-@click.group(context_settings=CONTEXT_SETTINGS, short_help='Windows utilities')
+@click.group(context_settings=CONTEXT_SETTINGS)
 def windows():
+    """Manage Windows-specific tools."""
     pass
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/windows/pdh.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/windows/pdh.py
@@ -84,8 +84,9 @@ COUNTER_TYPES = {
 }
 
 
-@click.group(context_settings=CONTEXT_SETTINGS, short_help='PDH utilities')
+@click.group(context_settings=CONTEXT_SETTINGS)
 def pdh():
+    """Manage Windows PDH performance counters."""
     pass
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/__init__.py
@@ -15,8 +15,9 @@ from .upload import upload
 ALL_COMMANDS = [build, changelog, make, show, stats, tag, upload]
 
 
-@click.group(context_settings=CONTEXT_SETTINGS, short_help='Manage the release of checks')
+@click.group(context_settings=CONTEXT_SETTINGS)
 def release():
+    """Manage the releases of checks."""
     pass
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/stats/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/stats/__init__.py
@@ -9,8 +9,9 @@ from .stats import merged_prs, report
 ALL_COMMANDS = (report, merged_prs)
 
 
-@click.group(context_settings=CONTEXT_SETTINGS, short_help='A collection of tasks to generate reports about releases')
+@click.group(context_settings=CONTEXT_SETTINGS)
 def stats():
+    """Generate release statistics."""
     pass
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/stats/stats.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/stats/stats.py
@@ -116,12 +116,13 @@ def merged_prs(ctx, from_ref, to_ref, release_milestone, exclude_releases, expor
         print(','.join([change[field] for field in ['url', 'teams', 'next_tag', 'title']]))
 
 
-@click.command(context_settings=CONTEXT_SETTINGS, short_help="Prints some release stats we want to track")
+@click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--from-ref', '-f', help="Reference to start stats on (first RC tagged)", required=True)
 @click.option('--to-ref', '-t', help="Reference to end stats at (current RC/final tag)", required=True)
 @click.option('--release-milestone', '-r', help="Github release milestone", required=True)
 @click.pass_context
 def report(ctx, from_ref, to_ref, release_milestone):
+    """Generate release statistics report."""
     agent_release = Release.from_github(ctx, 'datadog-agent', release_milestone, from_ref=from_ref, to_ref=to_ref)
     integrations_release = Release.from_github(
         ctx, 'integrations-core', release_milestone, from_ref=from_ref, to_ref=to_ref

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/__init__.py
@@ -47,8 +47,9 @@ ALL_COMMANDS = (
 )
 
 
-@click.group(context_settings=CONTEXT_SETTINGS, short_help='Verify certain aspects of the repo')
+@click.group(context_settings=CONTEXT_SETTINGS)
 def validate():
+    """Validate aspects of the repository."""
     pass
 
 

--- a/ddev/src/ddev/cli/config/__init__.py
+++ b/ddev/src/ddev/cli/config/__init__.py
@@ -13,8 +13,9 @@ from ddev.cli.config.set import set_value
 from ddev.cli.config.show import show
 
 
-@click.group(short_help='Manage the config file')
+@click.group()
 def config():
+    """Manage ddev's configuration."""
     pass
 
 

--- a/ddev/src/ddev/cli/dep/__init__.py
+++ b/ddev/src/ddev/cli/dep/__init__.py
@@ -9,8 +9,9 @@ from ddev.cli.dep.sync import sync
 from ddev.cli.dep.updates import updates
 
 
-@click.group(short_help='Manage dependencies')
+@click.group()
 def dep():
+    """Manage dependencies."""
     pass
 
 

--- a/ddev/src/ddev/cli/dep/updates.py
+++ b/ddev/src/ddev/cli/dep/updates.py
@@ -18,13 +18,14 @@ from ddev.cli.dep.common import (
 )
 
 
-@click.command(short_help='Automatically check for dependency updates')
+@click.command()
 @click.option('--sync', '-s', 'sync_dependencies', is_flag=True, help='Update the dependency definitions')
 @click.option('--include-security-deps', '-i', is_flag=True, help="Attempt to update security dependencies")
 @click.option('--batch-size', '-b', type=int, help='The maximum number of dependencies to upgrade if syncing')
 @click.pass_context
 @click.pass_obj
 def updates(app, ctx, sync_dependencies, include_security_deps, batch_size):
+    """Check for dependency updates."""
     ignore_deps = set(app.repo.config.get('/overrides/dep/updates/exclude', []))
 
     if not include_security_deps:

--- a/ddev/src/ddev/cli/env/config.py
+++ b/ddev/src/ddev/cli/env/config.py
@@ -11,8 +11,9 @@ if TYPE_CHECKING:
     from ddev.cli.application import Application
 
 
-@click.group(short_help='Manage the config file')
+@click.group()
 def config():
+    """Manage environment configuration."""
     pass
 
 

--- a/ddev/src/ddev/cli/validate/licenses.py
+++ b/ddev/src/ddev/cli/validate/licenses.py
@@ -330,10 +330,11 @@ def read_file_lines(file, encoding='utf-8'):
         return f.readlines()
 
 
-@click.command(short_help='Validate third-party license list')
+@click.command()
 @click.option('--sync', '-s', is_flag=True, help='Generate the `LICENSE-3rdparty.csv` file')
 @click.pass_obj
 def licenses(app: Application, sync: bool):
+    """Validate list of third-party licenses."""
     import difflib
     import os
     from collections import defaultdict


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Using `short_help` is not super idiomatic for `click` and should be more deliberate.
I'm starting to phase it out in favor of docstrings.
