### PR TITLE
Remove python 2 tests in PRs

### DIFF
--- a/.github/workflows/pr-all-windows.yml
+++ b/.github/workflows/pr-all-windows.yml
@@ -26,8 +26,8 @@ jobs:
       repo: core
 
       # Options
-      test-py2: true
       context: "pr"
+      
     secrets: inherit
 
   save-event:

--- a/.github/workflows/pr-all.yml
+++ b/.github/workflows/pr-all.yml
@@ -25,10 +25,8 @@ jobs:
 
     with:
       repo: core
-
-      # Options
-      test-py2: true
       context: "pr"
+
     secrets: inherit
 
   save-event:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Removes the python2 setup on PRs tests. We are not installing python 2 anywhere else and the python 2 setup job is causing some failures in CI due to failing installations of unsigned packages: https://github.com/DataDog/integrations-core/actions/runs/20954158159/job/60214544012?pr=22042

### Motivation
<!-- What inspired you to submit this pull request? -->
Avoid setting up python 2 bringing PRs jobs to the same footing as master execution.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
