### PR TITLE
[CONTINT-5069] Update cluster disk utilization metrics

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_clusters.json
+++ b/kubernetes/assets/dashboards/kubernetes_clusters.json
@@ -5070,6 +5070,5 @@
     ],
     "layout_type": "ordered",
     "notify_list": [],
-    "pause_auto_refresh": false,
     "reflow_type": "fixed"
 }


### PR DESCRIPTION
### What does this PR do?
This PR updates our Kubernetes Cluster Health OOTB dashboard to replace the cluster disk utilization metrics with more useful (i.e., not Docker runtime specific) metrics. New dashboard example can be seen here: https://dddev.datadoghq.com/dashboard/aqr-473-gvq?fromUser=true&refresh_mode=sliding&tpl_var_cluster%5B0%5D=openshift-cont-cluster&from_ts=1770056081206&to_ts=1770056981206&live=true


On the graph, we're now plotting `kubernetes.node.filesystem.usage` and `kubernetes_state.node.ephemeral_storage_capacity`, and on the left we're displaying the "last value" of `kubernetes.node.filesystem.usage / kubernetes_state.node.ephemeral_storage_capacity * 100`. The reason we don't display `kubernetes.node.filesystem.usage_pct` directly is because we actually need a weighted average across all nodes. 

### Motivation
https://datadoghq.atlassian.net/browse/CONTINT-5069

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
