### PR TITLE
Update build_agent.yaml to use agent branch: main

### DIFF
--- a/.gitlab/build_agent.yaml
+++ b/.gitlab/build_agent.yaml
@@ -13,7 +13,7 @@
   stage: build
   trigger:
     project: DataDog/datadog-agent
-    branch: 7.75.x
+    branch: main
     # It's more convenient to directly show if downstream pipeline succeeded.
     strategy: depend
 


### PR DESCRIPTION
### What does this PR do?
The agent’s release branch hasn’t been created yet, so the build needs to point to their main branch. This change will be reverted once the branch is created. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
