### PR TITLE
Fixing memory.usage OID

### DIFF
--- a/snmp/datadog_checks/snmp/data/default_profiles/peplink.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/peplink.yaml
@@ -26,7 +26,7 @@ metrics:
       OID: 1.3.6.1.4.1.23695.200.1.1.1.3.2.0
   - MIB: PEPLINK-DEVICE
     symbol:
-      name: memory.usage
+      name: memory.used
       OID: 1.3.6.1.4.1.23695.200.1.1.1.3.3.0
   - MIB: PEPLINK-DEVICE
     symbol:


### PR DESCRIPTION
1.3.6.1.4.1.23695.200.1.1.1.3.3.0 is memory.used not memory.usage

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
