### PR TITLE
Remove trendmicro from 7.73.x

### DIFF
--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -227,7 +227,6 @@ datadog-tomcat==4.1.0
 datadog-torchserve==4.1.1
 datadog-traefik-mesh==3.1.1
 datadog-traffic-server==3.3.1
-datadog-trend-micro-cloud-one==1.0.0
 datadog-twemproxy==3.1.0
 datadog-twistlock==6.1.1
 datadog-varnish==4.1.0


### PR DESCRIPTION
### What does this PR do?
This integration is removed in 7.73.x
