### PR TITLE
Update test-target to allow getting the bash scripts from extras and marketplace

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,10 +5,6 @@ on:
     paths-ignore:
     - datadog_checks_base/datadog_checks/**
     - datadog_checks_dev/datadog_checks/dev/*.py
-    # Also run if we modify the workflow files
-    - '.github/workflows/pr.yml'
-    - '.github/workflows/pr-test.yml'
-    - '.github/workflows/test-target.yml'
   merge_group:
     # We require this workflow to pass in order to merge a PR to master.
     # This means Github's Merge Queue also requires it to pass.

--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -112,7 +112,7 @@ jobs:
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - name: Download workflow scripts from integrations-core
+    - name: Download workflow scripts
       if: inputs.repo != 'core'
       run: |
         mkdir -p .github/workflows/scripts
@@ -185,7 +185,7 @@ jobs:
 
     - name: Tag job for CI Visibility
       # Skip on fork PRs and non-core repos since secrets won't be available
-      if: env.INPUT_IS_FORK != 'true' && env.INPUT_REPO == 'core'
+      if: env.INPUT_IS_FORK != 'true' || env.INPUT_REPO == 'core'
       uses: ./.github/actions/tag-job
       with:
         tags: ${{ env.DD_TAGS }}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR updates the `test-target` workflow to ensure it works from `extras` and `marketplace`.

Introduces a new job _Download workflow scripts_ that only runs if the repo is not `core` and gets the scripts from the `master` branch in the `integrations-core` repo.

Since I am also unsure if it is a good practice to add a secret to those repos for all PRs, for now I am removing CI visibility from those repos. We can later decide whether we want to at least have it when running in master and we can set the api key as an environment secret.

### Motivation
<!-- What inspired you to submit this pull request? -->
Tests are failing to setup in those repos. Instead of replicating the scripts I am taking this approach to ensure there is one single source of this scripts. If the workflow is modified and the scripts need modification, both repos should be working properly.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
