### PR TITLE
refactor: use mock_http_response in integrations (first batch)

### DIFF
--- a/dcgm/tests/conftest.py
+++ b/dcgm/tests/conftest.py
@@ -4,7 +4,6 @@
 
 import copy
 import os
-from unittest import mock
 
 import pytest
 
@@ -40,28 +39,18 @@ def check(instance):
 
 
 @pytest.fixture()
-def mock_metrics():
+def mock_metrics(mock_http_response):
     f_name = os.path.join(os.path.dirname(__file__), 'fixtures', 'metrics.txt')
     with open(f_name, 'r') as f:
         text_data = f.read()
-    with mock.patch(
-        'requests.Session.get',
-        return_value=mock.MagicMock(
-            status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
-        ),
-    ):
-        yield
+    mock_http_response(text_data)
+    yield
 
 
 @pytest.fixture()
-def mock_label_remap():
+def mock_label_remap(mock_http_response):
     f_name = os.path.join(os.path.dirname(__file__), 'fixtures', 'label_remap.txt')
     with open(f_name, 'r') as f:
         text_data = f.read()
-    with mock.patch(
-        'requests.Session.get',
-        return_value=mock.MagicMock(
-            status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
-        ),
-    ):
-        yield
+    mock_http_response(text_data)
+    yield

--- a/fluxcd/tests/conftest.py
+++ b/fluxcd/tests/conftest.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 from contextlib import ExitStack
-from unittest import mock
 
 import pytest
 
@@ -69,36 +68,18 @@ def check(instance):
 
 
 @pytest.fixture()
-def mock_metrics_v1():
+def mock_metrics_v1(mock_http_response):
     fixture_file = os.path.join(os.path.dirname(__file__), "fixtures", "metrics-v1.txt")
-
     with open(fixture_file, "r") as f:
         content = f.read()
-
-    with mock.patch(
-        "requests.Session.get",
-        return_value=mock.MagicMock(
-            status_code=200,
-            iter_lines=lambda **kwargs: content.split("\n"),
-            headers={"Content-Type": "text/plain"},
-        ),
-    ):
-        yield
+    mock_http_response(content)
+    yield
 
 
 @pytest.fixture()
-def mock_metrics_v2():
+def mock_metrics_v2(mock_http_response):
     fixture_file = os.path.join(os.path.dirname(__file__), "fixtures", "metrics-v2.txt")
-
     with open(fixture_file, "r") as f:
         content = f.read()
-
-    with mock.patch(
-        "requests.Session.get",
-        return_value=mock.MagicMock(
-            status_code=200,
-            iter_lines=lambda **kwargs: content.split("\n"),
-            headers={"Content-Type": "text/plain"},
-        ),
-    ):
-        yield
+    mock_http_response(content)
+    yield

--- a/http_check/tests/test_http_integration.py
+++ b/http_check/tests/test_http_integration.py
@@ -441,7 +441,7 @@ def test_data_methods(aggregator, http_check):
         aggregator.reset()
 
 
-def test_unexisting_ca_cert_should_log_warning(aggregator, dd_run_check):
+def test_unexisting_ca_cert_should_log_warning(aggregator, dd_run_check, mock_http_response):
     instance = {
         'name': 'Test Web VM HTTPS SSL',
         'url': 'https://foo.bar.net/',
@@ -453,10 +453,8 @@ def test_unexisting_ca_cert_should_log_warning(aggregator, dd_run_check):
         'skip_proxy': 'false',
     }
 
-    with (
-        mock.patch('datadog_checks.base.utils.http.logging.Logger.warning') as mock_warning,
-        mock.patch('requests.Session.get'),
-    ):
+    mock_http_response('')
+    with mock.patch('datadog_checks.base.utils.http.logging.Logger.warning') as mock_warning:
         check = HTTPCheck('http_check', {'ca_certs': 'foo'}, [instance])
         dd_run_check(check)
         mock_warning.assert_called()

--- a/impala/tests/conftest.py
+++ b/impala/tests/conftest.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 from contextlib import ExitStack, contextmanager
-from unittest import mock
 
 import pytest
 
@@ -92,22 +91,14 @@ def catalog_check(catalog_instance):
 
 
 @pytest.fixture()
-def mock_metrics(request):
+def mock_metrics(request, mock_http_response):
     metrics_file = request.node.get_closest_marker("metrics_file")
     with open(
         os.path.join(os.path.dirname(__file__), "fixtures", metrics_file.args[0], metrics_file.args[1]), "r"
     ) as fixture_file:
         content = fixture_file.read()
-
-    with mock.patch(
-        "requests.Session.get",
-        return_value=mock.MagicMock(
-            status_code=200,
-            iter_lines=lambda **kwargs: content.split("\n"),
-            headers={"Content-Type": "text/plain"},
-        ),
-    ):
-        yield
+    mock_http_response(content)
+    yield
 
 
 @contextmanager

--- a/scylla/tests/conftest.py
+++ b/scylla/tests/conftest.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 
-import mock
 import pytest
 
 from datadog_checks.dev import docker_run, get_docker_hostname, get_here
@@ -34,7 +33,7 @@ def instance():
 
 
 @pytest.fixture()
-def mock_db_data():
+def mock_db_data(mock_http_response):
     if os.environ['SCYLLA_VERSION'].startswith('5.'):
         f_name = os.path.join(os.path.dirname(__file__), 'fixtures', 'scylla_5_metrics.txt')
     elif os.environ['SCYLLA_VERSION'].startswith('3.3'):
@@ -44,12 +43,5 @@ def mock_db_data():
 
     with open(f_name, 'r') as f:
         text_data = f.read()
-    with mock.patch(
-        'requests.Session.get',
-        return_value=mock.MagicMock(
-            status_code=200,
-            iter_lines=lambda **kwargs: text_data.split("\n"),
-            headers={'Content-Type': "text/plain"},
-        ),
-    ):
-        yield
+    mock_http_response(text_data)
+    yield

--- a/temporal/tests/conftest.py
+++ b/temporal/tests/conftest.py
@@ -5,7 +5,6 @@ import copy
 import os
 import time
 from contextlib import contextmanager
-from unittest import mock
 
 import pytest
 
@@ -82,14 +81,9 @@ def check(instance):
 
 
 @pytest.fixture()
-def mock_metrics():
+def mock_metrics(mock_http_response):
     f_name = os.path.join(os.path.dirname(__file__), 'fixtures', 'metrics.txt')
     with open(f_name, 'r') as f:
         text_data = f.read()
-    with mock.patch(
-        'requests.Session.get',
-        return_value=mock.MagicMock(
-            status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
-        ),
-    ):
-        yield
+    mock_http_response(text_data)
+    yield


### PR DESCRIPTION
### What does this PR do?
This PR replaces direct `mock.patch('requests.Session.get')` calls with the `mock_http_response` fixture in a batch of integrations. These integrations were selected for the first batch because they were easy to refactor.

Integrations dcgm, fluxcd, impala, scylla, temporal were chosen because they all had the same conftest pattern that was easily refactored.

http_check was chosen because there was a single test to refactor.

### Motivation
This is a part of the first step of the requests to httpx migration. [RFC](https://datadoghq.atlassian.net/wiki/spaces/AI/pages/6214681547/RFC+2026-02-11+-+Migrate+the+HTTP+layer+from+requests+to+httpx)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
