### PR TITLE
Fix regression in tag-job in test-target when running on forks

### DIFF
--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -183,7 +183,7 @@ jobs:
 
     - name: Tag job for CI Visibility
       # Skip on fork PRs and non-core repos since secrets won't be available
-      if: env.INPUT_IS_FORK != 'true' || env.INPUT_REPO == 'core'
+      if: env.INPUT_IS_FORK != 'true' && env.INPUT_REPO == 'core'
       uses: ./.github/actions/tag-job
       with:
         tags: ${{ env.DD_TAGS }}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Rolback a regression in the fork check when tagging jobs in test-target. Seems that I modified this by mistake and was missed on a previous PR.

### Motivation
<!-- What inspired you to submit this pull request? -->
Need to be able to run in forks

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
