### PR TITLE
Fix devcontainer workflow by removing the legacy yarn source

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,8 @@
 # This dockerfile is used to build the devcontainer environment.
 # more info about vscode devcontainer: https://code.visualstudio.com/docs/devcontainers/containers
 FROM mcr.microsoft.com/devcontainers/python:1-3.13-bullseye
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y liblz4-dev libunwind-dev ca-certificates curl gnupg
+RUN rm -f /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y liblz4-dev libunwind-dev ca-certificates curl gnupg
 # Docker and docker-compose installation
 RUN install -m 0755 -d /etc/apt/keyrings
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg


### PR DESCRIPTION
### What does this PR do?

Fixes the devcontainer Docker image build by removing the stale Yarn APT repository source before running `apt-get update`.

The base image (`mcr.microsoft.com/devcontainers/python:1-3.13-bullseye`) ships with a pre-configured Yarn 1.x APT repository (`https://dl.yarnpkg.com/debian`). The GPG signing key for this repository (`62D54FD4003F6525`) is no longer valid, causing `apt update` to fail with:

```
E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.
```


The Yarn APT repo is a remnant of the legacy Yarn installation method included in Microsoft's devcontainer images. It is not needed by the devcontainer since modern Yarn is distributed via Corepack/Node.js.

The fix removes `/etc/apt/sources.list.d/yarn.list` before running `apt-get update`. Additionally, `apt` is replaced with `apt-get` which is the recommended command for non-interactive/scripted use.

We could keep getting the latest keys (suggestions in the [devcontainer repo](https://github.com/devcontainers/images/issues/1752
)) but since we do not require yarn for a devcontainer in `integrations-core` I would propose to get rid of it. This would avoid issues in the future when it expires again.

### Motivation

The `test build devcontainer image` workflow is [failing on master](https://github.com/DataDog/integrations-core/actions/runs/21944322527/attempts/1) due to the expired Yarn GPG key in the base image. This also prevents contributors from building the devcontainer locally.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged