### PR TITLE
Fix the core gitignore to include gitignores from the downloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,8 @@ size-compressed.txt
 treemap*.png
 
 # Ignore any metadata file except root json in the downloader
-datadog_checks_downloader/datadog_checks/downloader/data/repo/targets
+datadog_checks_downloader/datadog_checks/downloader/data/repo/targets/*
+!datadog_checks_downloader/datadog_checks/downloader/data/repo/targets/.gitignore
 datadog_checks_downloader/datadog_checks/downloader/data/repo/metadata/*
+!datadog_checks_downloader/datadog_checks/downloader/data/repo/metadata/.gitignore
 !datadog_checks_downloader/datadog_checks/downloader/data/repo/metadata/root.json


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Ensure that `.gitignore` files in the downloader repo folders are not ignored so they can be signed.

### Motivation
<!-- What inspired you to submit this pull request? -->
Ensure the release pipeline does not break on the downloader releases.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
