### PR TITLE
Fix documented min agent version

### DIFF
--- a/guarddog/README.md
+++ b/guarddog/README.md
@@ -7,7 +7,7 @@
 This integration monitors configured dependency files using GuardDog scans and sends the scan output to Datadog for analysis, providing visual insights through out-of-the-box dashboards and the Log Explorer. It also helps monitor and respond to security threats with ready-to-use Cloud SIEM detection rules.
 
 **Note:**
-- **Minimum Agent version:** 7.73.0
+- **Minimum Agent version:** 7.74.0
 
 ## Setup
 


### PR DESCRIPTION
### What does this PR do?
Fix documented min agent version for the guarddog check
### Motivation
guarddog was released in 7.74.x.
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
