### PR TITLE
IDP-801: Add owner field to agent-integrations integrations

### DIFF
--- a/forescout/manifest.json
+++ b/forescout/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "bcaf5c4c-cffc-4b33-866c-d5025f29c4b0",
   "app_id": "forescout",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/guarddog/manifest.json
+++ b/guarddog/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "1dc65430-866a-4400-bfbb-bbc6fdf7271b",
   "app_id": "guarddog",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/ibm_spectrum_lsf/manifest.json
+++ b/ibm_spectrum_lsf/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "5fba4c04-27ba-4b56-840b-db155ed030c8",
   "app_id": "ibm-spectrum-lsf",
+  "owner": "agent-integrations",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
## Summary
Adding the `owner` field to integrations owned by the agent-integrations team.

## Integrations Updated
- forescout
- guarddog
- ibm_spectrum_lsf

The `owner` field has been added right below the `app_id` field in each manifest.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>