### PR TITLE
Don't compare release branch to master

### DIFF
--- a/.gitlab/build_agent.yaml
+++ b/.gitlab/build_agent.yaml
@@ -29,9 +29,6 @@ build-agent-auto:
     # Only run if the branch is not a Github Merge Queue one.
     - if: $CI_COMMIT_BRANCH !~ /^gh-readonly-queue.*/
       changes:
-        # We don't yet support variable expansion in `compare_to`. It was added in gitlab 17.2:
-        # https://gitlab.com/gitlab-org/gitlab/-/issues/369916#note_1972773223
-        compare_to: "master"
         paths:
           - .deps/*
           - .gitlab/build_agent.yaml


### PR DESCRIPTION
### What does this PR do?
Attempt to lower the amount of downtime. If I'm understanding this correctly:
https://docs.gitlab.com/ci/yaml/#ruleschangescompare_to

Right now the gitlab pipeline will trigger anytime there's a difference between the .deps of the feature branch compared to that of master. So if let's say we branch off and then update a dep in master, and then we make any PRs to the feature branch, it will trigger the build because there's a difference between the .deps in master compared to the feature branch.

The intended behavior is suppose to be just detecting changes in .deps and if there are any, then trigger the agent build pipeline. 
