### PR TITLE
Add a test for search_string with spaces

### DIFF
--- a/process/tests/test_process.py
+++ b/process/tests/test_process.py
@@ -251,9 +251,6 @@ def test_check_missing_process_with_spaces(aggregator, dd_run_check, caplog):
 def test_search_string_with_spaces(mock_process_iter, aggregator, dd_run_check):
     instance = {'name': 'foo', 'search_string': ['foo bar --baz'], 'exact_match': False}
     process = ProcessCheck(common.CHECK_NAME, {}, [instance])
-    pids = process.find_pids(instance['name'], instance['search_string'], instance['exact_match'])
-    assert pids == {123}
-
     dd_run_check(process)
     expected_tags = generate_expected_tags(instance)
     aggregator.assert_metric('system.processes.number', value=1, tags=expected_tags)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds a test to verify the use case where the `search_string` property contains spaces.

### Motivation
<!-- What inspired you to submit this pull request? -->
Our current implementation already support this use case, it's good to add to protect it from regressions and to serve as documentation.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
