### PR TITLE
Remove note regarding log collection on batch

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -438,8 +438,6 @@ Datadog recommends using AWS FireLens for the following reasons:
 - You can configure Fluent Bit directly in your Fargate tasks.
 - The Datadog Fluent Bit output plugin provides additional tagging on logs. The [ECS Explorer][75] uses the tags to correlate logs with ECS resources.
 
-**Note**: Log collection with Fluent Bit and FireLens is not supported for AWS Batch on ECS Fargate.
-
 #### Fluent Bit and FireLens
 
 Configure the AWS FireLens integration built on Datadog's Fluent Bit output plugin to connect your FireLens monitored log data to Datadog Logs. You can find a full [sample task definition for this configuration here][19].


### PR DESCRIPTION
### What does this PR do?
Update the documentation for the ECS Fargate integration to remove mention of log collection in Batch

### Motivation
AWS added support for log collection via firelens in batch [earlier this year](https://aws.amazon.com/about-aws/whats-new/2025/04/aws-batch-amazon-elastic-container-service-exec-firelens-log-router/). The guide for configuring the agent on batch was updated with this information [here](https://github.com/DataDog/documentation/pull/30063), but the doc for this integration was not updated

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
