### PR TITLE
Document histogram to distribution limitation for Prometheus federate endpoints

### DIFF
--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -208,6 +208,14 @@ instances:
     ## Whether or not to send histogram buckets as Datadog distribution metrics. This implicitly
     ## enables the `collect_histogram_buckets` and `non_cumulative_histogram_buckets` options.
     ##
+    ## IMPORTANT:
+    ## - This option requires scraping an endpoint that exposes full Prometheus /
+    ##   OpenMetrics metadata (for example, `#TYPE <metric> histogram` and standard
+    ##   bucket labels). Prometheus *federate* endpoints strip `#TYPE` / `#HELP`
+    ##   information and expose metrics as untyped; they are not supported with
+    ##   `histogram_buckets_as_distributions` and may cause histogram processing
+    ##   errors.
+    ##
     ## Learn more about distribution metrics:
     ## https://docs.datadoghq.com/developers/metrics/types/?tab=distribution#metric-types
     #


### PR DESCRIPTION
The OpenMetrics v2 code path relies on full metric metadata (#TYPE, #HELP) and normalized bucket labels when converting Prometheus histograms to Datadog distributions using histogram_buckets_as_distributions.

Prometheus federated endpoints strip this metadata and expose metrics as untyped, which means the Agent cannot safely detect and normalize histograms. In practice this leads to errors such as KeyError: 'upper_bound' when forcing type: histogram on federated histogram buckets.

This PR makes that limitation explicit in the openmetrics configuration example so users don’t attempt to enable histogram_buckets_as_distributions against federated endpoints.

This behavior was confirmed by engineering during a recent escalation: https://datadoghq.atlassian.net/browse/AGENT-15755?focusedCommentId=3069904

### What does this PR do?
Document that the configuration option `histogram_buckets_as_distributions` does not support Prometheus federate endpoints.

### Motivation
This issue came up during a recent escalation because the limitation isn't properly documented: https://datadoghq.atlassian.net/browse/AGENT-15755?focusedCommentId=3069904

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
