### PR TITLE
Add flaky markers to tests identified as flaky

### DIFF
--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -67,7 +67,10 @@ pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')
 
 @pytest.mark.parametrize(
     'is_aurora',
-    [True, False],
+    [
+        pytest.param(True, id="aurora", marks=pytest.mark.flaky),
+        pytest.param(False, id="not_aurora"),
+    ],
 )
 def test_common_metrics(aggregator, integration_check, pg_instance, is_aurora):
     check = integration_check(pg_instance)
@@ -438,6 +441,7 @@ def test_activity_metrics_no_aggregations(aggregator, integration_check, pg_inst
 
 
 @requires_over_10
+@pytest.mark.flaky
 def test_activity_vacuum_excluded(aggregator, integration_check, pg_instance):
     pg_instance['collect_activity_metrics'] = True
     check = integration_check(pg_instance)

--- a/postgres/tests/test_pg_replication.py
+++ b/postgres/tests/test_pg_replication.py
@@ -221,6 +221,7 @@ def test_conflicts_bufferpin(aggregator, integration_check, pg_instance, pg_repl
 
 
 @requires_over_10
+@pytest.mark.flaky
 def test_pg_control_replication(aggregator, integration_check, pg_instance):
     check = integration_check(pg_instance)
     check.run()

--- a/postgres/tests/test_replication_slot.py
+++ b/postgres/tests/test_replication_slot.py
@@ -23,6 +23,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("dd_environment")
 
 
 @requires_over_10
+@pytest.mark.flaky
 def test_physical_replication_slots(aggregator, integration_check, pg_instance):
     check = integration_check(pg_instance)
     # It seemingly can take a small amount of time for the pg_replication_slots to be saturated

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1525,6 +1525,7 @@ def _check_until_time(check, dbm_instance, sleep_time, check_interval):
         elapsed = time.time() - start_time
 
 
+@pytest.mark.flaky
 def test_statement_samples_main_collection_rate_limit(aggregator, integration_check, dbm_instance):
     # test the main collection loop rate limit
     collection_interval = 0.2

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -577,6 +577,7 @@ def test_statement_metrics_limit(
     assert sqlserver_rows == sorted(sqlserver_rows, key=lambda i: i['total_elapsed_time'], reverse=True)
 
 
+@pytest.mark.flaky
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds the flaky markers to some tests for `postgres` and `sqlserver`. These tests have been identified as `known_flaky` by our CI monitoring dashboard and won't be run in `master`.

### Motivation
<!-- What inspired you to submit this pull request? -->
Having unstable tests makes harder for us to understand when a failure needs to be looked at as unexpected. These tests should be improved, for now they are marked as flaky to allow us to identify issues.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
