### PR TITLE
Update NDM Core Jira

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -71,20 +71,9 @@ jira_statuses = [
 github_team = "database-monitoring"
 github_labels = ["team/database-monitoring", "team/database-monitoring-agent"]
 
-[teams."Network Device Monitoring"]
-jira_project = "NDMII"
-jira_issue_type = "Task"
-jira_statuses = [
-  "To Do",
-  "In Progress",
-  "Done",
-]
-github_team = "network-device-monitoring"
-github_labels = ["team/network-device-monitoring"]
-
 [teams."Network Device Monitoring Core"]
-jira_project = "NDMII"
-jira_issue_type = "Task"
+jira_project = "NDMC"
+jira_issue_type = "Bug"
 jira_statuses = [
   "To Do",
   "In Progress",


### PR DESCRIPTION
Use new jira project for NDM Core.

Additionally, I'm taking one step further in the ownership split between NDM Core vs NDM Int by removing mentions of NDM as one team.

Related:

https://github.com/DataDog/datadog-agent/pull/45621