### PR TITLE
[DBMON-6003] Add Postgres unit tests to track all config default value changes

### DIFF
--- a/postgres/tests/test_config_defaults.py
+++ b/postgres/tests/test_config_defaults.py
@@ -14,7 +14,6 @@ import pytest
 
 from datadog_checks.postgres.config import build_config
 
-
 # Single source of truth for all expected default values
 # Organized by category for readability
 EXPECTED_DEFAULTS = {
@@ -22,7 +21,6 @@ EXPECTED_DEFAULTS = {
     'host': None,  # Required, user must provide
     'username': None,  # Required, user must provide
     'password': None,  # Required, user must provide (optional for managed auth)
-
     # === Connection configuration ===
     'port': 5432,
     'dbname': 'postgres',
@@ -35,7 +33,6 @@ EXPECTED_DEFAULTS = {
     'idle_connection_timeout': 60000,
     'max_connections': 30,
     'application_name': 'datadog-agent',
-
     # === Identification ===
     'reported_hostname': None,
     'exclude_hostname': False,
@@ -43,7 +40,6 @@ EXPECTED_DEFAULTS = {
     'database_identifier': {
         'template': '$resolved_hostname',
     },
-
     # === Metric collection toggles ===
     'dbstrict': False,
     'collect_function_metrics': False,
@@ -58,7 +54,6 @@ EXPECTED_DEFAULTS = {
     'tag_replication_role': True,
     'table_count_limit': 200,
     'max_relations': 300,
-
     # === Database filtering ===
     'ignore_databases': [
         'template0',
@@ -73,7 +68,6 @@ EXPECTED_DEFAULTS = {
         'rds_superuser',
         'rdsadmin',
     ],
-
     # === Database monitoring (DBM) ===
     'dbm': False,
     'pg_stat_statements_view': 'pg_stat_statements',
@@ -81,7 +75,6 @@ EXPECTED_DEFAULTS = {
     'log_unobfuscated_queries': False,
     'log_unobfuscated_plans': False,
     'database_instance_collection_interval': 300,
-
     # === DBM: Query metrics ===
     'query_metrics': {
         'enabled': True,
@@ -93,7 +86,6 @@ EXPECTED_DEFAULTS = {
         'full_statement_text_samples_per_hour_per_query': 1,
         'run_sync': False,
     },
-
     # === DBM: Query samples ===
     'query_samples': {
         'enabled': True,
@@ -108,14 +100,12 @@ EXPECTED_DEFAULTS = {
         'explain_errors_cache_ttl': 86400,
         'run_sync': False,
     },
-
     # === DBM: Query activity ===
     'query_activity': {
         'enabled': True,
         'collection_interval': 10,
         'payload_row_limit': 3500,
     },
-
     # === DBM: Settings collection ===
     'collect_settings': {
         'enabled': True,
@@ -123,7 +113,6 @@ EXPECTED_DEFAULTS = {
         'run_sync': False,
         'ignored_settings_patterns': ['plpgsql%'],
     },
-
     # === DBM: Schema collection ===
     'collect_schemas': {
         'enabled': False,
@@ -132,7 +121,6 @@ EXPECTED_DEFAULTS = {
         'collection_interval': 600,
         'max_query_duration': 60,
     },
-
     # === DBM: Obfuscator options ===
     'obfuscator_options': {
         'obfuscation_mode': 'obfuscate_and_normalize',
@@ -151,7 +139,6 @@ EXPECTED_DEFAULTS = {
         'keep_identifier_quotation': False,
         'keep_json_path': False,
     },
-
     # === DBM: Database autodiscovery ===
     'database_autodiscovery': {
         'enabled': False,
@@ -161,28 +148,22 @@ EXPECTED_DEFAULTS = {
         'exclude': ['cloudsqladmin', 'rdsadmin', 'alloydbadmin', 'alloydbmetadata'],
         'include': ['.*'],
     },
-
     # === DBM: Lock metrics ===
     'locks_idle_in_transaction': {
         'enabled': True,
         'collection_interval': 300,
         'max_rows': 100,
     },
-
     # === DBM: Raw query statements ===
     'collect_raw_query_statement': {
         'enabled': False,
     },
-
     # === Relations configuration ===
     'relations': [],
-
     # === Query encodings ===
     'query_encodings': ['utf8'],
-
     # === Activity metrics ===
     'activity_metrics_excluded_aggregations': [],
-
     # === Cloud provider configurations ===
     'aws': {
         'instance_endpoint': None,
@@ -198,12 +179,10 @@ EXPECTED_DEFAULTS = {
         'project_id': None,
         'instance_id': None,
     },
-
     # === Tagging ===
     'tags': ('server:localhost', 'port:5432', 'db:postgres'),  # Dynamically generated from connection info
     'disable_generic_tags': False,
     'propagate_agent_tags': False,
-
     # === Custom metrics/queries (deprecated/user-provided) ===
     'custom_metrics': (),  # Deprecated field, defaults to empty tuple
     'custom_queries': (),  # User-provided queries, defaults to empty tuple
@@ -211,7 +190,6 @@ EXPECTED_DEFAULTS = {
     'use_global_custom_queries': 'true',  # Use custom queries from init_config
     'service': None,  # User-provided service name
     'metric_patterns': None,  # User-provided patterns
-
     # === Agent standard fields ===
     'min_collection_interval': 15.0,  # Standard Agent field
     'empty_default_hostname': False,  # Deprecated field
@@ -312,23 +290,15 @@ def test_all_config_defaults(mock_check, minimal_instance):
             if isinstance(actual_value, (list, tuple)):
                 actual_as_type = type(expected_value)(actual_value)
                 if actual_as_type != expected_value:
-                    failures.append(
-                        f"{field_name}: expected {expected_value!r}, got {actual_value!r}"
-                    )
+                    failures.append(f"{field_name}: expected {expected_value!r}, got {actual_value!r}")
             elif actual_value is None:
-                failures.append(
-                    f"{field_name}: expected {expected_value!r}, got None"
-                )
+                failures.append(f"{field_name}: expected {expected_value!r}, got None")
             else:
-                failures.append(
-                    f"{field_name}: expected {expected_value!r}, got {actual_value!r}"
-                )
+                failures.append(f"{field_name}: expected {expected_value!r}, got {actual_value!r}")
         else:
             # Simple value comparison
             if actual_value != expected_value:
-                failures.append(
-                    f"{field_name}: expected {expected_value!r}, got {actual_value!r}"
-                )
+                failures.append(f"{field_name}: expected {expected_value!r}, got {actual_value!r}")
 
     if failures:
         error_msg = (
@@ -336,8 +306,8 @@ def test_all_config_defaults(mock_check, minimal_instance):
             f"DEFAULT VALUE MISMATCHES DETECTED!\n"
             f"{'=' * 80}\n\n"
             f"The following fields have default values that don't match expectations:\n\n"
-            + "\n".join(f"  • {failure}" for failure in failures) +
-            f"\n\n"
+            + "\n".join(f"  • {failure}" for failure in failures)
+            + f"\n\n"
             f"This indicates either:\n"
             f"  1. A regression in default values (BAD - investigate carefully!)\n"
             f"  2. EXPECTED_DEFAULTS needs to be updated to match new behavior\n\n"
@@ -371,26 +341,18 @@ def _compare_nested_object(actual_obj, expected_dict, field_path, failures):
             if isinstance(actual_value, (list, tuple)):
                 actual_as_type = type(expected_value)(actual_value)
                 if actual_as_type != expected_value:
-                    failures.append(
-                        f"{field_path}.{key}: expected {expected_value!r}, got {actual_value!r}"
-                    )
+                    failures.append(f"{field_path}.{key}: expected {expected_value!r}, got {actual_value!r}")
                     all_passed = False
             elif actual_value is None:
-                failures.append(
-                    f"{field_path}.{key}: expected {expected_value!r}, got None"
-                )
+                failures.append(f"{field_path}.{key}: expected {expected_value!r}, got None")
                 all_passed = False
             else:
-                failures.append(
-                    f"{field_path}.{key}: expected {expected_value!r}, got {actual_value!r}"
-                )
+                failures.append(f"{field_path}.{key}: expected {expected_value!r}, got {actual_value!r}")
                 all_passed = False
         else:
             # Simple value comparison
             if actual_value != expected_value:
-                failures.append(
-                    f"{field_path}.{key}: expected {expected_value!r}, got {actual_value!r}"
-                )
+                failures.append(f"{field_path}.{key}: expected {expected_value!r}, got {actual_value!r}")
                 all_passed = False
 
     return all_passed


### PR DESCRIPTION
### What does this PR do?
The goal of this PR is to ensure our default config values remain the same. We're now explicitly asserting against all default rendered config values from InstanceConfig. Any changes to our hardcoded expected defaults will trigger a test failure with a clear message as to why it's failing and steps to take to mitigate. Similarly if new config values are added and they aren't asserted against in this test it will trigger a failure and require fixing up.

Example failure message when a new `testConfig` value is added but wasn't updated in the test
<img width="621" height="341" alt="Screenshot 2025-12-17 at 1 57 39 PM" src="https://github.com/user-attachments/assets/39945937-8930-4e69-aecf-2e686e1813dd" />


### Motivation
The goal of this change is to ensure our config default values don't change unexpectedly or accidentally overtime to avoid regressions.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
