### PR TITLE
Add developer documentation for file-based metrics loading

### DIFF
--- a/datadog_checks_base/changelog.d/22773.added
+++ b/datadog_checks_base/changelog.d/22773.added
@@ -1,0 +1,1 @@
+Improve docstrings in metrics_mapping module for cleaner API reference rendering.

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/metrics_mapping.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/metrics_mapping.py
@@ -27,9 +27,11 @@ reference this directly.
 
 class MetricsPredicate(Protocol):
     """
-    Protocol for predicates that control whether a metrics mapping should be loaded.
+    Protocol for conditional metrics loading.
 
-    Implement ``should_load`` to create custom loading conditions.
+    Any class with a ``should_load(self, config) -> bool`` method satisfies
+    this protocol and can be used as a predicate in ``MetricsMapping``. No
+    inheritance or registration is required.
     """
 
     def should_load(self, config: InstanceType) -> bool: ...
@@ -37,10 +39,15 @@ class MetricsPredicate(Protocol):
 
 class ConfigOptionTruthy:
     """
-    Load metrics only if a configuration option is truthy.
+    Load metrics when a config option is truthy; skip when it is falsy.
 
-    Uses ``is_affirmative`` to evaluate the value. Defaults to ``True``
-    (include metrics unless explicitly disabled).
+    Uses ``is_affirmative`` to evaluate the option value. When the option is
+    absent from the config, ``default`` is used (``True`` by default, so
+    metrics are included unless explicitly disabled).
+
+    Args:
+        option: The instance config key to evaluate.
+        default: Fallback value when the option is not present.
     """
 
     def __init__(self, option: str, default: bool = True) -> None:
@@ -53,10 +60,14 @@ class ConfigOptionTruthy:
 
 class ConfigOptionEquals:
     """
-    Load metrics only if a configuration option equals a specific value.
+    Load metrics when a config option equals a specific value; skip otherwise.
 
     A missing key compares equal to ``None``: ``ConfigOptionEquals("flag", None)``
     matches both ``{"flag": None}`` and instances that omit the key entirely.
+
+    Args:
+        option: The instance config key to evaluate.
+        value: The exact value the option must equal.
     """
 
     def __init__(self, option: str, value: Any) -> None:
@@ -69,9 +80,13 @@ class ConfigOptionEquals:
 
 class AllOf:
     """
-    Compose predicates: all must pass for the metrics to be loaded.
+    Conjunction of predicates; all must pass for the metrics to be loaded.
 
-    Follows Python's ``all()`` semantics: returns ``True`` when empty.
+    Follows Python's ``all()`` semantics: returns ``True`` when given no
+    predicates.
+
+    Args:
+        predicates: One or more ``MetricsPredicate`` instances to evaluate.
     """
 
     def __init__(self, *predicates: MetricsPredicate) -> None:
@@ -83,9 +98,13 @@ class AllOf:
 
 class AnyOf:
     """
-    Compose predicates: any passing is sufficient to load the metrics.
+    Disjunction of predicates; any one passing is sufficient to load the metrics.
 
-    Follows Python's ``any()`` semantics: returns ``False`` when empty.
+    Follows Python's ``any()`` semantics: returns ``False`` when given no
+    predicates.
+
+    Args:
+        predicates: One or more ``MetricsPredicate`` instances to evaluate.
     """
 
     def __init__(self, *predicates: MetricsPredicate) -> None:
@@ -98,16 +117,23 @@ class AnyOf:
 @dataclass(frozen=True)
 class MetricsMapping:
     """
-    Declares a YAML file with metric name mappings to load automatically.
+    Declares a single YAML file containing metric name mappings to load automatically.
 
     Use in the ``METRICS_MAP`` class variable of ``OpenMetricsBaseCheckV2``
-    subclasses. The YAML file should contain a flat mapping of Prometheus
-    metric names to Datadog metric names::
+    subclasses. The path is relative to the package directory. An optional
+    predicate controls whether the file is loaded for a given instance config;
+    when omitted, the file is always loaded.
+
+    Example::
 
         METRICS_MAP = (
             MetricsMapping(Path("metrics/default.yaml")),
             MetricsMapping(Path("metrics/go.yaml"), predicate=ConfigOptionTruthy("go_metrics")),
         )
+
+    Args:
+        path: Path to the YAML metrics file, relative to the package directory.
+        predicate: Optional condition that gates loading. Defaults to always load.
     """
 
     path: Path

--- a/docs/developer/base/openmetrics-metrics-files.md
+++ b/docs/developer/base/openmetrics-metrics-files.md
@@ -1,0 +1,147 @@
+# Metrics Files
+
+-----
+
+Instead of hardcoding metric name mappings in Python or requiring per-instance user configuration, integrations can ship mappings as YAML files alongside the check module. The base class discovers and loads these files automatically and merges them into the scraper configuration before each scrape.
+
+For the user-level `metrics` configuration option, the
+[generic OpenMetrics check documentation](https://docs.datadoghq.com/integrations/guide/prometheus-host-collection/)
+covers the supported formats. The generic check exposes a default configuration that does not apply to all
+OpenMetrics-based integrations; each integration surfaces its own set of options. See the individual
+integration's documentation for the full reference (for example, the
+[KrakenD integration](https://docs.datadoghq.com/integrations/krakend/)).
+
+## Metrics File Format
+
+A metrics file is a YAML document containing a flat mapping of Prometheus metric names to Datadog metric names. The same formats supported by the `metrics` instance option are valid here.
+
+**Simple rename:**
+
+```yaml
+go_goroutines: go.goroutines
+go_threads: go.threads
+```
+
+**Rename with type override:**
+
+```yaml
+some_counter:
+  name: my.counter
+  type: counter
+```
+
+**Regex rename:**
+
+```yaml
+"(?P<name>.+)_total$": \g<name>
+```
+
+All keys in a single file are merged into the `metrics` list of the scraper configuration.
+
+## Convention-Based Discovery
+
+When `METRICS_MAP` is not set on the check class, the base class searches for a metrics file next to the check module automatically. The lookup order is:
+
+1. `metrics.yaml`
+2. `metrics.yml`
+
+The first match is loaded; if both exist, `.yaml` takes precedence. No code is required. Drop the file in the right place and the base class handles the rest.
+
+## Explicit Declaration with `METRICS_MAP`
+
+For integrations that ship multiple files or need to load files conditionally, declare `METRICS_MAP` as a class variable. The presence of `METRICS_MAP` (even if empty) suppresses convention-based discovery entirely.
+
+```python
+from pathlib import Path
+
+from datadog_checks.base.checks.openmetrics.v2 import (
+    ConfigOptionTruthy,
+    MetricsMapping,
+    OpenMetricsBaseCheckV2,
+)
+
+
+class MyCheck(OpenMetricsBaseCheckV2):
+    METRICS_MAP = (
+        MetricsMapping(Path("metrics/default.yaml")),
+        MetricsMapping(Path("metrics/go.yaml"), predicate=ConfigOptionTruthy("go_metrics")),
+        MetricsMapping(Path("metrics/process.yaml"), predicate=ConfigOptionTruthy("process_metrics")),
+    )
+```
+
+Paths in `METRICS_MAP` are relative to the package directory (the directory containing the check module). Files listed without a predicate are always loaded.
+
+## Conditional Loading with Predicates
+
+Any `MetricsMapping` can carry a predicate. When the predicate returns `False` for the current instance configuration, the file is skipped. A single check class can cover deployments that expose different metric sets based on their configuration.
+
+```python
+MetricsMapping(Path("metrics/go.yaml"), predicate=ConfigOptionTruthy("go_metrics"))
+```
+
+The file `metrics/go.yaml` is loaded only when the instance option `go_metrics` is truthy. When the option is absent, it defaults to `True`, so metrics are included unless explicitly disabled.
+
+Predicates are evaluated once per check instance, against the configuration at the time of the first scrape. For the full list of built-in predicates, see the [API Reference](#api-reference) below.
+
+### Custom Predicates
+
+Any class with a `should_load(self, config: Mapping) -> bool` method satisfies the `MetricsPredicate` protocol and can be used directly. No inheritance or registration is required:
+
+```python
+class MyPredicate:
+    def should_load(self, config: Mapping) -> bool:
+        return config.get("mode") in ("advanced", "full")
+
+
+class MyCheck(OpenMetricsBaseCheckV2):
+    METRICS_MAP = (
+        MetricsMapping(Path("metrics/default.yaml")),
+        MetricsMapping(Path("metrics/extra.yaml"), predicate=MyPredicate()),
+    )
+```
+
+## Customizing Defaults with `get_default_config`
+
+`get_default_config()` is the hook for providing instance-level scraper defaults. File-based metrics are merged on top of whatever this method returns, so you can combine file metrics with other defaults such as `rename_labels`:
+
+```python
+class MyCheck(OpenMetricsBaseCheckV2):
+    def get_default_config(self) -> dict:
+        return {
+            "rename_labels": {"exported_job": "job"},
+        }
+```
+
+The returned dict may be mutated by the framework before it is wrapped in a `ChainMap`. Return a fresh dict on every call. Returning a shared class-level or instance-level object can cause state leakage between check executions.
+
+## API Reference
+
+::: datadog_checks.base.checks.openmetrics.v2.metrics_mapping.MetricsMapping
+    options:
+      heading_level: 3
+      members: false
+
+::: datadog_checks.base.checks.openmetrics.v2.metrics_mapping.MetricsPredicate
+    options:
+      heading_level: 3
+      members: false
+
+::: datadog_checks.base.checks.openmetrics.v2.metrics_mapping.ConfigOptionTruthy
+    options:
+      heading_level: 3
+      members: false
+
+::: datadog_checks.base.checks.openmetrics.v2.metrics_mapping.ConfigOptionEquals
+    options:
+      heading_level: 3
+      members: false
+
+::: datadog_checks.base.checks.openmetrics.v2.metrics_mapping.AllOf
+    options:
+      heading_level: 3
+      members: false
+
+::: datadog_checks.base.checks.openmetrics.v2.metrics_mapping.AnyOf
+    options:
+      heading_level: 3
+      members: false

--- a/docs/developer/base/openmetrics.md
+++ b/docs/developer/base/openmetrics.md
@@ -2,7 +2,18 @@
 
 -----
 
-OpenMetrics is used for collecting metrics using the CNCF-backed OpenMetrics format. This version is the default version for all new OpenMetric-checks, and it is compatible with Python 3 only.
+OpenMetrics V2 is the current Prometheus/OpenMetrics scraping framework for Datadog integrations. It is Python 3 only and is the default for all new OpenMetrics-based checks.
+
+The base class handles the full scrape lifecycle: HTTP connection management, metric parsing, label renaming, type overrides, and submission to the Agent. Integration authors subclass `OpenMetricsBaseCheckV2` and configure it through instance options or by overriding a small set of hooks.
+
+For user-level configuration (the `metrics` instance option, label renaming, type overrides), the
+[generic OpenMetrics check documentation](https://docs.datadoghq.com/integrations/guide/prometheus-host-collection/)
+covers the supported formats. The generic check exposes a default configuration that does not apply to all
+OpenMetrics-based integrations; each integration surfaces its own set of options. See the individual
+integration's documentation for the full reference (for example, the
+[KrakenD integration](https://docs.datadoghq.com/integrations/krakend/)).
+
+For bundling metric name mappings as YAML files alongside the check module, see [Metrics Files](openmetrics-metrics-files.md).
 
 ## Interface
 
@@ -14,6 +25,7 @@ OpenMetrics is used for collecting metrics using the CNCF-backed OpenMetrics for
         - check
         - configure_scrapers
         - create_scraper
+        - get_default_config
 
 ## Scrapers
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,7 +54,9 @@ nav:
     - HTTP: base/http.md
     - TLS/SSL: base/tls.md
     - Databases: base/databases.md
-    - OpenMetrics: base/openmetrics.md
+    - OpenMetrics:
+      - Overview: base/openmetrics.md
+      - Metrics Files: base/openmetrics-metrics-files.md
     - Log Crawlers: base/logs-crawlers.md
     - Metadata: base/metadata.md
     - Persistent Cache: base/persistent-cache.md


### PR DESCRIPTION
> **Stacked PR 4/4** — This is part of a series to enable file-based YAML metrics loading for OpenMetrics V2 checks, eliminating the need for Python `metrics.py` modules when the only purpose is simple metric name mapping.
>
> * Stack 1: [**PR-22749**](https://github.com/DataDog/integrations-core/pull/22749) `_get_package_dir` utility on AgentCheck
> * Stack 2: [**PR-22750**](https://github.com/DataDog/integrations-core/pull/22750) File-based YAML metrics loading infrastructure + composable predicates
> * Stack 3: [**PR-22751**](https://github.com/DataDog/integrations-core/pull/22751) Krakend migration (proof of concept)
> * Stack 4: [**PR-22773**](https://github.com/DataDog/integrations-core/pull/22773) Developer documentation for file-based metrics loading **<-- you are here**

### What does this PR do?

Adds developer documentation for the file-based YAML metrics loading feature introduced in Stack 2.

- **New page** `docs/developer/base/openmetrics-metrics-files.md` covering the full feature: metrics file format, convention-based discovery, `METRICS_MAP` explicit declaration, conditional loading with predicates, custom predicates, and `get_default_config`.
- **Updated** `docs/developer/base/openmetrics.md` with an introductory prose section and a cross-reference to the new page. Also adds `get_default_config` to the autodoc Interface section.
- **Updated** `mkdocs.yml` to nest both OpenMetrics pages under an **OpenMetrics** section in the Base Package nav.
- **Improved docstrings** in `metrics_mapping.py` so the API Reference renders cleanly (class descriptions only, no noisy `__init__`/`should_load` stubs).

### Motivation

The feature landed in Stack 2 with no developer-facing documentation. Integration authors discovering `OpenMetricsBaseCheckV2` would have no guidance on how to use `METRICS_MAP`, the predicate system, or convention-based discovery.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.