### PR TITLE
Add PVEAuditor role to Proxmox docs

### DIFF
--- a/proxmox/README.md
+++ b/proxmox/README.md
@@ -16,7 +16,7 @@ Install the [Datadog Agent][2] and configure the Proxmox integration on one Prox
 
 ### Configuration
 
-1. Create an [API Token][10] in your Proxmox Management Interface.
+1. Create an [API Token][10] in your Proxmox Management Interface. The [PVEAuditor][11] role can be associated with the token to provide access to the necessary API endpoints.
 2. Edit the `proxmox.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your proxmox performance data. See the [sample proxmox.d/conf.yaml][4] for all available configuration options. Ensure you have set the following parameters:
 
     ```
@@ -88,3 +88,4 @@ Need help? Contact [Datadog support][9].
 [8]: https://github.com/DataDog/integrations-core/blob/master/proxmox/assets/service_checks.json
 [9]: https://docs.datadoghq.com/help/
 [10]: https://pve.proxmox.com/wiki/Proxmox_VE_API#API_Tokens
+[11]: https://pve.proxmox.com/wiki/User_Management#pveum_permission_management


### PR DESCRIPTION
### What does this PR do?

Add PVEAuditor role to Proxmox docs. The current version of the documentation does not specify the permissions needed by the token.

PVEAuditor provides read-access to the API endpoints, thus giving enough permissions for the datadog agent to query PVE.

### Motivation

Lack of information in the current version of the documentation.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
