### PR TITLE
Bump libpq version for Postgres 18

### DIFF
--- a/.builders/images/linux-aarch64/Dockerfile
+++ b/.builders/images/linux-aarch64/Dockerfile
@@ -107,8 +107,8 @@ RUN \
 # libpq and pg_config as needed by psycopg
 RUN yum install -y flex && \
  DOWNLOAD_URL="https://ftp.postgresql.org/pub/source/v{{version}}/postgresql-{{version}}.tar.bz2" \
- VERSION="16.9" \
- SHA256="07c00fb824df0a0c295f249f44691b86e3266753b380c96f633c3311e10bd005" \
+ VERSION="18.1" \
+ SHA256="ff86675c336c46e98ac991ebb306d1b67621ece1d06787beaade312c2c915d54" \
  RELATIVE_PATH="postgresql-{{version}}" \
  bash install-from-source.sh --without-readline --with-openssl --without-icu
 # Add paths to pg_config and to the library

--- a/.builders/images/linux-x86_64/Dockerfile
+++ b/.builders/images/linux-x86_64/Dockerfile
@@ -108,11 +108,11 @@ RUN \
  --without-debugger \
  --disable-static
 
-# libpq and pg_config as needed by psycopg2
+# libpq and pg_config as needed by psycopg
 RUN yum install -y flex && \
  DOWNLOAD_URL="https://ftp.postgresql.org/pub/source/v{{version}}/postgresql-{{version}}.tar.bz2" \
- VERSION="16.9" \
- SHA256="07c00fb824df0a0c295f249f44691b86e3266753b380c96f633c3311e10bd005" \
+ VERSION="18.1" \
+ SHA256="ff86675c336c46e98ac991ebb306d1b67621ece1d06787beaade312c2c915d54" \
  RELATIVE_PATH="postgresql-{{version}}" \
  bash install-from-source.sh --without-readline --with-openssl --without-icu
 # Add paths to pg_config and to the library

--- a/.builders/images/windows-x86_64/Dockerfile
+++ b/.builders/images/windows-x86_64/Dockerfile
@@ -140,12 +140,12 @@ RUN Get-RemoteFile `
     nmake && `
     nmake install_sw'
 # libpq and pg_config as needed by psycopg
-ENV PG_VERSION="16.9"
+ENV PG_VERSION="18.1"
 COPY pg_config.pl C:\pg_config.pl
 RUN Get-RemoteFile `
       -Uri https://ftp.postgresql.org/pub/source/v$Env:PG_VERSION/postgresql-$Env:PG_VERSION.tar.bz2 `
       -Path postgresql-$Env:PG_VERSION.tar.bz2 `
-      -Hash '07c00fb824df0a0c295f249f44691b86e3266753b380c96f633c3311e10bd005'; `
+      -Hash 'ff86675c336c46e98ac991ebb306d1b67621ece1d06787beaade312c2c915d54'; `
     7z x postgresql-$Env:PG_VERSION.tar.bz2 -r -y && `
     7z x postgresql-$Env:PG_VERSION.tar -oC:\postgresql_src && `
     cd C:\postgresql_src\postgresql-$Env:PG_VERSION\src\tools\msvc && `


### PR DESCRIPTION
### What does this PR do?
With the release of Postgres 18 and the recent support added to the Postgres integration for Postgres 18 we should update the libpq version we build the psycopg wheels against in order for customers monitoring Postgres 18 versions (and Postgres 17 as we seem to have let that slip 😅) benefit from all new client side support that might be available. libpq maintains strong backwards compatibility with older clients and gracefully drops wire protocol support when using an older client version against a new Postgres server so this bump shouldn't have negative impact on existing usage

### Motivation
I recently added support for Postgres 18 and noticed we're still on quite an old libpq version. We purposely skipped this a few months ago when upgrading from psycopg2 -> psycopg3, but now that we're past that hurdle we should get this on a newer version.

Newer libpq versions also contain a number of CVE fixes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
