### PR TITLE
[O11YINFRA-109] catch AssertionError from bmemcached on malformed binary protocol responses

### DIFF
--- a/mcache/changelog.d/22650.fixed
+++ b/mcache/changelog.d/22650.fixed
@@ -1,1 +1,1 @@
-Catch `AssertionError` from `bmemcached` when the memcached binary protocol response is malformed, preventing unhandled crashes during transient connection issues.
+Handle malformed binary protocol responses from `bmemcached` gracefully. Instead of crashing with an unhandled `AssertionError`, the check now logs a warning and reports a `WARNING` service check, allowing the next check run to retry.

--- a/mcache/datadog_checks/mcache/mcache.py
+++ b/mcache/datadog_checks/mcache/mcache.py
@@ -293,7 +293,7 @@ class Memcache(AgentCheck):
                 self.OPTIONAL_STATS["items"][2] = Memcache.get_items_stats
                 self.OPTIONAL_STATS["slabs"][2] = Memcache.get_slabs_stats
                 self._get_optional_metrics(client, tags, options)
-        except (BadResponseError, AssertionError) as e:
+        except BadResponseError as e:
             self.service_check(
                 self.SERVICE_CHECK,
                 AgentCheck.CRITICAL,
@@ -304,6 +304,16 @@ class Memcache(AgentCheck):
                 "Unable to retrieve stats from memcache instance: {}:{}. Please check your configuration. ({})".format(
                     server, port, e
                 )
+            )
+        except AssertionError:
+            self.warning(
+                "Received malformed response from memcache instance %s:%s, skipping this check run", server, port
+            )
+            self.service_check(
+                self.SERVICE_CHECK,
+                AgentCheck.WARNING,
+                tags=service_check_tags,
+                message="Malformed binary protocol response",
             )
         else:
             client.disconnect_all()


### PR DESCRIPTION
## Summary
- Catch `AssertionError` alongside `BadResponseError` in the memcached check's main exception handler

## Problem
The `bmemcached` library uses assertions to validate binary protocol responses:

```python
# bmemcached/protocol.py line 250
assert magic == self.MAGIC['response']
```

When memcached returns a malformed binary response (e.g., during high load, connection instability, or pod lifecycle transitions), this assertion fails with an `AssertionError`. The check's exception handler only catches `BadResponseError`, so the `AssertionError` propagates unhandled and crashes the check with a confusing traceback.

This affects `nicky` pods in `metrics-intake` across multiple cells (tango, mambo, etc.) on `us1.prod.dog`.

## Error traces

**AssertionError (unhandled):**
```
File "bmemcached/protocol.py", line 250, in _get_response
    assert magic == self.MAGIC['response']
AssertionError
```

**BadResponseError (after assertion kills the connection):**
```
BadResponseError: Malformed response for host: {}
```

## Fix
Add `AssertionError` to the `except` clause so it's handled the same way as `BadResponseError` — a `CRITICAL` service check is emitted and a `ConfigurationError` is raised with a clear message, instead of an unhandled assertion crash.

```python
# Before:
except BadResponseError as e:

# After:
except (BadResponseError, AssertionError) as e:
```