### PR TITLE
Don't report false negative lag when broker offsets are reset

### DIFF
--- a/kafka_consumer/changelog.d/22679.fixed
+++ b/kafka_consumer/changelog.d/22679.fixed
@@ -1,0 +1,1 @@
+Don't report negative lag when data is dropped (broker offset goes down).

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -315,10 +315,6 @@ class KafkaCheck(AgentCheck):
                         continue
                     producer_offset = highwater_offsets[(topic, partition)]
                     consumer_lag = producer_offset - consumer_offset
-                    if reported_contexts < contexts_limit:
-                        self.gauge('consumer_lag', consumer_lag, tags=consumer_group_tags)
-                        self.log.debug('%s consumer lag reported with %s tags', consumer_lag, consumer_group_tags)
-                        reported_contexts += 1
 
                     if consumer_lag < 0:
                         # this will effectively result in data loss, so emit an event for max visibility
@@ -331,6 +327,12 @@ class KafkaCheck(AgentCheck):
                         key = "{}:{}:{}".format(consumer_group, topic, partition)
                         self.send_event(title, message, consumer_group_tags, 'consumer_lag', key, severity="error")
                         self.log.debug(message)
+                        consumer_lag = 0
+
+                    if reported_contexts < contexts_limit:
+                        self.gauge('consumer_lag', consumer_lag, tags=consumer_group_tags)
+                        self.log.debug('%s consumer lag reported with %s tags', consumer_lag, consumer_group_tags)
+                        reported_contexts += 1
 
                     if not self._data_streams_enabled:
                         continue

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -237,6 +237,7 @@ def test_when_consumer_lag_less_than_zero_then_emit_event(check, kafka_instance,
     )
     aggregator.assert_metric(
         "kafka.consumer_lag",
+        value=0,
         count=1,
         tags=[
             'consumer_group:consumer_group1',


### PR DESCRIPTION
### What does this PR do?

When data loss happens, broker offsets can go to 0.
In that case, reported lag can be incorrectly reported as negative.
This PR is an easy fix for this case.

### Motivation

<img width="602" height="245" alt="image" src="https://github.com/user-attachments/assets/d4b46082-46f4-499a-b92f-ffb1ca7db258" />
Seeing negative lag being reported can be very confusing.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
