### PR TITLE
SEC-29280: Add BlueCat Edge integration manifest

### DIFF
--- a/bluecat_edge/assets/dataflows.yaml
+++ b/bluecat_edge/assets/dataflows.yaml
@@ -1,0 +1,4 @@
+provides:
+  - id: bluecat-edge-dns-query-logs
+    always_on: false
+    granular: true

--- a/bluecat_edge/manifest.json
+++ b/bluecat_edge/manifest.json
@@ -3,7 +3,7 @@
   "app_uuid": "ccd5850d-3e2d-49ab-8f9c-b8f796a20760",
   "app_id": "bluecat-edge",
   "owner": "saas-integrations",
-  "display_on_public_website": false,
+  "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
## What does this PR do?
Creates the `bluecat_edge/` integration directory with:
- `manifest.json` — sets `display_on_public_website: true`, `source_type_name: BlueCat Edge`, `source: bluecat-edge`
- `CHANGELOG.md` — initial GA release entry

**Note:** `source_type_id` in the manifest is currently `0` — needs to be updated with the actual numeric ID from the `dd_source_types` table before merging.

## Why is this being done?
Bluecat Edge is going GA as a Cloud SIEM log source (SEC-29280). This PR enables the public documentation tile on the Datadog integrations page.