### PR TITLE
[SIMI-455] Added a deprecation message to the Temporal Cloud integration

### DIFF
--- a/temporal_cloud/README.md
+++ b/temporal_cloud/README.md
@@ -1,6 +1,6 @@
 ## Overview
 
-<div class="alert alert-warning">This legacy integration is no longer maintained. Please migrate to the new <a href="https://docs.datadoghq.com/integrations/temporal-cloud-openmetrics/">Temporal Cloud OpenMetrics integration</a> for expanded metrics and improved monitoring.</div>
+<div class="alert alert-warning">This legacy integration is no longer maintained. Migrate to the new <a href="https://docs.datadoghq.com/integrations/temporal-cloud-openmetrics/">Temporal Cloud OpenMetrics integration</a> for expanded metrics and improved monitoring.</div>
 
 [Temporal Cloud][1] is a scalable platform for orchestrating complex workflows which enables developers to focus on building applications, without worrying about fault tolerance and consistency.
 


### PR DESCRIPTION
### What does this PR do?
Adding a deprecation message to the Temporal Cloud integration public docs page. 

### Motivation
The Temporal Cloud Integration is being deprecated in favour of the new Temporal Cloud - OpenMetrics integration

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
