### PR TITLE
cilium: add metrics from Cilium 1.17–1.20, flatten test metric lists

### DIFF
--- a/cilium/changelog.d/22765.added
+++ b/cilium/changelog.d/22765.added
@@ -1,0 +1,1 @@
+Add metrics from Cilium 1.17-1.19: node health connectivity, hive jobs, identity cache timers, clustermesh remote endpoints, IPsec, service implementation delay, BPF ratelimit, MTU/fragment drops, endpoint restoration, NAT, workqueue work duration, identity GC, and operator doublewrite/unmanaged-pods/clustermesh/MCS-API/CID-controller/k8s-workqueue metrics.

--- a/cilium/changelog.d/22765.changed
+++ b/cilium/changelog.d/22765.changed
@@ -1,0 +1,1 @@
+Stop emitting the value-less ``cilium.version`` gauge; the Cilium version is now surfaced only as Agent version metadata (``version.major``/``version.minor``/``version.patch``/``version.raw``).

--- a/cilium/changelog.d/22765.changed
+++ b/cilium/changelog.d/22765.changed
@@ -1,0 +1,5 @@
+Align the emitted metrics with Cilium 1.17-1.20:
+- Add agent metrics for node health connectivity, hive jobs, identity cache timers and garbage collection, ClusterMesh remote endpoints, IPsec, service implementation delay, BPF ratelimit, MTU and fragment drops, endpoint restoration, NAT, and workqueue work duration.
+- Add operator metrics for doublewrite identities, unmanaged pods, ClusterMesh, MCS-API, the CID controller, the Kubernetes workqueue, and IPAM.
+- Remove the value-less ``cilium.version`` gauge. The Cilium version is now reported only as Agent version metadata (``version.major``, ``version.minor``, ``version.patch``, and ``version.raw``).
+- Document the OpenMetrics V1 (``.total``) and OpenMetrics V2 (``.count``) names separately for counters previously listed under a single entry, and mark the ``cilium.operator.lbipam.*`` names emitted only with Cilium 1.15-1.16 as deprecated.

--- a/cilium/datadog_checks/cilium/metrics.py
+++ b/cilium/datadog_checks/cilium/metrics.py
@@ -51,9 +51,6 @@ AGENT_METRICS = {
     "cilium_process_virtual_memory_max_bytes": "process.virtual_memory.max.bytes",
     "cilium_services_events_total": "services.events.total",
     "cilium_subprocess_start_total": "subprocess.start.total",
-    "cilium_triggers_policy_update_call_duration_seconds": "triggers_policy.update_call_duration.seconds",
-    "cilium_triggers_policy_update_folds": "triggers_policy.update_folds",
-    "cilium_triggers_policy_update_total": "triggers_policy.update.total",
     "cilium_unreachable_health_endpoints": "unreachable.health_endpoints",
     "cilium_unreachable_nodes": "unreachable.nodes",
     "cilium_event_ts": "event_timestamp",
@@ -92,6 +89,7 @@ AGENT_METRICS = {
     "cilium_bpf_progs_virtual_memory_max_bytes": "bpf.progs.virtual_memory.max.bytes",
     "cilium_datapath_conntrack_dump_resets_total": "datapath.conntrack_dump.resets.total",
     "cilium_ipcache_errors_total": "ipcache.errors.total",
+    "cilium_ipcache_events_total": "ipcache.events.total",
     "cilium_k8s_event_lag_seconds": "k8s_event.lag.seconds",
     "cilium_k8s_terminating_endpoints_events_total": "k8s_terminating.endpoints_events.total",
     "cilium_proxy_datapath_update_timeout_total": "proxy.datapath.update_timeout.total",
@@ -101,10 +99,10 @@ AGENT_METRICS = {
     "cilium_fqdn_alive_zombie_connections": "fqdn.alive_zombie_connections",
     # Cilium 1.14+
     "cilium_endpoint": "endpoint.count",
-    "cilium_endpoint_max_ifindex": "endpoint.max_ifindex",
     "cilium_cidrgroup_policies": "cidrgroup.policies",
     "cilium_kvstore_sync_queue_size": "kvstore.sync_queue_size",
     "cilium_kvstore_initial_sync_completed": "kvstore.initial_sync_completed",
+    "cilium_kvstore_sync_errors_total": "kvstore.sync_errors.total",
     "cilium_k8s_client_rate_limiter_duration_seconds": "k8s_client.rate_limiter_duration.seconds",
     "cilium_policy_change_total": "policy.change.total",
     # Cilium 1.15+
@@ -112,17 +110,153 @@ AGENT_METRICS = {
     "cilium_hive_status": "hive.status",
     "cilium_ipam_capacity": "ipam.capacity",
     "cilium_cidrgroups_referenced": "cidrgroups.referenced",
-    "cilium_cidrgroup_translation_time_stats_seconds": "cidrgroup.translation.time.stats.seconds",
     "cilium_k8s_workqueue_adds_total": "k8s.workqueue.adds.total",
     "cilium_k8s_workqueue_depth": "k8s.workqueue.depth",
     "cilium_k8s_workqueue_longest_running_processor_seconds": "k8s.workqueue.longest.running.processor.seconds",
     "cilium_k8s_workqueue_queue_duration_seconds": "k8s.workqueue.queue.duration.seconds",
     "cilium_k8s_workqueue_retries_total": "k8s.workqueue.retries.total",
     "cilium_k8s_workqueue_unfinished_work_seconds": "k8s.workqueue.unfinished.work.seconds",
-    "cilium_version": "version",
+    "cilium_k8s_workqueue_work_duration_seconds": "k8s.workqueue.work_duration.seconds",
+    # cilium_version is intentionally excluded from the metrics mapper so that
+    # the metadata transformer fires and sets version.major/minor/patch via set_metadata.
+    # In V1, process_metric consults metrics_mapper before the metadata transformer, so
+    # mapping cilium_version here would emit a value-less gauge and skip version metadata.
+    #
     # Cilium 1.16+
     "cilium_fqdn_selectors": "fqdn.selectors",
     "cilium_identity_label_sources": "identity.label_sources",
+    # Cilium 1.14-1.18, removed in 1.19
+    "cilium_endpoint_max_ifindex": "endpoint.max_ifindex",
+    # Cilium 1.15-1.16, removed in 1.17
+    "cilium_cidrgroup_translation_time_stats_seconds": "cidrgroup.translation.time.stats.seconds",
+    # Cilium <= 1.16, removed in 1.17
+    "cilium_triggers_policy_update_call_duration_seconds": "triggers_policy.update_call_duration.seconds",
+    "cilium_triggers_policy_update_folds": "triggers_policy.update_folds",
+    "cilium_triggers_policy_update_total": "triggers_policy.update.total",
+    # ClusterMesh agent metrics
+    "cilium_clustermesh_remote_cluster_services": "clustermesh.remote_cluster_services",
+    "cilium_clustermesh_remote_cluster_nodes": "clustermesh.remote_cluster_nodes",
+    "cilium_clustermesh_remote_clusters": "clustermesh.remote_clusters",
+    "cilium_clustermesh_remote_cluster_failures": "clustermesh.remote_cluster_failures",
+    "cilium_clustermesh_remote_cluster_last_failure_ts": "clustermesh.remote_cluster_last_failure_ts",
+    "cilium_clustermesh_remote_cluster_readiness_status": "clustermesh.remote_cluster_readiness_status",
+    "cilium_clustermesh_remote_cluster_cache_revocations": "clustermesh.remote_cluster_cache_revocations",
+    # IPsec
+    "cilium_ipsec_xfrm_error": "ipsec.xfrm_error",
+    "cilium_ipsec_keys": "ipsec.keys",
+    "cilium_ipsec_xfrm_states": "ipsec.xfrm_states",
+    "cilium_ipsec_xfrm_policies": "ipsec.xfrm_policies",
+    # eBPF additions
+    "cilium_bpf_syscall_duration_seconds": "bpf.syscall_duration.seconds",
+    "cilium_bpf_ratelimit_dropped_total": "bpf.ratelimit_dropped.total",
+    # Drop/Forward additions
+    "cilium_mtu_error_message_total": "mtu_error_message.total",
+    "cilium_fragmented_count_total": "fragmented_count.total",
+    # Services
+    "cilium_service_implementation_delay": "service.implementation_delay",
+    # API limiter
+    "cilium_api_limiter_wait_history_duration_seconds": "api_limiter.wait_history_duration.seconds",
+    # Policy
+    "cilium_policy_incremental_update_duration": "policy.incremental_update_duration",
+    # Identity
+    "cilium_identity_gc_entries": "identity.gc_entries",
+    "cilium_identity_gc_runs": "identity.gc_runs",
+    "cilium_identity_gc_latency": "identity.gc_latency",
+    # Kubernetes
+    "cilium_k8s_cnp_status_completion_seconds": "k8s.cnp_status_completion.seconds",
+    # Controllers
+    "cilium_controllers_group_runs_total": "controllers.group_runs.total",
+    # Endpoint
+    "cilium_endpoint_restoration_endpoints": "endpoint.restoration_endpoints",
+    "cilium_endpoint_restoration_duration_seconds": "endpoint.restoration_duration.seconds",
+    # NAT
+    "cilium_nat_endpoint_max_connection": "nat.endpoint_max_connection",
+    # Hive Jobs (Cilium 1.17+)
+    "cilium_hive_jobs_runs_total": "hive.jobs_runs.total",
+    "cilium_hive_jobs_runs_failed": "hive.jobs_runs_failed",
+    "cilium_hive_jobs_oneshot_last_run_duration_seconds": "hive.jobs.oneshot.last_run_duration.seconds",
+    "cilium_hive_jobs_observer_last_run_duration_seconds": "hive.jobs.observer.last_run_duration.seconds",
+    "cilium_hive_jobs_observer_run_duration_seconds": "hive.jobs.observer.run_duration.seconds",
+    "cilium_hive_jobs_timer_last_run_duration_seconds": "hive.jobs.timer.last_run_duration.seconds",
+    "cilium_hive_jobs_timer_run_duration_seconds": "hive.jobs.timer.run_duration.seconds",
+    # Cilium 1.17+
+    "cilium_node_health_connectivity_status": "node_health.connectivity.status",
+    "cilium_node_health_connectivity_latency_seconds": "node_health.connectivity.latency.seconds",
+    "cilium_policy_selector_match_count_max": "policy.selector_match_count_max",
+    # Cilium 1.17-1.19, renamed to identity_updater_timer_* in 1.20+
+    "cilium_identity_cache_timer_duration": "identity.cache_timer.duration",
+    "cilium_identity_cache_timer_trigger_latency": "identity.cache_timer_trigger.latency",
+    "cilium_identity_cache_timer_trigger_folds": "identity.cache_timer_trigger.folds",
+    # Cilium 1.19+
+    "cilium_clustermesh_remote_cluster_endpoints": "clustermesh.remote_cluster_endpoints",
+    # Cilium 1.20+
+    # identity_updater_timer_* renamed from identity_cache_timer_*
+    "cilium_identity_updater_timer_duration": "identity.updater_timer.duration",
+    "cilium_identity_updater_timer_trigger_latency": "identity.updater_timer_trigger.latency",
+    "cilium_identity_updater_timer_trigger_folds": "identity.updater_timer_trigger.folds",
+    "cilium_endpoint_component_status": "endpoint.component_status",
+    "cilium_clustermesh_remote_cluster_endpoint_slices": "clustermesh.remote_cluster_endpoint_slices",
+    "cilium_policy_missing_proxy_redirects": "policy.missing_proxy_redirects",
+    "cilium_kubernetes_resource_sync_duration": "kubernetes.resource_sync_duration",
+    "cilium_hive_start_duration": "hive.start_duration",
+    "cilium_hive_stop_duration": "hive.stop_duration",
+    "cilium_hive_populate_duration": "hive.populate_duration",
+    # BGP Control Plane (enabled only when BGP is active)
+    "cilium_bgp_control_plane_session_state": "bgp.session_state",
+    "cilium_bgp_control_plane_advertised_routes": "bgp.advertised_routes",
+    "cilium_bgp_control_plane_received_routes": "bgp.received_routes",
+    "cilium_bgp_control_plane_reconcile_errors_total": "bgp.reconcile_errors.total",
+    "cilium_bgp_control_plane_reconcile_run_duration_seconds": "bgp.reconcile_run_duration.seconds",
+    # Feature metrics - adv_connect_and_lb
+    "cilium_feature_adv_connect_and_lb_bandwidth_manager_enabled": "feature.adv_connect_and_lb.bandwidth_manager_enabled",  # noqa: E501
+    "cilium_feature_adv_connect_and_lb_bgp_enabled": "feature.adv_connect_and_lb.bgp_enabled",
+    "cilium_feature_adv_connect_and_lb_big_tcp_enabled": "feature.adv_connect_and_lb.big_tcp_enabled",
+    "cilium_feature_adv_connect_and_lb_cilium_envoy_config_enabled": "feature.adv_connect_and_lb.cilium_envoy_config_enabled",  # noqa: E501
+    "cilium_feature_adv_connect_and_lb_cilium_node_config_enabled": "feature.adv_connect_and_lb.cilium_node_config_enabled",  # noqa: E501
+    "cilium_feature_adv_connect_and_lb_clustermesh_enabled": "feature.adv_connect_and_lb.clustermesh_enabled",
+    "cilium_feature_adv_connect_and_lb_egress_gateway_enabled": "feature.adv_connect_and_lb.egress_gateway_enabled",
+    "cilium_feature_adv_connect_and_lb_envoy_proxy_enabled": "feature.adv_connect_and_lb.envoy_proxy_enabled",
+    "cilium_feature_adv_connect_and_lb_kube_proxy_replacement_enabled": "feature.adv_connect_and_lb.kube_proxy_replacement_enabled",  # noqa: E501
+    "cilium_feature_adv_connect_and_lb_l2_lb_enabled": "feature.adv_connect_and_lb.l2_lb_enabled",
+    "cilium_feature_adv_connect_and_lb_l2_pod_announcement_enabled": "feature.adv_connect_and_lb.l2_pod_announcement_enabled",  # noqa: E501
+    "cilium_feature_adv_connect_and_lb_node_port_configuration": "feature.adv_connect_and_lb.node_port_configuration",
+    "cilium_feature_adv_connect_and_lb_sctp_enabled": "feature.adv_connect_and_lb.sctp_enabled",
+    "cilium_feature_adv_connect_and_lb_transparent_encryption": "feature.adv_connect_and_lb.transparent_encryption",
+    "cilium_feature_adv_connect_and_lb_vtep_enabled": "feature.adv_connect_and_lb.vtep_enabled",
+    # Feature metrics - controlplane
+    "cilium_feature_controlplane_cilium_endpoint_slices_enabled": "feature.controlplane.cilium_endpoint_slices_enabled",
+    "cilium_feature_controlplane_identity_allocation": "feature.controlplane.identity_allocation",
+    "cilium_feature_controlplane_ipam": "feature.controlplane.ipam",
+    # Feature metrics - datapath
+    "cilium_feature_datapath_chaining_enabled": "feature.datapath.chaining_enabled",
+    "cilium_feature_datapath_config": "feature.datapath.config",
+    "cilium_feature_datapath_internet_protocol": "feature.datapath.internet_protocol",
+    "cilium_feature_datapath_network": "feature.datapath.network",
+    # Feature metrics - network_policies
+    "cilium_feature_network_policies_cidr_policies": "feature.network_policies.cidr_policies",
+    "cilium_feature_network_policies_cilium_clusterwide_envoy_config_total": "feature.network_policies.cilium_clusterwide_envoy_config.total",  # noqa: E501
+    "cilium_feature_network_policies_cilium_clusterwide_network_policies_total": "feature.network_policies.cilium_clusterwide_network_policies.total",  # noqa: E501
+    "cilium_feature_network_policies_cilium_envoy_config_total": "feature.network_policies.cilium_envoy_config.total",
+    "cilium_feature_network_policies_cilium_network_policies_total": "feature.network_policies.cilium_network_policies.total",  # noqa: E501
+    "cilium_feature_network_policies_deny_policies_total": "feature.network_policies.deny_policies.total",
+    "cilium_feature_network_policies_dns_policies_total": "feature.network_policies.dns_policies.total",
+    "cilium_feature_network_policies_fqdn_policies_total": "feature.network_policies.fqdn_policies.total",
+    "cilium_feature_network_policies_host_firewall_enabled": "feature.network_policies.host_firewall_enabled",
+    "cilium_feature_network_policies_host_network_policies_total": "feature.network_policies.host_network_policies.total",  # noqa: E501
+    "cilium_feature_network_policies_http_header_matches_policies_total": "feature.network_policies.http_header_matches_policies.total",  # noqa: E501
+    "cilium_feature_network_policies_http_policies_total": "feature.network_policies.http_policies.total",
+    "cilium_feature_network_policies_ingress_cidr_group_policies_total": "feature.network_policies.ingress_cidr_group_policies.total",  # noqa: E501
+    "cilium_feature_network_policies_internal_traffic_policy_services_total": "feature.network_policies.internal_traffic_policy_services.total",  # noqa: E501
+    "cilium_feature_network_policies_l3_policies_total": "feature.network_policies.l3_policies.total",
+    "cilium_feature_network_policies_local_redirect_policies_total": "feature.network_policies.local_redirect_policies.total",  # noqa: E501
+    "cilium_feature_network_policies_local_redirect_policy_enabled": "feature.network_policies.local_redirect_policy_enabled",  # noqa: E501
+    "cilium_feature_network_policies_mutual_auth_enabled": "feature.network_policies.mutual_auth_enabled",
+    "cilium_feature_network_policies_mutual_auth_policies_total": "feature.network_policies.mutual_auth_policies.total",
+    "cilium_feature_network_policies_non_defaultdeny_policies_enabled": "feature.network_policies.non_defaultdeny_policies_enabled",  # noqa: E501
+    "cilium_feature_network_policies_non_defaultdeny_policies_total": "feature.network_policies.non_defaultdeny_policies.total",  # noqa: E501
+    "cilium_feature_network_policies_other_l7_policies_total": "feature.network_policies.other_l7_policies.total",
+    "cilium_feature_network_policies_sni_allow_list_policies_total": "feature.network_policies.sni_allow_list_policies.total",  # noqa: E501
+    "cilium_feature_network_policies_tls_inspection_policies_total": "feature.network_policies.tls_inspection_policies.total",  # noqa: E501
 }
 
 OPERATOR_V2_OVERRIDES = {
@@ -191,6 +325,7 @@ OPERATOR_METRICS = {
     # Cilium 1.11+
     "cilium_operator_identity_gc_entries": "operator.identity_gc.entries",
     "cilium_operator_identity_gc_runs": "operator.identity_gc.runs",
+    "cilium_operator_identity_gc_latency": "operator.identity_gc.latency",
     "cilium_operator_number_of_ceps_per_ces": "operator.num_ceps_per_ces",
     "cilium_operator_ces_queueing_delay_seconds": "operator.ces.queueing_delay.seconds",
     "cilium_operator_ces_sync_errors_total": "operator.ces.sync_errors.total",
@@ -208,6 +343,8 @@ OPERATOR_METRICS = {
     "cilium_operator_ipam_release_duration_seconds": "operator.ipam.release.duration.seconds",
     "cilium_operator_ipam_used_ips": "operator.ipam.used_ips",
     # Cilium 1.15+
+    # Note: lbipam metrics had _total suffix in 1.15-1.16; the _total is stripped by construct_metrics_config
+    # so the same entries match both old (counter) and new (gauge, renamed without _total in 1.17+) metric names.
     "cilium_hive_status": "operator.hive.status",
     "cilium_operator_errors_warnings_total": "operator.errors.warnings.total",
     "cilium_operator_lbipam_ips_available_total": "operator.lbipam.ips.available.total",
@@ -215,6 +352,50 @@ OPERATOR_METRICS = {
     "cilium_operator_lbipam_conflicting_pools_total": "operator.lbipam.conflicting.pools.total",
     "cilium_operator_lbipam_services_matching_total": "operator.lbipam.services.matching.total",
     "cilium_operator_lbipam_services_unsatisfied_total": "operator.lbipam.services.unsatisfied.total",
+    # Missing from earlier integrations
+    "cilium_operator_controllers_group_runs_total": "operator.controllers.group_runs.total",
+    "cilium_operator_number_of_cep_changes_per_ces": "operator.num_cep_changes_per_ces",
+    # ClusterMesh operator
+    "cilium_operator_clustermesh_remote_clusters": "operator.clustermesh.remote_clusters",
+    "cilium_operator_clustermesh_remote_cluster_failures": "operator.clustermesh.remote_cluster_failures",
+    "cilium_operator_clustermesh_remote_cluster_last_failure_ts": "operator.clustermesh.remote_cluster_last_failure_ts",
+    "cilium_operator_clustermesh_remote_cluster_readiness_status": "operator.clustermesh.remote_cluster_readiness_status",  # noqa: E501
+    "cilium_operator_clustermesh_remote_cluster_cache_revocations": "operator.clustermesh.remote_cluster_cache_revocations",  # noqa: E501
+    "cilium_operator_clustermesh_remote_cluster_services": "operator.clustermesh.remote_cluster_services",
+    "cilium_operator_clustermesh_remote_cluster_service_exports": "operator.clustermesh.remote_cluster_service_exports",
+    "cilium_operator_clustermesh_remote_cluster_endpoint_slices": "operator.clustermesh.remote_cluster_endpoint_slices",  # noqa: E501
+    # MCS-API
+    "cilium_operator_mcsapi_serviceexport_info": "operator.mcsapi.serviceexport_info",
+    "cilium_operator_mcsapi_serviceexport_status_condition": "operator.mcsapi.serviceexport_status_condition",
+    "cilium_operator_mcsapi_serviceimport_info": "operator.mcsapi.serviceimport_info",
+    "cilium_operator_mcsapi_serviceimport_status_condition": "operator.mcsapi.serviceimport_status_condition",
+    "cilium_operator_mcsapi_serviceimport_status_clusters": "operator.mcsapi.serviceimport_status_clusters",
+    # CID controller
+    "cilium_operator_cid_controller_work_queue_event_count": "operator.cid_controller.work_queue_event_count",
+    "cilium_operator_cid_controller_work_queue_latency": "operator.cid_controller.work_queue_latency",
+    # Cilium 1.17+
+    "cilium_operator_unmanaged_pods": "operator.unmanaged_pods",
+    "cilium_operator_doublewrite_crd_identities": "operator.doublewrite.crd_identities",
+    "cilium_operator_doublewrite_kvstore_identities": "operator.doublewrite.kvstore_identities",
+    "cilium_operator_doublewrite_crd_only_identities": "operator.doublewrite.crd_only_identities",
+    "cilium_operator_doublewrite_kvstore_only_identities": "operator.doublewrite.kvstore_only_identities",
+    # Operator internal workqueues (Cilium 1.18+): Cilium Node Synchronizer and CiliumEndpointSlice Controller queues
+    "cilium_operator_workqueue_depth": "operator.k8s.workqueue.depth",
+    "cilium_operator_workqueue_adds_total": "operator.k8s.workqueue.adds.total",
+    "cilium_operator_workqueue_queue_duration_seconds": "operator.k8s.workqueue.queue_duration.seconds",
+    "cilium_operator_workqueue_work_duration_seconds": "operator.k8s.workqueue.work_duration.seconds",
+    "cilium_operator_workqueue_unfinished_work_seconds": "operator.k8s.workqueue.unfinished_work.seconds",
+    "cilium_operator_workqueue_longest_running_processor_seconds": "operator.k8s.workqueue.longest_running_processor.seconds",  # noqa: E501
+    "cilium_operator_workqueue_retries_total": "operator.k8s.workqueue.retries.total",
+    # BGP Control Plane Operator (enabled only when BGP is active)
+    "cilium_operator_bgp_control_plane_reconcile_errors_total": "operator.bgp.reconcile_errors.total",
+    "cilium_operator_bgp_control_plane_reconcile_run_duration_seconds": "operator.bgp.reconcile_run_duration.seconds",  # noqa: E501
+    # Feature metrics - adv_connect_and_lb
+    "cilium_operator_feature_adv_connect_and_lb_gateway_api_enabled": "operator.feature.adv_connect_and_lb.gateway_api_enabled",  # noqa: E501
+    "cilium_operator_feature_adv_connect_and_lb_ingress_controller_enabled": "operator.feature.adv_connect_and_lb.ingress_controller_enabled",  # noqa: E501
+    "cilium_operator_feature_adv_connect_and_lb_l7_aware_traffic_management_enabled": "operator.feature.adv_connect_and_lb.l7_aware_traffic_management_enabled",  # noqa: E501
+    "cilium_operator_feature_adv_connect_and_lb_lb_ipam_enabled": "operator.feature.adv_connect_and_lb.lb_ipam_enabled",
+    "cilium_operator_feature_adv_connect_and_lb_node_ipam_enabled": "operator.feature.adv_connect_and_lb.node_ipam_enabled",  # noqa: E501
 }
 
 AGENT_V2_METRICS = deepcopy(AGENT_METRICS)

--- a/cilium/metadata.csv
+++ b/cilium/metadata.csv
@@ -12,16 +12,43 @@ cilium.api_limiter.processing_duration.seconds,gauge,,second,,[OpenMetrics V1 an
 cilium.api_limiter.rate_limit,gauge,,request,,[OpenMetrics V1 and V2] Current rate limiting configuration (limit and burst),0,cilium,limiter rate limit,,
 cilium.api_limiter.requests_in_flight,gauge,,request,,[OpenMetrics V1 and V2] Current and maximum allowed number of requests in flight.,0,cilium,limiter in flight,,
 cilium.api_limiter.wait_duration.seconds,gauge,,second,,[OpenMetrics V1 and V2] Wait duration aggregated per api call,-1,cilium,limiter wait,,
+cilium.api_limiter.wait_history_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of API rate limiter wait durations,0,cilium,limiter wait hist bucket,,api_call
+cilium.api_limiter.wait_history_duration.seconds.count,count,,request,,[OpenMetrics V2] Count of API rate limiter wait durations,0,cilium,limiter wait hist count,,api_call
+cilium.api_limiter.wait_history_duration.seconds.sum,count,,second,,[OpenMetrics V2] Sum of API rate limiter wait durations,0,cilium,limiter wait hist sum,,api_call
+cilium.bgp.advertised_routes,gauge,,,,[OpenMetrics V1 and V2] Number of routes advertised to the peer,0,cilium,bgp advertised routes,,afi:neighbor:neighbor_asn:safi:vrouter
+cilium.bgp.received_routes,gauge,,,,[OpenMetrics V1 and V2] Number of routes received from the peer,0,cilium,bgp received routes,,afi:neighbor:neighbor_asn:safi:vrouter
+cilium.bgp.reconcile_errors.count,count,,,,[OpenMetrics V2] Number of BGP reconciliation errors,0,cilium,bgp reconcile errors,,vrouter
+cilium.bgp.reconcile_errors.total,count,,,,[OpenMetrics V1] Number of BGP reconciliation errors,0,cilium,bgp reconcile errors v1,,vrouter
+cilium.bgp.reconcile_run_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of BGP reconciliation run durations,0,cilium,bgp reconcile dur bucket,,vrouter
+cilium.bgp.reconcile_run_duration.seconds.count,count,,request,,[OpenMetrics V2] Count of BGP reconciliation run durations,0,cilium,bgp reconcile dur count,,vrouter
+cilium.bgp.reconcile_run_duration.seconds.sum,count,,second,,[OpenMetrics V2] Sum of BGP reconciliation run durations,0,cilium,bgp reconcile dur sum,,vrouter
+cilium.bgp.session_state,gauge,,,,[OpenMetrics V1 and V2] Current state of the BGP session with the peer,0,cilium,bgp session state,,neighbor:neighbor_asn:vrouter
 cilium.bpf.map.capacity,gauge,,,,[OpenMetrics V1 and V2] Capacity of map tagged by map group. All maps with a capacity of 65536 are grouped under 'default',0,cilium,bpf map capacity,,
 cilium.bpf.map_ops.count,count,,operation,,[OpenMetrics V2] Total BPF map operations performed,0,cilium,bpf map ops,,
 cilium.bpf.map_ops.total,count,,operation,,[OpenMetrics V1] Total BPF map operations performed,0,cilium,bpf map ops,,
 cilium.bpf.map_pressure,gauge,,,,[OpenMetrics V1 and V2] Map pressure defined as a ratio of the map usage compared to it,0,cilium,bpf map pressure,,
 cilium.bpf.maps.virtual_memory.max.bytes,gauge,,byte,,[OpenMetrics V1 and V2] Max memory used by eBPF maps installed in the system,0,cilium,bpf map maps memory,,
 cilium.bpf.progs.virtual_memory.max.bytes,gauge,,byte,,[OpenMetrics V1 and V2] Max memory used by eBPF programs installed in the system,0,cilium,bpf map progs memory,,
+cilium.bpf.ratelimit_dropped.count,count,,packet,,[OpenMetrics V2] Total drops from BPF ratelimiter,0,cilium,bpf ratelimit dropped,,usage
+cilium.bpf.ratelimit_dropped.total,count,,packet,,[OpenMetrics V1] Total drops from BPF ratelimiter,0,cilium,bpf ratelimit dropped v1,,usage
+cilium.bpf.syscall_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of BPF syscall durations,0,cilium,bpf syscall dur bucket,,error:operation
+cilium.bpf.syscall_duration.seconds.count,count,,request,,[OpenMetrics V2] Count of BPF syscall durations,0,cilium,bpf syscall dur count,,error:operation
+cilium.bpf.syscall_duration.seconds.sum,count,,second,,[OpenMetrics V2] Sum of BPF syscall durations,0,cilium,bpf syscall dur sum,,error:operation
 cilium.cidrgroup.policies,gauge,,unit,,[OpenMetrics V1 and V2] Number of CNPs and CCNPs referencing at least one CiliumCIDRGroup,0,cilium,cidrgroup policies,,
 cilium.cidrgroup.translation.time.stats.seconds,gauge,,second,,[OpenMetrics V1 and V2] CIDRGroup translation time stats,0,cilium,cidrgroup translation time,,
 cilium.cidrgroups.referenced,gauge,,unit,,[OpenMetrics V1 and V2] Number of CNPs and CCNPs referencing at least one CiliumCIDRGroup. CNPs with empty or non-existing CIDRGroupRefs are not considered,0,cilium,cidrgroup referenced,,
+cilium.clustermesh.remote_cluster_cache_revocations,gauge,,,,[OpenMetrics V2] Total cache revocations in remote cluster,0,cilium,remote cluster cache revocations,,target_cluster
+cilium.clustermesh.remote_cluster_endpoint_slices,gauge,,,,[OpenMetrics V2] Total endpoint slices per remote cluster,0,cilium,remote cluster endpoint slices,,target_cluster
+cilium.clustermesh.remote_cluster_endpoints,gauge,,,,[OpenMetrics V2] Total endpoints in remote cluster,0,cilium,remote cluster endpoints,,target_cluster
+cilium.clustermesh.remote_cluster_failures,gauge,,,,[OpenMetrics V2] Total failures related to remote cluster,0,cilium,remote cluster failures,,target_cluster
+cilium.clustermesh.remote_cluster_last_failure_ts,gauge,,,,[OpenMetrics V2] Timestamp of last failure in remote cluster,0,cilium,remote cluster last failure,,target_cluster
+cilium.clustermesh.remote_cluster_nodes,gauge,,,,[OpenMetrics V2] Total nodes in remote cluster,0,cilium,remote cluster nodes,,target_cluster
+cilium.clustermesh.remote_cluster_readiness_status,gauge,,,,[OpenMetrics V2] Readiness status of remote cluster,0,cilium,remote cluster readiness,,target_cluster
+cilium.clustermesh.remote_cluster_services,gauge,,,,[OpenMetrics V2] Total services in remote cluster,0,cilium,remote cluster services,,target_cluster
+cilium.clustermesh.remote_clusters,gauge,,,,[OpenMetrics V2] Total number of remote clusters meshed,0,cilium,remote clusters,,
 cilium.controllers.failing.count,gauge,,error,,[OpenMetrics V1 and V2] Number of failing controllers,-1,cilium, fail controllers,,
+cilium.controllers.group_runs.count,count,,operation,,[OpenMetrics V2] Controller runs grouped by group name,0,cilium,controller group runs,,group_name:status
+cilium.controllers.group_runs.total,count,,operation,,[OpenMetrics V1] Controller runs grouped by group name,0,cilium,controller group runs v1,,group_name:status
 cilium.controllers.runs.count,count,,event,,[OpenMetrics V2] Total number of controller runs,0,cilium,controller runs,,
 cilium.controllers.runs.total,count,,event,,[OpenMetrics V1] Total number of controller runs,0,cilium,controller runs,,
 cilium.controllers.runs_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of controller processes duration,0,cilium,controller dur bucket,,
@@ -43,6 +70,7 @@ cilium.drop_bytes.count,count,,byte,,[OpenMetrics V2] Total dropped bytes,-1,cil
 cilium.drop_bytes.total,count,,byte,,[OpenMetrics V1] Total dropped bytes,-1,cilium,drop bytes,,
 cilium.drop_count.count,count,,packet,,[OpenMetrics V2] Total dropped packets,-1,cilium,drop packets,,
 cilium.drop_count.total,count,,packet,,[OpenMetrics V1] Total dropped packets,-1,cilium,drop packets,,
+cilium.endpoint.component_status,gauge,,,,[OpenMetrics V1 and V2] Number of endpoints by component type and status,0,cilium,endpoint component status,,status:type
 cilium.endpoint.count,gauge,,unit,,[OpenMetrics V1 and V2] Total ready endpoints managed by agent,0,cilium,total endpoints,,
 cilium.endpoint.max_ifindex,gauge,,unit,,[OpenMetrics V1 and V2] Maximum interface index observed for existing endpoints,0,cilium,endpoint max interface index,,
 cilium.endpoint.regeneration_time_stats.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of endpoint regeneration time stats,0,cilium,endpoint regen time bucket,,
@@ -50,10 +78,79 @@ cilium.endpoint.regeneration_time_stats.seconds.count,count,,operation,,[OpenMet
 cilium.endpoint.regeneration_time_stats.seconds.sum,count,,second,,[OpenMetrics V1 and V2] Sum of endpoint regeneration time stats,0,cilium,endpoint regen time sum,,
 cilium.endpoint.regenerations.count,count,,unit,,[OpenMetrics V2] Count of completed endpoint regenerations,1,cilium,endpoint regen count v2,,
 cilium.endpoint.regenerations.total,count,,unit,,[OpenMetrics V1] Count of completed endpoint regenerations,1,cilium,endpoint regen count v1,,
+cilium.endpoint.restoration_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of endpoint restoration phase durations,0,cilium,endpoint restore dur bucket,,phase
+cilium.endpoint.restoration_duration.seconds.count,count,,request,,[OpenMetrics V2] Count of endpoint restoration phase durations,0,cilium,endpoint restore dur count,,phase
+cilium.endpoint.restoration_duration.seconds.sum,count,,second,,[OpenMetrics V2] Sum of endpoint restoration phase durations,0,cilium,endpoint restore dur sum,,phase
+cilium.endpoint.restoration_endpoints,gauge,,,,[OpenMetrics V2] Number of restored endpoints by phase and outcome,0,cilium,endpoint restore count,,outcome:phase
 cilium.endpoint.state,gauge,,unit,,[OpenMetrics V1 and V2] Count of all endpoints,0,cilium,endpoint count,,
 cilium.errors_warning.count,count,,error,,[OpenMetrics V2] Total error warnings,-1,cilium,error total,,
 cilium.errors_warning.total,count,,error,,[OpenMetrics V1] Total error warnings,-1,cilium,error total,,
 cilium.event_timestamp,gauge,,time,,[OpenMetrics V1 and V2] Last timestamp of event received,0,cilium,event ts,,
+cilium.feature.adv_connect_and_lb.bandwidth_manager_enabled,gauge,,,,[OpenMetrics V1 and V2] Bandwidth Manager enabled on the agent,0,cilium,feat bandwidth mgr,,
+cilium.feature.adv_connect_and_lb.bgp_enabled,gauge,,,,[OpenMetrics V1 and V2] BGP enabled on the agent,0,cilium,feat bgp,,
+cilium.feature.adv_connect_and_lb.big_tcp_enabled,gauge,,,,[OpenMetrics V1 and V2] Big TCP enabled on the agent,0,cilium,feat big tcp,,address_family
+cilium.feature.adv_connect_and_lb.cilium_envoy_config_enabled,gauge,,,,[OpenMetrics V1 and V2] Cilium Envoy Config enabled on the agent,0,cilium,feat envoy config,,
+cilium.feature.adv_connect_and_lb.cilium_node_config_enabled,gauge,,,,[OpenMetrics V1 and V2] Cilium Node Config enabled on the agent,0,cilium,feat node config,,
+cilium.feature.adv_connect_and_lb.clustermesh_enabled,gauge,,,,[OpenMetrics V1 and V2] Cluster Mesh enabled on the agent,0,cilium,feat clustermesh,,max_connected_clusters:mode
+cilium.feature.adv_connect_and_lb.egress_gateway_enabled,gauge,,,,[OpenMetrics V1 and V2] Egress Gateway enabled on the agent,0,cilium,feat egress gw,,
+cilium.feature.adv_connect_and_lb.envoy_proxy_enabled,gauge,,,,[OpenMetrics V1 and V2] Envoy Proxy mode enabled on the agent,0,cilium,feat envoy proxy,,mode
+cilium.feature.adv_connect_and_lb.kube_proxy_replacement_enabled,gauge,,,,[OpenMetrics V1 and V2] KubeProxyReplacement enabled on the agent,0,cilium,feat kpr,,
+cilium.feature.adv_connect_and_lb.l2_lb_enabled,gauge,,,,[OpenMetrics V1 and V2] L2 LB announcement enabled on the agent,0,cilium,feat l2 lb,,
+cilium.feature.adv_connect_and_lb.l2_pod_announcement_enabled,gauge,,,,[OpenMetrics V1 and V2] L2 pod announcement enabled on the agent,0,cilium,feat l2 pod,,
+cilium.feature.adv_connect_and_lb.node_port_configuration,gauge,,,,[OpenMetrics V1 and V2] Node Port configuration enabled on the agent,0,cilium,feat nodeport,,acceleration:algorithm:mode
+cilium.feature.adv_connect_and_lb.sctp_enabled,gauge,,,,[OpenMetrics V1 and V2] SCTP enabled on the agent,0,cilium,feat sctp,,
+cilium.feature.adv_connect_and_lb.transparent_encryption,gauge,,,,[OpenMetrics V1 and V2] Encryption mode enabled on the agent,0,cilium,feat encryption,,mode:node2node_enabled
+cilium.feature.adv_connect_and_lb.vtep_enabled,gauge,,,,[OpenMetrics V1 and V2] VTEP enabled on the agent,0,cilium,feat vtep,,
+cilium.feature.controlplane.cilium_endpoint_slices_enabled,gauge,,,,[OpenMetrics V1 and V2] Cilium Endpoint Slices enabled on the agent,0,cilium,feat ces,,
+cilium.feature.controlplane.identity_allocation,gauge,,,,[OpenMetrics V1 and V2] Identity Allocation mode enabled on the agent,0,cilium,feat id alloc,,mode
+cilium.feature.controlplane.ipam,gauge,,,,[OpenMetrics V1 and V2] IPAM mode enabled on the agent,0,cilium,feat ipam,,mode
+cilium.feature.datapath.chaining_enabled,gauge,,,,[OpenMetrics V1 and V2] Chaining mode enabled on the agent,0,cilium,feat chaining,,mode
+cilium.feature.datapath.config,gauge,,,,[OpenMetrics V1 and V2] Datapath config mode enabled on the agent,0,cilium,feat dp config,,mode
+cilium.feature.datapath.internet_protocol,gauge,,,,[OpenMetrics V1 and V2] IP mode enabled on the agent,0,cilium,feat ip mode,,address_family
+cilium.feature.datapath.network,gauge,,,,[OpenMetrics V1 and V2] Network mode enabled on the agent,0,cilium,feat network,,mode
+cilium.feature.network_policies.cidr_policies,gauge,,,,[OpenMetrics V1 and V2] Mode to apply CIDR Policies to Nodes,0,cilium,feat cidr policies,,mode
+cilium.feature.network_policies.cilium_clusterwide_envoy_config.count,count,,,,[OpenMetrics V2] Cilium Clusterwide Envoy Config ingested,0,cilium,feat ccec count,,action
+cilium.feature.network_policies.cilium_clusterwide_envoy_config.total,count,,,,[OpenMetrics V1] Cilium Clusterwide Envoy Config ingested,0,cilium,feat ccec total,,action
+cilium.feature.network_policies.cilium_clusterwide_network_policies.count,count,,,,[OpenMetrics V2] Cilium Clusterwide Network Policies ingested,0,cilium,feat ccnp count,,action
+cilium.feature.network_policies.cilium_clusterwide_network_policies.total,count,,,,[OpenMetrics V1] Cilium Clusterwide Network Policies ingested,0,cilium,feat ccnp total,,action
+cilium.feature.network_policies.cilium_envoy_config.count,count,,,,[OpenMetrics V2] Cilium Envoy Config ingested,0,cilium,feat cec count,,action
+cilium.feature.network_policies.cilium_envoy_config.total,count,,,,[OpenMetrics V1] Cilium Envoy Config ingested,0,cilium,feat cec total,,action
+cilium.feature.network_policies.cilium_network_policies.count,count,,,,[OpenMetrics V2] Cilium Network Policies ingested,0,cilium,feat cnp count,,action
+cilium.feature.network_policies.cilium_network_policies.total,count,,,,[OpenMetrics V1] Cilium Network Policies ingested,0,cilium,feat cnp total,,action
+cilium.feature.network_policies.deny_policies.count,count,,,,[OpenMetrics V2] Deny Policies ingested,0,cilium,feat deny count,,action
+cilium.feature.network_policies.deny_policies.total,count,,,,[OpenMetrics V1] Deny Policies ingested,0,cilium,feat deny total,,action
+cilium.feature.network_policies.dns_policies.count,count,,,,[OpenMetrics V2] DNS Policies ingested,0,cilium,feat dns policies count,,action
+cilium.feature.network_policies.dns_policies.total,count,,,,[OpenMetrics V1] DNS Policies ingested,0,cilium,feat dns policies total,,action
+cilium.feature.network_policies.fqdn_policies.count,count,,,,[OpenMetrics V2] ToFQDNs Policies ingested,0,cilium,feat fqdn count,,action
+cilium.feature.network_policies.fqdn_policies.total,count,,,,[OpenMetrics V1] ToFQDNs Policies ingested,0,cilium,feat fqdn total,,action
+cilium.feature.network_policies.host_firewall_enabled,gauge,,,,[OpenMetrics V1 and V2] Host firewall enabled on the agent,0,cilium,feat host fw,,
+cilium.feature.network_policies.host_network_policies.count,count,,,,[OpenMetrics V2] Host Network Policies ingested,0,cilium,feat host np count,,action
+cilium.feature.network_policies.host_network_policies.total,count,,,,[OpenMetrics V1] Host Network Policies ingested,0,cilium,feat host np total,,action
+cilium.feature.network_policies.http_header_matches_policies.count,count,,,,[OpenMetrics V2] HTTP HeaderMatches Policies ingested,0,cilium,feat http hdr count,,action
+cilium.feature.network_policies.http_header_matches_policies.total,count,,,,[OpenMetrics V1] HTTP HeaderMatches Policies ingested,0,cilium,feat http hdr total,,action
+cilium.feature.network_policies.http_policies.count,count,,,,[OpenMetrics V2] HTTP and gRPC policies ingested,0,cilium,feat http count,,action
+cilium.feature.network_policies.http_policies.total,count,,,,[OpenMetrics V1] HTTP and gRPC policies ingested,0,cilium,feat http total,,action
+cilium.feature.network_policies.ingress_cidr_group_policies.count,count,,,,[OpenMetrics V2] Ingress CIDR Group Policies ingested,0,cilium,feat icg count,,action
+cilium.feature.network_policies.ingress_cidr_group_policies.total,count,,,,[OpenMetrics V1] Ingress CIDR Group Policies ingested,0,cilium,feat icg total,,action
+cilium.feature.network_policies.internal_traffic_policy_services.count,count,,,,[OpenMetrics V2] Kubernetes services with Internal Traffic Policy ingested,0,cilium,feat itp count,,action
+cilium.feature.network_policies.internal_traffic_policy_services.total,count,,,,[OpenMetrics V1] Kubernetes services with Internal Traffic Policy ingested,0,cilium,feat itp total,,action
+cilium.feature.network_policies.l3_policies.count,count,,,,[OpenMetrics V2] Layer 3 and Layer 4 policies ingested,0,cilium,feat l3 count,,action
+cilium.feature.network_policies.l3_policies.total,count,,,,[OpenMetrics V1] Layer 3 and Layer 4 policies ingested,0,cilium,feat l3 total,,action
+cilium.feature.network_policies.local_redirect_policies.count,count,,,,[OpenMetrics V2] Local Redirect Policies ingested,0,cilium,feat lrp count,,action
+cilium.feature.network_policies.local_redirect_policies.total,count,,,,[OpenMetrics V1] Local Redirect Policies ingested,0,cilium,feat lrp total,,action
+cilium.feature.network_policies.local_redirect_policy_enabled,gauge,,,,[OpenMetrics V1 and V2] Local Redirect Policy enabled on the agent,0,cilium,feat lrp enabled,,
+cilium.feature.network_policies.mutual_auth_enabled,gauge,,,,[OpenMetrics V1 and V2] Mutual Auth enabled on the agent,0,cilium,feat mauth,,
+cilium.feature.network_policies.mutual_auth_policies.count,count,,,,[OpenMetrics V2] Mutual Auth Policies ingested,0,cilium,feat mauth count,,action
+cilium.feature.network_policies.mutual_auth_policies.total,count,,,,[OpenMetrics V1] Mutual Auth Policies ingested,0,cilium,feat mauth total,,action
+cilium.feature.network_policies.non_defaultdeny_policies.count,count,,,,[OpenMetrics V2] Non DefaultDeny Policies ingested,0,cilium,feat non-dd count,,action
+cilium.feature.network_policies.non_defaultdeny_policies.total,count,,,,[OpenMetrics V1] Non DefaultDeny Policies ingested,0,cilium,feat non-dd total,,action
+cilium.feature.network_policies.non_defaultdeny_policies_enabled,gauge,,,,[OpenMetrics V1 and V2] Non DefaultDeny Policies enabled,0,cilium,feat non-dd enabled,,
+cilium.feature.network_policies.other_l7_policies.count,count,,,,[OpenMetrics V2] Other L7 Policies ingested,0,cilium,feat l7 count,,action
+cilium.feature.network_policies.other_l7_policies.total,count,,,,[OpenMetrics V1] Other L7 Policies ingested,0,cilium,feat l7 total,,action
+cilium.feature.network_policies.sni_allow_list_policies.count,count,,,,[OpenMetrics V2] SNI Allow List Policies ingested,0,cilium,feat sni count,,action
+cilium.feature.network_policies.sni_allow_list_policies.total,count,,,,[OpenMetrics V1] SNI Allow List Policies ingested,0,cilium,feat sni total,,action
+cilium.feature.network_policies.tls_inspection_policies.count,count,,,,[OpenMetrics V2] TLS Inspection Policies ingested,0,cilium,feat tls count,,action
+cilium.feature.network_policies.tls_inspection_policies.total,count,,,,[OpenMetrics V1] TLS Inspection Policies ingested,0,cilium,feat tls total,,action
 cilium.forward_bytes.count,count,,byte,,[OpenMetrics V2] Total forwarded bytes,1,cilium,forward bytes,,
 cilium.forward_bytes.total,count,,byte,,[OpenMetrics V1] Total forwarded bytes,1,cilium,forward bytes,,
 cilium.forward_count.count,count,,packet,,[OpenMetrics V2] Total forwarded packets,1,cilium,forward packet,,
@@ -64,23 +161,63 @@ cilium.fqdn.alive_zombie_connections,gauge,,item,,"Number of IPs associated with
 cilium.fqdn.gc_deletions.count,count,,event,,[OpenMetrics V2] Total number of FQDNs cleaned in FQDN garbage collector job.,0,cilium,fdqn total,,
 cilium.fqdn.gc_deletions.total,count,,event,,[OpenMetrics V1] Total number of FQDNs cleaned in FQDN garbage collector job.,0,cilium,fdqn total,,
 cilium.fqdn.selectors,gauge,,item,,Number of registered ToFQDN selectors. Available in Cilium v1.16+,0,cilium,fdqn selectors,,
+cilium.fragmented_count.count,count,,packet,,[OpenMetrics V2] Total number of fragmented packets,0,cilium,fragmented packets,,direction
+cilium.fragmented_count.total,count,,packet,,[OpenMetrics V1] Total number of fragmented packets,0,cilium,fragmented packets v1,,direction
+cilium.hive.jobs.observer.last_run_duration.seconds,gauge,,second,,[OpenMetrics V2] Observer job last run duration,0,cilium,hive observer last dur,,job_name:module
+cilium.hive.jobs.observer.run_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of observer job run durations,0,cilium,hive observer run bucket,,job_name:module
+cilium.hive.jobs.observer.run_duration.seconds.count,count,,request,,[OpenMetrics V2] Count of observer job run durations,0,cilium,hive observer run count,,job_name:module
+cilium.hive.jobs.observer.run_duration.seconds.sum,count,,second,,[OpenMetrics V2] Sum of observer job run durations,0,cilium,hive observer run sum,,job_name:module
+cilium.hive.jobs.oneshot.last_run_duration.seconds,gauge,,second,,[OpenMetrics V2] One-shot job last run duration,0,cilium,hive oneshot last dur,,job_name:module
+cilium.hive.jobs.timer.last_run_duration.seconds,gauge,,second,,[OpenMetrics V2] Timer job last run duration,0,cilium,hive timer last dur,,job_name:module
+cilium.hive.jobs.timer.run_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of timer job run durations,0,cilium,hive timer run bucket,,job_name:module
+cilium.hive.jobs.timer.run_duration.seconds.count,count,,request,,[OpenMetrics V2] Count of timer job run durations,0,cilium,hive timer run count,,job_name:module
+cilium.hive.jobs.timer.run_duration.seconds.sum,count,,second,,[OpenMetrics V2] Sum of timer job run durations,0,cilium,hive timer run sum,,job_name:module
+cilium.hive.jobs_runs.count,count,,operation,,[OpenMetrics V2] Total job runs,0,cilium,hive job runs,,job_name:module
+cilium.hive.jobs_runs.total,count,,operation,,[OpenMetrics V1] Total job runs,0,cilium,hive job runs v1,,job_name:module
+cilium.hive.jobs_runs_failed,gauge,,,,[OpenMetrics V2] Failed job runs,0,cilium,hive job runs failed,,job_name:module
+cilium.hive.populate_duration,gauge,,second,,[OpenMetrics V1 and V2] Duration of the hive Populate method,0,cilium,hive populate dur,,
+cilium.hive.start_duration,gauge,,second,,[OpenMetrics V1 and V2] Duration of the hive Start method,0,cilium,hive start dur,,
 cilium.hive.status,gauge,,item,,[OpenMetrics V1 and V2] Counts of health status levels of Hive components,0,cilium,hive status,,
+cilium.hive.stop_duration,gauge,,second,,[OpenMetrics V1 and V2] Duration of the hive Stop method,0,cilium,hive stop dur,,
+cilium.identity.cache_timer.duration,gauge,,second,,[OpenMetrics V2] Seconds for periodic policy processes,0,cilium,identity cache timer dur,,name
+cilium.identity.cache_timer_trigger.folds,gauge,,,,[OpenMetrics V2] Coalesced timer triggers in one execution,0,cilium,identity timer folds,,name
+cilium.identity.cache_timer_trigger.latency,gauge,,second,,[OpenMetrics V2] Wait time before starting next periodic policy round,0,cilium,identity timer latency,,name
 cilium.identity.count,gauge,,unit,,[OpenMetrics V1 and V2] Number of identities allocate.,0,cilium,id count,,
+cilium.identity.gc_entries,gauge,,,,[OpenMetrics V2] Identities alive and deleted at GC end,0,cilium,identity gc entries,,identity_type:outcome
+cilium.identity.gc_latency,gauge,,second,,[OpenMetrics V2] Duration of last successful identity GC,0,cilium,identity gc latency,,identity_type:outcome
+cilium.identity.gc_runs,gauge,,,,[OpenMetrics V2] Times identity GC process was run,0,cilium,identity gc runs,,identity_type:outcome
 cilium.identity.label_sources,gauge,,item,,Number of identities which contain at least one label from the given label source. Available in Cilium v1.16+,0,cilium,id label sources,,
+cilium.identity.updater_timer.duration,gauge,,second,,[OpenMetrics V1 and V2] Seconds to execute periodic policy processes (renamed from cache_timer in Cilium v1.20+),0,cilium,id updater timer dur,,name
+cilium.identity.updater_timer_trigger.folds,gauge,,,,[OpenMetrics V1 and V2] Timer triggers coalesced into one execution (renamed from cache_timer in Cilium v1.20+),0,cilium,id updater timer folds,,name
+cilium.identity.updater_timer_trigger.latency,gauge,,second,,[OpenMetrics V1 and V2] Seconds spent waiting for a previous process to finish (renamed from cache_timer in Cilium v1.20+),0,cilium,id updater timer lat,,name
 cilium.ip_addresses.count,gauge,,unit,,[OpenMetrics V1 and V2] Number of allocated ip_addresses,0,cilium,ip count,,
 cilium.ipam.capacity,gauge,,event,,[OpenMetrics V1 and V2] Total number of IPs in the IPAM pool labeled by family,0,cilium,ipam capacity,,
 cilium.ipam.events.count,count,,event,,[OpenMetrics V2] Number of IPAM events received by action and datapath family type,0,cilium,ipam total,,
 cilium.ipam.events.total,count,,event,,[OpenMetrics V1] Number of IPAM events received by action and datapath family type,0,cilium,ipam total,,
 cilium.ipcache.errors.count,count,,error,,[OpenMetrics V2] Number of errors interacting with the ipcache,-1,cilium,ipcache errors v2,,
 cilium.ipcache.errors.total,count,,error,,[OpenMetrics V1] Number of errors interacting with the ipcache,-1,cilium,ipcache errors v1,,
-cilium.k8s.workqueue.adds.total,count,,event,,[OpenMetrics V1 and V2] Total number of adds handled by workqueue,0,cilium,k8s workqueue adds,,
+cilium.ipcache.events.count,count,,event,,[OpenMetrics V2] Events interacting with ipcache,0,cilium,ipcache events,,type
+cilium.ipcache.events.total,count,,event,,[OpenMetrics V1] Events interacting with ipcache,0,cilium,ipcache events v1,,type
+cilium.ipsec.keys,gauge,,,,[OpenMetrics V2] Number of IPsec keys in use,0,cilium,ipsec keys,,
+cilium.ipsec.xfrm_error,gauge,,,,[OpenMetrics V2] Total XFRM errors,0,cilium,ipsec xfrm error,,error:type
+cilium.ipsec.xfrm_policies,gauge,,,,[OpenMetrics V2] Number of XFRM policies,0,cilium,ipsec xfrm policies,,direction
+cilium.ipsec.xfrm_states,gauge,,,,[OpenMetrics V2] Number of XFRM states,0,cilium,ipsec xfrm states,,direction
+cilium.k8s.cnp_status_completion.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of CNP status update completion durations,0,cilium,cnp status compl bucket,,attempts:outcome
+cilium.k8s.cnp_status_completion.seconds.count,count,,request,,[OpenMetrics V2] Count of CNP status update completions,0,cilium,cnp status compl count,,attempts:outcome
+cilium.k8s.cnp_status_completion.seconds.sum,count,,second,,[OpenMetrics V2] Sum of CNP status update completion durations,0,cilium,cnp status compl sum,,attempts:outcome
+cilium.k8s.workqueue.adds.count,count,,event,,[OpenMetrics V2] Total number of adds handled by workqueue,0,cilium,k8s workqueue adds count,,
+cilium.k8s.workqueue.adds.total,count,,event,,[OpenMetrics V1] Total number of adds handled by workqueue,0,cilium,k8s workqueue adds,,
 cilium.k8s.workqueue.depth,gauge,,event,,[OpenMetrics V1 and V2] Current depth of workqueue,0,cilium,k8s workqueue depth,,
 cilium.k8s.workqueue.longest.running.processor.seconds,gauge,,event,,[OpenMetrics V1 and V2] How many seconds has the longest running processor for workqueue been running,0,cilium,k8s workqueue running processor,,
 cilium.k8s.workqueue.queue.duration.seconds.bucket,count,,event,,[OpenMetrics V1 and V2] Count of how long in seconds an item stays in workqueue before being requested,0,cilium,k8s workqueue duration bucket,,
 cilium.k8s.workqueue.queue.duration.seconds.count,count,,event,,[OpenMetrics V1 and V2] Count of how long in seconds an item stays in workqueue before being requested,0,cilium,k8s workqueue duration count,,
 cilium.k8s.workqueue.queue.duration.seconds.sum,count,,event,,[OpenMetrics V1 and V2] Sum of how long in seconds an item stays in workqueue before being requested,0,cilium,k8s workqueue duration sum,,
-cilium.k8s.workqueue.retries.total,count,,event,,[OpenMetrics V1 and V2] Total number of retries handled by workqueue,0,cilium,k8s workqueue retries,,
+cilium.k8s.workqueue.retries.count,count,,event,,[OpenMetrics V2] Total number of retries handled by workqueue,0,cilium,k8s workqueue retries count,,
+cilium.k8s.workqueue.retries.total,count,,event,,[OpenMetrics V1] Total number of retries handled by workqueue,0,cilium,k8s workqueue retries,,
 cilium.k8s.workqueue.unfinished.work.seconds,gauge,,event,,[OpenMetrics V1 and V2] How many seconds of work has been done that is in progress and hasn't been observed by work_duration. Large values indicate stuck threads. One can deduce the number of stuck threads by observing the rate at which this increases.,0,cilium,k8s workqueue unfinished work,,
+cilium.k8s.workqueue.work_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of workqueue item processing durations,0,cilium,workqueue work dur bucket,,name
+cilium.k8s.workqueue.work_duration.seconds.count,count,,request,,[OpenMetrics V2] Count of workqueue item processing durations,0,cilium,workqueue work dur count,,name
+cilium.k8s.workqueue.work_duration.seconds.sum,count,,second,,[OpenMetrics V2] Sum of workqueue item processing durations,0,cilium,workqueue work dur sum,,name
 cilium.k8s_client.api_calls.count,count,,request,,[OpenMetrics V1 and V2] Number of API calls made to kube-apiserver. Available in Cilium v1.10+,0,cilium,api call count,,
 cilium.k8s_client.api_latency_time.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of processed API call duration,-1,cilium,api latency bucket,,
 cilium.k8s_client.api_latency_time.seconds.count,count,,request,,[OpenMetrics V1 and V2] Count of processed API call duration,-1,cilium,api latency count,,
@@ -95,6 +232,7 @@ cilium.kubernetes.events.count,count,,event,,[OpenMetrics V2] Number of Kubernet
 cilium.kubernetes.events.total,count,,event,,[OpenMetrics V1] Number of Kubernetes events processed,0,cilium,k8s events count,,
 cilium.kubernetes.events_received.count,count,,event,,[OpenMetrics V2] Number of Kubernetes received events processed,0,cilium,k8s events rcv count,,
 cilium.kubernetes.events_received.total,count,,event,,[OpenMetrics V1] Number of Kubernetes received events processed,0,cilium,k8s events rcv count,,
+cilium.kubernetes.resource_sync_duration,gauge,,second,,[OpenMetrics V1 and V2] Duration in seconds of a specific Kubernetes resource sync,0,cilium,k8s resource sync dur,,scope
 cilium.kvstore.events_queue.seconds.bucket,count,,second,,[OpenMetrics V2] Sum of duration in seconds received event was blocked before it could be queued,0,cilium,kvstore event block time bucket,,
 cilium.kvstore.events_queue.seconds.count,count,,,,[OpenMetrics V1 and V2] Count of duration in seconds of received event was blocked before it could be queued,0,cilium,kvstore event block time count,,
 cilium.kvstore.events_queue.seconds.sum,count,,second,,[OpenMetrics V1 and V2] Sum of duration in seconds received event was blocked before it could be queued,0,cilium,kvstore event block time sum,,
@@ -104,7 +242,16 @@ cilium.kvstore.operations_duration.seconds.count,count,,operation,,[OpenMetrics 
 cilium.kvstore.operations_duration.seconds.sum,count,,second,,[OpenMetrics V1 and V2] Duration of kvstore operation sum,0,cilium,kvstore op time sum,,
 cilium.kvstore.quorum_errors.count,count,,error,,[OpenMetrics V2] Number of quorum errors,-1,cilium,kvstore quorum errors,,
 cilium.kvstore.quorum_errors.total,count,,error,,[OpenMetrics V1] Number of quorum errors,-1,cilium,kvstore quorum errors,,
+cilium.kvstore.sync_errors.count,count,,error,,[OpenMetrics V2] Failed synchronizations to kvstore,0,cilium,kvstore sync errors,,scope:source_cluster
+cilium.kvstore.sync_errors.total,count,,error,,[OpenMetrics V1] Failed synchronizations to kvstore,0,cilium,kvstore sync errors v1,,scope:source_cluster
 cilium.kvstore.sync_queue_size,gauge,,item,,Number of elements queued for synchronization in the kvstore,-1,cilium,kvstore sync queue size,,
+cilium.mtu_error_message.count,count,,packet,,[OpenMetrics V2] Total ICMP fragmentation-needed messages sent,0,cilium,mtu error messages,,direction
+cilium.mtu_error_message.total,count,,packet,,[OpenMetrics V1] Total ICMP fragmentation-needed messages sent,0,cilium,mtu error messages v1,,direction
+cilium.nat.endpoint_max_connection,gauge,,,,[OpenMetrics V2] NAT connection saturation percent by family,0,cilium,nat endpoint max conn,,family
+cilium.node_health.connectivity.latency.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of connectivity latency between agents and nodes,0,cilium,node connectivity lat bucket,,address_type:protocol:type
+cilium.node_health.connectivity.latency.seconds.count,count,,request,,[OpenMetrics V2] Count of connectivity latency between agents and nodes,0,cilium,node connectivity lat count,,address_type:protocol:type
+cilium.node_health.connectivity.latency.seconds.sum,count,,second,,[OpenMetrics V2] Sum of connectivity latency between agents and nodes,0,cilium,node connectivity lat sum,,address_type:protocol:type
+cilium.node_health.connectivity.status,gauge,,,,[OpenMetrics V2] Connectivity between Cilium agents and nodes,0,cilium,node connectivity status,,status:type
 cilium.nodes.all_datapath_validations.count,count,,unit,,[OpenMetrics V2] Number of validation calls to implement the datapath implementation of a node,0,cilium,node validations,,
 cilium.nodes.all_datapath_validations.total,count,,unit,,[OpenMetrics V1] Number of validation calls to implement the datapath implementation of a node,0,cilium,node validations,,
 cilium.nodes.all_events_received.count,count,,event,,[OpenMetrics V2] Number of node events received,0,cilium,node events rcvd,,
@@ -116,12 +263,36 @@ cilium.operator.azure.api.duration.seconds.sum,count,,second,,[OpenMetrics V1 an
 cilium.operator.azure.api.rate_limit.duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of duration of client-side rate limiter blocking when interacting with the Azure API. Available in Cilium v1.9+,0,cilium,azure api rate limit duration sample,,
 cilium.operator.azure.api.rate_limit.duration.seconds.count,count,,request,,[OpenMetrics V1 and V2] Count of duration of client-side rate limiter blocking when interacting with the Azure API. Available in Cilium v1.9+,0,cilium,azure api rate limit duration count,,
 cilium.operator.azure.api.rate_limit.duration.seconds.sum,count,,second,,[OpenMetrics V1 and V2] Sum of duration of client-side rate limiter blocking when interacting with the Azure API. Available in Cilium v1.9+,0,cilium,azure api rate limit duration sum,,
+cilium.operator.bgp.reconcile_errors.count,count,,,,[OpenMetrics V2] Number of BGP resource reconciliation errors (operator),0,cilium,op bgp reconcile errors,,resource_kind:resource_name
+cilium.operator.bgp.reconcile_errors.total,count,,,,[OpenMetrics V1] Number of BGP resource reconciliation errors (operator),0,cilium,op bgp reconcile errors v1,,resource_kind:resource_name
+cilium.operator.bgp.reconcile_run_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of operator BGP reconciliation run durations,0,cilium,op bgp reconcile dur bucket,,
+cilium.operator.bgp.reconcile_run_duration.seconds.count,count,,request,,[OpenMetrics V2] Count of operator BGP reconciliation run durations,0,cilium,op bgp reconcile dur count,,
+cilium.operator.bgp.reconcile_run_duration.seconds.sum,count,,second,,[OpenMetrics V2] Sum of operator BGP reconciliation run durations,0,cilium,op bgp reconcile dur sum,,
 cilium.operator.ces.queueing_delay.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of CiliumEndpointSlice queueing delay in seconds. Available in Cilium v1.11+,0,cilium,ces queue delay sample,,
 cilium.operator.ces.queueing_delay.seconds.count,count,,unit,,[OpenMetrics V1 and V2] Count of CiliumEndpointSlice queueing delay in seconds. Available in Cilium v1.11+,0,cilium,ces queue delay count,,
 cilium.operator.ces.queueing_delay.seconds.sum,count,,second,,[OpenMetrics V1 and V2] Sum of CiliumEndpointSlice queueing delay in seconds. Available in Cilium v1.11+,0,cilium,ces queue delay sum,,
-cilium.operator.ces.sync.total,count,,unit,,[OpenMetrics V1 and V2] Number of completed CES syncs by outcome,0,cilium,ces syncs,,
+cilium.operator.ces.sync.count,count,,unit,,[OpenMetrics V2] Number of completed CES syncs by outcome,0,cilium,op ces syncs count,,
+cilium.operator.ces.sync.total,count,,unit,,[OpenMetrics V1] Number of completed CES syncs by outcome,0,cilium,ces syncs,,
 cilium.operator.ces.sync_errors.count,count,,error,,[OpenMetrics V2] Number of CES sync errors. Available in Cilium v1.11+,0,cilium,ces sync errors count,,
 cilium.operator.ces.sync_errors.total,count,,error,,[OpenMetrics V1] Number of CES sync errors. Available in Cilium v1.11+,0,cilium,ces sync errors count,,
+cilium.operator.cid_controller.work_queue_event_count,gauge,,,,[OpenMetrics V2] Processed events by CID controller,0,cilium,cid ctrl event count,,outcome:resource
+cilium.operator.cid_controller.work_queue_latency.bucket,count,,second,,[OpenMetrics V2] Sample of CID controller queue latencies,0,cilium,cid ctrl latency bucket,,phase:resource
+cilium.operator.cid_controller.work_queue_latency.count,count,,request,,[OpenMetrics V2] Count of CID controller queue latencies,0,cilium,cid ctrl latency count,,phase:resource
+cilium.operator.cid_controller.work_queue_latency.sum,count,,second,,[OpenMetrics V2] Sum of CID controller queue latencies,0,cilium,cid ctrl latency sum,,phase:resource
+cilium.operator.clustermesh.remote_cluster_cache_revocations,gauge,,,,[OpenMetrics V2] Cache revocations per remote cluster (operator),0,cilium,op remote cluster revocations,,target_cluster
+cilium.operator.clustermesh.remote_cluster_endpoint_slices,gauge,,,,[OpenMetrics V2] Endpoint slices per remote cluster (operator),0,cilium,op remote cluster endpoint slices,,target_cluster
+cilium.operator.clustermesh.remote_cluster_failures,gauge,,,,[OpenMetrics V2] Failures per remote cluster (operator),0,cilium,op remote cluster failures,,target_cluster
+cilium.operator.clustermesh.remote_cluster_last_failure_ts,gauge,,,,[OpenMetrics V2] Last failure timestamp per remote cluster (operator),0,cilium,op remote cluster last fail,,target_cluster
+cilium.operator.clustermesh.remote_cluster_readiness_status,gauge,,,,[OpenMetrics V2] Remote cluster readiness status (operator),0,cilium,op remote cluster readiness,,target_cluster
+cilium.operator.clustermesh.remote_cluster_service_exports,gauge,,,,[OpenMetrics V2] Service exports per remote cluster (operator),0,cilium,op remote cluster svc exports,,target_cluster
+cilium.operator.clustermesh.remote_cluster_services,gauge,,,,[OpenMetrics V2] Services per remote cluster (operator),0,cilium,op remote cluster services,,target_cluster
+cilium.operator.clustermesh.remote_clusters,gauge,,,,[OpenMetrics V2] Total remote clusters meshed (operator),0,cilium,op remote clusters,,
+cilium.operator.controllers.group_runs.count,count,,operation,,[OpenMetrics V2] Operator controller runs grouped by group name,0,cilium,op controller group runs,,group_name:status
+cilium.operator.controllers.group_runs.total,count,,operation,,[OpenMetrics V1] Operator controller runs grouped by group name,0,cilium,op controller group runs v1,,group_name:status
+cilium.operator.doublewrite.crd_identities,gauge,,,,[OpenMetrics V2] Total CRD identities,0,cilium,doublewrite crd identities,,
+cilium.operator.doublewrite.crd_only_identities,gauge,,,,[OpenMetrics V2] CRD identities not present in KVStore,0,cilium,doublewrite crd only,,
+cilium.operator.doublewrite.kvstore_identities,gauge,,,,[OpenMetrics V2] Total KVStore identities,0,cilium,doublewrite kvstore identities,,
+cilium.operator.doublewrite.kvstore_only_identities,gauge,,,,[OpenMetrics V2] KVStore identities not present as CRD,0,cilium,doublewrite kvstore only,,
 cilium.operator.ec2.api.duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of duration of interactions with the AWS EC2 API. Available in Cilium v1.9+,0,cilium,aws ec2 api duration sample,,
 cilium.operator.ec2.api.duration.seconds.count,count,,request,,[OpenMetrics V1 and V2] Count of duration of interactions with the AWS EC2 API. Available in Cilium v1.9+,0,cilium,aws ec2 api duration count,,
 cilium.operator.ec2.api.duration.seconds.sum,count,,second,,[OpenMetrics V1 and V2] Sum of duration of interactions with the AWS EC2 API. Available in Cilium v1.9+,0,cilium,aws ec2 api duration sum,,
@@ -169,9 +340,16 @@ cilium.operator.eni.resync.total,count,,unit,,[OpenMetrics V1] Number of resync 
 cilium.operator.eni_ec2.rate_limit.duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of duration of client-side rate limiter blocking. Available in Cilium <= v1.9,0,cilium,api rate limit duration sample,,
 cilium.operator.eni_ec2.rate_limit.duration.seconds.count,count,,request,,[OpenMetrics V1 and V2] Count of duration of client-side rate limiter blocking. Available in Cilium <= v1.9,0,cilium,api rate limit duration count,,
 cilium.operator.eni_ec2.rate_limit.duration.seconds.sum,count,,second,,[OpenMetrics V1 and V2] Sum of duration of client-side rate limiter blocking. Available in Cilium <= v1.9,0,cilium,api rate limit duration sum,,
-cilium.operator.errors.warnings.total,count,,item,,[OpenMetrics V1 and V2] Number of total errors in cilium-operator instances,0,cilium,errors total,,
+cilium.operator.errors.warnings.count,count,,item,,[OpenMetrics V2] Number of total errors in cilium-operator instances,0,cilium,op errors count,,
+cilium.operator.errors.warnings.total,count,,item,,[OpenMetrics V1] Number of total errors in cilium-operator instances,0,cilium,errors total,,
+cilium.operator.feature.adv_connect_and_lb.gateway_api_enabled,gauge,,,,[OpenMetrics V1 and V2] GatewayAPI enabled on the operator,0,cilium,op feat gateway api,,
+cilium.operator.feature.adv_connect_and_lb.ingress_controller_enabled,gauge,,,,[OpenMetrics V1 and V2] IngressController enabled on the operator,0,cilium,op feat ingress,,
+cilium.operator.feature.adv_connect_and_lb.l7_aware_traffic_management_enabled,gauge,,,,[OpenMetrics V1 and V2] L7 Aware Traffic Management enabled on the operator,0,cilium,op feat l7 traffic,,
+cilium.operator.feature.adv_connect_and_lb.lb_ipam_enabled,gauge,,,,[OpenMetrics V1 and V2] LB IPAM enabled on the operator,0,cilium,op feat lb ipam,,
+cilium.operator.feature.adv_connect_and_lb.node_ipam_enabled,gauge,,,,[OpenMetrics V1 and V2] Node IPAM enabled on the operator,0,cilium,op feat node ipam,,
 cilium.operator.hive.status,gauge,,item,,[OpenMetrics V1 and V2] Counts of health status levels of Hive components,0,cilium,hive status,,
 cilium.operator.identity_gc.entries,gauge,,garbage collection,,[OpenMetrics V1 and V2] The number of alive and deleted identities at the end of a garbage collector run. Available in Cilium v1.11+,0,cilium,gc entries,,
+cilium.operator.identity_gc.latency,gauge,,second,,[OpenMetrics V1 and V2] Duration of the last successful identity GC (operator),0,cilium,op gc latency,,outcome
 cilium.operator.identity_gc.runs,gauge,,garbage collection,,[OpenMetrics V1 and V2] The number of times identity garbage collector has run. Available in Cilium v1.11+,0,cilium,gc runs,,
 cilium.operator.ipam.allocation.duration.seconds.bucket,count,,second,,[OpenMetrics V2] Allocation ip or interface latency in seconds,0,cilium,ipam allocation latency bucket,,
 cilium.operator.ipam.allocation.duration.seconds.count,count,,operation,,[OpenMetrics V1 and V2] Allocation ip or interface latency in seconds,0,cilium,ipam allocation latency count,,
@@ -236,11 +414,32 @@ cilium.operator.ipam.resync.queued.count,count,,unit,,[OpenMetrics V2] Number of
 cilium.operator.ipam.resync.queued.total,count,,unit,,[OpenMetrics V1] Number of IPAM queued triggers. Available in Cilium v1.9+,0,cilium,ipam queued triggers count,,
 cilium.operator.ipam.resync.total,count,,operation,,[OpenMetrics V1] Number of resync operations to synchronize and resolve IP deficit of nodes. Available in Cilium v1.8+,0,cilium,ipam resync operations count,,
 cilium.operator.ipam.used_ips,gauge,,unit,,[OpenMetrics V1 and V2] Total used IPs on Node for IPAM allocation,0,cilium,used ips,,
-cilium.operator.lbipam.conflicting.pools.total,gauge,,unit,,[OpenMetrics V1 and V2] The number of conflicting pools,0,cilium,conflicting pools,,
-cilium.operator.lbipam.ips.available.total,gauge,,unit,,[OpenMetrics V1 and V2] The number of IP addresses available in a given pool,0,cilium,available pool ips,,
-cilium.operator.lbipam.ips.used.total,gauge,,unit,,[OpenMetrics V1 and V2] The number of IP addresses used in a given pool,0,cilium,used pool ips,,
-cilium.operator.lbipam.services.matching.total,gauge,,unit,,[OpenMetrics V1 and V2] The number of services matching pools,0,cilium,matching pools,,
-cilium.operator.lbipam.services.unsatisfied.total,gauge,,unit,,[OpenMetrics V1 and V2] The number of services which did not receive all requested IPs,0,cilium,unsatisfied pools,,
+cilium.operator.k8s.workqueue.adds.count,count,,operation,,[OpenMetrics V2] Total adds to operator workqueue,0,cilium,op workqueue adds,,name
+cilium.operator.k8s.workqueue.adds.total,count,,operation,,[OpenMetrics V1] Total adds to operator workqueue,0,cilium,op workqueue adds v1,,name
+cilium.operator.k8s.workqueue.depth,gauge,,,,[OpenMetrics V2] Current operator workqueue depth,0,cilium,op workqueue depth,,name
+cilium.operator.k8s.workqueue.longest_running_processor.seconds,gauge,,second,,[OpenMetrics V2] Longest running operator workqueue processor,0,cilium,op workqueue longest,,name
+cilium.operator.k8s.workqueue.queue_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of operator workqueue item durations,0,cilium,op workqueue queue dur bucket,,name
+cilium.operator.k8s.workqueue.queue_duration.seconds.count,count,,request,,[OpenMetrics V2] Count of operator workqueue item durations,0,cilium,op workqueue queue dur count,,name
+cilium.operator.k8s.workqueue.queue_duration.seconds.sum,count,,second,,[OpenMetrics V2] Sum of operator workqueue item durations,0,cilium,op workqueue queue dur sum,,name
+cilium.operator.k8s.workqueue.retries.count,count,,operation,,[OpenMetrics V2] Total operator workqueue retries,0,cilium,op workqueue retries,,name
+cilium.operator.k8s.workqueue.retries.total,count,,operation,,[OpenMetrics V1] Total operator workqueue retries,0,cilium,op workqueue retries v1,,name
+cilium.operator.k8s.workqueue.unfinished_work.seconds,gauge,,second,,[OpenMetrics V2] Work in progress duration not yet observed,0,cilium,op workqueue unfinished,,name
+cilium.operator.k8s.workqueue.work_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of operator workqueue processing durations,0,cilium,op workqueue work dur bucket,,name
+cilium.operator.k8s.workqueue.work_duration.seconds.count,count,,request,,[OpenMetrics V2] Count of operator workqueue processing durations,0,cilium,op workqueue work dur count,,name
+cilium.operator.k8s.workqueue.work_duration.seconds.sum,count,,second,,[OpenMetrics V2] Sum of operator workqueue processing durations,0,cilium,op workqueue work dur sum,,name
+cilium.operator.lbipam.conflicting.pools,gauge,,unit,,[OpenMetrics V2] The number of conflicting pools,0,cilium,conflicting pools,,
+cilium.operator.lbipam.ips.available,gauge,,unit,,[OpenMetrics V2] The number of IP addresses available in a given pool,0,cilium,available pool ips,,
+cilium.operator.lbipam.ips.used,gauge,,unit,,[OpenMetrics V2] The number of IP addresses used in a given pool,0,cilium,used pool ips,,
+cilium.operator.lbipam.services.matching,gauge,,unit,,[OpenMetrics V2] The number of services matching pools,0,cilium,matching pools,,
+cilium.operator.lbipam.services.unsatisfied,gauge,,unit,,[OpenMetrics V2] The number of services which did not receive all requested IPs,0,cilium,unsatisfied pools,,
+cilium.operator.mcsapi.serviceexport_info,gauge,,,,[OpenMetrics V2] ServiceExport information,0,cilium,mcsapi serviceexport info,,namespace:serviceexport
+cilium.operator.mcsapi.serviceexport_status_condition,gauge,,,,[OpenMetrics V2] ServiceExport status conditions,0,cilium,mcsapi serviceexport status,,condition:namespace:reason:serviceexport:status
+cilium.operator.mcsapi.serviceimport_info,gauge,,,,[OpenMetrics V2] ServiceImport information,0,cilium,mcsapi serviceimport info,,namespace:serviceimport
+cilium.operator.mcsapi.serviceimport_status_clusters,gauge,,,,[OpenMetrics V2] Clusters backing ServiceImport,0,cilium,mcsapi serviceimport clusters,,namespace:serviceimport
+cilium.operator.mcsapi.serviceimport_status_condition,gauge,,,,[OpenMetrics V2] ServiceImport status conditions,0,cilium,mcsapi serviceimport status,,condition:namespace:reason:serviceimport:status
+cilium.operator.num_cep_changes_per_ces.bucket,count,,unit,,[OpenMetrics V2] Sample of changed CEPs per CES update,0,cilium,cep changes per ces bucket,,failure_type:opcode
+cilium.operator.num_cep_changes_per_ces.count,count,,request,,[OpenMetrics V2] Count of changed CEPs per CES update,0,cilium,cep changes per ces count,,failure_type:opcode
+cilium.operator.num_cep_changes_per_ces.sum,count,,unit,,[OpenMetrics V2] Sum of changed CEPs per CES update,0,cilium,cep changes per ces sum,,failure_type:opcode
 cilium.operator.num_ceps_per_ces.bucket,count,,unit,,[OpenMetrics V2] Sample of CEPs batched in a CES. Available in Cilium v1.11+,0,cilium,cep per ces sample,,
 cilium.operator.num_ceps_per_ces.count,count,,unit,,[OpenMetrics V1 and V2] Count of CEPs batched in a CES. Available in Cilium v1.11+,0,cilium,cep per ces count,,
 cilium.operator.num_ceps_per_ces.sum,count,,unit,,[OpenMetrics V1 and V2] Sum of CEPs batched in a CES. Available in Cilium v1.11+,0,cilium,cep per ces sum,,
@@ -252,6 +451,7 @@ cilium.operator.process.resident_memory.bytes,gauge,,byte,,[OpenMetrics V1 and V
 cilium.operator.process.start_time.seconds,gauge,,second,,[OpenMetrics V1 and V2] Start time of the process since unix epoch in seconds,0,cilium,proc start time operator,,
 cilium.operator.process.virtual_memory.bytes,gauge,,byte,,[OpenMetrics V1 and V2] Virtual memory size in bytes,0,cilium,virtual mem size operator,,
 cilium.operator.process.virtual_memory_max.bytes,gauge,,byte,,[OpenMetrics V1 and V2] Maximum amount of virtual memory available in bytes,0,cilium,virtual mem size max operator,,
+cilium.operator.unmanaged_pods,gauge,,,,[OpenMetrics V2] Total unmanaged pods observed,0,cilium,unmanaged pods,,
 cilium.policy.change.count,count,,unit,,[OpenMetrics V2] Number of policy changes by outcome,0,cilium,policy change count,,
 cilium.policy.change.total,count,,unit,,[OpenMetrics V1] Number of policy changes by outcome,0,cilium,policy change,,
 cilium.policy.count,gauge,,unit,,[OpenMetrics V1 and V2] Number of policies currently loaded,0,cilium,policy count,,
@@ -260,6 +460,9 @@ cilium.policy.implementation_delay.bucket,count,,second,,[OpenMetrics V1 and V2]
 cilium.policy.implementation_delay.count,count,,unit,,[OpenMetrics V1 and V2] Time between a policy change and it being fully deployed into the datapath,0,cilium,impl delay count,,
 cilium.policy.implementation_delay.sum,count,,second,,[OpenMetrics V1 and V2] Time between a policy change and it being fully deployed into the datapath,0,cilium,impl delay sum,,
 cilium.policy.import_errors.count,count,,error,,[OpenMetrics V1 and V2] Number of failed policy imports,-1,cilium,failed policy,,
+cilium.policy.incremental_update_duration.bucket,count,,second,,[OpenMetrics V2] Sample of policy incremental update durations,0,cilium,policy incr update bucket,,scope
+cilium.policy.incremental_update_duration.count,count,,request,,[OpenMetrics V2] Count of policy incremental update durations,0,cilium,policy incr update count,,scope
+cilium.policy.incremental_update_duration.sum,count,,second,,[OpenMetrics V2] Sum of policy incremental update durations,0,cilium,policy incr update sum,,scope
 cilium.policy.l7.count,count,,unit,,[OpenMetrics V2] Number of total L7 requests/responses by type,0,cilium,policy l7 total,,
 cilium.policy.l7.total,count,,unit,,[OpenMetrics V1] Number of total L7 requests/responses by type,0,cilium,policy l7 total,,
 cilium.policy.l7_denied.count,count,,unit,,[OpenMetrics V2] Number of total L7 denied requests/responses due to policy. Available in Cilium <= v1.7,-1,cilium,denied l7 policy,,
@@ -271,11 +474,13 @@ cilium.policy.l7_parse_errors.total,count,,error,,[OpenMetrics V1] Number of tot
 cilium.policy.l7_received.count,count,,unit,,[OpenMetrics V2] Number of total L7 received requests/responses. Available in Cilium <= v1.7,1,cilium,l7 policy received,,
 cilium.policy.l7_received.total,count,,unit,,[OpenMetrics V1] Number of total L7 received requests/responses. Available in Cilium <= v1.7,1,cilium,l7 policy received,,
 cilium.policy.max_revision,gauge,,unit,,[OpenMetrics V1 and V2] Highest policy revision number in the agent,0,cilium,max policy,,
+cilium.policy.missing_proxy_redirects,gauge,,,,[OpenMetrics V1 and V2] Total number of proxy redirects missing in endpoint policies,0,cilium,policy missing redirects,,
 cilium.policy.regeneration.count,count,,unit,,[OpenMetrics V2] Total number of successful policy regenerations,0,cilium,policy regen count,,
 cilium.policy.regeneration.total,count,,unit,,[OpenMetrics V1] Total number of successful policy regenerations,0,cilium,policy regen count,,
 cilium.policy.regeneration_time_stats.seconds.bucket,count,,second,,[OpenMetrics V2] Policy regeneration time stats sample,0,cilium,policy regen time bucket,,
 cilium.policy.regeneration_time_stats.seconds.count,count,,operation,,[OpenMetrics V1 and V2] Policy regeneration time stats count,0,cilium,policy regen time count,,
 cilium.policy.regeneration_time_stats.seconds.sum,count,,second,,[OpenMetrics V1 and V2] Policy regeneration time stats count,0,cilium,policy regen time sum,,
+cilium.policy.selector_match_count_max,gauge,,,,[OpenMetrics V2] Maximum identities selected by policy selector,0,cilium,policy selector max,,class
 cilium.process.cpu.seconds.count,count,,second,,[OpenMetrics V2] Process CPU time in seconds,0,cilium,proc cpu second,,
 cilium.process.cpu.seconds.total,gauge,,second,,[OpenMetrics V1] Process CPU time in seconds,0,cilium,proc cpu second,,
 cilium.process.max_fds,gauge,,file,,[OpenMetrics V1 and V2] Process file descriptor maximum,0,cilium,max fd,,
@@ -290,6 +495,9 @@ cilium.proxy.redirects,gauge,,,,Number of redirects installed for endpoints by p
 cilium.proxy.upstream_reply.seconds.bucket,count,,second,,"[OpenMetrics V2] Seconds waited for upstream server to reply to a request labeled by error, protocol and span time",-1,cilium,proxy upstream reply seconds,,
 cilium.proxy.upstream_reply.seconds.count,count,,second,,"[OpenMetrics V1 and V2] Seconds waited for upstream server to reply to a request labeled by error, protocol and span time",-1,cilium,proxy upstream reply seconds,,
 cilium.proxy.upstream_reply.seconds.sum,count,,second,,"[OpenMetrics V1 and V2] Seconds waited for upstream server to reply to a request labeled by error, protocol and span time",-1,cilium,proxy upstream reply seconds,,
+cilium.service.implementation_delay.bucket,count,,second,,[OpenMetrics V2] Sample of service implementation delays,0,cilium,service impl delay bucket,,action
+cilium.service.implementation_delay.count,count,,request,,[OpenMetrics V2] Count of service implementation delays,0,cilium,service impl delay count,,action
+cilium.service.implementation_delay.sum,count,,second,,[OpenMetrics V2] Sum of service implementation delays,0,cilium,service impl delay sum,,action
 cilium.services.events.count,count,,event,,[OpenMetrics V2] Number of services events labeled by action type,0,cilium,service events count,,
 cilium.services.events.total,count,,event,,[OpenMetrics V1] Number of services events labeled by action type,0,cilium,service events,,
 cilium.subprocess.start.count,count,,unit,,[OpenMetrics V2] Number of times that Cilium has started a subprocess,0,cilium,subproc start,,
@@ -302,4 +510,3 @@ cilium.triggers_policy.update_call_duration.seconds.sum,count,,second,,[OpenMetr
 cilium.triggers_policy.update_folds,gauge,,unit,,[OpenMetrics V1 and V2] Number of folds,0,cilium,fold count,,
 cilium.unreachable.health_endpoints,gauge,,unit,,[OpenMetrics V1 and V2] Number of health endpoints that cannot be reached,0,cilium,unreachable health endpoint,,
 cilium.unreachable.nodes,gauge,,node,,[OpenMetrics V1 and V2] Number of nodes that cannot be reached,0,cilium,unreachable nodes,,
-cilium.version,gauge,,node,,[OpenMetrics V1 and V2] Cilium version,0,cilium,version,,

--- a/cilium/metadata.csv
+++ b/cilium/metadata.csv
@@ -12,16 +12,43 @@ cilium.api_limiter.processing_duration.seconds,gauge,,second,,[OpenMetrics V1 an
 cilium.api_limiter.rate_limit,gauge,,request,,[OpenMetrics V1 and V2] Current rate limiting configuration (limit and burst),0,cilium,limiter rate limit,,
 cilium.api_limiter.requests_in_flight,gauge,,request,,[OpenMetrics V1 and V2] Current and maximum allowed number of requests in flight.,0,cilium,limiter in flight,,
 cilium.api_limiter.wait_duration.seconds,gauge,,second,,[OpenMetrics V1 and V2] Wait duration aggregated per api call,-1,cilium,limiter wait,,
+cilium.api_limiter.wait_history_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of API rate limiter wait durations,0,cilium,limiter wait hist bucket,,api_call
+cilium.api_limiter.wait_history_duration.seconds.count,count,,request,,[OpenMetrics V2] Count of API rate limiter wait durations,0,cilium,limiter wait hist count,,api_call
+cilium.api_limiter.wait_history_duration.seconds.sum,count,,second,,[OpenMetrics V2] Sum of API rate limiter wait durations,0,cilium,limiter wait hist sum,,api_call
+cilium.bgp.advertised_routes,gauge,,,,[OpenMetrics V1 and V2] Number of routes advertised to the peer,0,cilium,bgp advertised routes,,afi:neighbor:neighbor_asn:safi:vrouter
+cilium.bgp.received_routes,gauge,,,,[OpenMetrics V1 and V2] Number of routes received from the peer,0,cilium,bgp received routes,,afi:neighbor:neighbor_asn:safi:vrouter
+cilium.bgp.reconcile_errors.count,count,,,,[OpenMetrics V2] Number of BGP reconciliation errors,0,cilium,bgp reconcile errors,,vrouter
+cilium.bgp.reconcile_errors.total,count,,,,[OpenMetrics V1] Number of BGP reconciliation errors,0,cilium,bgp reconcile errors v1,,vrouter
+cilium.bgp.reconcile_run_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of BGP reconciliation run durations,0,cilium,bgp reconcile dur bucket,,vrouter
+cilium.bgp.reconcile_run_duration.seconds.count,count,,request,,[OpenMetrics V2] Count of BGP reconciliation run durations,0,cilium,bgp reconcile dur count,,vrouter
+cilium.bgp.reconcile_run_duration.seconds.sum,count,,second,,[OpenMetrics V2] Sum of BGP reconciliation run durations,0,cilium,bgp reconcile dur sum,,vrouter
+cilium.bgp.session_state,gauge,,,,[OpenMetrics V1 and V2] Current state of the BGP session with the peer,0,cilium,bgp session state,,neighbor:neighbor_asn:vrouter
 cilium.bpf.map.capacity,gauge,,,,[OpenMetrics V1 and V2] Capacity of map tagged by map group. All maps with a capacity of 65536 are grouped under 'default',0,cilium,bpf map capacity,,
 cilium.bpf.map_ops.count,count,,operation,,[OpenMetrics V2] Total BPF map operations performed,0,cilium,bpf map ops,,
 cilium.bpf.map_ops.total,count,,operation,,[OpenMetrics V1] Total BPF map operations performed,0,cilium,bpf map ops,,
 cilium.bpf.map_pressure,gauge,,,,[OpenMetrics V1 and V2] Map pressure defined as a ratio of the map usage compared to it,0,cilium,bpf map pressure,,
 cilium.bpf.maps.virtual_memory.max.bytes,gauge,,byte,,[OpenMetrics V1 and V2] Max memory used by eBPF maps installed in the system,0,cilium,bpf map maps memory,,
 cilium.bpf.progs.virtual_memory.max.bytes,gauge,,byte,,[OpenMetrics V1 and V2] Max memory used by eBPF programs installed in the system,0,cilium,bpf map progs memory,,
+cilium.bpf.ratelimit_dropped.count,count,,packet,,[OpenMetrics V2] Total drops from BPF ratelimiter,0,cilium,bpf ratelimit dropped,,usage
+cilium.bpf.ratelimit_dropped.total,count,,packet,,[OpenMetrics V1] Total drops from BPF ratelimiter,0,cilium,bpf ratelimit dropped v1,,usage
+cilium.bpf.syscall_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of BPF syscall durations,0,cilium,bpf syscall dur bucket,,error:operation
+cilium.bpf.syscall_duration.seconds.count,count,,request,,[OpenMetrics V2] Count of BPF syscall durations,0,cilium,bpf syscall dur count,,error:operation
+cilium.bpf.syscall_duration.seconds.sum,count,,second,,[OpenMetrics V2] Sum of BPF syscall durations,0,cilium,bpf syscall dur sum,,error:operation
 cilium.cidrgroup.policies,gauge,,unit,,[OpenMetrics V1 and V2] Number of CNPs and CCNPs referencing at least one CiliumCIDRGroup,0,cilium,cidrgroup policies,,
 cilium.cidrgroup.translation.time.stats.seconds,gauge,,second,,[OpenMetrics V1 and V2] CIDRGroup translation time stats,0,cilium,cidrgroup translation time,,
 cilium.cidrgroups.referenced,gauge,,unit,,[OpenMetrics V1 and V2] Number of CNPs and CCNPs referencing at least one CiliumCIDRGroup. CNPs with empty or non-existing CIDRGroupRefs are not considered,0,cilium,cidrgroup referenced,,
+cilium.clustermesh.remote_cluster_cache_revocations,gauge,,,,[OpenMetrics V2] Total cache revocations in remote cluster,0,cilium,remote cluster cache revocations,,target_cluster
+cilium.clustermesh.remote_cluster_endpoint_slices,gauge,,,,[OpenMetrics V2] Total endpoint slices per remote cluster,0,cilium,remote cluster endpoint slices,,target_cluster
+cilium.clustermesh.remote_cluster_endpoints,gauge,,,,[OpenMetrics V2] Total endpoints in remote cluster,0,cilium,remote cluster endpoints,,target_cluster
+cilium.clustermesh.remote_cluster_failures,gauge,,,,[OpenMetrics V2] Total failures related to remote cluster,0,cilium,remote cluster failures,,target_cluster
+cilium.clustermesh.remote_cluster_last_failure_ts,gauge,,,,[OpenMetrics V2] Timestamp of last failure in remote cluster,0,cilium,remote cluster last failure,,target_cluster
+cilium.clustermesh.remote_cluster_nodes,gauge,,,,[OpenMetrics V2] Total nodes in remote cluster,0,cilium,remote cluster nodes,,target_cluster
+cilium.clustermesh.remote_cluster_readiness_status,gauge,,,,[OpenMetrics V2] Readiness status of remote cluster,0,cilium,remote cluster readiness,,target_cluster
+cilium.clustermesh.remote_cluster_services,gauge,,,,[OpenMetrics V2] Total services in remote cluster,0,cilium,remote cluster services,,target_cluster
+cilium.clustermesh.remote_clusters,gauge,,,,[OpenMetrics V2] Total number of remote clusters meshed,0,cilium,remote clusters,,
 cilium.controllers.failing.count,gauge,,error,,[OpenMetrics V1 and V2] Number of failing controllers,-1,cilium, fail controllers,,
+cilium.controllers.group_runs.count,count,,operation,,[OpenMetrics V2] Controller runs grouped by group name,0,cilium,controller group runs,,group_name:status
+cilium.controllers.group_runs.total,count,,operation,,[OpenMetrics V1] Controller runs grouped by group name,0,cilium,controller group runs v1,,group_name:status
 cilium.controllers.runs.count,count,,event,,[OpenMetrics V2] Total number of controller runs,0,cilium,controller runs,,
 cilium.controllers.runs.total,count,,event,,[OpenMetrics V1] Total number of controller runs,0,cilium,controller runs,,
 cilium.controllers.runs_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of controller processes duration,0,cilium,controller dur bucket,,
@@ -43,6 +70,7 @@ cilium.drop_bytes.count,count,,byte,,[OpenMetrics V2] Total dropped bytes,-1,cil
 cilium.drop_bytes.total,count,,byte,,[OpenMetrics V1] Total dropped bytes,-1,cilium,drop bytes,,
 cilium.drop_count.count,count,,packet,,[OpenMetrics V2] Total dropped packets,-1,cilium,drop packets,,
 cilium.drop_count.total,count,,packet,,[OpenMetrics V1] Total dropped packets,-1,cilium,drop packets,,
+cilium.endpoint.component_status,gauge,,,,[OpenMetrics V1 and V2] Number of endpoints by component type and status,0,cilium,endpoint component status,,status:type
 cilium.endpoint.count,gauge,,unit,,[OpenMetrics V1 and V2] Total ready endpoints managed by agent,0,cilium,total endpoints,,
 cilium.endpoint.max_ifindex,gauge,,unit,,[OpenMetrics V1 and V2] Maximum interface index observed for existing endpoints,0,cilium,endpoint max interface index,,
 cilium.endpoint.regeneration_time_stats.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of endpoint regeneration time stats,0,cilium,endpoint regen time bucket,,
@@ -50,10 +78,79 @@ cilium.endpoint.regeneration_time_stats.seconds.count,count,,operation,,[OpenMet
 cilium.endpoint.regeneration_time_stats.seconds.sum,count,,second,,[OpenMetrics V1 and V2] Sum of endpoint regeneration time stats,0,cilium,endpoint regen time sum,,
 cilium.endpoint.regenerations.count,count,,unit,,[OpenMetrics V2] Count of completed endpoint regenerations,1,cilium,endpoint regen count v2,,
 cilium.endpoint.regenerations.total,count,,unit,,[OpenMetrics V1] Count of completed endpoint regenerations,1,cilium,endpoint regen count v1,,
+cilium.endpoint.restoration_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of endpoint restoration phase durations,0,cilium,endpoint restore dur bucket,,phase
+cilium.endpoint.restoration_duration.seconds.count,count,,request,,[OpenMetrics V2] Count of endpoint restoration phase durations,0,cilium,endpoint restore dur count,,phase
+cilium.endpoint.restoration_duration.seconds.sum,count,,second,,[OpenMetrics V2] Sum of endpoint restoration phase durations,0,cilium,endpoint restore dur sum,,phase
+cilium.endpoint.restoration_endpoints,gauge,,,,[OpenMetrics V2] Number of restored endpoints by phase and outcome,0,cilium,endpoint restore count,,outcome:phase
 cilium.endpoint.state,gauge,,unit,,[OpenMetrics V1 and V2] Count of all endpoints,0,cilium,endpoint count,,
 cilium.errors_warning.count,count,,error,,[OpenMetrics V2] Total error warnings,-1,cilium,error total,,
 cilium.errors_warning.total,count,,error,,[OpenMetrics V1] Total error warnings,-1,cilium,error total,,
 cilium.event_timestamp,gauge,,time,,[OpenMetrics V1 and V2] Last timestamp of event received,0,cilium,event ts,,
+cilium.feature.adv_connect_and_lb.bandwidth_manager_enabled,gauge,,,,[OpenMetrics V1 and V2] Bandwidth Manager enabled on the agent,0,cilium,feat bandwidth mgr,,
+cilium.feature.adv_connect_and_lb.bgp_enabled,gauge,,,,[OpenMetrics V1 and V2] BGP enabled on the agent,0,cilium,feat bgp,,
+cilium.feature.adv_connect_and_lb.big_tcp_enabled,gauge,,,,[OpenMetrics V1 and V2] Big TCP enabled on the agent,0,cilium,feat big tcp,,address_family
+cilium.feature.adv_connect_and_lb.cilium_envoy_config_enabled,gauge,,,,[OpenMetrics V1 and V2] Cilium Envoy Config enabled on the agent,0,cilium,feat envoy config,,
+cilium.feature.adv_connect_and_lb.cilium_node_config_enabled,gauge,,,,[OpenMetrics V1 and V2] Cilium Node Config enabled on the agent,0,cilium,feat node config,,
+cilium.feature.adv_connect_and_lb.clustermesh_enabled,gauge,,,,[OpenMetrics V1 and V2] Cluster Mesh enabled on the agent,0,cilium,feat clustermesh,,max_connected_clusters:mode
+cilium.feature.adv_connect_and_lb.egress_gateway_enabled,gauge,,,,[OpenMetrics V1 and V2] Egress Gateway enabled on the agent,0,cilium,feat egress gw,,
+cilium.feature.adv_connect_and_lb.envoy_proxy_enabled,gauge,,,,[OpenMetrics V1 and V2] Envoy Proxy mode enabled on the agent,0,cilium,feat envoy proxy,,mode
+cilium.feature.adv_connect_and_lb.kube_proxy_replacement_enabled,gauge,,,,[OpenMetrics V1 and V2] KubeProxyReplacement enabled on the agent,0,cilium,feat kpr,,
+cilium.feature.adv_connect_and_lb.l2_lb_enabled,gauge,,,,[OpenMetrics V1 and V2] L2 LB announcement enabled on the agent,0,cilium,feat l2 lb,,
+cilium.feature.adv_connect_and_lb.l2_pod_announcement_enabled,gauge,,,,[OpenMetrics V1 and V2] L2 pod announcement enabled on the agent,0,cilium,feat l2 pod,,
+cilium.feature.adv_connect_and_lb.node_port_configuration,gauge,,,,[OpenMetrics V1 and V2] Node Port configuration enabled on the agent,0,cilium,feat nodeport,,acceleration:algorithm:mode
+cilium.feature.adv_connect_and_lb.sctp_enabled,gauge,,,,[OpenMetrics V1 and V2] SCTP enabled on the agent,0,cilium,feat sctp,,
+cilium.feature.adv_connect_and_lb.transparent_encryption,gauge,,,,[OpenMetrics V1 and V2] Encryption mode enabled on the agent,0,cilium,feat encryption,,mode:node2node_enabled
+cilium.feature.adv_connect_and_lb.vtep_enabled,gauge,,,,[OpenMetrics V1 and V2] VTEP enabled on the agent,0,cilium,feat vtep,,
+cilium.feature.controlplane.cilium_endpoint_slices_enabled,gauge,,,,[OpenMetrics V1 and V2] Cilium Endpoint Slices enabled on the agent,0,cilium,feat ces,,
+cilium.feature.controlplane.identity_allocation,gauge,,,,[OpenMetrics V1 and V2] Identity Allocation mode enabled on the agent,0,cilium,feat id alloc,,mode
+cilium.feature.controlplane.ipam,gauge,,,,[OpenMetrics V1 and V2] IPAM mode enabled on the agent,0,cilium,feat ipam,,mode
+cilium.feature.datapath.chaining_enabled,gauge,,,,[OpenMetrics V1 and V2] Chaining mode enabled on the agent,0,cilium,feat chaining,,mode
+cilium.feature.datapath.config,gauge,,,,[OpenMetrics V1 and V2] Datapath config mode enabled on the agent,0,cilium,feat dp config,,mode
+cilium.feature.datapath.internet_protocol,gauge,,,,[OpenMetrics V1 and V2] IP mode enabled on the agent,0,cilium,feat ip mode,,address_family
+cilium.feature.datapath.network,gauge,,,,[OpenMetrics V1 and V2] Network mode enabled on the agent,0,cilium,feat network,,mode
+cilium.feature.network_policies.cidr_policies,gauge,,,,[OpenMetrics V1 and V2] Mode to apply CIDR Policies to Nodes,0,cilium,feat cidr policies,,mode
+cilium.feature.network_policies.cilium_clusterwide_envoy_config.count,count,,,,[OpenMetrics V2] Cilium Clusterwide Envoy Config ingested,0,cilium,feat ccec count,,action
+cilium.feature.network_policies.cilium_clusterwide_envoy_config.total,count,,,,[OpenMetrics V1] Cilium Clusterwide Envoy Config ingested,0,cilium,feat ccec total,,action
+cilium.feature.network_policies.cilium_clusterwide_network_policies.count,count,,,,[OpenMetrics V2] Cilium Clusterwide Network Policies ingested,0,cilium,feat ccnp count,,action
+cilium.feature.network_policies.cilium_clusterwide_network_policies.total,count,,,,[OpenMetrics V1] Cilium Clusterwide Network Policies ingested,0,cilium,feat ccnp total,,action
+cilium.feature.network_policies.cilium_envoy_config.count,count,,,,[OpenMetrics V2] Cilium Envoy Config ingested,0,cilium,feat cec count,,action
+cilium.feature.network_policies.cilium_envoy_config.total,count,,,,[OpenMetrics V1] Cilium Envoy Config ingested,0,cilium,feat cec total,,action
+cilium.feature.network_policies.cilium_network_policies.count,count,,,,[OpenMetrics V2] Cilium Network Policies ingested,0,cilium,feat cnp count,,action
+cilium.feature.network_policies.cilium_network_policies.total,count,,,,[OpenMetrics V1] Cilium Network Policies ingested,0,cilium,feat cnp total,,action
+cilium.feature.network_policies.deny_policies.count,count,,,,[OpenMetrics V2] Deny Policies ingested,0,cilium,feat deny count,,action
+cilium.feature.network_policies.deny_policies.total,count,,,,[OpenMetrics V1] Deny Policies ingested,0,cilium,feat deny total,,action
+cilium.feature.network_policies.dns_policies.count,count,,,,[OpenMetrics V2] DNS Policies ingested,0,cilium,feat dns policies count,,action
+cilium.feature.network_policies.dns_policies.total,count,,,,[OpenMetrics V1] DNS Policies ingested,0,cilium,feat dns policies total,,action
+cilium.feature.network_policies.fqdn_policies.count,count,,,,[OpenMetrics V2] ToFQDNs Policies ingested,0,cilium,feat fqdn count,,action
+cilium.feature.network_policies.fqdn_policies.total,count,,,,[OpenMetrics V1] ToFQDNs Policies ingested,0,cilium,feat fqdn total,,action
+cilium.feature.network_policies.host_firewall_enabled,gauge,,,,[OpenMetrics V1 and V2] Host firewall enabled on the agent,0,cilium,feat host fw,,
+cilium.feature.network_policies.host_network_policies.count,count,,,,[OpenMetrics V2] Host Network Policies ingested,0,cilium,feat host np count,,action
+cilium.feature.network_policies.host_network_policies.total,count,,,,[OpenMetrics V1] Host Network Policies ingested,0,cilium,feat host np total,,action
+cilium.feature.network_policies.http_header_matches_policies.count,count,,,,[OpenMetrics V2] HTTP HeaderMatches Policies ingested,0,cilium,feat http hdr count,,action
+cilium.feature.network_policies.http_header_matches_policies.total,count,,,,[OpenMetrics V1] HTTP HeaderMatches Policies ingested,0,cilium,feat http hdr total,,action
+cilium.feature.network_policies.http_policies.count,count,,,,[OpenMetrics V2] HTTP and gRPC policies ingested,0,cilium,feat http count,,action
+cilium.feature.network_policies.http_policies.total,count,,,,[OpenMetrics V1] HTTP and gRPC policies ingested,0,cilium,feat http total,,action
+cilium.feature.network_policies.ingress_cidr_group_policies.count,count,,,,[OpenMetrics V2] Ingress CIDR Group Policies ingested,0,cilium,feat icg count,,action
+cilium.feature.network_policies.ingress_cidr_group_policies.total,count,,,,[OpenMetrics V1] Ingress CIDR Group Policies ingested,0,cilium,feat icg total,,action
+cilium.feature.network_policies.internal_traffic_policy_services.count,count,,,,[OpenMetrics V2] Kubernetes services with Internal Traffic Policy ingested,0,cilium,feat itp count,,action
+cilium.feature.network_policies.internal_traffic_policy_services.total,count,,,,[OpenMetrics V1] Kubernetes services with Internal Traffic Policy ingested,0,cilium,feat itp total,,action
+cilium.feature.network_policies.l3_policies.count,count,,,,[OpenMetrics V2] Layer 3 and Layer 4 policies ingested,0,cilium,feat l3 count,,action
+cilium.feature.network_policies.l3_policies.total,count,,,,[OpenMetrics V1] Layer 3 and Layer 4 policies ingested,0,cilium,feat l3 total,,action
+cilium.feature.network_policies.local_redirect_policies.count,count,,,,[OpenMetrics V2] Local Redirect Policies ingested,0,cilium,feat lrp count,,action
+cilium.feature.network_policies.local_redirect_policies.total,count,,,,[OpenMetrics V1] Local Redirect Policies ingested,0,cilium,feat lrp total,,action
+cilium.feature.network_policies.local_redirect_policy_enabled,gauge,,,,[OpenMetrics V1 and V2] Local Redirect Policy enabled on the agent,0,cilium,feat lrp enabled,,
+cilium.feature.network_policies.mutual_auth_enabled,gauge,,,,[OpenMetrics V1 and V2] Mutual Auth enabled on the agent,0,cilium,feat mauth,,
+cilium.feature.network_policies.mutual_auth_policies.count,count,,,,[OpenMetrics V2] Mutual Auth Policies ingested,0,cilium,feat mauth count,,action
+cilium.feature.network_policies.mutual_auth_policies.total,count,,,,[OpenMetrics V1] Mutual Auth Policies ingested,0,cilium,feat mauth total,,action
+cilium.feature.network_policies.non_defaultdeny_policies.count,count,,,,[OpenMetrics V2] Non DefaultDeny Policies ingested,0,cilium,feat non-dd count,,action
+cilium.feature.network_policies.non_defaultdeny_policies.total,count,,,,[OpenMetrics V1] Non DefaultDeny Policies ingested,0,cilium,feat non-dd total,,action
+cilium.feature.network_policies.non_defaultdeny_policies_enabled,gauge,,,,[OpenMetrics V1 and V2] Non DefaultDeny Policies enabled,0,cilium,feat non-dd enabled,,
+cilium.feature.network_policies.other_l7_policies.count,count,,,,[OpenMetrics V2] Other L7 Policies ingested,0,cilium,feat l7 count,,action
+cilium.feature.network_policies.other_l7_policies.total,count,,,,[OpenMetrics V1] Other L7 Policies ingested,0,cilium,feat l7 total,,action
+cilium.feature.network_policies.sni_allow_list_policies.count,count,,,,[OpenMetrics V2] SNI Allow List Policies ingested,0,cilium,feat sni count,,action
+cilium.feature.network_policies.sni_allow_list_policies.total,count,,,,[OpenMetrics V1] SNI Allow List Policies ingested,0,cilium,feat sni total,,action
+cilium.feature.network_policies.tls_inspection_policies.count,count,,,,[OpenMetrics V2] TLS Inspection Policies ingested,0,cilium,feat tls count,,action
+cilium.feature.network_policies.tls_inspection_policies.total,count,,,,[OpenMetrics V1] TLS Inspection Policies ingested,0,cilium,feat tls total,,action
 cilium.forward_bytes.count,count,,byte,,[OpenMetrics V2] Total forwarded bytes,1,cilium,forward bytes,,
 cilium.forward_bytes.total,count,,byte,,[OpenMetrics V1] Total forwarded bytes,1,cilium,forward bytes,,
 cilium.forward_count.count,count,,packet,,[OpenMetrics V2] Total forwarded packets,1,cilium,forward packet,,
@@ -64,23 +161,63 @@ cilium.fqdn.alive_zombie_connections,gauge,,item,,"Number of IPs associated with
 cilium.fqdn.gc_deletions.count,count,,event,,[OpenMetrics V2] Total number of FQDNs cleaned in FQDN garbage collector job.,0,cilium,fdqn total,,
 cilium.fqdn.gc_deletions.total,count,,event,,[OpenMetrics V1] Total number of FQDNs cleaned in FQDN garbage collector job.,0,cilium,fdqn total,,
 cilium.fqdn.selectors,gauge,,item,,Number of registered ToFQDN selectors. Available in Cilium v1.16+,0,cilium,fdqn selectors,,
+cilium.fragmented_count.count,count,,packet,,[OpenMetrics V2] Total number of fragmented packets,0,cilium,fragmented packets,,direction
+cilium.fragmented_count.total,count,,packet,,[OpenMetrics V1] Total number of fragmented packets,0,cilium,fragmented packets v1,,direction
+cilium.hive.jobs.observer.last_run_duration.seconds,gauge,,second,,[OpenMetrics V2] Observer job last run duration,0,cilium,hive observer last dur,,job_name:module
+cilium.hive.jobs.observer.run_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of observer job run durations,0,cilium,hive observer run bucket,,job_name:module
+cilium.hive.jobs.observer.run_duration.seconds.count,count,,request,,[OpenMetrics V2] Count of observer job run durations,0,cilium,hive observer run count,,job_name:module
+cilium.hive.jobs.observer.run_duration.seconds.sum,count,,second,,[OpenMetrics V2] Sum of observer job run durations,0,cilium,hive observer run sum,,job_name:module
+cilium.hive.jobs.oneshot.last_run_duration.seconds,gauge,,second,,[OpenMetrics V2] One-shot job last run duration,0,cilium,hive oneshot last dur,,job_name:module
+cilium.hive.jobs.timer.last_run_duration.seconds,gauge,,second,,[OpenMetrics V2] Timer job last run duration,0,cilium,hive timer last dur,,job_name:module
+cilium.hive.jobs.timer.run_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of timer job run durations,0,cilium,hive timer run bucket,,job_name:module
+cilium.hive.jobs.timer.run_duration.seconds.count,count,,request,,[OpenMetrics V2] Count of timer job run durations,0,cilium,hive timer run count,,job_name:module
+cilium.hive.jobs.timer.run_duration.seconds.sum,count,,second,,[OpenMetrics V2] Sum of timer job run durations,0,cilium,hive timer run sum,,job_name:module
+cilium.hive.jobs_runs.count,count,,operation,,[OpenMetrics V2] Total job runs,0,cilium,hive job runs,,job_name:module
+cilium.hive.jobs_runs.total,count,,operation,,[OpenMetrics V1] Total job runs,0,cilium,hive job runs v1,,job_name:module
+cilium.hive.jobs_runs_failed,gauge,,,,[OpenMetrics V2] Failed job runs,0,cilium,hive job runs failed,,job_name:module
+cilium.hive.populate_duration,gauge,,second,,[OpenMetrics V1 and V2] Duration of the hive Populate method,0,cilium,hive populate dur,,
+cilium.hive.start_duration,gauge,,second,,[OpenMetrics V1 and V2] Duration of the hive Start method,0,cilium,hive start dur,,
 cilium.hive.status,gauge,,item,,[OpenMetrics V1 and V2] Counts of health status levels of Hive components,0,cilium,hive status,,
+cilium.hive.stop_duration,gauge,,second,,[OpenMetrics V1 and V2] Duration of the hive Stop method,0,cilium,hive stop dur,,
+cilium.identity.cache_timer.duration,gauge,,second,,[OpenMetrics V2] Seconds for periodic policy processes,0,cilium,identity cache timer dur,,name
+cilium.identity.cache_timer_trigger.folds,gauge,,,,[OpenMetrics V2] Coalesced timer triggers in one execution,0,cilium,identity timer folds,,name
+cilium.identity.cache_timer_trigger.latency,gauge,,second,,[OpenMetrics V2] Wait time before starting next periodic policy round,0,cilium,identity timer latency,,name
 cilium.identity.count,gauge,,unit,,[OpenMetrics V1 and V2] Number of identities allocate.,0,cilium,id count,,
+cilium.identity.gc_entries,gauge,,,,[OpenMetrics V2] Identities alive and deleted at GC end,0,cilium,identity gc entries,,identity_type:outcome
+cilium.identity.gc_latency,gauge,,second,,[OpenMetrics V2] Duration of last successful identity GC,0,cilium,identity gc latency,,identity_type:outcome
+cilium.identity.gc_runs,gauge,,,,[OpenMetrics V2] Times identity GC process was run,0,cilium,identity gc runs,,identity_type:outcome
 cilium.identity.label_sources,gauge,,item,,Number of identities which contain at least one label from the given label source. Available in Cilium v1.16+,0,cilium,id label sources,,
+cilium.identity.updater_timer.duration,gauge,,second,,[OpenMetrics V1 and V2] Seconds to execute periodic policy processes (renamed from cache_timer in Cilium v1.20+),0,cilium,id updater timer dur,,name
+cilium.identity.updater_timer_trigger.folds,gauge,,,,[OpenMetrics V1 and V2] Timer triggers coalesced into one execution (renamed from cache_timer in Cilium v1.20+),0,cilium,id updater timer folds,,name
+cilium.identity.updater_timer_trigger.latency,gauge,,second,,[OpenMetrics V1 and V2] Seconds spent waiting for a previous process to finish (renamed from cache_timer in Cilium v1.20+),0,cilium,id updater timer lat,,name
 cilium.ip_addresses.count,gauge,,unit,,[OpenMetrics V1 and V2] Number of allocated ip_addresses,0,cilium,ip count,,
 cilium.ipam.capacity,gauge,,event,,[OpenMetrics V1 and V2] Total number of IPs in the IPAM pool labeled by family,0,cilium,ipam capacity,,
 cilium.ipam.events.count,count,,event,,[OpenMetrics V2] Number of IPAM events received by action and datapath family type,0,cilium,ipam total,,
 cilium.ipam.events.total,count,,event,,[OpenMetrics V1] Number of IPAM events received by action and datapath family type,0,cilium,ipam total,,
 cilium.ipcache.errors.count,count,,error,,[OpenMetrics V2] Number of errors interacting with the ipcache,-1,cilium,ipcache errors v2,,
 cilium.ipcache.errors.total,count,,error,,[OpenMetrics V1] Number of errors interacting with the ipcache,-1,cilium,ipcache errors v1,,
-cilium.k8s.workqueue.adds.total,count,,event,,[OpenMetrics V1 and V2] Total number of adds handled by workqueue,0,cilium,k8s workqueue adds,,
+cilium.ipcache.events.count,count,,event,,[OpenMetrics V2] Events interacting with ipcache,0,cilium,ipcache events,,type
+cilium.ipcache.events.total,count,,event,,[OpenMetrics V1] Events interacting with ipcache,0,cilium,ipcache events v1,,type
+cilium.ipsec.keys,gauge,,,,[OpenMetrics V2] Number of IPsec keys in use,0,cilium,ipsec keys,,
+cilium.ipsec.xfrm_error,gauge,,,,[OpenMetrics V2] Total XFRM errors,0,cilium,ipsec xfrm error,,error:type
+cilium.ipsec.xfrm_policies,gauge,,,,[OpenMetrics V2] Number of XFRM policies,0,cilium,ipsec xfrm policies,,direction
+cilium.ipsec.xfrm_states,gauge,,,,[OpenMetrics V2] Number of XFRM states,0,cilium,ipsec xfrm states,,direction
+cilium.k8s.cnp_status_completion.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of CNP status update completion durations,0,cilium,cnp status compl bucket,,attempts:outcome
+cilium.k8s.cnp_status_completion.seconds.count,count,,request,,[OpenMetrics V2] Count of CNP status update completions,0,cilium,cnp status compl count,,attempts:outcome
+cilium.k8s.cnp_status_completion.seconds.sum,count,,second,,[OpenMetrics V2] Sum of CNP status update completion durations,0,cilium,cnp status compl sum,,attempts:outcome
+cilium.k8s.workqueue.adds.count,count,,event,,[OpenMetrics V2] Total number of adds handled by workqueue,0,cilium,k8s workqueue adds count,,
+cilium.k8s.workqueue.adds.total,count,,event,,[OpenMetrics V1] Total number of adds handled by workqueue,0,cilium,k8s workqueue adds,,
 cilium.k8s.workqueue.depth,gauge,,event,,[OpenMetrics V1 and V2] Current depth of workqueue,0,cilium,k8s workqueue depth,,
 cilium.k8s.workqueue.longest.running.processor.seconds,gauge,,event,,[OpenMetrics V1 and V2] How many seconds has the longest running processor for workqueue been running,0,cilium,k8s workqueue running processor,,
 cilium.k8s.workqueue.queue.duration.seconds.bucket,count,,event,,[OpenMetrics V1 and V2] Count of how long in seconds an item stays in workqueue before being requested,0,cilium,k8s workqueue duration bucket,,
 cilium.k8s.workqueue.queue.duration.seconds.count,count,,event,,[OpenMetrics V1 and V2] Count of how long in seconds an item stays in workqueue before being requested,0,cilium,k8s workqueue duration count,,
 cilium.k8s.workqueue.queue.duration.seconds.sum,count,,event,,[OpenMetrics V1 and V2] Sum of how long in seconds an item stays in workqueue before being requested,0,cilium,k8s workqueue duration sum,,
-cilium.k8s.workqueue.retries.total,count,,event,,[OpenMetrics V1 and V2] Total number of retries handled by workqueue,0,cilium,k8s workqueue retries,,
+cilium.k8s.workqueue.retries.count,count,,event,,[OpenMetrics V2] Total number of retries handled by workqueue,0,cilium,k8s workqueue retries count,,
+cilium.k8s.workqueue.retries.total,count,,event,,[OpenMetrics V1] Total number of retries handled by workqueue,0,cilium,k8s workqueue retries,,
 cilium.k8s.workqueue.unfinished.work.seconds,gauge,,event,,[OpenMetrics V1 and V2] How many seconds of work has been done that is in progress and hasn't been observed by work_duration. Large values indicate stuck threads. One can deduce the number of stuck threads by observing the rate at which this increases.,0,cilium,k8s workqueue unfinished work,,
+cilium.k8s.workqueue.work_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of workqueue item processing durations,0,cilium,workqueue work dur bucket,,name
+cilium.k8s.workqueue.work_duration.seconds.count,count,,request,,[OpenMetrics V2] Count of workqueue item processing durations,0,cilium,workqueue work dur count,,name
+cilium.k8s.workqueue.work_duration.seconds.sum,count,,second,,[OpenMetrics V2] Sum of workqueue item processing durations,0,cilium,workqueue work dur sum,,name
 cilium.k8s_client.api_calls.count,count,,request,,[OpenMetrics V1 and V2] Number of API calls made to kube-apiserver. Available in Cilium v1.10+,0,cilium,api call count,,
 cilium.k8s_client.api_latency_time.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of processed API call duration,-1,cilium,api latency bucket,,
 cilium.k8s_client.api_latency_time.seconds.count,count,,request,,[OpenMetrics V1 and V2] Count of processed API call duration,-1,cilium,api latency count,,
@@ -95,6 +232,7 @@ cilium.kubernetes.events.count,count,,event,,[OpenMetrics V2] Number of Kubernet
 cilium.kubernetes.events.total,count,,event,,[OpenMetrics V1] Number of Kubernetes events processed,0,cilium,k8s events count,,
 cilium.kubernetes.events_received.count,count,,event,,[OpenMetrics V2] Number of Kubernetes received events processed,0,cilium,k8s events rcv count,,
 cilium.kubernetes.events_received.total,count,,event,,[OpenMetrics V1] Number of Kubernetes received events processed,0,cilium,k8s events rcv count,,
+cilium.kubernetes.resource_sync_duration,gauge,,second,,[OpenMetrics V1 and V2] Duration in seconds of a specific Kubernetes resource sync,0,cilium,k8s resource sync dur,,scope
 cilium.kvstore.events_queue.seconds.bucket,count,,second,,[OpenMetrics V2] Sum of duration in seconds received event was blocked before it could be queued,0,cilium,kvstore event block time bucket,,
 cilium.kvstore.events_queue.seconds.count,count,,,,[OpenMetrics V1 and V2] Count of duration in seconds of received event was blocked before it could be queued,0,cilium,kvstore event block time count,,
 cilium.kvstore.events_queue.seconds.sum,count,,second,,[OpenMetrics V1 and V2] Sum of duration in seconds received event was blocked before it could be queued,0,cilium,kvstore event block time sum,,
@@ -104,7 +242,16 @@ cilium.kvstore.operations_duration.seconds.count,count,,operation,,[OpenMetrics 
 cilium.kvstore.operations_duration.seconds.sum,count,,second,,[OpenMetrics V1 and V2] Duration of kvstore operation sum,0,cilium,kvstore op time sum,,
 cilium.kvstore.quorum_errors.count,count,,error,,[OpenMetrics V2] Number of quorum errors,-1,cilium,kvstore quorum errors,,
 cilium.kvstore.quorum_errors.total,count,,error,,[OpenMetrics V1] Number of quorum errors,-1,cilium,kvstore quorum errors,,
+cilium.kvstore.sync_errors.count,count,,error,,[OpenMetrics V2] Failed synchronizations to kvstore,0,cilium,kvstore sync errors,,scope:source_cluster
+cilium.kvstore.sync_errors.total,count,,error,,[OpenMetrics V1] Failed synchronizations to kvstore,0,cilium,kvstore sync errors v1,,scope:source_cluster
 cilium.kvstore.sync_queue_size,gauge,,item,,Number of elements queued for synchronization in the kvstore,-1,cilium,kvstore sync queue size,,
+cilium.mtu_error_message.count,count,,packet,,[OpenMetrics V2] Total ICMP fragmentation-needed messages sent,0,cilium,mtu error messages,,direction
+cilium.mtu_error_message.total,count,,packet,,[OpenMetrics V1] Total ICMP fragmentation-needed messages sent,0,cilium,mtu error messages v1,,direction
+cilium.nat.endpoint_max_connection,gauge,,,,[OpenMetrics V2] NAT connection saturation percent by family,0,cilium,nat endpoint max conn,,family
+cilium.node_health.connectivity.latency.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of connectivity latency between agents and nodes,0,cilium,node connectivity lat bucket,,address_type:protocol:type
+cilium.node_health.connectivity.latency.seconds.count,count,,request,,[OpenMetrics V2] Count of connectivity latency between agents and nodes,0,cilium,node connectivity lat count,,address_type:protocol:type
+cilium.node_health.connectivity.latency.seconds.sum,count,,second,,[OpenMetrics V2] Sum of connectivity latency between agents and nodes,0,cilium,node connectivity lat sum,,address_type:protocol:type
+cilium.node_health.connectivity.status,gauge,,,,[OpenMetrics V2] Connectivity between Cilium agents and nodes,0,cilium,node connectivity status,,status:type
 cilium.nodes.all_datapath_validations.count,count,,unit,,[OpenMetrics V2] Number of validation calls to implement the datapath implementation of a node,0,cilium,node validations,,
 cilium.nodes.all_datapath_validations.total,count,,unit,,[OpenMetrics V1] Number of validation calls to implement the datapath implementation of a node,0,cilium,node validations,,
 cilium.nodes.all_events_received.count,count,,event,,[OpenMetrics V2] Number of node events received,0,cilium,node events rcvd,,
@@ -116,12 +263,36 @@ cilium.operator.azure.api.duration.seconds.sum,count,,second,,[OpenMetrics V1 an
 cilium.operator.azure.api.rate_limit.duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of duration of client-side rate limiter blocking when interacting with the Azure API. Available in Cilium v1.9+,0,cilium,azure api rate limit duration sample,,
 cilium.operator.azure.api.rate_limit.duration.seconds.count,count,,request,,[OpenMetrics V1 and V2] Count of duration of client-side rate limiter blocking when interacting with the Azure API. Available in Cilium v1.9+,0,cilium,azure api rate limit duration count,,
 cilium.operator.azure.api.rate_limit.duration.seconds.sum,count,,second,,[OpenMetrics V1 and V2] Sum of duration of client-side rate limiter blocking when interacting with the Azure API. Available in Cilium v1.9+,0,cilium,azure api rate limit duration sum,,
+cilium.operator.bgp.reconcile_errors.count,count,,,,[OpenMetrics V2] Number of BGP resource reconciliation errors (operator),0,cilium,op bgp reconcile errors,,resource_kind:resource_name
+cilium.operator.bgp.reconcile_errors.total,count,,,,[OpenMetrics V1] Number of BGP resource reconciliation errors (operator),0,cilium,op bgp reconcile errors v1,,resource_kind:resource_name
+cilium.operator.bgp.reconcile_run_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of operator BGP reconciliation run durations,0,cilium,op bgp reconcile dur bucket,,
+cilium.operator.bgp.reconcile_run_duration.seconds.count,count,,request,,[OpenMetrics V2] Count of operator BGP reconciliation run durations,0,cilium,op bgp reconcile dur count,,
+cilium.operator.bgp.reconcile_run_duration.seconds.sum,count,,second,,[OpenMetrics V2] Sum of operator BGP reconciliation run durations,0,cilium,op bgp reconcile dur sum,,
 cilium.operator.ces.queueing_delay.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of CiliumEndpointSlice queueing delay in seconds. Available in Cilium v1.11+,0,cilium,ces queue delay sample,,
 cilium.operator.ces.queueing_delay.seconds.count,count,,unit,,[OpenMetrics V1 and V2] Count of CiliumEndpointSlice queueing delay in seconds. Available in Cilium v1.11+,0,cilium,ces queue delay count,,
 cilium.operator.ces.queueing_delay.seconds.sum,count,,second,,[OpenMetrics V1 and V2] Sum of CiliumEndpointSlice queueing delay in seconds. Available in Cilium v1.11+,0,cilium,ces queue delay sum,,
-cilium.operator.ces.sync.total,count,,unit,,[OpenMetrics V1 and V2] Number of completed CES syncs by outcome,0,cilium,ces syncs,,
+cilium.operator.ces.sync.count,count,,unit,,[OpenMetrics V2] Number of completed CES syncs by outcome,0,cilium,op ces syncs count,,
+cilium.operator.ces.sync.total,count,,unit,,[OpenMetrics V1] Number of completed CES syncs by outcome,0,cilium,ces syncs,,
 cilium.operator.ces.sync_errors.count,count,,error,,[OpenMetrics V2] Number of CES sync errors. Available in Cilium v1.11+,0,cilium,ces sync errors count,,
 cilium.operator.ces.sync_errors.total,count,,error,,[OpenMetrics V1] Number of CES sync errors. Available in Cilium v1.11+,0,cilium,ces sync errors count,,
+cilium.operator.cid_controller.work_queue_event_count,gauge,,,,[OpenMetrics V2] Processed events by CID controller,0,cilium,cid ctrl event count,,outcome:resource
+cilium.operator.cid_controller.work_queue_latency.bucket,count,,second,,[OpenMetrics V2] Sample of CID controller queue latencies,0,cilium,cid ctrl latency bucket,,phase:resource
+cilium.operator.cid_controller.work_queue_latency.count,count,,request,,[OpenMetrics V2] Count of CID controller queue latencies,0,cilium,cid ctrl latency count,,phase:resource
+cilium.operator.cid_controller.work_queue_latency.sum,count,,second,,[OpenMetrics V2] Sum of CID controller queue latencies,0,cilium,cid ctrl latency sum,,phase:resource
+cilium.operator.clustermesh.remote_cluster_cache_revocations,gauge,,,,[OpenMetrics V2] Cache revocations per remote cluster (operator),0,cilium,op remote cluster revocations,,target_cluster
+cilium.operator.clustermesh.remote_cluster_endpoint_slices,gauge,,,,[OpenMetrics V2] Endpoint slices per remote cluster (operator),0,cilium,op remote cluster endpoint slices,,target_cluster
+cilium.operator.clustermesh.remote_cluster_failures,gauge,,,,[OpenMetrics V2] Failures per remote cluster (operator),0,cilium,op remote cluster failures,,target_cluster
+cilium.operator.clustermesh.remote_cluster_last_failure_ts,gauge,,,,[OpenMetrics V2] Last failure timestamp per remote cluster (operator),0,cilium,op remote cluster last fail,,target_cluster
+cilium.operator.clustermesh.remote_cluster_readiness_status,gauge,,,,[OpenMetrics V2] Remote cluster readiness status (operator),0,cilium,op remote cluster readiness,,target_cluster
+cilium.operator.clustermesh.remote_cluster_service_exports,gauge,,,,[OpenMetrics V2] Service exports per remote cluster (operator),0,cilium,op remote cluster svc exports,,target_cluster
+cilium.operator.clustermesh.remote_cluster_services,gauge,,,,[OpenMetrics V2] Services per remote cluster (operator),0,cilium,op remote cluster services,,target_cluster
+cilium.operator.clustermesh.remote_clusters,gauge,,,,[OpenMetrics V2] Total remote clusters meshed (operator),0,cilium,op remote clusters,,
+cilium.operator.controllers.group_runs.count,count,,operation,,[OpenMetrics V2] Operator controller runs grouped by group name,0,cilium,op controller group runs,,group_name:status
+cilium.operator.controllers.group_runs.total,count,,operation,,[OpenMetrics V1] Operator controller runs grouped by group name,0,cilium,op controller group runs v1,,group_name:status
+cilium.operator.doublewrite.crd_identities,gauge,,,,[OpenMetrics V2] Total CRD identities,0,cilium,doublewrite crd identities,,
+cilium.operator.doublewrite.crd_only_identities,gauge,,,,[OpenMetrics V2] CRD identities not present in KVStore,0,cilium,doublewrite crd only,,
+cilium.operator.doublewrite.kvstore_identities,gauge,,,,[OpenMetrics V2] Total KVStore identities,0,cilium,doublewrite kvstore identities,,
+cilium.operator.doublewrite.kvstore_only_identities,gauge,,,,[OpenMetrics V2] KVStore identities not present as CRD,0,cilium,doublewrite kvstore only,,
 cilium.operator.ec2.api.duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of duration of interactions with the AWS EC2 API. Available in Cilium v1.9+,0,cilium,aws ec2 api duration sample,,
 cilium.operator.ec2.api.duration.seconds.count,count,,request,,[OpenMetrics V1 and V2] Count of duration of interactions with the AWS EC2 API. Available in Cilium v1.9+,0,cilium,aws ec2 api duration count,,
 cilium.operator.ec2.api.duration.seconds.sum,count,,second,,[OpenMetrics V1 and V2] Sum of duration of interactions with the AWS EC2 API. Available in Cilium v1.9+,0,cilium,aws ec2 api duration sum,,
@@ -169,9 +340,16 @@ cilium.operator.eni.resync.total,count,,unit,,[OpenMetrics V1] Number of resync 
 cilium.operator.eni_ec2.rate_limit.duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of duration of client-side rate limiter blocking. Available in Cilium <= v1.9,0,cilium,api rate limit duration sample,,
 cilium.operator.eni_ec2.rate_limit.duration.seconds.count,count,,request,,[OpenMetrics V1 and V2] Count of duration of client-side rate limiter blocking. Available in Cilium <= v1.9,0,cilium,api rate limit duration count,,
 cilium.operator.eni_ec2.rate_limit.duration.seconds.sum,count,,second,,[OpenMetrics V1 and V2] Sum of duration of client-side rate limiter blocking. Available in Cilium <= v1.9,0,cilium,api rate limit duration sum,,
-cilium.operator.errors.warnings.total,count,,item,,[OpenMetrics V1 and V2] Number of total errors in cilium-operator instances,0,cilium,errors total,,
+cilium.operator.errors.warnings.count,count,,item,,[OpenMetrics V2] Number of total errors in cilium-operator instances,0,cilium,op errors count,,
+cilium.operator.errors.warnings.total,count,,item,,[OpenMetrics V1] Number of total errors in cilium-operator instances,0,cilium,errors total,,
+cilium.operator.feature.adv_connect_and_lb.gateway_api_enabled,gauge,,,,[OpenMetrics V1 and V2] GatewayAPI enabled on the operator,0,cilium,op feat gateway api,,
+cilium.operator.feature.adv_connect_and_lb.ingress_controller_enabled,gauge,,,,[OpenMetrics V1 and V2] IngressController enabled on the operator,0,cilium,op feat ingress,,
+cilium.operator.feature.adv_connect_and_lb.l7_aware_traffic_management_enabled,gauge,,,,[OpenMetrics V1 and V2] L7 Aware Traffic Management enabled on the operator,0,cilium,op feat l7 traffic,,
+cilium.operator.feature.adv_connect_and_lb.lb_ipam_enabled,gauge,,,,[OpenMetrics V1 and V2] LB IPAM enabled on the operator,0,cilium,op feat lb ipam,,
+cilium.operator.feature.adv_connect_and_lb.node_ipam_enabled,gauge,,,,[OpenMetrics V1 and V2] Node IPAM enabled on the operator,0,cilium,op feat node ipam,,
 cilium.operator.hive.status,gauge,,item,,[OpenMetrics V1 and V2] Counts of health status levels of Hive components,0,cilium,hive status,,
 cilium.operator.identity_gc.entries,gauge,,garbage collection,,[OpenMetrics V1 and V2] The number of alive and deleted identities at the end of a garbage collector run. Available in Cilium v1.11+,0,cilium,gc entries,,
+cilium.operator.identity_gc.latency,gauge,,second,,[OpenMetrics V1 and V2] Duration of the last successful identity GC (operator),0,cilium,op gc latency,,outcome
 cilium.operator.identity_gc.runs,gauge,,garbage collection,,[OpenMetrics V1 and V2] The number of times identity garbage collector has run. Available in Cilium v1.11+,0,cilium,gc runs,,
 cilium.operator.ipam.allocation.duration.seconds.bucket,count,,second,,[OpenMetrics V2] Allocation ip or interface latency in seconds,0,cilium,ipam allocation latency bucket,,
 cilium.operator.ipam.allocation.duration.seconds.count,count,,operation,,[OpenMetrics V1 and V2] Allocation ip or interface latency in seconds,0,cilium,ipam allocation latency count,,
@@ -236,11 +414,42 @@ cilium.operator.ipam.resync.queued.count,count,,unit,,[OpenMetrics V2] Number of
 cilium.operator.ipam.resync.queued.total,count,,unit,,[OpenMetrics V1] Number of IPAM queued triggers. Available in Cilium v1.9+,0,cilium,ipam queued triggers count,,
 cilium.operator.ipam.resync.total,count,,operation,,[OpenMetrics V1] Number of resync operations to synchronize and resolve IP deficit of nodes. Available in Cilium v1.8+,0,cilium,ipam resync operations count,,
 cilium.operator.ipam.used_ips,gauge,,unit,,[OpenMetrics V1 and V2] Total used IPs on Node for IPAM allocation,0,cilium,used ips,,
-cilium.operator.lbipam.conflicting.pools.total,gauge,,unit,,[OpenMetrics V1 and V2] The number of conflicting pools,0,cilium,conflicting pools,,
-cilium.operator.lbipam.ips.available.total,gauge,,unit,,[OpenMetrics V1 and V2] The number of IP addresses available in a given pool,0,cilium,available pool ips,,
-cilium.operator.lbipam.ips.used.total,gauge,,unit,,[OpenMetrics V1 and V2] The number of IP addresses used in a given pool,0,cilium,used pool ips,,
-cilium.operator.lbipam.services.matching.total,gauge,,unit,,[OpenMetrics V1 and V2] The number of services matching pools,0,cilium,matching pools,,
-cilium.operator.lbipam.services.unsatisfied.total,gauge,,unit,,[OpenMetrics V1 and V2] The number of services which did not receive all requested IPs,0,cilium,unsatisfied pools,,
+cilium.operator.k8s.workqueue.adds.count,count,,operation,,[OpenMetrics V2] Total adds to operator workqueue,0,cilium,op workqueue adds,,name
+cilium.operator.k8s.workqueue.adds.total,count,,operation,,[OpenMetrics V1] Total adds to operator workqueue,0,cilium,op workqueue adds v1,,name
+cilium.operator.k8s.workqueue.depth,gauge,,,,[OpenMetrics V2] Current operator workqueue depth,0,cilium,op workqueue depth,,name
+cilium.operator.k8s.workqueue.longest_running_processor.seconds,gauge,,second,,[OpenMetrics V2] Longest running operator workqueue processor,0,cilium,op workqueue longest,,name
+cilium.operator.k8s.workqueue.queue_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of operator workqueue item durations,0,cilium,op workqueue queue dur bucket,,name
+cilium.operator.k8s.workqueue.queue_duration.seconds.count,count,,request,,[OpenMetrics V2] Count of operator workqueue item durations,0,cilium,op workqueue queue dur count,,name
+cilium.operator.k8s.workqueue.queue_duration.seconds.sum,count,,second,,[OpenMetrics V2] Sum of operator workqueue item durations,0,cilium,op workqueue queue dur sum,,name
+cilium.operator.k8s.workqueue.retries.count,count,,operation,,[OpenMetrics V2] Total operator workqueue retries,0,cilium,op workqueue retries,,name
+cilium.operator.k8s.workqueue.retries.total,count,,operation,,[OpenMetrics V1] Total operator workqueue retries,0,cilium,op workqueue retries v1,,name
+cilium.operator.k8s.workqueue.unfinished_work.seconds,gauge,,second,,[OpenMetrics V2] Work in progress duration not yet observed,0,cilium,op workqueue unfinished,,name
+cilium.operator.k8s.workqueue.work_duration.seconds.bucket,count,,second,,[OpenMetrics V2] Sample of operator workqueue processing durations,0,cilium,op workqueue work dur bucket,,name
+cilium.operator.k8s.workqueue.work_duration.seconds.count,count,,request,,[OpenMetrics V2] Count of operator workqueue processing durations,0,cilium,op workqueue work dur count,,name
+cilium.operator.k8s.workqueue.work_duration.seconds.sum,count,,second,,[OpenMetrics V2] Sum of operator workqueue processing durations,0,cilium,op workqueue work dur sum,,name
+cilium.operator.lbipam.conflicting.pools,gauge,,unit,,[OpenMetrics V2] The number of conflicting pools,0,cilium,conflicting pools,,
+cilium.operator.lbipam.conflicting.pools.count,count,,unit,,[OpenMetrics V2] The number of conflicting pools. Deprecated: only emitted with Cilium 1.15-1.16,0,cilium,conflicting pools count,,
+cilium.operator.lbipam.conflicting.pools.total,count,,unit,,[OpenMetrics V1] The number of conflicting pools. Deprecated: only emitted with Cilium 1.15-1.16,0,cilium,conflicting pools total,,
+cilium.operator.lbipam.ips.available,gauge,,unit,,[OpenMetrics V2] The number of IP addresses available in a given pool,0,cilium,available pool ips,,
+cilium.operator.lbipam.ips.available.count,count,,unit,,[OpenMetrics V2] The number of IP addresses available in a given pool. Deprecated: only emitted with Cilium 1.15-1.16,0,cilium,available pool ips count,,
+cilium.operator.lbipam.ips.available.total,count,,unit,,[OpenMetrics V1] The number of IP addresses available in a given pool. Deprecated: only emitted with Cilium 1.15-1.16,0,cilium,available pool ips total,,
+cilium.operator.lbipam.ips.used,gauge,,unit,,[OpenMetrics V2] The number of IP addresses used in a given pool,0,cilium,used pool ips,,
+cilium.operator.lbipam.ips.used.count,count,,unit,,[OpenMetrics V2] The number of IP addresses used in a given pool. Deprecated: only emitted with Cilium 1.15-1.16,0,cilium,used pool ips count,,
+cilium.operator.lbipam.ips.used.total,count,,unit,,[OpenMetrics V1] The number of IP addresses used in a given pool. Deprecated: only emitted with Cilium 1.15-1.16,0,cilium,used pool ips total,,
+cilium.operator.lbipam.services.matching,gauge,,unit,,[OpenMetrics V2] The number of services matching pools,0,cilium,matching pools,,
+cilium.operator.lbipam.services.matching.count,count,,unit,,[OpenMetrics V2] The number of services matching pools. Deprecated: only emitted with Cilium 1.15-1.16,0,cilium,matching pools count,,
+cilium.operator.lbipam.services.matching.total,count,,unit,,[OpenMetrics V1] The number of services matching pools. Deprecated: only emitted with Cilium 1.15-1.16,0,cilium,matching pools total,,
+cilium.operator.lbipam.services.unsatisfied,gauge,,unit,,[OpenMetrics V2] The number of services which did not receive all requested IPs,0,cilium,unsatisfied pools,,
+cilium.operator.lbipam.services.unsatisfied.count,count,,unit,,[OpenMetrics V2] The number of services which did not receive all requested IPs. Deprecated: only emitted with Cilium 1.15-1.16,0,cilium,unsatisfied pools count,,
+cilium.operator.lbipam.services.unsatisfied.total,count,,unit,,[OpenMetrics V1] The number of services which did not receive all requested IPs. Deprecated: only emitted with Cilium 1.15-1.16,0,cilium,unsatisfied pools total,,
+cilium.operator.mcsapi.serviceexport_info,gauge,,,,[OpenMetrics V2] ServiceExport information,0,cilium,mcsapi serviceexport info,,namespace:serviceexport
+cilium.operator.mcsapi.serviceexport_status_condition,gauge,,,,[OpenMetrics V2] ServiceExport status conditions,0,cilium,mcsapi serviceexport status,,condition:namespace:reason:serviceexport:status
+cilium.operator.mcsapi.serviceimport_info,gauge,,,,[OpenMetrics V2] ServiceImport information,0,cilium,mcsapi serviceimport info,,namespace:serviceimport
+cilium.operator.mcsapi.serviceimport_status_clusters,gauge,,,,[OpenMetrics V2] Clusters backing ServiceImport,0,cilium,mcsapi serviceimport clusters,,namespace:serviceimport
+cilium.operator.mcsapi.serviceimport_status_condition,gauge,,,,[OpenMetrics V2] ServiceImport status conditions,0,cilium,mcsapi serviceimport status,,condition:namespace:reason:serviceimport:status
+cilium.operator.num_cep_changes_per_ces.bucket,count,,unit,,[OpenMetrics V2] Sample of changed CEPs per CES update,0,cilium,cep changes per ces bucket,,failure_type:opcode
+cilium.operator.num_cep_changes_per_ces.count,count,,request,,[OpenMetrics V2] Count of changed CEPs per CES update,0,cilium,cep changes per ces count,,failure_type:opcode
+cilium.operator.num_cep_changes_per_ces.sum,count,,unit,,[OpenMetrics V2] Sum of changed CEPs per CES update,0,cilium,cep changes per ces sum,,failure_type:opcode
 cilium.operator.num_ceps_per_ces.bucket,count,,unit,,[OpenMetrics V2] Sample of CEPs batched in a CES. Available in Cilium v1.11+,0,cilium,cep per ces sample,,
 cilium.operator.num_ceps_per_ces.count,count,,unit,,[OpenMetrics V1 and V2] Count of CEPs batched in a CES. Available in Cilium v1.11+,0,cilium,cep per ces count,,
 cilium.operator.num_ceps_per_ces.sum,count,,unit,,[OpenMetrics V1 and V2] Sum of CEPs batched in a CES. Available in Cilium v1.11+,0,cilium,cep per ces sum,,
@@ -252,6 +461,7 @@ cilium.operator.process.resident_memory.bytes,gauge,,byte,,[OpenMetrics V1 and V
 cilium.operator.process.start_time.seconds,gauge,,second,,[OpenMetrics V1 and V2] Start time of the process since unix epoch in seconds,0,cilium,proc start time operator,,
 cilium.operator.process.virtual_memory.bytes,gauge,,byte,,[OpenMetrics V1 and V2] Virtual memory size in bytes,0,cilium,virtual mem size operator,,
 cilium.operator.process.virtual_memory_max.bytes,gauge,,byte,,[OpenMetrics V1 and V2] Maximum amount of virtual memory available in bytes,0,cilium,virtual mem size max operator,,
+cilium.operator.unmanaged_pods,gauge,,,,[OpenMetrics V2] Total unmanaged pods observed,0,cilium,unmanaged pods,,
 cilium.policy.change.count,count,,unit,,[OpenMetrics V2] Number of policy changes by outcome,0,cilium,policy change count,,
 cilium.policy.change.total,count,,unit,,[OpenMetrics V1] Number of policy changes by outcome,0,cilium,policy change,,
 cilium.policy.count,gauge,,unit,,[OpenMetrics V1 and V2] Number of policies currently loaded,0,cilium,policy count,,
@@ -260,6 +470,9 @@ cilium.policy.implementation_delay.bucket,count,,second,,[OpenMetrics V1 and V2]
 cilium.policy.implementation_delay.count,count,,unit,,[OpenMetrics V1 and V2] Time between a policy change and it being fully deployed into the datapath,0,cilium,impl delay count,,
 cilium.policy.implementation_delay.sum,count,,second,,[OpenMetrics V1 and V2] Time between a policy change and it being fully deployed into the datapath,0,cilium,impl delay sum,,
 cilium.policy.import_errors.count,count,,error,,[OpenMetrics V1 and V2] Number of failed policy imports,-1,cilium,failed policy,,
+cilium.policy.incremental_update_duration.bucket,count,,second,,[OpenMetrics V2] Sample of policy incremental update durations,0,cilium,policy incr update bucket,,scope
+cilium.policy.incremental_update_duration.count,count,,request,,[OpenMetrics V2] Count of policy incremental update durations,0,cilium,policy incr update count,,scope
+cilium.policy.incremental_update_duration.sum,count,,second,,[OpenMetrics V2] Sum of policy incremental update durations,0,cilium,policy incr update sum,,scope
 cilium.policy.l7.count,count,,unit,,[OpenMetrics V2] Number of total L7 requests/responses by type,0,cilium,policy l7 total,,
 cilium.policy.l7.total,count,,unit,,[OpenMetrics V1] Number of total L7 requests/responses by type,0,cilium,policy l7 total,,
 cilium.policy.l7_denied.count,count,,unit,,[OpenMetrics V2] Number of total L7 denied requests/responses due to policy. Available in Cilium <= v1.7,-1,cilium,denied l7 policy,,
@@ -271,11 +484,13 @@ cilium.policy.l7_parse_errors.total,count,,error,,[OpenMetrics V1] Number of tot
 cilium.policy.l7_received.count,count,,unit,,[OpenMetrics V2] Number of total L7 received requests/responses. Available in Cilium <= v1.7,1,cilium,l7 policy received,,
 cilium.policy.l7_received.total,count,,unit,,[OpenMetrics V1] Number of total L7 received requests/responses. Available in Cilium <= v1.7,1,cilium,l7 policy received,,
 cilium.policy.max_revision,gauge,,unit,,[OpenMetrics V1 and V2] Highest policy revision number in the agent,0,cilium,max policy,,
+cilium.policy.missing_proxy_redirects,gauge,,,,[OpenMetrics V1 and V2] Total number of proxy redirects missing in endpoint policies,0,cilium,policy missing redirects,,
 cilium.policy.regeneration.count,count,,unit,,[OpenMetrics V2] Total number of successful policy regenerations,0,cilium,policy regen count,,
 cilium.policy.regeneration.total,count,,unit,,[OpenMetrics V1] Total number of successful policy regenerations,0,cilium,policy regen count,,
 cilium.policy.regeneration_time_stats.seconds.bucket,count,,second,,[OpenMetrics V2] Policy regeneration time stats sample,0,cilium,policy regen time bucket,,
 cilium.policy.regeneration_time_stats.seconds.count,count,,operation,,[OpenMetrics V1 and V2] Policy regeneration time stats count,0,cilium,policy regen time count,,
 cilium.policy.regeneration_time_stats.seconds.sum,count,,second,,[OpenMetrics V1 and V2] Policy regeneration time stats count,0,cilium,policy regen time sum,,
+cilium.policy.selector_match_count_max,gauge,,,,[OpenMetrics V2] Maximum identities selected by policy selector,0,cilium,policy selector max,,class
 cilium.process.cpu.seconds.count,count,,second,,[OpenMetrics V2] Process CPU time in seconds,0,cilium,proc cpu second,,
 cilium.process.cpu.seconds.total,gauge,,second,,[OpenMetrics V1] Process CPU time in seconds,0,cilium,proc cpu second,,
 cilium.process.max_fds,gauge,,file,,[OpenMetrics V1 and V2] Process file descriptor maximum,0,cilium,max fd,,
@@ -290,6 +505,9 @@ cilium.proxy.redirects,gauge,,,,Number of redirects installed for endpoints by p
 cilium.proxy.upstream_reply.seconds.bucket,count,,second,,"[OpenMetrics V2] Seconds waited for upstream server to reply to a request labeled by error, protocol and span time",-1,cilium,proxy upstream reply seconds,,
 cilium.proxy.upstream_reply.seconds.count,count,,second,,"[OpenMetrics V1 and V2] Seconds waited for upstream server to reply to a request labeled by error, protocol and span time",-1,cilium,proxy upstream reply seconds,,
 cilium.proxy.upstream_reply.seconds.sum,count,,second,,"[OpenMetrics V1 and V2] Seconds waited for upstream server to reply to a request labeled by error, protocol and span time",-1,cilium,proxy upstream reply seconds,,
+cilium.service.implementation_delay.bucket,count,,second,,[OpenMetrics V2] Sample of service implementation delays,0,cilium,service impl delay bucket,,action
+cilium.service.implementation_delay.count,count,,request,,[OpenMetrics V2] Count of service implementation delays,0,cilium,service impl delay count,,action
+cilium.service.implementation_delay.sum,count,,second,,[OpenMetrics V2] Sum of service implementation delays,0,cilium,service impl delay sum,,action
 cilium.services.events.count,count,,event,,[OpenMetrics V2] Number of services events labeled by action type,0,cilium,service events count,,
 cilium.services.events.total,count,,event,,[OpenMetrics V1] Number of services events labeled by action type,0,cilium,service events,,
 cilium.subprocess.start.count,count,,unit,,[OpenMetrics V2] Number of times that Cilium has started a subprocess,0,cilium,subproc start,,
@@ -302,4 +520,3 @@ cilium.triggers_policy.update_call_duration.seconds.sum,count,,second,,[OpenMetr
 cilium.triggers_policy.update_folds,gauge,,unit,,[OpenMetrics V1 and V2] Number of folds,0,cilium,fold count,,
 cilium.unreachable.health_endpoints,gauge,,unit,,[OpenMetrics V1 and V2] Number of health endpoints that cannot be reached,0,cilium,unreachable health endpoint,,
 cilium.unreachable.nodes,gauge,,node,,[OpenMetrics V1 and V2] Number of nodes that cannot be reached,0,cilium,unreachable nodes,,
-cilium.version,gauge,,node,,[OpenMetrics V1 and V2] Cilium version,0,cilium,version,,

--- a/cilium/tests/common.py
+++ b/cilium/tests/common.py
@@ -22,6 +22,46 @@ requires_new_environment = pytest.mark.skipif(
 ON_CI = running_on_ci()
 skip_on_ci = pytest.mark.skipif(ON_CI, reason="This test environment flakes on CI")
 
+# NOTE: E2E environments only cover up to Cilium 1.11 (see `ddev env show cilium`).
+# All metrics from Cilium 1.12 onward are unit-tested against fixture data only.
+
+# Feature gauge flags are byte-for-byte identical across V1, V2, and the legacy path
+# (only the network_policies *_total / *_count counter variants differ), so they live
+# in one place and are spliced into each list to avoid four hand-maintained copies.
+FEATURE_GAUGE_METRICS = [
+    # adv_connect_and_lb
+    "cilium.feature.adv_connect_and_lb.bandwidth_manager_enabled",
+    "cilium.feature.adv_connect_and_lb.bgp_enabled",
+    "cilium.feature.adv_connect_and_lb.big_tcp_enabled",
+    "cilium.feature.adv_connect_and_lb.cilium_envoy_config_enabled",
+    "cilium.feature.adv_connect_and_lb.cilium_node_config_enabled",
+    "cilium.feature.adv_connect_and_lb.clustermesh_enabled",
+    "cilium.feature.adv_connect_and_lb.egress_gateway_enabled",
+    "cilium.feature.adv_connect_and_lb.envoy_proxy_enabled",
+    "cilium.feature.adv_connect_and_lb.kube_proxy_replacement_enabled",
+    "cilium.feature.adv_connect_and_lb.l2_lb_enabled",
+    "cilium.feature.adv_connect_and_lb.l2_pod_announcement_enabled",
+    "cilium.feature.adv_connect_and_lb.node_port_configuration",
+    "cilium.feature.adv_connect_and_lb.sctp_enabled",
+    "cilium.feature.adv_connect_and_lb.transparent_encryption",
+    "cilium.feature.adv_connect_and_lb.vtep_enabled",
+    # controlplane
+    "cilium.feature.controlplane.cilium_endpoint_slices_enabled",
+    "cilium.feature.controlplane.identity_allocation",
+    "cilium.feature.controlplane.ipam",
+    # datapath
+    "cilium.feature.datapath.chaining_enabled",
+    "cilium.feature.datapath.config",
+    "cilium.feature.datapath.internet_protocol",
+    "cilium.feature.datapath.network",
+    # network_policies (gauge flags only; counter variants differ per version)
+    "cilium.feature.network_policies.cidr_policies",
+    "cilium.feature.network_policies.host_firewall_enabled",
+    "cilium.feature.network_policies.local_redirect_policy_enabled",
+    "cilium.feature.network_policies.mutual_auth_enabled",
+    "cilium.feature.network_policies.non_defaultdeny_policies_enabled",
+]
+
 AGENT_V2_METRICS = [
     "cilium.agent.api_process_time.seconds.bucket",
     "cilium.agent.api_process_time.seconds.count",
@@ -112,10 +152,6 @@ AGENT_V2_METRICS = [
     "cilium.triggers_policy.update_folds",
     "cilium.unreachable.health_endpoints",
     "cilium.unreachable.nodes",
-    "cilium.k8s_client.api_calls.count",
-    "cilium.identity.count",
-    "cilium.policy.count",
-    "cilium.policy.import_errors.count",
     "cilium.datapath.conntrack_dump.resets.count",
     "cilium.ipcache.errors.count",
     "cilium.k8s_event.lag.seconds",
@@ -126,20 +162,135 @@ AGENT_V2_METRICS = [
     "cilium.kvstore.quorum_errors.count",
     "cilium.kvstore.sync_queue_size",
     "cilium.kvstore.initial_sync_completed",
-]
-
-AGENT_V2_METRICS_1_14 = [
-    # E2E not updated yet to 1.14+ of Cilium
+    # ClusterMesh agent metrics
+    "cilium.clustermesh.remote_cluster_services",
+    "cilium.clustermesh.remote_cluster_nodes",
+    "cilium.clustermesh.remote_clusters",
+    "cilium.clustermesh.remote_cluster_failures",
+    "cilium.clustermesh.remote_cluster_last_failure_ts",
+    "cilium.clustermesh.remote_cluster_readiness_status",
+    "cilium.clustermesh.remote_cluster_cache_revocations",
+    # IPsec
+    "cilium.ipsec.xfrm_error",
+    "cilium.ipsec.keys",
+    "cilium.ipsec.xfrm_states",
+    "cilium.ipsec.xfrm_policies",
+    # eBPF additions
+    "cilium.bpf.syscall_duration.seconds.bucket",
+    "cilium.bpf.syscall_duration.seconds.count",
+    "cilium.bpf.syscall_duration.seconds.sum",
+    "cilium.bpf.ratelimit_dropped.count",
+    # Drop/Forward additions
+    "cilium.mtu_error_message.count",
+    "cilium.fragmented_count.count",
+    # Services
+    "cilium.service.implementation_delay.bucket",
+    "cilium.service.implementation_delay.count",
+    "cilium.service.implementation_delay.sum",
+    # API limiter
+    "cilium.api_limiter.wait_history_duration.seconds.bucket",
+    "cilium.api_limiter.wait_history_duration.seconds.count",
+    "cilium.api_limiter.wait_history_duration.seconds.sum",
+    # Policy
+    "cilium.policy.incremental_update_duration.bucket",
+    "cilium.policy.incremental_update_duration.count",
+    "cilium.policy.incremental_update_duration.sum",
+    # Identity
+    "cilium.identity.gc_entries",
+    "cilium.identity.gc_runs",
+    "cilium.identity.gc_latency",
+    "cilium.ipcache.events.count",
+    # Controllers
+    "cilium.controllers.group_runs.count",
+    # Kubernetes
+    "cilium.k8s.cnp_status_completion.seconds.bucket",
+    "cilium.k8s.cnp_status_completion.seconds.count",
+    "cilium.k8s.cnp_status_completion.seconds.sum",
+    # Endpoint
+    "cilium.endpoint.restoration_endpoints",
+    "cilium.endpoint.restoration_duration.seconds.bucket",
+    "cilium.endpoint.restoration_duration.seconds.count",
+    "cilium.endpoint.restoration_duration.seconds.sum",
+    # NAT
+    "cilium.nat.endpoint_max_connection",
+    # Hive Jobs (1.17+)
+    "cilium.hive.jobs_runs.count",
+    "cilium.hive.jobs_runs_failed",
+    "cilium.hive.jobs.oneshot.last_run_duration.seconds",
+    "cilium.hive.jobs.observer.last_run_duration.seconds",
+    "cilium.hive.jobs.observer.run_duration.seconds.bucket",
+    "cilium.hive.jobs.observer.run_duration.seconds.count",
+    "cilium.hive.jobs.observer.run_duration.seconds.sum",
+    "cilium.hive.jobs.timer.last_run_duration.seconds",
+    "cilium.hive.jobs.timer.run_duration.seconds.bucket",
+    "cilium.hive.jobs.timer.run_duration.seconds.count",
+    "cilium.hive.jobs.timer.run_duration.seconds.sum",
+    # Cilium 1.14+
     "cilium.cidrgroup.policies",
     "cilium.k8s_client.rate_limiter_duration.seconds.bucket",
     "cilium.k8s_client.rate_limiter_duration.seconds.count",
     "cilium.k8s_client.rate_limiter_duration.seconds.sum",
     "cilium.policy.change.count",
     "cilium.services.events.count",
-    # 1.16+
+    # Cilium 1.15+
+    "cilium.k8s.workqueue.work_duration.seconds.bucket",
+    "cilium.k8s.workqueue.work_duration.seconds.count",
+    "cilium.k8s.workqueue.work_duration.seconds.sum",
+    "cilium.kvstore.sync_errors.count",
+    # Cilium 1.16+
     "cilium.fqdn.selectors",
     "cilium.identity.label_sources",
-]
+    # Cilium 1.17+
+    "cilium.node_health.connectivity.status",
+    "cilium.node_health.connectivity.latency.seconds.bucket",
+    "cilium.node_health.connectivity.latency.seconds.count",
+    "cilium.node_health.connectivity.latency.seconds.sum",
+    "cilium.policy.selector_match_count_max",
+    "cilium.identity.cache_timer.duration",
+    "cilium.identity.cache_timer_trigger.latency",
+    "cilium.identity.cache_timer_trigger.folds",
+    # Cilium 1.19+
+    "cilium.clustermesh.remote_cluster_endpoints",
+    # BGP Control Plane
+    "cilium.bgp.session_state",
+    "cilium.bgp.advertised_routes",
+    "cilium.bgp.received_routes",
+    "cilium.bgp.reconcile_errors.count",
+    "cilium.bgp.reconcile_run_duration.seconds.bucket",
+    "cilium.bgp.reconcile_run_duration.seconds.count",
+    "cilium.bgp.reconcile_run_duration.seconds.sum",
+    # Cilium 1.20+: identity_cache_timer_* renamed to identity_updater_timer_*
+    "cilium.identity.updater_timer.duration",
+    "cilium.identity.updater_timer_trigger.latency",
+    "cilium.identity.updater_timer_trigger.folds",
+    "cilium.endpoint.component_status",
+    "cilium.clustermesh.remote_cluster_endpoint_slices",
+    "cilium.policy.missing_proxy_redirects",
+    "cilium.kubernetes.resource_sync_duration",
+    "cilium.hive.start_duration",
+    "cilium.hive.stop_duration",
+    "cilium.hive.populate_duration",
+    # Feature metrics - network_policies counters (V2 .count variants; gauges in FEATURE_GAUGE_METRICS)
+    "cilium.feature.network_policies.cilium_clusterwide_envoy_config.count",
+    "cilium.feature.network_policies.cilium_clusterwide_network_policies.count",
+    "cilium.feature.network_policies.cilium_envoy_config.count",
+    "cilium.feature.network_policies.cilium_network_policies.count",
+    "cilium.feature.network_policies.deny_policies.count",
+    "cilium.feature.network_policies.dns_policies.count",
+    "cilium.feature.network_policies.fqdn_policies.count",
+    "cilium.feature.network_policies.host_network_policies.count",
+    "cilium.feature.network_policies.http_header_matches_policies.count",
+    "cilium.feature.network_policies.http_policies.count",
+    "cilium.feature.network_policies.ingress_cidr_group_policies.count",
+    "cilium.feature.network_policies.internal_traffic_policy_services.count",
+    "cilium.feature.network_policies.l3_policies.count",
+    "cilium.feature.network_policies.local_redirect_policies.count",
+    "cilium.feature.network_policies.mutual_auth_policies.count",
+    "cilium.feature.network_policies.non_defaultdeny_policies.count",
+    "cilium.feature.network_policies.other_l7_policies.count",
+    "cilium.feature.network_policies.sni_allow_list_policies.count",
+    "cilium.feature.network_policies.tls_inspection_policies.count",
+] + FEATURE_GAUGE_METRICS
 
 AGENT_V1_METRICS = [
     "cilium.agent.api_process_time.seconds.count",
@@ -231,11 +382,77 @@ AGENT_V1_METRICS = [
     "cilium.kvstore.quorum_errors.total",
     "cilium.kvstore.sync_queue_size",
     "cilium.kvstore.initial_sync_completed",
-    "cilium.version",
-]
-
-AGENT_V1_METRICS_1_14 = [
-    # E2E not updated yet to 1.14+ of Cilium
+    # ClusterMesh agent metrics (gauge)
+    "cilium.clustermesh.remote_cluster_services",
+    "cilium.clustermesh.remote_cluster_nodes",
+    "cilium.clustermesh.remote_clusters",
+    "cilium.clustermesh.remote_cluster_failures",
+    "cilium.clustermesh.remote_cluster_last_failure_ts",
+    "cilium.clustermesh.remote_cluster_readiness_status",
+    "cilium.clustermesh.remote_cluster_cache_revocations",
+    "cilium.clustermesh.remote_cluster_endpoints",
+    # IPsec (gauge)
+    "cilium.ipsec.xfrm_error",
+    "cilium.ipsec.keys",
+    "cilium.ipsec.xfrm_states",
+    "cilium.ipsec.xfrm_policies",
+    # eBPF (histogram V1: count+sum only; counter V1)
+    "cilium.bpf.syscall_duration.seconds.count",
+    "cilium.bpf.syscall_duration.seconds.sum",
+    "cilium.bpf.ratelimit_dropped.total",
+    # Drop/Forward (counter V1)
+    "cilium.mtu_error_message.total",
+    "cilium.fragmented_count.total",
+    # Services (histogram V1)
+    "cilium.service.implementation_delay.count",
+    "cilium.service.implementation_delay.sum",
+    # API limiter (histogram V1)
+    "cilium.api_limiter.wait_history_duration.seconds.count",
+    "cilium.api_limiter.wait_history_duration.seconds.sum",
+    # Policy (histogram V1)
+    "cilium.policy.incremental_update_duration.count",
+    "cilium.policy.incremental_update_duration.sum",
+    # Identity (gauge)
+    "cilium.identity.gc_entries",
+    "cilium.identity.gc_runs",
+    "cilium.identity.gc_latency",
+    # IPC cache (counter V1)
+    "cilium.ipcache.events.total",
+    # Controllers (counter V1)
+    "cilium.controllers.group_runs.total",
+    # Kubernetes (histogram V1)
+    "cilium.k8s.cnp_status_completion.seconds.count",
+    "cilium.k8s.cnp_status_completion.seconds.sum",
+    # Endpoint (gauge + histogram V1)
+    "cilium.endpoint.restoration_endpoints",
+    "cilium.endpoint.restoration_duration.seconds.count",
+    "cilium.endpoint.restoration_duration.seconds.sum",
+    # NAT (gauge)
+    "cilium.nat.endpoint_max_connection",
+    # Hive Jobs (counter V1, gauge, histogram V1)
+    "cilium.hive.jobs_runs.total",
+    "cilium.hive.jobs_runs_failed",
+    "cilium.hive.jobs.oneshot.last_run_duration.seconds",
+    "cilium.hive.jobs.observer.last_run_duration.seconds",
+    "cilium.hive.jobs.observer.run_duration.seconds.count",
+    "cilium.hive.jobs.observer.run_duration.seconds.sum",
+    "cilium.hive.jobs.timer.last_run_duration.seconds",
+    "cilium.hive.jobs.timer.run_duration.seconds.count",
+    "cilium.hive.jobs.timer.run_duration.seconds.sum",
+    # Cilium 1.15+ (histogram V1)
+    "cilium.k8s.workqueue.work_duration.seconds.count",
+    "cilium.k8s.workqueue.work_duration.seconds.sum",
+    # KVStore (counter V1)
+    "cilium.kvstore.sync_errors.total",
+    # Cilium 1.17+ (gauge + histogram V1)
+    "cilium.node_health.connectivity.status",
+    "cilium.node_health.connectivity.latency.seconds.count",
+    "cilium.node_health.connectivity.latency.seconds.sum",
+    "cilium.policy.selector_match_count_max",
+    "cilium.identity.cache_timer.duration",
+    "cilium.identity.cache_timer_trigger.latency",
+    "cilium.identity.cache_timer_trigger.folds",
+    # Cilium 1.14+
     "cilium.cidrgroup.policies",
     "cilium.k8s_client.rate_limiter_duration.seconds.count",
     "cilium.k8s_client.rate_limiter_duration.seconds.sum",
@@ -244,7 +461,45 @@ AGENT_V1_METRICS_1_14 = [
     # 1.16+
     "cilium.fqdn.selectors",
     "cilium.identity.label_sources",
-]
+    # BGP Control Plane (gauge + counter V1 + histogram V1)
+    "cilium.bgp.session_state",
+    "cilium.bgp.advertised_routes",
+    "cilium.bgp.received_routes",
+    "cilium.bgp.reconcile_errors.total",
+    "cilium.bgp.reconcile_run_duration.seconds.count",
+    "cilium.bgp.reconcile_run_duration.seconds.sum",
+    # Cilium 1.20+: identity_cache_timer_* renamed to identity_updater_timer_*
+    "cilium.identity.updater_timer.duration",
+    "cilium.identity.updater_timer_trigger.latency",
+    "cilium.identity.updater_timer_trigger.folds",
+    "cilium.endpoint.component_status",
+    "cilium.clustermesh.remote_cluster_endpoint_slices",
+    "cilium.policy.missing_proxy_redirects",
+    "cilium.kubernetes.resource_sync_duration",
+    "cilium.hive.start_duration",
+    "cilium.hive.stop_duration",
+    "cilium.hive.populate_duration",
+    # Feature metrics - network_policies counters (V1 .total variants; gauges in FEATURE_GAUGE_METRICS)
+    "cilium.feature.network_policies.cilium_clusterwide_envoy_config.total",
+    "cilium.feature.network_policies.cilium_clusterwide_network_policies.total",
+    "cilium.feature.network_policies.cilium_envoy_config.total",
+    "cilium.feature.network_policies.cilium_network_policies.total",
+    "cilium.feature.network_policies.deny_policies.total",
+    "cilium.feature.network_policies.dns_policies.total",
+    "cilium.feature.network_policies.fqdn_policies.total",
+    "cilium.feature.network_policies.host_network_policies.total",
+    "cilium.feature.network_policies.http_header_matches_policies.total",
+    "cilium.feature.network_policies.http_policies.total",
+    "cilium.feature.network_policies.ingress_cidr_group_policies.total",
+    "cilium.feature.network_policies.internal_traffic_policy_services.total",
+    "cilium.feature.network_policies.l3_policies.total",
+    "cilium.feature.network_policies.local_redirect_policies.total",
+    "cilium.feature.network_policies.mutual_auth_policies.total",
+    "cilium.feature.network_policies.non_defaultdeny_policies.total",
+    "cilium.feature.network_policies.other_l7_policies.total",
+    "cilium.feature.network_policies.sni_allow_list_policies.total",
+    "cilium.feature.network_policies.tls_inspection_policies.total",
+] + FEATURE_GAUGE_METRICS
 
 # Some types changed moving from v1 to v2. We keep v2 in the metadata.csv file.
 AGENT_V1_METRICS_EXCLUDE_METADATA_CHECK = [
@@ -271,6 +526,30 @@ AGENT_V1_METRICS_EXCLUDE_METADATA_CHECK = [
     "cilium.proxy.upstream_reply.seconds.sum",
     "cilium.k8s_client.rate_limiter_duration.seconds.count",
     "cilium.k8s_client.rate_limiter_duration.seconds.sum",
+    # New metrics: V2 metadata has .bucket but V1 doesn't emit it
+    "cilium.bpf.syscall_duration.seconds.count",
+    "cilium.bpf.syscall_duration.seconds.sum",
+    "cilium.service.implementation_delay.count",
+    "cilium.service.implementation_delay.sum",
+    "cilium.api_limiter.wait_history_duration.seconds.count",
+    "cilium.api_limiter.wait_history_duration.seconds.sum",
+    "cilium.policy.incremental_update_duration.count",
+    "cilium.policy.incremental_update_duration.sum",
+    "cilium.k8s.cnp_status_completion.seconds.count",
+    "cilium.k8s.cnp_status_completion.seconds.sum",
+    "cilium.endpoint.restoration_duration.seconds.count",
+    "cilium.endpoint.restoration_duration.seconds.sum",
+    "cilium.hive.jobs.observer.run_duration.seconds.count",
+    "cilium.hive.jobs.observer.run_duration.seconds.sum",
+    "cilium.hive.jobs.timer.run_duration.seconds.count",
+    "cilium.hive.jobs.timer.run_duration.seconds.sum",
+    "cilium.k8s.workqueue.work_duration.seconds.count",
+    "cilium.k8s.workqueue.work_duration.seconds.sum",
+    "cilium.node_health.connectivity.latency.seconds.count",
+    "cilium.node_health.connectivity.latency.seconds.sum",
+    # BGP histogram V1: count+sum only
+    "cilium.bgp.reconcile_run_duration.seconds.count",
+    "cilium.bgp.reconcile_run_duration.seconds.sum",
 ]
 
 OPERATOR_V2_PROCESS_METRICS = [
@@ -361,10 +640,32 @@ OPERATOR_V2_METRICS = [
     "cilium.operator.ipam.empty_interface_slots.count",
     "cilium.operator.ipam.interface_candidates.count",
     "cilium.operator.ipam.ip_allocation_ops.count",
-] + OPERATOR_V2_PROCESS_METRICS
-
-OPERATOR_V2_METRICS_1_14 = [
-    # E2E not updated yet to 1.14+ of Cilium
+    # Previously missing
+    "cilium.operator.controllers.group_runs.count",
+    "cilium.operator.num_cep_changes_per_ces.bucket",
+    "cilium.operator.num_cep_changes_per_ces.count",
+    "cilium.operator.num_cep_changes_per_ces.sum",
+    # ClusterMesh operator
+    "cilium.operator.clustermesh.remote_clusters",
+    "cilium.operator.clustermesh.remote_cluster_failures",
+    "cilium.operator.clustermesh.remote_cluster_last_failure_ts",
+    "cilium.operator.clustermesh.remote_cluster_readiness_status",
+    "cilium.operator.clustermesh.remote_cluster_cache_revocations",
+    "cilium.operator.clustermesh.remote_cluster_services",
+    "cilium.operator.clustermesh.remote_cluster_service_exports",
+    "cilium.operator.clustermesh.remote_cluster_endpoint_slices",
+    # MCS-API
+    "cilium.operator.mcsapi.serviceexport_info",
+    "cilium.operator.mcsapi.serviceexport_status_condition",
+    "cilium.operator.mcsapi.serviceimport_info",
+    "cilium.operator.mcsapi.serviceimport_status_condition",
+    "cilium.operator.mcsapi.serviceimport_status_clusters",
+    # CID controller
+    "cilium.operator.cid_controller.work_queue_event_count",
+    "cilium.operator.cid_controller.work_queue_latency.bucket",
+    "cilium.operator.cid_controller.work_queue_latency.count",
+    "cilium.operator.cid_controller.work_queue_latency.sum",
+    # Cilium 1.14+
     "cilium.operator.ipam.allocation.duration.seconds.bucket",
     "cilium.operator.ipam.allocation.duration.seconds.sum",
     "cilium.operator.ipam.allocation.duration.seconds.count",
@@ -376,7 +677,36 @@ OPERATOR_V2_METRICS_1_14 = [
     "cilium.operator.ipam.release.duration.seconds.sum",
     "cilium.operator.ipam.release.duration.seconds.count",
     "cilium.operator.ipam.used_ips",
-]
+    # Cilium 1.17+
+    "cilium.operator.unmanaged_pods",
+    "cilium.operator.doublewrite.crd_identities",
+    "cilium.operator.doublewrite.kvstore_identities",
+    "cilium.operator.doublewrite.crd_only_identities",
+    "cilium.operator.doublewrite.kvstore_only_identities",
+    # Operator internal workqueues (Cilium 1.18+)
+    "cilium.operator.k8s.workqueue.depth",
+    "cilium.operator.k8s.workqueue.adds.count",
+    "cilium.operator.k8s.workqueue.queue_duration.seconds.bucket",
+    "cilium.operator.k8s.workqueue.queue_duration.seconds.count",
+    "cilium.operator.k8s.workqueue.queue_duration.seconds.sum",
+    "cilium.operator.k8s.workqueue.work_duration.seconds.bucket",
+    "cilium.operator.k8s.workqueue.work_duration.seconds.count",
+    "cilium.operator.k8s.workqueue.work_duration.seconds.sum",
+    "cilium.operator.k8s.workqueue.unfinished_work.seconds",
+    "cilium.operator.k8s.workqueue.longest_running_processor.seconds",
+    "cilium.operator.k8s.workqueue.retries.count",
+    # BGP Control Plane Operator
+    "cilium.operator.bgp.reconcile_errors.count",
+    "cilium.operator.bgp.reconcile_run_duration.seconds.bucket",
+    "cilium.operator.bgp.reconcile_run_duration.seconds.count",
+    "cilium.operator.bgp.reconcile_run_duration.seconds.sum",
+    # Feature metrics - adv_connect_and_lb
+    "cilium.operator.feature.adv_connect_and_lb.gateway_api_enabled",
+    "cilium.operator.feature.adv_connect_and_lb.ingress_controller_enabled",
+    "cilium.operator.feature.adv_connect_and_lb.l7_aware_traffic_management_enabled",
+    "cilium.operator.feature.adv_connect_and_lb.lb_ipam_enabled",
+    "cilium.operator.feature.adv_connect_and_lb.node_ipam_enabled",
+] + OPERATOR_V2_PROCESS_METRICS
 
 # Not available in test metric fixtures
 ADDL_OPERATOR_AWS_METRICS = [
@@ -397,6 +727,7 @@ ADDL_OPERATOR_AWS_METRICS = [
 ADDL_GC_OPERATOR_METRICS = [
     "cilium.operator.identity_gc.entries",
     "cilium.operator.identity_gc.runs",
+    "cilium.operator.identity_gc.latency",
 ]
 
 ADDL_OPERATOR_METRICS = [
@@ -409,7 +740,10 @@ ADDL_OPERATOR_METRICS = [
     "cilium.operator.ces.sync_errors.count",
 ]
 
-# Optional metrics for integration tests
+# Optional metrics for integration tests.
+# Metrics not emitted by the Cilium 1.11 E2E environment (either conditionally
+# emitted at runtime, or introduced in Cilium 1.12+) must be listed here so
+# that test_e2e.py uses at_least=0 instead of at_least=1.
 OPTIONAL_METRICS = {
     "cilium.bpf.map_pressure",
     "cilium.datapath.conntrack_dump.resets.count",
@@ -442,4 +776,133 @@ OPTIONAL_METRICS = {
     "cilium.proxy.upstream_reply.seconds.sum",
     "cilium.proxy.datapath.update_timeout.count",
     "cilium.policy.l7.count",
-}
+    # Cilium 1.12+ - not present in E2E environments (max 1.11)
+    # ClusterMesh agent metrics
+    "cilium.clustermesh.remote_cluster_services",
+    "cilium.clustermesh.remote_cluster_nodes",
+    "cilium.clustermesh.remote_clusters",
+    "cilium.clustermesh.remote_cluster_failures",
+    "cilium.clustermesh.remote_cluster_last_failure_ts",
+    "cilium.clustermesh.remote_cluster_readiness_status",
+    "cilium.clustermesh.remote_cluster_cache_revocations",
+    # IPsec
+    "cilium.ipsec.xfrm_error",
+    "cilium.ipsec.keys",
+    "cilium.ipsec.xfrm_states",
+    "cilium.ipsec.xfrm_policies",
+    # eBPF additions
+    "cilium.bpf.syscall_duration.seconds.bucket",
+    "cilium.bpf.syscall_duration.seconds.count",
+    "cilium.bpf.syscall_duration.seconds.sum",
+    "cilium.bpf.ratelimit_dropped.count",
+    # Drop/Forward additions
+    "cilium.mtu_error_message.count",
+    "cilium.fragmented_count.count",
+    # Services
+    "cilium.service.implementation_delay.bucket",
+    "cilium.service.implementation_delay.count",
+    "cilium.service.implementation_delay.sum",
+    # API limiter
+    "cilium.api_limiter.wait_history_duration.seconds.bucket",
+    "cilium.api_limiter.wait_history_duration.seconds.count",
+    "cilium.api_limiter.wait_history_duration.seconds.sum",
+    # Policy
+    "cilium.policy.incremental_update_duration.bucket",
+    "cilium.policy.incremental_update_duration.count",
+    "cilium.policy.incremental_update_duration.sum",
+    # Identity
+    "cilium.identity.gc_entries",
+    "cilium.identity.gc_runs",
+    "cilium.identity.gc_latency",
+    "cilium.ipcache.events.count",
+    # Controllers
+    "cilium.controllers.group_runs.count",
+    # Kubernetes
+    "cilium.k8s.cnp_status_completion.seconds.bucket",
+    "cilium.k8s.cnp_status_completion.seconds.count",
+    "cilium.k8s.cnp_status_completion.seconds.sum",
+    # Endpoint
+    "cilium.endpoint.restoration_endpoints",
+    "cilium.endpoint.restoration_duration.seconds.bucket",
+    "cilium.endpoint.restoration_duration.seconds.count",
+    "cilium.endpoint.restoration_duration.seconds.sum",
+    # NAT
+    "cilium.nat.endpoint_max_connection",
+    # Hive Jobs (1.17+)
+    "cilium.hive.jobs_runs.count",
+    "cilium.hive.jobs_runs_failed",
+    "cilium.hive.jobs.oneshot.last_run_duration.seconds",
+    "cilium.hive.jobs.observer.last_run_duration.seconds",
+    "cilium.hive.jobs.observer.run_duration.seconds.bucket",
+    "cilium.hive.jobs.observer.run_duration.seconds.count",
+    "cilium.hive.jobs.observer.run_duration.seconds.sum",
+    "cilium.hive.jobs.timer.last_run_duration.seconds",
+    "cilium.hive.jobs.timer.run_duration.seconds.bucket",
+    "cilium.hive.jobs.timer.run_duration.seconds.count",
+    "cilium.hive.jobs.timer.run_duration.seconds.sum",
+    # Cilium 1.14+
+    "cilium.cidrgroup.policies",
+    "cilium.k8s_client.rate_limiter_duration.seconds.bucket",
+    "cilium.k8s_client.rate_limiter_duration.seconds.count",
+    "cilium.k8s_client.rate_limiter_duration.seconds.sum",
+    "cilium.policy.change.count",
+    "cilium.services.events.count",
+    # Cilium 1.15+
+    "cilium.k8s.workqueue.work_duration.seconds.bucket",
+    "cilium.k8s.workqueue.work_duration.seconds.count",
+    "cilium.k8s.workqueue.work_duration.seconds.sum",
+    "cilium.kvstore.sync_errors.count",
+    # Cilium 1.16+
+    "cilium.fqdn.selectors",
+    "cilium.identity.label_sources",
+    # Cilium 1.17+
+    "cilium.node_health.connectivity.status",
+    "cilium.node_health.connectivity.latency.seconds.bucket",
+    "cilium.node_health.connectivity.latency.seconds.count",
+    "cilium.node_health.connectivity.latency.seconds.sum",
+    "cilium.policy.selector_match_count_max",
+    "cilium.identity.cache_timer.duration",
+    "cilium.identity.cache_timer_trigger.latency",
+    "cilium.identity.cache_timer_trigger.folds",
+    # Cilium 1.19+
+    "cilium.clustermesh.remote_cluster_endpoints",
+    # BGP Control Plane
+    "cilium.bgp.session_state",
+    "cilium.bgp.advertised_routes",
+    "cilium.bgp.received_routes",
+    "cilium.bgp.reconcile_errors.count",
+    "cilium.bgp.reconcile_run_duration.seconds.bucket",
+    "cilium.bgp.reconcile_run_duration.seconds.count",
+    "cilium.bgp.reconcile_run_duration.seconds.sum",
+    # Cilium 1.20+: identity_cache_timer_* renamed to identity_updater_timer_*
+    "cilium.identity.updater_timer.duration",
+    "cilium.identity.updater_timer_trigger.latency",
+    "cilium.identity.updater_timer_trigger.folds",
+    "cilium.endpoint.component_status",
+    "cilium.clustermesh.remote_cluster_endpoint_slices",
+    "cilium.policy.missing_proxy_redirects",
+    "cilium.kubernetes.resource_sync_duration",
+    "cilium.hive.start_duration",
+    "cilium.hive.stop_duration",
+    "cilium.hive.populate_duration",
+    # Feature metrics - network_policies counters (V2 .count variants; gauges added via FEATURE_GAUGE_METRICS below)
+    "cilium.feature.network_policies.cilium_clusterwide_envoy_config.count",
+    "cilium.feature.network_policies.cilium_clusterwide_network_policies.count",
+    "cilium.feature.network_policies.cilium_envoy_config.count",
+    "cilium.feature.network_policies.cilium_network_policies.count",
+    "cilium.feature.network_policies.deny_policies.count",
+    "cilium.feature.network_policies.dns_policies.count",
+    "cilium.feature.network_policies.fqdn_policies.count",
+    "cilium.feature.network_policies.host_network_policies.count",
+    "cilium.feature.network_policies.http_header_matches_policies.count",
+    "cilium.feature.network_policies.http_policies.count",
+    "cilium.feature.network_policies.ingress_cidr_group_policies.count",
+    "cilium.feature.network_policies.internal_traffic_policy_services.count",
+    "cilium.feature.network_policies.l3_policies.count",
+    "cilium.feature.network_policies.local_redirect_policies.count",
+    "cilium.feature.network_policies.mutual_auth_policies.count",
+    "cilium.feature.network_policies.non_defaultdeny_policies.count",
+    "cilium.feature.network_policies.other_l7_policies.count",
+    "cilium.feature.network_policies.sni_allow_list_policies.count",
+    "cilium.feature.network_policies.tls_inspection_policies.count",
+} | set(FEATURE_GAUGE_METRICS)

--- a/cilium/tests/fixtures/agent_metrics.txt
+++ b/cilium/tests/fixtures/agent_metrics.txt
@@ -1326,3 +1326,359 @@ cilium_k8s_client_rate_limiter_duration_seconds_count{method="DELETE",path="/api
 # TYPE cilium_policy_change_total counter
 cilium_policy_change_total{outcome="fail"} 106
 cilium_policy_change_total{outcome="success"} 24128
+# HELP cilium_clustermesh_remote_cluster_services Total services in remote cluster
+# TYPE cilium_clustermesh_remote_cluster_services gauge
+cilium_clustermesh_remote_cluster_services{target_cluster="remote-cluster"} 12
+# HELP cilium_clustermesh_remote_cluster_nodes Total nodes in remote cluster
+# TYPE cilium_clustermesh_remote_cluster_nodes gauge
+cilium_clustermesh_remote_cluster_nodes{target_cluster="remote-cluster"} 3
+# HELP cilium_clustermesh_remote_clusters Total number of remote clusters meshed
+# TYPE cilium_clustermesh_remote_clusters gauge
+cilium_clustermesh_remote_clusters 1
+# HELP cilium_clustermesh_remote_cluster_failures Total failures related to remote cluster
+# TYPE cilium_clustermesh_remote_cluster_failures gauge
+cilium_clustermesh_remote_cluster_failures{target_cluster="remote-cluster"} 0
+# HELP cilium_clustermesh_remote_cluster_last_failure_ts Timestamp of last failure in remote cluster
+# TYPE cilium_clustermesh_remote_cluster_last_failure_ts gauge
+cilium_clustermesh_remote_cluster_last_failure_ts{target_cluster="remote-cluster"} 0
+# HELP cilium_clustermesh_remote_cluster_readiness_status Readiness status of remote cluster
+# TYPE cilium_clustermesh_remote_cluster_readiness_status gauge
+cilium_clustermesh_remote_cluster_readiness_status{target_cluster="remote-cluster"} 1
+# HELP cilium_clustermesh_remote_cluster_cache_revocations Total cache revocations in remote cluster
+# TYPE cilium_clustermesh_remote_cluster_cache_revocations gauge
+cilium_clustermesh_remote_cluster_cache_revocations{target_cluster="remote-cluster"} 0
+# HELP cilium_clustermesh_remote_cluster_endpoints Total endpoints in remote cluster
+# TYPE cilium_clustermesh_remote_cluster_endpoints gauge
+cilium_clustermesh_remote_cluster_endpoints{target_cluster="remote-cluster"} 5
+# HELP cilium_ipsec_xfrm_error Total XFRM errors
+# TYPE cilium_ipsec_xfrm_error gauge
+cilium_ipsec_xfrm_error{error="inStateProtoError",type="decrypt"} 0
+# HELP cilium_ipsec_keys Number of keys in use
+# TYPE cilium_ipsec_keys gauge
+cilium_ipsec_keys 2
+# HELP cilium_ipsec_xfrm_states Number of XFRM states
+# TYPE cilium_ipsec_xfrm_states gauge
+cilium_ipsec_xfrm_states{direction="in"} 4
+# HELP cilium_ipsec_xfrm_policies Number of XFRM policies
+# TYPE cilium_ipsec_xfrm_policies gauge
+cilium_ipsec_xfrm_policies{direction="in"} 4
+# HELP cilium_bpf_syscall_duration_seconds Duration of BPF system calls
+# TYPE cilium_bpf_syscall_duration_seconds histogram
+cilium_bpf_syscall_duration_seconds_bucket{error="0",operation="lookup",le="0.005"} 100
+cilium_bpf_syscall_duration_seconds_bucket{error="0",operation="lookup",le="0.025"} 100
+cilium_bpf_syscall_duration_seconds_bucket{error="0",operation="lookup",le="+Inf"} 100
+cilium_bpf_syscall_duration_seconds_sum{error="0",operation="lookup"} 0.123
+cilium_bpf_syscall_duration_seconds_count{error="0",operation="lookup"} 100
+# HELP cilium_bpf_ratelimit_dropped_total Total drops from BPF ratelimiter
+# TYPE cilium_bpf_ratelimit_dropped_total counter
+cilium_bpf_ratelimit_dropped_total{usage="ct_bpf"} 0
+# HELP cilium_mtu_error_message_total Total ICMP fragmentation-needed messages sent
+# TYPE cilium_mtu_error_message_total counter
+cilium_mtu_error_message_total{direction="egress"} 0
+# HELP cilium_fragmented_count_total Total number of fragmented packets
+# TYPE cilium_fragmented_count_total counter
+cilium_fragmented_count_total{direction="ingress"} 0
+# HELP cilium_service_implementation_delay Time between service change and datapath deployment
+# TYPE cilium_service_implementation_delay histogram
+cilium_service_implementation_delay_bucket{action="upsert",le="0.005"} 10
+cilium_service_implementation_delay_bucket{action="upsert",le="0.025"} 10
+cilium_service_implementation_delay_bucket{action="upsert",le="+Inf"} 10
+cilium_service_implementation_delay_sum{action="upsert"} 0.05
+cilium_service_implementation_delay_count{action="upsert"} 10
+# HELP cilium_api_limiter_wait_history_duration_seconds Wait duration histogram for API rate limiter
+# TYPE cilium_api_limiter_wait_history_duration_seconds histogram
+cilium_api_limiter_wait_history_duration_seconds_bucket{api_call="endpoint-create",le="0.005"} 5
+cilium_api_limiter_wait_history_duration_seconds_bucket{api_call="endpoint-create",le="0.025"} 5
+cilium_api_limiter_wait_history_duration_seconds_bucket{api_call="endpoint-create",le="+Inf"} 5
+cilium_api_limiter_wait_history_duration_seconds_sum{api_call="endpoint-create"} 0.01
+cilium_api_limiter_wait_history_duration_seconds_count{api_call="endpoint-create"} 5
+# HELP cilium_policy_incremental_update_duration Time for identities added to policy system
+# TYPE cilium_policy_incremental_update_duration histogram
+cilium_policy_incremental_update_duration_bucket{scope="incremental",le="0.005"} 3
+cilium_policy_incremental_update_duration_bucket{scope="incremental",le="0.025"} 3
+cilium_policy_incremental_update_duration_bucket{scope="incremental",le="+Inf"} 3
+cilium_policy_incremental_update_duration_sum{scope="incremental"} 0.003
+cilium_policy_incremental_update_duration_count{scope="incremental"} 3
+# HELP cilium_identity_gc_entries Identities alive and deleted at GC end
+# TYPE cilium_identity_gc_entries gauge
+cilium_identity_gc_entries{identity_type="global",outcome="alive"} 42
+# HELP cilium_identity_gc_runs Times identity GC process was run
+# TYPE cilium_identity_gc_runs gauge
+cilium_identity_gc_runs{identity_type="global",outcome="success"} 10
+# HELP cilium_identity_gc_latency Duration of last successful identity GC
+# TYPE cilium_identity_gc_latency gauge
+cilium_identity_gc_latency{identity_type="global",outcome="success"} 0.001
+# HELP cilium_ipcache_events_total Events interacting with ipcache
+# TYPE cilium_ipcache_events_total counter
+cilium_ipcache_events_total{type="upsert"} 100
+# HELP cilium_controllers_group_runs_total Controller runs grouped by name
+# TYPE cilium_controllers_group_runs_total counter
+cilium_controllers_group_runs_total{group_name="resolve-identity-references",status="success"} 50
+# HELP cilium_k8s_cnp_status_completion_seconds Time to complete CNP status update
+# TYPE cilium_k8s_cnp_status_completion_seconds histogram
+cilium_k8s_cnp_status_completion_seconds_bucket{attempts="1",outcome="succeeded",le="0.005"} 5
+cilium_k8s_cnp_status_completion_seconds_bucket{attempts="1",outcome="succeeded",le="0.025"} 5
+cilium_k8s_cnp_status_completion_seconds_bucket{attempts="1",outcome="succeeded",le="+Inf"} 5
+cilium_k8s_cnp_status_completion_seconds_sum{attempts="1",outcome="succeeded"} 0.02
+cilium_k8s_cnp_status_completion_seconds_count{attempts="1",outcome="succeeded"} 5
+# HELP cilium_endpoint_restoration_endpoints Number of restored endpoints by phase and outcome
+# TYPE cilium_endpoint_restoration_endpoints gauge
+cilium_endpoint_restoration_endpoints{outcome="success",phase="initial"} 2
+# HELP cilium_endpoint_restoration_duration_seconds Duration of endpoint restoration phases
+# TYPE cilium_endpoint_restoration_duration_seconds histogram
+cilium_endpoint_restoration_duration_seconds_bucket{phase="initial",le="0.005"} 1
+cilium_endpoint_restoration_duration_seconds_bucket{phase="initial",le="0.025"} 1
+cilium_endpoint_restoration_duration_seconds_bucket{phase="initial",le="+Inf"} 1
+cilium_endpoint_restoration_duration_seconds_sum{phase="initial"} 0.001
+cilium_endpoint_restoration_duration_seconds_count{phase="initial"} 1
+# HELP cilium_nat_endpoint_max_connection NAT connection saturation percent by family
+# TYPE cilium_nat_endpoint_max_connection gauge
+cilium_nat_endpoint_max_connection{family="ipv4"} 0.01
+# HELP cilium_hive_jobs_runs_total Total job runs
+# TYPE cilium_hive_jobs_runs_total counter
+cilium_hive_jobs_runs_total{job_name="update-bandwidth-map",module="bandwidth-manager"} 10
+# HELP cilium_hive_jobs_runs_failed Failed job runs
+# TYPE cilium_hive_jobs_runs_failed gauge
+cilium_hive_jobs_runs_failed{job_name="update-bandwidth-map",module="bandwidth-manager"} 0
+# HELP cilium_hive_jobs_oneshot_last_run_duration_seconds One-shot job last run duration
+# TYPE cilium_hive_jobs_oneshot_last_run_duration_seconds gauge
+cilium_hive_jobs_oneshot_last_run_duration_seconds{job_name="populate-initial-ipam-state",module="ipam"} 0.002
+# HELP cilium_hive_jobs_observer_last_run_duration_seconds Observer job last run duration
+# TYPE cilium_hive_jobs_observer_last_run_duration_seconds gauge
+cilium_hive_jobs_observer_last_run_duration_seconds{job_name="policy-distributor",module="policy"} 0.001
+# HELP cilium_hive_jobs_observer_run_duration_seconds Observer job run duration histogram
+# TYPE cilium_hive_jobs_observer_run_duration_seconds histogram
+cilium_hive_jobs_observer_run_duration_seconds_bucket{job_name="policy-distributor",module="policy",le="0.005"} 20
+cilium_hive_jobs_observer_run_duration_seconds_bucket{job_name="policy-distributor",module="policy",le="0.025"} 20
+cilium_hive_jobs_observer_run_duration_seconds_bucket{job_name="policy-distributor",module="policy",le="+Inf"} 20
+cilium_hive_jobs_observer_run_duration_seconds_sum{job_name="policy-distributor",module="policy"} 0.02
+cilium_hive_jobs_observer_run_duration_seconds_count{job_name="policy-distributor",module="policy"} 20
+# HELP cilium_hive_jobs_timer_last_run_duration_seconds Timer job last run duration
+# TYPE cilium_hive_jobs_timer_last_run_duration_seconds gauge
+cilium_hive_jobs_timer_last_run_duration_seconds{job_name="gc-nodes",module="node-manager"} 0.005
+# HELP cilium_hive_jobs_timer_run_duration_seconds Timer job run duration histogram
+# TYPE cilium_hive_jobs_timer_run_duration_seconds histogram
+cilium_hive_jobs_timer_run_duration_seconds_bucket{job_name="gc-nodes",module="node-manager",le="0.005"} 5
+cilium_hive_jobs_timer_run_duration_seconds_bucket{job_name="gc-nodes",module="node-manager",le="0.025"} 5
+cilium_hive_jobs_timer_run_duration_seconds_bucket{job_name="gc-nodes",module="node-manager",le="+Inf"} 5
+cilium_hive_jobs_timer_run_duration_seconds_sum{job_name="gc-nodes",module="node-manager"} 0.025
+cilium_hive_jobs_timer_run_duration_seconds_count{job_name="gc-nodes",module="node-manager"} 5
+# HELP cilium_node_health_connectivity_status Connectivity between Cilium agents and nodes
+# TYPE cilium_node_health_connectivity_status gauge
+cilium_node_health_connectivity_status{status="reachable",type="direct"} 3
+# HELP cilium_node_health_connectivity_latency_seconds Histogram of latency between current agent and other nodes
+# TYPE cilium_node_health_connectivity_latency_seconds histogram
+cilium_node_health_connectivity_latency_seconds_bucket{address_type="ipv4",protocol="icmp",type="direct",le="0.005"} 3
+cilium_node_health_connectivity_latency_seconds_bucket{address_type="ipv4",protocol="icmp",type="direct",le="0.025"} 3
+cilium_node_health_connectivity_latency_seconds_bucket{address_type="ipv4",protocol="icmp",type="direct",le="+Inf"} 3
+cilium_node_health_connectivity_latency_seconds_sum{address_type="ipv4",protocol="icmp",type="direct"} 0.003
+cilium_node_health_connectivity_latency_seconds_count{address_type="ipv4",protocol="icmp",type="direct"} 3
+# HELP cilium_policy_selector_match_count_max Maximum identities selected by policy selector
+# TYPE cilium_policy_selector_match_count_max gauge
+cilium_policy_selector_match_count_max{class="policy-namespace"} 5
+# HELP cilium_identity_cache_timer_duration Seconds for periodic policy processes
+# TYPE cilium_identity_cache_timer_duration gauge
+cilium_identity_cache_timer_duration{name="policy-trigger"} 0.001
+# HELP cilium_identity_cache_timer_trigger_latency Wait time before starting next round
+# TYPE cilium_identity_cache_timer_trigger_latency gauge
+cilium_identity_cache_timer_trigger_latency{name="policy-trigger"} 0.0005
+# HELP cilium_identity_cache_timer_trigger_folds Coalesced timer triggers in one execution
+# TYPE cilium_identity_cache_timer_trigger_folds gauge
+cilium_identity_cache_timer_trigger_folds{name="policy-trigger"} 1
+# HELP cilium_k8s_workqueue_work_duration_seconds How long in seconds processing an item from the workqueue takes
+# TYPE cilium_k8s_workqueue_work_duration_seconds histogram
+cilium_k8s_workqueue_work_duration_seconds_bucket{name="cilium-node",le="0.005"} 10
+cilium_k8s_workqueue_work_duration_seconds_bucket{name="cilium-node",le="0.025"} 10
+cilium_k8s_workqueue_work_duration_seconds_bucket{name="cilium-node",le="+Inf"} 10
+cilium_k8s_workqueue_work_duration_seconds_sum{name="cilium-node"} 0.05
+cilium_k8s_workqueue_work_duration_seconds_count{name="cilium-node"} 10
+# HELP cilium_kvstore_sync_errors_total Failed synchronizations to kvstore
+# TYPE cilium_kvstore_sync_errors_total counter
+cilium_kvstore_sync_errors_total{scope="state",source_cluster="local"} 0
+# HELP cilium_bgp_control_plane_session_state Current state of the BGP session with the peer
+# TYPE cilium_bgp_control_plane_session_state gauge
+cilium_bgp_control_plane_session_state{neighbor="10.0.0.1",neighbor_asn="65001",vrouter="65000"} 1
+# HELP cilium_bgp_control_plane_advertised_routes Number of routes advertised to the peer
+# TYPE cilium_bgp_control_plane_advertised_routes gauge
+cilium_bgp_control_plane_advertised_routes{afi="ipv4",neighbor="10.0.0.1",neighbor_asn="65001",safi="unicast",vrouter="65000"} 5
+# HELP cilium_bgp_control_plane_received_routes Number of routes received from the peer
+# TYPE cilium_bgp_control_plane_received_routes gauge
+cilium_bgp_control_plane_received_routes{afi="ipv4",neighbor="10.0.0.1",neighbor_asn="65001",safi="unicast",vrouter="65000"} 3
+# HELP cilium_bgp_control_plane_reconcile_errors_total Number of reconciliation errors
+# TYPE cilium_bgp_control_plane_reconcile_errors_total counter
+cilium_bgp_control_plane_reconcile_errors_total{vrouter="65000"} 0
+# HELP cilium_bgp_control_plane_reconcile_run_duration_seconds Histogram of reconciliation run duration
+# TYPE cilium_bgp_control_plane_reconcile_run_duration_seconds histogram
+cilium_bgp_control_plane_reconcile_run_duration_seconds_bucket{vrouter="65000",le="0.005"} 10
+cilium_bgp_control_plane_reconcile_run_duration_seconds_bucket{vrouter="65000",le="0.025"} 10
+cilium_bgp_control_plane_reconcile_run_duration_seconds_bucket{vrouter="65000",le="+Inf"} 10
+cilium_bgp_control_plane_reconcile_run_duration_seconds_sum{vrouter="65000"} 0.03
+cilium_bgp_control_plane_reconcile_run_duration_seconds_count{vrouter="65000"} 10
+# HELP cilium_feature_adv_connect_and_lb_bandwidth_manager_enabled Bandwidth Manager enabled on the agent
+# TYPE cilium_feature_adv_connect_and_lb_bandwidth_manager_enabled gauge
+cilium_feature_adv_connect_and_lb_bandwidth_manager_enabled 1
+# HELP cilium_feature_adv_connect_and_lb_bgp_enabled BGP enabled on the agent
+# TYPE cilium_feature_adv_connect_and_lb_bgp_enabled gauge
+cilium_feature_adv_connect_and_lb_bgp_enabled 1
+# HELP cilium_feature_adv_connect_and_lb_big_tcp_enabled Big TCP enabled on the agent
+# TYPE cilium_feature_adv_connect_and_lb_big_tcp_enabled gauge
+cilium_feature_adv_connect_and_lb_big_tcp_enabled{address_family="ipv4-only"} 0
+# HELP cilium_feature_adv_connect_and_lb_cilium_envoy_config_enabled Cilium Envoy Config enabled on the agent
+# TYPE cilium_feature_adv_connect_and_lb_cilium_envoy_config_enabled gauge
+cilium_feature_adv_connect_and_lb_cilium_envoy_config_enabled 0
+# HELP cilium_feature_adv_connect_and_lb_cilium_node_config_enabled Cilium Node Config enabled on the agent
+# TYPE cilium_feature_adv_connect_and_lb_cilium_node_config_enabled gauge
+cilium_feature_adv_connect_and_lb_cilium_node_config_enabled 0
+# HELP cilium_feature_adv_connect_and_lb_clustermesh_enabled Cluster Mesh enabled on the agent
+# TYPE cilium_feature_adv_connect_and_lb_clustermesh_enabled gauge
+cilium_feature_adv_connect_and_lb_clustermesh_enabled{max_connected_clusters="255",mode="clustermesh-apiserver"} 0
+# HELP cilium_feature_adv_connect_and_lb_egress_gateway_enabled Egress Gateway enabled on the agent
+# TYPE cilium_feature_adv_connect_and_lb_egress_gateway_enabled gauge
+cilium_feature_adv_connect_and_lb_egress_gateway_enabled 0
+# HELP cilium_feature_adv_connect_and_lb_envoy_proxy_enabled Envoy Proxy mode enabled on the agent
+# TYPE cilium_feature_adv_connect_and_lb_envoy_proxy_enabled gauge
+cilium_feature_adv_connect_and_lb_envoy_proxy_enabled{mode="embedded"} 1
+# HELP cilium_feature_adv_connect_and_lb_kube_proxy_replacement_enabled KubeProxyReplacement enabled on the agent
+# TYPE cilium_feature_adv_connect_and_lb_kube_proxy_replacement_enabled gauge
+cilium_feature_adv_connect_and_lb_kube_proxy_replacement_enabled 1
+# HELP cilium_feature_adv_connect_and_lb_l2_lb_enabled L2 LB announcement enabled on the agent
+# TYPE cilium_feature_adv_connect_and_lb_l2_lb_enabled gauge
+cilium_feature_adv_connect_and_lb_l2_lb_enabled 0
+# HELP cilium_feature_adv_connect_and_lb_l2_pod_announcement_enabled L2 pod announcement enabled on the agent
+# TYPE cilium_feature_adv_connect_and_lb_l2_pod_announcement_enabled gauge
+cilium_feature_adv_connect_and_lb_l2_pod_announcement_enabled 0
+# HELP cilium_feature_adv_connect_and_lb_node_port_configuration Node Port configuration enabled on the agent
+# TYPE cilium_feature_adv_connect_and_lb_node_port_configuration gauge
+cilium_feature_adv_connect_and_lb_node_port_configuration{acceleration="disabled",algorithm="random",mode="snat"} 1
+# HELP cilium_feature_adv_connect_and_lb_sctp_enabled SCTP enabled on the agent
+# TYPE cilium_feature_adv_connect_and_lb_sctp_enabled gauge
+cilium_feature_adv_connect_and_lb_sctp_enabled 0
+# HELP cilium_feature_adv_connect_and_lb_transparent_encryption Encryption mode enabled on the agent
+# TYPE cilium_feature_adv_connect_and_lb_transparent_encryption gauge
+cilium_feature_adv_connect_and_lb_transparent_encryption{mode="wireguard",node2node_enabled="false"} 0
+# HELP cilium_feature_adv_connect_and_lb_vtep_enabled VTEP enabled on the agent
+# TYPE cilium_feature_adv_connect_and_lb_vtep_enabled gauge
+cilium_feature_adv_connect_and_lb_vtep_enabled 0
+# HELP cilium_feature_controlplane_cilium_endpoint_slices_enabled Cilium Endpoint Slices enabled on the agent
+# TYPE cilium_feature_controlplane_cilium_endpoint_slices_enabled gauge
+cilium_feature_controlplane_cilium_endpoint_slices_enabled 1
+# HELP cilium_feature_controlplane_identity_allocation Identity Allocation mode enabled on the agent
+# TYPE cilium_feature_controlplane_identity_allocation gauge
+cilium_feature_controlplane_identity_allocation{mode="crd"} 1
+# HELP cilium_feature_controlplane_ipam IPAM mode enabled on the agent
+# TYPE cilium_feature_controlplane_ipam gauge
+cilium_feature_controlplane_ipam{mode="cluster-pool"} 1
+# HELP cilium_feature_datapath_chaining_enabled Chaining mode enabled on the agent
+# TYPE cilium_feature_datapath_chaining_enabled gauge
+cilium_feature_datapath_chaining_enabled{mode="none"} 1
+# HELP cilium_feature_datapath_config Datapath config mode enabled on the agent
+# TYPE cilium_feature_datapath_config gauge
+cilium_feature_datapath_config{mode="veth"} 1
+# HELP cilium_feature_datapath_internet_protocol IP mode enabled on the agent
+# TYPE cilium_feature_datapath_internet_protocol gauge
+cilium_feature_datapath_internet_protocol{address_family="ipv4-only"} 1
+# HELP cilium_feature_datapath_network Network mode enabled on the agent
+# TYPE cilium_feature_datapath_network gauge
+cilium_feature_datapath_network{mode="overlay-vxlan"} 1
+# HELP cilium_feature_network_policies_cidr_policies Mode to apply CIDR Policies to Nodes
+# TYPE cilium_feature_network_policies_cidr_policies gauge
+cilium_feature_network_policies_cidr_policies{mode="world"} 1
+# HELP cilium_feature_network_policies_cilium_clusterwide_envoy_config_total Cilium Clusterwide Envoy Config ingested
+# TYPE cilium_feature_network_policies_cilium_clusterwide_envoy_config_total counter
+cilium_feature_network_policies_cilium_clusterwide_envoy_config_total{action="add"} 0
+# HELP cilium_feature_network_policies_cilium_clusterwide_network_policies_total Cilium Clusterwide Network Policies ingested
+# TYPE cilium_feature_network_policies_cilium_clusterwide_network_policies_total counter
+cilium_feature_network_policies_cilium_clusterwide_network_policies_total{action="add"} 0
+# HELP cilium_feature_network_policies_cilium_envoy_config_total Cilium Envoy Config ingested
+# TYPE cilium_feature_network_policies_cilium_envoy_config_total counter
+cilium_feature_network_policies_cilium_envoy_config_total{action="add"} 0
+# HELP cilium_feature_network_policies_cilium_network_policies_total Cilium Network Policies ingested
+# TYPE cilium_feature_network_policies_cilium_network_policies_total counter
+cilium_feature_network_policies_cilium_network_policies_total{action="add"} 2
+# HELP cilium_feature_network_policies_deny_policies_total Deny Policies ingested
+# TYPE cilium_feature_network_policies_deny_policies_total counter
+cilium_feature_network_policies_deny_policies_total{action="add"} 0
+# HELP cilium_feature_network_policies_dns_policies_total DNS Policies ingested
+# TYPE cilium_feature_network_policies_dns_policies_total counter
+cilium_feature_network_policies_dns_policies_total{action="add"} 0
+# HELP cilium_feature_network_policies_fqdn_policies_total ToFQDNs Policies ingested
+# TYPE cilium_feature_network_policies_fqdn_policies_total counter
+cilium_feature_network_policies_fqdn_policies_total{action="add"} 0
+# HELP cilium_feature_network_policies_host_firewall_enabled Host firewall enabled on the agent
+# TYPE cilium_feature_network_policies_host_firewall_enabled gauge
+cilium_feature_network_policies_host_firewall_enabled 0
+# HELP cilium_feature_network_policies_host_network_policies_total Host Network Policies ingested
+# TYPE cilium_feature_network_policies_host_network_policies_total counter
+cilium_feature_network_policies_host_network_policies_total{action="add"} 0
+# HELP cilium_feature_network_policies_http_header_matches_policies_total HTTP HeaderMatches Policies ingested
+# TYPE cilium_feature_network_policies_http_header_matches_policies_total counter
+cilium_feature_network_policies_http_header_matches_policies_total{action="add"} 0
+# HELP cilium_feature_network_policies_http_policies_total HTTP/GRPC Policies ingested
+# TYPE cilium_feature_network_policies_http_policies_total counter
+cilium_feature_network_policies_http_policies_total{action="add"} 0
+# HELP cilium_feature_network_policies_ingress_cidr_group_policies_total Ingress CIDR Group Policies ingested
+# TYPE cilium_feature_network_policies_ingress_cidr_group_policies_total counter
+cilium_feature_network_policies_ingress_cidr_group_policies_total{action="add"} 0
+# HELP cilium_feature_network_policies_internal_traffic_policy_services_total K8s Services with Internal Traffic Policy ingested
+# TYPE cilium_feature_network_policies_internal_traffic_policy_services_total counter
+cilium_feature_network_policies_internal_traffic_policy_services_total{action="add"} 0
+# HELP cilium_feature_network_policies_l3_policies_total Layer 3 and Layer 4 policies ingested
+# TYPE cilium_feature_network_policies_l3_policies_total counter
+cilium_feature_network_policies_l3_policies_total{action="add"} 1
+# HELP cilium_feature_network_policies_local_redirect_policies_total Local Redirect Policies ingested
+# TYPE cilium_feature_network_policies_local_redirect_policies_total counter
+cilium_feature_network_policies_local_redirect_policies_total{action="add"} 0
+# HELP cilium_feature_network_policies_local_redirect_policy_enabled Local Redirect Policy enabled on the agent
+# TYPE cilium_feature_network_policies_local_redirect_policy_enabled gauge
+cilium_feature_network_policies_local_redirect_policy_enabled 0
+# HELP cilium_feature_network_policies_mutual_auth_enabled Mutual Auth enabled on the agent
+# TYPE cilium_feature_network_policies_mutual_auth_enabled gauge
+cilium_feature_network_policies_mutual_auth_enabled 0
+# HELP cilium_feature_network_policies_mutual_auth_policies_total Mutual Auth Policies ingested
+# TYPE cilium_feature_network_policies_mutual_auth_policies_total counter
+cilium_feature_network_policies_mutual_auth_policies_total{action="add"} 0
+# HELP cilium_feature_network_policies_non_defaultdeny_policies_enabled Non DefaultDeny Policies enabled
+# TYPE cilium_feature_network_policies_non_defaultdeny_policies_enabled gauge
+cilium_feature_network_policies_non_defaultdeny_policies_enabled 0
+# HELP cilium_feature_network_policies_non_defaultdeny_policies_total Non DefaultDeny Policies ingested
+# TYPE cilium_feature_network_policies_non_defaultdeny_policies_total counter
+cilium_feature_network_policies_non_defaultdeny_policies_total{action="add"} 0
+# HELP cilium_feature_network_policies_other_l7_policies_total Other L7 Policies ingested
+# TYPE cilium_feature_network_policies_other_l7_policies_total counter
+cilium_feature_network_policies_other_l7_policies_total{action="add"} 0
+# HELP cilium_feature_network_policies_sni_allow_list_policies_total SNI Allow List Policies ingested
+# TYPE cilium_feature_network_policies_sni_allow_list_policies_total counter
+cilium_feature_network_policies_sni_allow_list_policies_total{action="add"} 0
+# HELP cilium_feature_network_policies_tls_inspection_policies_total TLS Inspection Policies ingested
+# TYPE cilium_feature_network_policies_tls_inspection_policies_total counter
+cilium_feature_network_policies_tls_inspection_policies_total{action="add"} 0
+# HELP cilium_endpoint_component_status Number of endpoints tagged by different endpoint components type and their status
+# TYPE cilium_endpoint_component_status gauge
+cilium_endpoint_component_status{status="ok",type="policy"} 5
+# HELP cilium_clustermesh_remote_cluster_endpoint_slices The total number of endpoint slices per remote cluster
+# TYPE cilium_clustermesh_remote_cluster_endpoint_slices gauge
+cilium_clustermesh_remote_cluster_endpoint_slices{source_cluster="local",source_node_name="node1",target_cluster="remote1"} 3
+# HELP cilium_policy_missing_proxy_redirects Total number of proxy redirects missing in endpoint policies
+# TYPE cilium_policy_missing_proxy_redirects gauge
+cilium_policy_missing_proxy_redirects 0
+# HELP cilium_kubernetes_resource_sync_duration Duration in seconds of a specific Kubernetes resource sync
+# TYPE cilium_kubernetes_resource_sync_duration gauge
+cilium_kubernetes_resource_sync_duration{scope="CiliumNode"} 0.05
+# HELP cilium_hive_start_duration Hive start duration
+# TYPE cilium_hive_start_duration gauge
+cilium_hive_start_duration 0.5
+# HELP cilium_hive_stop_duration Hive stop duration
+# TYPE cilium_hive_stop_duration gauge
+cilium_hive_stop_duration 0.1
+# HELP cilium_hive_populate_duration Hive populate duration
+# TYPE cilium_hive_populate_duration gauge
+cilium_hive_populate_duration 0.2
+# HELP cilium_identity_updater_timer_duration Seconds required to execute periodic policy processes
+# TYPE cilium_identity_updater_timer_duration gauge
+cilium_identity_updater_timer_duration{name="id-alloc-update-policy-maps"} 0.001
+# HELP cilium_identity_updater_timer_trigger_latency Seconds spent waiting for a previous process to finish
+# TYPE cilium_identity_updater_timer_trigger_latency gauge
+cilium_identity_updater_timer_trigger_latency{name="id-alloc-update-policy-maps"} 0.0005
+# HELP cilium_identity_updater_timer_trigger_folds Number of timer triggers coalesced into one execution
+# TYPE cilium_identity_updater_timer_trigger_folds gauge
+cilium_identity_updater_timer_trigger_folds{name="id-alloc-update-policy-maps"} 1

--- a/cilium/tests/fixtures/operator_metrics.txt
+++ b/cilium/tests/fixtures/operator_metrics.txt
@@ -1415,3 +1415,134 @@ cilium_operator_ipam_used_ips{target_node="ip-10-131-49-46.ec2.internal"} 3
 cilium_operator_ipam_used_ips{target_node="ip-10-131-49-69.ec2.internal"} 4
 cilium_operator_ipam_used_ips{target_node="ip-10-131-49-73.ec2.internal"} 7
 cilium_operator_ipam_used_ips{target_node="ip-10-131-49-76.ec2.internal"} 23
+# HELP cilium_operator_controllers_group_runs_total Controller runs by group name
+# TYPE cilium_operator_controllers_group_runs_total counter
+cilium_operator_controllers_group_runs_total{group_name="sync-ces-with-ciliumendpoint",status="success"} 25
+# HELP cilium_operator_number_of_cep_changes_per_ces Changed CEPs per CES update
+# TYPE cilium_operator_number_of_cep_changes_per_ces histogram
+cilium_operator_number_of_cep_changes_per_ces_bucket{failure_type="",opcode="upsert",le="1"} 5
+cilium_operator_number_of_cep_changes_per_ces_bucket{failure_type="",opcode="upsert",le="10"} 5
+cilium_operator_number_of_cep_changes_per_ces_bucket{failure_type="",opcode="upsert",le="+Inf"} 5
+cilium_operator_number_of_cep_changes_per_ces_sum{failure_type="",opcode="upsert"} 5
+cilium_operator_number_of_cep_changes_per_ces_count{failure_type="",opcode="upsert"} 5
+# HELP cilium_operator_clustermesh_remote_clusters Total remote clusters meshed
+# TYPE cilium_operator_clustermesh_remote_clusters gauge
+cilium_operator_clustermesh_remote_clusters 1
+# HELP cilium_operator_clustermesh_remote_cluster_failures Failures per remote cluster
+# TYPE cilium_operator_clustermesh_remote_cluster_failures gauge
+cilium_operator_clustermesh_remote_cluster_failures{target_cluster="remote-cluster"} 0
+# HELP cilium_operator_clustermesh_remote_cluster_last_failure_ts Last failure timestamp per remote cluster
+# TYPE cilium_operator_clustermesh_remote_cluster_last_failure_ts gauge
+cilium_operator_clustermesh_remote_cluster_last_failure_ts{target_cluster="remote-cluster"} 0
+# HELP cilium_operator_clustermesh_remote_cluster_readiness_status Remote cluster readiness status
+# TYPE cilium_operator_clustermesh_remote_cluster_readiness_status gauge
+cilium_operator_clustermesh_remote_cluster_readiness_status{target_cluster="remote-cluster"} 1
+# HELP cilium_operator_clustermesh_remote_cluster_cache_revocations Cache revocations per remote cluster
+# TYPE cilium_operator_clustermesh_remote_cluster_cache_revocations gauge
+cilium_operator_clustermesh_remote_cluster_cache_revocations{target_cluster="remote-cluster"} 0
+# HELP cilium_operator_clustermesh_remote_cluster_services Services per remote cluster
+# TYPE cilium_operator_clustermesh_remote_cluster_services gauge
+cilium_operator_clustermesh_remote_cluster_services{target_cluster="remote-cluster"} 5
+# HELP cilium_operator_clustermesh_remote_cluster_service_exports Service exports per remote cluster
+# TYPE cilium_operator_clustermesh_remote_cluster_service_exports gauge
+cilium_operator_clustermesh_remote_cluster_service_exports{target_cluster="remote-cluster"} 2
+# HELP cilium_operator_mcsapi_serviceexport_info ServiceExport information
+# TYPE cilium_operator_mcsapi_serviceexport_info gauge
+cilium_operator_mcsapi_serviceexport_info{namespace="default",serviceexport="my-service"} 1
+# HELP cilium_operator_mcsapi_serviceexport_status_condition ServiceExport status conditions
+# TYPE cilium_operator_mcsapi_serviceexport_status_condition gauge
+cilium_operator_mcsapi_serviceexport_status_condition{condition="Ready",namespace="default",reason="Accepted",serviceexport="my-service",status="True"} 1
+# HELP cilium_operator_mcsapi_serviceimport_info ServiceImport information
+# TYPE cilium_operator_mcsapi_serviceimport_info gauge
+cilium_operator_mcsapi_serviceimport_info{namespace="default",serviceimport="my-service"} 1
+# HELP cilium_operator_mcsapi_serviceimport_status_condition ServiceImport status conditions
+# TYPE cilium_operator_mcsapi_serviceimport_status_condition gauge
+cilium_operator_mcsapi_serviceimport_status_condition{condition="Ready",namespace="default",reason="Accepted",serviceimport="my-service",status="True"} 1
+# HELP cilium_operator_mcsapi_serviceimport_status_clusters Clusters backing ServiceImport
+# TYPE cilium_operator_mcsapi_serviceimport_status_clusters gauge
+cilium_operator_mcsapi_serviceimport_status_clusters{namespace="default",serviceimport="my-service"} 1
+# HELP cilium_operator_cid_controller_work_queue_event_count Processed events by CID controller
+# TYPE cilium_operator_cid_controller_work_queue_event_count gauge
+cilium_operator_cid_controller_work_queue_event_count{outcome="success",resource="ciliumidentity"} 10
+# HELP cilium_operator_cid_controller_work_queue_latency CID controller queue latencies
+# TYPE cilium_operator_cid_controller_work_queue_latency histogram
+cilium_operator_cid_controller_work_queue_latency_bucket{phase="processing",resource="ciliumidentity",le="0.005"} 10
+cilium_operator_cid_controller_work_queue_latency_bucket{phase="processing",resource="ciliumidentity",le="0.025"} 10
+cilium_operator_cid_controller_work_queue_latency_bucket{phase="processing",resource="ciliumidentity",le="+Inf"} 10
+cilium_operator_cid_controller_work_queue_latency_sum{phase="processing",resource="ciliumidentity"} 0.05
+cilium_operator_cid_controller_work_queue_latency_count{phase="processing",resource="ciliumidentity"} 10
+# HELP cilium_operator_unmanaged_pods Total unmanaged pods observed
+# TYPE cilium_operator_unmanaged_pods gauge
+cilium_operator_unmanaged_pods 0
+# HELP cilium_operator_doublewrite_crd_identities Total CRD identities
+# TYPE cilium_operator_doublewrite_crd_identities gauge
+cilium_operator_doublewrite_crd_identities 42
+# HELP cilium_operator_doublewrite_kvstore_identities Total KVStore identities
+# TYPE cilium_operator_doublewrite_kvstore_identities gauge
+cilium_operator_doublewrite_kvstore_identities 42
+# HELP cilium_operator_doublewrite_crd_only_identities CRD identities not present in KVStore
+# TYPE cilium_operator_doublewrite_crd_only_identities gauge
+cilium_operator_doublewrite_crd_only_identities 0
+# HELP cilium_operator_doublewrite_kvstore_only_identities KVStore identities not present as CRD
+# TYPE cilium_operator_doublewrite_kvstore_only_identities gauge
+cilium_operator_doublewrite_kvstore_only_identities 0
+# HELP cilium_operator_workqueue_depth Current workqueue depth
+# TYPE cilium_operator_workqueue_depth gauge
+cilium_operator_workqueue_depth{queue_name="ciliumendpointslice"} 0
+# HELP cilium_operator_workqueue_adds_total Total adds to workqueue
+# TYPE cilium_operator_workqueue_adds_total counter
+cilium_operator_workqueue_adds_total{queue_name="ciliumendpointslice"} 100
+# HELP cilium_operator_workqueue_queue_duration_seconds Item duration in workqueue
+# TYPE cilium_operator_workqueue_queue_duration_seconds histogram
+cilium_operator_workqueue_queue_duration_seconds_bucket{queue_name="ciliumendpointslice",le="0.005"} 50
+cilium_operator_workqueue_queue_duration_seconds_bucket{queue_name="ciliumendpointslice",le="0.025"} 50
+cilium_operator_workqueue_queue_duration_seconds_bucket{queue_name="ciliumendpointslice",le="+Inf"} 50
+cilium_operator_workqueue_queue_duration_seconds_sum{queue_name="ciliumendpointslice"} 0.1
+cilium_operator_workqueue_queue_duration_seconds_count{queue_name="ciliumendpointslice"} 50
+# HELP cilium_operator_workqueue_work_duration_seconds Item processing duration from workqueue
+# TYPE cilium_operator_workqueue_work_duration_seconds histogram
+cilium_operator_workqueue_work_duration_seconds_bucket{queue_name="ciliumendpointslice",le="0.005"} 50
+cilium_operator_workqueue_work_duration_seconds_bucket{queue_name="ciliumendpointslice",le="0.025"} 50
+cilium_operator_workqueue_work_duration_seconds_bucket{queue_name="ciliumendpointslice",le="+Inf"} 50
+cilium_operator_workqueue_work_duration_seconds_sum{queue_name="ciliumendpointslice"} 0.05
+cilium_operator_workqueue_work_duration_seconds_count{queue_name="ciliumendpointslice"} 50
+# HELP cilium_operator_workqueue_unfinished_work_seconds Work in progress not yet observed
+# TYPE cilium_operator_workqueue_unfinished_work_seconds gauge
+cilium_operator_workqueue_unfinished_work_seconds{queue_name="ciliumendpointslice"} 0
+# HELP cilium_operator_workqueue_longest_running_processor_seconds Longest running workqueue processor
+# TYPE cilium_operator_workqueue_longest_running_processor_seconds gauge
+cilium_operator_workqueue_longest_running_processor_seconds{queue_name="ciliumendpointslice"} 0
+# HELP cilium_operator_workqueue_retries_total Total workqueue retries
+# TYPE cilium_operator_workqueue_retries_total counter
+cilium_operator_workqueue_retries_total{queue_name="ciliumendpointslice"} 5
+# HELP cilium_operator_bgp_control_plane_reconcile_errors_total Number of errors per BGP resource reconciliation
+# TYPE cilium_operator_bgp_control_plane_reconcile_errors_total counter
+cilium_operator_bgp_control_plane_reconcile_errors_total{resource_kind="CiliumBGPClusterConfig",resource_name="default"} 0
+# HELP cilium_operator_bgp_control_plane_reconcile_run_duration_seconds Histogram of reconciliation run duration
+# TYPE cilium_operator_bgp_control_plane_reconcile_run_duration_seconds histogram
+cilium_operator_bgp_control_plane_reconcile_run_duration_seconds_bucket{le="0.005"} 5
+cilium_operator_bgp_control_plane_reconcile_run_duration_seconds_bucket{le="0.025"} 5
+cilium_operator_bgp_control_plane_reconcile_run_duration_seconds_bucket{le="+Inf"} 5
+cilium_operator_bgp_control_plane_reconcile_run_duration_seconds_sum 0.01
+cilium_operator_bgp_control_plane_reconcile_run_duration_seconds_count 5
+# HELP cilium_operator_feature_adv_connect_and_lb_gateway_api_enabled GatewayAPI enabled on the operator
+# TYPE cilium_operator_feature_adv_connect_and_lb_gateway_api_enabled gauge
+cilium_operator_feature_adv_connect_and_lb_gateway_api_enabled 0
+# HELP cilium_operator_feature_adv_connect_and_lb_ingress_controller_enabled IngressController enabled on the operator
+# TYPE cilium_operator_feature_adv_connect_and_lb_ingress_controller_enabled gauge
+cilium_operator_feature_adv_connect_and_lb_ingress_controller_enabled 0
+# HELP cilium_operator_feature_adv_connect_and_lb_l7_aware_traffic_management_enabled L7 Aware Traffic Management enabled
+# TYPE cilium_operator_feature_adv_connect_and_lb_l7_aware_traffic_management_enabled gauge
+cilium_operator_feature_adv_connect_and_lb_l7_aware_traffic_management_enabled 0
+# HELP cilium_operator_feature_adv_connect_and_lb_lb_ipam_enabled LB IPAM enabled on the operator
+# TYPE cilium_operator_feature_adv_connect_and_lb_lb_ipam_enabled gauge
+cilium_operator_feature_adv_connect_and_lb_lb_ipam_enabled 0
+# HELP cilium_operator_feature_adv_connect_and_lb_node_ipam_enabled Node IPAM enabled on the operator
+# TYPE cilium_operator_feature_adv_connect_and_lb_node_ipam_enabled gauge
+cilium_operator_feature_adv_connect_and_lb_node_ipam_enabled 0
+# HELP cilium_operator_identity_gc_latency Duration of the last successful identity GC
+# TYPE cilium_operator_identity_gc_latency gauge
+cilium_operator_identity_gc_latency{outcome="success"} 0.002
+# HELP cilium_operator_clustermesh_remote_cluster_endpoint_slices The total number of endpoint slices per remote cluster
+# TYPE cilium_operator_clustermesh_remote_cluster_endpoint_slices gauge
+cilium_operator_clustermesh_remote_cluster_endpoint_slices{source_cluster="local",target_cluster="remote1"} 2

--- a/cilium/tests/legacy/legacy_common.py
+++ b/cilium/tests/legacy/legacy_common.py
@@ -2,6 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+from ..common import FEATURE_GAUGE_METRICS
+
 AGENT_DEFAULT_METRICS = [
     "cilium.agent.api_process_time.seconds.count",
     "cilium.agent.api_process_time.seconds.sum",
@@ -43,6 +45,8 @@ AGENT_DEFAULT_METRICS = [
     "cilium.kvstore.quorum_errors.total",
 ]
 
+# The legacy path intentionally keeps its `*_1_14` lists split (rather than flattening them like
+# tests/common.py) so the legacy E2E gate can still assert the pre-1.14 metrics unconditionally.
 AGENT_METRICS_1_14 = [
     # E2E not updated yet to 1.14+ of Cilium
     "cilium.cidrgroup.policies",
@@ -111,7 +115,114 @@ ADDL_AGENT_METRICS = [
     "cilium.endpoint.regenerations.total",
     "cilium.kvstore.sync_queue_size",
     "cilium.kvstore.initial_sync_completed",
-]
+    # ClusterMesh agent metrics
+    "cilium.clustermesh.remote_cluster_services",
+    "cilium.clustermesh.remote_cluster_nodes",
+    "cilium.clustermesh.remote_clusters",
+    "cilium.clustermesh.remote_cluster_failures",
+    "cilium.clustermesh.remote_cluster_last_failure_ts",
+    "cilium.clustermesh.remote_cluster_readiness_status",
+    "cilium.clustermesh.remote_cluster_cache_revocations",
+    "cilium.clustermesh.remote_cluster_endpoints",
+    # IPsec
+    "cilium.ipsec.xfrm_error",
+    "cilium.ipsec.keys",
+    "cilium.ipsec.xfrm_states",
+    "cilium.ipsec.xfrm_policies",
+    # eBPF
+    "cilium.bpf.syscall_duration.seconds.count",
+    "cilium.bpf.syscall_duration.seconds.sum",
+    "cilium.bpf.ratelimit_dropped.total",
+    # Drop/Forward
+    "cilium.mtu_error_message.total",
+    "cilium.fragmented_count.total",
+    # Services
+    "cilium.service.implementation_delay.count",
+    "cilium.service.implementation_delay.sum",
+    # API limiter
+    "cilium.api_limiter.wait_history_duration.seconds.count",
+    "cilium.api_limiter.wait_history_duration.seconds.sum",
+    # Policy
+    "cilium.policy.incremental_update_duration.count",
+    "cilium.policy.incremental_update_duration.sum",
+    "cilium.policy.selector_match_count_max",
+    # Identity
+    "cilium.identity.gc_entries",
+    "cilium.identity.gc_runs",
+    "cilium.identity.gc_latency",
+    "cilium.identity.cache_timer.duration",
+    "cilium.identity.cache_timer_trigger.latency",
+    "cilium.identity.cache_timer_trigger.folds",
+    # IPCache
+    "cilium.ipcache.events.total",
+    # Controllers
+    "cilium.controllers.group_runs.total",
+    # Kubernetes
+    "cilium.k8s.cnp_status_completion.seconds.count",
+    "cilium.k8s.cnp_status_completion.seconds.sum",
+    "cilium.k8s.workqueue.work_duration.seconds.count",
+    "cilium.k8s.workqueue.work_duration.seconds.sum",
+    # Endpoint
+    "cilium.endpoint.restoration_endpoints",
+    "cilium.endpoint.restoration_duration.seconds.count",
+    "cilium.endpoint.restoration_duration.seconds.sum",
+    # NAT
+    "cilium.nat.endpoint_max_connection",
+    # Hive jobs
+    "cilium.hive.jobs_runs.total",
+    "cilium.hive.jobs_runs_failed",
+    "cilium.hive.jobs.oneshot.last_run_duration.seconds",
+    "cilium.hive.jobs.observer.last_run_duration.seconds",
+    "cilium.hive.jobs.observer.run_duration.seconds.count",
+    "cilium.hive.jobs.observer.run_duration.seconds.sum",
+    "cilium.hive.jobs.timer.last_run_duration.seconds",
+    "cilium.hive.jobs.timer.run_duration.seconds.count",
+    "cilium.hive.jobs.timer.run_duration.seconds.sum",
+    # KVStore
+    "cilium.kvstore.sync_errors.total",
+    # Node health
+    "cilium.node_health.connectivity.status",
+    "cilium.node_health.connectivity.latency.seconds.count",
+    "cilium.node_health.connectivity.latency.seconds.sum",
+    # BGP Control Plane
+    "cilium.bgp.session_state",
+    "cilium.bgp.advertised_routes",
+    "cilium.bgp.received_routes",
+    "cilium.bgp.reconcile_errors.total",
+    "cilium.bgp.reconcile_run_duration.seconds.count",
+    "cilium.bgp.reconcile_run_duration.seconds.sum",
+    # Cilium 1.20+: identity_cache_timer_* renamed to identity_updater_timer_*
+    "cilium.identity.updater_timer.duration",
+    "cilium.identity.updater_timer_trigger.latency",
+    "cilium.identity.updater_timer_trigger.folds",
+    "cilium.endpoint.component_status",
+    "cilium.clustermesh.remote_cluster_endpoint_slices",
+    "cilium.policy.missing_proxy_redirects",
+    "cilium.kubernetes.resource_sync_duration",
+    "cilium.hive.start_duration",
+    "cilium.hive.stop_duration",
+    "cilium.hive.populate_duration",
+    # Feature metrics - network_policies counters (V1 .total variants; gauges in FEATURE_GAUGE_METRICS)
+    "cilium.feature.network_policies.cilium_clusterwide_envoy_config.total",
+    "cilium.feature.network_policies.cilium_clusterwide_network_policies.total",
+    "cilium.feature.network_policies.cilium_envoy_config.total",
+    "cilium.feature.network_policies.cilium_network_policies.total",
+    "cilium.feature.network_policies.deny_policies.total",
+    "cilium.feature.network_policies.dns_policies.total",
+    "cilium.feature.network_policies.fqdn_policies.total",
+    "cilium.feature.network_policies.host_network_policies.total",
+    "cilium.feature.network_policies.http_header_matches_policies.total",
+    "cilium.feature.network_policies.http_policies.total",
+    "cilium.feature.network_policies.ingress_cidr_group_policies.total",
+    "cilium.feature.network_policies.internal_traffic_policy_services.total",
+    "cilium.feature.network_policies.l3_policies.total",
+    "cilium.feature.network_policies.local_redirect_policies.total",
+    "cilium.feature.network_policies.mutual_auth_policies.total",
+    "cilium.feature.network_policies.non_defaultdeny_policies.total",
+    "cilium.feature.network_policies.other_l7_policies.total",
+    "cilium.feature.network_policies.sni_allow_list_policies.total",
+    "cilium.feature.network_policies.tls_inspection_policies.total",
+] + FEATURE_GAUGE_METRICS
 
 OPERATOR_METRICS = [
     "cilium.operator.process.cpu.seconds",
@@ -121,6 +232,55 @@ OPERATOR_METRICS = [
     "cilium.operator.process.start_time.seconds",
     "cilium.operator.process.virtual_memory.bytes",
     "cilium.operator.process.virtual_memory_max.bytes",
+    # ClusterMesh operator
+    "cilium.operator.clustermesh.remote_clusters",
+    "cilium.operator.clustermesh.remote_cluster_failures",
+    "cilium.operator.clustermesh.remote_cluster_last_failure_ts",
+    "cilium.operator.clustermesh.remote_cluster_readiness_status",
+    "cilium.operator.clustermesh.remote_cluster_cache_revocations",
+    "cilium.operator.clustermesh.remote_cluster_services",
+    "cilium.operator.clustermesh.remote_cluster_service_exports",
+    "cilium.operator.clustermesh.remote_cluster_endpoint_slices",
+    # MCS-API
+    "cilium.operator.mcsapi.serviceexport_info",
+    "cilium.operator.mcsapi.serviceexport_status_condition",
+    "cilium.operator.mcsapi.serviceimport_info",
+    "cilium.operator.mcsapi.serviceimport_status_condition",
+    "cilium.operator.mcsapi.serviceimport_status_clusters",
+    # CID controller
+    "cilium.operator.cid_controller.work_queue_event_count",
+    "cilium.operator.cid_controller.work_queue_latency.count",
+    "cilium.operator.cid_controller.work_queue_latency.sum",
+    # Cilium 1.17+
+    "cilium.operator.unmanaged_pods",
+    "cilium.operator.doublewrite.crd_identities",
+    "cilium.operator.doublewrite.kvstore_identities",
+    "cilium.operator.doublewrite.crd_only_identities",
+    "cilium.operator.doublewrite.kvstore_only_identities",
+    # Operator internal workqueues (Cilium 1.18+)
+    "cilium.operator.k8s.workqueue.depth",
+    "cilium.operator.k8s.workqueue.adds.total",
+    "cilium.operator.k8s.workqueue.queue_duration.seconds.count",
+    "cilium.operator.k8s.workqueue.queue_duration.seconds.sum",
+    "cilium.operator.k8s.workqueue.work_duration.seconds.count",
+    "cilium.operator.k8s.workqueue.work_duration.seconds.sum",
+    "cilium.operator.k8s.workqueue.unfinished_work.seconds",
+    "cilium.operator.k8s.workqueue.longest_running_processor.seconds",
+    "cilium.operator.k8s.workqueue.retries.total",
+    # Previously missing
+    "cilium.operator.controllers.group_runs.total",
+    "cilium.operator.num_cep_changes_per_ces.count",
+    "cilium.operator.num_cep_changes_per_ces.sum",
+    # BGP Control Plane Operator
+    "cilium.operator.bgp.reconcile_errors.total",
+    "cilium.operator.bgp.reconcile_run_duration.seconds.count",
+    "cilium.operator.bgp.reconcile_run_duration.seconds.sum",
+    # Feature metrics - adv_connect_and_lb
+    "cilium.operator.feature.adv_connect_and_lb.gateway_api_enabled",
+    "cilium.operator.feature.adv_connect_and_lb.ingress_controller_enabled",
+    "cilium.operator.feature.adv_connect_and_lb.l7_aware_traffic_management_enabled",
+    "cilium.operator.feature.adv_connect_and_lb.lb_ipam_enabled",
+    "cilium.operator.feature.adv_connect_and_lb.node_ipam_enabled",
 ]
 
 OPERATOR_METRICS_1_14 = [
@@ -170,6 +330,7 @@ OPERATOR_AWS_METRICS = [
     "cilium.operator.ec2.api.duration.seconds.sum",
     "cilium.operator.identity_gc.entries",
     "cilium.operator.identity_gc.runs",
+    "cilium.operator.identity_gc.latency",
     "cilium.operator.ipam.allocation_ops",
     "cilium.operator.ipam.available",
     "cilium.operator.ipam.available.ips_per_subnet",

--- a/cilium/tests/test_cilium.py
+++ b/cilium/tests/test_cilium.py
@@ -9,12 +9,11 @@ from .common import (
     ADDL_GC_OPERATOR_METRICS,
     ADDL_OPERATOR_METRICS,
     AGENT_V1_METRICS,
-    AGENT_V1_METRICS_1_14,
     AGENT_V1_METRICS_EXCLUDE_METADATA_CHECK,
     AGENT_V2_METRICS,
-    AGENT_V2_METRICS_1_14,
     OPERATOR_V2_METRICS,
-    OPERATOR_V2_METRICS_1_14,
+    OPERATOR_V2_PROCESS_METRICS,
+    OPTIONAL_METRICS,
     requires_new_environment,
 )
 
@@ -25,11 +24,13 @@ pytestmark = [requires_new_environment, pytest.mark.unit]
 def test_agent_check(aggregator, agent_instance_use_openmetrics, mock_agent_data, dd_run_check, check, use_openmetrics):
     c = check(agent_instance_use_openmetrics(use_openmetrics))
     dd_run_check(c)
-    for m in AGENT_V2_METRICS + AGENT_V2_METRICS_1_14 if use_openmetrics else AGENT_V1_METRICS + AGENT_V1_METRICS_1_14:
+    for m in AGENT_V2_METRICS if use_openmetrics else AGENT_V1_METRICS:
         aggregator.assert_metric(m)
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(
-        get_metadata_metrics(), exclude=None if use_openmetrics else AGENT_V1_METRICS_EXCLUDE_METADATA_CHECK
+        get_metadata_metrics(),
+        check_submission_type=True,
+        exclude=None if use_openmetrics else AGENT_V1_METRICS_EXCLUDE_METADATA_CHECK,
     )
 
 
@@ -37,7 +38,16 @@ def test_operator_check(aggregator, operator_instance_use_openmetrics, mock_oper
     c = check(operator_instance_use_openmetrics(True))
 
     dd_run_check(c)
-    for m in OPERATOR_V2_METRICS + ADDL_OPERATOR_METRICS + ADDL_GC_OPERATOR_METRICS + OPERATOR_V2_METRICS_1_14:
+    for m in OPERATOR_V2_METRICS + ADDL_OPERATOR_METRICS + ADDL_GC_OPERATOR_METRICS:
         aggregator.assert_metric(m)
     aggregator.assert_all_metrics_covered()
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)
+
+
+def test_optional_metrics_are_asserted():
+    # The E2E gate (test_e2e.py) only relaxes a metric to `at_least=0` when it appears in
+    # OPTIONAL_METRICS. A stale or misspelled OPTIONAL_METRICS entry (e.g. after a metric rename)
+    # would silently never match, so guard that every optional metric is one the E2E test asserts.
+    asserted = set(AGENT_V2_METRICS) | set(OPERATOR_V2_PROCESS_METRICS)
+    orphaned = OPTIONAL_METRICS - asserted
+    assert not orphaned, f"OPTIONAL_METRICS entries not covered by an asserted metric: {sorted(orphaned)}"


### PR DESCRIPTION
### What does this PR do?

#### Metric coverage

Extended agent and operator metric mappings to cover what was missing since the integration was last updated (Cilium 1.16).

Agent (`cilium_agent`):
- ClusterMesh: remote_cluster_services/nodes/clusters/failures/last_failure_ts/readiness_status/cache_revocations/endpoints (1.19+)
- IPsec: xfrm_error/keys/xfrm_states/xfrm_policies
- eBPF: syscall_duration, ratelimit_dropped
- Drop/forward: mtu_error_message, fragmented_count
- Services: implementation_delay
- API limiter: wait_history_duration
- Policy: incremental_update_duration, selector_match_count_max (1.17+)
- Identity: gc_entries/runs/latency, cache_timer/trigger (1.17+)
- IPCache: events
- Controllers: group_runs
- Kubernetes: cnp_status_completion, workqueue work_duration
- Endpoint: restoration_endpoints, restoration_duration
- NAT: endpoint_max_connection
- Hive jobs (1.17+): runs, runs_failed, oneshot/observer/timer durations
- KVStore: sync_errors
- Node health connectivity status and latency (1.17+)

Operator (`cilium_operator`):
- ClusterMesh: remote_clusters/failures/last_failure_ts/readiness_status/ cache_revocations/services/service_exports
- MCS-API: serviceexport/serviceimport info, status conditions, clusters
- CID controller: work_queue_event_count, work_queue_latency
- Doublewrite: crd/kvstore/crd_only/kvstore_only identities (1.17+)
- Unmanaged pods (1.17+)
- k8s workqueue with cilium_operator_ prefix (1.19+): depth, adds, queue_duration, work_duration, unfinished_work, longest_running_processor, retries
- num_cep_changes_per_ces, controllers.group_runs
- IPAM: allocation/release duration, available_interfaces/ips, ip_release_ops, needed_ips, used_ips (these were present in 1.14+ but missing from the list)

Deprecated metrics are preserved in metrics.py with version annotations (triggers_policy_update_* removed in 1.17, endpoint_max_ifindex removed in 1.19).

Reference material:
* Metrics reference: https://docs.cilium.io/en/stable/observability/metrics/#metrics-reference
* 1.19 upgrade guide: https://docs.cilium.io/en/v1.19/operations/upgrade/#changes-to-metrics
* 1.18 upgrade guide: https://docs.cilium.io/en/v1.18/operations/upgrade/#changed-metrics
* 1.17 upgrade guide: https://docs.cilium.io/en/v1.17/operations/upgrade/#added-metrics

#### Test list cleanup

The test metric lists in `tests/common.py` had accumulated artificial fragmentation: `AGENT_V2_METRICS` and `AGENT_V2_METRICS_1_14` were always concatenated unconditionally in every assertion — the split carried no functional value. Same for the V1 and operator equivalents.

Flattened all versioned sublists into their respective base lists (`AGENT_V2_METRICS`, `AGENT_V1_METRICS`, `OPERATOR_V2_METRICS`). Version boundaries are preserved as inline comments. Simplified `test_cilium.py` imports and assertions accordingly.

Added a note in `common.py` that E2E environments only cover up to Cilium 1.11; all metrics from 1.12 onward are unit-tested against fixture data only.

### Motivation

Metrics from recent cilium releases were missing.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
