### PR TITLE
[LOGSC-2554] Add bypass annotations for new linter checks

### DIFF
--- a/argo_workflows/assets/logs/argo_workflows_tests.yaml
+++ b/argo_workflows/assets/logs/argo_workflows_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "argo_workflows"
 tests:
  -

--- a/argocd/assets/logs/argocd_tests.yaml
+++ b/argocd/assets/logs/argocd_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "argocd"
 tests:
  -

--- a/azure_active_directory/assets/logs/azure.activedirectory_tests.yaml
+++ b/azure_active_directory/assets/logs/azure.activedirectory_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "azure.activedirectory"
 tests:
   - sample: |-

--- a/beyondtrust_password_safe/assets/logs/beyondtrust-password-safe_tests.yaml
+++ b/beyondtrust_password_safe/assets/logs/beyondtrust-password-safe_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: beyondtrust-password-safe
 tests:
   - 

--- a/bitwarden/assets/logs/bitwarden_tests.yaml
+++ b/bitwarden/assets/logs/bitwarden_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "bitwarden"
 tests:
  -

--- a/boundary/assets/logs/boundary_tests.yaml
+++ b/boundary/assets/logs/boundary_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "boundary"
 tests:
  -

--- a/brevo/assets/logs/brevo_tests.yaml
+++ b/brevo/assets/logs/brevo_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: brevo
 tests:
   - sample: |-

--- a/checkpoint_quantum_firewall/assets/logs/checkpoint-quantum-firewall_tests.yaml
+++ b/checkpoint_quantum_firewall/assets/logs/checkpoint-quantum-firewall_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "checkpoint-quantum-firewall"
 tests:
  -

--- a/cisco_secure_web_appliance/assets/logs/cisco-secure-web-appliance_tests.yaml
+++ b/cisco_secure_web_appliance/assets/logs/cisco-secure-web-appliance_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: cisco-secure-web-appliance
 tests:
   - sample: '<38>Sep 25 12:13:55 Crest.CSWA accesslogs: Info: 1727246631.866 93971 10.10.10.10 TCP_MISS/200 8560 CONNECT tunnel://csp.withgoogle.com:443/ - DIRECT/csp.withgoogle.com application/octet-stream DEFAULT_CASE_12-DefaultGroup-match_network-NONE-NONE-NONE-DefaultGroup-NONE <"IW_comp",3.0,1,"-",-,-,-,1,"-",-,-,-,"-",1,-,"-","-",-,-,"IW_comp,IW_csec",-,"-","Computers and Internet","-","Unknown","Unknown","-","-",0.73,0,-,"-","-",1,"-",-,-,"-","-",-,1,"-",-,-> - -'

--- a/citrix_hypervisor/assets/logs/citrix_hypervisor_tests.yaml
+++ b/citrix_hypervisor/assets/logs/citrix_hypervisor_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "citrix_hypervisor"
 tests:
  -

--- a/consul/assets/logs/consul_tests.yaml
+++ b/consul/assets/logs/consul_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "consul"
 tests:
  -

--- a/crowdstrike_fdr/assets/logs/crowdstrike-fdr_tests.yaml
+++ b/crowdstrike_fdr/assets/logs/crowdstrike-fdr_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: crowdstrike-fdr
 tests:
  -

--- a/docker_daemon/assets/logs/docker_tests.yaml
+++ b/docker_daemon/assets/logs/docker_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "docker"
 tests:
  -

--- a/docusign/assets/logs/docusign_tests.yaml
+++ b/docusign/assets/logs/docusign_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: docusign
 tests:
  -

--- a/druid/assets/logs/druid_tests.yaml
+++ b/druid/assets/logs/druid_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "druid"
 tests:
  -

--- a/falco/assets/logs/falco_tests.yaml
+++ b/falco/assets/logs/falco_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "falco"
 tests:
  -

--- a/forescout/assets/logs/forescout_tests.yaml
+++ b/forescout/assets/logs/forescout_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: forescout
 tests:
  -

--- a/gitlab/assets/logs/gitlab_tests.yaml
+++ b/gitlab/assets/logs/gitlab_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "gitlab"
 tests:
  -

--- a/gitlab_runner/assets/logs/gitlab-runner_tests.yaml
+++ b/gitlab_runner/assets/logs/gitlab-runner_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "gitlab-runner"
 tests:
  -

--- a/guarddog/assets/logs/guarddog_tests.yaml
+++ b/guarddog/assets/logs/guarddog_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "guarddog"
 tests:
  -

--- a/harbor/assets/logs/harbor_tests.yaml
+++ b/harbor/assets/logs/harbor_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "harbor"
 tests:
  -

--- a/impala/assets/logs/impala_tests.yaml
+++ b/impala/assets/logs/impala_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "impala"
 tests:
  -

--- a/intercom/assets/logs/intercom_tests.yaml
+++ b/intercom/assets/logs/intercom_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: intercom
 tests:
   - sample: |-

--- a/ivanti_connect_secure/assets/logs/ivanti-connect-secure_tests.yaml
+++ b/ivanti_connect_secure/assets/logs/ivanti-connect-secure_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "ivanti-connect-secure"
 tests:
  -

--- a/ivanti_nzta/assets/logs/ivanti-nzta_tests.yaml
+++ b/ivanti_nzta/assets/logs/ivanti-nzta_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: ivanti-nzta
 tests:
  -

--- a/kafka/assets/logs/kafka_tests.yaml
+++ b/kafka/assets/logs/kafka_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "kafka"
 tests:
  -

--- a/keda/assets/logs/keda_tests.yaml
+++ b/keda/assets/logs/keda_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "keda"
 tests:
  -

--- a/kube_scheduler/assets/logs/kube_scheduler_tests.yaml
+++ b/kube_scheduler/assets/logs/kube_scheduler_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "kube_scheduler"
 tests:
  -

--- a/kuma/assets/logs/kuma_tests.yaml
+++ b/kuma/assets/logs/kuma_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: kuma
 tests:
  -

--- a/linux_audit_logs/assets/logs/linux-audit-logs_tests.yaml
+++ b/linux_audit_logs/assets/logs/linux-audit-logs_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "linux-audit-logs"
 tests:
  -

--- a/mesos_slave/assets/logs/mesos_tests.yaml
+++ b/mesos_slave/assets/logs/mesos_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "mesos"
 tests:
  -

--- a/microsoft_dns/assets/logs/microsoft-dns_tests.yaml
+++ b/microsoft_dns/assets/logs/microsoft-dns_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: microsoft-dns
 tests:
  -

--- a/microsoft_sysmon/assets/logs/microsoft-sysmon_tests.yaml
+++ b/microsoft_sysmon/assets/logs/microsoft-sysmon_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: microsoft-sysmon
 tests:
  -

--- a/mimecast/assets/logs/mimecast_tests.yaml
+++ b/mimecast/assets/logs/mimecast_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: mimecast
 tests:
   -

--- a/mysql/assets/logs/mysql_tests.yaml
+++ b/mysql/assets/logs/mysql_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "mysql"
 tests:
  -

--- a/nagios/assets/logs/nagios_tests.yaml
+++ b/nagios/assets/logs/nagios_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "nagios"
 tests:
  -

--- a/nfsstat/assets/logs/nfsstat_tests.yaml
+++ b/nfsstat/assets/logs/nfsstat_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "nfsstat"
 tests:
  -

--- a/nginx_ingress_controller/assets/logs/nginx-ingress-controller_tests.yaml
+++ b/nginx_ingress_controller/assets/logs/nginx-ingress-controller_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "nginx-ingress-controller"
 tests:
  -

--- a/nvidia_triton/assets/logs/nvidia_triton_tests.yaml
+++ b/nvidia_triton/assets/logs/nvidia_triton_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "nvidia_triton"
 tests:
  -

--- a/openvpn/assets/logs/openvpn_tests.yaml
+++ b/openvpn/assets/logs/openvpn_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: openvpn
 tests:
   - sample: "<14>Feb 24 05:11:20 openvpnas2 openvpnas: [-] [OVPN 2] OUT: '2025-02-24

--- a/ossec_security/assets/logs/ossec-security_tests.yaml
+++ b/ossec_security/assets/logs/ossec-security_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: ossec-security
 tests:
   -

--- a/postfix/assets/logs/postfix_tests.yaml
+++ b/postfix/assets/logs/postfix_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "postfix"
 tests:
  -

--- a/postmark/assets/logs/postmark_tests.yaml
+++ b/postmark/assets/logs/postmark_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: postmark
 tests:
  -

--- a/powerdns_recursor/assets/logs/powerdns_tests.yaml
+++ b/powerdns_recursor/assets/logs/powerdns_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "powerdns"
 tests:
  -

--- a/proofpoint_on_demand/assets/logs/proofpoint-on-demand_tests.yaml
+++ b/proofpoint_on_demand/assets/logs/proofpoint-on-demand_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: proofpoint-on-demand
 tests:
   - sample: |-

--- a/proxysql/assets/logs/proxysql_tests.yaml
+++ b/proxysql/assets/logs/proxysql_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "proxysql"
 tests:
  -

--- a/push_security/assets/logs/push-security_tests.yaml
+++ b/push_security/assets/logs/push-security_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: push-security
 tests:
  -

--- a/redisdb/assets/logs/redis_tests.yaml
+++ b/redisdb/assets/logs/redis_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "redis"
 tests:
  -

--- a/squid/assets/logs/squid_tests.yaml
+++ b/squid/assets/logs/squid_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "squid"
 tests:
  -

--- a/statsd/assets/logs/statsd_tests.yaml
+++ b/statsd/assets/logs/statsd_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "statsd"
 tests:
  -

--- a/supply_chain_firewall/assets/logs/supply-chain-firewall_tests.yaml
+++ b/supply_chain_firewall/assets/logs/supply-chain-firewall_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: supply-chain-firewall
 tests:
  -

--- a/suricata/assets/logs/suricata_tests.yaml
+++ b/suricata/assets/logs/suricata_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: suricata
 tests:
  -

--- a/symantec_endpoint_protection/assets/logs/symantec-endpoint-protection_tests.yaml
+++ b/symantec_endpoint_protection/assets/logs/symantec-endpoint-protection_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "symantec-endpoint-protection"
 tests:
  -

--- a/tomcat/assets/logs/tomcat_tests.yaml
+++ b/tomcat/assets/logs/tomcat_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "tomcat"
 tests:
  -

--- a/traffic_server/assets/logs/traffic_server_tests.yaml
+++ b/traffic_server/assets/logs/traffic_server_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "traffic_server"
 tests:
  -

--- a/twistlock/assets/logs/twistlock_tests.yaml
+++ b/twistlock/assets/logs/twistlock_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "twistlock"
 tests:
  -

--- a/wazuh/assets/logs/wazuh_tests.yaml
+++ b/wazuh/assets/logs/wazuh_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: wazuh
 tests:
   -

--- a/zeek/assets/logs/zeek_tests.yaml
+++ b/zeek/assets/logs/zeek_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "zeek"
 tests:
  -

--- a/zk/assets/logs/zookeeper_tests.yaml
+++ b/zk/assets/logs/zookeeper_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "zookeeper"
 tests:
  -


### PR DESCRIPTION
We’re enabling new linter rules and some integrations are expected to remain non‑compliant. Add permanent bypass annotations so CI stays green and not fail for new PRs.

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
