### PR TITLE
Update Versa and Cisco SD-WAN dashboards

### DIFF
--- a/cisco_sdwan/assets/dashboards/cisco_sd-wan.json
+++ b/cisco_sdwan/assets/dashboards/cisco_sd-wan.json
@@ -2891,6 +2891,5 @@
     ],
     "layout_type": "ordered",
     "notify_list": [],
-    "pause_auto_refresh": false,
     "reflow_type": "fixed"
 }

--- a/versa/assets/dashboards/versa.json
+++ b/versa/assets/dashboards/versa.json
@@ -2856,6 +2856,5 @@
   ],
   "layout_type": "ordered",
   "notify_list": [],
-  "pause_auto_refresh": false,
   "reflow_type": "fixed"
 }


### PR DESCRIPTION
### What does this PR do?
Updates the OOTB dashboards from Versa and Cisco ACI to be up to date with @kylerkang 's desired version found [here](https://demo.datadoghq.com/dashboard/72p-qvw-5vi?fromUser=false&refresh_mode=sliding&storage=flex_tier&from_ts=1769697769831&to_ts=1769701369831&live=true)  (demo org) and [here](https://demo.datadoghq.com/dashboard/dk8-iqi-j5r/cisco-sd-wan-cloned?fromUser=false&refresh_mode=sliding&from_ts=1769699877236&to_ts=1769703477236&live=true) (demo org)


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
