### PR TITLE
Add dependency-review workflow to validate dependencies security before merging

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,5 +22,5 @@ jobs:
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2
         with:
-            comment-summary-in-pr: always
+            comment-summary-in-pr: on-failure
             fail-on-severity: high


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add a workflow that uses the [`actions/dependency-review-actions`](https://github.com/actions/dependency-review-action/tree/main) to validate any dependency update we do proactively in the PR that updates/adds them.

### Motivation
<!-- What inspired you to submit this pull request? -->
While CVE report allow us to know if a known vulnerability needs to be addressed, we might be updating our code to a given version that is already considered vulnerable and for which we still have not gotten any CVE report because until now we didn't have it as a depndency.

This is more important for GitHub Actions which are not covered by CVE reports. The main goal is to be able to get automatic security notifications in Dependabot PRs to ensure we are not consuming an action version that is considered vulnerable.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
