### PR TITLE
Update dependabot config and avoid running tag job in dependabot prs

### DIFF
--- a/.github/actions/tag-job/action.yml
+++ b/.github/actions/tag-job/action.yml
@@ -16,12 +16,46 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    # Update this job to inclue any reason why the job should be skipped.
+    - name: Check if job should be tagged
+      id: check_tagging
+      shell: bash
+      env:
+        IS_PR: ${{ github.event_name == 'pull_request' }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+      run: |
+        should_skip="false"
+        skip_reason=""
+
+        if [[ "$IS_PR" == "true" ]]; then
+          if [[ "$PR_AUTHOR" == "dependabot[bot]" ]]; then
+            # Dependabot has no access to secrets so we can't tag the job.
+            should_skip="true"
+            skip_reason="Action is being run from a PR with dependabot as author"
+          elif [[ "$IS_FORK" == "true" ]]; then
+            # Forked repos have no access to secrets so we can't tag the job.
+            should_skip="true"
+            skip_reason="Action is being run from a fork"
+          fi
+        fi
+
+        echo "should_skip=$should_skip" >> $GITHUB_OUTPUT
+        echo "skip_reason=$skip_reason" >> $GITHUB_OUTPUT
+
+    - name: Log skip reason
+      if: steps.check_tagging.outputs.should_skip == 'true'
+      shell: bash
+      run: |
+        echo "Skipping tagging. Reason: ${{ steps.check_tagging.outputs.skip_reason }}"
+
     - name: Set up Node.js
       uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
       with:
         node-version: '20'
 
     - name: Install datadog-ci and tag job
+      if: steps.check_tagging.outputs.should_skip != 'true'
       shell: bash
       env:
         DATADOG_API_KEY: ${{ inputs.dd_api_key }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,7 @@
 version: 2
+
 updates:
+  # For dependabot to update actions in composite actions we need to have separate entries for each directory.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -8,8 +10,24 @@ updates:
       time: "06:00"
     # Group all actions updates together in the same PR
     groups:
-       actions:
-          patterns:
-             - "*"
+      actions:
+        patterns:
+          - "*"
     labels:
-    - dependabot
+      - dependabot/actions
+      - qa/skip-qa
+
+  - package-ecosystem: "github-actions"
+    directory: "/actions/tag-job"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+    # Group all actions updates together in the same PR
+    groups:
+      actions:
+        patterns:
+          - "*"
+    labels:
+      - dependabot/actions
+      - qa/skip-qa


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
- Updates dependabot config to ensure we are updating actions in the repo's composite actions.
- Workflows run in dependabot PRs run in read only mode. We are also avoiding tagging the job since we have no way of reporting that information to DD without being able to read secrets.

### Motivation
<!-- What inspired you to submit this pull request? -->
Ensure dependabot udpates all actions and we can validate our workflows after the actions have been udpated in the pr.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
