### PR TITLE
fix(apache): add custom.date as fallback source for ocsf.time

### DIFF
--- a/apache/assets/logs/apache.yaml
+++ b/apache/assets/logs/apache.yaml
@@ -426,6 +426,7 @@ pipeline:
               name: Map `date_access` to `ocsf.time`
               sources:
                 - date_access
+                - custom.date
               target: ocsf.time
               preserveSource: true
               overrideOnConflict: true


### PR DESCRIPTION
## Summary

- The Apache OCSF sub-pipeline maps `date_access` → `ocsf.time`, but when the Datadog Agent pre-parses Apache access logs it stores the timestamp as `custom.date` instead of `date_access`
- The remapper found no value for `date_access` in these pre-parsed events, leaving `ocsf.time` unset
- This caused ~**2,100 `attribute_required_missing` validation errors per day** (`time` missing) in the OCSF validation job

**Change:** Add `custom.date` as a second source on the existing `ocsf.time` schema-remapper. The `date_access` source remains first so Agent-side-parsed events that do have it are unaffected.

## Test plan

- [ ] Verify that pre-parsed Apache logs (with `custom.date`) have `ocsf.time` populated after the pipeline runs
- [ ] Confirm `attribute_required_missing` error count drops for source `apache` in `event-jobs-security-monitoring`
- [ ] Confirm logs that were already passing (with `date_access`) continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)