### PR TITLE
Fix empty table name in synology-disk-station.yaml profile

### DIFF
--- a/snmp/datadog_checks/snmp/data/default_profiles/synology-disk-station.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/synology-disk-station.yaml
@@ -194,7 +194,7 @@ metrics:
         tag: synology_service_name
   - MIB: SYNOLOGY-STORAGEIO-MIB
     table:
-      name:
+      name: storageIOTable
       OID: 1.3.6.1.4.1.6574.101.1
     symbols:
       - name: synology.storageIOReads


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

https://mibbrowser.online/mibdb_search.php?mib=SYNOLOGY-STORAGEIO-MIB
https://mibbrowser.online/mibdb_search.php?mib=SYNOLOGY-SPACEIO-MIB

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
