### PR TITLE
[NDM] fix snmp listener test

### DIFF
--- a/snmp/tests/conftest.py
+++ b/snmp/tests/conftest.py
@@ -146,7 +146,7 @@ def create_datadog_conf_file(tmp_dir):
                         'privacy_key': 'doggiePRIVkey',
                         'privacy_protocol': 'des',
                         'context_name': 'public',
-                        'ignored_ip_addresses': {'{}.2'.format(prefix): True},
+                        'ignored_ip_addresses': ['{}.2'.format(prefix)],
                         'loader': 'core',
                     },
                     {
@@ -162,7 +162,7 @@ def create_datadog_conf_file(tmp_dir):
                         'privacy_key': 'doggiePRIVkey',
                         'privacy_protocol': 'AES',
                         'context_name': 'public',
-                        'ignored_ip_addresses': {'{}.2'.format(prefix): True},
+                        'ignored_ip_addresses': ['{}.2'.format(prefix)],
                         'loader': 'core',
                     },
                 ],


### PR DESCRIPTION
### What does this PR do?
[this pr](https://github.com/DataDog/datadog-agent/pull/44304) broke the snmp listener e2e test because ignored_ip_addressed changed from map[string]bool to []string

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
