### PR TITLE
Swap mock_http_response to MockHTTPResponse

### DIFF
--- a/appgate_sdp/tests/test_unit.py
+++ b/appgate_sdp/tests/test_unit.py
@@ -31,7 +31,7 @@ def test_check_appgate_sdp(dd_run_check, aggregator, instance, mock_http_respons
 def test_emits_critical_service_check_when_service_is_down(dd_run_check, aggregator, instance, mock_http_response):
     mock_http_response(status_code=404)
     check = AppgateSDPCheck('appgate_sdp', {}, [instance])
-    with pytest.raises(Exception, match='requests.exceptions.HTTPError'):
+    with pytest.raises(Exception, match='HTTPStatusError'):
         dd_run_check(check)
     aggregator.assert_service_check('appgate_sdp.openmetrics.health', AppgateSDPCheck.CRITICAL)
 

--- a/argo_workflows/tests/test_unit.py
+++ b/argo_workflows/tests/test_unit.py
@@ -135,6 +135,6 @@ def test_check_with_fixtures(dd_run_check, aggregator, instance, mock_http_respo
 def test_emits_critical_service_check_when_service_is_down(dd_run_check, aggregator, instance, mock_http_response):
     mock_http_response(status_code=404)
     check = ArgoWorkflowsCheck('argo_workflows', {}, [instance])
-    with pytest.raises(Exception, match='requests.exceptions.HTTPError'):
+    with pytest.raises(Exception, match='HTTPStatusError'):
         dd_run_check(check)
     aggregator.assert_service_check('argo_workflows.openmetrics.health', ArgoWorkflowsCheck.CRITICAL)

--- a/celery/tests/test_unit.py
+++ b/celery/tests/test_unit.py
@@ -44,7 +44,7 @@ def test_emits_critical_openemtrics_service_check_when_service_is_down(
     """
     mock_http_response(status_code=404)
     check = CeleryCheck("celery", {}, [instance])
-    with pytest.raises(Exception, match="requests.exceptions.HTTPError"):
+    with pytest.raises(Exception, match="HTTPStatusError"):
         dd_run_check(check)
 
     aggregator.assert_all_metrics_covered()

--- a/datadog_checks_base/datadog_checks/base/utils/http_testing.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http_testing.py
@@ -17,6 +17,7 @@ __all__ = ['MockHTTPResponse']
 class MockHTTPResponse:
     """Library-agnostic mock HTTP response implementing HTTPResponseProtocol."""
 
+    # Parameter order differs from MockResponse; not a compatibility concern since all callers use keyword args.
     def __init__(
         self,
         content: str | bytes = '',

--- a/datadog_checks_base/datadog_checks/base/utils/http_testing.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http_testing.py
@@ -14,6 +14,26 @@ from datadog_checks.base.utils.http_exceptions import HTTPStatusError
 __all__ = ['MockHTTPResponse']
 
 
+class _CaseInsensitiveDict(dict):
+    def __init__(self, data=None):
+        super().__init__()
+        if data:
+            for k, v in data.items():
+                self[k] = v
+
+    def __setitem__(self, key, value):
+        super().__setitem__(key.lower(), value)
+
+    def __getitem__(self, key):
+        return super().__getitem__(key.lower())
+
+    def __contains__(self, key):
+        return super().__contains__(key.lower() if isinstance(key, str) else key)
+
+    def get(self, key, default=None):
+        return super().get(key.lower(), default)
+
+
 class MockHTTPResponse:
     """Library-agnostic mock HTTP response implementing HTTPResponseProtocol."""
 
@@ -48,7 +68,7 @@ class MockHTTPResponse:
 
         self._content = content.encode('utf-8') if isinstance(content, str) else content
         self.status_code = status_code
-        self.headers = {k.lower(): v for k, v in (headers or {}).items()}
+        self.headers = _CaseInsensitiveDict(headers or {})
         self.cookies = cookies or {}
         self.encoding: str | None = None
         self.elapsed = timedelta(seconds=elapsed_seconds)

--- a/datadog_checks_base/datadog_checks/base/utils/http_testing.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http_testing.py
@@ -65,7 +65,10 @@ class MockHTTPResponse:
         cookies: dict[str, str] | None = None,
         elapsed_seconds: float = 0.1,
         normalize_content: bool = True,
+        url: str = '',
     ):
+        self.url = url
+
         if json_data is not None:
             content = json.dumps(json_data)
             # Copy to avoid mutating the caller's dict
@@ -92,6 +95,7 @@ class MockHTTPResponse:
         self._stream = BytesIO(self._content)
 
         self.raw = MagicMock()
+        self.raw.read = self._stream.read
         self.raw.connection.sock.getpeercert.side_effect = lambda binary_form=False: b'mock-cert' if binary_form else {}
 
     @property

--- a/datadog_checks_base/datadog_checks/base/utils/http_testing.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http_testing.py
@@ -15,6 +15,8 @@ __all__ = ['MockHTTPResponse']
 
 
 class _CaseInsensitiveDict(dict):
+    """Case-insensitive dict for HTTP headers. Keys are stored lowercased."""
+
     def __init__(self, data=None):
         super().__init__()
         if data:
@@ -22,16 +24,31 @@ class _CaseInsensitiveDict(dict):
                 self[k] = v
 
     def __setitem__(self, key, value):
-        super().__setitem__(key.lower(), value)
+        super().__setitem__(key.lower() if isinstance(key, str) else key, value)
 
     def __getitem__(self, key):
-        return super().__getitem__(key.lower())
+        return super().__getitem__(key.lower() if isinstance(key, str) else key)
 
     def __contains__(self, key):
         return super().__contains__(key.lower() if isinstance(key, str) else key)
 
+    def __delitem__(self, key):
+        super().__delitem__(key.lower() if isinstance(key, str) else key)
+
     def get(self, key, default=None):
-        return super().get(key.lower(), default)
+        return super().get(key.lower() if isinstance(key, str) else key, default)
+
+    def pop(self, key, *args):
+        return super().pop(key.lower() if isinstance(key, str) else key, *args)
+
+    def update(self, other=(), **kwargs):
+        if isinstance(other, dict):
+            other = {(k.lower() if isinstance(k, str) else k): v for k, v in other.items()}
+        kwargs = {k.lower(): v for k, v in kwargs.items()}
+        super().update(other, **kwargs)
+
+    def setdefault(self, key, default=None):
+        return super().setdefault(key.lower() if isinstance(key, str) else key, default)
 
 
 class MockHTTPResponse:

--- a/datadog_checks_base/datadog_checks/base/utils/http_testing.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http_testing.py
@@ -44,6 +44,8 @@ class _CaseInsensitiveDict(dict):
     def update(self, other=(), **kwargs):
         if isinstance(other, dict):
             other = {(k.lower() if isinstance(k, str) else k): v for k, v in other.items()}
+        elif other:
+            other = [(k.lower() if isinstance(k, str) else k, v) for k, v in other]
         kwargs = {k.lower(): v for k, v in kwargs.items()}
         super().update(other, **kwargs)
 

--- a/datadog_checks_base/tests/base/utils/http/test_http_testing.py
+++ b/datadog_checks_base/tests/base/utils/http/test_http_testing.py
@@ -100,5 +100,27 @@ def test_mock_response_headers_case_insensitive():
     assert response.headers['Content-Type'] == 'text/plain'
     assert response.headers['content-type'] == 'text/plain'
     assert response.headers.get('Content-Type') == 'text/plain'
-    assert 'Content-Type' in response.headers
-    assert 'content-type' in response.headers
+    assert response.headers.get('cOnTeNt-tYpE') == 'text/plain'
+
+
+def test_mock_response_headers_delete_and_pop():
+    response = MockHTTPResponse(headers={'Content-Type': 'text/plain', 'X-Custom': 'val'})
+
+    del response.headers['Content-Type']
+    assert 'content-type' not in response.headers
+
+    assert response.headers.pop('X-Custom') == 'val'
+    assert response.headers.pop('X-Custom', 'gone') == 'gone'
+
+
+def test_mock_response_headers_update_and_setdefault():
+    response = MockHTTPResponse(headers={'Content-Type': 'text/plain'})
+
+    response.headers.update({'X-New': 'new_val'})
+    assert response.headers['x-new'] == 'new_val'
+
+    response.headers.setdefault('X-Default', 'default_val')
+    assert response.headers['x-default'] == 'default_val'
+
+    response.headers.setdefault('Content-Type', 'should-not-change')
+    assert response.headers['content-type'] == 'text/plain'

--- a/datadog_checks_base/tests/base/utils/http/test_http_testing.py
+++ b/datadog_checks_base/tests/base/utils/http/test_http_testing.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2026-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+
 import pytest
 
 from datadog_checks.base import AgentCheck
@@ -124,3 +126,8 @@ def test_mock_response_headers_update_and_setdefault():
 
     response.headers.setdefault('Content-Type', 'should-not-change')
     assert response.headers['content-type'] == 'text/plain'
+
+
+def test_mock_response_raw_readable():
+    response = MockHTTPResponse(json_data={'key': 'value'})
+    assert json.load(response.raw) == {'key': 'value'}

--- a/datadog_checks_base/tests/base/utils/http/test_http_testing.py
+++ b/datadog_checks_base/tests/base/utils/http/test_http_testing.py
@@ -19,7 +19,7 @@ def test_mock_response_json_with_custom_headers():
     headers = {'X-Custom': 'value'}
     response = MockHTTPResponse(json_data={'key': 'value'}, headers=headers)
 
-    assert response.headers['Content-Type'] == 'application/json'
+    assert response.headers['content-type'] == 'application/json'
     assert response.headers['x-custom'] == 'value'
 
 

--- a/datadog_checks_base/tests/base/utils/http/test_http_testing.py
+++ b/datadog_checks_base/tests/base/utils/http/test_http_testing.py
@@ -17,7 +17,7 @@ def test_mock_response_json_with_custom_headers():
     headers = {'X-Custom': 'value'}
     response = MockHTTPResponse(json_data={'key': 'value'}, headers=headers)
 
-    assert response.headers['content-type'] == 'application/json'
+    assert response.headers['Content-Type'] == 'application/json'
     assert response.headers['x-custom'] == 'value'
 
 
@@ -92,3 +92,13 @@ def test_mock_response_reason_property():
     assert MockHTTPResponse(status_code=200).reason == 'OK'
     assert MockHTTPResponse(status_code=404).reason == 'Not Found'
     assert MockHTTPResponse(status_code=999).reason == ''
+
+
+def test_mock_response_headers_case_insensitive():
+    response = MockHTTPResponse(headers={'Content-Type': 'text/plain', 'X-Custom': 'val'})
+
+    assert response.headers['Content-Type'] == 'text/plain'
+    assert response.headers['content-type'] == 'text/plain'
+    assert response.headers.get('Content-Type') == 'text/plain'
+    assert 'Content-Type' in response.headers
+    assert 'content-type' in response.headers

--- a/datadog_checks_base/tests/base/utils/http/test_http_testing.py
+++ b/datadog_checks_base/tests/base/utils/http/test_http_testing.py
@@ -127,6 +127,14 @@ def test_mock_response_headers_update_and_setdefault():
     response.headers.setdefault('Content-Type', 'should-not-change')
     assert response.headers['content-type'] == 'text/plain'
 
+    response.headers.update([('X-Iter', 'iter_val')])
+    assert response.headers['x-iter'] == 'iter_val'
+
+
+def test_mock_response_url():
+    assert MockHTTPResponse(url='http://example.com').url == 'http://example.com'
+    assert MockHTTPResponse().url == ''
+
 
 def test_mock_response_raw_readable():
     response = MockHTTPResponse(json_data={'key': 'value'})

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -367,7 +367,7 @@ def mock_http_response_per_endpoint(mocker, mock_response):
         responses_by_endpoint: Dict[str, list[MockHTTPResponse]],
         mode: Literal['cycle', 'exhaust', 'default'] = 'cycle',
         default_response: MockHTTPResponse | None = None,
-        method: str = 'requests.Session.get',
+        method: str = 'requests.Session.get',  # TODO(httpx-migration): update default when backend changes
         url_arg_index: int = 1,
         url_kwarg_name: str = "url",
         strict: bool = True,

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -33,7 +33,7 @@ from datadog_checks.dev._env import (
 
 __aggregator = None
 __datadog_agent = None
-MockResponse = None
+MockHTTPResponse = None
 
 
 @pytest.fixture
@@ -286,12 +286,11 @@ def dd_default_hostname():
 
 @pytest.fixture
 def mock_response():
-    # Lazily import `requests` as it may be costly under certain conditions
-    global MockResponse
-    if MockResponse is None:
-        from datadog_checks.dev.http import MockResponse
+    global MockHTTPResponse
+    if MockHTTPResponse is None:
+        from datadog_checks.base.utils.http_testing import MockHTTPResponse
 
-    yield MockResponse
+    yield MockHTTPResponse
 
 
 @pytest.fixture
@@ -344,10 +343,10 @@ def mock_http(mocker):
 def mock_http_response_per_endpoint(mocker, mock_response):
     @overload
     def _mock(
-        responses_by_endpoint: Dict[str, list[MockResponse]],
+        responses_by_endpoint: Dict[str, list[MockHTTPResponse]],
         *,
         mode: Literal["default"],
-        default_response: MockResponse,
+        default_response: MockHTTPResponse,
         method: str = ...,
         url_arg_index: int = ...,
         url_kwarg_name: str = ...,
@@ -355,7 +354,7 @@ def mock_http_response_per_endpoint(mocker, mock_response):
     ): ...
     @overload
     def _mock(
-        responses_by_endpoint: Dict[str, list[MockResponse]],
+        responses_by_endpoint: Dict[str, list[MockHTTPResponse]],
         *,
         mode: Literal["cycle", "exhaust"],
         default_response: None = None,
@@ -365,9 +364,9 @@ def mock_http_response_per_endpoint(mocker, mock_response):
         strict: bool = ...,
     ): ...
     def _mock(
-        responses_by_endpoint: Dict[str, list[MockResponse]],
+        responses_by_endpoint: Dict[str, list[MockHTTPResponse]],
         mode: Literal['cycle', 'exhaust', 'default'] = 'cycle',
-        default_response: MockResponse | None = None,
+        default_response: MockHTTPResponse | None = None,
         method: str = 'requests.Session.get',
         url_arg_index: int = 1,
         url_kwarg_name: str = "url",
@@ -403,7 +402,7 @@ def mock_http_response_per_endpoint(mocker, mock_response):
                 if strict:
                     raise ValueError(f"Endpoint {url} not found in mocked responses")
                 else:
-                    return MockResponse(status_code=404)
+                    return mock_response(status_code=404)
             else:
                 try:
                     return next(queues[url])

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -35,6 +35,8 @@ __aggregator = None
 __datadog_agent = None
 MockHTTPResponse = None
 
+_DEFAULT_MOCK_METHOD = 'requests.Session.get'  # TODO(httpx-migration): update when backend changes
+
 
 @pytest.fixture
 def aggregator():
@@ -296,7 +298,7 @@ def mock_response():
 @pytest.fixture
 def mock_http_response(mocker, mock_response):
     yield lambda *args, **kwargs: mocker.patch(
-        kwargs.pop('method', 'requests.Session.get'), return_value=mock_response(*args, **kwargs)
+        kwargs.pop('method', _DEFAULT_MOCK_METHOD), return_value=mock_response(*args, **kwargs)
     )
 
 
@@ -367,7 +369,7 @@ def mock_http_response_per_endpoint(mocker, mock_response):
         responses_by_endpoint: Dict[str, list[MockHTTPResponse]],
         mode: Literal['cycle', 'exhaust', 'default'] = 'cycle',
         default_response: MockHTTPResponse | None = None,
-        method: str = 'requests.Session.get',  # TODO(httpx-migration): update default when backend changes
+        method: str = _DEFAULT_MOCK_METHOD,
         url_arg_index: int = 1,
         url_kwarg_name: str = "url",
         strict: bool = True,

--- a/dcgm/tests/test_unit.py
+++ b/dcgm/tests/test_unit.py
@@ -17,7 +17,7 @@ def test_critical_service_check(dd_run_check, aggregator, mock_http_response, ch
     When we can't connect to dcgm-exporter for whatever reason we should only submit a CRITICAL service check.
     """
     mock_http_response(status_code=404)
-    with pytest.raises(Exception, match="requests.exceptions.HTTPError"):
+    with pytest.raises(Exception, match="HTTPStatusError"):
         dd_run_check(check)
     aggregator.assert_service_check('dcgm.openmetrics.health', status=check.CRITICAL)
 

--- a/nvidia_nim/tests/test_unit.py
+++ b/nvidia_nim/tests/test_unit.py
@@ -54,7 +54,7 @@ def test_emits_critical_openemtrics_service_check_when_service_is_down(
     """
     mock_http_response(status_code=404)
     check = NvidiaNIMCheck("nvidia_nim", {}, [instance])
-    with pytest.raises(Exception, match="requests.exceptions.HTTPError"):
+    with pytest.raises(Exception, match="HTTPStatusError"):
         dd_run_check(check)
 
     aggregator.assert_all_metrics_covered()

--- a/nvidia_triton/tests/test_unit.py
+++ b/nvidia_triton/tests/test_unit.py
@@ -35,7 +35,7 @@ def test_emits_critical_openemtrics_service_check_when_service_is_down(
     """
     mock_http_response(status_code=404)
     check = NvidiaTritonCheck('nvidia_triton', {}, [instance])
-    with pytest.raises(Exception, match="requests.exceptions.HTTPError"):
+    with pytest.raises(Exception, match="HTTPStatusError"):
         dd_run_check(check)
 
     aggregator.assert_all_metrics_covered()

--- a/quarkus/tests/test_unit.py
+++ b/quarkus/tests/test_unit.py
@@ -83,7 +83,7 @@ def test_emits_critical_service_check_when_service_is_down(dd_run_check, aggrega
     mock_http_response(status_code=404)
     check = QuarkusCheck('quarkus', {}, [instance])
     # When
-    with pytest.raises(Exception, match="requests.exceptions.HTTPError"):
+    with pytest.raises(Exception, match="HTTPStatusError"):
         dd_run_check(check)
     # Then
     aggregator.assert_service_check('quarkus.openmetrics.health', QuarkusCheck.CRITICAL)

--- a/rabbitmq/tests/test_openmetrics.py
+++ b/rabbitmq/tests/test_openmetrics.py
@@ -352,6 +352,6 @@ def test_config(prom_plugin_settings, err):
 def test_service_check_critical(aggregator, dd_run_check, mock_http_response):
     mock_http_response(status_code=404)
     check = _rmq_om_check({'url': 'http://fail'})
-    with pytest.raises(Exception, match="requests.exceptions.HTTPError"):
+    with pytest.raises(Exception, match="HTTPStatusError"):
         dd_run_check(check)
     aggregator.assert_service_check('rabbitmq.openmetrics.health', status=check.CRITICAL)

--- a/sonatype_nexus/tests/test_check.py
+++ b/sonatype_nexus/tests/test_check.py
@@ -3,20 +3,12 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
-from datadog_checks.dev.http import MockResponse
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.sonatype_nexus import constants
 from datadog_checks.sonatype_nexus.check import SonatypeNexusCheck
 from datadog_checks.sonatype_nexus.errors import EmptyResponseError
 
 from .conftest import instance
-
-
-@pytest.fixture
-def mock_http_response(mocker):
-    yield lambda *args, **kwargs: mocker.patch(
-        kwargs.pop("method", "requests.Session.get"), return_value=MockResponse(*args, **kwargs)
-    )
 
 
 def test_successful_metrics_collection(dd_run_check, mock_http_response, aggregator):

--- a/sonatype_nexus/tests/test_check.py
+++ b/sonatype_nexus/tests/test_check.py
@@ -13,16 +13,28 @@ from .conftest import instance
 
 def test_successful_metrics_collection(dd_run_check, mock_http_response, aggregator):
     status_metrics_response_data = {key: {"healthy": True} for key in constants.STATUS_METRICS_MAP.keys()}
+    status_metrics_response_data["gauges"] = {
+        "jvm.memory.heap.used": {"value": 123456789},
+        "nexus.analytics.bytes_transferred_by_format": {
+            "value": [{"maven": {"bytes_uploaded": 100, "bytes_downloaded": 200}}],
+        },
+        "nexus.analytics.blobstore_type_counts": {"value": {"file": 5}},
+    }
 
     mock_http_response(
-        "https://example.com/service/rest/v1/status/check",
         status_code=200,
-        json_data=status_metrics_response_data.update({"gauges": {"jvm.memory.heap.used": {"value": 123456789}}}),
+        json_data=status_metrics_response_data,
     )
 
     check = SonatypeNexusCheck("sonatype_nexus", {}, [instance])
     dd_run_check(check)
 
+    for metric_name in constants.STATUS_METRICS_MAP.values():
+        aggregator.assert_metric(f"sonatype_nexus.{metric_name}")
+    aggregator.assert_metric("sonatype_nexus.analytics.jvm.heap_memory_used")
+    aggregator.assert_metric("sonatype_nexus.analytics.uploaded_bytes_by_format")
+    aggregator.assert_metric("sonatype_nexus.analytics.downloaded_bytes_by_format")
+    aggregator.assert_metric("sonatype_nexus.analytics.blob_store.count_by_type")
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 

--- a/sonatype_nexus/tests/test_check.py
+++ b/sonatype_nexus/tests/test_check.py
@@ -87,7 +87,6 @@ def test_empty_instance(dd_run_check):
 
 def test_invalid_credentials(dd_run_check, mock_http_response):
     mock_http_response(
-        "https://example.com/service/rest/v1/status/check",
         status_code=401,
         json_data={"error": "Invalid credentials"},
     )
@@ -107,7 +106,6 @@ def test_invalid_credentials(dd_run_check, mock_http_response):
 
 def test_bad_request_error(dd_run_check, mock_http_response):
     mock_http_response(
-        "https://example.com/service/rest/v1/status/check",
         status_code=400,
         json_data={"error": "Bad request"},
     )
@@ -120,7 +118,6 @@ def test_bad_request_error(dd_run_check, mock_http_response):
 
 def test_license_expired_error(dd_run_check, mock_http_response):
     mock_http_response(
-        "https://example.com/service/rest/v1/status/check",
         status_code=402,
         json_data={"error": "License expired"},
     )
@@ -133,7 +130,6 @@ def test_license_expired_error(dd_run_check, mock_http_response):
 
 def test_insufficient_permission_error(dd_run_check, mock_http_response):
     mock_http_response(
-        "https://example.com/service/rest/v1/status/check",
         status_code=403,
         json_data={"error": "Insufficient permissions"},
     )
@@ -146,7 +142,6 @@ def test_insufficient_permission_error(dd_run_check, mock_http_response):
 
 def test_not_found_error(dd_run_check, mock_http_response):
     mock_http_response(
-        "https://example.com/service/rest/v1/status/check",
         status_code=404,
         json_data={"error": "Resource not found"},
     )
@@ -159,7 +154,6 @@ def test_not_found_error(dd_run_check, mock_http_response):
 
 def test_server_error(dd_run_check, mock_http_response):
     mock_http_response(
-        "https://example.com/service/rest/v1/status/check",
         status_code=500,
         json_data={"error": "Internal server error"},
     )
@@ -172,7 +166,6 @@ def test_server_error(dd_run_check, mock_http_response):
 
 def test_timeout_error(dd_run_check, mock_http_response):
     mock_http_response(
-        "https://example.com/service/rest/v1/status/check",
         status_code=408,
         json_data={"error": "TimeoutError"},
     )

--- a/vllm/tests/test_unit.py
+++ b/vllm/tests/test_unit.py
@@ -81,7 +81,7 @@ def test_emits_critical_openemtrics_service_check_when_service_is_down(
     """
     mock_http_response(status_code=404)
     check = vLLMCheck("vllm", {}, [instance])
-    with pytest.raises(Exception, match='requests.exceptions.HTTPError'):
+    with pytest.raises(Exception, match='HTTPStatusError'):
         dd_run_check(check)
 
     aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
## Motivation

Part of the httpx migration: decouple the shared `mock_http_response` test fixture from the `requests` library so individual integration tests don't need to change when we swap HTTP backends.

## Approach

- Swap the `mock_http_response` fixture from `MockResponse` (requests-backed) to `MockHTTPResponse` (library-agnostic) in the central pytest plugin — this implicitly covers ~102 test files (228 calls) without touching individual test code
- 13 files needed explicit changes: 9 match string updates, sonatype_nexus fixture override removal, and base package updates
- Re-add `_CaseInsensitiveDict` to `MockHTTPResponse.headers` — previously unnecessary when only used in controlled new tests, now required because production code (e.g. `prometheus/mixins.py`) accesses `response.headers['Content-Type']`
- Fix sonatype_nexus test bug: `dict.update()` returns `None`, so `json_data=data.update({...})` was passing an empty response body — now builds the dict before passing it

See [plan](https://datadoghq.atlassian.net/wiki/spaces/AI/pages/6404866080/PR+3b+Swap+mock_http_response+Fixture+Update+Test+Match+Strings) for more details.

## agint-review follow-ups

Addressed nits from the [agint-review findings](https://datadoghq.atlassian.net/wiki/spaces/AI/pages/6454018506/PR+3b+Review+Follow-ups+agint-review+Findings):

- Fix `_CaseInsensitiveDict.update()` to handle iterable-of-pairs (aligns with httpx's `Headers` interface)
- Add `test_mock_response_url()` for `MockHTTPResponse.url` coverage
- Remove dead URL positional args from 7 sonatype_nexus tests

## Verification

- `ddev test -fs datadog_checks_base` — clean
- `ddev test datadog_checks_base` — 1280 passed
- `ddev test sonatype_nexus` — 13 passed

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged