### PR TITLE
Don't set up python 2 when running the nightly base package check

### DIFF
--- a/.github/workflows/nightly-base-package.yml
+++ b/.github/workflows/nightly-base-package.yml
@@ -25,7 +25,6 @@ jobs:
 
       # Options
       minimum-base-package: true
-      test-py2: true
       pytest-args: '-m "not flaky"'
       context: "nightly-base-package"
     secrets: inherit


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
I think we simply missed it when dropping python 2 support.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
