### PR TITLE
Fix DBM enable links to point to integration-specific setup pages

### DIFF
--- a/mongo/README.md
+++ b/mongo/README.md
@@ -611,5 +611,5 @@ Additional helpful documentation, links, and articles:
 [25]: https://docs.datadoghq.com/help/
 [26]: https://www.datadoghq.com/blog/monitoring-mongodb-performance-metrics-wiredtiger
 [27]: https://www.datadoghq.com/blog/monitoring-mongodb-performance-metrics-mmap
-[28]: https://docs.datadoghq.com/database_monitoring/
+[28]: https://docs.datadoghq.com/database_monitoring/setup_mongodb/
 [29]: https://docs.datadoghq.com/database_monitoring/#mongodb

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -602,5 +602,5 @@ Additional helpful documentation, links, and articles:
 [29]: https://docs.datadoghq.com/integrations/faq/database-user-lacks-privileges/
 [30]: https://docs.datadoghq.com/integrations/guide/collect-sql-server-custom-metrics/#collecting-metrics-from-a-custom-procedure
 [31]: https://www.datadoghq.com/blog/monitoring-mysql-performance-metrics
-[32]: https://docs.datadoghq.com/database_monitoring/
+[32]: https://docs.datadoghq.com/database_monitoring/setup_mysql/
 [33]: https://docs.datadoghq.com/database_monitoring/#mysql

--- a/oracle/README.md
+++ b/oracle/README.md
@@ -428,7 +428,7 @@ See [service_checks.json][12] for a list of service checks provided by this inte
 Need help? Contact [Datadog support][14].
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/oracle/images/oracle_dashboard.png
-[2]: https://docs.datadoghq.com/database_monitoring/
+[2]: https://docs.datadoghq.com/database_monitoring/setup_oracle/
 [3]: https://support.microsoft.com/en-us/topic/the-latest-supported-visual-c-downloads-2647da03-1eea-4433-9aff-95f26a218cc0
 [4]: https://www.oracle.com/database/technologies/instant-client/winx64-64-downloads.html#ic_winx64_inst
 [5]: https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -521,6 +521,6 @@ Additional helpful documentation, links, and articles:
 [25]: https://www.datadoghq.com/blog/postgresql-monitoring-tools
 [26]: https://www.datadoghq.com/blog/collect-postgresql-data-with-datadog
 [27]: https://docs.datadoghq.com/agent/docker/apm/
-[28]: https://docs.datadoghq.com/database_monitoring/
+[28]: https://docs.datadoghq.com/database_monitoring/setup_postgres/
 [29]: https://docs.datadoghq.com/database_monitoring/#postgres
 [30]: https://docs.datadoghq.com/integrations/postgres/?tab=host#faq

--- a/sqlserver/README.md
+++ b/sqlserver/README.md
@@ -6,7 +6,7 @@
 
 The SQL Server integration tracks the performance of your SQL Server instances. It collects metrics for number of user connections, rate of SQL compilations, and more.
 
-Enable [Database Monitoring](https://docs.datadoghq.com/database_monitoring/) (DBM) for enhanced insight into query performance and database health. In addition to the standard integration, Datadog DBM provides query-level metrics, live and historical query snapshots, wait event analysis, database load, query explain plans, and blocking query insights.
+Enable [Database Monitoring](https://docs.datadoghq.com/database_monitoring/setup_sql_server/) (DBM) for enhanced insight into query performance and database health. In addition to the standard integration, Datadog DBM provides query-level metrics, live and historical query snapshots, wait event analysis, database load, query explain plans, and blocking query insights.
 
 SQL Server 2012, 2014, 2016, 2017, 2019, and 2022 are supported.
 


### PR DESCRIPTION
## Summary
- Fix "enable Database Monitoring" links in postgres, mysql, sqlserver, oracle, and mongo READMEs
- Links previously pointed to the generic `/database_monitoring/` page
- Now point to the integration-specific setup pages (e.g., `/database_monitoring/setup_postgres/`)

## Test plan
- [ ] Verify links on rendered docs pages navigate to the correct DBM setup page for each integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)