### PR TITLE
[LOGSC-2554] Add new bypass annotations for new linter checks

### DIFF
--- a/cisco_secure_client/assets/logs/cisco-secure-client_tests.yaml
+++ b/cisco_secure_client/assets/logs/cisco-secure-client_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: "cisco-secure-client"
 tests:
  -

--- a/supabase_cloud/assets/logs/supabase-cloud_tests.yaml
+++ b/supabase_cloud/assets/logs/supabase-cloud_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: supabase-cloud
 tests:
  -

--- a/valence_security/assets/logs/valence-security_tests.yaml
+++ b/valence_security/assets/logs/valence-security_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-timestamp-format-in-sample-checks
 id: valence-security
 tests:
  -


### PR DESCRIPTION
We’re enabling new linter rules and some integrations are expected to remain non‑compliant.
Add permanent bypass annotations so CI stays green and not fail for new PRs.