### PR TITLE
Add DDQA conf for network path

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -104,6 +104,13 @@ jira_statuses = [
 github_team = "ndm-integrations"
 github_labels = ["team/ndm-integrations"]
 
+[teams."Network Path"]
+jira_project = "NETPATH"
+jira_issue_type = "Task"
+jira_statuses = ["To Do", "In Progress", "Done"]
+github_team = "network-path"
+github_labels = ["team/network-path"]
+
 [teams."Windows Agent"]
 jira_project = "WINA"
 jira_issue_type = "QA Task"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add DDQA conf for network path. QA tickets are currently routed to NDM

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
