### PR TITLE
Transfer kafka_actions ownership to data-streams-monitoring

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -176,9 +176,9 @@ datadog_checks_base/tests/**/test_db_statements.py  @DataDog/database-monitoring
 /clickhouse/manifest.json                           @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation
 
 # Data Streams Monitoring
-/kafka_actions/                                     @DataDog/data-streams-monitoring @DataDog/agent-integrations
-/kafka_actions/*.md                                 @DataDog/data-streams-monitoring @DataDog/agent-integrations @DataDog/documentation
-/kafka_actions/manifest.json                        @DataDog/data-streams-monitoring @DataDog/agent-integrations @DataDog/documentation
+/kafka_actions/                                     @DataDog/data-streams-monitoring
+/kafka_actions/*.md                                 @DataDog/data-streams-monitoring @DataDog/documentation
+/kafka_actions/manifest.json                        @DataDog/data-streams-monitoring @DataDog/documentation
 
 # APM Integrations
 /langchain/         @DataDog/ml-observability @DataDog/agent-integrations @DataDog/documentation


### PR DESCRIPTION
## Summary

Changes ownership of the kafka_actions integrations to be `data-streams-monitoring` team only.
This integration is used by a new product from Data Streams Monitoring for performing actions (reading messages, producing messages, etc) on Kafka.