### PR TITLE
[ECT-4454][prometheus] Add documentation for V2 webhook

### DIFF
--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -72,92 +72,92 @@ Send Prometheus Alertmanager alerts in the event stream. Natively, Alertmanager 
 
 1. Edit the `alertmanager.yml` configuration file to include the following:
 
-```yaml
-receivers:
-- name: datadog
-  webhook_configs: 
-  - send_resolved: true
-    url: https://event-management-intake.datadoghq.com/api/v2/events/webhook?dd-api-key=<DATADOG_API_KEY>&integration_id=prometheus
-route:
-  group_by: ['alertname']
-  group_wait: 10s
-  group_interval: 5m
-  receiver: datadog
-  repeat_interval: 3h
-```
+    ```yaml
+    receivers:
+    - name: datadog
+      webhook_configs: 
+      - send_resolved: true
+        url: https://event-management-intake.datadoghq.com/api/v2/events/webhook?dd-api-key=<DATADOG_API_KEY>&integration_id=prometheus
+    route:
+      group_by: ['alertname']
+      group_wait: 10s
+      group_interval: 5m
+      receiver: datadog
+      repeat_interval: 3h
+    ```
 
-<div class="alert alert-info">
-<ul>
-  <li> The <code>group_by</code> parameter determines how alerts are grouped together when sent to Datadog. Alerts with matching values for the specified labels are combined into a single notification. For details on routing configuration, see the <a href="https://prometheus.io/docs/alerting/latest/configuration/">Prometheus Alertmanager documentation</a>.</li>
-  <li>This endpoint accepts only one event in the payload at a time.</li>
-</ul>
-</div>
+    <div class="alert alert-info">
+    <ul>
+      <li> The <code>group_by</code> parameter determines how alerts are grouped together when sent to Datadog. Alerts with matching values for the specified labels are combined into a single notification. For details on routing configuration, see the <a href="https://prometheus.io/docs/alerting/latest/configuration/">Prometheus Alertmanager documentation</a>.</li>
+      <li>This endpoint accepts only one event in the payload at a time.</li>
+    </ul>
+    </div>
 
 2. (Optional) Use matchers to redirect specific alerts to different receivers. Matchers allow routing based on any alert label. For syntax details, see the [Alertmanager matcher documentation][12].
 
-The V2 webhook supports additional query parameters. For example, use the `oncall_team` parameter to integrate with [Datadog On-Call][11] and redirect pages to different teams:
+    The V2 webhook supports additional query parameters. For example, use the `oncall_team` parameter to integrate with [Datadog On-Call][11] and redirect pages to different teams:
 
-```yaml
-receivers:
-- name: datadog-ops
-  webhook_configs: 
-  - send_resolved: true
-    url: https://event-management-intake.datadoghq.com/api/v2/events/webhook?dd-api-key=<DATADOG_API_KEY>&integration_id=prometheus&oncall_team=ops
-- name: datadog-db
-  webhook_configs:
-  - send_resolved: true
-    url: https://event-management-intake.datadoghq.com/api/v2/events/webhook?dd-api-key=<DATADOG_API_KEY>&integration_id=prometheus&oncall_team=database
+    ```yaml
+    receivers:
+    - name: datadog-ops
+      webhook_configs: 
+      - send_resolved: true
+        url: https://event-management-intake.datadoghq.com/api/v2/events/webhook?dd-api-key=<DATADOG_API_KEY>&integration_id=prometheus&oncall_team=ops
+    - name: datadog-db
+      webhook_configs:
+      - send_resolved: true
+        url: https://event-management-intake.datadoghq.com/api/v2/events/webhook?dd-api-key=<DATADOG_API_KEY>&integration_id=prometheus&oncall_team=database
 
-route:
-  group_by: ['alertname']
-  group_wait: 10s
-  group_interval: 5m
-  receiver: datadog-ops
-  repeat_interval: 3h
-  routes:
-  - matchers:
-    - team="database"
-    receiver: datadog-db
-```
+    route:
+      group_by: ['alertname']
+      group_wait: 10s
+      group_interval: 5m
+      receiver: datadog-ops
+      repeat_interval: 3h
+      routes:
+      - matchers:
+        - team="database"
+        receiver: datadog-db
+    ```
 
-<div class="alert alert-tip">
-Setting <code>send_resolved: true</code> (the default value) enables Alertmanager to send notifications when alerts are resolved in Prometheus. This is particularly important when using the <code>oncall_team</code> parameter to ensure that pages are marked as resolved. Note that resolved notifications may be delayed until the next <code>group_interval</code>.
-</div>
+    <div class="alert alert-tip">
+    Setting <code>send_resolved: true</code> (the default value) enables Alertmanager to send notifications when alerts are resolved in Prometheus. This is particularly important when using the <code>oncall_team</code> parameter to ensure that pages are marked as resolved. Note that resolved notifications may be delayed until the next <code>group_interval</code>.
+    </div>
 
 3. Restart the Prometheus and Alertmanager services.
 
-```shell
-sudo systemctl restart prometheus.service alertmanager.service
-```
+    ```shell
+    sudo systemctl restart prometheus.service alertmanager.service
+    ```
 
 <!-- xxz tab xxx -->
 <!-- xxx tab "V1" xxx -->
 
 1. Edit the `alertmanager.yml` configuration file to include the following:
 
-```yaml
-receivers:
-- name: datadog
-  webhook_configs: 
-  - send_resolved: true
-    url: https://app.datadoghq.com/intake/webhook/prometheus?api_key=<DATADOG_API_KEY>
-route:
-  group_by: ['alertname']
-  group_wait: 10s
-  group_interval: 5m
-  receiver: datadog
-  repeat_interval: 3h
-```
+    ```yaml
+    receivers:
+    - name: datadog
+      webhook_configs: 
+      - send_resolved: true
+        url: https://app.datadoghq.com/intake/webhook/prometheus?api_key=<DATADOG_API_KEY>
+    route:
+      group_by: ['alertname']
+      group_wait: 10s
+      group_interval: 5m
+      receiver: datadog
+      repeat_interval: 3h
+    ```
 
-<div class="alert alert-info">
-This endpoint accepts only one event in the payload at a time.
-</div>
+    <div class="alert alert-info">
+    This endpoint accepts only one event in the payload at a time.
+    </div>
 
 2. Restart the Prometheus and Alertmanager services.
 
-```shell
-sudo systemctl restart prometheus.service alertmanager.service
-```
+    ```shell
+    sudo systemctl restart prometheus.service alertmanager.service
+    ```
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->


### PR DESCRIPTION
### What does this PR do?

Updates the Prometheus integration README to document the V2 webhook endpoint for Alertmanager and improves the overall setup documentation with tabs, enhanced explanations, and better formatting.

### Motivation

The Prometheus integration now supports a V2 webhook endpoint (`event-management-intake.datadoghq.com/api/v2/events/webhook`) that offers additional features compared to V1, including:
- Support for multiple query parameters (e.g., `oncall_team` for Datadog On-Call integration)
- Better integration with Datadog's event management system

This PR documents both webhook versions using tabs, with V2 as the preferred option. It also enhances the setup instructions by:
- Adding information about using Alertmanager matchers to route alerts to different receivers
- Including helpful tips about `send_resolved` configuration and its importance for On-Call page resolution
- Highlighting relevant configuration lines in code blocks
- Adding informational notes about `group_by` behavior
- Providing a link to the Prometheus Alertmanager section from the Events section for easier navigation

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged