### PR TITLE
feat(SIMI-109): Showing kandji docs as public

### DIFF
--- a/kandji/manifest.json
+++ b/kandji/manifest.json
@@ -3,7 +3,7 @@
   "app_uuid": "3677fa0b-49e4-49df-b0f2-6a3a983d6637",
   "app_id": "kandji",
   "owner": "saas-integrations",
-  "display_on_public_website": false,
+  "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?
Setting Kandji integration docs as public since it'll go GA

### Motivation
Jira ticket: [SIMI-109](https://datadoghq.atlassian.net/browse/SIMI-109)


[SIMI-109]: https://datadoghq.atlassian.net/browse/SIMI-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ