### PR TITLE
IDP-801: Add owner field to data-streams-monitoring integrations

### DIFF
--- a/kafka_actions/manifest.json
+++ b/kafka_actions/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "07b3b75f-f0b2-4e13-8ece-8db043f7b0e5",
   "app_id": "kafka-actions",
+  "owner": "data-streams-monitoring",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
## Summary
Adding the `owner` field to integrations owned by the data-streams-monitoring team.

## Integrations Updated
- kafka_actions

The `owner` field has been added right below the `app_id` field in the manifest.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>