### PR TITLE
Remove cursor_cachehit_ratio from metadata.csv

### DIFF
--- a/oracle/metadata.csv
+++ b/oracle/metadata.csv
@@ -6,7 +6,6 @@ oracle.asm_diskgroup.total_mb,gauge,,,,"The total usable capacity of the disk gr
 oracle.buffer_cachehit_ratio,gauge,,percent,,Ratio of buffer cache hits,1,oracle_database,buff cache hit ratio,,
 oracle.cache_blocks_corrupt,gauge,,block,,Corrupt cache blocks,0,oracle_database,corrupt cache blocks,,
 oracle.cache_blocks_lost,gauge,,block,,Lost cache blocks,0,oracle_database,lost cache blocks,,
-oracle.cursor_cachehit_ratio,gauge,,percent,,Ratio of cursor cache hits,1,oracle_database,cursor cache hit ratio,,
 oracle.database_wait_time_ratio,gauge,,percent,,Memory sorts per second,0,oracle_database,db wait-time ratio,,
 oracle.disk_sorts,gauge,,operation,second,Disk sorts per second,0,oracle_database,disk sorts,,
 oracle.enqueue_timeouts,gauge,,timeout,second,Enqueue timeouts per sec,0,oracle_database,enqueue timeouts,,


### PR DESCRIPTION
Removed cursor cache hit ratio metric from metadata. Has not been collected since agent 7.47 with this PR: https://github.com/DataDog/datadog-agent/pull/17466

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Removed cursor cache hit ratio metric from metadata in order to remove it from our public docs

### Motivation
<!-- What inspired you to submit this pull request? -->¨
Has not been collected since agent 7.47 with this PR: https://github.com/DataDog/datadog-agent/pull/17466

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
