### PR TITLE
Upgrade the aerospike client for more ergonomic testing

### DIFF
--- a/aerospike/changelog.d/22203.added
+++ b/aerospike/changelog.d/22203.added
@@ -1,0 +1,1 @@
+Upgrade aerospike client to work on windows and macos.

--- a/aerospike/pyproject.toml
+++ b/aerospike/pyproject.toml
@@ -37,7 +37,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "aerospike==7.1.1; sys_platform != 'win32' and sys_platform != 'darwin'",
+    "aerospike==18.1.0",
 ]
 
 [project.urls]

--- a/aerospike/tests/conftest.py
+++ b/aerospike/tests/conftest.py
@@ -6,7 +6,6 @@ from copy import deepcopy
 import aerospike
 import pytest
 
-from datadog_checks.base.utils.platform import Platform
 from datadog_checks.dev.conditions import WaitFor
 from datadog_checks.dev.docker import CheckDockerLogs, docker_run
 

--- a/aerospike/tests/conftest.py
+++ b/aerospike/tests/conftest.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from copy import deepcopy
 
+import aerospike
 import pytest
 
 from datadog_checks.base.utils.platform import Platform
@@ -13,13 +14,6 @@ from .common import COMPOSE_FILE, HOST, INSTANCE, OPENMETRICS_V2_INSTANCE, PORT
 
 
 def init_db():
-    # exit if we are not on linux
-    # that's the only platform where the client successfully installs for version 3.10
-    if not Platform.is_linux():
-        return
-
-    import aerospike
-
     # sample Aerospike Python Client code
     # https://www.aerospike.com/docs/client/python/usage/kvs/write.html
     client = aerospike.client({'hosts': [(HOST, PORT)]}).connect()
@@ -47,7 +41,7 @@ def init_db():
         client.get(key)
         batch_key = ('test', 'demo', 'key' + str(i))
         batch_keys.append(batch_key)
-    client.get_many(batch_keys)
+    client.batch_read(batch_keys)
 
     client.close()
 

--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -1,4 +1,4 @@
-aerospike==7.1.1; sys_platform != 'win32' and sys_platform != 'darwin'
+aerospike==18.1.0
 aws-requests-auth==0.4.3
 azure-identity==1.24.0
 beautifulsoup4==4.13.5


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Customers running on windows or macos can use the aerospike integration!

We can now run e2e tests on MacOS, we also simplify our setup.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
