### PR TITLE
SDBM-2260 Make query error tracking optional, default true

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -382,6 +382,20 @@ files:
                   type: boolean
                   example: false
 
+              - name: query_error_stats
+                description: |
+                  These metrics are reported if `performance_schema` is enabled in the MySQL instance,
+                  the version for that instance is >= 8.0.0, and DBM is enabled.
+
+                  Metric provided: 
+                  - mysql.performance.errors_raised
+                  This metric is tagged with:
+                  - `error_number` (the MySQL error number)
+                  - `error_name` (the MySQL error name, e.g., ER_NO_SUCH_TABLE)
+                value:
+                  type: boolean
+                  example: true
+
           - name: dbm
             description: |
               Set to `true` enable Database Monitoring.

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -43,6 +43,7 @@ class MySQLConfig(object):
         self.dbm_enabled = is_affirmative(instance.get('dbm', instance.get('deep_database_monitoring', False)))
         self.replication_enabled = is_affirmative(self.options.get('replication', self.dbm_enabled))
         self.table_rows_stats_enabled = is_affirmative(self.options.get('table_rows_stats_metrics', False))
+        self.query_error_stats_enabled = is_affirmative(self.options.get('query_error_stats', True))
         self.statement_metrics_limits = instance.get('statement_metrics_limits', None)
         self.full_statement_text_cache_max_size = instance.get('full_statement_text_cache_max_size', 10000)
         self.full_statement_text_samples_per_hour_per_query = instance.get(

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -145,6 +145,7 @@ class Options(BaseModel):
     extra_performance_metrics: Optional[bool] = None
     extra_status_metrics: Optional[bool] = None
     galera_cluster: Optional[bool] = None
+    query_error_stats: Optional[bool] = None
     replication: Optional[bool] = None
     replication_channel: Optional[str] = None
     schema_size_metrics: Optional[bool] = None

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -378,6 +378,18 @@ instances:
         #
         # extra_performance_metrics: false
 
+        ## @param query_error_stats - boolean - optional - default: true
+        ## These metrics are reported if `performance_schema` is enabled in the MySQL instance,
+        ## the version for that instance is >= 8.0.0, and DBM is enabled.
+        ##
+        ## Metric provided: 
+        ## - mysql.performance.errors_raised
+        ## This metric is tagged with:
+        ## - `error_number` (the MySQL error number)
+        ## - `error_name` (the MySQL error name, e.g., ER_NO_SUCH_TABLE)
+        #
+        # query_error_stats: true
+
     ## @param dbm - boolean - optional - default: false
     ## Set to `true` enable Database Monitoring.
     #

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -468,7 +468,12 @@ class MySql(DatabaseCheck):
 
         if self.global_variables.performance_schema_enabled:
             queries.extend([QUERY_USER_CONNECTIONS])
-            if not self.is_mariadb and self.version.version_compatible((8, 0, 0)) and self._config.dbm_enabled:
+            if (
+                not self.is_mariadb
+                and self.version.version_compatible((8, 0, 0))
+                and self._config.dbm_enabled
+                and self._config.query_error_stats_enabled
+            ):
                 error_query = QUERY_ERRORS_RAISED.copy()
                 error_query['query'] = error_query['query'].format(user=self._config.user)
                 queries.extend([error_query])


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

In SDBM-2260 we have a user who upgraded to Agent 7.73 and started seeing issues with performance related to the Query Errors query starting with `SUM(SUM_ERROR_RAISED)`, causing them to downgrade the agent. The query runtime ranges from 18s - 50s on their host. The query was introduced in [this PR](https://github.com/DataDog/integrations-core/pull/21451/files). 

There are no performance issues with this query in our integration environments, and on most of the hosts in that user's environment, so part of the investigation will be understanding why that particular host is seeing high runtimes. The current theory is that there is some contention on `performance_schema` that might be caused by RDS Performance Insights making queries to the same table. In the meantime this PR makes the query configurable, but default true, for users that are having issues with it.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
