### PR TITLE
[CONTP-669] Document availability_zone tag deprecation for ECS Fargate

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -1148,7 +1148,10 @@ The Agent can autodiscover and attach tags to all data emitted by the entire tas
   | `task_name`                   | Low          | ECS API              |
   | `task_version`                | Low          | ECS API              |
   | `availability-zone`           | Low          | ECS API              |
+  | `availability_zone` (deprecated) | Low       | ECS API              |
   | `region`                      | Low          | ECS API              |
+
+**Note**: The `availability_zone` tag is deprecated in favor of `availability-zone`. Both tags are currently sent by the Agent, but `availability_zone` may be removed in a future release.
 
 ## Data Collected
 


### PR DESCRIPTION
Add the deprecated availability_zone tag to the out-of-the-box tags documentation and clarify that it is deprecated in favor of availability-zone. Both tags are currently sent by the Agent but availability_zone may be removed in a future release.

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
