### PR TITLE
[Backport master] Bumped datadog_checks_base version to 37.27.0

### DIFF
--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 37.27.0 / 2026-01-13
+
+***Security***:
+
+* Bump urllib3 version to 2.6.3 ([#22308](https://github.com/DataDog/integrations-core/pull/22308))
+
 ## 37.26.1 / 2025-12-22
 
 ***Fixed***:

--- a/datadog_checks_base/changelog.d/22308.security
+++ b/datadog_checks_base/changelog.d/22308.security
@@ -1,1 +1,0 @@
-Bump urllib3 version to 2.6.3

--- a/datadog_checks_base/datadog_checks/base/__about__.py
+++ b/datadog_checks_base/datadog_checks/base/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = "37.26.1"
+__version__ = "37.27.0"

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -32,7 +32,7 @@ datadog-ceph==4.3.0; sys_platform != 'win32'
 datadog-cert-manager==6.2.0
 datadog-checkpoint-harmony-endpoint==1.1.0
 datadog-checkpoint-quantum-firewall==1.2.0
-datadog-checks-base==37.26.1
+datadog-checks-base==37.27.0
 datadog-checks-dependency-provider==3.2.0
 datadog-checks-downloader==9.0.0
 datadog-cilium==6.2.0


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Brings the bump to `datadog-checks-base` made on the `7.75.x` release branch to `master`.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
