### PR TITLE
Enable allow_failure on release manual

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,6 +64,7 @@ release-manual:
     - if: $CI_COMMIT_TAG =~ /.*-\d+\.\d+\.\d+(-(rc|pre|alpha|beta)\.\d+)?$/
     - if: $CI_COMMIT_BRANCH == 'master'
       when: manual
+      allow_failure: true
   script:
     - |
       if [[ -z "$CI_COMMIT_TAG" ]]; then


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Modifies the rules in `release-manual` job to set `allow_failure` to true. 

### Motivation
<!-- What inspired you to submit this pull request? -->
In GitLab, a manual job blocks the pipeline as an automatic job. This means that there is something that needs to happen but it is triggered on demand. For this reason, the pipeline never succeeds because it is waiting for the job to be triggered. This leaves the pipeline in a blocked state because the notify job also does not run, waiting for the manual job to trigger. See the pipelines we have blocked [here](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Apipeline%20%40git.repository.id_v2%3A%22github.com%2Fdatadog%2Fintegrations-core%22%20%40git.branch%3Amaster%20%40ci.status%3Arunning%20%40ci.provider.name%3Agitlab&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=cipipeline&tab=overview&start=1768500209109&end=1769105009109&paused=falsee).

To make manual jobs optional, the `allow_failure` is set to true. Since this job is intended to trigger the pipeline in those cases where it is not needed by we might want to run it, this is an acceptable behavior.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
