### PR TITLE
feat(.builders): store hashes of all dependency resolution inputs in metadata.json

### DIFF
--- a/.builders/tests/test_upload.py
+++ b/.builders/tests/test_upload.py
@@ -604,6 +604,25 @@ def test_generate_artifact_listings():
     assert 'href="package2/"' in root_html
 
 
+@pytest.fixture
+def patched_input_files(tmp_path, monkeypatch):
+    dep_file = tmp_path / 'agent_requirements.in'
+    dep_file.write_bytes(b'requests==2.31.0\n')
+
+    workflow_file = tmp_path / 'resolve-build-deps.yaml'
+    workflow_file.write_bytes(b'on: push\n')
+
+    builder_dir = tmp_path / '.builders'
+    builder_dir.mkdir()
+    (builder_dir / 'upload.py').write_bytes(b'# script\n')
+
+    monkeypatch.setattr(upload, 'DIRECT_DEP_FILE', dep_file)
+    monkeypatch.setattr(upload, 'WORKFLOW_FILE', workflow_file)
+    monkeypatch.setattr(upload, 'BUILDER_DIR', builder_dir)
+
+    return dep_file, workflow_file, builder_dir
+
+
 def test_hash_directory(tmp_path):
     (tmp_path / 'a.txt').write_bytes(b'hello')
     (tmp_path / 'b.txt').write_bytes(b'world')
@@ -614,21 +633,15 @@ def test_hash_directory(tmp_path):
     (tmp_path / 'a.txt').write_bytes(b'changed')
     assert upload.hash_directory(tmp_path) != result
 
+    (tmp_path / 'a.txt').write_bytes(b'hello')
+    assert upload.hash_directory(tmp_path) == result
 
-def test_compute_input_hashes(tmp_path, monkeypatch):
-    dep_file = tmp_path / 'agent_requirements.in'
-    dep_file.write_bytes(b'requests==2.31.0\n')
+    (tmp_path / 'a.txt').rename(tmp_path / 'z.txt')
+    assert upload.hash_directory(tmp_path) != result
 
-    workflow_file = tmp_path / 'resolve-build-deps.yaml'
-    workflow_file.write_bytes(b'on: push\n')
 
-    builder_dir = tmp_path / '.builders'
-    builder_dir.mkdir()
-    (builder_dir / 'upload.py').write_bytes(b'# script\n')
-
-    monkeypatch.setattr(upload, 'DIRECT_DEP_FILE', dep_file)
-    monkeypatch.setattr(upload, 'WORKFLOW_FILE', workflow_file)
-    monkeypatch.setattr(upload, 'BUILDER_DIR', builder_dir)
+def test_compute_input_hashes(patched_input_files):
+    _, _, builder_dir = patched_input_files
 
     result = upload.compute_input_hashes()
 
@@ -638,25 +651,12 @@ def test_compute_input_hashes(tmp_path, monkeypatch):
     assert result['.builders'] == upload.hash_directory(builder_dir)
 
 
-def test_generate_lockfiles_metadata_contains_inputs(tmp_path, monkeypatch):
-    dep_file = tmp_path / 'agent_requirements.in'
-    dep_file.write_bytes(b'requests==2.31.0\n')
-
-    workflow_file = tmp_path / 'resolve-build-deps.yaml'
-    workflow_file.write_bytes(b'on: push\n')
-
-    builder_dir = tmp_path / '.builders'
-    builder_dir.mkdir()
-    (builder_dir / 'upload.py').write_bytes(b'# script\n')
-
+def test_generate_lockfiles_metadata_contains_inputs(tmp_path, patched_input_files, monkeypatch):
     fake_deps_dir = tmp_path / '.deps'
     fake_resolved_dir = fake_deps_dir / 'resolved'
     fake_deps_dir.mkdir()
     fake_resolved_dir.mkdir()
 
-    monkeypatch.setattr(upload, 'DIRECT_DEP_FILE', dep_file)
-    monkeypatch.setattr(upload, 'WORKFLOW_FILE', workflow_file)
-    monkeypatch.setattr(upload, 'BUILDER_DIR', builder_dir)
     monkeypatch.setattr(upload, 'RESOLUTION_DIR', fake_deps_dir)
     monkeypatch.setattr(upload, 'LOCK_FILE_DIR', fake_resolved_dir)
 
@@ -665,6 +665,7 @@ def test_generate_lockfiles_metadata_contains_inputs(tmp_path, monkeypatch):
     metadata = json.loads((fake_deps_dir / 'metadata.json').read_text())
     assert 'inputs' in metadata
     assert set(metadata['inputs'].keys()) == {'agent_requirements.in', '.github/workflows/resolve-build-deps.yaml', '.builders'}
+    assert metadata['inputs']['agent_requirements.in'] == sha256(b'requests==2.31.0\n').hexdigest()
     assert metadata['sha256'] == sha256(b'requests==2.31.0\n').hexdigest()
 
 

--- a/.builders/tests/test_upload.py
+++ b/.builders/tests/test_upload.py
@@ -606,21 +606,25 @@ def test_generate_artifact_listings():
 
 @pytest.fixture
 def patched_input_files(tmp_path, monkeypatch):
+    dep_content = b'requests==2.31.0\n'
     dep_file = tmp_path / 'agent_requirements.in'
-    dep_file.write_bytes(b'requests==2.31.0\n')
+    dep_file.write_bytes(dep_content)
 
-    workflow_file = tmp_path / 'resolve-build-deps.yaml'
-    workflow_file.write_bytes(b'on: push\n')
+    workflow_content = b'on: push\n'
+    workflow_file = tmp_path / '.github' / 'workflows' / 'resolve-build-deps.yaml'
+    workflow_file.parent.mkdir(parents=True)
+    workflow_file.write_bytes(workflow_content)
 
     builder_dir = tmp_path / '.builders'
     builder_dir.mkdir()
     (builder_dir / 'upload.py').write_bytes(b'# script\n')
 
+    monkeypatch.setattr(upload, 'REPO_DIR', tmp_path)
     monkeypatch.setattr(upload, 'DIRECT_DEP_FILE', dep_file)
     monkeypatch.setattr(upload, 'WORKFLOW_FILE', workflow_file)
     monkeypatch.setattr(upload, 'BUILDER_DIR', builder_dir)
 
-    return dep_file, workflow_file, builder_dir
+    return dep_content, workflow_content, builder_dir
 
 
 def test_hash_directory(tmp_path):
@@ -641,17 +645,19 @@ def test_hash_directory(tmp_path):
 
 
 def test_compute_input_hashes(patched_input_files):
-    _, _, builder_dir = patched_input_files
+    dep_content, workflow_content, builder_dir = patched_input_files
 
     result = upload.compute_input_hashes()
 
     assert set(result.keys()) == {'agent_requirements.in', '.github/workflows/resolve-build-deps.yaml', '.builders'}
-    assert result['agent_requirements.in'] == sha256(b'requests==2.31.0\n').hexdigest()
-    assert result['.github/workflows/resolve-build-deps.yaml'] == sha256(b'on: push\n').hexdigest()
+    assert result['agent_requirements.in'] == sha256(dep_content).hexdigest()
+    assert result['.github/workflows/resolve-build-deps.yaml'] == sha256(workflow_content).hexdigest()
     assert result['.builders'] == upload.hash_directory(builder_dir)
 
 
 def test_generate_lockfiles_metadata_contains_inputs(tmp_path, patched_input_files, monkeypatch):
+    dep_content, _, _ = patched_input_files
+
     fake_deps_dir = tmp_path / '.deps'
     fake_resolved_dir = fake_deps_dir / 'resolved'
     fake_deps_dir.mkdir()
@@ -665,8 +671,8 @@ def test_generate_lockfiles_metadata_contains_inputs(tmp_path, patched_input_fil
     metadata = json.loads((fake_deps_dir / 'metadata.json').read_text())
     assert 'inputs' in metadata
     assert set(metadata['inputs'].keys()) == {'agent_requirements.in', '.github/workflows/resolve-build-deps.yaml', '.builders'}
-    assert metadata['inputs']['agent_requirements.in'] == sha256(b'requests==2.31.0\n').hexdigest()
-    assert metadata['sha256'] == sha256(b'requests==2.31.0\n').hexdigest()
+    assert metadata['inputs']['agent_requirements.in'] == sha256(dep_content).hexdigest()
+    assert metadata['sha256'] == sha256(dep_content).hexdigest()
 
 
 def test_upload(setup_targets_dir, setup_fake_hash):

--- a/.builders/tests/test_upload.py
+++ b/.builders/tests/test_upload.py
@@ -1,4 +1,6 @@
 import email.message
+import json
+from hashlib import sha256
 from pathlib import Path
 from unittest import mock
 from zipfile import ZipFile
@@ -600,6 +602,70 @@ def test_generate_artifact_listings():
     assert "<h1>Agent integrations dependencies</h1>" in root_html
     assert 'href="package1/"' in root_html
     assert 'href="package2/"' in root_html
+
+
+def test_hash_directory(tmp_path):
+    (tmp_path / 'a.txt').write_bytes(b'hello')
+    (tmp_path / 'b.txt').write_bytes(b'world')
+
+    result = upload.hash_directory(tmp_path)
+    assert result == upload.hash_directory(tmp_path)
+
+    (tmp_path / 'a.txt').write_bytes(b'changed')
+    assert upload.hash_directory(tmp_path) != result
+
+
+def test_compute_input_hashes(tmp_path, monkeypatch):
+    dep_file = tmp_path / 'agent_requirements.in'
+    dep_file.write_bytes(b'requests==2.31.0\n')
+
+    workflow_file = tmp_path / 'resolve-build-deps.yaml'
+    workflow_file.write_bytes(b'on: push\n')
+
+    builder_dir = tmp_path / '.builders'
+    builder_dir.mkdir()
+    (builder_dir / 'upload.py').write_bytes(b'# script\n')
+
+    monkeypatch.setattr(upload, 'DIRECT_DEP_FILE', dep_file)
+    monkeypatch.setattr(upload, 'WORKFLOW_FILE', workflow_file)
+    monkeypatch.setattr(upload, 'BUILDER_DIR', builder_dir)
+
+    result = upload.compute_input_hashes()
+
+    assert set(result.keys()) == {'agent_requirements.in', '.github/workflows/resolve-build-deps.yaml', '.builders'}
+    assert result['agent_requirements.in'] == sha256(b'requests==2.31.0\n').hexdigest()
+    assert result['.github/workflows/resolve-build-deps.yaml'] == sha256(b'on: push\n').hexdigest()
+    assert result['.builders'] == upload.hash_directory(builder_dir)
+
+
+def test_generate_lockfiles_metadata_contains_inputs(tmp_path, monkeypatch):
+    dep_file = tmp_path / 'agent_requirements.in'
+    dep_file.write_bytes(b'requests==2.31.0\n')
+
+    workflow_file = tmp_path / 'resolve-build-deps.yaml'
+    workflow_file.write_bytes(b'on: push\n')
+
+    builder_dir = tmp_path / '.builders'
+    builder_dir.mkdir()
+    (builder_dir / 'upload.py').write_bytes(b'# script\n')
+
+    fake_deps_dir = tmp_path / '.deps'
+    fake_resolved_dir = fake_deps_dir / 'resolved'
+    fake_deps_dir.mkdir()
+    fake_resolved_dir.mkdir()
+
+    monkeypatch.setattr(upload, 'DIRECT_DEP_FILE', dep_file)
+    monkeypatch.setattr(upload, 'WORKFLOW_FILE', workflow_file)
+    monkeypatch.setattr(upload, 'BUILDER_DIR', builder_dir)
+    monkeypatch.setattr(upload, 'RESOLUTION_DIR', fake_deps_dir)
+    monkeypatch.setattr(upload, 'LOCK_FILE_DIR', fake_resolved_dir)
+
+    upload.generate_lockfiles(tmp_path, {})
+
+    metadata = json.loads((fake_deps_dir / 'metadata.json').read_text())
+    assert 'inputs' in metadata
+    assert set(metadata['inputs'].keys()) == {'agent_requirements.in', '.github/workflows/resolve-build-deps.yaml', '.builders'}
+    assert metadata['sha256'] == sha256(b'requests==2.31.0\n').hexdigest()
 
 
 def test_upload(setup_targets_dir, setup_fake_hash):

--- a/.builders/upload.py
+++ b/.builders/upload.py
@@ -78,21 +78,25 @@ def hash_file(path: Path) -> str:
 
 
 def hash_directory(path: Path) -> str:
-    """Compute a combined SHA256 hash of all files in a directory, sorted by relative path."""
+    """Compute a combined SHA256 hash of all files in a directory."""
     h = sha256()
-    for file_path in sorted(path.rglob('*')):
+    for file_path in sorted(path.rglob('*'), key=lambda p: p.relative_to(path)):
         if file_path.is_file():
+            h.update(file_path.relative_to(path).as_posix().encode())
             h.update(file_path.read_bytes())
     return h.hexdigest()
 
 
 def compute_input_hashes() -> dict[str, str]:
     """Compute SHA256 hashes for all dependency resolution inputs."""
-    return {
-        'agent_requirements.in': sha256(DIRECT_DEP_FILE.read_bytes()).hexdigest(),
-        '.github/workflows/resolve-build-deps.yaml': sha256(WORKFLOW_FILE.read_bytes()).hexdigest(),
-        '.builders': hash_directory(BUILDER_DIR),
-    }
+    try:
+        return {
+            'agent_requirements.in': hash_file(DIRECT_DEP_FILE),
+            '.github/workflows/resolve-build-deps.yaml': hash_file(WORKFLOW_FILE),
+            '.builders': hash_directory(BUILDER_DIR),
+        }
+    except FileNotFoundError as e:
+        raise RuntimeError(f'Missing dependency resolution input: {e}') from e
 
 
 def _build_number_of_wheel(wheel_info: dict) -> int:
@@ -298,10 +302,11 @@ def generate_lockfiles(targets_dir, lockfiles):
     targets_dir = Path(targets_dir)
     LOCK_FILE_DIR.mkdir(parents=True, exist_ok=True)
     with RESOLUTION_DIR.joinpath('metadata.json').open('w', encoding='utf-8') as f:
+        inputs = compute_input_hashes()
         contents = json.dumps(
             {
-                'inputs': compute_input_hashes(),
-                'sha256': sha256(DIRECT_DEP_FILE.read_bytes()).hexdigest(),
+                'inputs': inputs,
+                'sha256': inputs['agent_requirements.in'],
             },
             indent=2,
             sort_keys=True,

--- a/.builders/upload.py
+++ b/.builders/upload.py
@@ -81,8 +81,12 @@ def hash_directory(path: Path) -> str:
     """Compute a combined SHA256 hash of all files in a directory."""
     h = sha256()
     for file_path in sorted(path.rglob('*'), key=lambda p: p.relative_to(path)):
-        if file_path.is_file():
-            h.update(file_path.relative_to(path).as_posix().encode())
+        rel = file_path.relative_to(path)
+        if file_path.is_file() and not any(
+            part in {'__pycache__', '.pytest_cache'} or part.endswith('.pyc')
+            for part in rel.parts
+        ):
+            h.update(rel.as_posix().encode())
             h.update(file_path.read_bytes())
     return h.hexdigest()
 
@@ -91,9 +95,9 @@ def compute_input_hashes() -> dict[str, str]:
     """Compute SHA256 hashes for all dependency resolution inputs."""
     try:
         return {
-            'agent_requirements.in': hash_file(DIRECT_DEP_FILE),
-            '.github/workflows/resolve-build-deps.yaml': hash_file(WORKFLOW_FILE),
-            '.builders': hash_directory(BUILDER_DIR),
+            DIRECT_DEP_FILE.relative_to(REPO_DIR).as_posix(): hash_file(DIRECT_DEP_FILE),
+            WORKFLOW_FILE.relative_to(REPO_DIR).as_posix(): hash_file(WORKFLOW_FILE),
+            BUILDER_DIR.relative_to(REPO_DIR).as_posix(): hash_directory(BUILDER_DIR),
         }
     except FileNotFoundError as e:
         raise RuntimeError(f'Missing dependency resolution input: {e}') from e

--- a/.builders/upload.py
+++ b/.builders/upload.py
@@ -22,6 +22,7 @@ REPO_DIR = BUILDER_DIR.parent
 RESOLUTION_DIR = REPO_DIR / '.deps'
 LOCK_FILE_DIR = RESOLUTION_DIR / 'resolved'
 DIRECT_DEP_FILE = REPO_DIR / 'agent_requirements.in'
+WORKFLOW_FILE = REPO_DIR / '.github/workflows/resolve-build-deps.yaml'
 CACHE_CONTROL = 'public, max-age=15'
 VALID_PROJECT_NAME = re.compile(r'^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$', re.IGNORECASE)
 UNNORMALIZED_PROJECT_NAME_CHARS = re.compile(r'[-_.]+')
@@ -74,6 +75,24 @@ def hash_file(path: Path) -> str:
     """Calculate the hash of the file pointed at by `path`"""
     with path.open('rb') as f:
         return sha256(f.read()).hexdigest()
+
+
+def hash_directory(path: Path) -> str:
+    """Compute a combined SHA256 hash of all files in a directory, sorted by relative path."""
+    h = sha256()
+    for file_path in sorted(path.rglob('*')):
+        if file_path.is_file():
+            h.update(file_path.read_bytes())
+    return h.hexdigest()
+
+
+def compute_input_hashes() -> dict[str, str]:
+    """Compute SHA256 hashes for all dependency resolution inputs."""
+    return {
+        'agent_requirements.in': sha256(DIRECT_DEP_FILE.read_bytes()).hexdigest(),
+        '.github/workflows/resolve-build-deps.yaml': sha256(WORKFLOW_FILE.read_bytes()).hexdigest(),
+        '.builders': hash_directory(BUILDER_DIR),
+    }
 
 
 def _build_number_of_wheel(wheel_info: dict) -> int:
@@ -281,6 +300,7 @@ def generate_lockfiles(targets_dir, lockfiles):
     with RESOLUTION_DIR.joinpath('metadata.json').open('w', encoding='utf-8') as f:
         contents = json.dumps(
             {
+                'inputs': compute_input_hashes(),
                 'sha256': sha256(DIRECT_DEP_FILE.read_bytes()).hexdigest(),
             },
             indent=2,


### PR DESCRIPTION
## Summary

- Add `WORKFLOW_FILE` constant, `hash_directory()`, and `compute_input_hashes()` to `.builders/upload.py`
- Write an `inputs` dict into `.deps/metadata.json` alongside the existing `sha256` key (backward compatible)
- Add unit tests for `hash_directory`, `compute_input_hashes`, and the new `metadata.json` structure

## Motivation

`.deps/metadata.json` previously only stored the SHA256 of `agent_requirements.in`. The `resolve-build-deps.yaml` workflow is also triggered by changes to the workflow file itself and the entire `.builders/` directory. Storing hashes for all three inputs enables a future check to determine whether a new dependency resolution PR is actually needed.

**Resulting `metadata.json` structure:**
```json
{
  "inputs": {
    ".builders": "<sha256>",
    ".github/workflows/resolve-build-deps.yaml": "<sha256>",
    "agent_requirements.in": "<sha256>"
  },
  "sha256": "<sha256 of agent_requirements.in>"
}
```

## Test plan

- [ ] Unit tests pass: `cd .builders && pytest -vvv`
- [ ] Type check passes: `cd .builders && python -m mypy --config-file pyproject.toml .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)