### PR TITLE
Avoid max length problem with string_agg for indexes with many columns

### DIFF
--- a/sqlserver/changelog.d/22337.fixed
+++ b/sqlserver/changelog.d/22337.fixed
@@ -1,0 +1,1 @@
+Avoid SQL Server max length with string_agg for indexes with many columns

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -47,13 +47,13 @@ WHERE
 GROUP BY object_id
 """
 
+# Cast the column names to nvarchar(max) to avoid exceeding the max length when using STRING_AGG
 INDEX_QUERY = """
 SELECT
     i.name, i.type, i.is_unique, i.is_primary_key, i.is_unique_constraint,
-    i.is_disabled, STRING_AGG(c.name, ',') AS column_names
+    i.is_disabled, STRING_AGG(CAST(COL_NAME(ic.object_id, ic.column_id) as nvarchar(max)), ',') AS column_names
 FROM
-    sys.indexes i JOIN sys.index_columns ic ON i.object_id = ic.object_id
-    AND i.index_id = ic.index_id JOIN sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id
+    sys.indexes i JOIN sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id
 WHERE i.object_id = schema_tables.table_id
 GROUP BY i.object_id, i.name, i.type,
     i.is_unique, i.is_primary_key, i.is_unique_constraint, i.is_disabled


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
* Cast the column names passed to `STRING_AGG` to `nvarchar(max)` to avoid hitting the max length when aggregating. 
* Use `COL_NAME` instead of joining to the columns table.

### Motivation
<!-- What inspired you to submit this pull request? -->
`STRING_AGG` inherits the data size of the arguments passed to it and was [erroring](https://github.com/DataDog/integrations-core/issues/21929) when indexes had many columns

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
