### PR TITLE
[postgres] Hardcode expected defaults in test file

### DIFF
--- a/postgres/tests/test_config_defaults.py
+++ b/postgres/tests/test_config_defaults.py
@@ -13,7 +13,6 @@ from unittest.mock import MagicMock
 import pytest
 
 from datadog_checks.postgres.config import build_config
-from datadog_checks.postgres.config_models.dict_defaults import DEFAULT_EXCLUDED_DATABASES
 
 # Single source of truth for all expected default values
 # Organized by category for readability
@@ -56,7 +55,15 @@ EXPECTED_DEFAULTS = {
     'table_count_limit': 200,
     'max_relations': 300,
     # === Database filtering ===
-    'ignore_databases': list(DEFAULT_EXCLUDED_DATABASES),
+    'ignore_databases': [
+        'template0',
+        'template1',
+        'rdsadmin',
+        'azure_maintenance',
+        'cloudsqladmin',
+        'alloydbadmin',
+        'alloydbmetadata',
+    ],
     'ignore_schemas_owned_by': [
         'rds_superuser',
         'rdsadmin',
@@ -114,7 +121,15 @@ EXPECTED_DEFAULTS = {
         'collection_interval': 600,
         'max_query_duration': 60,
         'include_databases': [],
-        'exclude_databases': list(DEFAULT_EXCLUDED_DATABASES),
+        'exclude_databases': [
+            'template0',
+            'template1',
+            'rdsadmin',
+            'azure_maintenance',
+            'cloudsqladmin',
+            'alloydbadmin',
+            'alloydbmetadata',
+        ],
         'include_schemas': [],
         'exclude_schemas': [],
         'include_tables': [],
@@ -144,7 +159,15 @@ EXPECTED_DEFAULTS = {
         'global_view_db': 'postgres',
         'max_databases': 100,
         'refresh': 600,
-        'exclude': list(DEFAULT_EXCLUDED_DATABASES),
+        'exclude': [
+            'template0',
+            'template1',
+            'rdsadmin',
+            'azure_maintenance',
+            'cloudsqladmin',
+            'alloydbadmin',
+            'alloydbmetadata',
+        ],
         'include': ['.*'],
     },
     # === DBM: Lock metrics ===


### PR DESCRIPTION
## Summary
- Hardcode the excluded database list in `test_config_defaults.py` instead of importing `DEFAULT_EXCLUDED_DATABASES`
- The test file is designed to have hardcoded values so that if someone accidentally changes the default values, the test will catch it
- Using the imported constant defeats this purpose of catching unintended changes

## Test plan
- [x] Tests pass with hardcoded values
- [x] If someone changes `DEFAULT_EXCLUDED_DATABASES` in `dict_defaults.py`, this test will now fail (as intended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)