### PR TITLE
[SIMI-380] Add anthropic-usage-metrics dataflow

### DIFF
--- a/anthropic_usage_and_costs/assets/dataflows.yaml
+++ b/anthropic_usage_and_costs/assets/dataflows.yaml
@@ -2,3 +2,6 @@ provides:
   - id: anthropic-cloud-cost-metrics
     always_on: false
     granular: true
+  - id: anthropic-usage-metrics
+    always_on: true
+    granular: false


### PR DESCRIPTION
Adds the `anthropic-usage-metrics` dataflow provided from `anthropic_usage_and_costs`