### PR TITLE
Add JOB_ID environment variable to allow correlation between the job and the test run

### DIFF
--- a/.github/workflows/scripts/setup-test-env.sh
+++ b/.github/workflows/scripts/setup-test-env.sh
@@ -115,6 +115,8 @@ fi
   echo "INPUT_MINIMUM_BASE_PACKAGE=${INPUT_MINIMUM_BASE_PACKAGE:-false}"
   echo "INPUT_PYTEST_ARGS=${INPUT_PYTEST_ARGS:-}"
   echo "INPUT_IS_FORK=${INPUT_IS_FORK:-false}"
+  # GitHub Actions job run ID for CI Visibility correlation
+  echo "JOB_ID=${INPUT_JOB_ID}"
 } >> "$GITHUB_ENV"
 
 # Override with custom vars if provided

--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -156,6 +156,7 @@ jobs:
       #   INPUT_MINIMUM_BASE_PACKAGE
       #   INPUT_PYTEST_ARGS
       #   INPUT_IS_FORK
+      #   JOB_ID
       run: bash .github/workflows/scripts/setup-test-env.sh
       env:
         INPUT_PYTHON_VERSION: ${{ inputs.python-version }}
@@ -174,6 +175,7 @@ jobs:
         INPUT_JOB_NAME: "${{ inputs.job-name }}${{ inputs.target-env && format('-{0}', inputs.target-env) || '' }}"
         INPUT_PYTEST_ARGS: ${{ inputs.pytest-args }}
         INPUT_IS_FORK: ${{ github.event.pull_request.head.repo.fork || false }}
+        INPUT_JOB_ID: ${{ job.check_run_id }}
         DD_API_KEY_SECRET: ${{ secrets.DD_API_KEY }}
         SETUP_ENV_VARS: ${{ inputs.setup-env-vars }}
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds `JOB_ID` environment variable that allows correlation between the test executed in a given job with the the job execution in Datadog.

### Motivation
<!-- What inspired you to submit this pull request? -->
There is a limitation by which `ddtrace` does not have access to the run id of the job that is running the tests. Because of this, tests are properly correlated at a pipeline level but not at a job level. After asking the CI visibility team, adding an environment variable `JOB_ID` with that information, correlation can be achieved.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
