### PR TITLE
fix(workflows): ensure dependent repos can access test scripts

### DIFF
--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -137,15 +137,6 @@ jobs:
         # Use a specific sub-folder
         path: core-temp
 
-    - name: DEBUG - List What Was Checked Out
-      if: inputs.repo != 'core'
-      run: |
-        echo "Checking root of checkout..."
-        ls -la core-temp/
-
-        echo "Checking for actions folder..."
-        ls -la core-temp/.github/actions || echo "Actions folder not found!"
-
     - name: Install workflow scripts (core)
       if: inputs.repo == 'core'
       uses: ./.github/actions/setup-test-target-scripts


### PR DESCRIPTION
### What does this PR do?

Fixes the `test-target.yml` reusable workflow so CI works again for non-core repos (`integrations-internal`, `marketplace`, `extras`).

The composite action reference (`uses: ./.github/actions/setup-test-target-scripts`) introduced in #22420 resolves against the caller's repo checkout, not `integrations-core`, so non-core repos fail with:

```
Can't find 'action.yml' under '.github/actions/setup-test-target-scripts'
```

This splits the step into two: the local composite action for core (where it exists in the checkout), and a `curl`-based download for non-core repos using `github.workflow_sha` to respect pinned workflow versions.

### Motivation

Since #22420 was merged on Jan 27, CI is broken for non-core repos that reference this workflow at `@master` (e.g., `integrations-internal`). Repos pinned to an older SHA (e.g., `integrations-extras` at `574d63ba`) are unaffected since they still use the pre-#22420 workflow. Discovered via [integrations-internal#273](https://github.com/DataDog/integrations-internal/pull/273) which fails before tests even run.

Tested fix here: https://github.com/DataDog/integrations-internal/pull/274

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
