### PR TITLE
Update gitignore in root to avoid signing metadata files in downloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,5 +143,6 @@ size-compressed.txt
 treemap*.png
 
 # Ignore any metadata file except root json in the downloader
-datadog_checks_downloader/datadog_checks/downloader/data
+datadog_checks_downloader/datadog_checks/downloader/data/repo/targets
+datadog_checks_downloader/datadog_checks/downloader/data/repo/metadata/*
 !datadog_checks_downloader/datadog_checks/downloader/data/repo/metadata/root.json


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates `.gitignore` in the root of the project to ensure that `ddev release make` ignores the contents of the metadata folder in `datadog_checks_downloader` except the `root.json`.

### Motivation
<!-- What inspired you to submit this pull request? -->
The sining uses whatever patterns we have in the core `.gitignore` ([ref](https://github.com/DataDog/integrations-core/blob/15189d84d8a3da4895ec0f841f7236d588fa0501/datadog_checks_dev/datadog_checks/dev/tooling/signing.py#L48-L56)) to make sure we do not sign anything that is ignored. These files are already ignored [within the repo path](https://github.com/DataDog/integrations-core/blob/15189d84d8a3da4895ec0f841f7236d588fa0501/datadog_checks_downloader/datadog_checks/downloader/data/repo/metadata/.gitignore#L1-L6) but the signing is done globally and the `.gitignore` file that is read is the core one.

This prevents error like the following after having run the downloader to test locally after ceremony.

```
UntrackedButIgnoredFileException: datadog_checks_downloader/datadog_checks/downloader/data/repo/metadata/in-toto-metadata-signer-e.json has not been tracked, but it should be ignored by git and in-toto!
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
