### PR TITLE
Add test policy to test dispatcher

### DIFF
--- a/.github/chainguard/self.test-dispatcher.sts.yaml
+++ b/.github/chainguard/self.test-dispatcher.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/integrations-core:ref:refs/heads/master
+
+claim_pattern:
+  job_workflow_ref: DataDog/integrations-core/.github/workflows/zz-test-worker-poc.yaml
+  event_name: (pull_request|push|workflow_dispatch)
+
+permissions:
+  # Need to manage workflow runs
+  actions: write
+  # Need to read the repository contents to trigger the workflow
+  contents: read


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds an octo-sts policy to test limit rate evaluation when getting a token provided by octo-sts instead of the github token in the PR context.

### Motivation
<!-- What inspired you to submit this pull request? -->
Validate API rate limits when using octo-sts token.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
