### PR TITLE
Mark `test_common_metrics` as flaky

### DIFF
--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -68,10 +68,11 @@ pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(
     'is_aurora',
     [
-        pytest.param(True, id="aurora", marks=pytest.mark.flaky),
+        pytest.param(True, id="aurora"),
         pytest.param(False, id="not_aurora"),
     ],
 )
+@pytest.mark.flaky
 def test_common_metrics(aggregator, integration_check, pg_instance, is_aurora):
     check = integration_check(pg_instance)
     check.is_aurora = is_aurora


### PR DESCRIPTION
### What does this PR do?
Marks the entire test_common_metrics as flaky


### Motivation
One parameter was marked flakey here: https://github.com/DataDog/integrations-core/pull/22367 but the test has [failed](https://github.com/DataDog/integrations-core/actions/runs/21180930511/job/60923018696) since so both should be considered flaky for now

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
