### PR TITLE
Reuse wheels for dependencies that don't need upgrades.

### DIFF
--- a/.builders/build.py
+++ b/.builders/build.py
@@ -128,7 +128,7 @@ def build_macos():
             'CFLAGS': f'-I{prefix_path}/include -O2',
             'CXXFLAGS': f'-I{prefix_path}/include -O2',
             # Build command for extra platform-specific build steps
-            'DD_BUILD_COMMAND': f'bash {build_context_dir}/extra_build.sh'
+            'DD_BUILD_COMMAND': f'bash {build_context_dir}/extra_build.sh',
             # For figuring out which existing lockfile to load.
             'DD_TARGET_NAME': image,
         }

--- a/.builders/scripts/build_wheels.py
+++ b/.builders/scripts/build_wheels.py
@@ -319,7 +319,23 @@ def main():
         if constraints_file := env_vars.get('PIP_CONSTRAINT'):
             env_vars['PIP_CONSTRAINT'] = path_to_uri(constraints_file)
 
-        # Fetch or build wheels
+        # Reuse wheels from previous resolution runs.
+        check_process(
+            [
+                str(python_path),
+                '-m',
+                'pip',
+                'wheel',
+                '-r',
+                str(MOUNT_DIR / 'resolved' / f'{os.environ["DD_TARGET_NAME"]}_{os.environ["DD_PYHON_VERSION"]}.txt'),
+                '--wheel-dir',
+                str(staged_wheel_dir),
+                '--index-url',
+                CUSTOM_EXTERNAL_INDEX,
+            ]
+        )
+
+        # Fetch or build wheels for dependencies that need updating.
         command_args = [
             str(python_path),
             '-m',

--- a/.builders/scripts/build_wheels.py
+++ b/.builders/scripts/build_wheels.py
@@ -327,7 +327,7 @@ def main():
                 'pip',
                 'wheel',
                 '-r',
-                str(MOUNT_DIR / 'resolved' / f'{os.environ["DD_TARGET_NAME"]}_{os.environ["DD_PYHON_VERSION"]}.txt'),
+                str(MOUNT_DIR / 'resolved' / f'{os.environ["DD_TARGET_NAME"]}_{os.environ["PYTHON_VERSION"]}.txt'),
                 '--wheel-dir',
                 str(staged_wheel_dir),
                 '--index-url',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

**Scope: dependencies that have python packages! Stuff like openssl and librdkafka not affected!**

We reuse wheels from previous dependency resolutions.
In other words, we first fetch all the wheels based on the **old lock files**, then we `pip wheel` from `agent_requirements.in`. `pip` takes care of the diff and only downloads (and builds) wheels for dependencies that need upgrades. 

#### Known limitations

I'll address this in follow-ups:

- how do we handle python version upgrades? In that case the `DD_PYTHON_VERSION` envvar will point to a lock file that does not exist yet.
- how do we disable this nicely, maybe we need a break-glass here. Realistic scenario: we have a CVE in an indirect dep that we need to bump. I *guess it's reasonable* to add it to `agent_requirements.in`, but maybe not?
- how do we avoid rebuilding binary deps like confluent-kafka? Do we even want to avoid those?

### Motivation
<!-- What inspired you to submit this pull request? -->
This should make dependency resolution more deterministic and dependency bumps more atomic. It may also speed things up, but that's not the main goal.

Deterministic and atomic dependency bumps are safer during releases. They should also play nicer with quality gates.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
