### PR TITLE
go_expvar: migrate to httpx

### DIFF
--- a/go_expvar/tests/common.py
+++ b/go_expvar/tests/common.py
@@ -17,7 +17,12 @@ GO_EXPVAR_URL_PATH = "/debug/vars"
 
 URL_WITH_PATH = "{}{}".format(URL, GO_EXPVAR_URL_PATH)
 
-INSTANCE = {"expvar_url": URL, 'tags': ['my_tag'], 'metrics': [{'path': 'num_calls', "type": "rate"}]}
+INSTANCE = {
+    "expvar_url": URL,
+    'tags': ['my_tag'],
+    'metrics': [{'path': 'num_calls', "type": "rate"}],
+    'use_httpx': True,
+}
 
 CHECK_GAUGES = [
     'go_expvar.memstats.alloc',

--- a/go_expvar/tests/compose/Dockerfile
+++ b/go_expvar/tests/compose/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.6
+# Use Go 1.21+ for multi-arch (arm64/amd64). Go 1.6 panics under QEMU emulation (lfstackpush).
+FROM golang:1.21-alpine
 RUN mkdir /test_go
 ADD test_expvar.go /test_go
 EXPOSE 8079


### PR DESCRIPTION
### What does this PR do?
go_expvar: migrate tests to httpx and fix integration env on ARM64

- Enable use_httpx in test INSTANCE so the check uses HTTPXWrapper.
- Upgrade compose Dockerfile from golang:1.6 to golang:1.21-alpine so the
  image is multi-arch (arm64/amd64) and avoids the Go 1.6 runtime panic
  (lfstackpush) under QEMU emulation on Apple Silicon.

### Motivation
[RFC](https://datadoghq.atlassian.net/wiki/spaces/AI/pages/6214681547/RFC+2026-02-11+-+Migrate+the+HTTP+layer+from+requests+to+httpx)


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
