### PR TITLE
nginx: migrate to httpx

### DIFF
--- a/nginx/tests/conftest.py
+++ b/nginx/tests/conftest.py
@@ -32,6 +32,7 @@ INSTANCE = {
     'nginx_status_url': 'http://{}:{}/nginx_status'.format(HOST, PORT),
     'tags': TAGS,
     'disable_generic_tags': True,
+    'use_httpx': True,
 }
 
 

--- a/nginx/tests/test_nginx.py
+++ b/nginx/tests/test_nginx.py
@@ -7,6 +7,9 @@ import mock
 import pytest
 import requests
 
+from .common import FIXTURES_PATH, HOST, NGINX_VERSION, PORT_SSL, TAGS_WITH_HOST, TAGS_WITH_HOST_AND_PORT, USING_VTS
+from .utils import mocked_perform_request, requires_static_version
+
 
 def _get_ssl_error_types():
     try:
@@ -18,9 +21,6 @@ def _get_ssl_error_types():
 
 
 SSL_ERROR_TYPES = _get_ssl_error_types()
-
-from .common import FIXTURES_PATH, HOST, NGINX_VERSION, PORT_SSL, TAGS_WITH_HOST, TAGS_WITH_HOST_AND_PORT, USING_VTS
-from .utils import mocked_perform_request, requires_static_version
 
 pytestmark = [pytest.mark.skipif(USING_VTS, reason='Using VTS'), pytest.mark.integration]
 

--- a/nginx/tests/test_nginx.py
+++ b/nginx/tests/test_nginx.py
@@ -9,6 +9,7 @@ import requests
 
 try:
     import httpx
+
     SSL_ERROR_TYPES = (requests.exceptions.SSLError, httpx.ConnectError)
 except ImportError:
     httpx = None

--- a/nginx/tests/test_nginx.py
+++ b/nginx/tests/test_nginx.py
@@ -3,9 +3,9 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 
+import httpx
 import mock
 import pytest
-import httpx
 import requests
 
 from .common import FIXTURES_PATH, HOST, NGINX_VERSION, PORT_SSL, TAGS_WITH_HOST, TAGS_WITH_HOST_AND_PORT, USING_VTS

--- a/nginx/tests/test_nginx.py
+++ b/nginx/tests/test_nginx.py
@@ -5,6 +5,7 @@ import os
 
 import mock
 import pytest
+import httpx
 import requests
 
 from .common import FIXTURES_PATH, HOST, NGINX_VERSION, PORT_SSL, TAGS_WITH_HOST, TAGS_WITH_HOST_AND_PORT, USING_VTS
@@ -56,8 +57,8 @@ def test_connect_ssl(check, instance_ssl, aggregator):
     check_no_ssl.check(instance_ssl)
     aggregator.assert_metric("nginx.net.connections", tags=TAGS_WITH_HOST + ['port:{}'.format(PORT_SSL)], count=1)
 
-    # assert ssl validation throws an error
-    with pytest.raises(requests.exceptions.SSLError):
+    # assert ssl validation throws an error (requests vs httpx raise different types)
+    with pytest.raises((requests.exceptions.SSLError, httpx.ConnectError)):
         instance_ssl['ssl_validation'] = True
         check_ssl = check(instance_ssl)
         check_ssl.check(instance_ssl)

--- a/nginx/tests/test_unit.py
+++ b/nginx/tests/test_unit.py
@@ -96,9 +96,7 @@ def test_no_version(check, instance, caplog):
 
     r = mock.MagicMock()
     with mock.patch('datadog_checks.base.utils.http.requests.Session', return_value=r):
-        r.get.return_value = mock.MagicMock(
-            status_code=200, content=b'{}', headers={'server': 'nginx'}
-        )
+        r.get.return_value = mock.MagicMock(status_code=200, content=b'{}', headers={'server': 'nginx'})
 
         c.check(instance)
 

--- a/nginx/tests/test_unit.py
+++ b/nginx/tests/test_unit.py
@@ -65,6 +65,7 @@ def test_nest_payload(check, instance):
 def test_config(check, instance, test_case, extra_config, expected_http_kwargs):
     instance = deepcopy(instance)
     instance.update(extra_config)
+    instance['use_httpx'] = False  # use requests so Session mock applies
 
     c = check(instance)
 
@@ -89,11 +90,15 @@ def test_config(check, instance, test_case, extra_config, expected_http_kwargs):
 
 
 def test_no_version(check, instance, caplog):
+    instance = deepcopy(instance)
+    instance['use_httpx'] = False  # use requests so Session mock applies
     c = check(instance)
 
     r = mock.MagicMock()
     with mock.patch('datadog_checks.base.utils.http.requests.Session', return_value=r):
-        r.get.return_value = mock.MagicMock(status_code=200, content=b'{}', headers={'server': 'nginx'})
+        r.get.return_value = mock.MagicMock(
+            status_code=200, content=b'{}', headers={'server': 'nginx'}
+        )
 
         c.check(instance)
 


### PR DESCRIPTION
### What does this PR do?
- Enable use_httpx in test INSTANCE so integration and most unit tests use HTTPXWrapper.
- In test_connect_ssl, accept both requests.exceptions.SSLError and httpx.ConnectError when SSL validation fails.
- In test_config and test_no_version, force use_httpx: False and keep mocking requests.Session so config remapping and no-version behavior are still covered.

### Motivation
[RFC](https://datadoghq.atlassian.net/wiki/spaces/AI/pages/6214681547/RFC+2026-02-11+-+Migrate+the+HTTP+layer+from+requests+to+httpx)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
