### PR TITLE
Fix broken Data Streams documentation links in kafka_consumer README

### DIFF
--- a/kafka_consumer/README.md
+++ b/kafka_consumer/README.md
@@ -168,7 +168,7 @@ Depending on your Kafka cluster's Kerberos setup, you may need to configure the 
 [14]: https://www.datadoghq.com/blog/collecting-kafka-performance-metrics
 [15]: https://www.datadoghq.com/blog/monitor-kafka-with-datadog
 [17]: https://docs.datadoghq.com/containers/kubernetes/integrations/
-[18]: /data-streams
+[18]: https://docs.datadoghq.com/data_streams/
 [19]: /integrations/kafka?search=kafka
 [20]: /containers/cluster_agent/clusterchecks/
-[21]: /data_streams/messages/
+[21]: https://docs.datadoghq.com/data_streams/messages/


### PR DESCRIPTION
## Summary

The `kafka_consumer/README.md` contains two relative documentation links that incorrectly redirect to `app.datadoghq.com` instead of the public documentation at `docs.datadoghq.com`:

- `[18]: /data-streams` → redirects to `app.datadoghq.com/data-streams`
- `[21]: /data_streams/messages/` → redirects to `app.datadoghq.com/data_streams/messages/`

This PR changes them to absolute URLs pointing to the correct public documentation pages.

## Changes

- `[18]: /data-streams` → `[18]: https://docs.datadoghq.com/data_streams/`
- `[21]: /data_streams/messages/` → `[21]: https://docs.datadoghq.com/data_streams/messages/`