### PR TITLE
Add tls_ciphers support for SOAP connection in VSphere

### DIFF
--- a/vsphere/assets/configuration/spec.yaml
+++ b/vsphere/assets/configuration/spec.yaml
@@ -145,7 +145,7 @@ files:
         value:
           type: boolean
           example: false
-      - name: tls_ciphers
+      - name: ssl_ciphers
         description: |
           A list of TLS cipher suites to use when connecting to vCenter.
           If not specified, the default ciphers from the system's OpenSSL configuration are used.

--- a/vsphere/changelog.d/22723.added
+++ b/vsphere/changelog.d/22723.added
@@ -1,1 +1,1 @@
-Add `tls_ciphers` support for the SOAP connection to allow configuring TLS cipher suites when connecting to vCenter.
+Add `ssl_ciphers` support for the SOAP connection to allow configuring TLS cipher suites when connecting to vCenter.

--- a/vsphere/datadog_checks/vsphere/api.py
+++ b/vsphere/datadog_checks/vsphere/api.py
@@ -114,7 +114,7 @@ class VSphereAPI(object):
         Docs for vim.ServiceInstance:
             https://vdc-download.vmware.com/vmwb-repository/dcr-public/b525fb12-61bb-4ede-b9e3-c4a1f8171510/99ba073a-60e9-4933-8690-149860ce8754/doc/vim.ServiceInstance.html
         """
-        tls_ciphers = self.config.tls_ciphers or []
+        tls_ciphers = self.config.ssl_ciphers or []
         context = None
         if not self.config.ssl_verify:
             context = create_ssl_context({"tls_verify": False, "tls_ciphers": tls_ciphers})

--- a/vsphere/datadog_checks/vsphere/config.py
+++ b/vsphere/datadog_checks/vsphere/config.py
@@ -64,7 +64,7 @@ class VSphereConfig(object):
         self.ssl_capath = instance.get('ssl_capath')
         self.ssl_cafile = instance.get('ssl_cafile')
         self.tls_ignore_warning = instance.get('tls_ignore_warning', False)
-        self.tls_ciphers = instance.get('tls_ciphers')
+        self.ssl_ciphers = instance.get('ssl_ciphers')
 
         self.rest_api_options = {
             'username': self.username,

--- a/vsphere/datadog_checks/vsphere/config_models/instance.py
+++ b/vsphere/datadog_checks/vsphere/config_models/instance.py
@@ -176,11 +176,11 @@ class InstanceConfig(BaseModel):
     service: Optional[str] = None
     ssl_cafile: Optional[str] = None
     ssl_capath: Optional[str] = None
+    ssl_ciphers: Optional[tuple[str, ...]] = None
     ssl_verify: Optional[bool] = None
     tags: Optional[tuple[str, ...]] = None
     tags_prefix: Optional[str] = None
     threads_count: Optional[int] = None
-    tls_ciphers: Optional[tuple[str, ...]] = None
     tls_ignore_warning: Optional[bool] = None
     use_collect_events_fallback: Optional[bool] = None
     use_guest_hostname: Optional[bool] = None

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -152,7 +152,7 @@ instances:
     #
     # tls_ignore_warning: false
 
-    ## @param tls_ciphers - list of strings - optional
+    ## @param ssl_ciphers - list of strings - optional
     ## A list of TLS cipher suites to use when connecting to vCenter.
     ## If not specified, the default ciphers from the system's OpenSSL configuration are used.
     ##
@@ -162,7 +162,7 @@ instances:
     ## Note: This setting only affects the SOAP connection. To configure ciphers for the
     ## REST API connection, use `rest_api_options`.
     #
-    # tls_ciphers:
+    # ssl_ciphers:
     #   - TLS_AES_256_GCM_SHA384
     #   - TLS_CHACHA20_POLY1305_SHA256
     #   - TLS_AES_128_GCM_SHA256


### PR DESCRIPTION
### What does this PR do?                                                                                                                                                                                                                                                       
                                                          
  Adds `tls_ciphers` support to the vSphere SOAP/pyVmomi connection. This is a new top-level instance option that allows configuring TLS cipher suites used when connecting to vCenter via `SmartConnect`.                                                                        
                                                          
  The new option passes the configured ciphers to `create_ssl_context()` across all SSL branches:                                                                                                                                                                                 
  - `ssl_verify=False` with custom ciphers                
  - Custom CA (`ssl_capath`/`ssl_cafile`) with custom ciphers
  - Default SSL verification (`ssl_verify=True`, no custom CA) with custom ciphers

  When `tls_ciphers` is not set, behavior is unchanged — no ciphers are configured and system defaults are used.

  Note: This setting only affects the SOAP connection. The REST API connection (used for tag collection) already supports `tls_ciphers` through `rest_api_options`.

  ### Motivation

  Customers with EOL vCenter servers (6.5/6.7) cannot connect when the Datadog Agent uses OpenSSL 3.x, which drops legacy cipher suites by default. This option lets them explicitly configure the cipher suites needed for those older servers.

  Ticket: AGENT-15319

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
