### PR TITLE
Run master pipeline every day to ensure we have test results during weekends and avoid false firings on Mondays

### DIFF
--- a/.github/workflows/master-windows.yml
+++ b/.github/workflows/master-windows.yml
@@ -24,6 +24,8 @@ on:
     - '*/metadata.csv'
     # In case some linting formatting config has changed
     - 'pyproject.toml'
+  schedule:
+    - cron: '0 2 * * *'
 
 jobs:
   cache:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -22,6 +22,8 @@ on:
     - '*/metadata.csv'
     # In case some linting formatting config has changed
     - 'pyproject.toml'
+  schedule:
+    - cron: '0 2 * * *'
 
 jobs:
   cache:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Run master on schedule to provide data for the sustained error tests monitor.

### Motivation
<!-- What inspired you to submit this pull request? -->
We have created a monitor to alert whenver tests in master fail for a given itnegration 2 days in a row. If an integration has 2 days were some tests have failed in master we are alerted to either fix those tests or identify if they are flaky.

For weekends, were PRs are not merged to master, we will be without any data to collected, either passed or failed tests. This can cause issues when evaluating the monitor (evaluated daily at 9am Paris time). Running on a schedule every night ensures we still have data to evaluate the monitor and provides a good source of stability information, since we will be running weekly tests repeatedly on master over the same commit.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
