### PR TITLE
prometheus/openmetrics: request wrapper mock for httpx migration

### DIFF
--- a/datadog_checks_base/changelog.d/22615.changed
+++ b/datadog_checks_base/changelog.d/22615.changed
@@ -1,0 +1,1 @@
+Use shared HTTP exceptions (HTTPError) and built-in ConnectionError; allow removing requests from exception paths.

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -5,7 +5,8 @@ from copy import deepcopy
 
 from datadog_checks.base.checks import AgentCheck
 from datadog_checks.base.errors import CheckException
-from datadog_checks.base.utils.http_exceptions import HTTPError as SharedHTTPError, SSLError as SharedSSLError
+from datadog_checks.base.utils.http_exceptions import HTTPError as SharedHTTPError
+from datadog_checks.base.utils.http_exceptions import SSLError as SharedSSLError
 from datadog_checks.base.utils.tracing import traced_class
 
 from .mixins import OpenMetricsScraperMixin

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -3,10 +3,9 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from copy import deepcopy
 
-import requests
-
 from datadog_checks.base.checks import AgentCheck
 from datadog_checks.base.errors import CheckException
+from datadog_checks.base.utils.http_exceptions import HTTPError as SharedHTTPError, SSLError as SharedSSLError
 from datadog_checks.base.utils.tracing import traced_class
 
 from .mixins import OpenMetricsScraperMixin
@@ -120,7 +119,7 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
                             instance['prometheus_url'] = url
                             self.get_scraper_config(instance)
                             break
-                        except (IOError, requests.HTTPError, requests.exceptions.SSLError) as e:
+                        except (IOError, SharedHTTPError, SharedSSLError) as e:
                             self.log.info("Couldn't connect to %s: %s, trying next possible URL.", url, str(e))
                     else:
                         raise CheckException(

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -19,7 +19,8 @@ from datadog_checks.base.config import is_affirmative
 from datadog_checks.base.errors import CheckException
 from datadog_checks.base.utils.common import to_native_string
 from datadog_checks.base.utils.http import RequestsWrapper
-from datadog_checks.base.utils.http_exceptions import HTTPError as SharedHTTPError, SSLError as SharedSSLError
+from datadog_checks.base.utils.http_exceptions import HTTPError as SharedHTTPError
+from datadog_checks.base.utils.http_exceptions import SSLError as SharedSSLError
 
 
 class OpenMetricsScraperMixin(object):

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper/base_scraper.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper/base_scraper.py
@@ -13,7 +13,6 @@ from typing import List  # noqa: F401
 from prometheus_client import Metric
 from prometheus_client.openmetrics.parser import text_fd_to_metric_families as parse_openmetrics
 from prometheus_client.parser import text_fd_to_metric_families as parse_prometheus
-from requests.exceptions import ConnectionError
 
 from datadog_checks.base.agent import datadog_agent
 from datadog_checks.base.checks.openmetrics.v2.first_scrape_handler import first_scrape_handler

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
@@ -14,7 +14,8 @@ from datadog_checks.base.checks import AgentCheck
 from datadog_checks.base.checks.libs.prometheus import text_fd_to_metric_families
 from datadog_checks.base.config import is_affirmative
 from datadog_checks.base.utils.http import RequestsWrapper
-from datadog_checks.base.utils.http_exceptions import HTTPError as SharedHTTPError, SSLError as SharedSSLError
+from datadog_checks.base.utils.http_exceptions import HTTPError as SharedHTTPError
+from datadog_checks.base.utils.http_exceptions import SSLError as SharedSSLError
 from datadog_checks.base.utils.prometheus import metrics_pb2
 
 

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -29,7 +29,8 @@ from datadog_checks.base.utils import _http_utils
 
 from .common import ensure_bytes, ensure_unicode
 from .headers import get_default_headers, update_headers
-from .http_exceptions import HTTPError as SharedHTTPError, SSLError as SharedSSLError
+from .http_exceptions import HTTPError as SharedHTTPError
+from .http_exceptions import SSLError as SharedSSLError
 from .time import get_timestamp
 from .tls import SUPPORTED_PROTOCOL_VERSIONS, TlsConfig, create_ssl_context
 
@@ -130,11 +131,11 @@ def create_socket_connection(hostname, port=443, sock_type=socket.SOCK_STREAM, t
         if err is not None:
             raise err
         else:
-            raise socket.error('No valid addresses found, try checking your IPv6 connectivity')  # noqa: G
+            raise socket.error('No valid addresses found, try checking your IPv6 connectivity')  # noqa: B904
     except socket.gaierror as e:
         err_code, message = e.args
         if err_code == socket.EAI_NODATA or err_code == socket.EAI_NONAME:
-            raise socket.error('Unable to resolve host, check your DNS: {}'.format(message))  # noqa: G
+            raise socket.error('Unable to resolve host, check your DNS: {}'.format(message))  # noqa: B904
 
         raise
 

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_bench.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_bench.py
@@ -9,6 +9,7 @@ from datadog_checks.base import OpenMetricsBaseCheck
 from datadog_checks.dev import get_here
 
 from ..bench_utils import AMAZON_MSK_JMX_METRICS_MAP, AMAZON_MSK_JMX_METRICS_OVERRIDES
+from .utils import LEGACY_OPENMETRICS_HTTP_TARGET
 
 HERE = get_here()
 FIXTURE_PATH = os.path.abspath(os.path.join(os.path.dirname(HERE), '..', '..', '..', 'fixtures', 'prometheus'))
@@ -25,7 +26,7 @@ def fixture_amazon_msk_jmx_metrics():
 
 
 def test_ksm_old(benchmark, dd_run_check, mock_http_response, fixture_ksm):
-    mock_http_response(file_path=fixture_ksm)
+    mock_http_response(LEGACY_OPENMETRICS_HTTP_TARGET, file_path=fixture_ksm)
     instance = {'prometheus_url': 'foo', 'namespace': 'bar', 'metrics': ['*']}
     c = OpenMetricsBaseCheck('test', {}, [instance])
 
@@ -36,7 +37,7 @@ def test_ksm_old(benchmark, dd_run_check, mock_http_response, fixture_ksm):
 
 
 def test_amazon_msk_jmx_metrics_old(benchmark, dd_run_check, mock_http_response, fixture_amazon_msk_jmx_metrics):
-    mock_http_response(file_path=fixture_amazon_msk_jmx_metrics)
+    mock_http_response(LEGACY_OPENMETRICS_HTTP_TARGET, file_path=fixture_amazon_msk_jmx_metrics)
     instance = {
         'prometheus_url': 'foo',
         'namespace': 'bar',
@@ -52,7 +53,7 @@ def test_amazon_msk_jmx_metrics_old(benchmark, dd_run_check, mock_http_response,
 
 
 def test_label_joins_old(benchmark, dd_run_check, mock_http_response, fixture_ksm):
-    mock_http_response(file_path=fixture_ksm)
+    mock_http_response(LEGACY_OPENMETRICS_HTTP_TARGET, file_path=fixture_ksm)
     instance = {
         'prometheus_url': 'foo',
         'namespace': 'bar',

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_compat_scraper.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_compat_scraper.py
@@ -5,7 +5,7 @@ import pytest
 
 from tests.base.checks.openmetrics.test_v2.utils import OPENMETRICS_SCRAPER_HTTP_TARGET
 
-from .utils import LegacyCheck, get_legacy_check
+from .utils import get_legacy_check
 
 
 class TestRawMetricPrefix:
@@ -124,7 +124,7 @@ class TestShareLabels:
             # HELP go_memstats_free_bytes Number of bytes free and available for use.
             # TYPE go_memstats_free_bytes gauge
             go_memstats_free_bytes{bar="baz",baz="bar"} 6.396288e+06
-            """
+            """,
         )
         check = get_legacy_check(
             {
@@ -162,7 +162,7 @@ class TestShareLabels:
             # HELP kubernetes_build_info A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.
             # TYPE kubernetes_build_info gauge
             kubernetes_build_info{buildDate="2016-11-18T23:57:26Z",compiler="gc",gitCommit="3872cb93abf9482d770e651b5fe14667a6fca7e0",gitTreeState="dirty",gitVersion="v1.6.0-alpha.0.680+3872cb93abf948-dirty",goVersion="go1.7.3",major="1",minor="6+",platform="linux/amd64"} 1
-            """  # noqa: E501
+            """,  # noqa: E501
         )
         check = get_legacy_check(
             {'metadata_metric_name': 'kubernetes_build_info', 'metadata_label_map': {'version': 'gitVersion'}}

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_compat_scraper.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_compat_scraper.py
@@ -3,7 +3,9 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
-from .utils import get_legacy_check
+from tests.base.checks.openmetrics.test_v2.utils import OPENMETRICS_SCRAPER_HTTP_TARGET
+
+from .utils import LegacyCheck, get_legacy_check
 
 
 class TestRawMetricPrefix:
@@ -111,6 +113,7 @@ class TestShareLabels:
 
     def test_share_labels(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -154,6 +157,7 @@ class TestShareLabels:
 
     def test_metadata(self, aggregator, datadog_agent, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP kubernetes_build_info A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.
             # TYPE kubernetes_build_info gauge

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_openmetrics.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_openmetrics.py
@@ -18,10 +18,9 @@ from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily, Histo
 from prometheus_client.samples import Sample
 
 from datadog_checks.base import ensure_bytes
-from datadog_checks.dev.http import HTTPResponseMock, RequestWrapperMock
 from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.dev import get_here
-from datadog_checks.dev.http import MockResponse
+from datadog_checks.dev.http import HTTPResponseMock, MockResponse, RequestWrapperMock
 
 text_content_type = 'text/plain; version=0.0.4'
 FIXTURE_PATH = os.path.abspath(os.path.join(get_here(), '..', '..', '..', '..', 'fixtures', 'prometheus'))

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_openmetrics.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_openmetrics.py
@@ -4,7 +4,6 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import copy
-import io
 import logging
 import math
 import os
@@ -166,9 +165,7 @@ def test_poll_text_plain(mocked_prometheus_check, mocked_prometheus_scraper_conf
     check = mocked_prometheus_check
     content = text_data.encode('utf-8') if isinstance(text_data, str) else text_data
     mock_resp = HTTPResponseMock(200, content=content, headers={'Content-Type': text_content_type})
-    with mock.patch.object(
-        check, 'get_http_handler', return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp)
-    ):
+    with mock.patch.object(check, 'get_http_handler', return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp)):
         response = check.poll(mocked_prometheus_scraper_config)
         messages = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
         messages.sort(key=lambda x: x.name)
@@ -181,9 +178,7 @@ def test_poll_octet_stream(mocked_prometheus_check, mocked_prometheus_scraper_co
     check = mocked_prometheus_check
     content = ensure_bytes(text_data)
     mock_resp = HTTPResponseMock(200, content=content, headers={'Content-Type': 'application/octet-stream'})
-    with mock.patch.object(
-        check, 'get_http_handler', return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp)
-    ):
+    with mock.patch.object(check, 'get_http_handler', return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp)):
         response = check.poll(mocked_prometheus_scraper_config)
         messages = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
         assert len(messages) == 40
@@ -1703,9 +1698,7 @@ def test_ignore_metrics_multiple_wildcards(
 
     content = text_data.encode('utf-8') if isinstance(text_data, str) else text_data
     mock_resp = HTTPResponseMock(200, content=content, headers={'Content-Type': text_content_type})
-    with mock.patch.object(
-        check, 'get_http_handler', return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp)
-    ):
+    with mock.patch.object(check, 'get_http_handler', return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp)):
         check.process(config)
 
         # Make sure metrics are ignored
@@ -1812,9 +1805,7 @@ def test_metrics_with_ignore_label_values(
     expected_tags = ['cause:nxdomain']
     content = text_data.encode('utf-8') if isinstance(text_data, str) else text_data
     mock_resp = HTTPResponseMock(200, content=content, headers={'Content-Type': text_content_type})
-    with mock.patch.object(
-        check, 'get_http_handler', return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp)
-    ):
+    with mock.patch.object(check, 'get_http_handler', return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp)):
         check.process(config)
 
         # Make sure metrics are ignored
@@ -1864,9 +1855,7 @@ def test_match_metrics_multiple_wildcards(
 
     content = text_data.encode('utf-8') if isinstance(text_data, str) else text_data
     mock_resp = HTTPResponseMock(200, content=content, headers={'Content-Type': text_content_type})
-    with mock.patch.object(
-        check, 'get_http_handler', return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp)
-    ):
+    with mock.patch.object(check, 'get_http_handler', return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp)):
         check.process(config)
 
         aggregator.assert_metric('prometheus.go_memstats_mcache_inuse_bytes', count=1)
@@ -2315,9 +2304,7 @@ def test_label_joins_gc(aggregator, mocked_prometheus_check, mocked_prometheus_s
 
     content = text_data.encode('utf-8') if isinstance(text_data, str) else text_data
     mock_resp = HTTPResponseMock(200, content=content, headers={'Content-Type': text_content_type})
-    with mock.patch.object(
-        check, 'get_http_handler', return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp)
-    ):
+    with mock.patch.object(check, 'get_http_handler', return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp)):
         check.process(mocked_prometheus_scraper_config)
         assert 'dd-agent-1337' in mocked_prometheus_scraper_config['_label_mapping']['pod']
         assert 'dd-agent-62bgh' not in mocked_prometheus_scraper_config['_label_mapping']['pod']
@@ -2476,9 +2463,7 @@ def test_label_join_state_change(aggregator, mocked_prometheus_check, mocked_pro
 
     content = text_data.encode('utf-8') if isinstance(text_data, str) else text_data
     mock_resp = HTTPResponseMock(200, content=content, headers={'Content-Type': text_content_type})
-    with mock.patch.object(
-        check, 'get_http_handler', return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp)
-    ):
+    with mock.patch.object(check, 'get_http_handler', return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp)):
         check.process(mocked_prometheus_scraper_config)
         assert 15 == len(mocked_prometheus_scraper_config['_label_mapping']['pod'])
         assert mocked_prometheus_scraper_config['_label_mapping']['pod']['dd-agent-62bgh']['phase'] == 'Test'
@@ -2685,10 +2670,13 @@ def test_ssl_verify_not_raise_warning(caplog, mocked_openmetrics_check_factory, 
     check = mocked_openmetrics_check_factory(instance)
     scraper_config = check.get_scraper_config(instance)
     mock_resp = HTTPResponseMock(200, content=b'httpbin.org')
-    with caplog.at_level(logging.DEBUG), mock.patch.object(
-        check,
-        'get_http_handler',
-        return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp, ignore_tls_warning=True),
+    with (
+        caplog.at_level(logging.DEBUG),
+        mock.patch.object(
+            check,
+            'get_http_handler',
+            return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp, ignore_tls_warning=True),
+        ),
     ):
         resp = check.send_request('https://httpbin.org/get', scraper_config)
 
@@ -2714,10 +2702,13 @@ def test_send_request_with_dynamic_prometheus_url(caplog, mocked_openmetrics_che
     scraper_config['prometheus_url'] = 'https://www.example.com/foo/bar'
 
     mock_resp = HTTPResponseMock(200, content=b'httpbin.org')
-    with caplog.at_level(logging.DEBUG), mock.patch.object(
-        check,
-        'get_http_handler',
-        return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp, ignore_tls_warning=True),
+    with (
+        caplog.at_level(logging.DEBUG),
+        mock.patch.object(
+            check,
+            'get_http_handler',
+            return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp, ignore_tls_warning=True),
+        ),
     ):
         resp = check.send_request('https://httpbin.org/get', scraper_config)
 

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_openmetrics.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_openmetrics.py
@@ -1835,9 +1835,7 @@ def test_metrics_with_ignore_label_values(
 
     # Make sure metrics are ignored
     aggregator.assert_metric('prometheus.skydns.dns.error.count', count=0, tags=expected_tags + ['system:auth'])
-    aggregator.assert_metric(
-        'prometheus.skydns.dns.error.count', count=0, tags=expected_tags + ['system:recursive']
-    )
+    aggregator.assert_metric('prometheus.skydns.dns.error.count', count=0, tags=expected_tags + ['system:recursive'])
     aggregator.assert_metric('prometheus.skydns.dns.cache_missed', count=0)
     # Make sure we don't ignore other metrics
     aggregator.assert_metric('prometheus.skydns.dns.error.count', count=1, tags=expected_tags + ['system:reverse'])
@@ -2578,9 +2576,7 @@ def test_health_service_check_ok(mock_get, aggregator, mocked_prometheus_check, 
     )
 
 
-def test_health_service_check_failing(
-    aggregator, mocker, mocked_prometheus_check, mocked_prometheus_scraper_config
-):
+def test_health_service_check_failing(aggregator, mocker, mocked_prometheus_check, mocked_prometheus_scraper_config):
     """Tests endpoint health service check failing (connection failure simulated via mock)."""
     check = mocked_prometheus_check
 

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/utils.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/utils.py
@@ -4,6 +4,9 @@
 from datadog_checks.base import OpenMetricsBaseCheckV2
 from datadog_checks.base.checks.openmetrics.v2.scraper import OpenMetricsCompatibilityScraper
 
+# Patch target for mock_http_response when testing legacy OpenMetricsBaseCheck (get_http_handler → RequestsWrapper).
+LEGACY_OPENMETRICS_HTTP_TARGET = 'datadog_checks.base.utils.http.RequestsWrapper.get'
+
 
 class LegacyCheck(OpenMetricsBaseCheckV2):
     def create_scraper(self, config):

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/scraper/test_first_scrape_handler.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/scraper/test_first_scrape_handler.py
@@ -153,7 +153,9 @@ def test_first_scrape_handler(
             # V2 scrapers are created once and keep the same http wrapper; patch does not
             # apply to existing scrapers. Inject a failure response into each scraper.
             fail_resp = HTTPResponseMock(500, content=b'')
-            fail_wrapper = RequestWrapperMock(get=lambda url, **kw: fail_resp)
+            fail_wrapper = RequestWrapperMock(
+                get=lambda url, resp=fail_resp, **kw: resp,
+            )
             fail_wrapper.options.setdefault('headers', {})
             saved_http = {ep: s.http for ep, s in check.scrapers.items()}
             for scraper in check.scrapers.values():

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/scraper/test_http_status_class_scraper.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/scraper/test_http_status_class_scraper.py
@@ -8,6 +8,7 @@ from typing import Optional
 import pytest
 
 from datadog_checks.base.checks.openmetrics.v2.base import OpenMetricsBaseCheckV2
+from tests.base.checks.openmetrics.test_v2.utils import OPENMETRICS_SCRAPER_HTTP_TARGET
 from datadog_checks.base.checks.openmetrics.v2.scraper import OpenMetricsScraper, decorators
 from datadog_checks.base.stubs.aggregator import AggregatorStub
 
@@ -78,7 +79,7 @@ def test_http_status_class_scraper(
     dd_run_check: Callable,
     target_info: bool,
 ):
-    mock_http_response(response(status_label, status_code, target_info))
+    mock_http_response(OPENMETRICS_SCRAPER_HTTP_TARGET, response(status_label, status_code, target_info))
 
     check = get_check(status_label=status_label, target_info=target_info)
     dd_run_check(check)

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/scraper/test_http_status_class_scraper.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/scraper/test_http_status_class_scraper.py
@@ -8,9 +8,9 @@ from typing import Optional
 import pytest
 
 from datadog_checks.base.checks.openmetrics.v2.base import OpenMetricsBaseCheckV2
-from tests.base.checks.openmetrics.test_v2.utils import OPENMETRICS_SCRAPER_HTTP_TARGET
 from datadog_checks.base.checks.openmetrics.v2.scraper import OpenMetricsScraper, decorators
 from datadog_checks.base.stubs.aggregator import AggregatorStub
+from tests.base.checks.openmetrics.test_v2.utils import OPENMETRICS_SCRAPER_HTTP_TARGET
 
 RESPONSE_TEMPLATE = """
 # HELP http_client_request_size_total

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_bench.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_bench.py
@@ -6,6 +6,7 @@ import os
 import pytest
 
 from datadog_checks.base import OpenMetricsBaseCheckV2
+from tests.base.checks.openmetrics.test_v2.utils import OPENMETRICS_SCRAPER_HTTP_TARGET
 from datadog_checks.dev import get_here
 
 from ..bench_utils import AMAZON_MSK_JMX_METRICS_MAP, AMAZON_MSK_JMX_METRICS_OVERRIDES
@@ -25,7 +26,7 @@ def fixture_amazon_msk_jmx_metrics():
 
 
 def test_ksm_new(benchmark, dd_run_check, mock_http_response, fixture_ksm):
-    mock_http_response(file_path=fixture_ksm)
+    mock_http_response(OPENMETRICS_SCRAPER_HTTP_TARGET, file_path=fixture_ksm)
     c = OpenMetricsBaseCheckV2('test', {}, [{'openmetrics_endpoint': 'foo', 'namespace': 'bar', 'metrics': ['.+']}])
 
     # Run once to get initialization steps out of the way.
@@ -35,7 +36,7 @@ def test_ksm_new(benchmark, dd_run_check, mock_http_response, fixture_ksm):
 
 
 def test_amazon_msk_jmx_metrics_new(benchmark, dd_run_check, mock_http_response, fixture_amazon_msk_jmx_metrics):
-    mock_http_response(file_path=fixture_amazon_msk_jmx_metrics)
+    mock_http_response(OPENMETRICS_SCRAPER_HTTP_TARGET, file_path=fixture_amazon_msk_jmx_metrics)
 
     metrics = []
     for raw_metric_name, metric_name in AMAZON_MSK_JMX_METRICS_MAP.items():
@@ -54,7 +55,7 @@ def test_amazon_msk_jmx_metrics_new(benchmark, dd_run_check, mock_http_response,
 
 
 def test_label_joins_new(benchmark, dd_run_check, mock_http_response, fixture_ksm):
-    mock_http_response(file_path=fixture_ksm)
+    mock_http_response(OPENMETRICS_SCRAPER_HTTP_TARGET, file_path=fixture_ksm)
     instance = {
         'openmetrics_endpoint': 'foo',
         'namespace': 'bar',

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_bench.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_bench.py
@@ -6,8 +6,8 @@ import os
 import pytest
 
 from datadog_checks.base import OpenMetricsBaseCheckV2
-from tests.base.checks.openmetrics.test_v2.utils import OPENMETRICS_SCRAPER_HTTP_TARGET
 from datadog_checks.dev import get_here
+from tests.base.checks.openmetrics.test_v2.utils import OPENMETRICS_SCRAPER_HTTP_TARGET
 
 from ..bench_utils import AMAZON_MSK_JMX_METRICS_MAP, AMAZON_MSK_JMX_METRICS_OVERRIDES
 

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_interface.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_interface.py
@@ -20,7 +20,7 @@ def test_default_config(aggregator, dd_run_check, mock_http_response):
         # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
         # TYPE go_memstats_alloc_bytes gauge
         go_memstats_alloc_bytes{foo="baz"} 6.396288e+06
-        """
+        """,
     )
     check = Check('test', {}, [{'openmetrics_endpoint': 'test'}])
     dd_run_check(check)
@@ -39,7 +39,7 @@ def test_tag_by_endpoint(aggregator, dd_run_check, mock_http_response):
         # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
         # TYPE go_memstats_alloc_bytes gauge
         go_memstats_alloc_bytes{foo="baz"} 6.396288e+06
-        """
+        """,
     )
     check = get_check({'metrics': ['.+'], 'tag_by_endpoint': False})
     dd_run_check(check)
@@ -57,7 +57,7 @@ def test_service_check_dynamic_tags(aggregator, dd_run_check, mock_http_response
         # HELP state Node state
         # TYPE state gauge
         state{bar="baz"} 3
-        """
+        """,
     )
     check = get_check(
         {'metrics': ['.+', {'state': {'type': 'service_check', 'status_map': {'3': 'ok'}}}], 'tags': ['foo:bar']}
@@ -123,7 +123,7 @@ def test_custom_transformer(aggregator, dd_run_check, mock_http_response):
         envoy_server_worker_0_watchdog_mega_miss{} 1
         # TYPE envoy_server_worker_1_watchdog_mega_miss counter
         envoy_server_worker_1_watchdog_mega_miss{} 0
-        """
+        """,
     )
     check = Check('test', {}, [{'openmetrics_endpoint': 'test'}])
     dd_run_check(check)

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_interface.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_interface.py
@@ -4,7 +4,7 @@
 from datadog_checks.base import OpenMetricsBaseCheckV2
 from datadog_checks.base.constants import ServiceCheck
 
-from .utils import get_check
+from .utils import OPENMETRICS_SCRAPER_HTTP_TARGET, get_check
 
 
 def test_default_config(aggregator, dd_run_check, mock_http_response):
@@ -15,6 +15,7 @@ def test_default_config(aggregator, dd_run_check, mock_http_response):
             return {'metrics': ['.+'], 'rename_labels': {'foo': 'bar'}}
 
     mock_http_response(
+        OPENMETRICS_SCRAPER_HTTP_TARGET,
         """
         # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
         # TYPE go_memstats_alloc_bytes gauge
@@ -33,6 +34,7 @@ def test_default_config(aggregator, dd_run_check, mock_http_response):
 
 def test_tag_by_endpoint(aggregator, dd_run_check, mock_http_response):
     mock_http_response(
+        OPENMETRICS_SCRAPER_HTTP_TARGET,
         """
         # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
         # TYPE go_memstats_alloc_bytes gauge
@@ -47,6 +49,7 @@ def test_tag_by_endpoint(aggregator, dd_run_check, mock_http_response):
 
 def test_service_check_dynamic_tags(aggregator, dd_run_check, mock_http_response):
     mock_http_response(
+        OPENMETRICS_SCRAPER_HTTP_TARGET,
         """
         # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
         # TYPE go_memstats_alloc_bytes gauge
@@ -114,6 +117,7 @@ def test_custom_transformer(aggregator, dd_run_check, mock_http_response):
             )
 
     mock_http_response(
+        OPENMETRICS_SCRAPER_HTTP_TARGET,
         """
         # TYPE envoy_server_worker_0_watchdog_mega_miss counter
         envoy_server_worker_0_watchdog_mega_miss{} 1

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_options.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_options.py
@@ -17,7 +17,7 @@ class TestNamespace:
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
             go_memstats_alloc_bytes 6.396288e+06
-            """
+            """,
         )
         check = get_check({'metrics': ['.+'], 'namespace': 'foo'})
         check.__NAMESPACE__ = ''
@@ -38,7 +38,7 @@ class TestRawMetricPrefix:
             # HELP foo_go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE foo_go_memstats_alloc_bytes gauge
             foo_go_memstats_alloc_bytes 6.396288e+06
-            """
+            """,
         )
         check = get_check({'metrics': ['go_memstats_alloc_bytes'], 'raw_metric_prefix': 'foo_'})
         dd_run_check(check)
@@ -58,7 +58,7 @@ class TestEnableHealthServiceCheck:
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
             go_memstats_alloc_bytes 6.396288e+06
-            """
+            """,
         )
         check = get_check({'metrics': ['.+'], 'tags': ['foo:bar']})
         dd_run_check(check)
@@ -120,7 +120,7 @@ class TestHostnameLabel:
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
             go_memstats_alloc_bytes{foo="bar"} 6.396288e+06
-            """
+            """,
         )
         check = get_check({'metrics': ['.+'], 'hostname_label': 'foo'})
         dd_run_check(check)
@@ -144,7 +144,7 @@ class TestHostnameFormat:
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
             go_memstats_alloc_bytes{foo="bar"} 6.396288e+06
-            """
+            """,
         )
         check = get_check({'metrics': ['.+'], 'hostname_label': 'foo', 'hostname_format': 'region_<HOSTNAME>'})
         dd_run_check(check)
@@ -199,7 +199,7 @@ class TestExcludeIncludeLabels:
             # HELP go_memstats_free_bytes Number of bytes free and available for use.
             # TYPE go_memstats_free_bytes gauge
             go_memstats_free_bytes{foo="bar", zip="zap"} 6.396288e+06
-            """
+            """,
         )
 
         check = get_check({'metrics': ['.+'], 'include_labels': included_labels, 'exclude_labels': excluded_labels})
@@ -220,7 +220,7 @@ class TestRenameLabels:
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
             go_memstats_alloc_bytes{foo="baz"} 6.396288e+06
-            """
+            """,
         )
         check = get_check({'metrics': ['.+'], 'rename_labels': {'foo': 'bar'}})
         dd_run_check(check)
@@ -246,7 +246,7 @@ class TestExcludeMetrics:
             # HELP go_memstats_free_bytes Number of bytes free and available for use.
             # TYPE go_memstats_free_bytes gauge
             go_memstats_free_bytes{foo="bar"} 6.396288e+06
-            """
+            """,
         )
         check = get_check({'metrics': ['.+'], 'exclude_metrics': ['^go_memstats_(alloc|free)_bytes$']})
         dd_run_check(check)
@@ -272,7 +272,7 @@ class TestExcludeMetricsByLabels:
             # HELP go_memstats_free_bytes Number of bytes free and available for use.
             # TYPE go_memstats_free_bytes gauge
             go_memstats_free_bytes{foo="baz"} 6.396288e+06
-            """
+            """,
         )
         check = get_check({'metrics': ['.+'], 'exclude_metrics_by_labels': {'foo': ['ba(t|z)']}})
         dd_run_check(check)
@@ -296,7 +296,7 @@ class TestExcludeMetricsByLabels:
             # HELP go_memstats_free_bytes Number of bytes free and available for use.
             # TYPE go_memstats_free_bytes gauge
             go_memstats_free_bytes{foo="baz"} 6.396288e+06
-            """
+            """,
         )
         check = get_check({'metrics': ['.+'], 'exclude_metrics_by_labels': {'foo': True}})
         dd_run_check(check)
@@ -318,7 +318,7 @@ class TestRawLineFilters:
             # HELP go_memstats_free_bytes Number of bytes free and available for use.
             # TYPE go_memstats_free_bytes gauge
             go_memstats_free_bytes{foo=""} 6.396288e+06
-            """
+            """,
         )
         check = get_check({'metrics': ['.+'], 'raw_line_filters': ['=""']})
         dd_run_check(check)
@@ -338,7 +338,7 @@ class TestMetrics:
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes untyped
             go_memstats_alloc_bytes 6.396288e+06
-            """
+            """,
         )
         check = get_check({'metrics': [{'.+': {'type': 'gauge'}}]})
         dd_run_check(check)
@@ -364,7 +364,7 @@ class TestShareLabels:
             # HELP go_memstats_free_bytes Number of bytes free and available for use.
             # TYPE go_memstats_free_bytes gauge
             go_memstats_free_bytes{bar="baz"} 6.396288e+06
-            """
+            """,
         )
         check = get_check({'metrics': ['.+'], 'share_labels': {'go_memstats_alloc_bytes': True}})
         dd_run_check(check)
@@ -400,7 +400,7 @@ class TestShareLabels:
             # HELP go_memstats_free_bytes Number of bytes free and available for use.
             # TYPE go_memstats_free_bytes gauge
             go_memstats_free_bytes{bar="baz"} 6.396288e+06
-            """
+            """,
         )
         check = get_check({'metrics': ['.+'], 'share_labels': {'go_memstats_alloc_bytes': {'labels': ['baz']}}})
         dd_run_check(check)
@@ -439,7 +439,7 @@ class TestShareLabels:
             # HELP go_memstats_free_bytes Number of bytes free and available for use.
             # TYPE go_memstats_free_bytes gauge
             go_memstats_free_bytes{bar="baz",baz="bar"} 6.396288e+06
-            """
+            """,
         )
         check = get_check({'metrics': ['.+'], 'share_labels': {'go_memstats_alloc_bytes': {'match': ['baz']}}})
         dd_run_check(check)
@@ -478,7 +478,7 @@ class TestShareLabels:
             # HELP go_memstats_free_bytes Number of bytes free and available for use.
             # TYPE go_memstats_free_bytes gauge
             go_memstats_free_bytes{bar="baz",baz="bar"} 6.396288e+06
-            """
+            """,
         )
         check = get_check(
             {'metrics': ['.+'], 'share_labels': {'go_memstats_alloc_bytes': {'match': ['baz'], 'labels': ['pod']}}}
@@ -520,7 +520,7 @@ class TestShareLabels:
             # HELP go_memstats_free_bytes Number of bytes free and available for use.
             # TYPE go_memstats_free_bytes gauge
             go_memstats_free_bytes{bar="baz"} 6.396288e+06
-            """
+            """,
         )
         check = get_check({'metrics': ['.+'], 'share_labels': {'go_memstats_alloc_bytes': {'values': values}}})
         dd_run_check(check)
@@ -556,7 +556,7 @@ class TestShareLabels:
             # HELP go_memstats_free_bytes Number of bytes free and available for use.
             # TYPE go_memstats_free_bytes gauge
             go_memstats_free_bytes{bar="baz"} 6.396288e+06
-            """
+            """,
         )
         check = get_check({'metrics': ['.+'], 'share_labels': {'go_memstats_alloc_bytes': {'values': [9000]}}})
         dd_run_check(check)
@@ -586,7 +586,7 @@ class TestShareLabels:
             # HELP go_memstats_free_bytes Number of bytes free and available for use.
             # TYPE go_memstats_free_bytes gauge
             go_memstats_free_bytes{bar="baz"} 6.396288e+06
-            """
+            """,
         )
         check = get_check(
             {
@@ -625,7 +625,7 @@ class TestShareLabels:
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
             go_memstats_alloc_bytes{foo="bar"} 6.396288e+06
-            """
+            """,
         )
         check = get_check({'metrics': ['.+'], 'share_labels': {'go_memstats_alloc_bytes': True}})
         dd_run_check(check)
@@ -679,7 +679,7 @@ class TestShareLabels:
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
             go_memstats_alloc_bytes{foo="bar"} 6.396288e+06
-            """
+            """,
         )
         check = get_check(
             {'metrics': ['.+'], 'share_labels': {'go_memstats_alloc_bytes': True}, 'cache_shared_labels': False}
@@ -716,7 +716,7 @@ class TestShareLabels:
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
             go_memstats_alloc_bytes{foo="bar"} 6.396288e+06
-            """
+            """,
         )
 
         dd_run_check(check)
@@ -742,7 +742,7 @@ class TestShareLabels:
             # HELP target Target metadata
             # TYPE target info
             target_info{env="prod", region="europe"} 1.0
-            """
+            """,
         )
 
         dd_run_check(check)
@@ -768,7 +768,7 @@ class TestShareLabels:
             # HELP target Target metadata
             # TYPE target info
             target_info{env="prod", region="europe"} 1.0
-            """
+            """,
         )
 
         dd_run_check(check)
@@ -804,7 +804,7 @@ class TestShareLabels:
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
             go_memstats_alloc_bytes{foo="bar"} 6.396288e+06
-            """
+            """,
         )
 
         dd_run_check(check_var)
@@ -825,7 +825,7 @@ class TestShareLabels:
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
             go_memstats_alloc_bytes{foo="bar2"} 6.396288e+06
-            """
+            """,
         )
 
         dd_run_check(check_var)
@@ -855,7 +855,7 @@ class TestShareLabels:
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
             go_memstats_alloc_bytes{bar="foo"} 6.396288e+06
-            """
+            """,
         )
 
         dd_run_check(check_var)
@@ -879,7 +879,7 @@ class TestShareLabels:
             # HELP go_memstats_free_bytes Number of bytes free and available for use.
             # TYPE go_memstats_free_bytes gauge
             go_memstats_free_bytes{bar2="baz2"} 6.396288e+06
-            """
+            """,
         )
 
         dd_run_check(check_var)
@@ -909,7 +909,7 @@ class TestIgnoreTags:
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
             go_memstats_alloc_bytes 6.396288e+06
-            """
+            """,
         )
         all_tags = ['foo', 'foobar', 'bar', 'bar:baz', 'bar:bar']
         ignored_tags = ['foo', 'bar:baz']
@@ -930,7 +930,7 @@ class TestIgnoreTags:
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
             go_memstats_alloc_bytes 6.396288e+06
-            """
+            """,
         )
         all_tags = ['foo', 'foobar', 'bar', 'bar:baz', 'bar:bar']
         ignored_tags = ['foo*', '.*baz']
@@ -951,7 +951,7 @@ class TestIgnoreTags:
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
             go_memstats_alloc_bytes 6.396288e+06
-            """
+            """,
         )
         all_tags = ['foo', 'foobar', 'bar:baz', 'bar:bar']
         ignored_tags = ['^foo', '.+:bar$']

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_options.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_options.py
@@ -6,12 +6,13 @@ from mock import Mock
 
 from datadog_checks.base.constants import ServiceCheck
 
-from .utils import get_check
+from .utils import OPENMETRICS_SCRAPER_HTTP_TARGET, get_check
 
 
 class TestNamespace:
     def test(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -32,6 +33,7 @@ class TestNamespace:
 class TestRawMetricPrefix:
     def test(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP foo_go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE foo_go_memstats_alloc_bytes gauge
@@ -51,6 +53,7 @@ class TestRawMetricPrefix:
 class TestEnableHealthServiceCheck:
     def test_default(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -64,6 +67,7 @@ class TestEnableHealthServiceCheck:
 
     def test_enddpoint_fails(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -81,6 +85,7 @@ class TestEnableHealthServiceCheck:
 
     def test_disable_health_check(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -110,6 +115,7 @@ class TestEnableHealthServiceCheck:
 class TestHostnameLabel:
     def test(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -133,6 +139,7 @@ class TestHostnameLabel:
 class TestHostnameFormat:
     def test(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -181,6 +188,7 @@ class TestExcludeIncludeLabels:
         expected_c,
     ):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -207,6 +215,7 @@ class TestExcludeIncludeLabels:
 class TestRenameLabels:
     def test(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -226,6 +235,7 @@ class TestRenameLabels:
 class TestExcludeMetrics:
     def test(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -251,6 +261,7 @@ class TestExcludeMetrics:
 class TestExcludeMetricsByLabels:
     def test_pattern(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -274,6 +285,7 @@ class TestExcludeMetricsByLabels:
 
     def test_all(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -295,6 +307,7 @@ class TestExcludeMetricsByLabels:
 class TestRawLineFilters:
     def test(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -320,6 +333,7 @@ class TestRawLineFilters:
 class TestMetrics:
     def test_unknown_type_override(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes untyped
@@ -339,6 +353,7 @@ class TestMetrics:
 class TestShareLabels:
     def test_unconditional_labels_all(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -374,6 +389,7 @@ class TestShareLabels:
 
     def test_unconditional_labels_subset(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -412,6 +428,7 @@ class TestShareLabels:
 
     def test_match_with_unconditional_labels(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -450,6 +467,7 @@ class TestShareLabels:
 
     def test_match_with_select_labels(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -491,6 +509,7 @@ class TestShareLabels:
     @pytest.mark.parametrize('values', [pytest.param([6396288], id='integer'), pytest.param(['6396288'], id='string')])
     def test_values_match(self, aggregator, dd_run_check, mock_http_response, values):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -526,6 +545,7 @@ class TestShareLabels:
 
     def test_values_no_match(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -555,6 +575,7 @@ class TestShareLabels:
 
     def test_excluded_metric(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -593,6 +614,7 @@ class TestShareLabels:
 
     def test_shared_labels_with_cache(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
             # TYPE go_memstats_gc_sys_bytes gauge
@@ -646,6 +668,7 @@ class TestShareLabels:
 
     def test_shared_labels_without_cache(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
             # TYPE go_memstats_gc_sys_bytes gauge
@@ -685,6 +708,7 @@ class TestShareLabels:
         check = get_check({'metrics': ['.+'], 'target_info': True})
 
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP target Target metadata
             # TYPE target info
@@ -710,6 +734,7 @@ class TestShareLabels:
         check = get_check({'metrics': ['.+'], 'target_info': True, 'cache_shared_labels': False})
 
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -735,6 +760,7 @@ class TestShareLabels:
         check = get_check({'metrics': ['.+'], 'target_info': True})
 
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -770,6 +796,7 @@ class TestShareLabels:
         check_var = check
 
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP target Target metadata
             # TYPE target info
@@ -790,6 +817,7 @@ class TestShareLabels:
         )
 
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP target Target metadata
             # TYPE target info
@@ -816,6 +844,7 @@ class TestShareLabels:
         check_var = check
 
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP target Target metadata
             # TYPE target info
@@ -839,6 +868,7 @@ class TestShareLabels:
         )
 
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP target Target metadata
             # TYPE target info
@@ -874,6 +904,7 @@ class TestShareLabels:
 class TestIgnoreTags:
     def test_simple_match(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -894,6 +925,7 @@ class TestIgnoreTags:
 
     def test_simple_wildcard(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge
@@ -914,6 +946,7 @@ class TestIgnoreTags:
 
     def test_regex(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
+            OPENMETRICS_SCRAPER_HTTP_TARGET,
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
             # TYPE go_memstats_alloc_bytes gauge

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_counter.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_counter.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from ..utils import get_check
+from ..utils import OPENMETRICS_SCRAPER_HTTP_TARGET, get_check
 
 
 def test_basic(aggregator, dd_run_check, mock_http_response):
@@ -13,6 +13,7 @@ def test_basic(aggregator, dd_run_check, mock_http_response):
     """
 
     mock_http_response(
+        OPENMETRICS_SCRAPER_HTTP_TARGET,
         """
         # HELP foo_total Example of '_total' getting dropped
         # TYPE foo_total counter
@@ -43,6 +44,7 @@ def test_basic(aggregator, dd_run_check, mock_http_response):
 
 def test_tags(aggregator, dd_run_check, mock_http_response):
     mock_http_response(
+        OPENMETRICS_SCRAPER_HTTP_TARGET,
         """
         # HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
         # TYPE go_memstats_alloc_bytes_total counter

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_counter.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_counter.py
@@ -24,7 +24,7 @@ def test_basic(aggregator, dd_run_check, mock_http_response):
         # HELP baz Example that doesn't end in '_total' nor '_count'
         # TYPE baz counter
         baz 1.28219257e+08
-        """
+        """,
     )
     check = get_check({'metrics': ['.+']})
     dd_run_check(check)
@@ -52,7 +52,7 @@ def test_tags(aggregator, dd_run_check, mock_http_response):
         # HELP go_memstats_frees_total Total number of frees.
         # TYPE go_memstats_frees_total counter
         go_memstats_frees_total{bar="foo"} 1.28219257e+08
-        """
+        """,
     )
     check = get_check({'metrics': ['.+']})
     dd_run_check(check)

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_counter_gauge.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_counter_gauge.py
@@ -2,11 +2,12 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from ..utils import get_check
+from ..utils import OPENMETRICS_SCRAPER_HTTP_TARGET, get_check
 
 
 def test(aggregator, dd_run_check, mock_http_response):
     mock_http_response(
+        OPENMETRICS_SCRAPER_HTTP_TARGET,
         """
         # HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
         # TYPE go_memstats_alloc_bytes_total counter

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_counter_gauge.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_counter_gauge.py
@@ -15,7 +15,7 @@ def test(aggregator, dd_run_check, mock_http_response):
         # HELP go_memstats_frees_total Total number of frees.
         # TYPE go_memstats_frees_total counter
         go_memstats_frees_total{bar="foo"} 1.28219257e+08
-        """
+        """,
     )
     check = get_check(
         {

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_gauge.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_gauge.py
@@ -15,7 +15,7 @@ def test_basic(aggregator, dd_run_check, mock_http_response):
         # HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
         # TYPE go_memstats_gc_sys_bytes gauge
         go_memstats_gc_sys_bytes 901120
-        """
+        """,
     )
     check = get_check({'metrics': ['.+']})
     dd_run_check(check)
@@ -40,7 +40,7 @@ def test_tags(aggregator, dd_run_check, mock_http_response):
         # HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
         # TYPE go_memstats_gc_sys_bytes gauge
         go_memstats_gc_sys_bytes{bar="foo"} 901120
-        """
+        """,
     )
     check = get_check({'metrics': ['.+']})
     dd_run_check(check)

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_gauge.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_gauge.py
@@ -2,11 +2,12 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from ..utils import get_check
+from ..utils import OPENMETRICS_SCRAPER_HTTP_TARGET, get_check
 
 
 def test_basic(aggregator, dd_run_check, mock_http_response):
     mock_http_response(
+        OPENMETRICS_SCRAPER_HTTP_TARGET,
         """
         # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
         # TYPE go_memstats_alloc_bytes gauge
@@ -31,6 +32,7 @@ def test_basic(aggregator, dd_run_check, mock_http_response):
 
 def test_tags(aggregator, dd_run_check, mock_http_response):
     mock_http_response(
+        OPENMETRICS_SCRAPER_HTTP_TARGET,
         """
         # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
         # TYPE go_memstats_alloc_bytes gauge

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_histogram.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_histogram.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from ..utils import get_check
+from ..utils import OPENMETRICS_SCRAPER_HTTP_TARGET, get_check
 
 
 def assert_metric_counts(aggregator, payload):
@@ -66,7 +66,7 @@ def test_default(aggregator, dd_run_check, mock_http_response):
         etcd_disk_wal_fsync_duration_seconds_sum{kind="fs",app="kubernetes"} 0.3097010759999998
         etcd_disk_wal_fsync_duration_seconds_count{kind="fs",app="kubernetes"} 751
         """
-    mock_http_response(payload)
+    mock_http_response(OPENMETRICS_SCRAPER_HTTP_TARGET, payload)
     check = get_check({'metrics': ['.+']})
     dd_run_check(check)
 
@@ -151,7 +151,7 @@ def test_disable_histogram_buckets(aggregator, dd_run_check, mock_http_response)
         etcd_disk_wal_fsync_duration_seconds_sum{kind="fs",app="kubernetes"} 0.3097010759999998
         etcd_disk_wal_fsync_duration_seconds_count{kind="fs",app="kubernetes"} 751
         """
-    mock_http_response(payload)
+    mock_http_response(OPENMETRICS_SCRAPER_HTTP_TARGET, payload)
     check = get_check({'metrics': ['.+'], 'collect_histogram_buckets': False})
     dd_run_check(check)
 
@@ -204,7 +204,7 @@ def test_non_cumulative_histogram_buckets(aggregator, dd_run_check, mock_http_re
         rest_client_request_latency_seconds_sum{url="http://127.0.0.1:8080/api",verb="GET"} 2.185820220000001
         rest_client_request_latency_seconds_count{url="http://127.0.0.1:8080/api",verb="GET"} 755
         """
-    mock_http_response(payload)
+    mock_http_response(OPENMETRICS_SCRAPER_HTTP_TARGET, payload)
     check = get_check({'metrics': ['.+'], 'non_cumulative_histogram_buckets': True})
     dd_run_check(check)
 
@@ -293,7 +293,7 @@ def test_non_cumulative_histogram_buckets_single_bucket(aggregator, dd_run_check
         rest_client_request_latency_seconds_sum{url="http://127.0.0.1:8080/api",verb="GET"} 2.185820220000001
         rest_client_request_latency_seconds_count{url="http://127.0.0.1:8080/api",verb="GET"} 755
         """
-    mock_http_response(payload)
+    mock_http_response(OPENMETRICS_SCRAPER_HTTP_TARGET, payload)
     check = get_check({'metrics': ['.+'], 'non_cumulative_histogram_buckets': True})
     dd_run_check(check)
 
@@ -331,7 +331,7 @@ def test_histogram_buckets_as_distributions(aggregator, dd_run_check, mock_http_
         rest_client_request_latency_seconds_sum{url="http://127.0.0.1:8080/api",verb="GET"} 2.185820220000001
         rest_client_request_latency_seconds_count{url="http://127.0.0.1:8080/api",verb="GET"} 755
         """
-    mock_http_response(payload)
+    mock_http_response(OPENMETRICS_SCRAPER_HTTP_TARGET, payload)
     check = get_check(
         {
             'metrics': ['.+'],
@@ -463,7 +463,7 @@ def test_histogram_buckets_as_distributions_with_counters(aggregator, dd_run_che
         rest_client_request_latency_seconds_sum{url="http://127.0.0.1:8080/api",verb="GET"} 2.185820220000001
         rest_client_request_latency_seconds_count{url="http://127.0.0.1:8080/api",verb="GET"} 755
         """
-    mock_http_response(payload)
+    mock_http_response(OPENMETRICS_SCRAPER_HTTP_TARGET, payload)
     check = get_check(
         {
             'metrics': ['.+'],

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_metadata.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_metadata.py
@@ -12,7 +12,7 @@ def test_basic(aggregator, datadog_agent, dd_run_check, mock_http_response):
         # HELP kubernetes_build_info A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.
         # TYPE kubernetes_build_info gauge
         kubernetes_build_info{buildDate="2016-11-18T23:57:26Z",compiler="gc",gitCommit="3872cb93abf9482d770e651b5fe14667a6fca7e0",gitTreeState="dirty",gitVersion="v1.6.0-alpha.0.680+3872cb93abf948-dirty",goVersion="go1.7.3",major="1",minor="6+",platform="linux/amd64"} 1
-        """  # noqa: E501
+        """,  # noqa: E501
     )
     check = get_check(
         {'metrics': [{'kubernetes_build_info': {'name': 'version', 'type': 'metadata', 'label': 'gitVersion'}}]}
@@ -42,7 +42,7 @@ def test_options(aggregator, datadog_agent, dd_run_check, mock_http_response):
         # HELP kubernetes_build_info A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.
         # TYPE kubernetes_build_info gauge
         kubernetes_build_info{buildDate="2016-11-18T23:57:26Z",compiler="gc",gitCommit="3872cb93abf9482d770e651b5fe14667a6fca7e0",gitTreeState="dirty",gitVersion="v1.6.0-alpha.0.680+3872cb93abf948-dirty",goVersion="go1.7.3",major="1",minor="6+",platform="linux/amd64"} 1
-        """  # noqa: E501
+        """,  # noqa: E501
     )
     check = get_check(
         {

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_metadata.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_metadata.py
@@ -2,11 +2,12 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from ..utils import get_check
+from ..utils import OPENMETRICS_SCRAPER_HTTP_TARGET, get_check
 
 
 def test_basic(aggregator, datadog_agent, dd_run_check, mock_http_response):
     mock_http_response(
+        OPENMETRICS_SCRAPER_HTTP_TARGET,
         """
         # HELP kubernetes_build_info A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.
         # TYPE kubernetes_build_info gauge
@@ -36,6 +37,7 @@ def test_basic(aggregator, datadog_agent, dd_run_check, mock_http_response):
 
 def test_options(aggregator, datadog_agent, dd_run_check, mock_http_response):
     mock_http_response(
+        OPENMETRICS_SCRAPER_HTTP_TARGET,
         """
         # HELP kubernetes_build_info A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.
         # TYPE kubernetes_build_info gauge

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_native_dynamic.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_native_dynamic.py
@@ -2,11 +2,12 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from ..utils import get_check
+from ..utils import OPENMETRICS_SCRAPER_HTTP_TARGET, get_check
 
 
 def test_basic(aggregator, dd_run_check, mock_http_response):
     mock_http_response(
+        OPENMETRICS_SCRAPER_HTTP_TARGET,
         """
         # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
         # TYPE go_memstats_alloc_bytes gauge

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_native_dynamic.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_native_dynamic.py
@@ -15,7 +15,7 @@ def test_basic(aggregator, dd_run_check, mock_http_response):
         # HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
         # TYPE go_memstats_alloc_bytes_total counter
         go_memstats_alloc_bytes_total 2.58684656e+08
-        """
+        """,
     )
     check = get_check({'metrics': [{'go_memstats_alloc_bytes': {'type': 'native_dynamic'}}]})
     dd_run_check(check)

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_rate.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_rate.py
@@ -12,7 +12,7 @@ def test(aggregator, dd_run_check, mock_http_response):
         # HELP istio_requests_total requests_total
         # TYPE istio_requests_total counter
         istio_requests_total 6.396288e+06
-        """
+        """,
     )
     check = get_check({'metrics': [{'istio_requests': {'type': 'rate'}}]})
     dd_run_check(check)

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_rate.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_rate.py
@@ -2,11 +2,12 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from ..utils import get_check
+from ..utils import OPENMETRICS_SCRAPER_HTTP_TARGET, get_check
 
 
 def test(aggregator, dd_run_check, mock_http_response):
     mock_http_response(
+        OPENMETRICS_SCRAPER_HTTP_TARGET,
         """
         # HELP istio_requests_total requests_total
         # TYPE istio_requests_total counter

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_service_check.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_service_check.py
@@ -3,11 +3,12 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from datadog_checks.base.constants import ServiceCheck
 
-from ..utils import get_check
+from ..utils import OPENMETRICS_SCRAPER_HTTP_TARGET, get_check
 
 
 def test_known(aggregator, dd_run_check, mock_http_response):
     mock_http_response(
+        OPENMETRICS_SCRAPER_HTTP_TARGET,
         """
         # HELP state Node state
         # TYPE state gauge
@@ -24,6 +25,7 @@ def test_known(aggregator, dd_run_check, mock_http_response):
 
 def test_unknown(aggregator, dd_run_check, mock_http_response):
     mock_http_response(
+        OPENMETRICS_SCRAPER_HTTP_TARGET,
         """
         # HELP state Node state
         # TYPE state gauge

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_service_check.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_service_check.py
@@ -13,7 +13,7 @@ def test_known(aggregator, dd_run_check, mock_http_response):
         # HELP state Node state
         # TYPE state gauge
         state{foo="bar"} 3
-        """
+        """,
     )
     check = get_check({'metrics': [{'state': {'type': 'service_check', 'status_map': {'3': 'ok'}}}]})
     dd_run_check(check)
@@ -30,7 +30,7 @@ def test_unknown(aggregator, dd_run_check, mock_http_response):
         # HELP state Node state
         # TYPE state gauge
         state{foo="bar"} 3
-        """
+        """,
     )
     check = get_check({'metrics': [{'state': {'type': 'service_check', 'status_map': {'7': 'ok'}}}]})
     dd_run_check(check)

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_summary.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_summary.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from ..utils import get_check
+from ..utils import OPENMETRICS_SCRAPER_HTTP_TARGET, get_check
 
 
 def assert_metric_counts(aggregator, payload):
@@ -37,7 +37,7 @@ def test_default(aggregator, dd_run_check, mock_http_response):
         http_request_duration_microseconds_sum{handler="prometheus"} 65093.229
         http_request_duration_microseconds_count{handler="prometheus"} 25
         """
-    mock_http_response(payload)
+    mock_http_response(OPENMETRICS_SCRAPER_HTTP_TARGET, payload)
     check = get_check({'metrics': ['.+']})
     dd_run_check(check)
 
@@ -83,7 +83,7 @@ def test_no_quantiles(aggregator, dd_run_check, mock_http_response):
         http_request_duration_microseconds_sum{handler="prometheus"} 65093.229
         http_request_duration_microseconds_count{handler="prometheus"} 25
         """
-    mock_http_response(payload)
+    mock_http_response(OPENMETRICS_SCRAPER_HTTP_TARGET, payload)
     check = get_check({'metrics': ['.+']})
     dd_run_check(check)
 
@@ -115,7 +115,7 @@ def test_quantiles_remapped_metric_name(aggregator, dd_run_check, mock_http_resp
         prometheus_target_interval_length_seconds_sum{interval="1s"} 26649.83516454906
         prometheus_target_interval_length_seconds_count{interval="1s"} 26032
         """
-    mock_http_response(payload)
+    mock_http_response(OPENMETRICS_SCRAPER_HTTP_TARGET, payload)
     check = get_check({'metrics': [{'prometheus_target_interval_length_seconds': 'target_interval_seconds'}]})
     dd_run_check(check)
 

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_temporal_percent.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_temporal_percent.py
@@ -12,7 +12,7 @@ def test_named(aggregator, dd_run_check, mock_http_response):
         # HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
         # TYPE process_cpu_seconds_total counter
         process_cpu_seconds_total{foo="bar"} 5.2
-        """
+        """,
     )
     check = get_check(
         {
@@ -43,7 +43,7 @@ def test_integer(aggregator, dd_run_check, mock_http_response):
         # HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
         # TYPE process_cpu_seconds_total counter
         process_cpu_seconds_total{foo="bar"} 5.2
-        """
+        """,
     )
     check = get_check(
         {'metrics': [{'process_cpu_seconds': {'name': 'process_cpu_usage', 'type': 'temporal_percent', 'scale': 1}}]}

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_temporal_percent.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_temporal_percent.py
@@ -2,11 +2,12 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from ..utils import get_check
+from ..utils import OPENMETRICS_SCRAPER_HTTP_TARGET, get_check
 
 
 def test_named(aggregator, dd_run_check, mock_http_response):
     mock_http_response(
+        OPENMETRICS_SCRAPER_HTTP_TARGET,
         """
         # HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
         # TYPE process_cpu_seconds_total counter
@@ -37,6 +38,7 @@ def test_named(aggregator, dd_run_check, mock_http_response):
 
 def test_integer(aggregator, dd_run_check, mock_http_response):
     mock_http_response(
+        OPENMETRICS_SCRAPER_HTTP_TARGET,
         """
         # HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
         # TYPE process_cpu_seconds_total counter

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_time_elapsed.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_time_elapsed.py
@@ -13,7 +13,7 @@ def test(aggregator, dd_run_check, mock_http_response):
         # HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
         # TYPE go_memstats_last_gc_time_seconds gauge
         go_memstats_last_gc_time_seconds{{foo="bar"}} {}
-        """.format(get_timestamp() - 1.2)
+        """.format(get_timestamp() - 1.2),
     )
     check = get_check({'metrics': [{'go_memstats_last_gc_time_seconds': {'type': 'time_elapsed'}}]})
     dd_run_check(check)

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_time_elapsed.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_time_elapsed.py
@@ -3,11 +3,12 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from datadog_checks.base.utils.time import get_timestamp
 
-from ..utils import get_check
+from ..utils import OPENMETRICS_SCRAPER_HTTP_TARGET, get_check
 
 
 def test(aggregator, dd_run_check, mock_http_response):
     mock_http_response(
+        OPENMETRICS_SCRAPER_HTTP_TARGET,
         """
         # HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
         # TYPE go_memstats_last_gc_time_seconds gauge

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_type_override.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_type_override.py
@@ -51,7 +51,7 @@ def test_untyped_counter(aggregator, dd_run_check, mock_http_response, metric_ty
         # HELP bux The metricset and metric samples are a non counter type
         # TYPE bux histogram
         bux 4
-        """
+        """,
     )
     check = get_check(
         {

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_type_override.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_type_override.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
-from ..utils import get_check
+from ..utils import OPENMETRICS_SCRAPER_HTTP_TARGET, get_check
 
 
 @pytest.mark.parametrize(
@@ -34,6 +34,7 @@ def test_untyped_counter(aggregator, dd_run_check, mock_http_response, metric_ty
     """
 
     mock_http_response(
+        OPENMETRICS_SCRAPER_HTTP_TARGET,
         """
         # HELP foo The metricset and metric sample does not end in '_total' and is untyped.
         # TYPE foo untyped

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/utils.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/utils.py
@@ -3,6 +3,11 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from datadog_checks.base import OpenMetricsBaseCheckV2
 
+# Patch target for mock_http_response: scraper calls self.http.get(endpoint, ...).
+OPENMETRICS_SCRAPER_HTTP_TARGET = (
+    'datadog_checks.base.checks.openmetrics.v2.scraper.base_scraper.RequestsWrapper.get'
+)
+
 
 def get_check(instance=None, init_config=None):
     return _get_check(OpenMetricsBaseCheckV2, instance, init_config)

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/utils.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/utils.py
@@ -4,9 +4,7 @@
 from datadog_checks.base import OpenMetricsBaseCheckV2
 
 # Patch target for mock_http_response: scraper calls self.http.get(endpoint, ...).
-OPENMETRICS_SCRAPER_HTTP_TARGET = (
-    'datadog_checks.base.checks.openmetrics.v2.scraper.base_scraper.RequestsWrapper.get'
-)
+OPENMETRICS_SCRAPER_HTTP_TARGET = 'datadog_checks.base.checks.openmetrics.v2.scraper.base_scraper.RequestsWrapper.get'
 
 
 def get_check(instance=None, init_config=None):

--- a/datadog_checks_base/tests/base/checks/prometheus/test_prometheus.py
+++ b/datadog_checks_base/tests/base/checks/prometheus/test_prometheus.py
@@ -6,6 +6,7 @@
 import logging
 import os
 import ssl
+
 import mock
 import pytest
 import requests
@@ -1680,7 +1681,9 @@ def test_label_joins_gc(sorted_tags_check):
 
     content2 = text_data.encode('utf-8') if isinstance(text_data, str) else text_data
     mock_resp2 = HTTPResponseMock(200, content=content2, headers={'Content-Type': "text/plain"})
-    with mock.patch.object(check, 'get_http_handler', return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp2)):
+    with mock.patch.object(
+        check, 'get_http_handler', return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp2)
+    ):
         check.process("http://fake.endpoint:10055/metrics")
         assert 'dd-agent-1337' in check._label_mapping['pod']
         assert 'dd-agent-62bgh' not in check._label_mapping['pod']
@@ -1952,10 +1955,13 @@ def test_text_filter_input():
 def test_ssl_verify_not_raise_warning(caplog, mocked_prometheus_check, text_data):
     check = mocked_prometheus_check
     mock_resp = HTTPResponseMock(200, content=b'httpbin.org')
-    with caplog.at_level(logging.DEBUG), mock.patch.object(
-        check,
-        'get_http_handler',
-        return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp, ignore_tls_warning=True),
+    with (
+        caplog.at_level(logging.DEBUG),
+        mock.patch.object(
+            check,
+            'get_http_handler',
+            return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp, ignore_tls_warning=True),
+        ),
     ):
         resp = check.poll('https://httpbin.org/get')
 
@@ -1970,10 +1976,13 @@ def test_ssl_verify_not_raise_warning_cert_false(caplog, mocked_prometheus_check
     check = mocked_prometheus_check
     check.ssl_ca_cert = False
     mock_resp = HTTPResponseMock(200, content=b'httpbin.org')
-    with caplog.at_level(logging.DEBUG), mock.patch.object(
-        check,
-        'get_http_handler',
-        return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp, ignore_tls_warning=True),
+    with (
+        caplog.at_level(logging.DEBUG),
+        mock.patch.object(
+            check,
+            'get_http_handler',
+            return_value=RequestWrapperMock(get=lambda url, **kw: mock_resp, ignore_tls_warning=True),
+        ),
     ):
         resp = check.poll('https://httpbin.org/get')
 

--- a/datadog_checks_base/tests/base/checks/prometheus/test_prometheus.py
+++ b/datadog_checks_base/tests/base/checks/prometheus/test_prometheus.py
@@ -9,7 +9,6 @@ import ssl
 
 import mock
 import pytest
-import requests
 
 from datadog_checks.checks.prometheus import PrometheusCheck, UnknownFormatError
 from datadog_checks.dev.http import HTTPResponseMock, RequestWrapperMock
@@ -1890,7 +1889,7 @@ def test_health_service_check_failing():
     check.NAMESPACE = 'ksm'
     check.health_service_check = True
     check.service_check = mock.MagicMock()
-    with pytest.raises(requests.ConnectionError):
+    with pytest.raises(ConnectionError):
         check.process("http://fake.endpoint:10055/metrics")
     check.service_check.assert_called_with(
         "ksm.prometheus.health", PrometheusCheck.CRITICAL, tags=["endpoint:http://fake.endpoint:10055/metrics"]

--- a/datadog_checks_base/tests/base/checks/test_kubelet_base.py
+++ b/datadog_checks_base/tests/base/checks/test_kubelet_base.py
@@ -9,6 +9,7 @@ import mock
 
 from datadog_checks.base.checks.kubelet_base.base import KubeletBase, urljoin
 from datadog_checks.dev import get_here
+from datadog_checks.dev.http import HTTPResponseMock
 
 HERE = get_here()
 
@@ -22,12 +23,11 @@ def mock_from_file(filename):
         return f.read()
 
 
-def test_retrieve_pod_list_success(monkeypatch, mock_http_response):
+def test_retrieve_pod_list_success(monkeypatch):
     check = KubeletBase('kubelet', {}, [{}])
     check.pod_list_url = "dummyurl"
-    monkeypatch.setattr(
-        check, 'perform_kubelet_query', mock_http_response(file_path=get_fixture_path('kubelet_base/pod_list_raw.dat'))
-    )
+    mock_resp = HTTPResponseMock(200, file_path=get_fixture_path('kubelet_base/pod_list_raw.dat'))
+    monkeypatch.setattr(check, 'perform_kubelet_query', lambda *args, **kwargs: mock_resp)
 
     retrieved = check.retrieve_pod_list()
     expected = json.loads(mock_from_file("kubelet_base/pod_list_raw.json"))

--- a/datadog_checks_base/tests/base/utils/http/test_http_mock.py
+++ b/datadog_checks_base/tests/base/utils/http/test_http_mock.py
@@ -7,12 +7,12 @@ import pytest
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.http import RequestsWrapper
-from datadog_checks.dev.http import HTTPResponseMock, RequestWrapperMock
 from datadog_checks.base.utils.http_protocol import (
     HTTPClientProtocol,
     HTTPResponseProtocol,
     HTTPSessionLike,
 )
+from datadog_checks.dev.http import HTTPResponseMock, RequestWrapperMock
 
 
 class TestHTTPResponseMock:

--- a/datadog_checks_dev/datadog_checks/dev/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/http.py
@@ -14,11 +14,13 @@ legacy. One testing path keeps tests simple and future work minimal.
   HTTPResponseMock), ``mock_http_response(patch_target, ...)``, and
   ``mock_http_response_per_endpoint(responses_by_endpoint, ...)``. All three
   fixtures use these mock classes so tests do not depend on requests/httpx.
-  Example (direct patch): ``mock.patch.object(check, 'get_http_handler', return_value=RequestWrapperMock(get=lambda url, **kw: HTTPResponseMock(200, content=b'...')))``.
+  Example (direct patch): ``mock.patch.object(check, 'get_http_handler',
+  return_value=RequestWrapperMock(get=lambda url, **kw: HTTPResponseMock(200, content=b'...')))``.
   Example (fixture): ``mock_http_response('module.path.ToPatch', content=b'...')``.
 - **Legacy tests**: Migrate to the above pattern; do not add legacy-only branches to
   fixtures or helpers.
 """
+
 from __future__ import annotations
 
 import json

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -301,6 +301,7 @@ def dd_default_hostname():
 # For manual patching: HTTPResponseMock, RequestWrapperMock from datadog_checks.dev.http.
 # -----------------------------------------------------------------------------
 
+
 @pytest.fixture
 def mock_response():
     """Yield the HTTPResponseMock class. Used by mock_http_response* fixtures."""

--- a/docs/developer/base/http.md
+++ b/docs/developer/base/http.md
@@ -49,7 +49,7 @@ response = self.http.get(url)
 
 ## Testing
 
-To mock HTTP in tests without depending on `requests` or `httpx`, use the helpers in `datadog_checks.dev.http` (or the `http_response_mock` and `request_wrapper_mock` pytest fixtures from the dev plugin):
+To mock HTTP in tests without depending on `requests` or `httpx`, use the helpers in `datadog_checks.dev.http` and the `mock_http_response` pytest fixture for check tests:
 
 - **`HTTPResponseMock`**: Builds a response (status_code, content, headers, json_data) that satisfies the same interface as the real response.
 - **`RequestWrapperMock`**: Implements the HTTP client interface. Pass callables for `get`, `post`, etc. to control responses. As a context manager with a check instance, it patches `check.http` for the duration:


### PR DESCRIPTION
### What does this PR do?
This PR migrates Prometheus and OpenMetrics tests to RequestWrapperMock by replacing `requests.Session.get` patches with `get_http_handler` + `RequestWrapperMock` / `HTTPResponseMock` so tests are implementation-agnostic and do not depend on requests. 

It also adds `ignore_tls_warning` to `RequestWrapperMock` so scraper code that checks `handler.ignore_tls_warning` works when the handler is the mock.

### Motivation
[RFC](https://datadoghq.atlassian.net/wiki/spaces/AI/pages/6214681547/RFC+2026-02-11+-+Migrate+the+HTTP+layer+from+requests+to+httpx)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
