### PR TITLE
Stop checking for ddev updates in CI steps

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,6 +45,7 @@ jobs:
 
     - name: Configure ddev
       run: |
+        ddev config set upgrade_check false
         ddev config set repos.core .
         ddev config set repo core
 

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -32,6 +32,7 @@ jobs:
 
     - name: Configure ddev
       run: |
+        ddev config set upgrade_check false
         ddev config set repos.core .
         ddev config set repo core
 

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -32,6 +32,7 @@ jobs:
 
     - name: Configure ddev
       run: |
+        ddev config set upgrade_check false
         ddev config set repos.core .
         ddev config set repo core
 

--- a/.github/workflows/test-fips-e2e.yml
+++ b/.github/workflows/test-fips-e2e.yml
@@ -90,6 +90,7 @@ jobs:
 
     - name: Configure ddev
       run: |-
+        ddev config set upgrade_check false
         ddev config set repos.core .
         ddev config set repo core
 

--- a/.github/workflows/update-agent-changelog.yml
+++ b/.github/workflows/update-agent-changelog.yml
@@ -25,6 +25,7 @@ jobs:
         pip install -e ./ddev
     - name: Configure ddev
       run: |-
+        ddev config set upgrade_check false
         ddev config set repos.core .
         ddev config set repo core
     - name: Update the Agent changelog

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -25,6 +25,7 @@ jobs:
         pip install -e ./ddev
     - name: Configure ddev
       run: |-
+        ddev config set upgrade_check false
         ddev config set repos.core .
         ddev config set repo core
     - name: Create token

--- a/.github/workflows/upgrade-python-version.yml
+++ b/.github/workflows/upgrade-python-version.yml
@@ -28,6 +28,7 @@ jobs:
         pip install -e ./ddev
     - name: Configure ddev
       run: |-
+        ddev config set upgrade_check false
         ddev config set repos.core .
         ddev config set repo core
     - name: Get GitHub token via dd-octo-sts


### PR DESCRIPTION
### What does this PR do?
I merged in a change that allows for ddev to periodically check for ddev upgrades but this isn't needed in CI.
