### PR TITLE
SAASINT-5001 Fix dashboard images for Proofpoint TAP

### DIFF
--- a/proofpoint_tap/assets/dashboards/proofpoint_tap_clicks_insights.json
+++ b/proofpoint_tap/assets/dashboards/proofpoint_tap_clicks_insights.json
@@ -6,8 +6,8 @@
             "id": 6795959842001555,
             "definition": {
                 "type": "image",
-                "url": "https://www.proofpoint.com/sites/default/files/styles/image_auto_200/public/pr/Proofpoint-logo-reg-K.png.webp",
-                "url_dark_theme": "https://www.proofpoint.com/sites/default/files/styles/image_auto_200/public/pr/Proofpoint-logo-reg-Reversed.png.webp",
+                "url": "/static/images/logos/proofpoint-tap_large.svg",
+                "url_dark_theme": "/static/images/logos/proofpoint-tap_reversed_large.svg",
                 "sizing": "contain",
                 "margin": "md",
                 "has_background": true,

--- a/proofpoint_tap/assets/dashboards/proofpoint_tap_messages_insights.json
+++ b/proofpoint_tap/assets/dashboards/proofpoint_tap_messages_insights.json
@@ -6,8 +6,8 @@
             "id": 6795959842001555,
             "definition": {
                 "type": "image",
-                "url": "https://www.proofpoint.com/sites/default/files/styles/image_auto_200/public/pr/Proofpoint-logo-reg-K.png.webp",
-                "url_dark_theme": "https://www.proofpoint.com/sites/default/files/styles/image_auto_200/public/pr/Proofpoint-logo-reg-Reversed.png.webp",
+                "url": "/static/images/logos/proofpoint-tap_large.svg",
+                "url_dark_theme": "/static/images/logos/proofpoint-tap_reversed_large.svg",
                 "sizing": "contain",
                 "margin": "md",
                 "has_background": true,

--- a/proofpoint_tap/assets/dashboards/proofpoint_tap_overview.json
+++ b/proofpoint_tap/assets/dashboards/proofpoint_tap_overview.json
@@ -6,8 +6,8 @@
             "id": 6795959842001555,
             "definition": {
                 "type": "image",
-                "url": "https://www.proofpoint.com/sites/default/files/styles/image_auto_200/public/pr/Proofpoint-logo-reg-K.png.webp",
-                "url_dark_theme": "https://www.proofpoint.com/sites/default/files/styles/image_auto_200/public/pr/Proofpoint-logo-reg-Reversed.png.webp",
+                "url": "/static/images/logos/proofpoint-tap_large.svg",
+                "url_dark_theme": "/static/images/logos/proofpoint-tap_reversed_large.svg",
                 "sizing": "contain",
                 "margin": "md",
                 "has_background": true,


### PR DESCRIPTION
### What does this PR do?
The images on these dashboards are broken.  They're trying to link to:
https://www.proofpoint.com/sites/default/files/styles/image_auto_200/public/pr/Proofpoint-logo-reg-K.png.webp
https://www.proofpoint.com/sites/default/files/styles/image_auto_200/public/pr/Proofpoint-logo-reg-Reversed.png.webp


Light mode:
<img width="835" height="419" alt="image" src="https://github.com/user-attachments/assets/c380c86a-08f1-4556-b1f6-27b53ae4be06" />


Dark mode:
<img width="850" height="471" alt="image" src="https://github.com/user-attachments/assets/8f92261d-1b78-489d-b847-511fd4f51147" />


Fixed to link to our images in web-ui:
Light mode:
<img width="828" height="469" alt="image" src="https://github.com/user-attachments/assets/07cae1b9-63ea-4ec8-b475-a261cbafc4af" />


Dark mode:
<img width="834" height="464" alt="image" src="https://github.com/user-attachments/assets/7db90780-b58d-43df-b15c-2b7378a24c31" />



### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
