### PR TITLE
[SDBM-2278] Memory optimizations for high-instance PostgreSQL monitoring

### DIFF
--- a/datadog_checks_base/changelog.d/22354.fixed
+++ b/datadog_checks_base/changelog.d/22354.fixed
@@ -1,0 +1,1 @@
+Reduce memory usage by caching degeneralise_tag results and stripping large string columns from statement metrics cache

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -75,20 +75,9 @@ ONE_PER_CONTEXT_METRIC_TYPES = [aggregator.GAUGE, aggregator.RATE, aggregator.MO
 TYPO_SIMILARITY_THRESHOLD = 0.95
 
 
-# SDBM-2278: LRU cache for degeneralise_tag to reduce memory allocations
-# Profiler data showed degeneralise_tag consuming ~890 MiB due to repeated string operations
 @functools.lru_cache(maxsize=50000)
 def _cached_degeneralise_tag(check_name, tag):
-    """
-    Cached implementation of tag degeneralization.
-
-    Args:
-        check_name: The name of the check (e.g., 'postgres')
-        tag: The tag to process
-
-    Returns:
-        The degeneralised tag string
-    """
+    """Cached implementation of tag degeneralization to reduce memory allocations."""
     split_tag = tag.split(':', 1)
     if len(split_tag) > 1:
         tag_name, value = split_tag
@@ -1461,7 +1450,6 @@ class AgentCheck(object):
         return normalized_tags
 
     def degeneralise_tag(self, tag):
-        # SDBM-2278: Use module-level cached implementation to reduce memory allocations
         return _cached_degeneralise_tag(self.name, tag)
 
     def get_debug_metric_tags(self):

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -75,6 +75,37 @@ ONE_PER_CONTEXT_METRIC_TYPES = [aggregator.GAUGE, aggregator.RATE, aggregator.MO
 TYPO_SIMILARITY_THRESHOLD = 0.95
 
 
+# SDBM-2278: LRU cache for degeneralise_tag to reduce memory allocations
+# Profiler data showed degeneralise_tag consuming ~890 MiB due to repeated string operations
+@functools.lru_cache(maxsize=50000)
+def _cached_degeneralise_tag(check_name, tag):
+    """
+    Cached implementation of tag degeneralization.
+
+    Args:
+        check_name: The name of the check (e.g., 'postgres')
+        tag: The tag to process
+
+    Returns:
+        The degeneralised tag string
+    """
+    split_tag = tag.split(':', 1)
+    if len(split_tag) > 1:
+        tag_name, value = split_tag
+    else:
+        tag_name = tag
+        value = None
+
+    if tag_name in GENERIC_TAGS:
+        new_name = '{}_{}'.format(check_name, tag_name)
+        if value:
+            return '{}:{}'.format(new_name, value)
+        else:
+            return new_name
+    else:
+        return tag
+
+
 @traced_class
 class AgentCheck(object):
     """
@@ -1430,21 +1461,8 @@ class AgentCheck(object):
         return normalized_tags
 
     def degeneralise_tag(self, tag):
-        split_tag = tag.split(':', 1)
-        if len(split_tag) > 1:
-            tag_name, value = split_tag
-        else:
-            tag_name = tag
-            value = None
-
-        if tag_name in GENERIC_TAGS:
-            new_name = '{}_{}'.format(self.name, tag_name)
-            if value:
-                return '{}:{}'.format(new_name, value)
-            else:
-                return new_name
-        else:
-            return tag
+        # SDBM-2278: Use module-level cached implementation to reduce memory allocations
+        return _cached_degeneralise_tag(self.name, tag)
 
     def get_debug_metric_tags(self):
         tags = ['check_name:{}'.format(self.name), 'check_version:{}'.format(self.check_version)]

--- a/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
@@ -158,9 +158,6 @@ def _strip_statement_columns(merged_rows, metrics):
     stripped = {}
     for row_key, row in merged_rows.items():
         # Keep metric columns and any column not in the exclusion list
-        stripped_row = {
-            k: v for k, v in row.items()
-            if k in metrics or k not in _STATEMENT_METRICS_EXCLUDED_COLUMNS
-        }
+        stripped_row = {k: v for k, v in row.items() if k in metrics or k not in _STATEMENT_METRICS_EXCLUDED_COLUMNS}
         stripped[row_key] = stripped_row
     return stripped

--- a/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
@@ -5,6 +5,10 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# SDBM-2278: Large string columns to exclude from _previous_statements cache
+# These columns can be several KB each and are not needed for derivative calculations
+_STATEMENT_METRICS_EXCLUDED_COLUMNS = frozenset({'query', 'statement', 'query_text', 'sql_text', 'digest_text'})
+
 
 class StatementMetrics:
     """
@@ -105,8 +109,10 @@ class StatementMetrics:
 
             result.append(diffed_row)
 
+        # SDBM-2278: Strip large string columns before storing in _previous_statements
+        # This reduces memory by not caching query text that isn't needed for derivative calculations
         self._previous_statements.clear()
-        self._previous_statements = merged_rows
+        self._previous_statements = _strip_statement_columns(merged_rows, metrics)
 
         return result
 
@@ -136,3 +142,25 @@ def _merge_duplicate_rows(rows, metrics, key):
             queries_by_key[query_key] = row
 
     return queries_by_key, dropped_metrics
+
+
+def _strip_statement_columns(merged_rows, metrics):
+    """
+    SDBM-2278: Strip large string columns from rows before caching in _previous_statements.
+
+    This dramatically reduces memory usage by not storing query text strings that can be
+    several KB each. With 10,000+ statements, this can save 20+ MB per check instance.
+
+    :param merged_rows: Dictionary of {row_key: row_dict}
+    :param metrics: Set of metric column names that need to be preserved
+    :return: Dictionary with same keys but stripped row values
+    """
+    stripped = {}
+    for row_key, row in merged_rows.items():
+        # Keep metric columns and any column not in the exclusion list
+        stripped_row = {
+            k: v for k, v in row.items()
+            if k in metrics or k not in _STATEMENT_METRICS_EXCLUDED_COLUMNS
+        }
+        stripped[row_key] = stripped_row
+    return stripped

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -1368,7 +1368,7 @@ def test_profile_memory_when_enabled(should_profile_value, expected_calls):
 
 
 class TestDegeneraliseTagCaching:
-    """Tests for SDBM-2278: LRU caching of degeneralise_tag to reduce memory allocations."""
+    """Tests for LRU caching of degeneralise_tag."""
 
     def test_degeneralise_tag_caching_returns_same_result(self):
         """Verify cached function returns identical results to original behavior."""

--- a/postgres/changelog.d/22354.fixed
+++ b/postgres/changelog.d/22354.fixed
@@ -1,0 +1,1 @@
+Reduce memory usage by minimizing connection pool background threads

--- a/postgres/datadog_checks/postgres/connection_pool.py
+++ b/postgres/datadog_checks/postgres/connection_pool.py
@@ -203,9 +203,6 @@ class LRUConnectionPoolManager:
         self.sqlascii_encodings = sqlascii_encodings
         self.token_provider = token_provider
 
-        # SDBM-2278: num_workers=1 reduces background threads that cause memory overhead
-        # Default num_workers=3 creates 3 worker threads + scheduler per pool, ~1MB each
-        # Setting to 1 (minimum allowed) reduces thread count significantly
         self.pool_config = {
             **(pool_config or {}),
             "min_size": 0,

--- a/postgres/datadog_checks/postgres/connection_pool.py
+++ b/postgres/datadog_checks/postgres/connection_pool.py
@@ -203,11 +203,15 @@ class LRUConnectionPoolManager:
         self.sqlascii_encodings = sqlascii_encodings
         self.token_provider = token_provider
 
+        # SDBM-2278: num_workers=1 reduces background threads that cause memory overhead
+        # Default num_workers=3 creates 3 worker threads + scheduler per pool, ~1MB each
+        # Setting to 1 (minimum allowed) reduces thread count significantly
         self.pool_config = {
             **(pool_config or {}),
             "min_size": 0,
             "max_size": 2,
             "open": True,
+            "num_workers": 1,
         }
 
         self.lock = threading.Lock()


### PR DESCRIPTION
### What does this PR do?
Address memory issues affecting customers monitoring multiple PostgreSQL instances. 
Changes implemented based on profiler data showing top memory consumers.

#### Changes:
- Add LRU cache to degeneralise_tag
- Strip query text from _previous_statements cache
- Set num_workers=1 in ConnectionPool to reduce thread overhead

### Motivation
Customer-reported Memory increase issue

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
