### PR TITLE
[postgres] Hardcode expected defaults in test_config_defaults.py

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -794,7 +794,7 @@ files:
               - "mydb"
         - name: exclude_databases
           description: |
-            A list of regex patterns to exclude databases. 
+            A list of regex patterns to exclude databases.
             Any database whose name matches any one of these patterns will be excluded.
             If empty, all databases matching other filters are included.
           value:
@@ -803,6 +803,8 @@ files:
               type: string
             example:
               - "privatedb.*"
+            default:
+              - "rdsadmin"
         - name: include_schemas
           description: |
             A list of regex patterns to include schemas. 

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -471,8 +471,11 @@ files:
               - "cloudsqladmin"
               - "rdsadmin"
             display_default:
+              - "template0"
+              - "template1"
+              - "rdsadmin"
+              - "azure_maintenance"
               - "cloudsqladmin"
-              - "rdsadmin" 
               - "alloydbadmin"
               - "alloydbmetadata"
         - name: refresh
@@ -804,7 +807,13 @@ files:
             example:
               - "privatedb.*"
             default:
+              - "template0"
+              - "template1"
               - "rdsadmin"
+              - "azure_maintenance"
+              - "cloudsqladmin"
+              - "alloydbadmin"
+              - "alloydbmetadata"
         - name: include_schemas
           description: |
             A list of regex patterns to include schemas. 

--- a/postgres/changelog.d/22470.fixed
+++ b/postgres/changelog.d/22470.fixed
@@ -1,0 +1,1 @@
+Exclude system and cloud provider admin databases from schema collection by default

--- a/postgres/datadog_checks/postgres/config_models/dict_defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/dict_defaults.py
@@ -7,6 +7,19 @@
 
 from . import instance
 
+# Default databases to exclude from schema collection and autodiscovery.
+# These are system databases or cloud provider admin databases that are not accessible to users.
+# This list should match the default value for `ignore_databases` in spec.yaml.
+DEFAULT_EXCLUDED_DATABASES = [
+    "template0",
+    "template1",
+    "rdsadmin",
+    "azure_maintenance",
+    "cloudsqladmin",
+    "alloydbadmin",
+    "alloydbmetadata",
+]
+
 
 def instance_database_identifier():
     return instance.DatabaseIdentifier(
@@ -20,7 +33,7 @@ def instance_database_autodiscovery():
         global_view_db="postgres",
         max_databases=100,
         include=[".*"],
-        exclude=["cloudsqladmin", "rdsadmin", "alloydbadmin", "alloydbmetadata"],
+        exclude=list(DEFAULT_EXCLUDED_DATABASES),
         refresh=600,
     )
 
@@ -78,7 +91,7 @@ def instance_collect_schemas():
         max_columns=50,
         collection_interval=600,
         include_databases=[],
-        exclude_databases=["rdsadmin"],
+        exclude_databases=list(DEFAULT_EXCLUDED_DATABASES),
         include_schemas=[],
         exclude_schemas=[],
         include_tables=[],

--- a/postgres/datadog_checks/postgres/config_models/dict_defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/dict_defaults.py
@@ -78,7 +78,7 @@ def instance_collect_schemas():
         max_columns=50,
         collection_interval=600,
         include_databases=[],
-        exclude_databases=[],
+        exclude_databases=["rdsadmin"],
         include_schemas=[],
         exclude_schemas=[],
         include_tables=[],

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -402,7 +402,7 @@ instances:
         #   - master$
         #   - AdventureWorks.*
 
-        ## @param exclude - list of strings - optional - default: ['cloudsqladmin', 'rdsadmin', 'alloydbadmin', 'alloydbmetadata']
+        ## @param exclude - list of strings - optional - default: ['template0', 'template1', 'rdsadmin', 'azure_maintenance', 'cloudsqladmin', 'alloydbadmin', 'alloydbmetadata']
         ## Regular expression for database names to exclude as part of `database_autodiscovery`.
         ## Character casing is ignored. The regular expressions start matching from the beginning,
         ## so to match anywhere, prepend `.*`. For exact matches append `$`.

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -594,7 +594,7 @@ instances:
         #   - mydb
 
         ## @param exclude_databases - list of strings - optional
-        ## A list of regex patterns to exclude databases. 
+        ## A list of regex patterns to exclude databases.
         ## Any database whose name matches any one of these patterns will be excluded.
         ## If empty, all databases matching other filters are included.
         #

--- a/postgres/tests/test_config_defaults.py
+++ b/postgres/tests/test_config_defaults.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from datadog_checks.postgres.config import build_config
+from datadog_checks.postgres.config_models.dict_defaults import DEFAULT_EXCLUDED_DATABASES
 
 # Single source of truth for all expected default values
 # Organized by category for readability
@@ -55,15 +56,7 @@ EXPECTED_DEFAULTS = {
     'table_count_limit': 200,
     'max_relations': 300,
     # === Database filtering ===
-    'ignore_databases': [
-        'template0',
-        'template1',
-        'rdsadmin',
-        'azure_maintenance',
-        'cloudsqladmin',
-        'alloydbadmin',
-        'alloydbmetadata',
-    ],
+    'ignore_databases': list(DEFAULT_EXCLUDED_DATABASES),
     'ignore_schemas_owned_by': [
         'rds_superuser',
         'rdsadmin',
@@ -121,7 +114,7 @@ EXPECTED_DEFAULTS = {
         'collection_interval': 600,
         'max_query_duration': 60,
         'include_databases': [],
-        'exclude_databases': ['rdsadmin'],
+        'exclude_databases': list(DEFAULT_EXCLUDED_DATABASES),
         'include_schemas': [],
         'exclude_schemas': [],
         'include_tables': [],
@@ -151,7 +144,7 @@ EXPECTED_DEFAULTS = {
         'global_view_db': 'postgres',
         'max_databases': 100,
         'refresh': 600,
-        'exclude': ['cloudsqladmin', 'rdsadmin', 'alloydbadmin', 'alloydbmetadata'],
+        'exclude': list(DEFAULT_EXCLUDED_DATABASES),
         'include': ['.*'],
     },
     # === DBM: Lock metrics ===

--- a/postgres/tests/test_config_defaults.py
+++ b/postgres/tests/test_config_defaults.py
@@ -13,7 +13,6 @@ from unittest.mock import MagicMock
 import pytest
 
 from datadog_checks.postgres.config import build_config
-from datadog_checks.postgres.config_models.dict_defaults import DEFAULT_EXCLUDED_DATABASES
 
 # Single source of truth for all expected default values
 # Organized by category for readability
@@ -56,7 +55,15 @@ EXPECTED_DEFAULTS = {
     'table_count_limit': 200,
     'max_relations': 300,
     # === Database filtering ===
-    'ignore_databases': list(DEFAULT_EXCLUDED_DATABASES),
+    'ignore_databases': [
+        'template0',
+        'template1',
+        'rdsadmin',
+        'azure_maintenance',
+        'cloudsqladmin',
+        'alloydbadmin',
+        'alloydbmetadata',
+    ],
     'ignore_schemas_owned_by': [
         'rds_superuser',
         'rdsadmin',
@@ -114,7 +121,15 @@ EXPECTED_DEFAULTS = {
         'collection_interval': 600,
         'max_query_duration': 60,
         'include_databases': [],
-        'exclude_databases': list(DEFAULT_EXCLUDED_DATABASES),
+        'exclude_databases': [
+            'template0',
+            'template1',
+            'rdsadmin',
+            'azure_maintenance',
+            'cloudsqladmin',
+            'alloydbadmin',
+            'alloydbmetadata',
+        ],
         'include_schemas': [],
         'exclude_schemas': [],
         'include_tables': [],
@@ -144,7 +159,15 @@ EXPECTED_DEFAULTS = {
         'global_view_db': 'postgres',
         'max_databases': 100,
         'refresh': 600,
-        'exclude': list(DEFAULT_EXCLUDED_DATABASES),
+        'exclude': [
+            'template0',
+            'template1',
+            'rdsadmin',
+            'azure_maintenance',
+            'cloudsqladmin',
+            'alloydbadmin',
+            'alloydbmetadata',
+        ],
         'include': ['.*'],
     },
     # === DBM: Lock metrics ===

--- a/postgres/tests/test_config_defaults.py
+++ b/postgres/tests/test_config_defaults.py
@@ -120,6 +120,12 @@ EXPECTED_DEFAULTS = {
         'max_columns': 50,
         'collection_interval': 600,
         'max_query_duration': 60,
+        'include_databases': [],
+        'exclude_databases': ['rdsadmin'],
+        'include_schemas': [],
+        'exclude_schemas': [],
+        'include_tables': [],
+        'exclude_tables': [],
     },
     # === DBM: Obfuscator options ===
     'obfuscator_options': {


### PR DESCRIPTION
## Summary
- Revert the import of `DEFAULT_EXCLUDED_DATABASES` in `test_config_defaults.py`
- Use hardcoded values as originally intended by the test design

The test file is designed to have hardcoded values to catch regressions - if someone changes the defaults without updating the test, the test will fail. This ensures that default value changes are intentional and reviewed.

## Test plan
- [x] Ran `ddev test postgres -- -k test_config_defaults` - passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)