### PR TITLE
Optimize Kafka config queries

### DIFF
--- a/kafka_consumer/assets/configuration/spec.yaml
+++ b/kafka_consumer/assets/configuration/spec.yaml
@@ -397,6 +397,19 @@ files:
             The OAuth scope to request.
           value:
             type: string
+        - name: custom_headers
+          enabled: false
+          description: |
+            Additional HTTP headers to include in Schema Registry requests.
+            For Confluent Cloud, this typically includes the identity pool ID and
+            the Schema Registry cluster ID.
+            Example:
+              Confluent-Identity-Pool-Id: pool-xxxxx
+              target-sr-cluster: lsrc-xxxxx
+          value:
+            type: object
+            additionalProperties:
+              type: string
         - name: tls_ca_cert
           enabled: false
           description: |

--- a/kafka_consumer/assets/configuration/spec.yaml
+++ b/kafka_consumer/assets/configuration/spec.yaml
@@ -305,6 +305,18 @@ files:
           type: boolean
           example: false
           display_default: false
+      - name: kafka_configs_refresh_interval
+        description: |
+          How often (in seconds) to re-fetch broker configurations, topic configurations,
+          and schema registry version checks from Kafka. A longer interval reduces load on
+          the Kafka cluster and Schema Registry. On clusters with many topics or schemas,
+          the check fetches in batches and gracefully degrades by re-fetching less often if
+          it cannot keep up within this interval. Minimum value is 60 seconds.
+        fleet_configurable: true
+        value:
+          type: integer
+          example: 180
+          display_default: 180
       - name: schema_registry_url
         description: |
           Schema Registry URL. When set with enable_cluster_monitoring, collects schema information.

--- a/kafka_consumer/assets/configuration/spec.yaml
+++ b/kafka_consumer/assets/configuration/spec.yaml
@@ -372,6 +372,7 @@ files:
         - name: url
           fleet_configurable: true
           required: true
+          enabled: false
           description: |
             The token endpoint.
           value:
@@ -379,6 +380,7 @@ files:
         - name: client_id
           fleet_configurable: true
           required: true
+          enabled: false
           description: |
             The client identifier.
           value:
@@ -387,6 +389,7 @@ files:
           fleet_configurable: true
           secret: true
           required: true
+          enabled: false
           description: |
             The client secret.
           value:

--- a/kafka_consumer/assets/configuration/spec.yaml
+++ b/kafka_consumer/assets/configuration/spec.yaml
@@ -362,3 +362,45 @@ files:
         value:
           type: string
           example: /path/to/client_key.pem
+      - name: schema_registry_oauth_token_provider
+        description: |
+          OAuth token provider settings for Schema Registry authentication.
+          When configured, the check will fetch an OAuth token and use it as a Bearer token
+          for Schema Registry HTTP requests.
+        fleet_configurable: true
+        options:
+        - name: url
+          fleet_configurable: true
+          required: true
+          description: |
+            The token endpoint.
+          value:
+            type: string
+        - name: client_id
+          fleet_configurable: true
+          required: true
+          description: |
+            The client identifier.
+          value:
+            type: string
+        - name: client_secret
+          fleet_configurable: true
+          secret: true
+          required: true
+          description: |
+            The client secret.
+          value:
+            type: string
+        - name: scope
+          enabled: false
+          description: |
+            The OAuth scope to request.
+          value:
+            type: string
+        - name: tls_ca_cert
+          enabled: false
+          description: |
+            Path to a CA certificate file used to verify the OIDC token endpoint's TLS certificate.
+          value:
+            type: string
+            example: /path/to/oauth_ca_cert.pem

--- a/kafka_consumer/changelog.d/22665.added
+++ b/kafka_consumer/changelog.d/22665.added
@@ -1,0 +1,1 @@
+Support oauth for schema registry

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import random
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from confluent_kafka.admin import ConfigResource, ResourceType
 
@@ -25,16 +26,29 @@ class ClusterMetadataCollector:
         self.http = check.http
 
         self.EVENT_CACHE_TTL = 600  # 10 minutes in seconds
-        self.CONFIG_FETCH_CACHE_TTL_BASE = 45  # Base TTL in seconds for config fetch caching
-        self.CONFIG_FETCH_CACHE_TTL_JITTER = 15  # Jitter range in seconds (total: 45-60s)
+        self.SCHEMA_EVENT_CACHE_TTL = 7200  # 2 hours in seconds
+
+        # Broker/topic config refresh interval (configurable, default 3 min)
+        configs_refresh = self.config._kafka_configs_refresh_interval
+        self.CONFIGS_REFRESH_INTERVAL = configs_refresh
+        self.CONFIGS_REFRESH_JITTER = max(15, configs_refresh // 10)  # 10% jitter, min 15s
+        self.BROKER_CONFIG_BATCH_SIZE = 5  # Max brokers to describe_configs per run (one per call, Kafka limitation)
+        self.TOPIC_CONFIG_BATCH_SIZE = 100  # Max topics to describe_configs per check run
+
+        self.SCHEMA_VERSION_CHECK_BATCH_SIZE = 200  # Lightweight calls, can do more per run
+        self.SCHEMA_FETCH_CONCURRENCY = 10  # Parallel HTTP requests
 
         self.BROKER_CONFIG_CACHE_KEY = 'kafka_broker_config_cache'
         self.BROKER_CONFIG_FETCH_CACHE_KEY = 'kafka_broker_config_fetch_cache'
+        self.BROKER_CONFIG_METRICS_CACHE_KEY = 'kafka_broker_config_metrics_cache'
         self.TOPIC_CONFIG_CACHE_KEY = 'kafka_topic_config_cache'
         self.TOPIC_CONFIG_FETCH_CACHE_KEY = 'kafka_topic_config_fetch_cache'
+        self.TOPIC_CONFIG_METRICS_CACHE_KEY = 'kafka_topic_config_metrics_cache'
         self.TOPIC_HWM_SUM_CACHE_KEY = 'kafka_topic_hwm_sum_cache'
         self.SCHEMA_CACHE_KEY = 'kafka_schema_cache'
-        self.SCHEMA_FETCH_CACHE_KEY = 'kafka_schema_fetch_cache'
+        self.SCHEMA_VERSION_CHECK_CACHE_KEY = 'kafka_schema_version_check_cache'
+        self.SCHEMA_LATEST_VERSION_CACHE_KEY = 'kafka_schema_latest_version_cache'
+        self.SCHEMA_ID_CACHE_KEY = 'kafka_schema_id_cache'
 
         self._schema_registry_oauth_token = None
         self._schema_registry_oauth_token_expiry = 0
@@ -132,7 +146,8 @@ class ClusterMetadataCollector:
         response.raise_for_status()
         return response.json()
 
-    def _get_schema_registry_versions(self, subject):
+    def _get_schema_registry_versions(self, subject: str) -> list[int]:
+        """Fetch the list of version numbers for a subject (lightweight call)."""
         base_url = self.config._collect_schema_registry
         response = self.http.get(f"{base_url}/subjects/{subject}/versions")
         response.raise_for_status()
@@ -175,12 +190,17 @@ class ClusterMetadataCollector:
         """
         Check which items need fetching based on cache expiration.
 
+        Returns items sorted oldest-first (earliest expiry first) so that
+        when combined with batch limits, the least recently fetched items
+        are prioritized.
+
         Args:
             cache_key_prefix: Cache key to load
             item_keys: List of item keys to check
 
         Returns:
-            List of item keys that need fetching (not cached or expired)
+            List of item keys that need fetching (not cached or expired),
+            sorted by expiry time ascending (oldest first)
         """
         current_time = time.time()
         items_to_fetch = []
@@ -196,18 +216,33 @@ class ClusterMetadataCollector:
             expire_at = cache_dict.get(item_key, 0)
 
             if current_time >= expire_at:
-                items_to_fetch.append(item_key)
+                items_to_fetch.append((expire_at, item_key))
 
-        return items_to_fetch
+        # Sort by expiry time ascending — items that expired longest ago are fetched first.
+        items_to_fetch.sort()
+        return [item_key for _, item_key in items_to_fetch]
 
-    def _mark_items_fetched(self, cache_key_prefix: str, item_keys: list[str]):
+    def _mark_items_fetched(
+        self,
+        cache_key_prefix: str,
+        item_keys: list[str],
+        ttl_base: float | None = None,
+        ttl_jitter: float | None = None,
+    ):
         """
         Mark items as fetched in cache with jittered TTL.
 
         Args:
             cache_key_prefix: Cache key to update
             item_keys: List of item keys that were fetched
+            ttl_base: Base TTL in seconds (defaults to CONFIGS_REFRESH_INTERVAL)
+            ttl_jitter: Jitter range in seconds (defaults to CONFIGS_REFRESH_JITTER)
         """
+        if ttl_base is None:
+            ttl_base = self.CONFIGS_REFRESH_INTERVAL
+        if ttl_jitter is None:
+            ttl_jitter = self.CONFIGS_REFRESH_JITTER
+
         current_time = time.time()
 
         try:
@@ -218,7 +253,7 @@ class ClusterMetadataCollector:
             cache_dict = {}
 
         for item_key in item_keys:
-            ttl = self.CONFIG_FETCH_CACHE_TTL_BASE + random.uniform(0, self.CONFIG_FETCH_CACHE_TTL_JITTER)
+            ttl = ttl_base + random.uniform(0, ttl_jitter)
             cache_dict[item_key] = current_time + ttl
 
         try:
@@ -226,19 +261,45 @@ class ClusterMetadataCollector:
         except Exception as e:
             self.log.debug("Could not write cache %s: %s", cache_key_prefix, e)
 
-    def _get_events_to_send(self, cache_key_prefix: str, items: dict[str, str]) -> list[str]:
+    def _load_metrics_cache(self, cache_key: str) -> dict[str, list]:
+        """Load cached config metrics from persistent storage.
+
+        Returns:
+            Dict mapping item_key -> list of [metric_name, value, tags]
+        """
+        try:
+            cached_str = self.check.read_persistent_cache(cache_key)
+            return json.loads(cached_str) if cached_str else {}
+        except Exception as e:
+            self.log.debug("Could not read metrics cache %s: %s", cache_key, e)
+            return {}
+
+    def _save_metrics_cache(self, cache_key: str, cache: dict[str, list]):
+        """Persist the config metrics cache."""
+        try:
+            self.check.write_persistent_cache(cache_key, json.dumps(cache))
+        except Exception as e:
+            self.log.debug("Could not write metrics cache %s: %s", cache_key, e)
+
+    def _get_events_to_send(
+        self, cache_key_prefix: str, items: dict[str, str], event_cache_ttl: float | None = None
+    ) -> list[str]:
         """
         Determine which items should emit events based on content changes or expiration.
 
         Args:
             cache_key_prefix: Cache key to load/update
             items: Dict mapping item_key -> event_content
+            event_cache_ttl: TTL in seconds before re-emitting unchanged events (defaults to EVENT_CACHE_TTL)
 
         Returns:
             List of item keys that should emit events
         """
         if not items:
             return []
+
+        if event_cache_ttl is None:
+            event_cache_ttl = self.EVENT_CACHE_TTL
 
         current_time = time.time()
         events_to_send = []
@@ -263,13 +324,14 @@ class ClusterMetadataCollector:
                 events_to_send.append(item_key)
                 cache_dict[item_key] = {
                     'hash': current_hash,
-                    'expire_at': current_time + self.EVENT_CACHE_TTL,
+                    'expire_at': current_time + event_cache_ttl,
                 }
 
-        try:
-            self.check.write_persistent_cache(cache_key_prefix, json.dumps(cache_dict))
-        except Exception as e:
-            self.log.debug("Could not write cache %s: %s", cache_key_prefix, e)
+        if events_to_send:
+            try:
+                self.check.write_persistent_cache(cache_key_prefix, json.dumps(cache_dict))
+            except Exception as e:
+                self.log.debug("Could not write cache %s: %s", cache_key_prefix, e)
 
         return events_to_send
 
@@ -318,39 +380,56 @@ class ClusterMetadataCollector:
                     if replica in broker_partition_count:
                         broker_partition_count[replica] += 1
 
-        broker_ids_to_fetch = self._get_items_to_fetch(
-            self.BROKER_CONFIG_FETCH_CACHE_KEY, [str(bid) for bid in brokers.keys()]
-        )
-        fetched_broker_configs = {}
-
+        # Emit per-broker metrics (fast, in-memory only)
         for broker_id, broker_metadata in brokers.items():
-            broker_host = broker_metadata.host
-            broker_port = broker_metadata.port
-
             tags = self._get_tags(cluster_id) + [
                 f'broker_id:{broker_id}',
-                f'broker_host:{broker_host}',
-                f'broker_port:{broker_port}',
+                f'broker_host:{broker_metadata.host}',
+                f'broker_port:{broker_metadata.port}',
             ]
-
             self.check.gauge('broker.leader_count', broker_leader_count.get(broker_id, 0), tags=tags)
             self.check.gauge('broker.partition_count', broker_partition_count.get(broker_id, 0), tags=tags)
 
-            if str(broker_id) not in broker_ids_to_fetch:
-                self.log.debug("Skipping config fetch for broker %s (cache still valid)", broker_id)
-                continue
+        # --- Broker config fetching ---
+        # Kafka only allows one BROKER resource per describe_configs call,
+        # so we fetch one broker per check run and rely on the TTL cache
+        # to rotate through all brokers over time.
+        all_broker_ids = [str(bid) for bid in brokers.keys()]
+        broker_ids_to_fetch = self._get_items_to_fetch(self.BROKER_CONFIG_FETCH_CACHE_KEY, all_broker_ids)
+        fetched_broker_configs = {}
+        broker_metrics_cache = self._load_metrics_cache(self.BROKER_CONFIG_METRICS_CACHE_KEY)
 
-            try:
-                resources = [ConfigResource(ResourceType.BROKER, str(broker_id))]
-                futures = self.client.kafka_client.describe_configs(resources)
+        if broker_ids_to_fetch:
+            # Kafka only allows one BROKER resource per describe_configs call,
+            # so cap per run to keep the check fast.
+            broker_ids_batch = broker_ids_to_fetch[: self.BROKER_CONFIG_BATCH_SIZE]
+            self.log.debug(
+                "Fetching configs for %d/%d brokers",
+                len(broker_ids_batch),
+                len(broker_ids_to_fetch),
+            )
 
-                for _resource, future in futures.items():
-                    config_entries = future.result(timeout=self.config._request_timeout)
+            for broker_id_str in broker_ids_batch:
+                broker_meta = brokers.get(int(broker_id_str))
+                if not broker_meta:
+                    continue
+
+                tags = self._get_tags(cluster_id) + [
+                    f'broker_id:{broker_id_str}',
+                    f'broker_host:{broker_meta.host}',
+                    f'broker_port:{broker_meta.port}',
+                ]
+
+                try:
+                    resources = [ConfigResource(ResourceType.BROKER, broker_id_str)]
+                    futures = self.client.kafka_client.describe_configs(resources)
+                    config_entries = futures[resources[0]].result(timeout=self.config._request_timeout)
 
                     config_data = {}
                     for config_name, config_entry in config_entries.items():
                         config_data[config_name] = config_entry.value
 
+                    cached_metrics = []
                     for config_name in [
                         'log.retention.bytes',
                         'log.retention.ms',
@@ -366,23 +445,40 @@ class ClusterMetadataCollector:
                                 value = float(config_data[config_name]) if config_data[config_name] else 0
                                 metric_name = f"broker.config.{config_name.replace('.', '_')}"
                                 self.check.gauge(metric_name, value, tags=tags)
+                                cached_metrics.append([metric_name, value, tags])
                             except (ValueError, TypeError):
                                 pass
+
+                    broker_metrics_cache[broker_id_str] = cached_metrics
 
                     truncated_config = self._truncate_config_for_event(config_data, max_configs=50)
                     event_text = json.dumps(truncated_config, indent=2, sort_keys=True)
 
-                    fetched_broker_configs[str(broker_id)] = {
+                    fetched_broker_configs[broker_id_str] = {
                         'event_text': event_text,
                         'tags': tags,
-                        'broker_host': broker_host,
-                        'broker_port': broker_port,
+                        'broker_host': broker_meta.host,
+                        'broker_port': broker_meta.port,
                     }
+                except Exception as e:
+                    self.log.warning("Failed to describe configs for broker %s: %s", broker_id_str, e)
 
-            except Exception as e:
-                self.log.warning("Failed to describe configs for broker %s: %s", broker_id, e)
+        # Re-emit cached metrics for brokers not freshly fetched
+        fetched_ids = set(fetched_broker_configs.keys())
+        for broker_id_str in all_broker_ids:
+            if broker_id_str in fetched_ids:
+                continue
+            for metric_name, value, tags in broker_metrics_cache.get(broker_id_str, []):
+                self.check.gauge(metric_name, value, tags=tags)
 
-        self._mark_items_fetched(self.BROKER_CONFIG_FETCH_CACHE_KEY, list(fetched_broker_configs.keys()))
+        self._save_metrics_cache(self.BROKER_CONFIG_METRICS_CACHE_KEY, broker_metrics_cache)
+
+        self._mark_items_fetched(
+            self.BROKER_CONFIG_FETCH_CACHE_KEY,
+            list(fetched_broker_configs.keys()),
+            ttl_base=self.CONFIGS_REFRESH_INTERVAL,
+            ttl_jitter=self.CONFIGS_REFRESH_JITTER,
+        )
 
         broker_contents = {bid: info['event_text'] for bid, info in fetched_broker_configs.items()}
         brokers_to_emit = self._get_events_to_send(self.BROKER_CONFIG_CACHE_KEY, broker_contents)
@@ -444,12 +540,6 @@ class ClusterMetadataCollector:
             self.log.debug("Could not read topic HWM cache: %s", e)
 
         current_partition_offsets = {}
-
-        topic_names_to_fetch = self._get_items_to_fetch(
-            self.TOPIC_CONFIG_FETCH_CACHE_KEY,
-            [name for name in topic_partitions.keys() if name not in KAFKA_INTERNAL_TOPICS],
-        )
-        fetched_topic_configs = {}
 
         for topic_name, partitions in topic_partitions.items():
             if topic_name in KAFKA_INTERNAL_TOPICS:
@@ -554,45 +644,87 @@ class ClusterMetadataCollector:
                 message_rate = (sum_latest - sum_previous) / (now_ts - prev_ts)
                 self.check.gauge('topic.message_rate', message_rate, tags=topic_tags)
 
-            if topic_name not in topic_names_to_fetch:
-                self.log.debug("Skipping config fetch for topic %s (cache still valid)", topic_name)
-                continue
+        # --- Topic config fetching (batched describe_configs) ---
+        all_topic_names = [name for name in topic_partitions.keys() if name not in KAFKA_INTERNAL_TOPICS]
+        topic_names_to_fetch = self._get_items_to_fetch(self.TOPIC_CONFIG_FETCH_CACHE_KEY, all_topic_names)
 
-            resources = [ConfigResource(ResourceType.TOPIC, topic_name)]
+        # Batch: cap the number of topic configs fetched per check run.
+        if len(topic_names_to_fetch) > self.TOPIC_CONFIG_BATCH_SIZE:
+            topic_names_to_fetch = topic_names_to_fetch[: self.TOPIC_CONFIG_BATCH_SIZE]
+
+        fetched_topic_configs = {}
+        topic_metrics_cache = self._load_metrics_cache(self.TOPIC_CONFIG_METRICS_CACHE_KEY)
+
+        if topic_names_to_fetch:
+            self.log.debug("Fetching configs for %d topics", len(topic_names_to_fetch))
+
+            # Single batched describe_configs call for all topics at once
+            resources = [ConfigResource(ResourceType.TOPIC, name) for name in topic_names_to_fetch]
             futures = self.client.kafka_client.describe_configs(resources)
-            config_result = futures[resources[0]].result(timeout=self.config._request_timeout)
 
-            if not config_result:
+            for resource, future in futures.items():
+                topic_name = resource.name
+                topic_tags = self._get_tags(cluster_id) + [f'topic:{topic_name}']
+
+                try:
+                    config_result = future.result(timeout=self.config._request_timeout)
+                except Exception as e:
+                    self.log.warning("Failed to describe configs for topic %s: %s", topic_name, e)
+                    continue
+
+                if not config_result:
+                    continue
+
+                topic_config = {}
+                for config_name, config_entry in config_result.items():
+                    topic_config[config_name] = config_entry.value
+
+                if not topic_config:
+                    continue
+
+                cached_metrics = []
+
+                if 'retention.ms' in topic_config and topic_config['retention.ms'] != '-1':
+                    retention_ms = int(topic_config['retention.ms'])
+                    self.check.gauge('topic.config.retention_ms', retention_ms, tags=topic_tags)
+                    cached_metrics.append(['topic.config.retention_ms', retention_ms, topic_tags])
+
+                if 'retention.bytes' in topic_config and topic_config['retention.bytes'] != '-1':
+                    retention_bytes = int(topic_config['retention.bytes'])
+                    self.check.gauge('topic.config.retention_bytes', retention_bytes, tags=topic_tags)
+                    cached_metrics.append(['topic.config.retention_bytes', retention_bytes, topic_tags])
+
+                if 'max.message.bytes' in topic_config:
+                    max_bytes = int(topic_config['max.message.bytes'])
+                    self.check.gauge('topic.config.max_message_bytes', max_bytes, tags=topic_tags)
+                    cached_metrics.append(['topic.config.max_message_bytes', max_bytes, topic_tags])
+
+                topic_metrics_cache[topic_name] = cached_metrics
+
+                truncated_config = self._truncate_config_for_event(topic_config, max_configs=30)
+                event_text = json.dumps(truncated_config, indent=2, sort_keys=True)
+
+                fetched_topic_configs[topic_name] = {
+                    'event_text': event_text,
+                    'tags': topic_tags,
+                }
+
+        # Re-emit cached metrics for topics not freshly fetched
+        fetched_names = set(fetched_topic_configs.keys())
+        for topic_name in all_topic_names:
+            if topic_name in fetched_names:
                 continue
+            for metric_name, value, tags in topic_metrics_cache.get(topic_name, []):
+                self.check.gauge(metric_name, value, tags=tags)
 
-            topic_config = {}
-            for config_name, config_entry in config_result.items():
-                topic_config[config_name] = config_entry.value
+        self._save_metrics_cache(self.TOPIC_CONFIG_METRICS_CACHE_KEY, topic_metrics_cache)
 
-            if not topic_config:
-                continue
-
-            if 'retention.ms' in topic_config and topic_config['retention.ms'] != '-1':
-                retention_ms = int(topic_config['retention.ms'])
-                self.check.gauge('topic.config.retention_ms', retention_ms, tags=topic_tags)
-
-            if 'retention.bytes' in topic_config and topic_config['retention.bytes'] != '-1':
-                retention_bytes = int(topic_config['retention.bytes'])
-                self.check.gauge('topic.config.retention_bytes', retention_bytes, tags=topic_tags)
-
-            if 'max.message.bytes' in topic_config:
-                max_bytes = int(topic_config['max.message.bytes'])
-                self.check.gauge('topic.config.max_message_bytes', max_bytes, tags=topic_tags)
-
-            truncated_config = self._truncate_config_for_event(topic_config, max_configs=30)
-            event_text = json.dumps(truncated_config, indent=2, sort_keys=True)
-
-            fetched_topic_configs[topic_name] = {
-                'event_text': event_text,
-                'tags': topic_tags,
-            }
-
-        self._mark_items_fetched(self.TOPIC_CONFIG_FETCH_CACHE_KEY, list(fetched_topic_configs.keys()))
+        self._mark_items_fetched(
+            self.TOPIC_CONFIG_FETCH_CACHE_KEY,
+            list(fetched_topic_configs.keys()),
+            ttl_base=self.CONFIGS_REFRESH_INTERVAL,
+            ttl_jitter=self.CONFIGS_REFRESH_JITTER,
+        )
 
         topic_contents = {name: info['event_text'] for name, info in fetched_topic_configs.items()}
         topics_to_emit = self._get_events_to_send(self.TOPIC_CONFIG_CACHE_KEY, topic_contents)
@@ -691,6 +823,46 @@ class ClusterMetadataCollector:
                     for tp in member.assignment.topic_partitions:
                         topics_for_group.add(tp.topic)
 
+    def _load_schema_id_cache(self) -> dict[str, dict]:
+        """Load the permanent schema ID cache from persistent storage.
+
+        Schema IDs in Confluent Schema Registry are immutable: once a schema is
+        registered with a given ID, that ID always maps to the same content.
+        This cache avoids re-fetching schema content for already-seen IDs.
+
+        Returns:
+            Dict mapping schema_id (str) -> {schema, schema_type}
+        """
+        try:
+            cached_str = self.check.read_persistent_cache(self.SCHEMA_ID_CACHE_KEY)
+            return json.loads(cached_str) if cached_str else {}
+        except Exception as e:
+            self.log.debug("Could not read schema ID cache: %s", e)
+            return {}
+
+    def _save_schema_id_cache(self, cache: dict[str, dict]):
+        """Persist the schema ID cache."""
+        try:
+            self.check.write_persistent_cache(self.SCHEMA_ID_CACHE_KEY, json.dumps(cache))
+        except Exception as e:
+            self.log.debug("Could not write schema ID cache: %s", e)
+
+    def _load_latest_version_cache(self) -> dict[str, int]:
+        """Load cache mapping subject -> last known max version number."""
+        try:
+            cached_str = self.check.read_persistent_cache(self.SCHEMA_LATEST_VERSION_CACHE_KEY)
+            return json.loads(cached_str) if cached_str else {}
+        except Exception as e:
+            self.log.debug("Could not read schema latest version cache: %s", e)
+            return {}
+
+    def _save_latest_version_cache(self, cache: dict[str, int]):
+        """Persist the latest version cache."""
+        try:
+            self.check.write_persistent_cache(self.SCHEMA_LATEST_VERSION_CACHE_KEY, json.dumps(cache))
+        except Exception as e:
+            self.log.debug("Could not write schema latest version cache: %s", e)
+
     def _collect_schema_registry_info(self, metadata):
         if not self.config._collect_schema_registry:
             return
@@ -711,76 +883,219 @@ class ClusterMetadataCollector:
 
         cluster_id = metadata.cluster_id if hasattr(metadata, 'cluster_id') else 'unknown'
 
-        self.log.debug("Found %s schemas in schema registry", len(subjects))
+        self.log.debug("Found %d subjects in schema registry", len(subjects))
 
         self.check.gauge('schema_registry.subjects', len(subjects), tags=self._get_tags(cluster_id))
 
-        subjects_to_fetch = self._get_items_to_fetch(self.SCHEMA_FETCH_CACHE_KEY, subjects)
+        # --- Tier 1: Lightweight version checks ---
+        # GET /subjects/{subject}/versions returns just [1, 2, 3] — very cheap.
+        # We use this to detect if a subject has a new version without fetching schema content.
+        subjects_to_check = self._get_items_to_fetch(self.SCHEMA_VERSION_CHECK_CACHE_KEY, subjects)
+
+        if len(subjects_to_check) > self.SCHEMA_VERSION_CHECK_BATCH_SIZE:
+            subjects_to_check = subjects_to_check[: self.SCHEMA_VERSION_CHECK_BATCH_SIZE]
+
+        self.log.debug("Checking versions for %d/%d subjects", len(subjects_to_check), len(subjects))
+
+        # Load the cache of last known max version per subject
+        latest_version_cache = self._load_latest_version_cache()
+
+        # Fetch version lists in parallel (lightweight calls)
+        version_responses = {}
+        if subjects_to_check:
+            with ThreadPoolExecutor(max_workers=self.SCHEMA_FETCH_CONCURRENCY) as executor:
+                future_to_subject = {
+                    executor.submit(self._get_schema_registry_versions, subject): subject
+                    for subject in subjects_to_check
+                }
+                for future in as_completed(future_to_subject):
+                    subject = future_to_subject[future]
+                    try:
+                        version_responses[subject] = future.result()
+                    except Exception as e:
+                        self.log.warning("Error getting version list for %s: %s", subject, e)
+
+        # Mark all checked subjects as fetched (even if they didn't change)
+        self._mark_items_fetched(
+            self.SCHEMA_VERSION_CHECK_CACHE_KEY,
+            list(version_responses.keys()),
+        )
+
+        # --- Tier 2: Full fetch only for subjects with new versions ---
+        # Compare the max version number to what we've seen before.
+        # New subjects (not in cache) also need a full fetch.
+        subjects_needing_full_fetch = []
+        for subject, versions in version_responses.items():
+            if not versions:
+                continue
+            max_version = max(versions)
+            cached = latest_version_cache.get(subject)
+            cached_version = cached.get('version', 0) if isinstance(cached, dict) else (cached or 0)
+            if max_version > cached_version:
+                subjects_needing_full_fetch.append(subject)
+
+        self.log.debug(
+            "%d/%d checked subjects have new versions",
+            len(subjects_needing_full_fetch),
+            len(version_responses),
+        )
+
+        # Load permanent schema ID cache — schema IDs are immutable in the registry,
+        # so once we have the content for a given ID we never need to fetch it again.
+        schema_id_cache = self._load_schema_id_cache()
+        schema_id_cache_updated = False
+
+        # Fetch latest versions in parallel for subjects that changed
+        schema_responses = {}
+        if subjects_needing_full_fetch:
+            with ThreadPoolExecutor(max_workers=self.SCHEMA_FETCH_CONCURRENCY) as executor:
+                future_to_subject = {
+                    executor.submit(self._get_schema_registry_latest_version, subject): subject
+                    for subject in subjects_needing_full_fetch
+                }
+                for future in as_completed(future_to_subject):
+                    subject = future_to_subject[future]
+                    try:
+                        schema_responses[subject] = future.result()
+                    except Exception as e:
+                        self.log.warning("Error getting schema details for %s: %s", subject, e)
+
         fetched_schemas = {}
 
-        for subject in subjects:
-            subject_tags = self._get_tags(cluster_id) + [f'subject:{subject}']
+        for subject, latest_schema in schema_responses.items():
+            schema_id = latest_schema.get('id')
+            schema_version = latest_schema.get('version')
+            schema_type = latest_schema.get('schemaType', 'AVRO')
 
-            if subject not in subjects_to_fetch:
-                self.log.debug("Skipping schema fetch for subject %s (cache still valid)", subject)
+            subject_tags = self._get_tags(cluster_id) + [f'subject:{subject}']
+            self.check.gauge('schema_registry.versions', schema_version, tags=subject_tags)
+
+            # Update the latest version cache with version and schema_id
+            latest_version_cache[subject] = {'version': schema_version, 'schema_id': schema_id}
+
+            # Use permanent schema ID cache to avoid processing unchanged schemas.
+            schema_id_str = str(schema_id)
+            cached_entry = schema_id_cache.get(schema_id_str)
+            if cached_entry:
+                schema_content = cached_entry['schema']
+                schema_type = cached_entry.get('schema_type', schema_type)
+            else:
+                schema_content = latest_schema.get('schema', '')
+                schema_id_cache[schema_id_str] = {
+                    'schema': schema_content,
+                    'schema_type': schema_type,
+                }
+                schema_id_cache_updated = True
+
+            # Extract topic name and schema type (key/value) from subject
+            # Subjects follow patterns: "topic-key", "topic-value"
+            topic_name = subject
+            schema_for = 'unknown'
+
+            if subject.endswith('-value'):
+                topic_name = subject[:-6]  # Remove '-value'
+                schema_for = 'value'
+            elif subject.endswith('-key'):
+                topic_name = subject[:-4]  # Remove '-key'
+                schema_for = 'key'
+
+            event_tags = subject_tags + [
+                f'schema_id:{schema_id}',
+                f'schema_version:{schema_version}',
+                f'schema_type:{schema_type}',
+                f'topic:{topic_name}',
+                f'schema_for:{schema_for}',
+                'event_type:schema_registry',
+            ]
+
+            cache_content = f"{schema_id}:{schema_version}:{schema_content}"
+
+            fetched_schemas[subject] = {
+                'cache_content': cache_content,
+                'schema_content': schema_content,
+                'topic_name': topic_name,
+                'schema_for': schema_for,
+                'schema_version': schema_version,
+                'schema_id': schema_id,
+                'schema_type': schema_type,
+                'event_tags': event_tags,
+            }
+
+        # Persist caches
+        self._save_latest_version_cache(latest_version_cache)
+        if schema_id_cache_updated:
+            self._save_schema_id_cache(schema_id_cache)
+
+        # Build lightweight cache_content strings for all known subjects (from cache, no extra HTTP calls).
+        # This allows re-emission of unchanged schemas when the event cache TTL expires.
+        all_schema_cache_contents = {subject: info['cache_content'] for subject, info in fetched_schemas.items()}
+        for subject in subjects:
+            if subject in all_schema_cache_contents:
                 continue
 
-            try:
-                versions = self._get_schema_registry_versions(subject)
+            cached_info = latest_version_cache.get(subject)
+            if not isinstance(cached_info, dict):
+                continue
 
-                self.check.gauge('schema_registry.versions', len(versions), tags=subject_tags)
+            version = cached_info.get('version')
+            schema_id = cached_info.get('schema_id')
+            if version is None or schema_id is None:
+                continue
 
-                latest_schema = self._get_schema_registry_latest_version(subject)
+            schema_id_str = str(schema_id)
+            id_entry = schema_id_cache.get(schema_id_str)
+            if not id_entry:
+                continue
 
-                schema_id = latest_schema.get('id')
-                schema_version = latest_schema.get('version')
-                schema_type = latest_schema.get('schemaType', 'AVRO')
-                schema_content = latest_schema.get('schema', '')
+            all_schema_cache_contents[subject] = f"{schema_id}:{version}:{id_entry['schema']}"
 
-                # Extract topic name and schema type (key/value) from subject
-                # Subjects follow patterns: "topic-key", "topic-value"
+        # Determine which subjects need event emission (changed or TTL expired)
+        schemas_to_emit = self._get_events_to_send(
+            self.SCHEMA_CACHE_KEY, all_schema_cache_contents, event_cache_ttl=self.SCHEMA_EVENT_CACHE_TTL
+        )
+
+        # Build full payloads only for subjects that need emission
+        for subject in schemas_to_emit:
+            if subject in fetched_schemas:
+                info = fetched_schemas[subject]
+            else:
+                # Reconstruct from caches
+                cached_info = latest_version_cache.get(subject, {})
+                version = cached_info.get('version')
+                schema_id = cached_info.get('schema_id')
+                id_entry = schema_id_cache.get(str(schema_id), {})
+                schema_content = id_entry.get('schema', '')
+                schema_type = id_entry.get('schema_type', 'AVRO')
+
                 topic_name = subject
                 schema_for = 'unknown'
-
                 if subject.endswith('-value'):
-                    topic_name = subject[:-6]  # Remove '-value'
+                    topic_name = subject[:-6]
                     schema_for = 'value'
                 elif subject.endswith('-key'):
-                    topic_name = subject[:-4]  # Remove '-key'
+                    topic_name = subject[:-4]
                     schema_for = 'key'
 
+                subject_tags = self._get_tags(cluster_id) + [f'subject:{subject}']
                 event_tags = subject_tags + [
                     f'schema_id:{schema_id}',
-                    f'schema_version:{schema_version}',
+                    f'schema_version:{version}',
                     f'schema_type:{schema_type}',
                     f'topic:{topic_name}',
                     f'schema_for:{schema_for}',
                     'event_type:schema_registry',
                 ]
 
-                cache_content = f"{schema_id}:{schema_version}:{schema_content}"
-
-                fetched_schemas[subject] = {
-                    'cache_content': cache_content,
+                info = {
                     'schema_content': schema_content,
                     'topic_name': topic_name,
                     'schema_for': schema_for,
-                    'schema_version': schema_version,
+                    'schema_version': version,
                     'schema_id': schema_id,
                     'schema_type': schema_type,
                     'event_tags': event_tags,
                 }
 
-            except Exception as e:
-                self.log.warning("Error getting schema details for %s: %s", subject, e)
-
-        self._mark_items_fetched(self.SCHEMA_FETCH_CACHE_KEY, list(fetched_schemas.keys()))
-
-        schema_contents = {subject: info['cache_content'] for subject, info in fetched_schemas.items()}
-        schemas_to_emit = self._get_events_to_send(self.SCHEMA_CACHE_KEY, schema_contents)
-
-        for subject in schemas_to_emit:
-            info = fetched_schemas[subject]
             self.check.event(
                 {
                     'timestamp': int(time.time()),

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -84,10 +84,16 @@ class ClusterMetadataCollector:
 
         self._schema_registry_oauth_token = token
         self._schema_registry_oauth_token_expiry = expires_at
-        self.http.options['headers'] = {
+        headers = {
             **self.http.options.get('headers', {}),
             'Authorization': f'Bearer {token}',
         }
+
+        custom_headers = oauth_config.get("custom_headers")
+        if custom_headers:
+            headers.update(custom_headers)
+
+        self.http.options['headers'] = headers
         self.log.debug("Schema Registry OAuth token refreshed, expires at %s", expires_at)
 
     def _fetch_oidc_token(self, oauth_config: dict) -> tuple[str, float]:

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -9,7 +9,6 @@ import json
 import random
 import time
 
-import requests
 from confluent_kafka.admin import ConfigResource, ResourceType
 
 from datadog_checks.kafka_consumer.constants import KAFKA_INTERNAL_TOPICS, LOW_WATERMARK
@@ -107,17 +106,16 @@ class ClusterMetadataCollector:
         if scope:
             data["scope"] = scope
 
-        verify = True
+        options = {}
         tls_ca_cert = oauth_config.get("tls_ca_cert")
         if tls_ca_cert:
-            verify = tls_ca_cert
+            options["verify"] = tls_ca_cert
 
-        response = requests.post(
+        response = self.http.post(
             token_url,
             data=data,
             auth=(client_id, client_secret),
-            verify=verify,
-            timeout=10,
+            **options,
         )
         response.raise_for_status()
         token_data = response.json()

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -9,6 +9,7 @@ import json
 import random
 import time
 
+import requests
 from confluent_kafka.admin import ConfigResource, ResourceType
 
 from datadog_checks.kafka_consumer.constants import KAFKA_INTERNAL_TOPICS, LOW_WATERMARK
@@ -35,6 +36,9 @@ class ClusterMetadataCollector:
         self.TOPIC_HWM_SUM_CACHE_KEY = 'kafka_topic_hwm_sum_cache'
         self.SCHEMA_CACHE_KEY = 'kafka_schema_cache'
         self.SCHEMA_FETCH_CACHE_KEY = 'kafka_schema_fetch_cache'
+
+        self._schema_registry_oauth_token = None
+        self._schema_registry_oauth_token_expiry = 0
 
         if self.config._collect_schema_registry:
             self._configure_schema_registry_http_client()
@@ -65,6 +69,58 @@ class ClusterMetadataCollector:
             )
         elif self.config._schema_registry_tls_cert:
             self.http.options['cert'] = self.config._schema_registry_tls_cert
+
+    def _refresh_schema_registry_oauth_token(self):
+        """Fetch or refresh the OAuth token for Schema Registry if configured and expired."""
+        oauth_config = self.config._schema_registry_oauth_token_provider
+        if not oauth_config:
+            return
+
+        # Check if token is still valid (with 30s buffer)
+        if self._schema_registry_oauth_token and time.time() < (self._schema_registry_oauth_token_expiry - 30):
+            return
+
+        token, expires_at = self._fetch_oidc_token(oauth_config)
+
+        self._schema_registry_oauth_token = token
+        self._schema_registry_oauth_token_expiry = expires_at
+        self.http.options['headers'] = {
+            **self.http.options.get('headers', {}),
+            'Authorization': f'Bearer {token}',
+        }
+        self.log.debug("Schema Registry OAuth token refreshed, expires at %s", expires_at)
+
+    def _fetch_oidc_token(self, oauth_config: dict) -> tuple[str, float]:
+        """Fetch an OIDC token using client credentials grant."""
+        token_url = oauth_config["url"]
+        client_id = oauth_config["client_id"]
+        client_secret = oauth_config["client_secret"]
+
+        data = {"grant_type": "client_credentials"}
+        scope = oauth_config.get("scope")
+        if scope:
+            data["scope"] = scope
+
+        verify = True
+        tls_ca_cert = oauth_config.get("tls_ca_cert")
+        if tls_ca_cert:
+            verify = tls_ca_cert
+
+        response = requests.post(
+            token_url,
+            data=data,
+            auth=(client_id, client_secret),
+            verify=verify,
+            timeout=10,
+        )
+        response.raise_for_status()
+        token_data = response.json()
+
+        access_token = token_data["access_token"]
+        expires_in = token_data.get("expires_in", 300)
+        expires_at = time.time() + expires_in
+
+        return access_token, expires_at
 
     def _get_schema_registry_subjects(self):
         base_url = self.config._collect_schema_registry
@@ -636,6 +692,12 @@ class ClusterMetadataCollector:
             return
 
         self.log.debug("Collecting schema registry information from %s", self.config._collect_schema_registry)
+
+        try:
+            self._refresh_schema_registry_oauth_token()
+        except Exception as e:
+            self.log.error("Failed to refresh Schema Registry OAuth token: %s", e)
+            return
 
         try:
             subjects = self._get_schema_registry_subjects()

--- a/kafka_consumer/datadog_checks/kafka_consumer/config.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config.py
@@ -106,6 +106,16 @@ class KafkaConfig:
         else:
             self._data_streams_enabled = is_affirmative(instance.get('data_streams_enabled', False))
 
+        kafka_configs_refresh = int(instance.get('kafka_configs_refresh_interval', 180))
+        if kafka_configs_refresh < 60:
+            self.log.warning(
+                "kafka_configs_refresh_interval is set to %d, which is below the minimum of 60 seconds. "
+                "Using 60 seconds.",
+                kafka_configs_refresh,
+            )
+            kafka_configs_refresh = 60
+        self._kafka_configs_refresh_interval = kafka_configs_refresh
+
         self._collect_schema_registry = instance.get('schema_registry_url')
 
         # Schema Registry authentication

--- a/kafka_consumer/datadog_checks/kafka_consumer/config.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config.py
@@ -115,6 +115,7 @@ class KafkaConfig:
         self._schema_registry_tls_cert = instance.get('schema_registry_tls_cert')
         self._schema_registry_tls_key = instance.get('schema_registry_tls_key')
         self._schema_registry_tls_ca_cert = instance.get('schema_registry_tls_ca_cert')
+        self._schema_registry_oauth_token_provider = instance.get('schema_registry_oauth_token_provider')
 
     def validate_config(self):
         if not self._kafka_connect_str:
@@ -141,6 +142,26 @@ class KafkaConfig:
 
             elif self._sasl_oauth_token_provider.get("client_secret") is None:
                 raise ConfigurationError("The `client_secret` setting of `auth_token` reader is required")
+
+        if self._schema_registry_oauth_token_provider is not None:
+            if not isinstance(self._schema_registry_oauth_token_provider, dict):
+                raise ConfigurationError(
+                    "schema_registry_oauth_token_provider must be a dictionary. "
+                    f"Got: {type(self._schema_registry_oauth_token_provider)}"
+                )
+
+            if self._schema_registry_oauth_token_provider.get("url") is None:
+                raise ConfigurationError(
+                    "The `url` setting of `schema_registry_oauth_token_provider` is required"
+                )
+            if self._schema_registry_oauth_token_provider.get("client_id") is None:
+                raise ConfigurationError(
+                    "The `client_id` setting of `schema_registry_oauth_token_provider` is required"
+                )
+            if self._schema_registry_oauth_token_provider.get("client_secret") is None:
+                raise ConfigurationError(
+                    "The `client_secret` setting of `schema_registry_oauth_token_provider` is required"
+                )
 
         # If `monitor_unlisted_consumer_groups` is set to true and
         # using `consumer_groups`, we prioritize `monitor_unlisted_consumer_groups`

--- a/kafka_consumer/datadog_checks/kafka_consumer/config.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config.py
@@ -151,9 +151,7 @@ class KafkaConfig:
                 )
 
             if self._schema_registry_oauth_token_provider.get("url") is None:
-                raise ConfigurationError(
-                    "The `url` setting of `schema_registry_oauth_token_provider` is required"
-                )
+                raise ConfigurationError("The `url` setting of `schema_registry_oauth_token_provider` is required")
             if self._schema_registry_oauth_token_provider.get("client_id") is None:
                 raise ConfigurationError(
                     "The `client_id` setting of `schema_registry_oauth_token_provider` is required"

--- a/kafka_consumer/datadog_checks/kafka_consumer/config_models/defaults.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config_models/defaults.py
@@ -44,6 +44,10 @@ def instance_enable_legacy_tags_normalization():
     return True
 
 
+def instance_kafka_configs_refresh_interval():
+    return 180
+
+
 def instance_min_collection_interval():
     return 15
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
@@ -72,6 +72,7 @@ class InstanceConfig(BaseModel):
     enable_cluster_monitoring: Optional[bool] = None
     enable_legacy_tags_normalization: Optional[bool] = None
     kafka_client_api_version: Optional[str] = None
+    kafka_configs_refresh_interval: Optional[int] = None
     kafka_connect_str: Union[str, tuple[str, ...]]
     metric_patterns: Optional[MetricPatterns] = None
     min_collection_interval: Optional[float] = None

--- a/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
@@ -42,6 +42,18 @@ class SaslOauthTokenProvider(BaseModel):
     url: Optional[str] = None
 
 
+class SchemaRegistryOauthTokenProvider(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    client_id: Optional[str] = None
+    client_secret: Optional[str] = None
+    scope: Optional[str] = None
+    tls_ca_cert: Optional[str] = None
+    url: Optional[str] = None
+
+
 class InstanceConfig(BaseModel):
     model_config = ConfigDict(
         validate_default=True,
@@ -72,6 +84,7 @@ class InstanceConfig(BaseModel):
     sasl_oauth_token_provider: Optional[SaslOauthTokenProvider] = None
     sasl_plain_password: Optional[str] = None
     sasl_plain_username: Optional[str] = None
+    schema_registry_oauth_token_provider: Optional[SchemaRegistryOauthTokenProvider] = None
     schema_registry_password: Optional[str] = None
     schema_registry_tls_ca_cert: Optional[str] = None
     schema_registry_tls_cert: Optional[str] = None

--- a/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
@@ -49,6 +49,7 @@ class SchemaRegistryOauthTokenProvider(BaseModel):
     )
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
+    custom_headers: Optional[MappingProxyType[str, str]] = None
     scope: Optional[str] = None
     tls_ca_cert: Optional[str] = None
     url: Optional[str] = None

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -383,3 +383,34 @@ instances:
     ## Must be used in combination with schema_registry_tls_cert.
     #
     # schema_registry_tls_key: /path/to/client_key.pem
+
+    ## OAuth token provider settings for Schema Registry authentication.
+    ## When configured, the check will fetch an OAuth token and use it as a Bearer token
+    ## for Schema Registry HTTP requests.
+    #
+    # schema_registry_oauth_token_provider:
+
+        ## @param url - string - required
+        ## The token endpoint.
+        #
+        url: <URL>
+
+        ## @param client_id - string - required
+        ## The client identifier.
+        #
+        client_id: <CLIENT_ID>
+
+        ## @param client_secret - string - required
+        ## The client secret.
+        #
+        client_secret: <CLIENT_SECRET>
+
+        ## @param scope - string - optional
+        ## The OAuth scope to request.
+        #
+        # scope: <SCOPE>
+
+        ## @param tls_ca_cert - string - optional - default: /path/to/oauth_ca_cert.pem
+        ## Path to a CA certificate file used to verify the OIDC token endpoint's TLS certificate.
+        #
+        # tls_ca_cert: /path/to/oauth_ca_cert.pem

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -393,17 +393,17 @@ instances:
         ## @param url - string - required
         ## The token endpoint.
         #
-        url: <URL>
+        # url: <URL>
 
         ## @param client_id - string - required
         ## The client identifier.
         #
-        client_id: <CLIENT_ID>
+        # client_id: <CLIENT_ID>
 
         ## @param client_secret - string - required
         ## The client secret.
         #
-        client_secret: <CLIENT_SECRET>
+        # client_secret: <CLIENT_SECRET>
 
         ## @param scope - string - optional
         ## The OAuth scope to request.

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -410,6 +410,16 @@ instances:
         #
         # scope: <SCOPE>
 
+        ## @param custom_headers - mapping - optional
+        ## Additional HTTP headers to include in Schema Registry requests.
+        ## For Confluent Cloud, this typically includes the identity pool ID and
+        ## the Schema Registry cluster ID.
+        ## Example:
+        ##   Confluent-Identity-Pool-Id: pool-xxxxx
+        ##   target-sr-cluster: lsrc-xxxxx
+        #
+        # custom_headers: {}
+
         ## @param tls_ca_cert - string - optional - default: /path/to/oauth_ca_cert.pem
         ## Path to a CA certificate file used to verify the OIDC token endpoint's TLS certificate.
         #

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -343,6 +343,15 @@ instances:
     #
     # enable_cluster_monitoring: false
 
+    ## @param kafka_configs_refresh_interval - integer - optional - default: 180
+    ## How often (in seconds) to re-fetch broker configurations, topic configurations,
+    ## and schema registry version checks from Kafka. A longer interval reduces load on
+    ## the Kafka cluster and Schema Registry. On clusters with many topics or schemas,
+    ## the check fetches in batches and gracefully degrades by re-fetching less often if
+    ## it cannot keep up within this interval. Minimum value is 60 seconds.
+    #
+    # kafka_configs_refresh_interval: 180
+
     ## @param schema_registry_url - string - optional - default: http://localhost:8081
     ## Schema Registry URL. When set with enable_cluster_monitoring, collects schema information.
     #


### PR DESCRIPTION
### What does this PR do?

When a Kafka cluster has thousands of topics or schemas, querying all of them each time can slow down the check, causing metrics to only be reported sparsely.

This change optimizes fetching Kafka broker / topic configuration and schemas, to minimize number of calls per check.

### Motivation

When check is to slow to run, it causes sparse metrics.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
