### PR TITLE
Robust handling of audit log file rotation 

### DIFF
--- a/mac_audit_logs/changelog.d/22925.fixed
+++ b/mac_audit_logs/changelog.d/22925.fixed
@@ -1,0 +1,1 @@
+Robust handling of audit log file rotation. The check can keep up with audit log files that get rotated every few seconds.

--- a/mac_audit_logs/changelog.d/22925.fixed
+++ b/mac_audit_logs/changelog.d/22925.fixed
@@ -1,1 +1,1 @@
-Robust handling of audit log file rotation. The check can keep up with audit log files that get rotated every few seconds.
+Batch audit log files into a single auditreduce invocation so the check keeps up with frequent file rotation.

--- a/mac_audit_logs/datadog_checks/mac_audit_logs/check.py
+++ b/mac_audit_logs/datadog_checks/mac_audit_logs/check.py
@@ -110,14 +110,13 @@ class MacAuditLogsCheck(AgentCheck):
 
         return last_record_time, last_record_milli_sec, last_collected_file_name
 
-    def fetch_audit_logs(self, file_path, time_filter_arg) -> Tuple[str, str]:
+    def fetch_audit_logs(self, file_paths: list[str], time_filter_arg) -> tuple[str, str]:
         output = error = ""
 
-        auditreduce_command = f"sudo auditreduce -a {time_filter_arg} {file_path}"
+        auditreduce_command = f"sudo auditreduce -a {time_filter_arg} {' '.join(file_paths)}"
         praudit_command = "sudo praudit -xsl"
 
         try:
-            # use TZ=UTC because auditreduce does not translate daylight savings to UTC and always uses standard time
             auditreduce_process = subprocess.Popen(
                 auditreduce_command,
                 shell=True,
@@ -140,7 +139,7 @@ class MacAuditLogsCheck(AgentCheck):
             return output, error
 
         except Exception as e:
-            err_message = f"Error processing file {file_path}: {e}"
+            err_message = f"Error processing files {file_paths}: {e}"
             self.log.exception(constants.LOG_TEMPLATE.format(message=err_message))
         finally:
             message = "Processes auditreduce and praudit have been closed."
@@ -263,7 +262,7 @@ class MacAuditLogsCheck(AgentCheck):
             time_filter_arg = last_record_time if file_index == 0 else start_time_str
 
             try:
-                output, error = self.fetch_audit_logs(file_path, time_filter_arg)
+                output, error = self.fetch_audit_logs([file_path], time_filter_arg)
 
                 output_str = output.decode("utf-8", errors="replace")
 

--- a/mac_audit_logs/datadog_checks/mac_audit_logs/check.py
+++ b/mac_audit_logs/datadog_checks/mac_audit_logs/check.py
@@ -19,7 +19,6 @@ from . import constants, utils
 
 
 class MacAuditLogsCheck(AgentCheck):
-    # This will be the prefix of every metric and service check the integration sends
     __NAMESPACE__ = "mac_audit_logs"
 
     def __init__(self, name, init_config, instances):
@@ -59,7 +58,6 @@ class MacAuditLogsCheck(AgentCheck):
             if file_name == "current":
                 continue
 
-            # Skip directories
             file_path = os.path.join(self.audit_logs_dir_path, file_name)
             if not os.path.isfile(file_path):
                 self.log.debug(constants.LOG_TEMPLATE.format(message=f"Skipping non-file entry: {file_name}"))
@@ -84,11 +82,9 @@ class MacAuditLogsCheck(AgentCheck):
 
                 end_time = utils.time_string_to_datetime_utc(end_time_str)
 
-                # Include all the files which are withing the time interval
                 if start_time <= last_record_datetime <= end_time or last_record_datetime < start_time:
                     relevant_files.append((start_time, file_name))
             else:
-                # Skip files that don't match the expected audit log format
                 self.log.debug(
                     constants.LOG_TEMPLATE.format(message=f"Skipping file with unexpected format: {file_name}")
                 )
@@ -159,13 +155,9 @@ class MacAuditLogsCheck(AgentCheck):
                 time_value = data_xml.get("time")
                 milli_sec_value = data_xml.get("msec")
 
-                # This condition is used to reduce the duplicacy of the records.
-                # Skip records until not find the last ingested record milli second time value
                 if last_record_milli_sec and last_record_milli_sec != milli_sec_value:
                     continue
 
-                # Set the `last_record_milli_sec` None when reach the last ingested record's milli second time value
-                # Once set to None skipping logic will be not initiated
                 if last_record_milli_sec == milli_sec_value:
                     last_record_milli_sec = None
 
@@ -176,15 +168,9 @@ class MacAuditLogsCheck(AgentCheck):
                 cursor["file_name"] = file
 
                 if log_index + 1 == total_entries:
-                    # Set `record_milli_sec` to None and `is_file_collection_completed` to True
-                    # when reach the last entry of the file. This indicates the successful
-                    # execution of the particular file
                     cursor["record_milli_sec"] = None
                     cursor["is_file_collection_completed"] = True
                 else:
-                    # Set `record_milli_sec` to millisecond  time value of record and
-                    # `is_file_collection_completed` to False for remaining entries
-                    # This indicates the ongoing execution of the file
                     cursor["record_milli_sec"] = milli_sec_value
                     cursor["is_file_collection_completed"] = False
 
@@ -311,7 +297,6 @@ class MacAuditLogsCheck(AgentCheck):
 
             timezone_offset = subprocess.run(["date", "+%z"], capture_output=True, text=True).stdout.strip()
 
-            # Collect all the files from `audit_logs_dir_path` path which falls under the time range
             relevant_files = self.collect_relevant_files(last_record_time)
 
             if (

--- a/mac_audit_logs/datadog_checks/mac_audit_logs/check.py
+++ b/mac_audit_logs/datadog_checks/mac_audit_logs/check.py
@@ -203,6 +203,45 @@ class MacAuditLogsCheck(AgentCheck):
                 self.log.exception(constants.LOG_TEMPLATE.format(message=err_message))
                 raise
 
+    def _should_skip_file(self, file, previous_cursor, last_collected_file_name, last_record_time) -> bool:
+        start_time_str, end_time_str = file.split(".")
+
+        if end_time_str not in ["not_terminated", "crash_recovery"] and utils.time_string_to_datetime_utc(
+            end_time_str
+        ) < utils.time_string_to_datetime_utc(utils.get_utc_timestamp_minus_hours(constants.HOURS_OFFSET)):
+            self.log.info(
+                constants.LOG_TEMPLATE.format(
+                    message=f"Skipping the log collection of {file} file as logs are not within the "
+                    f"last {constants.HOURS_OFFSET} hours timeframe."
+                )
+            )
+            return True
+
+        if not previous_cursor:
+            return False
+
+        cursor_file_start_time_str, cursor_file_end_time_str = last_collected_file_name.split(".")
+
+        if (
+            cursor_file_end_time_str == "not_terminated"
+            and previous_cursor["is_file_collection_completed"]
+            and cursor_file_start_time_str == start_time_str
+            and last_record_time == end_time_str
+        ):
+            self.log.debug(f"Skipping the collection of {file} file")  # noqa: G004
+            return True
+
+        if (last_collected_file_name == file and previous_cursor["is_file_collection_completed"]) or (
+            end_time_str not in ["not_terminated", "crash_recovery"]
+            and utils.time_string_to_datetime_utc(start_time_str) <= utils.time_string_to_datetime_utc(last_record_time)
+            and utils.time_string_to_datetime_utc(end_time_str) == utils.time_string_to_datetime_utc(last_record_time)
+            and last_collected_file_name != file
+        ):
+            self.log.debug(f"Skipping the collection of {file} file")  # noqa: G004
+            return True
+
+        return False
+
     def collect_data_from_files(
         self,
         relevant_files,
@@ -212,74 +251,45 @@ class MacAuditLogsCheck(AgentCheck):
         last_record_milli_sec,
         timezone_offset,
     ) -> None:
-        for file_index, (_, file) in enumerate(relevant_files):
+        valid_file_paths = []
+        for _, file in relevant_files:
             file_path = os.path.join(self.audit_logs_dir_path, file)
 
             if not os.path.exists(file_path):
-                message = f"{file_path} is not available. Skipping collection for this file."
-                self.log.info(constants.LOG_TEMPLATE.format(message=message))
-                continue
-
-            start_time_str, end_time_str = file.split(".")
-
-            # Skip execution of the file if it is not falls within the time range
-            if end_time_str not in ["not_terminated", "crash_recovery"] and utils.time_string_to_datetime_utc(
-                end_time_str
-            ) < utils.time_string_to_datetime_utc(utils.get_utc_timestamp_minus_hours(constants.HOURS_OFFSET)):
-                err_message = (
-                    f"Skipping the log collection of {file} file as logs are not within the "
-                    f"last {constants.HOURS_OFFSET} hours timeframe."
-                )
-                self.log.info(constants.LOG_TEMPLATE.format(message=err_message))
-                continue
-
-            if previous_cursor:
-                cursor_file_start_time_str, cursor_file_end_time_str = last_collected_file_name.split(".")
-                # If last proccessed file is `not_terminated`, Skip the already processed files
-                if (
-                    cursor_file_end_time_str == "not_terminated"
-                    and previous_cursor["is_file_collection_completed"]
-                    and cursor_file_start_time_str == start_time_str
-                    and last_record_time == end_time_str
-                ):
-                    self.log.debug(f"Skipping the collection of {file} file")  # noqa: G004
-                    continue
-
-                # Skip the file if it has been already processed
-                if (last_collected_file_name == file and previous_cursor["is_file_collection_completed"]) or (
-                    end_time_str not in ["not_terminated", "crash_recovery"]
-                    and utils.time_string_to_datetime_utc(start_time_str)
-                    <= utils.time_string_to_datetime_utc(last_record_time)
-                    and utils.time_string_to_datetime_utc(end_time_str)
-                    == utils.time_string_to_datetime_utc(last_record_time)
-                    and last_collected_file_name != file
-                ):
-                    self.log.debug(f"Skipping the collection of {file} file")  # noqa: G004
-                    continue
-
-            # Prepare time filter argument for auditreduce command. Set `last_record_time` as a value if
-            # the first file to be processed otherwise set this to start-time of file
-            time_filter_arg = last_record_time if file_index == 0 else start_time_str
-
-            try:
-                output, error = self.fetch_audit_logs([file_path], time_filter_arg)
-
-                output_str = output.decode("utf-8", errors="replace")
-
-                if not output_str.strip():
-                    err_message = (
-                        f"praudit command produced no output. Error: {error.decode('utf-8', errors='replace')}"
+                self.log.info(
+                    constants.LOG_TEMPLATE.format(
+                        message=f"{file_path} is not available. Skipping collection for this file."
                     )
-                    self.log.error(constants.LOG_TEMPLATE.format(message=err_message))
-                    continue
+                )
+                continue
 
-                log_entries = output_str.strip().split("\n")
+            if self._should_skip_file(file, previous_cursor, last_collected_file_name, last_record_time):
+                continue
 
-                self.process_and_ingest_log_entries(log_entries, file, timezone_offset, last_record_milli_sec)
+            valid_file_paths.append(file_path)
 
-            except Exception as e:
-                err_message = f"Error processing file {file}: {e}"
-                self.log.exception(constants.LOG_TEMPLATE.format(message=err_message))
+        if not valid_file_paths:
+            return
+
+        last_file = os.path.basename(valid_file_paths[-1])
+
+        try:
+            output, error = self.fetch_audit_logs(valid_file_paths, last_record_time)
+
+            output_str = output.decode("utf-8", errors="replace")
+
+            if not output_str.strip():
+                err_message = f"praudit command produced no output. Error: {error.decode('utf-8', errors='replace')}"
+                self.log.error(constants.LOG_TEMPLATE.format(message=err_message))
+                return
+
+            log_entries = output_str.strip().split("\n")
+
+            self.process_and_ingest_log_entries(log_entries, last_file, timezone_offset, last_record_milli_sec)
+
+        except Exception as e:
+            err_message = f"Error processing files {valid_file_paths}: {e}"
+            self.log.exception(constants.LOG_TEMPLATE.format(message=err_message))
 
     def check(self, _):
         try:

--- a/mac_audit_logs/datadog_checks/mac_audit_logs/check.py
+++ b/mac_audit_logs/datadog_checks/mac_audit_logs/check.py
@@ -4,7 +4,6 @@
 import os
 import subprocess
 from datetime import datetime
-from typing import List, Tuple
 from xml.etree.ElementTree import ParseError
 
 from lxml import etree
@@ -47,7 +46,7 @@ class MacAuditLogsCheck(AgentCheck):
             self.log.error(constants.LOG_TEMPLATE.format(message=err_message))
             raise ConfigurationError(err_message)
 
-    def collect_relevant_files(self, last_record_time: str) -> List[Tuple[datetime, str]]:
+    def collect_relevant_files(self, last_record_time: str) -> list[tuple[datetime, str]]:
         if not os.path.isdir(self.audit_logs_dir_path):
             err_message = (
                 f"`{self.audit_logs_dir_path}` directory does not exist. Please ensure BSM auditing is enabled."
@@ -97,7 +96,7 @@ class MacAuditLogsCheck(AgentCheck):
         relevant_files.sort(key=lambda x: (x[1].endswith('.not_terminated'), x[0]))
         return relevant_files
 
-    def get_previous_iteration_log_cursor(self, previous_cursor) -> Tuple[str, str, str]:
+    def get_previous_iteration_log_cursor(self, previous_cursor) -> tuple[str, str | None, str | None]:
         last_record_time = utils.get_utc_timestamp_minus_hours(constants.HOURS_OFFSET)
         last_record_milli_sec = None
         last_collected_file_name = None

--- a/mac_audit_logs/datadog_checks/mac_audit_logs/check.py
+++ b/mac_audit_logs/datadog_checks/mac_audit_logs/check.py
@@ -105,13 +105,14 @@ class MacAuditLogsCheck(AgentCheck):
 
         return last_record_time, last_record_milli_sec, last_collected_file_name
 
-    def fetch_audit_logs(self, file_paths: list[str], time_filter_arg) -> tuple[str, str]:
-        output = error = ""
+    def fetch_audit_logs(self, file_paths: list[str], time_filter_arg: str) -> tuple[bytes, bytes]:
+        output = error = b""
 
         auditreduce_command = f"sudo auditreduce -a {time_filter_arg} {' '.join(file_paths)}"
         praudit_command = "sudo praudit -xsl"
 
         try:
+            # use TZ=UTC because auditreduce does not translate daylight savings to UTC and always uses standard time
             auditreduce_process = subprocess.Popen(
                 auditreduce_command,
                 shell=True,
@@ -188,7 +189,13 @@ class MacAuditLogsCheck(AgentCheck):
                 self.log.exception(constants.LOG_TEMPLATE.format(message=err_message))
                 raise
 
-    def _should_skip_file(self, file, previous_cursor, last_collected_file_name, last_record_time) -> bool:
+    def _should_skip_file(
+        self,
+        file: str,
+        previous_cursor: dict | None,
+        last_collected_file_name: str | None,
+        last_record_time: str,
+    ) -> bool:
         start_time_str, end_time_str = file.split(".")
 
         if end_time_str not in ["not_terminated", "crash_recovery"] and utils.time_string_to_datetime_utc(
@@ -256,7 +263,7 @@ class MacAuditLogsCheck(AgentCheck):
         if not valid_file_paths:
             return
 
-        last_file = os.path.basename(valid_file_paths[-1])
+        first_file = os.path.basename(valid_file_paths[0])
 
         try:
             output, error = self.fetch_audit_logs(valid_file_paths, last_record_time)
@@ -270,7 +277,7 @@ class MacAuditLogsCheck(AgentCheck):
 
             log_entries = output_str.strip().split("\n")
 
-            self.process_and_ingest_log_entries(log_entries, last_file, timezone_offset, last_record_milli_sec)
+            self.process_and_ingest_log_entries(log_entries, first_file, timezone_offset, last_record_milli_sec)
 
         except Exception as e:
             err_message = f"Error processing files {valid_file_paths}: {e}"

--- a/mac_audit_logs/datadog_checks/mac_audit_logs/check.py
+++ b/mac_audit_logs/datadog_checks/mac_audit_logs/check.py
@@ -189,8 +189,8 @@ class MacAuditLogsCheck(AgentCheck):
                     "record_time": utils.convert_local_to_utc_timezone_timestamp_str(time_value, timezone_offset),
                     "record_milli_sec": None if is_last_in_batch else milli_sec_value,
                     "is_file_collection_completed": is_last_in_batch,
-                    "last_completed_closed": completed_closed,
-                    "last_completed_open": completed_open,
+                    "last_completed_closed": completed_closed if is_last_in_batch else [],
+                    "last_completed_open": completed_open if is_last_in_batch else [],
                 }
 
                 data = {"timestamp": get_timestamp(datetime_aware), "message": log}

--- a/mac_audit_logs/datadog_checks/mac_audit_logs/check.py
+++ b/mac_audit_logs/datadog_checks/mac_audit_logs/check.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2025-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import bisect
 import os
 import subprocess
 from datetime import datetime
@@ -45,15 +46,21 @@ class MacAuditLogsCheck(AgentCheck):
             self.log.error(constants.LOG_TEMPLATE.format(message=err_message))
             raise ConfigurationError(err_message)
 
-    def collect_relevant_files(self, last_record_time: str) -> list[tuple[datetime, str]]:
+    def collect_relevant_files(
+        self, last_record_time: str
+    ) -> tuple[list[tuple[datetime, datetime, str]], list[tuple[datetime, str]]]:
         if not os.path.isdir(self.audit_logs_dir_path):
             err_message = (
                 f"`{self.audit_logs_dir_path}` directory does not exist. Please ensure BSM auditing is enabled."
             )
             self.log.error(constants.LOG_TEMPLATE.format(message=err_message))
-            return []
+            return [], []
 
-        relevant_files = []
+        closed: list[tuple[datetime, datetime, str]] = []
+        still_open: list[tuple[datetime, str]] = []
+        lookback_cutoff = utils.time_string_to_datetime_utc(utils.get_utc_timestamp_minus_hours(constants.HOURS_OFFSET))
+        last_record_datetime = utils.time_string_to_datetime_utc(last_record_time)
+
         for file_name in os.listdir(self.audit_logs_dir_path):
             if file_name == "current":
                 continue
@@ -63,47 +70,56 @@ class MacAuditLogsCheck(AgentCheck):
                 self.log.debug(constants.LOG_TEMPLATE.format(message=f"Skipping non-file entry: {file_name}"))
                 continue
 
-            if file_name.count(".") == 1:
-                start_time_str, end_time_str = file_name.split(".")
-
-                start_time = utils.time_string_to_datetime_utc(start_time_str)
-                last_record_datetime = utils.time_string_to_datetime_utc(last_record_time)
-
-                if end_time_str == "not_terminated":
-                    relevant_files.append((start_time, file_name))
-                    continue
-
-                if end_time_str == "crash_recovery":
-                    if start_time >= utils.time_string_to_datetime_utc(
-                        utils.get_utc_timestamp_minus_hours(constants.HOURS_OFFSET)
-                    ):
-                        relevant_files.append((start_time, file_name))
-                    continue
-
-                end_time = utils.time_string_to_datetime_utc(end_time_str)
-
-                if start_time <= last_record_datetime <= end_time or last_record_datetime < start_time:
-                    relevant_files.append((start_time, file_name))
-            else:
+            if file_name.count(".") != 1:
                 self.log.debug(
                     constants.LOG_TEMPLATE.format(message=f"Skipping file with unexpected format: {file_name}")
                 )
+                continue
 
-        relevant_files.sort(key=lambda x: (x[1].endswith('.not_terminated'), x[0]))
-        return relevant_files
+            start_time_str, end_time_str = file_name.split(".")
+            start_time = utils.time_string_to_datetime_utc(start_time_str)
 
-    def get_previous_iteration_log_cursor(self, previous_cursor) -> tuple[str, str | None, str | None]:
+            if end_time_str == "not_terminated":
+                still_open.append((start_time, file_name))
+                continue
+
+            if end_time_str == "crash_recovery":
+                if start_time >= lookback_cutoff:
+                    still_open.append((start_time, file_name))
+                continue
+
+            end_time = utils.time_string_to_datetime_utc(end_time_str)
+            if end_time < lookback_cutoff:
+                self.log.info(
+                    constants.LOG_TEMPLATE.format(
+                        message=f"Skipping the log collection of {file_name} file as logs are not within "
+                        f"the last {constants.HOURS_OFFSET} hours timeframe."
+                    )
+                )
+                continue
+            if start_time <= last_record_datetime <= end_time or last_record_datetime < start_time:
+                closed.append((start_time, end_time, file_name))
+
+        closed.sort(key=lambda x: x[0])
+        still_open.sort(key=lambda x: x[0])
+        return closed, still_open
+
+    def get_previous_iteration_log_cursor(
+        self, previous_cursor: dict | None
+    ) -> tuple[str, str | None, list[str], list[str]]:
         last_record_time = utils.get_utc_timestamp_minus_hours(constants.HOURS_OFFSET)
         last_record_milli_sec = None
-        last_collected_file_name = None
+        last_completed_closed: list[str] = []
+        last_completed_open: list[str] = []
 
         self.log.debug(constants.LOG_TEMPLATE.format(message=f"Previous Cursor: {previous_cursor}"))  # noqa: G004
         if previous_cursor:
             last_record_time = previous_cursor["record_time"]
             last_record_milli_sec = previous_cursor["record_milli_sec"]
-            last_collected_file_name = previous_cursor["file_name"]
+            last_completed_closed = previous_cursor.get("last_completed_closed", [])
+            last_completed_open = previous_cursor.get("last_completed_open", [])
 
-        return last_record_time, last_record_milli_sec, last_collected_file_name
+        return last_record_time, last_record_milli_sec, last_completed_closed, last_completed_open
 
     def fetch_audit_logs(self, file_paths: list[str], time_filter_arg: str) -> tuple[bytes, bytes]:
         output = error = b""
@@ -145,7 +161,14 @@ class MacAuditLogsCheck(AgentCheck):
                 praudit_process.terminate()
             self.log.info(constants.LOG_TEMPLATE.format(message=message))
 
-    def process_and_ingest_log_entries(self, log_entries, file, timezone_offset, last_record_milli_sec) -> None:
+    def process_and_ingest_log_entries(
+        self,
+        log_entries: list[str],
+        completed_closed: list[str],
+        completed_open: list[str],
+        timezone_offset: str,
+        last_record_milli_sec: str | None,
+    ) -> None:
         total_entries = len(log_entries)
         for log_index, log in enumerate(log_entries):
             try:
@@ -156,28 +179,23 @@ class MacAuditLogsCheck(AgentCheck):
                 time_value = data_xml.get("time")
                 milli_sec_value = data_xml.get("msec")
 
-                if last_record_milli_sec and last_record_milli_sec != milli_sec_value:
+                if last_record_milli_sec is not None:
+                    if last_record_milli_sec == milli_sec_value:
+                        last_record_milli_sec = None
                     continue
-
-                if last_record_milli_sec == milli_sec_value:
-                    last_record_milli_sec = None
 
                 datetime_aware = utils.get_datetime_aware(time_value, timezone_offset)
 
-                cursor = {}
-                cursor["record_time"] = utils.convert_local_to_utc_timezone_timestamp_str(time_value, timezone_offset)
-                cursor["file_name"] = file
+                is_last_in_batch = log_index + 1 == total_entries
+                cursor = {
+                    "record_time": utils.convert_local_to_utc_timezone_timestamp_str(time_value, timezone_offset),
+                    "record_milli_sec": None if is_last_in_batch else milli_sec_value,
+                    "is_file_collection_completed": is_last_in_batch,
+                    "last_completed_closed": completed_closed,
+                    "last_completed_open": completed_open,
+                }
 
-                if log_index + 1 == total_entries:
-                    cursor["record_milli_sec"] = None
-                    cursor["is_file_collection_completed"] = True
-                else:
-                    cursor["record_milli_sec"] = milli_sec_value
-                    cursor["is_file_collection_completed"] = False
-
-                data = {}
-                data["timestamp"] = get_timestamp(datetime_aware)
-                data["message"] = log
+                data = {"timestamp": get_timestamp(datetime_aware), "message": log}
 
                 self.send_log(data, cursor=cursor)
             except ParseError as exe:
@@ -189,64 +207,19 @@ class MacAuditLogsCheck(AgentCheck):
                 self.log.exception(constants.LOG_TEMPLATE.format(message=err_message))
                 raise
 
-    def _should_skip_file(
-        self,
-        file: str,
-        previous_cursor: dict | None,
-        last_collected_file_name: str | None,
-        last_record_time: str,
-    ) -> bool:
-        start_time_str, end_time_str = file.split(".")
-
-        if end_time_str not in ["not_terminated", "crash_recovery"] and utils.time_string_to_datetime_utc(
-            end_time_str
-        ) < utils.time_string_to_datetime_utc(utils.get_utc_timestamp_minus_hours(constants.HOURS_OFFSET)):
-            self.log.info(
-                constants.LOG_TEMPLATE.format(
-                    message=f"Skipping the log collection of {file} file as logs are not within the "
-                    f"last {constants.HOURS_OFFSET} hours timeframe."
-                )
-            )
-            return True
-
-        if not previous_cursor:
-            return False
-
-        cursor_file_start_time_str, cursor_file_end_time_str = last_collected_file_name.split(".")
-
-        if (
-            cursor_file_end_time_str == "not_terminated"
-            and previous_cursor["is_file_collection_completed"]
-            and cursor_file_start_time_str == start_time_str
-            and last_record_time == end_time_str
-        ):
-            self.log.debug(f"Skipping the collection of {file} file")  # noqa: G004
-            return True
-
-        if (last_collected_file_name == file and previous_cursor["is_file_collection_completed"]) or (
-            end_time_str not in ["not_terminated", "crash_recovery"]
-            and utils.time_string_to_datetime_utc(start_time_str) <= utils.time_string_to_datetime_utc(last_record_time)
-            and utils.time_string_to_datetime_utc(end_time_str) == utils.time_string_to_datetime_utc(last_record_time)
-            and last_collected_file_name != file
-        ):
-            self.log.debug(f"Skipping the collection of {file} file")  # noqa: G004
-            return True
-
-        return False
-
     def collect_data_from_files(
         self,
-        relevant_files,
-        previous_cursor,
-        last_record_time,
-        last_collected_file_name,
-        last_record_milli_sec,
-        timezone_offset,
+        closed: list[tuple[datetime, datetime, str]],
+        still_open: list[tuple[datetime, str]],
+        last_completed_closed: list[str],
+        last_completed_open: list[str],
+        last_record_time: str,
+        last_record_milli_sec: str | None,
+        timezone_offset: str,
     ) -> None:
-        valid_file_paths = []
-        for _, file in relevant_files:
-            file_path = os.path.join(self.audit_logs_dir_path, file)
-
+        valid_closed: list[tuple[datetime, datetime, str]] = []
+        for start_time, end_time, file_name in closed:
+            file_path = os.path.join(self.audit_logs_dir_path, file_name)
             if not os.path.exists(file_path):
                 self.log.info(
                     constants.LOG_TEMPLATE.format(
@@ -254,19 +227,38 @@ class MacAuditLogsCheck(AgentCheck):
                     )
                 )
                 continue
-
-            if self._should_skip_file(file, previous_cursor, last_collected_file_name, last_record_time):
+            if file_name in last_completed_closed:
+                self.log.debug(f"Skipping already-collected closed file: {file_name}")  # noqa: G004
                 continue
+            if _rotated_from_open(start_time, end_time, last_completed_open, last_record_time):
+                self.log.debug(f"Skipping file rotated from previously-open file: {file_name}")  # noqa: G004
+                continue
+            valid_closed.append((start_time, end_time, file_name))
 
-            valid_file_paths.append(file_path)
+        valid_open: list[tuple[datetime, str]] = []
+        for start_time, file_name in still_open:
+            file_path = os.path.join(self.audit_logs_dir_path, file_name)
+            if not os.path.exists(file_path):
+                self.log.info(
+                    constants.LOG_TEMPLATE.format(
+                        message=f"{file_path} is not available. Skipping collection for this file."
+                    )
+                )
+                continue
+            valid_open.append((start_time, file_name))
 
-        if not valid_file_paths:
+        valid_paths = [os.path.join(self.audit_logs_dir_path, c[2]) for c in valid_closed] + [
+            os.path.join(self.audit_logs_dir_path, o[1]) for o in valid_open
+        ]
+
+        if not valid_paths:
             return
 
-        first_file = os.path.basename(valid_file_paths[0])
+        completed_closed = [c[2] for c in valid_closed]
+        completed_open = [o[1] for o in valid_open]
 
         try:
-            output, error = self.fetch_audit_logs(valid_file_paths, last_record_time)
+            output, error = self.fetch_audit_logs(valid_paths, last_record_time)
 
             output_str = output.decode("utf-8", errors="replace")
 
@@ -277,10 +269,12 @@ class MacAuditLogsCheck(AgentCheck):
 
             log_entries = output_str.strip().split("\n")
 
-            self.process_and_ingest_log_entries(log_entries, first_file, timezone_offset, last_record_milli_sec)
+            self.process_and_ingest_log_entries(
+                log_entries, completed_closed, completed_open, timezone_offset, last_record_milli_sec
+            )
 
         except Exception as e:
-            err_message = f"Error processing files {valid_file_paths}: {e}"
+            err_message = f"Error processing files {valid_paths}: {e}"
             self.log.exception(constants.LOG_TEMPLATE.format(message=err_message))
 
     def check(self, _):
@@ -298,33 +292,65 @@ class MacAuditLogsCheck(AgentCheck):
 
         if self.monitor:
             previous_cursor = self.get_log_cursor()
-            last_record_time, last_record_milli_sec, last_collected_file_name = self.get_previous_iteration_log_cursor(
-                previous_cursor
-            )
+            (
+                last_record_time,
+                last_record_milli_sec,
+                last_completed_closed,
+                last_completed_open,
+            ) = self.get_previous_iteration_log_cursor(previous_cursor)
 
             timezone_offset = subprocess.run(["date", "+%z"], capture_output=True, text=True).stdout.strip()
 
-            relevant_files = self.collect_relevant_files(last_record_time)
+            closed, still_open = self.collect_relevant_files(last_record_time)
 
-            if (
-                relevant_files
-                and previous_cursor
-                and not previous_cursor["is_file_collection_completed"]
-                and relevant_files[-1][1] == last_collected_file_name
-            ):
-                relevant_files = [relevant_files[-1]]
+            if previous_cursor and not previous_cursor["is_file_collection_completed"]:
+                closed, still_open = _narrow_to_resume_tail(
+                    closed, still_open, utils.time_string_to_datetime_utc(last_record_time)
+                )
                 self.log.debug(
-                    f"Found the same file as the last failed iteration, relevant files: {relevant_files}"  # noqa: G004
+                    f"Resuming aborted cycle, narrowed batch: closed={[c[2] for c in closed]}, "  # noqa: G004
+                    f"open={[o[1] for o in still_open]}"
                 )
 
             self.collect_data_from_files(
-                relevant_files,
-                previous_cursor,
+                closed,
+                still_open,
+                last_completed_closed,
+                last_completed_open,
                 last_record_time,
-                last_collected_file_name,
                 last_record_milli_sec,
                 timezone_offset,
             )
         else:
             message = "Monitoring to the Mac Audit Logs is disabled."
             self.log.info(constants.LOG_TEMPLATE.format(message=message))
+
+
+def _narrow_to_resume_tail(
+    closed: list[tuple[datetime, datetime, str]],
+    still_open: list[tuple[datetime, str]],
+    last_record_datetime: datetime,
+) -> tuple[list[tuple[datetime, datetime, str]], list[tuple[datetime, str]]]:
+    if closed:
+        starts = [c[0] for c in closed]
+        i = bisect.bisect_right(starts, last_record_datetime) - 1
+        if i >= 0:
+            start, end, _ = closed[i]
+            if start <= last_record_datetime <= end:
+                return closed[i:], still_open
+    return [], still_open
+
+
+def _rotated_from_open(
+    start_time: datetime,
+    end_time: datetime,
+    last_completed_open: list[str],
+    last_record_time: str,
+) -> bool:
+    if end_time != utils.time_string_to_datetime_utc(last_record_time):
+        return False
+    start_time_str = start_time.strftime(constants.FILE_TIMESTAMP_FORMAT)
+    for name in last_completed_open:
+        if name.split(".", 1)[0] == start_time_str:
+            return True
+    return False

--- a/mac_audit_logs/datadog_checks/mac_audit_logs/check.py
+++ b/mac_audit_logs/datadog_checks/mac_audit_logs/check.py
@@ -123,22 +123,19 @@ class MacAuditLogsCheck(AgentCheck):
 
     def fetch_audit_logs(self, file_paths: list[str], time_filter_arg: str) -> tuple[bytes, bytes]:
         output = error = b""
-
-        auditreduce_command = f"sudo auditreduce -a {time_filter_arg} {' '.join(file_paths)}"
-        praudit_command = "sudo praudit -xsl"
+        auditreduce_process = None
+        praudit_process = None
 
         try:
             # use TZ=UTC because auditreduce does not translate daylight savings to UTC and always uses standard time
             auditreduce_process = subprocess.Popen(
-                auditreduce_command,
-                shell=True,
+                ["sudo", "auditreduce", "-a", time_filter_arg, *file_paths],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 env={**os.environ, "TZ": "UTC"},
             )
             praudit_process = subprocess.Popen(
-                praudit_command,
-                shell=True,
+                ["sudo", "praudit", "-xsl"],
                 stdin=auditreduce_process.stdout,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -147,19 +144,20 @@ class MacAuditLogsCheck(AgentCheck):
             auditreduce_process.stdout.close()
 
             output, error = praudit_process.communicate()
-
-            return output, error
-
         except Exception as e:
             err_message = f"Error processing files {file_paths}: {e}"
             self.log.exception(constants.LOG_TEMPLATE.format(message=err_message))
         finally:
-            message = "Processes auditreduce and praudit have been closed."
-            if auditreduce_process.poll() is None:
-                auditreduce_process.terminate()
-            if praudit_process.poll() is None:
-                praudit_process.terminate()
-            self.log.info(constants.LOG_TEMPLATE.format(message=message))
+            for proc in (auditreduce_process, praudit_process):
+                if proc is not None and proc.poll() is None:
+                    proc.terminate()
+                    try:
+                        proc.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        proc.kill()
+            self.log.info(constants.LOG_TEMPLATE.format(message="Processes auditreduce and praudit have been closed."))
+
+        return output, error
 
     def process_and_ingest_log_entries(
         self,
@@ -252,6 +250,14 @@ class MacAuditLogsCheck(AgentCheck):
         ]
 
         if not valid_paths:
+            self.log.debug(
+                constants.LOG_TEMPLATE.format(
+                    message=(
+                        f"No files to collect from this cycle "
+                        f"(closed candidates: {len(closed)}, open candidates: {len(still_open)})."
+                    )
+                )
+            )
             return
 
         completed_closed = [c[2] for c in valid_closed]

--- a/mac_audit_logs/tests/test_unit.py
+++ b/mac_audit_logs/tests/test_unit.py
@@ -260,28 +260,28 @@ def test_get_previous_iteration_log_cursor_when_cusror_is_not_none(utc_timestamp
 
 @patch('datadog_checks.mac_audit_logs.check.subprocess.Popen')
 def test_fetch_audit_logs(mock_popen, instance):
+    """Multiple file paths are joined into a single auditreduce command."""
     logs = (
         "<record time=\"Thu Jun  5 13:51:38 2025\" msec=\" + 244 msec\" > /></record>\n<record time=\"Thu Jun  5 "
         "13:51:39 2025\" msec=\" + 154 msec\" > /></record>"
     )
     log_file_entries = logs.split("\n")
     check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
-    # Create a mock for the stdout and stderr data
     mock_auditreduce_stdout = MagicMock()
     mock_auditreduce_process = MagicMock(stdout=mock_auditreduce_stdout)
     mock_praudit_process = MagicMock(communicate=MagicMock(return_value=(logs, "")))
 
-    # Set up the mock Popen objects
     mock_popen.side_effect = [mock_auditreduce_process, mock_praudit_process]
 
-    # Call the method
-    file_path = "/var/audit/20250605082138.20250605082142"
+    file_paths = [
+        "/var/audit/20250605082138.20250605082142",
+        "/var/audit/20250605082142.20250605082150",
+    ]
     time_filter_arg = "20250605132138"
-    output, error = check.fetch_audit_logs(file_path, time_filter_arg)
+    output, error = check.fetch_audit_logs(file_paths, time_filter_arg)
 
-    # Check that Popen was called with the correct arguments
     mock_popen.assert_any_call(
-        f"sudo auditreduce -a {time_filter_arg} {file_path}",
+        f"sudo auditreduce -a {time_filter_arg} {file_paths[0]} {file_paths[1]}",
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -291,18 +291,40 @@ def test_fetch_audit_logs(mock_popen, instance):
         'sudo praudit -xsl', shell=True, stdin=mock_auditreduce_stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
 
-    # Check the communicate method was called
     mock_praudit_process.communicate.assert_called_once()
 
-    # Define expected results
-    expected_output = logs
     log_entries = output.split("\n")
-    expected_error = ""
-
-    # Check if the result matches the expected output
-    assert output == expected_output
-    assert error == expected_error
+    assert output == logs
+    assert error == ""
     assert len(log_entries) == len(log_file_entries)
+
+
+@patch('datadog_checks.mac_audit_logs.check.subprocess.Popen')
+def test_fetch_audit_logs_single_file(mock_popen, instance):
+    """A single-element list produces the correct auditreduce command."""
+    logs = "<record time=\"Thu Jun  5 13:51:38 2025\" msec=\" + 244 msec\" > /></record>"
+    check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
+    mock_auditreduce_stdout = MagicMock()
+    mock_auditreduce_process = MagicMock(stdout=mock_auditreduce_stdout)
+    mock_praudit_process = MagicMock(communicate=MagicMock(return_value=(logs, "")))
+
+    mock_popen.side_effect = [mock_auditreduce_process, mock_praudit_process]
+
+    file_path = "/var/audit/20250605082138.20250605082142"
+    time_filter_arg = "20250605132138"
+    output, error = check.fetch_audit_logs([file_path], time_filter_arg)
+
+    mock_popen.assert_any_call(
+        f"sudo auditreduce -a {time_filter_arg} {file_path}",
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={**os.environ, "TZ": "UTC"},
+    )
+    assert mock_popen.call_count == 2
+    mock_praudit_process.communicate.assert_called_once()
+    assert output == logs
+    assert error == ""
 
 
 @patch.object(MacAuditLogsCheck, 'send_log')

--- a/mac_audit_logs/tests/test_unit.py
+++ b/mac_audit_logs/tests/test_unit.py
@@ -327,6 +327,124 @@ def test_fetch_audit_logs_single_file(mock_popen, instance):
     assert error == ""
 
 
+@pytest.mark.unit
+@patch("os.path.exists", return_value=True)
+@patch("datadog_checks.mac_audit_logs.utils.get_utc_timestamp_minus_hours", return_value="20230401000000")
+def test_collect_data_from_files_batches_all_existing_files(mock_utc, mock_exists, instance):
+    """All existing files are batched into a single auditreduce call."""
+    check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
+    check.fetch_audit_logs = MagicMock(return_value=(b"<record/>", b""))
+    check.process_and_ingest_log_entries = MagicMock()
+
+    relevant_files = [
+        (utils.time_string_to_datetime_utc("20230401000000"), "20230401000000.20230401010000"),
+        (utils.time_string_to_datetime_utc("20230401010000"), "20230401010000.20230401020000"),
+        (utils.time_string_to_datetime_utc("20230401020000"), "20230401020000.20230401030000"),
+    ]
+    last_record_time = "20230401000000"
+
+    check.collect_data_from_files(relevant_files, None, last_record_time, None, None, "+0000")
+
+    expected_paths = [os.path.join(check.audit_logs_dir_path, f) for _, f in relevant_files]
+    check.fetch_audit_logs.assert_called_once_with(expected_paths, last_record_time)
+    check.process_and_ingest_log_entries.assert_called_once()
+
+
+@pytest.mark.unit
+@patch("datadog_checks.mac_audit_logs.utils.get_utc_timestamp_minus_hours", return_value="20230401000000")
+def test_collect_data_from_files_excludes_missing_files(mock_utc, instance):
+    """Files that no longer exist on disk are excluded from the auditreduce batch."""
+    check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
+    check.fetch_audit_logs = MagicMock(return_value=(b"<record/>", b""))
+    check.process_and_ingest_log_entries = MagicMock()
+
+    relevant_files = [
+        (utils.time_string_to_datetime_utc("20230401000000"), "20230401000000.20230401010000"),
+        (utils.time_string_to_datetime_utc("20230401010000"), "20230401010000.20230401020000"),
+        (utils.time_string_to_datetime_utc("20230401020000"), "20230401020000.20230401030000"),
+    ]
+    missing_file = os.path.join(check.audit_logs_dir_path, relevant_files[1][1])
+
+    with patch("os.path.exists", side_effect=lambda p: p != missing_file):
+        check.collect_data_from_files(relevant_files, None, "20230401000000", None, None, "+0000")
+
+    expected_paths = [
+        os.path.join(check.audit_logs_dir_path, relevant_files[0][1]),
+        os.path.join(check.audit_logs_dir_path, relevant_files[2][1]),
+    ]
+    check.fetch_audit_logs.assert_called_once_with(expected_paths, "20230401000000")
+
+
+@pytest.mark.unit
+@patch("os.path.exists", return_value=True)
+@patch("datadog_checks.mac_audit_logs.utils.get_utc_timestamp_minus_hours", return_value="20230401000000")
+def test_collect_data_from_files_skips_already_processed_files(mock_utc, mock_exists, instance):
+    """Files fully processed in a previous iteration are excluded from the batch."""
+    check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
+    check.fetch_audit_logs = MagicMock(return_value=(b"<record/>", b""))
+    check.process_and_ingest_log_entries = MagicMock()
+
+    relevant_files = [
+        (utils.time_string_to_datetime_utc("20230401000000"), "20230401000000.20230401010000"),
+        (utils.time_string_to_datetime_utc("20230401010000"), "20230401010000.20230401020000"),
+        (utils.time_string_to_datetime_utc("20230401020000"), "20230401020000.20230401030000"),
+    ]
+    previous_cursor = {"is_file_collection_completed": True}
+    last_collected_file_name = relevant_files[0][1]
+    last_record_time = "20230401010000"
+
+    check.collect_data_from_files(
+        relevant_files, previous_cursor, last_record_time, last_collected_file_name, None, "+0000"
+    )
+
+    expected_paths = [
+        os.path.join(check.audit_logs_dir_path, relevant_files[1][1]),
+        os.path.join(check.audit_logs_dir_path, relevant_files[2][1]),
+    ]
+    check.fetch_audit_logs.assert_called_once_with(expected_paths, last_record_time)
+
+
+@pytest.mark.unit
+@patch("datadog_checks.mac_audit_logs.utils.get_utc_timestamp_minus_hours", return_value="20230401000000")
+def test_collect_data_from_files_no_valid_files(mock_utc, instance):
+    """No subprocess call when all files are filtered out."""
+    check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
+    check.fetch_audit_logs = MagicMock()
+
+    relevant_files = [
+        (utils.time_string_to_datetime_utc("20230401000000"), "20230401000000.20230401010000"),
+        (utils.time_string_to_datetime_utc("20230401010000"), "20230401010000.20230401020000"),
+    ]
+
+    with patch("os.path.exists", return_value=False):
+        check.collect_data_from_files(relevant_files, None, "20230401000000", None, None, "+0000")
+
+    check.fetch_audit_logs.assert_not_called()
+
+
+@pytest.mark.unit
+@patch("os.path.exists", return_value=True)
+@patch("datadog_checks.mac_audit_logs.utils.get_utc_timestamp_minus_hours", return_value="20230401000000")
+def test_collect_data_from_files_always_uses_last_record_time(mock_utc, mock_exists, instance):
+    """The time filter is always last_record_time (regression test for file_index bug)."""
+    check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
+    check.fetch_audit_logs = MagicMock(return_value=(b"<record/>", b""))
+    check.process_and_ingest_log_entries = MagicMock()
+
+    relevant_files = [
+        (utils.time_string_to_datetime_utc("20230401000000"), "20230401000000.20230401010000"),
+        (utils.time_string_to_datetime_utc("20230401010000"), "20230401010000.20230401020000"),
+        (utils.time_string_to_datetime_utc("20230401020000"), "20230401020000.20230401030000"),
+    ]
+    last_record_time = "20230401000030"
+
+    check.collect_data_from_files(relevant_files, None, last_record_time, None, None, "+0000")
+
+    _, call_kwargs = check.fetch_audit_logs.call_args
+    call_args = check.fetch_audit_logs.call_args[0]
+    assert call_args[1] == last_record_time
+
+
 @patch.object(MacAuditLogsCheck, 'send_log')
 def test_process_and_ingest_log_entries_skipping_logs_milli_seconds(mock_send_log, instance):
     logs = (

--- a/mac_audit_logs/tests/test_unit.py
+++ b/mac_audit_logs/tests/test_unit.py
@@ -258,6 +258,7 @@ def test_get_previous_iteration_log_cursor_when_cusror_is_not_none(utc_timestamp
     assert last_collected_file_name == "20230401000000.20230401000015"
 
 
+@pytest.mark.unit
 @patch('datadog_checks.mac_audit_logs.check.subprocess.Popen')
 def test_fetch_audit_logs(mock_popen, instance):
     """Multiple file paths are joined into a single auditreduce command."""
@@ -299,6 +300,7 @@ def test_fetch_audit_logs(mock_popen, instance):
     assert len(log_entries) == len(log_file_entries)
 
 
+@pytest.mark.unit
 @patch('datadog_checks.mac_audit_logs.check.subprocess.Popen')
 def test_fetch_audit_logs_single_file(mock_popen, instance):
     """A single-element list produces the correct auditreduce command."""
@@ -347,7 +349,8 @@ def test_collect_data_from_files_batches_all_existing_files(mock_utc, mock_exist
 
     expected_paths = [os.path.join(check.audit_logs_dir_path, f) for _, f in relevant_files]
     check.fetch_audit_logs.assert_called_once_with(expected_paths, last_record_time)
-    check.process_and_ingest_log_entries.assert_called_once()
+    call_args = check.process_and_ingest_log_entries.call_args[0]
+    assert call_args[1] == relevant_files[0][1], "cursor file_name should be the first file in the batch"
 
 
 @pytest.mark.unit
@@ -424,6 +427,52 @@ def test_collect_data_from_files_no_valid_files(mock_utc, instance):
 
 @pytest.mark.unit
 @patch("os.path.exists", return_value=True)
+@patch("datadog_checks.mac_audit_logs.utils.get_utc_timestamp_minus_hours", return_value="20230401030000")
+def test_collect_data_from_files_skips_files_outside_time_range(mock_utc, mock_exists, instance):
+    """Files whose end time is before the HOURS_OFFSET cutoff are excluded from the batch."""
+    check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
+    check.fetch_audit_logs = MagicMock(return_value=(b"<record/>", b""))
+    check.process_and_ingest_log_entries = MagicMock()
+
+    relevant_files = [
+        (utils.time_string_to_datetime_utc("20230401000000"), "20230401000000.20230401010000"),
+        (utils.time_string_to_datetime_utc("20230401010000"), "20230401010000.20230401020000"),
+        (utils.time_string_to_datetime_utc("20230401030000"), "20230401030000.20230401040000"),
+    ]
+
+    check.collect_data_from_files(relevant_files, None, "20230401000000", None, None, "+0000")
+
+    expected_paths = [os.path.join(check.audit_logs_dir_path, relevant_files[2][1])]
+    check.fetch_audit_logs.assert_called_once_with(expected_paths, "20230401000000")
+
+
+@pytest.mark.unit
+@patch("os.path.exists", return_value=True)
+@patch("datadog_checks.mac_audit_logs.utils.get_utc_timestamp_minus_hours", return_value="20230401000000")
+def test_collect_data_from_files_skips_rotated_not_terminated_file(mock_utc, mock_exists, instance):
+    """A not_terminated file that was completed and rotated into a named file is skipped."""
+    check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
+    check.fetch_audit_logs = MagicMock(return_value=(b"<record/>", b""))
+    check.process_and_ingest_log_entries = MagicMock()
+
+    relevant_files = [
+        (utils.time_string_to_datetime_utc("20230401000000"), "20230401000000.20230401010000"),
+        (utils.time_string_to_datetime_utc("20230401010000"), "20230401010000.20230401020000"),
+    ]
+    previous_cursor = {"is_file_collection_completed": True}
+    last_collected_file_name = "20230401000000.not_terminated"
+    last_record_time = "20230401010000"
+
+    check.collect_data_from_files(
+        relevant_files, previous_cursor, last_record_time, last_collected_file_name, None, "+0000"
+    )
+
+    expected_paths = [os.path.join(check.audit_logs_dir_path, relevant_files[1][1])]
+    check.fetch_audit_logs.assert_called_once_with(expected_paths, last_record_time)
+
+
+@pytest.mark.unit
+@patch("os.path.exists", return_value=True)
 @patch("datadog_checks.mac_audit_logs.utils.get_utc_timestamp_minus_hours", return_value="20230401000000")
 def test_collect_data_from_files_always_uses_last_record_time(mock_utc, mock_exists, instance):
     """The time filter is always last_record_time (regression test for file_index bug)."""
@@ -440,9 +489,7 @@ def test_collect_data_from_files_always_uses_last_record_time(mock_utc, mock_exi
 
     check.collect_data_from_files(relevant_files, None, last_record_time, None, None, "+0000")
 
-    _, call_kwargs = check.fetch_audit_logs.call_args
-    call_args = check.fetch_audit_logs.call_args[0]
-    assert call_args[1] == last_record_time
+    assert check.fetch_audit_logs.call_args[0][1] == last_record_time
 
 
 @patch.object(MacAuditLogsCheck, 'send_log')

--- a/mac_audit_logs/tests/test_unit.py
+++ b/mac_audit_logs/tests/test_unit.py
@@ -677,3 +677,36 @@ def test_cursor_record_time_never_moves_backwards(mock_send_log, instance):
 
     record_times = [call.kwargs["cursor"]["record_time"] for call in mock_send_log.call_args_list]
     assert record_times == sorted(record_times)
+
+
+@pytest.mark.unit
+@patch.object(MacAuditLogsCheck, "send_log")
+def test_only_final_cursor_in_batch_marks_files_completed(mock_send_log, instance):
+    """Only the cursor for the last record in a batch carries the completed-file lists.
+
+    If a cycle aborts after an intermediate record, the resumed cycle must still see the
+    in-flight files as candidates to process. Marking files completed on every emission
+    would let the next cycle skip files whose records had not all been ingested yet.
+    """
+    logs = (
+        "<record time=\"Thu Jun  5 13:51:38 2025\" msec=\" + 100 msec\" > /></record>\n"
+        "<record time=\"Thu Jun  5 13:51:39 2025\" msec=\" + 200 msec\" > /></record>\n"
+        "<record time=\"Thu Jun  5 13:51:40 2025\" msec=\" + 300 msec\" > /></record>"
+    )
+    completed_closed = ["20250605082138.20250605082142", "20250605082142.20250605082150"]
+    completed_open = ["20250605082150.not_terminated"]
+
+    check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
+    check.process_and_ingest_log_entries(logs.split("\n"), completed_closed, completed_open, "+0000", None)
+
+    cursors = [call.kwargs["cursor"] for call in mock_send_log.call_args_list]
+    assert len(cursors) == 3
+
+    for cursor in cursors[:-1]:
+        assert cursor["is_file_collection_completed"] is False
+        assert cursor["last_completed_closed"] == []
+        assert cursor["last_completed_open"] == []
+
+    assert cursors[-1]["is_file_collection_completed"] is True
+    assert cursors[-1]["last_completed_closed"] == completed_closed
+    assert cursors[-1]["last_completed_open"] == completed_open

--- a/mac_audit_logs/tests/test_unit.py
+++ b/mac_audit_logs/tests/test_unit.py
@@ -24,15 +24,22 @@ file_names = [
     "current",
 ]
 
-file_names1 = [
-    (utils.time_string_to_datetime_utc("20230401000000"), "20230401000000.20230401000001"),
+closed_files1 = [
+    (
+        utils.time_string_to_datetime_utc("20230401000000"),
+        utils.time_string_to_datetime_utc("20230401000001"),
+        "20230401000000.20230401000001",
+    ),
+]
+open_files1 = [
     (utils.time_string_to_datetime_utc("20230401000001"), "20230401000001.not_terminated"),
 ]
 log_cursor = {
     "record_time": "20230401000001",
-    "file_name": "20230401000001.not_terminated",
     "record_milli_sec": " + 244 msec",
     "is_file_collection_completed": False,
+    "last_completed_closed": [],
+    "last_completed_open": [],
 }
 
 
@@ -143,20 +150,28 @@ def test_convert_local_to_utc_timezone_timestamp_str():
 @patch("datadog_checks.mac_audit_logs.utils.get_utc_timestamp_minus_hours", return_value="20230401000000")
 def test_collect_relevant_files(mock_get_utc, mock_isfile, mock_listdir, mock_isdir, instance):
     check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
-    # Call the method
-    result = check.collect_relevant_files("20230401120000")
+    closed, still_open = check.collect_relevant_files("20230401120000")
 
-    # Define expected results - "current" should be skipped
-    expected = [
-        (utils.time_string_to_datetime_utc("20230401000000"), "20230401000000.20230401120000"),
-        (utils.time_string_to_datetime_utc("20230401120000"), "20230401120000.20230401123045"),
+    expected_closed = [
+        (
+            utils.time_string_to_datetime_utc("20230401000000"),
+            utils.time_string_to_datetime_utc("20230401120000"),
+            "20230401000000.20230401120000",
+        ),
+        (
+            utils.time_string_to_datetime_utc("20230401120000"),
+            utils.time_string_to_datetime_utc("20230401123045"),
+            "20230401120000.20230401123045",
+        ),
+    ]
+    expected_still_open = [
         (utils.time_string_to_datetime_utc("20230401123045"), "20230401123045.crash_recovery"),
         (utils.time_string_to_datetime_utc("20230401123047"), "20230401123047.crash_recovery"),
         (utils.time_string_to_datetime_utc("20230401123056"), "20230401123056.not_terminated"),
         (utils.time_string_to_datetime_utc("20230401123058"), "20230401123058.not_terminated"),
     ]
-    # Check if the result matches the expected output
-    assert result == expected
+    assert closed == expected_closed
+    assert still_open == expected_still_open
 
 
 @pytest.mark.unit
@@ -174,14 +189,17 @@ def test_collect_relevant_files_with_non_standard_entries(
     check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
     check.log = MagicMock()
 
-    # Call the method
-    result = check.collect_relevant_files("20230401120000")
+    closed, still_open = check.collect_relevant_files("20230401120000")
 
-    # Only the valid audit log file should be returned
-    expected = [
-        (utils.time_string_to_datetime_utc("20230401000000"), "20230401000000.20230401120000"),
+    expected_closed = [
+        (
+            utils.time_string_to_datetime_utc("20230401000000"),
+            utils.time_string_to_datetime_utc("20230401120000"),
+            "20230401000000.20230401120000",
+        ),
     ]
-    assert result == expected
+    assert closed == expected_closed
+    assert still_open == []
 
     # Verify debug logging for skipped entries
     debug_calls = check.log.debug.call_args_list
@@ -201,29 +219,93 @@ def test_collect_relevant_files_with_non_standard_entries(
 @patch("datadog_checks.mac_audit_logs.check.MacAuditLogsCheck.validate_configurations", return_value=None)
 @patch("datadog_checks.mac_audit_logs.check.MacAuditLogsCheck.get_log_cursor", return_value=log_cursor)
 @patch("datadog_checks.mac_audit_logs.utils.get_utc_timestamp_minus_hours", return_value="20230401000000")
-@patch("datadog_checks.mac_audit_logs.check.MacAuditLogsCheck.collect_relevant_files", return_value=file_names1)
+@patch(
+    "datadog_checks.mac_audit_logs.check.MacAuditLogsCheck.collect_relevant_files",
+    return_value=(closed_files1, open_files1),
+)
 @patch("datadog_checks.mac_audit_logs.check.MacAuditLogsCheck.collect_data_from_files", return_value=None)
 @patch("subprocess.run")
 def test_collect_relevant_files_for_failed_last_iteration(
-    mack_validate_config,
-    mock_get_cursor,
-    utc_timestamp_minus_hours,
-    mock_relevent_files,
-    mock_collect_data,
     mock_subprocess_run,
+    mock_collect_data,
+    mock_relevant_files,
+    utc_timestamp_minus_hours,
+    mock_get_cursor,
+    mock_validate_config,
     instance,
 ):
+    """When the previous cycle aborted partway through, the next cycle resumes from the file
+    containing the last emitted record and continues forward through later files."""
     mac_audit_logs_check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
-    # Call the method
     mock_subprocess_run.return_value = MagicMock(stdout='+0530\n')
     mac_audit_logs_check.log = MagicMock()
-    _ = mac_audit_logs_check.check(None)
-    expected_files = [
-        (utils.time_string_to_datetime_utc("20230401000001"), "20230401000001.not_terminated"),
-    ]
-    mac_audit_logs_check.log.debug.assert_called_with(
-        f"Found the same file as the last failed iteration, relevant files: {expected_files}"
-    )
+    mac_audit_logs_check.check(None)
+
+    call_args = mock_collect_data.call_args
+    narrowed_closed = call_args[0][0]
+    narrowed_open = call_args[0][1]
+    assert narrowed_closed == closed_files1
+    assert narrowed_open == open_files1
+
+
+_boundary_cursor = {
+    "record_time": "20230401020000",
+    "record_milli_sec": " + 100 msec",
+    "is_file_collection_completed": False,
+    "last_completed_closed": [],
+    "last_completed_open": [],
+}
+_boundary_closed = [
+    (
+        utils.time_string_to_datetime_utc("20230401010000"),
+        utils.time_string_to_datetime_utc("20230401020000"),
+        "20230401010000.20230401020000",
+    ),
+    (
+        utils.time_string_to_datetime_utc("20230401020000"),
+        utils.time_string_to_datetime_utc("20230401030000"),
+        "20230401020000.20230401030000",
+    ),
+    (
+        utils.time_string_to_datetime_utc("20230401030000"),
+        utils.time_string_to_datetime_utc("20230401040000"),
+        "20230401030000.20230401040000",
+    ),
+]
+
+
+@pytest.mark.unit
+@patch("datadog_checks.mac_audit_logs.check.MacAuditLogsCheck.validate_configurations", return_value=None)
+@patch("datadog_checks.mac_audit_logs.check.MacAuditLogsCheck.get_log_cursor", return_value=_boundary_cursor)
+@patch("datadog_checks.mac_audit_logs.utils.get_utc_timestamp_minus_hours", return_value="20230401000000")
+@patch(
+    "datadog_checks.mac_audit_logs.check.MacAuditLogsCheck.collect_relevant_files",
+    return_value=(_boundary_closed, []),
+)
+@patch("datadog_checks.mac_audit_logs.check.MacAuditLogsCheck.collect_data_from_files", return_value=None)
+@patch("subprocess.run")
+def test_resume_narrowing_picks_file_starting_at_cursor_record_time(
+    mock_subprocess_run,
+    mock_collect_data,
+    mock_relevant_files,
+    utc_timestamp_minus_hours,
+    mock_get_cursor,
+    mock_validate_config,
+    instance,
+):
+    """When the last emitted record's timestamp coincides exactly with the
+    start of a new audit file, resuming an aborted cycle reads forward from
+    that new file (and any files after it), not from the file whose end
+    matches the timestamp. Reading from the older file would re-process
+    records that were already emitted in the prior cycle.
+    """
+    mock_subprocess_run.return_value = MagicMock(stdout="+0000\n")
+    check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
+    check.log = MagicMock()
+    check.check(None)
+
+    narrowed_closed = mock_collect_data.call_args[0][0]
+    assert narrowed_closed == _boundary_closed[1:]
 
 
 @pytest.mark.unit
@@ -231,12 +313,14 @@ def test_collect_relevant_files_for_failed_last_iteration(
 def test_get_previous_iteration_log_cursor_when_cusror_is_none(utc_timestamp_minus_hours, instance):
     check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
 
-    last_record_time, last_record_milli_sec, last_collected_file_name = check.get_previous_iteration_log_cursor(None)
+    last_record_time, last_record_milli_sec, last_completed_closed, last_completed_open = (
+        check.get_previous_iteration_log_cursor(None)
+    )
 
-    # Check if the result matches the expected output
     assert last_record_time == "20230401000000"
     assert last_record_milli_sec is None
-    assert last_collected_file_name is None
+    assert last_completed_closed == []
+    assert last_completed_open == []
 
 
 @pytest.mark.unit
@@ -246,16 +330,17 @@ def test_get_previous_iteration_log_cursor_when_cusror_is_not_none(utc_timestamp
     previous_cursor = {
         "record_time": "20230401000000",
         "record_milli_sec": " + 430 msec",
-        "file_name": "20230401000000.20230401000015",
+        "last_completed_closed": ["20230401000000.20230401000015"],
+        "last_completed_open": ["20230401000015.not_terminated"],
     }
-    last_record_time, last_record_milli_sec, last_collected_file_name = check.get_previous_iteration_log_cursor(
-        previous_cursor
+    last_record_time, last_record_milli_sec, last_completed_closed, last_completed_open = (
+        check.get_previous_iteration_log_cursor(previous_cursor)
     )
 
-    # Check if the result matches the expected output
     assert last_record_time == "20230401000000"
     assert last_record_milli_sec == " + 430 msec"
-    assert last_collected_file_name == "20230401000000.20230401000015"
+    assert last_completed_closed == ["20230401000000.20230401000015"]
+    assert last_completed_open == ["20230401000015.not_terminated"]
 
 
 @pytest.mark.unit
@@ -329,167 +414,108 @@ def test_fetch_audit_logs_single_file(mock_popen, instance):
     assert error == ""
 
 
-@pytest.mark.unit
-@patch("os.path.exists", return_value=True)
-@patch("datadog_checks.mac_audit_logs.utils.get_utc_timestamp_minus_hours", return_value="20230401000000")
-def test_collect_data_from_files_batches_all_existing_files(mock_utc, mock_exists, instance):
-    """All existing files are batched into a single auditreduce call."""
+def _make_closed(start: str, end: str) -> tuple[datetime, datetime, str]:
+    return (
+        utils.time_string_to_datetime_utc(start),
+        utils.time_string_to_datetime_utc(end),
+        f"{start}.{end}",
+    )
+
+
+THREE_CLOSED_FILES = [
+    _make_closed("20230401000000", "20230401010000"),
+    _make_closed("20230401010000", "20230401020000"),
+    _make_closed("20230401020000", "20230401030000"),
+]
+
+
+def _path(check: MacAuditLogsCheck, file_name: str) -> str:
+    return os.path.join(check.audit_logs_dir_path, file_name)
+
+
+def _make_check_for_collection(instance: dict) -> MacAuditLogsCheck:
     check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
     check.fetch_audit_logs = MagicMock(return_value=(b"<record/>", b""))
     check.process_and_ingest_log_entries = MagicMock()
+    return check
 
-    relevant_files = [
-        (utils.time_string_to_datetime_utc("20230401000000"), "20230401000000.20230401010000"),
-        (utils.time_string_to_datetime_utc("20230401010000"), "20230401010000.20230401020000"),
-        (utils.time_string_to_datetime_utc("20230401020000"), "20230401020000.20230401030000"),
-    ]
-    last_record_time = "20230401000000"
 
-    check.collect_data_from_files(relevant_files, None, last_record_time, None, None, "+0000")
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "last_completed_closed,last_completed_open,last_record_time,expected_indices",
+    [
+        pytest.param([], [], "20230401000000", [0, 1, 2], id="batches_all_existing"),
+        pytest.param([THREE_CLOSED_FILES[0][2]], [], "20230401010000", [1, 2], id="skips_already_processed"),
+        pytest.param([], [], "20230401000000", [], id="no_valid_files"),
+        pytest.param([], ["20230401000000.not_terminated"], "20230401010000", [1, 2], id="skips_rotated_open"),
+        pytest.param([], [], "20230401000030", [0, 1, 2], id="always_uses_last_record_time"),
+    ],
+)
+@patch("datadog_checks.mac_audit_logs.utils.get_utc_timestamp_minus_hours", return_value="20230401000000")
+def test_collect_data_from_files(
+    mock_utc, last_completed_closed, last_completed_open, last_record_time, expected_indices, instance
+):
+    """Files surviving the skip checks are batched into one auditreduce call with
+    the cursor's last-record timestamp as the filter."""
+    check = _make_check_for_collection(instance)
+    exists_return = expected_indices != []
 
-    expected_paths = [os.path.join(check.audit_logs_dir_path, f) for _, f in relevant_files]
+    with patch("os.path.exists", return_value=exists_return):
+        check.collect_data_from_files(
+            THREE_CLOSED_FILES, [], last_completed_closed, last_completed_open, last_record_time, None, "+0000"
+        )
+
+    if not expected_indices:
+        check.fetch_audit_logs.assert_not_called()
+        return
+
+    expected_names = [THREE_CLOSED_FILES[i][2] for i in expected_indices]
+    expected_paths = [_path(check, name) for name in expected_names]
     check.fetch_audit_logs.assert_called_once_with(expected_paths, last_record_time)
-    call_args = check.process_and_ingest_log_entries.call_args[0]
-    assert call_args[1] == relevant_files[0][1], "cursor file_name should be the first file in the batch"
+    forwarded_completed_closed = check.process_and_ingest_log_entries.call_args[0][1]
+    assert forwarded_completed_closed == expected_names
 
 
 @pytest.mark.unit
 @patch("datadog_checks.mac_audit_logs.utils.get_utc_timestamp_minus_hours", return_value="20230401000000")
 def test_collect_data_from_files_excludes_missing_files(mock_utc, instance):
     """Files that no longer exist on disk are excluded from the auditreduce batch."""
-    check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
-    check.fetch_audit_logs = MagicMock(return_value=(b"<record/>", b""))
-    check.process_and_ingest_log_entries = MagicMock()
-
-    relevant_files = [
-        (utils.time_string_to_datetime_utc("20230401000000"), "20230401000000.20230401010000"),
-        (utils.time_string_to_datetime_utc("20230401010000"), "20230401010000.20230401020000"),
-        (utils.time_string_to_datetime_utc("20230401020000"), "20230401020000.20230401030000"),
-    ]
-    missing_file = os.path.join(check.audit_logs_dir_path, relevant_files[1][1])
+    check = _make_check_for_collection(instance)
+    missing_file = _path(check, THREE_CLOSED_FILES[1][2])
 
     with patch("os.path.exists", side_effect=lambda p: p != missing_file):
-        check.collect_data_from_files(relevant_files, None, "20230401000000", None, None, "+0000")
+        check.collect_data_from_files(THREE_CLOSED_FILES, [], [], [], "20230401000000", None, "+0000")
 
-    expected_paths = [
-        os.path.join(check.audit_logs_dir_path, relevant_files[0][1]),
-        os.path.join(check.audit_logs_dir_path, relevant_files[2][1]),
-    ]
+    expected_paths = [_path(check, THREE_CLOSED_FILES[0][2]), _path(check, THREE_CLOSED_FILES[2][2])]
     check.fetch_audit_logs.assert_called_once_with(expected_paths, "20230401000000")
 
 
 @pytest.mark.unit
-@patch("os.path.exists", return_value=True)
-@patch("datadog_checks.mac_audit_logs.utils.get_utc_timestamp_minus_hours", return_value="20230401000000")
-def test_collect_data_from_files_skips_already_processed_files(mock_utc, mock_exists, instance):
-    """Files fully processed in a previous iteration are excluded from the batch."""
-    check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
-    check.fetch_audit_logs = MagicMock(return_value=(b"<record/>", b""))
-    check.process_and_ingest_log_entries = MagicMock()
-
-    relevant_files = [
-        (utils.time_string_to_datetime_utc("20230401000000"), "20230401000000.20230401010000"),
-        (utils.time_string_to_datetime_utc("20230401010000"), "20230401010000.20230401020000"),
-        (utils.time_string_to_datetime_utc("20230401020000"), "20230401020000.20230401030000"),
-    ]
-    previous_cursor = {"is_file_collection_completed": True}
-    last_collected_file_name = relevant_files[0][1]
-    last_record_time = "20230401010000"
-
-    check.collect_data_from_files(
-        relevant_files, previous_cursor, last_record_time, last_collected_file_name, None, "+0000"
-    )
-
-    expected_paths = [
-        os.path.join(check.audit_logs_dir_path, relevant_files[1][1]),
-        os.path.join(check.audit_logs_dir_path, relevant_files[2][1]),
-    ]
-    check.fetch_audit_logs.assert_called_once_with(expected_paths, last_record_time)
-
-
-@pytest.mark.unit
-@patch("datadog_checks.mac_audit_logs.utils.get_utc_timestamp_minus_hours", return_value="20230401000000")
-def test_collect_data_from_files_no_valid_files(mock_utc, instance):
-    """No subprocess call when all files are filtered out."""
-    check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
-    check.fetch_audit_logs = MagicMock()
-
-    relevant_files = [
-        (utils.time_string_to_datetime_utc("20230401000000"), "20230401000000.20230401010000"),
-        (utils.time_string_to_datetime_utc("20230401010000"), "20230401010000.20230401020000"),
-    ]
-
-    with patch("os.path.exists", return_value=False):
-        check.collect_data_from_files(relevant_files, None, "20230401000000", None, None, "+0000")
-
-    check.fetch_audit_logs.assert_not_called()
-
-
-@pytest.mark.unit
-@patch("os.path.exists", return_value=True)
+@patch("os.path.isdir", return_value=True)
+@patch("os.path.isfile", return_value=True)
 @patch("datadog_checks.mac_audit_logs.utils.get_utc_timestamp_minus_hours", return_value="20230401030000")
-def test_collect_data_from_files_skips_files_outside_time_range(mock_utc, mock_exists, instance):
-    """Files whose end time is before the HOURS_OFFSET cutoff are excluded from the batch."""
+@patch(
+    "os.listdir",
+    return_value=[
+        "20230401000000.20230401010000",
+        "20230401010000.20230401020000",
+        "20230401030000.20230401040000",
+    ],
+)
+def test_collect_relevant_files_excludes_out_of_window(
+    _mock_listdir, _mock_get_utc, _mock_isfile, _mock_isdir, instance
+):
+    """Closed files whose end time is before the look-back cutoff are excluded."""
     check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
-    check.fetch_audit_logs = MagicMock(return_value=(b"<record/>", b""))
-    check.process_and_ingest_log_entries = MagicMock()
-
-    relevant_files = [
-        (utils.time_string_to_datetime_utc("20230401000000"), "20230401000000.20230401010000"),
-        (utils.time_string_to_datetime_utc("20230401010000"), "20230401010000.20230401020000"),
-        (utils.time_string_to_datetime_utc("20230401030000"), "20230401030000.20230401040000"),
+    closed, still_open = check.collect_relevant_files("20230401030000")
+    assert closed == [
+        (
+            utils.time_string_to_datetime_utc("20230401030000"),
+            utils.time_string_to_datetime_utc("20230401040000"),
+            "20230401030000.20230401040000",
+        ),
     ]
-
-    check.collect_data_from_files(relevant_files, None, "20230401000000", None, None, "+0000")
-
-    expected_paths = [os.path.join(check.audit_logs_dir_path, relevant_files[2][1])]
-    check.fetch_audit_logs.assert_called_once_with(expected_paths, "20230401000000")
-
-
-@pytest.mark.unit
-@patch("os.path.exists", return_value=True)
-@patch("datadog_checks.mac_audit_logs.utils.get_utc_timestamp_minus_hours", return_value="20230401000000")
-def test_collect_data_from_files_skips_rotated_not_terminated_file(mock_utc, mock_exists, instance):
-    """A not_terminated file that was completed and rotated into a named file is skipped."""
-    check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
-    check.fetch_audit_logs = MagicMock(return_value=(b"<record/>", b""))
-    check.process_and_ingest_log_entries = MagicMock()
-
-    relevant_files = [
-        (utils.time_string_to_datetime_utc("20230401000000"), "20230401000000.20230401010000"),
-        (utils.time_string_to_datetime_utc("20230401010000"), "20230401010000.20230401020000"),
-    ]
-    previous_cursor = {"is_file_collection_completed": True}
-    last_collected_file_name = "20230401000000.not_terminated"
-    last_record_time = "20230401010000"
-
-    check.collect_data_from_files(
-        relevant_files, previous_cursor, last_record_time, last_collected_file_name, None, "+0000"
-    )
-
-    expected_paths = [os.path.join(check.audit_logs_dir_path, relevant_files[1][1])]
-    check.fetch_audit_logs.assert_called_once_with(expected_paths, last_record_time)
-
-
-@pytest.mark.unit
-@patch("os.path.exists", return_value=True)
-@patch("datadog_checks.mac_audit_logs.utils.get_utc_timestamp_minus_hours", return_value="20230401000000")
-def test_collect_data_from_files_always_uses_last_record_time(mock_utc, mock_exists, instance):
-    """The time filter is always last_record_time (regression test for file_index bug)."""
-    check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
-    check.fetch_audit_logs = MagicMock(return_value=(b"<record/>", b""))
-    check.process_and_ingest_log_entries = MagicMock()
-
-    relevant_files = [
-        (utils.time_string_to_datetime_utc("20230401000000"), "20230401000000.20230401010000"),
-        (utils.time_string_to_datetime_utc("20230401010000"), "20230401010000.20230401020000"),
-        (utils.time_string_to_datetime_utc("20230401020000"), "20230401020000.20230401030000"),
-    ]
-    last_record_time = "20230401000030"
-
-    check.collect_data_from_files(relevant_files, None, last_record_time, None, None, "+0000")
-
-    assert check.fetch_audit_logs.call_args[0][1] == last_record_time
+    assert still_open == []
 
 
 @patch.object(MacAuditLogsCheck, 'send_log')
@@ -501,5 +527,83 @@ def test_process_and_ingest_log_entries_skipping_logs_milli_seconds(mock_send_lo
     )
     log_entries = logs.split("\n")
     check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
-    check.process_and_ingest_log_entries(log_entries, "20250605082138.20250605082142", "+0000", " + 278 msec")
-    assert mock_send_log.call_count == 2
+    check.process_and_ingest_log_entries(log_entries, ["20250605082138.20250605082142"], [], "+0000", " + 278 msec")
+    assert mock_send_log.call_count == 1
+
+
+LOG_TEMPLATE_RECORDS = (
+    "<record time=\"Thu Jun  5 13:51:38 2025\" msec=\" + 244 msec\" > /></record>\n"
+    "<record time=\"Thu Jun  5 13:51:39 2025\" msec=\" + 154 msec\" > /></record>"
+)
+DEFAULT_BATCH_CLOSED = ["20250605082138.20250605082142"]
+
+
+def _ingest(check: MacAuditLogsCheck, log_entries: list[str], resume_msec: str | None = None) -> None:
+    check.process_and_ingest_log_entries(log_entries, DEFAULT_BATCH_CLOSED, [], "+0000", resume_msec)
+
+
+# ---------------------------------------------------------------------------
+# Deduplication across emissions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@patch.object(MacAuditLogsCheck, "send_log")
+def test_each_unique_record_is_emitted_at_most_once_per_cycle(mock_send_log, instance):
+    """Within one cycle, every distinct record turns into at most one log entry."""
+    logs = (
+        "<record time=\"Thu Jun  5 13:51:38 2025\" msec=\" + 100 msec\" > /></record>\n"
+        "<record time=\"Thu Jun  5 13:51:39 2025\" msec=\" + 200 msec\" > /></record>\n"
+        "<record time=\"Thu Jun  5 13:51:40 2025\" msec=\" + 300 msec\" > /></record>"
+    )
+    check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
+
+    _ingest(check, logs.split("\n"))
+
+    messages = [call.args[0]["message"] for call in mock_send_log.call_args_list]
+    assert len(messages) == len(set(messages)) == 3
+
+
+@pytest.mark.unit
+@patch.object(MacAuditLogsCheck, "send_log")
+def test_records_after_the_resume_point_are_emitted(mock_send_log, instance):
+    """After the resume cursor's msec is matched, every subsequent record is emitted."""
+    logs = (
+        "<record time=\"Thu Jun  5 13:51:38 2025\" msec=\" + 100 msec\" > /></record>\n"
+        "<record time=\"Thu Jun  5 13:51:38 2025\" msec=\" + 200 msec\" > /></record>\n"
+        "<record time=\"Thu Jun  5 13:51:39 2025\" msec=\" + 300 msec\" > /></record>\n"
+        "<record time=\"Thu Jun  5 13:51:40 2025\" msec=\" + 400 msec\" > /></record>"
+    )
+    check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
+
+    _ingest(check, logs.split("\n"), resume_msec=" + 200 msec")
+
+    emitted_msecs = [
+        msec
+        for call in mock_send_log.call_args_list
+        for msec in [" + 100 msec", " + 200 msec", " + 300 msec", " + 400 msec"]
+        if msec in call.args[0]["message"]
+    ]
+    assert emitted_msecs == [" + 300 msec", " + 400 msec"]
+
+
+# ---------------------------------------------------------------------------
+# Cursor monotonicity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@patch.object(MacAuditLogsCheck, "send_log")
+def test_cursor_record_time_never_moves_backwards(mock_send_log, instance):
+    """Successive cursors emitted within one cycle have monotonically non-decreasing record_time."""
+    logs = (
+        "<record time=\"Thu Jun  5 13:51:38 2025\" msec=\" + 100 msec\" > /></record>\n"
+        "<record time=\"Thu Jun  5 13:51:39 2025\" msec=\" + 200 msec\" > /></record>\n"
+        "<record time=\"Thu Jun  5 13:51:40 2025\" msec=\" + 300 msec\" > /></record>"
+    )
+    check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
+
+    _ingest(check, logs.split("\n"))
+
+    record_times = [call.kwargs["cursor"]["record_time"] for call in mock_send_log.call_args_list]
+    assert record_times == sorted(record_times)

--- a/mac_audit_logs/tests/test_unit.py
+++ b/mac_audit_logs/tests/test_unit.py
@@ -43,6 +43,7 @@ log_cursor = {
 }
 
 
+@pytest.mark.unit
 def test_instance_check(dd_run_check, aggregator, instance):
     check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
 
@@ -367,14 +368,16 @@ def test_fetch_audit_logs(mock_popen, instance):
     output, error = check.fetch_audit_logs(file_paths, time_filter_arg)
 
     mock_popen.assert_any_call(
-        f"sudo auditreduce -a {time_filter_arg} {file_paths[0]} {file_paths[1]}",
-        shell=True,
+        ["sudo", "auditreduce", "-a", time_filter_arg, file_paths[0], file_paths[1]],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env={**os.environ, "TZ": "UTC"},
     )
     mock_popen.assert_any_call(
-        'sudo praudit -xsl', shell=True, stdin=mock_auditreduce_stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        ["sudo", "praudit", "-xsl"],
+        stdin=mock_auditreduce_stdout,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
 
     mock_praudit_process.communicate.assert_called_once()
@@ -402,8 +405,7 @@ def test_fetch_audit_logs_single_file(mock_popen, instance):
     output, error = check.fetch_audit_logs([file_path], time_filter_arg)
 
     mock_popen.assert_any_call(
-        f"sudo auditreduce -a {time_filter_arg} {file_path}",
-        shell=True,
+        ["sudo", "auditreduce", "-a", time_filter_arg, file_path],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env={**os.environ, "TZ": "UTC"},
@@ -497,6 +499,30 @@ def test_collect_data_from_files_excludes_missing_files(mock_utc, instance):
 @patch(
     "os.listdir",
     return_value=[
+        "20230401000000.crash_recovery",
+        "20230401040000.crash_recovery",
+    ],
+)
+def test_collect_relevant_files_drops_crash_recovery_before_cutoff(
+    _mock_listdir, _mock_get_utc, _mock_isfile, _mock_isdir, instance
+):
+    """Crash-recovery files whose start time is before the look-back cutoff are dropped;
+    only those at or after the cutoff carry through as still-open candidates."""
+    check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
+    closed, still_open = check.collect_relevant_files("20230401030000")
+    assert closed == []
+    assert still_open == [
+        (utils.time_string_to_datetime_utc("20230401040000"), "20230401040000.crash_recovery"),
+    ]
+
+
+@pytest.mark.unit
+@patch("os.path.isdir", return_value=True)
+@patch("os.path.isfile", return_value=True)
+@patch("datadog_checks.mac_audit_logs.utils.get_utc_timestamp_minus_hours", return_value="20230401030000")
+@patch(
+    "os.listdir",
+    return_value=[
         "20230401000000.20230401010000",
         "20230401010000.20230401020000",
         "20230401030000.20230401040000",
@@ -518,6 +544,7 @@ def test_collect_relevant_files_excludes_out_of_window(
     assert still_open == []
 
 
+@pytest.mark.unit
 @patch.object(MacAuditLogsCheck, 'send_log')
 def test_process_and_ingest_log_entries_skipping_logs_milli_seconds(mock_send_log, instance):
     logs = (
@@ -590,6 +617,49 @@ def test_records_after_the_resume_point_are_emitted(mock_send_log, instance):
 # ---------------------------------------------------------------------------
 # Cursor monotonicity
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@patch.object(MacAuditLogsCheck, "send_log")
+@patch("os.path.exists", return_value=True)
+@patch("datadog_checks.mac_audit_logs.utils.get_utc_timestamp_minus_hours", return_value="20250605000000")
+def test_clean_resume_at_same_second_emits_only_new_records(_mock_utc, _mock_exists, mock_send_log, instance):
+    """After a cleanly-completed cycle (`record_milli_sec=None`) the next cycle calls auditreduce
+    with the cursor's `record_time` and must emit every record returned, including any that share
+    the cursor's UTC second but come from a newly-rotated file. No record is dropped, no record is
+    duplicated, because already-completed files are excluded before the batch."""
+    completed_file = "20250605135137.20250605135138"
+    new_file = "20250605135138.not_terminated"
+
+    next_batch_logs = (
+        b"<record time=\"Thu Jun  5 13:51:38 2025\" msec=\" + 950 msec\" > /></record>\n"
+        b"<record time=\"Thu Jun  5 13:51:39 2025\" msec=\" + 010 msec\" > /></record>"
+    )
+    check = MacAuditLogsCheck("mac_audit_logs", {}, [instance])
+    check.fetch_audit_logs = MagicMock(return_value=(next_batch_logs, b""))
+
+    closed: list[tuple[datetime, datetime, str]] = []
+    still_open = [(utils.time_string_to_datetime_utc("20250605135138"), new_file)]
+
+    check.collect_data_from_files(
+        closed,
+        still_open,
+        [completed_file],
+        [],
+        "20250605135138",
+        None,
+        "+0000",
+    )
+
+    check.fetch_audit_logs.assert_called_once()
+    forwarded_paths, time_filter = check.fetch_audit_logs.call_args.args
+    assert forwarded_paths == [_path(check, new_file)]
+    assert time_filter == "20250605135138"
+
+    emitted_msecs = [call.args[0]["message"] for call in mock_send_log.call_args_list]
+    assert len(emitted_msecs) == 2
+    assert " + 950 msec" in emitted_msecs[0]
+    assert " + 010 msec" in emitted_msecs[1]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR combines several changes (in separate commits, can be reviewed as such)
- **Change fetch_audit_logs to accept multiple file paths**
- **Restructure collect_data_from_files for batched processing**
- **Modernize type annotations in check.py**
- **Clean up inline comments in check.py**


### Motivation
<!-- What inspired you to submit this pull request? -->
Customer support case.

We were not keeping up with logfiles when they got rotated fast.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
