### PR TITLE
Fix test_load in dcd after update from FA in templates

### DIFF
--- a/datadog_checks_dev/tests/tooling/configuration/test_load.py
+++ b/datadog_checks_dev/tests/tooling/configuration/test_load.py
@@ -2694,6 +2694,7 @@ def test_template_mapping():
             '\n'
             'Learn more about tagging at https://docs.datadoghq.com/tagging\n'
         ),
+        "fleet_configurable": True,
         # Defaults should be post-populated
         'required': False,
         'hidden': False,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR fixes tests in dcd that were broken after #22270 when the templates where updated.

### Motivation
<!-- What inspired you to submit this pull request? -->
Make ti pass CI. For some reason the tests from dcd did not run or didn't trigger a `test-all` workflow (which I imagine it should) when these changes were made. I am looking into why the tests did not run now.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
