### PR TITLE
Forward instance config (auth, TLS, timeout, proxy, headers) to HTTPXWrapper

### DIFF
--- a/datadog_checks_base/changelog.d/22704.added.1
+++ b/datadog_checks_base/changelog.d/22704.added.1
@@ -1,0 +1,1 @@
+Forward instance config (auth, TLS, timeout, proxy, headers) to HTTPXWrapper.

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -416,11 +416,14 @@ class AgentCheck(object):
         if not hasattr(self, '_http'):
             # See Performance Optimizations in this package's README.md.
             if is_affirmative((self.instance or {}).get('use_httpx', False)):
-                import httpx
-
                 from datadog_checks.base.utils.http_httpx import HTTPXWrapper
 
-                self._http = HTTPXWrapper(httpx.Client())
+                self._http = HTTPXWrapper(
+                    self.instance or {},
+                    self.init_config,
+                    self.HTTP_CONFIG_REMAPPER,
+                    self.log,
+                )
             else:
                 from datadog_checks.base.utils.http import RequestsWrapper
 

--- a/datadog_checks_base/tests/base/utils/http/test_http_backend_equivalence.py
+++ b/datadog_checks_base/tests/base/utils/http/test_http_backend_equivalence.py
@@ -40,7 +40,11 @@ def http_client(request):
         with patch.object(requests.Session, "get", return_value=_requests_response(_BODY)):
             yield RequestsWrapper({}, {})
     else:
-        yield HTTPXWrapper(httpx.Client(transport=_httpx_transport(_BODY)))
+        with patch(
+            'datadog_checks.base.utils.http_httpx._build_httpx_client',
+            return_value=httpx.Client(transport=_httpx_transport(_BODY)),
+        ):
+            yield HTTPXWrapper({}, {})
 
 
 def test_status_code(http_client):

--- a/datadog_checks_base/tests/base/utils/http/test_http_httpx.py
+++ b/datadog_checks_base/tests/base/utils/http/test_http_httpx.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2026-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
@@ -12,7 +12,7 @@ from datadog_checks.base.utils.http_exceptions import (
     HTTPStatusError,
     HTTPTimeoutError,
 )
-from datadog_checks.base.utils.http_httpx import HTTPXResponseAdapter, HTTPXWrapper
+from datadog_checks.base.utils.http_httpx import HTTPXResponseAdapter, HTTPXWrapper, _build_httpx_client
 
 
 class TestHTTPXResponseAdapter:
@@ -73,28 +73,34 @@ class TestHTTPXResponseAdapter:
 
 class TestHTTPXWrapper:
     def test_successful_request_returns_response_adapter(self):
-        client = MagicMock(spec=httpx.Client)
-        client.request.return_value = MagicMock(spec=httpx.Response)
-        wrapper = HTTPXWrapper(client)
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_client.request.return_value = MagicMock(spec=httpx.Response)
+
+        with patch('datadog_checks.base.utils.http_httpx._build_httpx_client', return_value=mock_client):
+            wrapper = HTTPXWrapper({}, {})
 
         result = wrapper.get("http://example.com")
 
         assert isinstance(result, HTTPXResponseAdapter)
 
     def test_timeout_raises_http_timeout_error(self):
-        client = MagicMock(spec=httpx.Client)
+        mock_client = MagicMock(spec=httpx.Client)
         request = httpx.Request("GET", "http://example.com")
-        client.request.side_effect = httpx.TimeoutException("timed out", request=request)
-        wrapper = HTTPXWrapper(client)
+        mock_client.request.side_effect = httpx.TimeoutException("timed out", request=request)
+
+        with patch('datadog_checks.base.utils.http_httpx._build_httpx_client', return_value=mock_client):
+            wrapper = HTTPXWrapper({}, {})
 
         with pytest.raises(HTTPTimeoutError):
             wrapper.get("http://example.com")
 
     def test_connect_error_raises_http_connection_error(self):
-        client = MagicMock(spec=httpx.Client)
+        mock_client = MagicMock(spec=httpx.Client)
         request = httpx.Request("GET", "http://example.com")
-        client.request.side_effect = httpx.ConnectError("connection refused", request=request)
-        wrapper = HTTPXWrapper(client)
+        mock_client.request.side_effect = httpx.ConnectError("connection refused", request=request)
+
+        with patch('datadog_checks.base.utils.http_httpx._build_httpx_client', return_value=mock_client):
+            wrapper = HTTPXWrapper({}, {})
 
         with pytest.raises(HTTPConnectionError):
             wrapper.get("http://example.com")
@@ -108,9 +114,11 @@ class TestHTTPXWrapper:
             wrapper.get("not a url")
 
     def test_all_http_methods_delegate_to_client(self):
-        client = MagicMock(spec=httpx.Client)
-        client.request.return_value = MagicMock(spec=httpx.Response)
-        wrapper = HTTPXWrapper(client)
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_client.request.return_value = MagicMock(spec=httpx.Response)
+
+        with patch('datadog_checks.base.utils.http_httpx._build_httpx_client', return_value=mock_client):
+            wrapper = HTTPXWrapper({}, {})
 
         url = "http://example.com"
         wrapper.get(url)
@@ -121,5 +129,131 @@ class TestHTTPXWrapper:
         wrapper.delete(url)
         wrapper.options_method(url)
 
-        methods = [call.args[0] for call in client.request.call_args_list]
+        methods = [call.args[0] for call in mock_client.request.call_args_list]
         assert methods == ["GET", "POST", "HEAD", "PUT", "PATCH", "DELETE", "OPTIONS"]
+
+
+class TestBuildHttpxClient:
+    @staticmethod
+    def _get_client_kwargs(instance, init_config=None, **kwargs):
+        """Capture the kwargs passed to httpx.Client() without constructing a real client.
+
+        Uses mock.patch so the real httpx.Client is not instantiated, allowing tests to
+        inspect constructor arguments (e.g. 'verify') that aren't exposed as attributes.
+        """
+        if init_config is None:
+            init_config = {}
+        with patch('datadog_checks.base.utils.http_httpx.httpx.Client') as mock_cls:
+            mock_cls.return_value = MagicMock()
+            _build_httpx_client(instance, init_config, **kwargs)
+        return mock_cls.call_args.kwargs
+
+    # --- Auth ---
+
+    def test_basic_auth_sets_client_auth(self):
+        client = _build_httpx_client({'username': 'user', 'password': 'pass'}, {})
+        assert isinstance(client.auth, httpx.BasicAuth)
+
+    def test_basic_auth_not_set_without_username(self):
+        client = _build_httpx_client({}, {})
+        assert client.auth is None
+
+    def test_digest_auth(self):
+        client = _build_httpx_client({'username': 'u', 'password': 'p', 'auth_type': 'digest'}, {})
+        assert isinstance(client.auth, httpx.DigestAuth)
+
+    def test_kerberos_auth_type_builds_kerberos_adapter(self):
+        from datadog_checks.base.utils.httpx_auth import KerberosAuth
+
+        client = _build_httpx_client({'auth_type': 'kerberos'}, {})
+        assert isinstance(client.auth, KerberosAuth)
+
+    def test_ntlm_auth_type_builds_ntlm_adapter(self):
+        from datadog_checks.base.utils.httpx_auth import NTLMAuth
+
+        client = _build_httpx_client({'auth_type': 'ntlm', 'ntlm_domain': 'DOMAIN\\user', 'password': 'pass'}, {})
+        assert isinstance(client.auth, NTLMAuth)
+
+    # --- TLS ---
+
+    def test_tls_verify_false(self):
+        kwargs = self._get_client_kwargs({'tls_verify': False})
+        assert kwargs['verify'] is False
+
+    def test_tls_ca_cert(self):
+        # _get_client_kwargs avoids real SSL context loading
+        kwargs = self._get_client_kwargs({'tls_ca_cert': '/path/to/ca.pem'})
+        assert kwargs['verify'] == '/path/to/ca.pem'
+
+    def test_tls_verify_true_by_default(self):
+        kwargs = self._get_client_kwargs({})
+        assert kwargs['verify'] is True
+
+    # --- Redirects ---
+
+    def test_follow_redirects_default_true(self):
+        client = _build_httpx_client({}, {})
+        assert client.follow_redirects is True
+
+    def test_follow_redirects_false(self):
+        client = _build_httpx_client({'allow_redirects': False}, {})
+        assert client.follow_redirects is False
+
+    # --- Timeouts ---
+
+    def test_timeout_from_instance(self):
+        client = _build_httpx_client({'timeout': 30}, {})
+        assert client.timeout.read == 30.0
+        assert client.timeout.connect == 30.0
+
+    def test_timeout_read_connect_split(self):
+        client = _build_httpx_client({'read_timeout': 20, 'connect_timeout': 5}, {})
+        assert client.timeout.read == 20.0
+        assert client.timeout.connect == 5.0
+
+    def test_timeout_from_init_config(self):
+        client = _build_httpx_client({}, {'timeout': 42})
+        assert client.timeout.read == 42.0
+
+    # --- Remapper ---
+
+    def test_remapper_applied(self):
+        # 'user' should be remapped to 'username' via remapper dict
+        remapper = {'user': {'name': 'username'}}
+        client = _build_httpx_client({'user': 'alice', 'password': 'secret'}, {}, remapper=remapper)
+        assert isinstance(client.auth, httpx.BasicAuth)
+
+    def test_remapper_invert(self):
+        # ssl_validation=False with invert=True → tls_verify=True (not disabled)
+        remapper = {'ssl_validation': {'name': 'tls_verify', 'default': False, 'invert': True}}
+        kwargs_false = self._get_client_kwargs({'ssl_validation': False}, remapper=remapper)
+        assert kwargs_false['verify'] is True
+
+        kwargs_true = self._get_client_kwargs({'ssl_validation': True}, remapper=remapper)
+        assert kwargs_true['verify'] is False
+
+    # --- Proxies ---
+
+    def test_skip_proxy_disables_trust_env(self):
+        client = _build_httpx_client({'skip_proxy': True}, {})
+        assert client.trust_env is False
+
+    def test_proxy_config_converted_to_mounts(self):
+        proxy_url = 'http://proxy.example.com:8080'
+        kwargs = self._get_client_kwargs({'proxy': {'http': proxy_url}})
+        mounts = kwargs.get('mounts') or {}
+        assert 'http://' in mounts
+
+    # --- Headers ---
+
+    def test_headers_replaced_when_headers_set(self):
+        # When 'headers' is set, it replaces our default Datadog headers;
+        # the custom header must be present.
+        client = _build_httpx_client({'headers': {'X-Custom': 'value'}}, {})
+        assert client.headers.get('x-custom') == 'value'
+
+    def test_extra_headers_merged(self):
+        # 'extra_headers' are merged on top of defaults; Datadog User-Agent still present
+        client = _build_httpx_client({'extra_headers': {'X-Extra': 'yes'}}, {})
+        assert client.headers.get('x-extra') == 'yes'
+        assert 'user-agent' in client.headers

--- a/nginx/tests/test_unit.py
+++ b/nginx/tests/test_unit.py
@@ -72,6 +72,43 @@ def test_config(check, instance, test_case, extra_config, expected_http_kwargs):
         assert c.http.options[key] == value
 
 
+@pytest.mark.parametrize(
+    'test_case, extra_config, expected',
+    [
+        ("legacy auth config", {'user': 'legacy_foo', 'password': 'legacy_bar'}, {'auth_is_basic': True}),
+        ("new auth config", {'username': 'new_foo', 'password': 'new_bar'}, {'auth_is_basic': True}),
+        ("legacy ssl config True", {'ssl_validation': True}, {'verify': True}),
+        ("legacy ssl config False", {'ssl_validation': False}, {'verify': False}),
+    ],
+)
+def test_config_httpx(check, instance, test_case, extra_config, expected):
+    import httpx as _httpx
+
+    instance = deepcopy(instance)
+    instance.update(extra_config)
+    instance['use_httpx'] = True
+
+    c = check(instance)
+
+    client_kwargs = {}
+
+    def spy_httpx_client(**kwargs):
+        client_kwargs.update(kwargs)
+        return mock.MagicMock()
+
+    with mock.patch('datadog_checks.base.utils.http_httpx.httpx.Client', side_effect=spy_httpx_client):
+        _ = c.http
+
+    if expected.get('auth_is_basic'):
+        assert isinstance(client_kwargs.get('auth'), _httpx.BasicAuth), (
+            f"{test_case}: expected BasicAuth, got {client_kwargs.get('auth')!r}"
+        )
+    if 'verify' in expected:
+        assert client_kwargs.get('verify') == expected['verify'], (
+            f"{test_case}: verify expected {expected['verify']!r}, got {client_kwargs.get('verify')!r}"
+        )
+
+
 def test_no_version(check, instance, caplog, mock_http):
     c = check(instance)
 


### PR DESCRIPTION
## Summary

- Add `_build_httpx_client()` that reads instance/init_config with the same field names, remapper, and priority rules as `RequestsWrapper`
- Update `HTTPXWrapper.__init__` to accept `(instance, init_config, remapper, logger)` instead of a pre-built `httpx.Client`
- Wire basic/digest auth, TLS verify/cert, timeouts, headers, redirects, and proxy mounts; `skip_proxy` disables `trust_env`
- Update `AgentCheck.http` property to pass instance config through to `HTTPXWrapper`
- Add `TestBuildHttpxClient` config-parity tests and `test_config_httpx` to nginx unit tests

## Test plan

- [ ] `ddev test datadog_checks_base -- tests/base/utils/http/test_http_httpx.py -v`
- [ ] `ddev test datadog_checks_base -- tests/base/utils/http/test_http_backend_equivalence.py -v`
- [ ] `ddev test nginx -- tests/test_unit.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)