### PR TITLE
Fix licenses for orjson

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -39,6 +39,7 @@ oauthlib,PyPI,BSD-3-Clause,Copyright (c) The OAuthlib Community
 openstacksdk,PyPI,Apache-2.0,Copyright OpenStack <openstack-discuss@lists.openstack.org>
 orjson,PyPI,Apache-2.0,
 orjson,PyPI,MIT,
+orjson,PyPI,MPL-2.0,
 packaging,PyPI,Apache-2.0,Copyright (c) Donald Stufft and individual contributors.
 packaging,PyPI,BSD-3-Clause,Copyright (c) Donald Stufft and individual contributors.
 paramiko,PyPI,LGPL-2.1-only,Copyright (C) 2009 Jeff Forcier


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix `orjson` licenses. Have been failing in master since the bump to `orjson` (PR #22556) was merged. It also failed in the PR apparently but we force merged it.

### Motivation
<!-- What inspired you to submit this pull request? -->
People are blocked with PRs failing to validate and we keep getting questions about why it is failing. Should not merge PRs where validations are failing.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
