### PR TITLE
Add LRU cache for SQL obfuscation to reduce CGO calls

### DIFF
--- a/datadog_checks_base/changelog.d/22382.added
+++ b/datadog_checks_base/changelog.d/22382.added
@@ -1,0 +1,1 @@
+Add LRU cache for SQL obfuscation to reduce CGO calls in high-volume DBM deployments

--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -39,6 +39,11 @@ class DatadogAgentStub(object):
         self._process_start_time = 0
         self._external_tags = []
         self._host_tags = "{}"
+        # Clear the SQL obfuscation cache to ensure test isolation when mocking obfuscate_sql.
+        # Import lazily to avoid circular import (stubs -> utils -> agent -> stubs).
+        from datadog_checks.base.utils.db.utils import clear_obfuscation_cache
+
+        clear_obfuscation_cache()
 
     def assert_logs(self, check_id, logs):
         sent_logs = self._sent_logs[check_id]

--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -39,8 +39,7 @@ class DatadogAgentStub(object):
         self._process_start_time = 0
         self._external_tags = []
         self._host_tags = "{}"
-        # Clear the SQL obfuscation cache to ensure test isolation when mocking obfuscate_sql.
-        # Import lazily to avoid circular import (stubs -> utils -> agent -> stubs).
+        # Lazy import to avoid circular import
         from datadog_checks.base.utils.db.utils import clear_obfuscation_cache
 
         clear_obfuscation_cache()


### PR DESCRIPTION
### What does this PR do?

  - Add Python-level LRU cache to `obfuscate_sql_with_metadata()` that stores obfuscation results keyed by query hash
  - Cache hits skip the expensive CGO call to the Go obfuscator entirely
  - Thread-safe implementation using lock-protected `cachetools.LRUCache` with 50,000 entry capacity

### Motivation

  In DBM deployments with many instances, the same normalized queries from `pg_stat_statements` are obfuscated repeatedly every collection interval. Each call to `obfuscate_sql_with_metadata()` crosses the Python → C → Go boundary, allocating memory via `_Cfunc_GoString`.

  Profiler data showed high allocation rate from `_Cfunc_GoString` (~60% of total memory allocations in a high-volume DBM deployment), leading to excessive memory growth and eventual OOM.

### Compatibility

  - **Complementary with PR #45109** - That PR optimizes Go-side memory per cached result; this cache reduces how often Go is called
  - **Thread-safe** - Uses lock for concurrent access from DBM async jobs
  - **No behavior change** - Same obfuscation results, just cached

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
