### PR TITLE
Don't set max_execution_time for MySQL 5.6

### DIFF
--- a/mysql/changelog.d/22097.fixed
+++ b/mysql/changelog.d/22097.fixed
@@ -1,0 +1,1 @@
+Don't set max_execution_time for MySQL 5.6

--- a/mysql/datadog_checks/mysql/schemas.py
+++ b/mysql/datadog_checks/mysql/schemas.py
@@ -83,7 +83,7 @@ class MySqlSchemaCollector(SchemaCollector):
             if self._check.is_mariadb:
                 # MariaDB is in seconds
                 cursor.execute(f"SET SESSION MAX_STATEMENT_TIME={max_execution_time};")
-            elif self._check.version.version_compatible((5, 7, 8)):
+            elif self._check.version.version_compatible((5, 7)):
                 # Versions prior to 5.7.8 don't support MAX_EXECUTION_TIME
                 # MySQL is in milliseconds
                 cursor.execute(f"SET SESSION MAX_EXECUTION_TIME={max_execution_time * 1000};")

--- a/mysql/datadog_checks/mysql/schemas.py
+++ b/mysql/datadog_checks/mysql/schemas.py
@@ -83,7 +83,8 @@ class MySqlSchemaCollector(SchemaCollector):
             if self._check.is_mariadb:
                 # MariaDB is in seconds
                 cursor.execute(f"SET SESSION MAX_STATEMENT_TIME={max_execution_time};")
-            else:
+            elif self._check.version.version_compatible((5, 7, 8)):
+                # Versions prior to 5.7.8 don't support MAX_EXECUTION_TIME
                 # MySQL is in milliseconds
                 cursor.execute(f"SET SESSION MAX_EXECUTION_TIME={max_execution_time * 1000};")
             cursor.execute(query)

--- a/mysql/datadog_checks/mysql/schemas.py
+++ b/mysql/datadog_checks/mysql/schemas.py
@@ -83,7 +83,7 @@ class MySqlSchemaCollector(SchemaCollector):
             if self._check.is_mariadb:
                 # MariaDB is in seconds
                 cursor.execute(f"SET SESSION MAX_STATEMENT_TIME={max_execution_time};")
-            elif self._check.version.version_compatible((5, 7)):
+            elif self._check.version.version_compatible((5, 7, 8)):
                 # Versions prior to 5.7.8 don't support MAX_EXECUTION_TIME
                 # MySQL is in milliseconds
                 cursor.execute(f"SET SESSION MAX_EXECUTION_TIME={max_execution_time * 1000};")

--- a/mysql/datadog_checks/mysql/version_utils.py
+++ b/mysql/datadog_checks/mysql/version_utils.py
@@ -48,7 +48,7 @@ class MySQLVersion(namedtuple('MySQLVersion', ['version', 'flavor', 'build'])):
             log.warning("Cannot compute MySQL version, assuming it's older: %s", e)
             return False
 
-        patchlevel = int(PATCHLEVEL_REGEX.match(mysql_version[2]).group(1))
+        patchlevel = int(PATCHLEVEL_REGEX.match(mysql_version[2] if len(mysql_version) > 2 else '0').group(1))
         version = (int(mysql_version[0]), int(mysql_version[1]), patchlevel)
 
         return version >= compat_version


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Skips setting the `max_execution_time` when collecting schemas for MySQL 5.6.

### Motivation
<!-- What inspired you to submit this pull request? -->
`max_execution_time` is not supported in MySQL 5.6.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
