### PR TITLE
IDP-801: Add owner field to saas-integrations integrations

### DIFF
--- a/cato_networks/manifest.json
+++ b/cato_networks/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "4139f2e2-ba87-4e17-bcda-73bdade3ed8f",
   "app_id": "cato-networks",
+  "owner": "saas-integrations",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/resend/manifest.json
+++ b/resend/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "eeb832db-844d-4c6e-b3ec-e277461e5281",
   "app_id": "resend",
+  "owner": "saas-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/supabase_cloud/manifest.json
+++ b/supabase_cloud/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "76054e37-5919-442f-a7a6-5a77ed5e7b0e",
   "app_id": "supabase-cloud",
+  "owner": "saas-integrations",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/valence_security/manifest.json
+++ b/valence_security/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a9265d8a-1531-4f1a-9719-54b03a1f0634",
   "app_id": "valence-security",
+  "owner": "saas-integrations",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/vectra/manifest.json
+++ b/vectra/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "ea75e670-67d1-4953-a6b8-63665fc27582",
   "app_id": "vectra",
+  "owner": "saas-integrations",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
## Summary
Add `owner` field to manifest.json files for 5 integrations owned by the saas-integrations team.

## Integrations Updated
- **cato_networks** → `saas-integrations` (from CODEOWNERS)
- **resend** → `saas-integrations` (from CODEOWNERS)
- **supabase_cloud** → `saas-integrations` (from git history, SIMI- ticket prefix)
- **valence_security** → `saas-integrations` (from CODEOWNERS)
- **vectra** → `saas-integrations` (from CODEOWNERS)

## Changes
- Added `"owner": "saas-integrations"` field right after `app_id` in each manifest.json

## Ownership Verification
All owner assignments were verified through CODEOWNERS file and git commit history.

This provides clear ownership tracking as part of the initiative to add owner fields to all integration manifest.json files.

cc @DataDog/saas-integrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)