### PR TITLE
Stop building ddev on merges to master

### DIFF
--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
     - ddev-v*
-    branches:
-    - master
   pull_request:
     paths:
     - .github/workflows/build-ddev.yml


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We build ddev when we release it, no need to rebuild every time we merge anything to master.

### Motivation
<!-- What inspired you to submit this pull request? -->
Wasting compute and introducing noise to our monitoring dashboards: the build job flakes sometimes due to networking issues.
These flakes teach us to ignore the failures, so hide the real ones.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
