### PR TITLE
migrate endpoint out of service - have-i-been-powned

### DIFF
--- a/have_i_been_pwned/assets/dashboards/have_i_been_pwned_overview.json
+++ b/have_i_been_pwned/assets/dashboards/have_i_been_pwned_overview.json
@@ -58,7 +58,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -119,7 +119,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -169,7 +169,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -231,7 +231,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -292,7 +292,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -344,7 +344,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -420,7 +420,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -491,7 +491,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -570,7 +570,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -622,7 +622,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -693,7 +693,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -783,7 +783,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach @IsMalware:true $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach @IsMalware:true $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -840,7 +840,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach @IsMalware:true $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach @IsMalware:true $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -900,7 +900,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -971,7 +971,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach @IsMalware:true $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach @IsMalware:true $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -1041,7 +1041,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach @IsMalware:true $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach @IsMalware:true $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -1110,7 +1110,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach @IsSensitive:true $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach @IsSensitive:true $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -1181,7 +1181,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach @IsSensitive:true $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach @IsSensitive:true $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -1245,7 +1245,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach @IsSensitive:true $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach @IsSensitive:true $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -1304,7 +1304,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -1375,7 +1375,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach @IsSensitive:true $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach @IsSensitive:true $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -1444,7 +1444,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -1514,7 +1514,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -1589,7 +1589,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach @IsSpamList:true $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach @IsSpamList:true $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -1642,7 +1642,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach @IsStealerLog:true $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach @IsStealerLog:true $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -1695,7 +1695,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach @IsRetired:true $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach @IsRetired:true $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -1747,7 +1747,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach @IsSubscriptionFree:true $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach @IsSubscriptionFree:true $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"
@@ -1794,7 +1794,7 @@
                                 "name": "query1",
                                 "data_source": "logs",
                                 "search": {
-                                    "query": "source:have-i-been-pwned service:breach $user_name $breached_platform $org_domain"
+                                    "query": "source:have-i-been-pwned @origin_endpoint:breach $user_name $breached_platform $org_domain"
                                 },
                                 "indexes": [
                                     "*"

--- a/have_i_been_pwned/assets/logs/have-i-been-pwned.yaml
+++ b/have_i_been_pwned/assets/logs/have-i-been-pwned.yaml
@@ -19,11 +19,21 @@ pipeline:
   filter:
     query: source:have-i-been-pwned
   processors:
-    - type: service-remapper
-      name: Define `service` as the official service of the log
+    - type: attribute-remapper
+      name: Extract origin endpoint from the service attribute, stored by the crawler
       enabled: true
       sources:
         - service
+      sourceType: attribute
+      target: origin_endpoint
+      targetType: attribute
+      preserveSource: true
+      overrideOnConflict: false
+    - type: service-remapper
+      name: Use the integration source as the service
+      enabled: true
+      sources:
+        - source
     - type: attribute-remapper
       name: Remapping user_details.user_name value to usr.name attribute
       enabled: true
@@ -49,7 +59,7 @@ pipeline:
       name: Processing of Latest Breach
       enabled: true
       filter:
-        query: service:latest-breach
+        query: @origin_endpoint:latest-breach
       processors:
         - type: date-remapper
           name: Defining AddedDate as the official timestamp of log


### PR DESCRIPTION
The endpoint called by the crawler is set to service, migrating this out to an explicit attribute.
This migration would need to be done in 3 phase:
1. migrate the assets here
2. change the crawler to avoid adding @service
3. cleanup the asset (service-remapper and attribute-remapper)

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
