### PR TITLE
Improve pr-quick-check.yml GitHub reusable workflow

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -17,5 +17,4 @@ jobs:
       contents: read
     with:
       repo: core
-    secrets: inherit
 

--- a/.github/workflows/pr-quick-check.yml
+++ b/.github/workflows/pr-quick-check.yml
@@ -17,13 +17,15 @@ env:
   WARN_MAJOR_UPDATE_MESSAGE: "⚠️ **Major version bump**\nThe changelog type `changed` or `removed` was used in this Pull Request, so the next release will bump major version. Please make sure this is a breaking change, or use the `fixed` or `added` type instead."
 
 jobs:
-  check:
-    name: Check PR
+  check_changelog:
+    name: Check PR changelog
     runs-on: ubuntu-22.04
+    outputs:
+      major_bump_fragments: ${{ steps.changes.outputs.major_bump_fragments }}
 
     permissions:
-      pull-requests: write # For the "Comment" step, read for the "Fetch script" and "Check changelog" steps
-      contents: read # For the "Fetch diff" and "Check changelog" steps
+      pull-requests: read
+      contents: read
 
     steps:
     # Uncomment for testing purposes
@@ -74,8 +76,18 @@ jobs:
             - '*/changelog.d/*.removed'
             - '*/changelog.d/*.major'
 
+  comment_for_changelog:
+    name: Comment for PR changelog
+    needs: check_changelog
+    runs-on: ubuntu-22.04
+
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
     - name: Check for major version bump comment
-      if: ${{ steps.changes.outputs.major_bump_fragments == 'true' }}
+      if: ${{ needs.check_changelog.outputs.major_bump_fragments == 'true' }}
       id: find_comment
       uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
       with:
@@ -83,7 +95,7 @@ jobs:
         body-includes: ${{ env.WARN_MAJOR_UPDATE_MESSAGE }}
 
     - name: Comment
-      if: ${{ steps.changes.outputs.major_bump_fragments == 'true' && steps.find_comment.outputs.comment-id == '' }}
+      if: ${{ needs.check_changelog.outputs.major_bump_fragments == 'true' && steps.find_comment.outputs.comment-id == '' }}
       uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
       with:
         issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Improves the `pr-quick-check.yml` reusable workflow with the following:
- removes `secrets: inherit` from the initial call to the workflow, as no secrets are used in the `pr-quick-check` workflow,
- splits the workflow into multiple job, each job having its own set of appropriate permissions. 

**Note:** Since this workflow is called by a `pull_request_target` workflow, the changes cannot be tested before landing on `master`. Once this is merged, we should very carefully review runs of the `pr-check` workflow and verify that nothing broke.


### Motivation
<!-- What inspired you to submit this pull request? -->

Better follow the principle of least privileges in GitHub Actions ([task](https://datadoghq.atlassian.net/browse/VULN-13673)).


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
