### PR TITLE
Fix cassandra nodetool test failure: remove version 2.14.1

### DIFF
--- a/cassandra_nodetool/hatch.toml
+++ b/cassandra_nodetool/hatch.toml
@@ -2,11 +2,10 @@
 
 [[envs.default.matrix]]
 python = ["3.13"]
-version = ["2.1", "3.0"]
+version = ["3.0"]
 
 [envs.default.overrides]
 matrix.version.env-vars = [
-  { key = "CASSANDRA_VERSION", value = "2.1.14", if = ["2.1"] },
   { key = "CASSANDRA_VERSION", value = "3.0.23", if = ["3.0"] },
 ]
 


### PR DESCRIPTION
### What does this PR do?
Add a default cassandra docker version to fix the test failing.

Root cause of the issue #22131 CASSANDRA_VERSION is empty during the Docker build, so the FROM becomes FROM cassandra: (invalid) => This is a Docker BuildKit issue ([it seems to be updated on Feb 9th](https://github.com/actions/runner-images/issues/13474))

Solution: Remove testing for version 2.14.1 as it is very old and causing the failure.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
