### PR TITLE
[dbm] Fix MySQL to collect both standard and group replication metrics

### DIFF
--- a/mysql/changelog.d/22452.fixed
+++ b/mysql/changelog.d/22452.fixed
@@ -1,0 +1,1 @@
+Collect both standard and group replication metrics when group replication is active

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -686,15 +686,15 @@ class MySql(DatabaseCheck):
             metrics.update(TABLE_VARS)
 
         if self._config.replication_enabled:
+            with tracked_query(self, operation="replication_metrics"):
+                replication_metrics = self._collect_replication_metrics(db, results, above_560)
+            metrics.update(replication_metrics)
+            self._check_replication_status(results)
+
             if self.global_variables.performance_schema_enabled and self._group_replication_active:
                 self.log.debug('Collecting group replication metrics.')
                 with tracked_query(self, operation="group_replication_metrics"):
                     self._collect_group_replica_metrics(db, results)
-            else:
-                with tracked_query(self, operation="replication_metrics"):
-                    replication_metrics = self._collect_replication_metrics(db, results, above_560)
-                metrics.update(replication_metrics)
-                self._check_replication_status(results)
 
         if len(self._config.additional_status) > 0:
             additional_status_dict = {}

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -199,6 +199,8 @@ def _assert_complex_config(
 
     operation_time_metrics = variables.SIMPLE_OPERATION_TIME_METRICS + variables.COMPLEX_OPERATION_TIME_METRICS
 
+    operation_time_metrics.extend(variables.REPLICATION_OPERATION_TIME_METRICS)
+
     if MYSQL_REPLICATION == 'group':
         testable_metrics.extend(variables.GROUP_REPLICATION_VARS)
         group_replication_tags = ('channel_name:group_replication_applier', 'member_state:ONLINE')
@@ -212,8 +214,6 @@ def _assert_complex_config(
             count=1,
         )
         operation_time_metrics.extend(variables.GROUP_REPLICATION_OPERATION_TIME_METRICS)
-    else:
-        operation_time_metrics.extend(variables.REPLICATION_OPERATION_TIME_METRICS)
 
     if MYSQL_VERSION_PARSED >= parse_version('5.6'):
         testable_metrics.extend(variables.PERFORMANCE_VARS + variables.COMMON_PERFORMANCE_VARS)


### PR DESCRIPTION
## Summary

A customer reported a bug in MySQL replication metrics collection

- Fix bug where standard replication metrics were skipped when group replication was active
- MySQL allows both standard and group replication to coexist, so both should be monitored
- Now standard replication metrics are always collected when replication is enabled, and group replication metrics are collected additionally when active

## Test plan

- [x] Unit tests pass
- [ ] Run E2E tests with group replication environment (`MYSQL_REPLICATION=group`)
- [ ] Verify both `mysql.replication.*` and `mysql.replication.group.*` metrics are collected when group replication is active

mysql.replication.seconds_behind_master emits when no group replication is enabled
<img width="2964" height="1006" alt="CleanShot 2026-01-29 at 16 56 08@2x" src="https://github.com/user-attachments/assets/f8a69dd2-07f8-4a58-a006-029271bbd0ba" />

mysql.replication.seconds_behind_master emits when group replication is enabled 

replication group metrics emit when group replication is enabled
<img width="2990" height="1624" alt="CleanShot 2026-01-29 at 18 16 06@2x" src="https://github.com/user-attachments/assets/2477ebae-e108-42f6-96a6-be3532b46df1" />


🤖 Generated with [Claude Code](https://claude.ai/code)