### PR TITLE
[TEEP-3956] docs: add troubleshooting section for certificates with identical subjects

### DIFF
--- a/windows_certificate/README.md
+++ b/windows_certificate/README.md
@@ -55,7 +55,7 @@ instances:
     enable_crl_monitoring: true
 ```
 
-Begnning with Agent v7.70, the integration can validate certificates and their certificate chains. To enable the certificate chain validation, set the following in the integration:
+Beginning with Agent v7.70, the integration can validate certificates and their certificate chains. To enable the certificate chain validation, set the following in the integration:
 ```yaml
 instances:    
   - certificate_store: CA
@@ -91,6 +91,12 @@ The windows_certificate integration does not include any events.
 See [service_checks.json][8] for a list of service checks provided by this integration.
 
 ## Troubleshooting
+
+### Certificates with identical subjects
+
+The integration identifies certificates primarily by their subject, not by serial number. When multiple certificates share the same subject but have different serial numbers (for example, an expired certificate and its renewed replacement), the integration may only detect one of them, often the expired certificate.
+
+**Solution**: Delete the expired certificate from the Windows Certificate Store so only the valid, renewed certificate is monitored. While `certificate_serial_number` is available as a tag on metrics and service checks, it cannot be used for filtering in the configuration. The integration only supports filtering by `certificate_subjects`.
 
 Need help? Contact [Datadog support][9].
 


### PR DESCRIPTION
[https://datadoghq.atlassian.net/browse/TEEP-3956](https://datadoghq.atlassian.net/browse/TEEP-3956)

### What does this PR do?
Document that the integration identifies certificates by subject, not serial number. When multiple certificates share the same subject, only one may be detected. Solution is to delete expired certificates from the Windows Certificate Store.

Fix typo: Begnning → Beginning

### Motivation

Link to the thread: [https://dd.slack.com/archives/C08PGQYM0SG/p1766501098701879](https://dd.slack.com/archives/C08PGQYM0SG/p1766501098701879)

Chaima Belgaied 23 Dec 25 14:44 UTC
Hi team! [hi-dog] Sodexo Group | 1000133333 | Tier 0 | Pro  [Ticket](https://datadog.zendesk.com/agent/tickets/2399705) 2399705
My customer is trying to use the windows store ([docs](https://docs.datadoghq.com/integrations/windows-certificate/)) to verify their Local Machine certificates.
The issue they are facing is that we are detecting only the expired certificate, and not the new valid one. They mentioned this is because the expired and the valid certificates are exactly the same except for the date. [Partlow](https://support-admin.eu1.prod.dog/admin/switch_handle_get/org_id/1000133333?next_url=%2Fmetric%2Fexplorer%3FfromUser%3Dfalse%26graph_layout%3Dstacked%26start%3D1766146029306%26end%3D1766149629306%26paused%3Dfalse%23N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGABuMMiQIlA4YBpO2doSwpmecAB0yVhNRh6iojDAAFQ8AAQARlgTwC1tEB0IcGnBGGhOIniqUzo8IDwAulSu7niYoeFnqhcYMaXxhycgGnJoOaDyG4gryvUwZqXDRLRJoUSrOSKZTpcFQMEQpz0JjKERuDxoQ78CD2TBYJxQnIgcEiJTHHh8V7ycEIADCUmEMBQ2zQaB4QA&reason=zd-2399705)
ASK: is this linked to the fact the certificates have the exact same subjects?
There's no certificate_serial_number configuration option. The serial number is only available as a tag on the metrics. The best solution is to delete the expired certificate from the Windows certificate store, so only the renewed certificate is monitored. [Github](https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/dist/conf.d/windows_certificate.d/conf.yaml.example) is this correct please ?

Morgan Wang 23 Dec 25 19:38 UTC
yep, the intg identifies certificates primarily by their subject, not serial number. the best approach here is to delete the expired certificate so that only the valid renewed certificate is monitored

### Review checklist (to be filled by reviewers)

- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
