### PR TITLE
Remove unnecessary configuration suggestions in the Openshift Integration page

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -2,7 +2,7 @@
 
 Red Hat OpenShift is an open source container application platform based on the Kubernetes container orchestrator for enterprise application development and deployment.
 
-> This README describes the necessary configuration to enable collection of OpenShift-specific metrics in the Agent. Data described here are collected by the [`kubernetes_apiserver` check][1]. You must configure the check to collect the `openshift.*` metrics.
+This integration supports the collection of Openshift `AppliedClusterResourceQuota` and `ClusterResourceQuota` metrics.
 
 ## Setup
 


### PR DESCRIPTION
### What does this PR do?
Remove unnecessary configuration suggestion in the Openshift Integration page.

Mainly this part:
```
Data described here are collected by the kubernetes_apiserver[ check](https://github.com/DataDog/datadog-agent/blob/master/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example). You must configure the check to collect the openshift.* metrics.
```
The link is outdated and `collect_openshift_clusterquotas` is defaulted to `true` as defined in the code here: https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go#L129
Unless the user sets this to `false` explicitly, the metrics should be collected automatically.

### Motivation
Outdated docs.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
