### PR TITLE
Add tag alias feature to WMI check documentation

### DIFF
--- a/wmi_check/README.md
+++ b/wmi_check/README.md
@@ -205,7 +205,7 @@ Get-WmiObject -List -Namespace ROOT\xyz | Select Name
 
 ... or drop `-Namespace` parameter for the default namespace.
 
-To find a WMI class `abc`, one can run the following PowerShell command:
+To find a WMI class `abc`, run the following PowerShell command:
 
 ```
 Get-WmiObject -List | WHERE{$_.Name -Like "*abc*"}

--- a/wmi_check/assets/configuration/spec.yaml
+++ b/wmi_check/assets/configuration/spec.yaml
@@ -152,7 +152,7 @@ files:
         example: Name AS wmi_name,Label
     - name: tag_queries
       description: |
-        The `tag_queries` parameter lets you specify a list of queries, to tag metrics with a target class property.
+        The `tag_queries` parameter lets you specify a list of queries to tag metrics with a target class property.
         Each item in the list is a set of :
 
         `[<LINK_SOURCE_PROPERTY>, <TARGET_CLASS>, <LINK_TARGET_CLASS_PROPERTY>, <TARGET_PROPERTY> AS <TAG_ALIAS>]`
@@ -161,7 +161,7 @@ files:
           * `<TARGET_CLASS>` is the class to link to
           * `<LINK_TARGET_CLASS_PROPERTY>` is the target class property to link to
           * `<TARGET_PROPERTY>` contains the value to tag with
-          * `<TAG_ALIAS>` is the alias to use for the tag. If not provided, the target property's name will be used.
+          * `<TAG_ALIAS>` is the alias to use for the tag. If not provided, the target property's name is used.
 
         It translates to a WMI query:
 

--- a/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
+++ b/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
@@ -138,7 +138,7 @@ instances:
     # tag_by: Name AS wmi_name,Label
 
     ## @param tag_queries - list of lists - optional
-    ## The `tag_queries` parameter lets you specify a list of queries, to tag metrics with a target class property.
+    ## The `tag_queries` parameter lets you specify a list of queries to tag metrics with a target class property.
     ## Each item in the list is a set of :
     ##
     ## `[<LINK_SOURCE_PROPERTY>, <TARGET_CLASS>, <LINK_TARGET_CLASS_PROPERTY>, <TARGET_PROPERTY> AS <TAG_ALIAS>]`
@@ -147,7 +147,7 @@ instances:
     ##   * `<TARGET_CLASS>` is the class to link to
     ##   * `<LINK_TARGET_CLASS_PROPERTY>` is the target class property to link to
     ##   * `<TARGET_PROPERTY>` contains the value to tag with
-    ##   * `<TAG_ALIAS>` is the alias to use for the tag. If not provided, the target property's name will be used.
+    ##   * `<TAG_ALIAS>` is the alias to use for the tag. If not provided, the target property's name is used.
     ##
     ## It translates to a WMI query:
     ##


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR updates the WMI check documentation with the new tag aliasing feature added in https://github.com/DataDog/integrations-core/pull/21792

### Motivation
<!-- What inspired you to submit this pull request? -->
https://datadoghq.atlassian.net/browse/WINA-2173

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
