### PR TITLE
Mark secrets in fleet_configurable cloudera, mongo, silverstripe_cms config specs

### DIFF
--- a/cloudera/assets/configuration/spec.yaml
+++ b/cloudera/assets/configuration/spec.yaml
@@ -19,6 +19,7 @@ files:
         Console in the `Workload Password`.
       fleet_configurable: true
       required: true
+      secret: true
       value:
         type: string
     - template: init_config/default

--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -697,6 +697,7 @@ files:
       description: |
         Specify the MongoDB URI, with database to use for reporting (defaults to "admin")
         E.g. mongodb://datadog:LnCbkX4uhpuLHSUrcayEoAZA@localhost:27016/admin
+      secret: true
       value:
         example: mongodb://<USER>:<PASSWORD>@<HOST>:<PORT>/<DB_NAME>
         display_default: null

--- a/silverstripe_cms/assets/configuration/spec.yaml
+++ b/silverstripe_cms/assets/configuration/spec.yaml
@@ -46,6 +46,7 @@ files:
       fleet_configurable: true
       required: true
       description: "Silverstripe Database Password."
+      secret: true
       value:
         type: string
         example: "<PASSWORD>"


### PR DESCRIPTION
### What does this PR do?
Mark password fields as secret for remote configuration.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
