### PR TITLE
Enforce read-only mode for custom_queries in postgres

### DIFF
--- a/postgres/changelog.d/22499.changed
+++ b/postgres/changelog.d/22499.changed
@@ -1,0 +1,1 @@
+Enforce read-only mode for custom_queries

--- a/postgres/datadog_checks/postgres/connection_pool.py
+++ b/postgres/datadog_checks/postgres/connection_pool.py
@@ -228,6 +228,8 @@ class LRUConnectionPoolManager:
         with conn.cursor() as cur:
             if self.statement_timeout is not None:
                 cur.execute("SET statement_timeout = %s", (self.statement_timeout,))
+            # Enforce read-only mode for all queries to prevent data modification
+            cur.execute("SET default_transaction_read_only = ON")
 
     def _create_pool(self, dbname: str) -> ConnectionPool:
         """

--- a/postgres/tests/test_e2e.py
+++ b/postgres/tests/test_e2e.py
@@ -7,7 +7,7 @@ import socket
 import pytest
 
 from .common import _get_expected_tags, check_bgw_metrics, check_common_metrics
-from .utils import _get_conn
+from .utils import _get_conn, _get_superconn
 
 
 @pytest.mark.e2e
@@ -32,3 +32,68 @@ def test_e2e(check, dd_agent_check, pg_instance):
     expected_tags = _get_expected_tags(check, pg_instance, with_host=False)
     check_bgw_metrics(aggregator, expected_tags)
     check_common_metrics(aggregator, expected_tags=expected_tags, count=None)
+
+
+@pytest.mark.e2e
+def test_custom_queries_readonly_blocks_writes(dd_agent_check, pg_instance):
+    """Verify that all write operations are blocked by read-only enforcement"""
+    conn = _get_superconn(pg_instance)
+
+    # Setup: Create test table with full permissions for datadog user
+    with conn.cursor() as cur:
+        cur.execute("CREATE TABLE public.test_readonly_table (id INT, value TEXT)")
+        cur.execute("INSERT INTO public.test_readonly_table VALUES (1, 'initial')")
+        cur.execute(f"GRANT ALL ON public.test_readonly_table TO {pg_instance['username']}")
+        cur.execute(f"GRANT CREATE ON SCHEMA public TO {pg_instance['username']}")
+        conn.commit()
+
+    try:
+        # Test each type of write operation
+        write_operations = [
+            "INSERT INTO public.test_readonly_table VALUES (2, 'test')",
+            "UPDATE public.test_readonly_table SET value = 'updated' WHERE id = 1",
+            "DELETE FROM public.test_readonly_table WHERE id = 1",
+            "CREATE TABLE public.test_write_table (id INT)",
+        ]
+
+        for query in write_operations:
+            pg_instance['custom_queries'] = [
+                {
+                    'query': query,
+                    'columns': [{'name': 'result', 'type': 'gauge'}],
+                    'metric_prefix': 'postgres',
+                }
+            ]
+
+            aggregator = dd_agent_check(pg_instance)
+
+            # Write queries should fail, so no metrics should be submitted
+            metrics = list(aggregator.metrics('postgres.result'))
+            assert len(metrics) == 0, f"Write query succeeded but should have been blocked: {query}"
+
+        # Verify database state unchanged
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM public.test_readonly_table")
+            assert cur.fetchone()[0] == 1, "Database was modified despite read-only mode"
+    finally:
+        with conn.cursor() as cur:
+            cur.execute(f"REVOKE CREATE ON SCHEMA public FROM {pg_instance['username']}")
+            cur.execute("DROP TABLE IF EXISTS public.test_readonly_table")
+            cur.execute("DROP TABLE IF EXISTS public.test_write_table")
+            conn.commit()
+        conn.close()
+
+
+@pytest.mark.e2e
+def test_custom_queries_readonly_allows_reads(dd_agent_check, pg_instance):
+    """Verify that read operations work normally in read-only mode"""
+    pg_instance['custom_queries'] = [
+        {
+            'query': 'SELECT 1 as test_value',
+            'columns': [{'name': 'test_value', 'type': 'gauge'}],
+            'metric_prefix': 'postgres',
+        }
+    ]
+
+    aggregator = dd_agent_check(pg_instance)
+    aggregator.assert_metric('postgres.test_value', value=1)


### PR DESCRIPTION
## Summary

This PR enforces read-only mode for all database queries in the Postgres integration to prevent accidental or malicious data modification.

## Motivation

The Postgres integration is designed for monitoring - it should only read data, never modify it. Enforcing read-only mode at the database level provides strong guarantees that the integration cannot inadvertently change customer data, even through custom queries or potential code bugs.

## Implementation

Sets `default_transaction_read_only = ON` in the connection configuration (`_configure_connection` in `connection_pool.py`). This PostgreSQL setting ensures that all queries executed on the connection run in read-only mode.

This approach:
- Applies to **all queries** across the entire integration (not just custom queries)
- Enforces read-only at the PostgreSQL level for maximum protection
- Affects all connection types: main connection, pooled connections, and autodiscovered databases

## Testing

Added comprehensive E2E tests that verify:
- Write operations (INSERT, UPDATE, DELETE, CREATE) are blocked
- Read operations continue to work normally

## Tradeoffs

Breaking change: custom queries that perform write operations will fail. This is intentional - the integration is designed for metric collection, not data modification.