### PR TITLE
Fix markdown syntax for ddsource in README

### DIFF
--- a/fly_io/README.md
+++ b/fly_io/README.md
@@ -124,7 +124,7 @@ Use the [fly_logs_shipper][10] to collect logs from your Fly.io applications.
     inputs = ["nats"]
     source  = '''
     . = parse_json!(.message)
-    .ddsource = 'fly-io'
+    .ddsource = "fly-io"
     .host = .fly.app.instance
     .env = <YOUR_ENV_NAME>
     '''


### PR DESCRIPTION
Double quotes are necessary around "fly-io" due to VRL syntax.

### What does this PR do?
edits `.ddsource = 'fly-io'` to `.ddsource = "fly-io"` which is necessary due to VRL syntax requiring double quotes around string literals.

### Motivation
Working with a prospect enabling log collection for Fly.io integration.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
