### PR TITLE
add_namespace_in_snmp_integration

### DIFF
--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -13,6 +13,16 @@ init_config:
     #
     loader: core
 
+    ## @param namespace - string - optional - default: default
+    ## Optional namespace override for this instance.
+    ## Namespace can be used to disambiguate devices with the same IP.
+    ## Changing namespace will cause devices being recreated in NDM app.
+    ## It should contain less than 100 characters and should not contain any of
+    ## `<`, `>`, `\n`, `\t`, `\r` characters.
+    ## This field is used by NDM features (SNMP check, SNMP Traps listener, etc).
+    #
+    # namespace: default
+
     ## @param use_device_id_as_hostname - boolean - optional - default: false
     ## Use `device:<DEVICE_ID>` (device_id is composed of `<NAMESPACE>:<DEVICE_IP_ADDRESS>`) as `hostname`
     ## for metrics and service checks (meaning that metrics and services checks will have


### PR DESCRIPTION
### What does this PR do?
This PR is for adding namespace parameter in snmp.d/conf.yaml


### Motivation
When the customer connect network devices with same IP where their private network is different, the agent can't recognize it's different device. 
We currently have an option - network_devices.namespace but this is more of global option but we are still accepting the instance level parameter namespace 
- reference : https://github.com/DataDog/datadog-agent/blob/4862c809541337b2577154ad3c0d8a7cb0c61e69/pkg/snmp/snmp.go#L199

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
