### PR TITLE
[PANA-6154] Add dataflows for hubspot to use it for PINT page of Product Analytics

### DIFF
--- a/hubspot_content_hub/assets/dataflows.yaml
+++ b/hubspot_content_hub/assets/dataflows.yaml
@@ -1,0 +1,3 @@
+provides:
+  - id: hubspot-content-hub-reference-tables
+    always_on: true


### PR DESCRIPTION
### What does this PR do?
Adding dataflows.yaml for hubspot in order to add hubspot tile to Product Analytics PINT page.

### Motivation
We would like to add Hubspot tile to PINT page of Product Analytics. In order to do that we need to have dataflows registered for Hubspot to add it to list of uses of Product Analytics ([pr](https://github.com/DataDog/integrations-internal-core/pull/2791))


More context: integrations that can be used on a PINT page have the dataflows.yaml file defined, even if dataflow-specific status is not built and dataflows are not fully implemented / GA'd. The dataflow definitions must be registered for the integration to appear on PINT pages
For example, product_analytics_bigquery has the following dataflow defined: https://github.com/DataDog/integrations-internal-core/blob/main/product_analytics_bigquery/assets/dataflows.yaml. It does not affect the tile experience and does not require any backend/tile updates

