### PR TITLE
Update README.md to fix the link for example conf.yaml file

### DIFF
--- a/cisco_secure_firewall/README.md
+++ b/cisco_secure_firewall/README.md
@@ -164,5 +164,5 @@ For any further assistance, contact [Datadog support][3].
 [3]: https://docs.datadoghq.com/help/
 [4]: https://docs.datadoghq.com/agent/
 [5]: https://www.cisco.com/c/en/us/support/security/firepower-ngfw/series.html
-[6]: https://docs.datadoghq.com/agent/guide/integration-management/?tab=linux#install
+[6]: https://github.com/DataDog/integrations-core/blob/master/cisco_secure_firewall/datadog_checks/cisco_secure_firewall/data/conf.yaml.example
 [7]: https://www.cisco.com/c/en/us/products/collateral/security/firesight-management-center/datasheet-c78-736775.html


### PR DESCRIPTION
Currently the link to conf.yaml file points to a different page other than the example config.

### What does this PR do?
Currently the example conf.yaml file for this integration is pointed to - https://docs.datadoghq.com/agent/guide/integration-management/?tab=linux#install. This PR fixes this link and points to the example config file.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
