### PR TITLE
[Spark Integration] Add app_id tag to all metrics

### DIFF
--- a/spark/changelog.d/22417.added
+++ b/spark/changelog.d/22417.added
@@ -1,0 +1,1 @@
+Add app_id to metric tags for all Spark metrics

--- a/spark/datadog_checks/spark/spark.py
+++ b/spark/datadog_checks/spark/spark.py
@@ -446,7 +446,7 @@ class SparkCheck(AgentCheck):
                 self.log.debug("Got an error collecting %s", property, exc_info=True)
                 continue
             try:
-                yield (response.json(), [f'app_name:{app_name}'] + addl_tags)
+                yield (response.json(), [f'app_name:{app_name}', f'app_id:{app_id}'] + addl_tags)
             except JSONDecodeError:
                 self.log.debug(
                     'Skipping metrics for %s from app %s due to unparsable JSON payload.', property, app_name
@@ -543,7 +543,7 @@ class SparkCheck(AgentCheck):
         - `SET spark.sql.streaming.metricsEnabled=true` in the app
         """
 
-        for app_name, tracking_url in running_apps.values():
+        for app_id, (app_name, tracking_url) in running_apps.items():
             try:
                 base_url = self._get_request_url(tracking_url)
                 response = self._rest_request_to_json(
@@ -568,7 +568,7 @@ class SparkCheck(AgentCheck):
                         self.log.debug("Unknown metric_name encountered: '%s'", str(metric_name))
                         continue
                     metric_name, submission_type = SPARK_STRUCTURED_STREAMING_METRICS[metric_name]
-                    tags = ['app_name:%s' % str(app_name)]
+                    tags = ['app_name:%s' % str(app_name), 'app_id:%s' % str(app_id)]
                     tags.extend(addl_tags)
 
                     if self._enable_query_name_tag:

--- a/spark/tests/test_spark.py
+++ b/spark/tests/test_spark.py
@@ -56,6 +56,9 @@ STANDALONE_SERVICE_CHECK = 'spark.standalone_master.can_connect'
 TEST_USERNAME = 'admin'
 TEST_PASSWORD = 'password'
 
+YARN_APP_ID_TAG = ['app_id:' + SPARK_APP_ID]
+SPARK_APP_ID_TAG = ['app_id:' + SPARK_APP_ID]
+SPARK_APP_ID_TAG_PRE20 = ['app_id:' + APP_NAME]
 CUSTOM_TAGS = ['optional:tag1']
 COMMON_TAGS = [
     'app_name:' + APP_NAME,
@@ -697,32 +700,32 @@ def test_yarn(aggregator, dd_run_check):
             aggregator,
             [
                 # Check the succeeded job metrics
-                (SPARK_JOB_SUCCEEDED_METRIC_VALUES, SPARK_JOB_SUCCEEDED_METRIC_TAGS + CUSTOM_TAGS),
+                (SPARK_JOB_SUCCEEDED_METRIC_VALUES, SPARK_JOB_SUCCEEDED_METRIC_TAGS + CUSTOM_TAGS + YARN_APP_ID_TAG),
                 # Check the running stage metrics
-                (SPARK_STAGE_RUNNING_METRIC_VALUES, SPARK_STAGE_RUNNING_METRIC_TAGS + CUSTOM_TAGS),
+                (SPARK_STAGE_RUNNING_METRIC_VALUES, SPARK_STAGE_RUNNING_METRIC_TAGS + CUSTOM_TAGS + YARN_APP_ID_TAG),
                 # Check the complete stage metrics
-                (SPARK_STAGE_COMPLETE_METRIC_VALUES, SPARK_STAGE_COMPLETE_METRIC_TAGS + CUSTOM_TAGS),
+                (SPARK_STAGE_COMPLETE_METRIC_VALUES, SPARK_STAGE_COMPLETE_METRIC_TAGS + CUSTOM_TAGS + YARN_APP_ID_TAG),
                 # Check the driver metrics
-                (SPARK_DRIVER_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS),
+                (SPARK_DRIVER_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS + YARN_APP_ID_TAG),
                 # Check the optional driver metrics
-                (SPARK_DRIVER_OPTIONAL_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS),
+                (SPARK_DRIVER_OPTIONAL_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS + YARN_APP_ID_TAG),
                 # Check the executor level metrics
-                (SPARK_EXECUTOR_LEVEL_METRIC_VALUES, SPARK_EXECUTOR_LEVEL_METRIC_TAGS + CUSTOM_TAGS),
+                (SPARK_EXECUTOR_LEVEL_METRIC_VALUES, SPARK_EXECUTOR_LEVEL_METRIC_TAGS + CUSTOM_TAGS + YARN_APP_ID_TAG),
                 # Check the optional executor level metrics
                 (
                     SPARK_EXECUTOR_LEVEL_OPTIONAL_PROCESS_TREE_METRIC_VALUES,
-                    SPARK_EXECUTOR_LEVEL_METRIC_TAGS + CUSTOM_TAGS,
+                    SPARK_EXECUTOR_LEVEL_METRIC_TAGS + CUSTOM_TAGS + YARN_APP_ID_TAG,
                 ),
                 # Check the summary executor metrics
-                (SPARK_EXECUTOR_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS),
+                (SPARK_EXECUTOR_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS + YARN_APP_ID_TAG),
                 # Check the optional summary executor metrics
-                (SPARK_EXECUTOR_OPTIONAL_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS),
+                (SPARK_EXECUTOR_OPTIONAL_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS + YARN_APP_ID_TAG),
                 # Check the RDD metrics
-                (SPARK_RDD_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS),
+                (SPARK_RDD_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS + YARN_APP_ID_TAG),
                 # Check the streaming statistics metrics
-                (SPARK_STREAMING_STATISTICS_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS),
+                (SPARK_STREAMING_STATISTICS_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS + YARN_APP_ID_TAG),
                 # Check the structured streaming metrics
-                (SPARK_STRUCTURED_STREAMING_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS),
+                (SPARK_STRUCTURED_STREAMING_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS + YARN_APP_ID_TAG),
             ],
         )
         tags = ['url:http://localhost:8088'] + CLUSTER_TAGS + CUSTOM_TAGS
@@ -767,38 +770,39 @@ def test_mesos(aggregator, dd_run_check):
     with mock.patch('requests.Session.get', mesos_requests_get_mock):
         c = SparkCheck('spark', {}, [MESOS_CONFIG])
         dd_run_check(c)
+
         _assert(
             aggregator,
             [
                 # Check the running job metrics
-                (SPARK_JOB_RUNNING_METRIC_VALUES, SPARK_JOB_RUNNING_METRIC_TAGS + CUSTOM_TAGS),
+                (SPARK_JOB_RUNNING_METRIC_VALUES, SPARK_JOB_RUNNING_METRIC_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the succeeded job metrics
-                (SPARK_JOB_SUCCEEDED_METRIC_VALUES, SPARK_JOB_SUCCEEDED_METRIC_TAGS + CUSTOM_TAGS),
+                (SPARK_JOB_SUCCEEDED_METRIC_VALUES, SPARK_JOB_SUCCEEDED_METRIC_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the running stage metrics
-                (SPARK_STAGE_RUNNING_METRIC_VALUES, SPARK_STAGE_RUNNING_METRIC_TAGS + CUSTOM_TAGS),
+                (SPARK_STAGE_RUNNING_METRIC_VALUES, SPARK_STAGE_RUNNING_METRIC_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the complete stage metrics
-                (SPARK_STAGE_COMPLETE_METRIC_VALUES, SPARK_STAGE_COMPLETE_METRIC_TAGS + CUSTOM_TAGS),
+                (SPARK_STAGE_COMPLETE_METRIC_VALUES, SPARK_STAGE_COMPLETE_METRIC_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the driver metrics
-                (SPARK_DRIVER_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS),
+                (SPARK_DRIVER_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the optional driver metrics
-                (SPARK_DRIVER_OPTIONAL_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS),
+                (SPARK_DRIVER_OPTIONAL_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the executor level metrics
-                (SPARK_EXECUTOR_LEVEL_METRIC_VALUES, SPARK_EXECUTOR_LEVEL_METRIC_TAGS + CUSTOM_TAGS),
+                (SPARK_EXECUTOR_LEVEL_METRIC_VALUES, SPARK_EXECUTOR_LEVEL_METRIC_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the optional executor level metrics
                 (
                     SPARK_EXECUTOR_LEVEL_OPTIONAL_PROCESS_TREE_METRIC_VALUES,
-                    SPARK_EXECUTOR_LEVEL_METRIC_TAGS + CUSTOM_TAGS,
+                    SPARK_EXECUTOR_LEVEL_METRIC_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG,
                 ),
                 # Check the summary executor metrics
-                (SPARK_EXECUTOR_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS),
+                (SPARK_EXECUTOR_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the optional summary executor metrics
-                (SPARK_EXECUTOR_OPTIONAL_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS),
+                (SPARK_EXECUTOR_OPTIONAL_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the RDD metrics
-                (SPARK_RDD_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS),
+                (SPARK_RDD_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the streaming statistics metrics,
-                (SPARK_STREAMING_STATISTICS_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS),
+                (SPARK_STREAMING_STATISTICS_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the structured streaming metrics
-                (SPARK_STRUCTURED_STREAMING_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS),
+                (SPARK_STRUCTURED_STREAMING_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
             ],
         )
         # Check the service tests
@@ -844,34 +848,34 @@ def test_driver_unit(aggregator, dd_run_check):
             aggregator,
             [
                 # Check the running job metrics
-                (SPARK_JOB_RUNNING_METRIC_VALUES, SPARK_JOB_RUNNING_METRIC_TAGS + CUSTOM_TAGS),
+                (SPARK_JOB_RUNNING_METRIC_VALUES, SPARK_JOB_RUNNING_METRIC_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the succeeded job metrics
-                (SPARK_JOB_SUCCEEDED_METRIC_VALUES, SPARK_JOB_SUCCEEDED_METRIC_TAGS + CUSTOM_TAGS),
+                (SPARK_JOB_SUCCEEDED_METRIC_VALUES, SPARK_JOB_SUCCEEDED_METRIC_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the running stage metrics
-                (SPARK_STAGE_RUNNING_METRIC_VALUES, SPARK_STAGE_RUNNING_METRIC_TAGS + CUSTOM_TAGS),
+                (SPARK_STAGE_RUNNING_METRIC_VALUES, SPARK_STAGE_RUNNING_METRIC_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the complete stage metrics
-                (SPARK_STAGE_COMPLETE_METRIC_VALUES, SPARK_STAGE_COMPLETE_METRIC_TAGS + CUSTOM_TAGS),
+                (SPARK_STAGE_COMPLETE_METRIC_VALUES, SPARK_STAGE_COMPLETE_METRIC_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the driver metrics
-                (SPARK_DRIVER_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS),
+                (SPARK_DRIVER_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the optional driver metrics
-                (SPARK_DRIVER_OPTIONAL_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS),
+                (SPARK_DRIVER_OPTIONAL_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the executor level metrics
-                (SPARK_EXECUTOR_LEVEL_METRIC_VALUES, SPARK_EXECUTOR_LEVEL_METRIC_TAGS + CUSTOM_TAGS),
+                (SPARK_EXECUTOR_LEVEL_METRIC_VALUES, SPARK_EXECUTOR_LEVEL_METRIC_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the optional executor level metrics
                 (
                     SPARK_EXECUTOR_LEVEL_OPTIONAL_PROCESS_TREE_METRIC_VALUES,
-                    SPARK_EXECUTOR_LEVEL_METRIC_TAGS + CUSTOM_TAGS,
+                    SPARK_EXECUTOR_LEVEL_METRIC_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG,
                 ),
                 # Check the summary executor metrics
-                (SPARK_EXECUTOR_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS),
+                (SPARK_EXECUTOR_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the optional summary executor metrics
-                (SPARK_EXECUTOR_OPTIONAL_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS),
+                (SPARK_EXECUTOR_OPTIONAL_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the RDD metrics
-                (SPARK_RDD_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS),
+                (SPARK_RDD_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the streaming statistics metrics
-                (SPARK_STREAMING_STATISTICS_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS),
+                (SPARK_STREAMING_STATISTICS_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
                 # Check the structured streaming metrics
-                (SPARK_STRUCTURED_STREAMING_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS),
+                (SPARK_STRUCTURED_STREAMING_METRIC_VALUES, COMMON_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
             ],
         )
         # Check the service tests
@@ -904,33 +908,36 @@ def test_standalone_unit(aggregator, dd_run_check):
             aggregator,
             [
                 # Check the running job metrics
-                (SPARK_JOB_RUNNING_METRIC_VALUES, SPARK_JOB_RUNNING_METRIC_TAGS),
+                (SPARK_JOB_RUNNING_METRIC_VALUES, SPARK_JOB_RUNNING_METRIC_TAGS + SPARK_APP_ID_TAG),
                 # Check the running job metrics
-                (SPARK_JOB_RUNNING_METRIC_VALUES, SPARK_JOB_RUNNING_METRIC_TAGS),
+                (SPARK_JOB_RUNNING_METRIC_VALUES, SPARK_JOB_RUNNING_METRIC_TAGS + SPARK_APP_ID_TAG),
                 # Check the succeeded job metrics
-                (SPARK_JOB_SUCCEEDED_METRIC_VALUES, SPARK_JOB_SUCCEEDED_METRIC_TAGS),
+                (SPARK_JOB_SUCCEEDED_METRIC_VALUES, SPARK_JOB_SUCCEEDED_METRIC_TAGS + SPARK_APP_ID_TAG),
                 # Check the running stage metrics
-                (SPARK_STAGE_RUNNING_METRIC_VALUES, SPARK_STAGE_RUNNING_METRIC_TAGS),
+                (SPARK_STAGE_RUNNING_METRIC_VALUES, SPARK_STAGE_RUNNING_METRIC_TAGS + SPARK_APP_ID_TAG),
                 # Check the complete stage metrics
-                (SPARK_STAGE_COMPLETE_METRIC_VALUES, SPARK_STAGE_COMPLETE_METRIC_TAGS),
+                (SPARK_STAGE_COMPLETE_METRIC_VALUES, SPARK_STAGE_COMPLETE_METRIC_TAGS + SPARK_APP_ID_TAG),
                 # Check the driver metrics
-                (SPARK_DRIVER_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_DRIVER_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG),
                 # Check the optional driver metrics
-                (SPARK_DRIVER_OPTIONAL_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_DRIVER_OPTIONAL_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG),
                 # Check the executor level metrics
-                (SPARK_EXECUTOR_LEVEL_METRIC_VALUES, SPARK_EXECUTOR_LEVEL_METRIC_TAGS),
+                (SPARK_EXECUTOR_LEVEL_METRIC_VALUES, SPARK_EXECUTOR_LEVEL_METRIC_TAGS + SPARK_APP_ID_TAG),
                 # Check the optional executor level metrics
-                (SPARK_EXECUTOR_LEVEL_OPTIONAL_PROCESS_TREE_METRIC_VALUES, SPARK_EXECUTOR_LEVEL_METRIC_TAGS),
+                (
+                    SPARK_EXECUTOR_LEVEL_OPTIONAL_PROCESS_TREE_METRIC_VALUES,
+                    SPARK_EXECUTOR_LEVEL_METRIC_TAGS + SPARK_APP_ID_TAG,
+                ),
                 # Check the executor metrics
-                (SPARK_EXECUTOR_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_EXECUTOR_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG),
                 # Check the optional summary executor metrics
-                (SPARK_EXECUTOR_OPTIONAL_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_EXECUTOR_OPTIONAL_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG),
                 # Check the RDD metrics
-                (SPARK_RDD_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_RDD_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG),
                 # Check the streaming statistics metrics
-                (SPARK_STREAMING_STATISTICS_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_STREAMING_STATISTICS_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG),
                 # Check the structured streaming metrics
-                (SPARK_STRUCTURED_STREAMING_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_STRUCTURED_STREAMING_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG),
             ],
         )
         # Check the service tests
@@ -956,29 +963,32 @@ def test_standalone_stage_disabled_unit(aggregator, dd_run_check):
             aggregator,
             [
                 # Check the running job metrics
-                (SPARK_JOB_RUNNING_METRIC_VALUES, SPARK_JOB_RUNNING_NO_STAGE_METRIC_TAGS),
+                (SPARK_JOB_RUNNING_METRIC_VALUES, SPARK_JOB_RUNNING_NO_STAGE_METRIC_TAGS + SPARK_APP_ID_TAG),
                 # Check the running job metrics
-                (SPARK_JOB_RUNNING_METRIC_VALUES, SPARK_JOB_RUNNING_NO_STAGE_METRIC_TAGS),
+                (SPARK_JOB_RUNNING_METRIC_VALUES, SPARK_JOB_RUNNING_NO_STAGE_METRIC_TAGS + SPARK_APP_ID_TAG),
                 # Check the succeeded job metrics
-                (SPARK_JOB_SUCCEEDED_METRIC_VALUES, SPARK_JOB_SUCCEEDED_NO_STAGE_METRIC_TAGS),
+                (SPARK_JOB_SUCCEEDED_METRIC_VALUES, SPARK_JOB_SUCCEEDED_NO_STAGE_METRIC_TAGS + SPARK_APP_ID_TAG),
                 # Check the driver metrics
-                (SPARK_DRIVER_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_DRIVER_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG),
                 # Check the optional driver metrics
-                (SPARK_DRIVER_OPTIONAL_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_DRIVER_OPTIONAL_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG),
                 # Check the executor level metrics
-                (SPARK_EXECUTOR_LEVEL_METRIC_VALUES, SPARK_EXECUTOR_LEVEL_METRIC_TAGS),
+                (SPARK_EXECUTOR_LEVEL_METRIC_VALUES, SPARK_EXECUTOR_LEVEL_METRIC_TAGS + SPARK_APP_ID_TAG),
                 # Check the optional executor level metrics
-                (SPARK_EXECUTOR_LEVEL_OPTIONAL_PROCESS_TREE_METRIC_VALUES, SPARK_EXECUTOR_LEVEL_METRIC_TAGS),
+                (
+                    SPARK_EXECUTOR_LEVEL_OPTIONAL_PROCESS_TREE_METRIC_VALUES,
+                    SPARK_EXECUTOR_LEVEL_METRIC_TAGS + SPARK_APP_ID_TAG,
+                ),
                 # Check the executor metrics
-                (SPARK_EXECUTOR_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_EXECUTOR_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG),
                 # Check the optional summary executor metrics
-                (SPARK_EXECUTOR_OPTIONAL_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_EXECUTOR_OPTIONAL_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG),
                 # Check the RDD metrics
-                (SPARK_RDD_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_RDD_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG),
                 # Check the streaming statistics metrics
-                (SPARK_STREAMING_STATISTICS_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_STREAMING_STATISTICS_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG),
                 # Check the structured streaming metrics
-                (SPARK_STRUCTURED_STREAMING_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_STRUCTURED_STREAMING_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG),
             ],
         )
         # Check the service tests
@@ -1004,33 +1014,36 @@ def test_standalone_unit_with_proxy_warning_page(aggregator, dd_run_check):
             aggregator,
             [
                 # Check the running job metrics
-                (SPARK_JOB_RUNNING_METRIC_VALUES, SPARK_JOB_RUNNING_METRIC_TAGS),
+                (SPARK_JOB_RUNNING_METRIC_VALUES, SPARK_JOB_RUNNING_METRIC_TAGS + SPARK_APP_ID_TAG),
                 # Check the running job metrics
-                (SPARK_JOB_RUNNING_METRIC_VALUES, SPARK_JOB_RUNNING_METRIC_TAGS),
+                (SPARK_JOB_RUNNING_METRIC_VALUES, SPARK_JOB_RUNNING_METRIC_TAGS + SPARK_APP_ID_TAG),
                 # Check the succeeded job metrics
-                (SPARK_JOB_SUCCEEDED_METRIC_VALUES, SPARK_JOB_SUCCEEDED_METRIC_TAGS),
+                (SPARK_JOB_SUCCEEDED_METRIC_VALUES, SPARK_JOB_SUCCEEDED_METRIC_TAGS + SPARK_APP_ID_TAG),
                 # Check the running stage metrics
-                (SPARK_STAGE_RUNNING_METRIC_VALUES, SPARK_STAGE_RUNNING_METRIC_TAGS),
+                (SPARK_STAGE_RUNNING_METRIC_VALUES, SPARK_STAGE_RUNNING_METRIC_TAGS + SPARK_APP_ID_TAG),
                 # Check the complete stage metrics
-                (SPARK_STAGE_COMPLETE_METRIC_VALUES, SPARK_STAGE_COMPLETE_METRIC_TAGS),
+                (SPARK_STAGE_COMPLETE_METRIC_VALUES, SPARK_STAGE_COMPLETE_METRIC_TAGS + SPARK_APP_ID_TAG),
                 # Check the driver metrics
-                (SPARK_DRIVER_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_DRIVER_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG),
                 # Check the optional driver metrics
-                (SPARK_DRIVER_OPTIONAL_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_DRIVER_OPTIONAL_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG),
                 # Check the executor level metrics
-                (SPARK_EXECUTOR_LEVEL_METRIC_VALUES, SPARK_EXECUTOR_LEVEL_METRIC_TAGS),
+                (SPARK_EXECUTOR_LEVEL_METRIC_VALUES, SPARK_EXECUTOR_LEVEL_METRIC_TAGS + SPARK_APP_ID_TAG),
                 # Check the optional executor level metrics
-                (SPARK_EXECUTOR_LEVEL_OPTIONAL_PROCESS_TREE_METRIC_VALUES, SPARK_EXECUTOR_LEVEL_METRIC_TAGS),
+                (
+                    SPARK_EXECUTOR_LEVEL_OPTIONAL_PROCESS_TREE_METRIC_VALUES,
+                    SPARK_EXECUTOR_LEVEL_METRIC_TAGS + SPARK_APP_ID_TAG,
+                ),
                 # Check the summary executor metrics
-                (SPARK_EXECUTOR_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_EXECUTOR_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG),
                 # Check the optional summary executor metrics
-                (SPARK_EXECUTOR_OPTIONAL_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_EXECUTOR_OPTIONAL_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG),
                 # Check the RDD metrics
-                (SPARK_RDD_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_RDD_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG),
                 # Check the streaming statistics metrics
-                (SPARK_STREAMING_STATISTICS_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_STREAMING_STATISTICS_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG),
                 # Check the structured streaming metrics
-                (SPARK_STRUCTURED_STREAMING_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_STRUCTURED_STREAMING_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG),
             ],
         )
 
@@ -1057,33 +1070,36 @@ def test_standalone_pre20(aggregator, dd_run_check):
             aggregator,
             [
                 # Check the running job metrics
-                (SPARK_JOB_RUNNING_METRIC_VALUES, SPARK_JOB_RUNNING_METRIC_TAGS),
+                (SPARK_JOB_RUNNING_METRIC_VALUES, SPARK_JOB_RUNNING_METRIC_TAGS + SPARK_APP_ID_TAG_PRE20),
                 # Check the running job metrics
-                (SPARK_JOB_RUNNING_METRIC_VALUES, SPARK_JOB_RUNNING_METRIC_TAGS),
+                (SPARK_JOB_RUNNING_METRIC_VALUES, SPARK_JOB_RUNNING_METRIC_TAGS + SPARK_APP_ID_TAG_PRE20),
                 # Check the succeeded job metrics
-                (SPARK_JOB_SUCCEEDED_METRIC_VALUES, SPARK_JOB_SUCCEEDED_METRIC_TAGS),
+                (SPARK_JOB_SUCCEEDED_METRIC_VALUES, SPARK_JOB_SUCCEEDED_METRIC_TAGS + SPARK_APP_ID_TAG_PRE20),
                 # Check the running stage metrics
-                (SPARK_STAGE_RUNNING_METRIC_VALUES, SPARK_STAGE_RUNNING_METRIC_TAGS),
+                (SPARK_STAGE_RUNNING_METRIC_VALUES, SPARK_STAGE_RUNNING_METRIC_TAGS + SPARK_APP_ID_TAG_PRE20),
                 # Check the complete stage metrics
-                (SPARK_STAGE_COMPLETE_METRIC_VALUES, SPARK_STAGE_COMPLETE_METRIC_TAGS),
+                (SPARK_STAGE_COMPLETE_METRIC_VALUES, SPARK_STAGE_COMPLETE_METRIC_TAGS + SPARK_APP_ID_TAG_PRE20),
                 # Check the driver metrics
-                (SPARK_DRIVER_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_DRIVER_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG_PRE20),
                 # Check the optional driver metrics
-                (SPARK_DRIVER_OPTIONAL_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_DRIVER_OPTIONAL_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG_PRE20),
                 # Check the executor level metrics
-                (SPARK_EXECUTOR_LEVEL_METRIC_VALUES, SPARK_EXECUTOR_LEVEL_METRIC_TAGS),
+                (SPARK_EXECUTOR_LEVEL_METRIC_VALUES, SPARK_EXECUTOR_LEVEL_METRIC_TAGS + SPARK_APP_ID_TAG_PRE20),
                 # Check the optional executor level metrics
-                (SPARK_EXECUTOR_LEVEL_OPTIONAL_PROCESS_TREE_METRIC_VALUES, SPARK_EXECUTOR_LEVEL_METRIC_TAGS),
+                (
+                    SPARK_EXECUTOR_LEVEL_OPTIONAL_PROCESS_TREE_METRIC_VALUES,
+                    SPARK_EXECUTOR_LEVEL_METRIC_TAGS + SPARK_APP_ID_TAG_PRE20,
+                ),
                 # Check the summary executor metrics
-                (SPARK_EXECUTOR_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_EXECUTOR_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG_PRE20),
                 # Check the optional summary executor metrics
-                (SPARK_EXECUTOR_OPTIONAL_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_EXECUTOR_OPTIONAL_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG_PRE20),
                 # Check the RDD metrics
-                (SPARK_RDD_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_RDD_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG_PRE20),
                 # Check the streaming statistics metrics
-                (SPARK_STREAMING_STATISTICS_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_STREAMING_STATISTICS_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG_PRE20),
                 # Check the structured streaming metrics
-                (SPARK_STRUCTURED_STREAMING_METRIC_VALUES, COMMON_TAGS),
+                (SPARK_STRUCTURED_STREAMING_METRIC_VALUES, COMMON_TAGS + SPARK_APP_ID_TAG_PRE20),
             ],
         )
 
@@ -1144,11 +1160,11 @@ def test_disable_legacy_cluster_tags(aggregator, dd_run_check):
 @pytest.mark.parametrize(
     "instance, requests_get_mock, base_tags",
     [
-        (DRIVER_CONFIG, driver_requests_get_mock, COMMON_TAGS + CUSTOM_TAGS),
-        (YARN_CONFIG, yarn_requests_get_mock, COMMON_TAGS + CUSTOM_TAGS),
-        (MESOS_CONFIG, mesos_requests_get_mock, COMMON_TAGS + CUSTOM_TAGS),
-        (STANDALONE_CONFIG, standalone_requests_get_mock, COMMON_TAGS),
-        (STANDALONE_CONFIG_PRE_20, standalone_requests_pre20_get_mock, COMMON_TAGS),
+        (DRIVER_CONFIG, driver_requests_get_mock, COMMON_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
+        (YARN_CONFIG, yarn_requests_get_mock, COMMON_TAGS + CUSTOM_TAGS + YARN_APP_ID_TAG),
+        (MESOS_CONFIG, mesos_requests_get_mock, COMMON_TAGS + CUSTOM_TAGS + SPARK_APP_ID_TAG),
+        (STANDALONE_CONFIG, standalone_requests_get_mock, COMMON_TAGS + SPARK_APP_ID_TAG),
+        (STANDALONE_CONFIG_PRE_20, standalone_requests_pre20_get_mock, COMMON_TAGS + SPARK_APP_ID_TAG_PRE20),
     ],
     ids=["driver", "yarn", "mesos", "standalone", "standalone_pre_20"],
 )


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- Adds a tag `app_id` to metrics produced by the Spark integration

### Motivation
<!-- What inspired you to submit this pull request? -->

In Databricks, `app_name` is set generically to `databricks_shell` or similar, which renders it unusable in that env (`app_name` is still useful for vanilla Spark, though). Add `app_id` instead to differentiate between different jobs in Databricks. 

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
