### PR TITLE
Add changelog to datadog-checks-base after latest patch update

### DIFF
--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 <!-- towncrier release notes start -->
 
-## 37.23.2 / 2025-12-19
-
-***Security***:
-
-* Bump urllib3 to version 2.6.2 ([#22172](https://github.com/DataDog/integrations-core/pull/22172))
-
 ## 37.25.0 / 2025-12-12
 
 ***Security***:
@@ -29,6 +23,12 @@
 ***Fixed***:
 
 * Fix YAML configuration parsing to properly handle Unicode characters on Windows systems where the UTF-8 locale is not enabled by default. ([#21852](https://github.com/DataDog/integrations-core/pull/21852))
+
+## 37.23.2 / 2025-12-19
+
+***Security***:
+
+* Bump urllib3 to version 2.6.2 ([#22172](https://github.com/DataDog/integrations-core/pull/22172))
 
 ## 37.23.1 / 2025-12-15 / Agent 7.73.1
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add latest changelog for datadog_checks_base 37.23.2 to master

### Motivation
<!-- What inspired you to submit this pull request? -->
Keep it up to date. This was released in 7.73.x as a patch for urllib3. 

PR for the release: #22197

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
