### PR TITLE
[NDM] update ootb monitors for sdwan and versa

### DIFF
--- a/cisco_sdwan/assets/monitors/device_reboot.json
+++ b/cisco_sdwan/assets/monitors/device_reboot.json
@@ -10,7 +10,7 @@
   "definition": {
 	"name": "[Cisco SD-WAN] Device {{device_hostname.name}} ({{device_ip.name}}) rebooted more than 3 times in the last 10 minutes",
 	"type": "query alert",
-	"query": "sum(last_10m):sum:cisco_sdwan.reboot.count{*} by {device_namespace,device_hostname,device_ip,device_id} > 3",
+	"query": "sum(last_10m):sum:cisco_sdwan.reboot.count{*} by {device_namespace,system_ip,device_hostname,device_ip,device_id} > 3",
 	"message": "{{#is_alert}}\nSD-WAN Device {{device_hostname.name}} ({{device_ip.name}}) rebooted more than 3 times in the last 10 minutes.\n{{/is_alert}}\n\nTo know more about the status of your device, you can have more information from the [NDM page for the device {{device_namespace.name}}:{{device_ip.name}}](/devices?inspectedDevice={{device_namespace.name}}%3A{{device_ip.name}}).",
 	"tags": [],
 	"options": {

--- a/cisco_sdwan/assets/monitors/device_unreachable.json
+++ b/cisco_sdwan/assets/monitors/device_unreachable.json
@@ -10,7 +10,7 @@
   "definition": {
 	"name": "[Cisco SD-WAN] Device unreachable alert on {{device_hostname.name}} in namespace {{device_namespace.name}}",
 	"type": "query alert",
-	"query": "avg(last_5m):max:cisco_sdwan.device.reachable{*} by {device_hostname,device_ip,device_namespace,device_id} < 0.8",
+	"query": "avg(last_5m):max:cisco_sdwan.device.reachable{*} by {device_namespace,system_ip,device_hostname,device_ip,device_id} < 0.8",
 	"message": "{{#is_alert}}\nA network device {{device_hostname.name}} with IP {{device_ip.name}} in namespace {{device_namespace.name}} is unreachable.\n{{/is_alert}}\n{{#is_alert_recovery}}\nA network device {{device_hostname.name}} with IP {{device_ip.name}} in namespace {{device_namespace.name}} is reachable again.\n{{/is_alert_recovery}}\n\nTo know more about the status of your device, you can have more information from the [NDM page for the device {{device_namespace.name}}:{{device_ip.name}}](/devices?inspectedDevice={{device_namespace.name}}%3A{{device_ip.name}}).",
 	"tags": [],
 	"options": {

--- a/cisco_sdwan/assets/monitors/tunnel_down.json
+++ b/cisco_sdwan/assets/monitors/tunnel_down.json
@@ -10,7 +10,7 @@
 	"definition": {
 		"name": "[Cisco SD-WAN] Tunnel is down between {{local_color.name}} {{hostname.name}} ({{device_ip.name}}) to {{remote_color.name}} {{remote_hostname.name}} ({{remote_device_ip.name}})",
 		"type": "query alert",
-		"query": "min(last_15m):min:cisco_sdwan.tunnel.status{*} by {device_id,device_namespace,device_ip,device_hostname,local_color,remote_device_ip,remote_device_hostname,remote_color} < 1",
+		"query": "min(last_15m):min:cisco_sdwan.tunnel.status{*} by {device_id,device_namespace,system_ip,device_ip,device_hostname,local_color,remote_device_ip,remote_device_hostname,remote_color} < 1",
 		"message": "{{#is_alert}}\nSD-WAN Tunnel is down between device {{device_hostname.name}} ({{device_ip.name}}), color {{local_color.name}} to device {{remote_device_hostname.name}} ({{remote_device_ip.name}}), color {{remote_color.name}}.\n{{/is_alert}}\n\n{{#is_alert_recovery}}\nSD-WAN Tunnel is back up between device {{device_hostname.name}} ({{device_ip.name}}), color {{local_color.name}} to device {{remote_device_hostname.name}} ({{remote_device_ip.name}}), color {{remote_color.name}}.\n{{/is_alert_recovery}}\n\nTo know more about the status of your device, you can have more information from the [NDM page for the device {{device_namespace.name}}:{{device_ip.name}}](/devices?inspectedDevice={{device_namespace.name}}%3A{{device_ip.name}}).",
 		"tags": [],
 		"options": {

--- a/versa/assets/monitors/inbound_link_utilization_high.json
+++ b/versa/assets/monitors/inbound_link_utilization_high.json
@@ -8,7 +8,7 @@
 		"id": 183690711,
 		"name": "[Versa] Inbound Link Utilization >90% on {{access_circuit.name}} at {{site.name}} over the last 5 minutes",
 		"type": "query alert",
-		"query": "avg(last_5m):avg:versa.link.rx_util{*} by {site,access_circuit,device_hostname,device_id,device_namespace,device_ip} > 90",
+		"query": "avg(last_5m):avg:versa.link.rx_util{*} by {site,access_circuit,interface,device_hostname,device_id,device_namespace,device_ip} > 90",
 		"message": "{{#is_alert}}\nInbound Link Utilization exceeded 90% in the last 5 minutes.\n\nSite: {{site.name}}\nAccess Circuit: {{access_circuit.name}}\nDevice: {{device_hostname.name}}\n{{/is_alert}}\n\n{{#is_alert_recovery}}\nInbound Link Utilization is <90% in the last 5 minutes.\n\nSite: {{site.name}}\nAccess Circuit: {{access_circuit.name}}\nDevice: {{device_hostname.name}}\n{{/is_alert_recovery}}\n\nTo know more about the status of your device, you can have more information from the [NDM page for the device {{device_hostname.name}}](/devices?inspectedDevice={{device_namespace.name}}%3A{{device_ip.name}}).",
 		"tags": [],
 		"options": {

--- a/versa/assets/monitors/outbound_link_utilization_high.json
+++ b/versa/assets/monitors/outbound_link_utilization_high.json
@@ -8,7 +8,7 @@
 		"id": 183692872,
 		"name": "[Versa] Outbound Link Utilization >90% on {{access_circuit.name}} at {{site.name}} over the last 5 minutes",
 		"type": "query alert",
-		"query": "avg(last_5m):avg:versa.link.tx_util{*} by {site,access_circuit,device_hostname,device_id,device_namespace,device_ip} > 90",
+		"query": "avg(last_5m):avg:versa.link.tx_util{*} by {site,access_circuit,interface,device_hostname,device_id,device_namespace,device_ip} > 90",
 		"message": "{{#is_alert}}\nOutbound Link Utilization exceeded 90% in the last 5 minutes.\n\nSite: {{site.name}}\nAccess Circuit: {{access_circuit.name}}\nDevice: {{device_hostname.name}}\n{{/is_alert}}\n\n{{#is_alert_recovery}}\nInbound Link Utilization is <90% in the last 5 minutes.\n\nSite: {{site.name}}\nAccess Circuit: {{access_circuit.name}}\nDevice: {{device_hostname.name}}\n{{/is_alert_recovery}}\n\nTo know more about the status of your device, you can have more information from the [NDM page for the device {{device_hostname.name}}](/devices?inspectedDevice={{device_namespace.name}}%3A{{device_ip.name}}).",
 		"tags": [],
 		"options": {


### PR DESCRIPTION
### What does this PR do?
This PR udpates cisco sdwan and versa OOTB monitors to tag queries by corresponding id tags

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
