### PR TITLE
Fix the cloned-repo test to make it non-flaky

### DIFF
--- a/ddev/tests/conftest.py
+++ b/ddev/tests/conftest.py
@@ -22,7 +22,7 @@ from ddev.utils.fs import Path, temp_directory
 from ddev.utils.github import GitHubManager
 from ddev.utils.platform import Platform
 
-from .helpers import APPLICATION, PLATFORM
+from .helpers import APPLICATION, LOCAL_REPO_BRANCH, PLATFORM
 from .helpers.git import ClonedRepo
 from .helpers.runner import CliRunner
 
@@ -177,7 +177,7 @@ def local_clone(isolation, local_repo) -> Generator[ClonedRepo, None, None]:
         PLATFORM.check_command_output(['git', 'worktree', 'add', 'wt', 'HEAD'])
         PLATFORM.check_command_output(['git', 'worktree', 'add', '../wt2', 'HEAD'])
 
-    cloned_repo = ClonedRepo(cloned_repo_path, 'origin/master', 'ddev-testing')
+    cloned_repo = ClonedRepo(cloned_repo_path, 'origin/master', LOCAL_REPO_BRANCH)
     cloned_repo.reset_branch()
 
     yield cloned_repo

--- a/ddev/tests/helpers/__init__.py
+++ b/ddev/tests/helpers/__init__.py
@@ -6,3 +6,4 @@ from ddev.utils.platform import Platform
 
 PLATFORM = Platform()
 APPLICATION = Application(lambda code: print(f"Applicatione exited with code: {code}"), 1, False, False)
+LOCAL_REPO_BRANCH = "ddev-testing"

--- a/ddev/tests/test__utils.py
+++ b/ddev/tests/test__utils.py
@@ -5,16 +5,36 @@
 # This file is named with a double underscore so it comes first lexicographically
 
 
-def test_cloned_repo(repository, local_repo):
-    integrations = {
-        entry.name for entry in repository.path.iterdir() if (repository.path / entry.name / 'manifest.json').is_file()
-    }
-    expected_integrations = {
-        entry.name for entry in local_repo.iterdir() if (local_repo / entry.name / 'manifest.json').is_file()
-    }
+from ddev.utils.fs import Path
+from ddev.utils.git import GitRepository
+from tests.helpers import LOCAL_REPO_BRANCH
+from tests.helpers.git import ClonedRepo
 
-    # Note: We are checking that the number of integrations is +- 1 from the `master`
-    # branch as a workaround for scenarios where the current branch adds/removes
-    # an integration and there has a different integration count than master.
-    if abs(len(integrations) - len(expected_integrations)) > 1:
-        assert integrations == expected_integrations
+
+def commit_from_branch(repository: GitRepository, branch: str) -> str:
+    return repository.capture('rev-parse', branch).strip()
+
+
+def ref_list(repository: GitRepository, left_ref: str, right_ref: str) -> list[str]:
+    return repository.capture('rev-list', f"{left_ref}..{right_ref}").strip().splitlines()
+
+
+def test_cloned_repo(repository: ClonedRepo, local_repo: Path):
+    # The cloned repo (repository) should be a repository that is in the LOCAL_REPO_BRANCH
+    # branching of from the latest commit in origin master
+    # To validate this, we will get the current origin/master updated (in local_repo), check the rev-list
+    # between the current branch and origin/master and then validate that this is the same
+    # as the rev-list between the repository and local_repo.
+
+    current_repo = GitRepository(local_repo)
+    cloned_repo = GitRepository(repository.path)
+
+    current_repo.capture('fetch', 'origin', 'master')
+    current_repo_origin_master_ref = commit_from_branch(current_repo, 'origin/master')
+    current_repo_head_ref = commit_from_branch(current_repo, "HEAD")
+
+    current_repo_commit_list = ref_list(current_repo, current_repo_origin_master_ref, "HEAD")
+
+    cloned_repo_commit_list = ref_list(cloned_repo, LOCAL_REPO_BRANCH, current_repo_head_ref)
+
+    assert current_repo_commit_list == cloned_repo_commit_list


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix the `test_cloned_repo` test to avoid it being flaky on release branches.

The current tests test what the cloned repo should be: a cloned of the current repo with a branched checked-out in the latest commit of `origin/master`. The only flake possibility is if between the fecth in the local repo and the fetch in the cloned repo there is a commit that enters master, but the windows is pretty small.

### Motivation
<!-- What inspired you to submit this pull request? -->
The test was ill conceived as it relied on not many integrations changed between this commit and master. This is not true specially for release branches and when many integrations are being added/removed.

It also relied on the manifest file existing which is going to disappear soon. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
