### PR TITLE
Fix service check and metrics for stopped volumes

### DIFF
--- a/glusterfs/changelog.d/22486.fixed
+++ b/glusterfs/changelog.d/22486.fixed
@@ -1,0 +1,1 @@
+Fix service check and metrics for stopped volumes


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fixes status parsing for stopped volumes. When a volume is stopped the `health` property is not provided and the `block_size` property is set to `'N/A'`, and the integration currently does not properly handle these cases.

- https://github.com/gluster/glustercli-python/blob/920ddcec3d774de28a7f8cf04e033f0d0fa40c13/glustercli/cli/parsers.py#L54-L55
- https://github.com/gluster/glustercli-python/blob/920ddcec3d774de28a7f8cf04e033f0d0fa40c13/glustercli/cli/parsers.py#L329

### Motivation
<!-- What inspired you to submit this pull request? -->

Currently the integration check fails when there is a stopped volume, preventing metrics for all volumes from being submitted.

Example traceback:
```
... | CORE | ERROR | (pkg/collector/worker/check_logger.go:71 in Error) | check:glusterfs | Error running check: [{"message":"'health'","traceback":
...
Traceback (most recent call last):
  File "/opt/datadog-agent/embedded/lib/python3.13/site-packages/datadog_checks/base/checks/base.py", line 1316, in run
    self.check(instance)
    ~~~~~~~~~~^^^^^^^^^^
  File "/opt/datadog-agent/embedded/lib/python3.13/site-packages/datadog_checks/glusterfs/check.py", line 100, in check
    self.parse_volume_summary(volume_info)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/opt/datadog-agent/embedded/lib/python3.13/site-packages/datadog_checks/glusterfs/check.py", line 157, in parse_volume_summary
    self.parse_subvols_stats(volume.get('subvols', []), volume_tags)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/datadog-agent/embedded/lib/python3.13/site-packages/datadog_checks/glusterfs/check.py", line 168, in parse_subvols_stats
    self.submit_service_check(self.BRICK_SC, subvol['health'], subvol_tags)
                                             ~~~~~~^^^^^^^^^^
KeyError: 'health'
"}]
```

<details>
<summary>Example `gstatus` output</summary>

```
{
  "last_updated": "...",
  "data": {
    "cluster_status": "Healthy",
    "glfs_version": "10.1",
    "node_count": 3,
    "nodes_active": 3,
    "volume_count": 2,
    "volumes_started": 1,
    "volume_summary": [
      {
        "name": "...",
        "uuid": "...",
        "type": "REPLICATE",
        "status": "Stopped",
        "num_bricks": 2,
        "distribute": 1,
        "replica": 2,
        "disperse": 0,
        "disperse_redundancy": 0,
        "transport": "TCP",
        "snapshot_count": 0,
        "options": [
          ...
        ],
        "subvols": [
          {
            "name": "...",
            "replica": 2,
            "disperse": 0,
            "disperse_redundancy": 0,
            "type": "REPLICATE",
            "bricks": [
              {
                "name": "...",
                "uuid": "...",
                "type": "Brick",
                "online": false,
                "ports": {
                  "tcp": "N/A",
                  "rdma": "N/A"
                },
                "pid": "N/A",
                "size_total": 0,
                "size_free": 0,
                "size_used": 0,
                "inodes_total": 0,
                "inodes_free": 0,
                "inodes_used": 0,
                "device": "N/A",
                "block_size": "N/A",
                "mnt_options": "N/A",
                "fs_name": "N/A"
              },
              {
                "name": "...",
                "uuid": "...",
                "type": "Brick",
                "online": false,
                "ports": {
                  "tcp": "N/A",
                  "rdma": "N/A"
                },
                "pid": "N/A",
                "size_total": 0,
                "size_free": 0,
                "size_used": 0,
                "inodes_total": 0,
                "inodes_free": 0,
                "inodes_used": 0,
                "device": "N/A",
                "block_size": "N/A",
                "mnt_options": "N/A",
                "fs_name": "N/A"
              }
            ]
          }
        ],
        "size_total": 0,
        "size_free": 0,
        "size_used": 0,
        "inodes_total": 0,
        "inodes_free": 0,
        "inodes_used": 0,
        "online": 0,
        "voltype": "",
        "quota": ""
      },
      ...
    ]
  }
}
```

</details>


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
