### PR TITLE
Test bits dev agent

### DIFF
--- a/.github/workflows/run-validations.yml
+++ b/.github/workflows/run-validations.yml
@@ -144,10 +144,12 @@ jobs:
       run: pip install ddev${{ inputs.ddev-version }}
 
     - name: Configure ddev
+      env:
+        REPO_NAME: ${{ inputs.repo }}
       run: |
         ddev config set upgrade_check false
-        ddev config set repos.${{ inputs.repo }} .
-        ddev config set repo ${{ inputs.repo }}
+        ddev config set repos.${REPO_NAME} .
+        ddev config set repo ${REPO_NAME}
         ddev config set orgs.ci.dd_url "https://app.datadoghq.com"
         ddev config set org ci
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"88f820d4-da64-4cd5-8e71-62d5d6b1e56c","source":"chat","resourceId":"4783b319-9745-4510-98f3-67635ef0d5ec","workflowId":"39759ac2-2e58-4927-8551-f0c4dbba543c","codeChangeId":"39759ac2-2e58-4927-8551-f0c4dbba543c","sourceType":"csv_campaign"} -->
### What does this PR do?
Fixes a GitHub Actions template injection vulnerability in the "Configure ddev" step of `.github/workflows/run-validations.yml` by replacing inline `${{ inputs.repo }}` expansions with a shell environment variable.

### Motivation
The `${{ inputs.repo }}` expression was used directly in a `run:` block, which is vulnerable to code injection via template expansion ([zizmor audit](#removed-for-safety)). Moving it to an `env:` block and referencing it as `${REPO_NAME}` ensures the value is safely passed through the shell environment rather than interpolated into the script body.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

<a name="removed-for-safety"></a>
> **_NOTE:_** some AI-generated links and images were removed to ensure safety.

---

PR by Bits from Dev Agent Campaign
[View session in Datadog](https://app.datadoghq.com/code/4783b319-9745-4510-98f3-67635ef0d5ec) • [View in Dev Agent Campaign](https://app.datadoghq.com/code/campaigns/c-429884e7)

Comment @datadog to request changes