### PR TITLE
[Release] Bumped sqlserver version to 22.12.4 (port from 7.76.x)

### DIFF
--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -205,7 +205,7 @@ datadog-sonarqube==5.5.0
 datadog-sonatype-nexus==2.2.0; sys_platform != 'darwin'
 datadog-sonicwall-firewall==1.3.0
 datadog-spark==7.4.0
-datadog-sqlserver==22.12.3
+datadog-sqlserver==22.12.4
 datadog-squid==5.2.0
 datadog-ssh-check==4.5.0
 datadog-statsd==3.2.0

--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 22.12.4 / 2026-02-05
+
+***Fixed***:
+
+* Fixed an issue where schema collection thread connections could get abruptly closed from the main check loop ([#22471](https://github.com/DataDog/integrations-core/pull/22471))
+
 ## 22.12.3 / 2026-01-21
 
 ***Fixed***:

--- a/sqlserver/changelog.d/22471.fixed
+++ b/sqlserver/changelog.d/22471.fixed
@@ -1,1 +1,0 @@
-Fixed an issue where schema collection thread connections could get abruptly closed from the main check loop

--- a/sqlserver/datadog_checks/sqlserver/__about__.py
+++ b/sqlserver/datadog_checks/sqlserver/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = '22.12.3'
+__version__ = '22.12.4'


### PR DESCRIPTION
### What does this PR do?
ports release from https://github.com/DataDog/integrations-core/pull/22561
### Motivation
changelog wasn't updated here: https://github.com/DataDog/integrations-core/pull/22655/changes
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
