### PR TITLE
Replace requests library with httpx

### DIFF
--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -1,4 +1,5 @@
 aerospike==7.1.1; sys_platform != 'win32' and sys_platform != 'darwin'
+authlib==1.6.6
 aws-requests-auth==0.4.3
 azure-identity==1.24.0
 beautifulsoup4==4.13.5
@@ -15,6 +16,9 @@ dnspython==2.7.0
 fastavro==1.12.0
 foundationdb==6.3.25
 hazelcast-python-client==5.5.0
+httpx-gssapi==1.0.0
+httpx-ntlm==1.3.0
+httpx==0.28.1
 in-toto==2.0.0
 jellyfish==1.2.0
 kubernetes==33.1.0
@@ -50,12 +54,9 @@ pyvmomi==8.0.3.0.1
 pywin32==311; sys_platform == 'win32'
 pyyaml==6.0.2
 redis==6.2.0
-requests-kerberos==0.15.0
 requests-ntlm==1.3.0
 requests-oauthlib==2.0.0
 requests-toolbelt==1.0.0
-requests-unixsocket2==1.0.0
-requests==2.32.5
 rethinkdb==2.4.10.post1
 securesystemslib[crypto,pynacl]==0.28.0
 semver==3.0.4

--- a/datadog_checks_base/changelog.d/22466.changed
+++ b/datadog_checks_base/changelog.d/22466.changed
@@ -1,0 +1,1 @@
+Replace requests library with httpx

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -38,6 +38,7 @@ deps = [
     "cachetools==6.2.0",
     "cryptography==45.0.6",
     "ddtrace==3.16.4",
+    "httpx==0.28.1",
     "jellyfish==1.2.0",
     "lazy-loader==0.4",
     "prometheus-client==0.22.1",
@@ -47,22 +48,20 @@ deps = [
     "pywin32==311; sys_platform == 'win32'",
     "pyyaml==6.0.2",
     "requests-toolbelt==1.0.0",
-    "requests-unixsocket2==1.0.0",
-    "requests==2.32.5",
     "simplejson==3.20.1",
     "urllib3==2.6.3",
     "wrapt==1.17.3",
 ]
 http = [
+    "authlib==1.6.6",
     "aws-requests-auth==0.4.3",
     "botocore==1.40.21",
+    "httpx-gssapi==1.0.0",
+    "httpx-ntlm==1.3.0",
     "oauthlib==3.3.1",
     "pyjwt==2.10.1",
     "pyopenssl==25.1.0",
     "pysocks==1.7.1",
-    "requests-kerberos==0.15.0",
-    "requests-ntlm==1.3.0",
-    "requests-oauthlib==2.0.0",
 ]
 json = [
     "orjson==3.11.3",

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -56,7 +56,7 @@ http = [
     "authlib==1.6.6",
     "aws-requests-auth==0.4.3",
     "botocore==1.40.21",
-    "httpx-gssapi==1.0.0",
+    "httpx-gssapi==0.6.0",
     "httpx-ntlm==1.3.0",
     "oauthlib==3.3.1",
     "pyjwt==2.10.1",


### PR DESCRIPTION
- Replace requests==2.32.5 with httpx==0.28.1 in dependencies

- Migrate authentication libraries: requests-kerberos→httpx-gssapi, requests-ntlm→httpx-ntlm, requests-oauthlib→authlib

- Replace requests.Session with httpx.Client for HTTP connection management

- Convert SSL/TLS adapter-based approach to httpx.HTTPTransport with SSL context

- Update ResponseWrapper to use httpx streaming API (iter_bytes/iter_text instead of iter_content)

- Migrate all authentication handlers to httpx equivalents (Basic, Digest, NTLM, Kerberos, AWS, OAuth2)

- Convert Unix Domain Socket support from unix:// URL scheme to httpx transport parameter

- Update timeout handling from tuple (connect, read) to httpx.Timeout object

- Replace SSLError exception handling with httpx.ConnectError and httpx.RemoteProtocolError

- Update DCOSAuthTokenReader to use httpx.Client instead of requests.post

Rationale: The requests library lacks native HTTP/2 support and has limited async capabilities. Migrating to httpx provides improved performance through HTTP/2, better connection pooling, and a modern async-ready architecture. This maintains full backward compatibility with existing integrations while positioning the codebase for future async enhancements.

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
