### PR TITLE
Document why we don't want pip build isolation.

### DIFF
--- a/.builders/scripts/build_wheels.py
+++ b/.builders/scripts/build_wheels.py
@@ -302,6 +302,8 @@ def main():
         env_vars['DD_ENV_FILE'] = str(ENV_FILE)
 
         # Off is on, see: https://github.com/pypa/pip/issues/5735
+        # We don't want pip build isolation because we manage have one env for everything.
+        # We manage our build dependencies in .builders/deps/build_dependencies.txt.
         env_vars['PIP_NO_BUILD_ISOLATION'] = '0'
 
         # Spaces are used to separate multiple values which means paths themselves cannot contain spaces, see:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
We had an incident a few months ago and we were confused about why we disabled build isolation for pip.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
