### PR TITLE
Update builders to use new base image

### DIFF
--- a/.builders/images/linux-aarch64/Dockerfile
+++ b/.builders/images/linux-aarch64/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=quay.io/pypa/manylinux2014_aarch64
+ARG BASE_IMAGE=quay.io/pypa/manylinux_2_28_aarch64
 FROM ${BASE_IMAGE}
 
 ARG SOURCE_DATE_EPOCH
@@ -16,9 +16,15 @@ ENV CXXFLAGS="${CFLAGS}"
 ENV LDFLAGS="-Wl,-rpath,'\$\$ORIGIN' -Wl,--strip-debug"
 
 # openssl
-RUN yum install -y perl-IPC-Cmd perl-CPANPLUS perl-core && \
- cpanp -i List::Util 1.66 && \
- DOWNLOAD_URL="https://www.openssl.org/source/openssl-{{version}}.tar.gz" \
+RUN yum install -y \
+    perl-App-cpanminus \
+    perl-ExtUtils-MakeMaker \
+    perl-ExtUtils-ParseXS \
+    perl-IPC-Cmd \
+    perl-Scalar-List-Utils \
+    perl-core \
+    perl-devel
+RUN DOWNLOAD_URL="https://www.openssl.org/source/openssl-{{version}}.tar.gz" \
  VERSION="3.6.1" \
  SHA256="b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a82e" \
  RELATIVE_PATH="openssl-{{version}}" \
@@ -143,6 +149,8 @@ RUN \
 RUN \
  # Add -fPIC to let librdkafka link against it statically
  CFLAGS="${CFLAGS} -fPIC" \
+ # cyrus-sasl 2.1.28 misses some headers on newer toolchains
+ CPPFLAGS="${CPPFLAGS} -D_GNU_SOURCE -include time.h -include stdio.h" \
  # Explicitly ask the linker to use gssapi_krb5, otherwise static compilation fails
  LDFLAGS="${LDFLAGS} -L/usr/local/lib -lgssapi_krb5" \
  DOWNLOAD_URL="https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-{{version}}/cyrus-sasl-{{version}}.tar.gz" \
@@ -187,6 +195,6 @@ RUN python3 -m pip install --no-warn-script-location -r /runner_dependencies.txt
 COPY build_script.sh /build_script.sh
 ENV DD_BUILD_COMMAND="bash /build_script.sh"
 
-ENV MANYLINUX_POLICY="manylinux2014_aarch64"
+ENV MANYLINUX_POLICY="manylinux_2_28_aarch64"
 
 ENTRYPOINT ["python3", "/home/scripts/build_wheels.py"]

--- a/.builders/images/linux-x86_64/Dockerfile
+++ b/.builders/images/linux-x86_64/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=quay.io/pypa/manylinux2014_x86_64
+ARG BASE_IMAGE=quay.io/pypa/manylinux_2_28_x86_64
 FROM ${BASE_IMAGE}
 
 ARG SOURCE_DATE_EPOCH
@@ -16,9 +16,15 @@ ENV CXXFLAGS="${CFLAGS}"
 ENV LDFLAGS="-Wl,-rpath,'\$\$ORIGIN' -Wl,--strip-debug"
 
 # openssl
-RUN yum install -y perl-IPC-Cmd perl-CPANPLUS perl-core && \
- cpanp -i List::Util 1.66 && \
- DOWNLOAD_URL="https://www.openssl.org/source/openssl-{{version}}.tar.gz" \
+RUN yum install -y \
+    perl-App-cpanminus \
+    perl-ExtUtils-MakeMaker \
+    perl-ExtUtils-ParseXS \
+    perl-IPC-Cmd \
+    perl-Scalar-List-Utils \
+    perl-core \
+    perl-devel
+RUN DOWNLOAD_URL="https://www.openssl.org/source/openssl-{{version}}.tar.gz" \
  VERSION="3.6.1" \
  SHA256="b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a82e" \
  RELATIVE_PATH="openssl-{{version}}" \
@@ -147,6 +153,8 @@ RUN \
 RUN \
  # Add -fPIC to let librdkafka link against it statically
  CFLAGS="${CFLAGS} -fPIC" \
+ # cyrus-sasl 2.1.28 misses some headers on newer toolchains
+ CPPFLAGS="${CPPFLAGS} -D_GNU_SOURCE -include time.h -include stdio.h" \
  # Explicitly ask the linker to use gssapi_krb5, otherwise static compilation fails
  LDFLAGS="${LDFLAGS} -L/usr/local/lib -lgssapi_krb5" \
  DOWNLOAD_URL="https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-{{version}}/cyrus-sasl-{{version}}.tar.gz" \
@@ -191,6 +199,6 @@ RUN python3 -m pip install --no-warn-script-location -r /runner_dependencies.txt
 COPY build_script.sh /build_script.sh
 ENV DD_BUILD_COMMAND="bash /build_script.sh"
 
-ENV MANYLINUX_POLICY="manylinux2014_x86_64"
+ENV MANYLINUX_POLICY="manylinux_2_28_x86_64"
 
 ENTRYPOINT ["python3", "/home/scripts/build_wheels.py"]


### PR DESCRIPTION
### What does this PR do?
Update linux builders to new image. A dependency that we're trying to upgrade (confluent-kafka) requires a new header that isn't available in the glibc of manylinux_2014. The next upgrade in pypa catalog is manylinux_2_28:
https://github.com/pypa/manylinux?tab=readme-ov-file#manylinux_2_28-almalinux-8-based

I updated the commands needed to build the deps using this new image.