### PR TITLE
refactor: use mock_http_response in prometheus and openmetrics tests

### DIFF
--- a/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_openmetrics.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_openmetrics.py
@@ -2662,7 +2662,7 @@ def test_metadata_transformer(mocked_openmetrics_check_factory, text_data, datad
     datadog_agent.assert_metadata_count(len(version_metadata))
 
 
-def test_ssl_verify_not_raise_warning(caplog, mocked_openmetrics_check_factory, text_data):
+def test_ssl_verify_not_raise_warning(caplog, mocked_openmetrics_check_factory, mock_http_response):
     instance = {
         'prometheus_url': 'https://www.example.com',
         'metrics': [{'foo': 'bar'}],
@@ -2672,7 +2672,8 @@ def test_ssl_verify_not_raise_warning(caplog, mocked_openmetrics_check_factory, 
     check = mocked_openmetrics_check_factory(instance)
     scraper_config = check.get_scraper_config(instance)
 
-    with caplog.at_level(logging.DEBUG), mock.patch('requests.Session.get', return_value=MockResponse('httpbin.org')):
+    mock_http_response('httpbin.org')
+    with caplog.at_level(logging.DEBUG):
         resp = check.send_request('https://httpbin.org/get', scraper_config)
 
     assert "httpbin.org" in resp.content.decode('utf-8')
@@ -2682,7 +2683,7 @@ def test_ssl_verify_not_raise_warning(caplog, mocked_openmetrics_check_factory, 
         assert message != expected_message
 
 
-def test_send_request_with_dynamic_prometheus_url(caplog, mocked_openmetrics_check_factory, text_data):
+def test_send_request_with_dynamic_prometheus_url(caplog, mocked_openmetrics_check_factory, mock_http_response):
     instance = {
         'prometheus_url': 'https://www.example.com',
         'metrics': [{'foo': 'bar'}],
@@ -2696,7 +2697,8 @@ def test_send_request_with_dynamic_prometheus_url(caplog, mocked_openmetrics_che
     # `prometheus_url` changed just before calling `send_request`
     scraper_config['prometheus_url'] = 'https://www.example.com/foo/bar'
 
-    with caplog.at_level(logging.DEBUG), mock.patch('requests.Session.get', return_value=MockResponse('httpbin.org')):
+    mock_http_response('httpbin.org')
+    with caplog.at_level(logging.DEBUG):
         resp = check.send_request('https://httpbin.org/get', scraper_config)
 
     assert "httpbin.org" in resp.content.decode('utf-8')


### PR DESCRIPTION
### What does this PR do?
This PR replaces direct `mock.patch('requests.Session.get')` calls with the `mock_http_response` fixture in `datadog_checks_base/tests/base/checks/prometheus/test_prometheus.py` and `datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_openmetrics.py`.

For the Prometheus tests, only 2 tests were migrated. The following tests were left as direct patches:
- `test_poll_protobuf`: uses binary `bin_data`; `mock_http_response` only supports text because it encodes with `content.encode('utf-8')`. 
- `test_poll_text_plain` + `test_label_join*` + `mock_get` fixture + `test_health_service_check_ok`: uses a custom mock with `iter_lines` so that the Prometheus text parser gets **string** lines. With `mock_http_response`, the parser was seeing bytes and would fail on `line.startswith('#')`. 

The same exceptions mentioned above for the Prometheus tests exist for the OM tests as well. 

### Motivation
This is a part of the first step of the requests to httpx migration. [RFC](https://datadoghq.atlassian.net/wiki/spaces/AI/pages/6214681547/RFC+2026-02-11+-+Migrate+the+HTTP+layer+from+requests+to+httpx)

We want to start by refactoring as many tests as possible to use fixture `mock_http_response`. That way, when we switch out `requests.Session.get` in `mock_http_response`, we won't need to hunt down all the direct calls to `requests.Session.get` later on. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
