### PR TITLE
[Backport 7.76.x] Remove tight coupling in ddev test that started failing after new packaging release

### DIFF
--- a/ddev/tests/cli/validate/test_licenses.py
+++ b/ddev/tests/cli/validate/test_licenses.py
@@ -86,6 +86,6 @@ def test_invalid_requirement(repository, ddev, helpers):
 
     result = ddev("validate", "licenses")
 
-    expected_error_output = 'Detected InvalidRequirement error in agent_requirements.in:1 Expected end'
+    expected_error_output = 'InvalidRequirement error'
     assert expected_error_output in helpers.remove_trailing_spaces(result.output)
     assert 'aerospike==^4.0.0' in helpers.remove_trailing_spaces(result.output)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Backports fix to 7.76.x so ddev tests no longer fail.

### Motivation
<!-- What inspired you to submit this pull request? -->
- https://github.com/DataDog/integrations-core/pull/22395/changes
- https://github.com/DataDog/integrations-core/actions/runs/21649743909/job/62494333908?pr=22525
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
