### PR TITLE
[kafka_consumer] Add consumer lag in bytes metric

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/byte_position_store.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/byte_position_store.py
@@ -1,0 +1,155 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+import bisect
+import json
+
+
+class PartitionByteStore:
+    """Tracks known (offset, byte_position) points for a single partition.
+
+    Uses leveled thinning: level 0 holds the finest-grained (most recent) points.
+    When a level overflows, the two oldest points are removed and one is promoted
+    to the next level, halving resolution at each tier.
+    """
+
+    def __init__(self, max_points_per_level: int = 60, num_levels: int = 10):
+        self.max_points = max_points_per_level
+        self.num_levels = num_levels
+        # Each level is a sorted list of (offset, byte_position)
+        self.levels: list[list[tuple[int, int]]] = [[] for _ in range(num_levels)]
+
+    def add(self, offset: int, byte_position: int):
+        _insert_sorted(self.levels[0], offset, byte_position)
+        self._thin()
+
+    def prune_below(self, min_offset: int):
+        for i in range(self.num_levels):
+            idx = bisect.bisect_left(self.levels[i], (min_offset,))
+            self.levels[i] = self.levels[i][idx:]
+
+    def query(self, offset: int) -> int | None:
+        all_points = _merge_sorted_levels(self.levels)
+        return _interpolate(all_points, offset)
+
+    def _thin(self):
+        for i in range(self.num_levels - 1):
+            while len(self.levels[i]) > self.max_points:
+                older = self.levels[i].pop(0)
+                self.levels[i].pop(0)  # discard the second-oldest
+                _insert_sorted(self.levels[i + 1], older[0], older[1])
+        # Last level: just drop excess
+        while len(self.levels[-1]) > self.max_points:
+            self.levels[-1].pop(0)
+
+    @property
+    def total_points(self) -> int:
+        return sum(len(level) for level in self.levels)
+
+
+def _insert_sorted(level: list[tuple[int, int]], offset: int, byte_position: int):
+    idx = bisect.bisect_left(level, (offset,))
+    if idx < len(level) and level[idx][0] == offset:
+        level[idx] = (offset, byte_position)
+    else:
+        level.insert(idx, (offset, byte_position))
+
+
+def _merge_sorted_levels(levels: list[list[tuple[int, int]]]) -> list[tuple[int, int]]:
+    merged: dict[int, int] = {}
+    for level in levels:
+        for offset, bp in level:
+            if offset not in merged:
+                merged[offset] = bp
+    return sorted(merged.items())
+
+
+def _interpolate(points: list[tuple[int, int]], offset: int) -> int | None:
+    if not points:
+        return None
+
+    idx = bisect.bisect_left(points, (offset,))
+
+    if idx < len(points) and points[idx][0] == offset:
+        return points[idx][1]
+
+    if idx == 0 or idx >= len(points):
+        return None
+
+    o1, b1 = points[idx - 1]
+    o2, b2 = points[idx]
+    t = (offset - o1) / (o2 - o1)
+    return int(b1 + t * (b2 - b1))
+
+
+class BytePositionStore:
+    """Manages byte position tracking across all topic-partitions.
+
+    Each check run provides (low_offset, high_offset, size_bytes) per partition.
+    The store maintains cumulative byte positions B(offset) such that:
+        B(high) - B(low) = size_bytes
+    These can then be used to estimate the byte size of any sub-range,
+    e.g. bytes(committed_offset, high_watermark) for consumer lag in bytes.
+    """
+
+    PERSISTENT_CACHE_KEY = "byte_position_store"
+
+    def __init__(self, max_points_per_level: int = 60, num_levels: int = 10):
+        self.max_points_per_level = max_points_per_level
+        self.num_levels = num_levels
+        self._stores: dict[tuple[str, int], PartitionByteStore] = {}
+
+    def _get_or_create(self, topic: str, partition: int) -> PartitionByteStore:
+        key = (topic, partition)
+        if key not in self._stores:
+            self._stores[key] = PartitionByteStore(self.max_points_per_level, self.num_levels)
+        return self._stores[key]
+
+    def update(self, topic: str, partition: int, low_offset: int, high_offset: int, size_bytes: int):
+        store = self._get_or_create(topic, partition)
+
+        b_low = store.query(low_offset)
+        if b_low is None:
+            b_low = 0
+            store.add(low_offset, b_low)
+
+        store.add(high_offset, b_low + size_bytes)
+        store.prune_below(low_offset)
+
+    def estimate_bytes(self, topic: str, partition: int, from_offset: int, to_offset: int) -> int | None:
+        key = (topic, partition)
+        if key not in self._stores:
+            return None
+        store = self._stores[key]
+        b_from = store.query(from_offset)
+        b_to = store.query(to_offset)
+        if b_from is None or b_to is None:
+            return None
+        return b_to - b_from
+
+    def to_json(self) -> str:
+        data = {}
+        for (topic, partition), store in self._stores.items():
+            # Use JSON array as key to handle topics with underscores
+            key = json.dumps([topic, partition])
+            data[key] = [level[:] for level in store.levels]
+        return json.dumps(data)
+
+    @classmethod
+    def from_json(cls, json_str: str, max_points_per_level: int = 60, num_levels: int = 10) -> BytePositionStore:
+        instance = cls(max_points_per_level, num_levels)
+        if not json_str:
+            return instance
+        try:
+            data = json.loads(json_str)
+        except (json.JSONDecodeError, TypeError):
+            return instance
+        for key, levels_data in data.items():
+            topic, partition = json.loads(key)
+            store = instance._get_or_create(topic, int(partition))
+            for i, level_data in enumerate(levels_data):
+                if i < num_levels:
+                    store.levels[i] = [(int(o), int(b)) for o, b in level_data]
+        return instance

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -13,13 +13,15 @@ from google.protobuf import descriptor_pb2, descriptor_pool, message_factory
 from google.protobuf.json_format import MessageToJson
 from google.protobuf.message import DecodeError, EncodeError
 
-from datadog_checks.base import AgentCheck
+from datadog_checks.base import AgentCheck, is_affirmative
+from datadog_checks.kafka_consumer.byte_position_store import BytePositionStore
 from datadog_checks.kafka_consumer.client import KafkaClient
 from datadog_checks.kafka_consumer.cluster_metadata import ClusterMetadataCollector
 from datadog_checks.kafka_consumer.config import KafkaConfig
 from datadog_checks.kafka_consumer.constants import (
     HIGH_WATERMARK,
     KAFKA_INTERNAL_TOPICS,
+    LOW_WATERMARK,
     OFFSET_INVALID,
 )
 
@@ -43,6 +45,12 @@ class KafkaCheck(AgentCheck):
 
         # Initialize cluster metadata collector
         self.metadata_collector = ClusterMetadataCollector(self, self.client, self.config, self.log)
+
+        # Byte position store for consumer lag in bytes estimation
+        self._consumer_lag_bytes_enabled = is_affirmative(self.instance.get('collect_consumer_lag_bytes', False))
+        self._byte_store_max_points = int(self.instance.get('byte_position_max_points_per_level', 60))
+        self._byte_store_num_levels = int(self.instance.get('byte_position_num_levels', 10))
+        self._byte_position_store: BytePositionStore | None = None
 
     def check(self, _):
         """The main entrypoint of the check."""
@@ -117,6 +125,13 @@ class KafkaCheck(AgentCheck):
         self.config._auto_detected_cluster_id = cluster_id
         if self.config._kafka_cluster_id_override:
             cluster_id = self.config._kafka_cluster_id_override
+
+        # Update byte position store for consumer lag in bytes
+        if self._consumer_lag_bytes_enabled and highwater_offsets:
+            try:
+                self._update_byte_position_store(partitions, highwater_offsets)
+            except Exception:
+                self.log.exception("Error updating byte position store.")
 
         self.report_highwater_offsets(highwater_offsets, self._context_limit, cluster_id)
         self.report_consumer_offsets_and_lag(
@@ -342,6 +357,14 @@ class KafkaCheck(AgentCheck):
                         self.log.debug('%s consumer lag reported with %s tags', consumer_lag, consumer_group_tags)
                         reported_contexts += 1
 
+                    if self._consumer_lag_bytes_enabled and self._byte_position_store is not None:
+                        lag_bytes = self._byte_position_store.estimate_bytes(
+                            topic, partition, consumer_offset, producer_offset
+                        )
+                        if lag_bytes is not None and reported_contexts < contexts_limit:
+                            self.gauge('consumer_lag_bytes', lag_bytes, tags=consumer_group_tags)
+                            reported_contexts += 1
+
                     if not self._data_streams_enabled:
                         continue
 
@@ -426,6 +449,58 @@ class KafkaCheck(AgentCheck):
 
         self.log.debug('Got %s %s offsets', len(result), 'highwater' if mode == HIGH_WATERMARK else 'lowwater')
         return result, cluster_id
+
+    def _load_byte_position_store(self) -> BytePositionStore:
+        if self._byte_position_store is not None:
+            return self._byte_position_store
+        try:
+            cached = self.read_persistent_cache(BytePositionStore.PERSISTENT_CACHE_KEY)
+            self._byte_position_store = BytePositionStore.from_json(
+                cached, self._byte_store_max_points, self._byte_store_num_levels
+            )
+        except Exception:
+            self._byte_position_store = BytePositionStore(
+                self._byte_store_max_points, self._byte_store_num_levels
+            )
+        return self._byte_position_store
+
+    def _save_byte_position_store(self):
+        if self._byte_position_store is not None:
+            self.write_persistent_cache(
+                BytePositionStore.PERSISTENT_CACHE_KEY, self._byte_position_store.to_json()
+            )
+
+    def _update_byte_position_store(self, partitions, highwater_offsets):
+        store = self._load_byte_position_store()
+
+        # Fetch lowwater offsets
+        lowwater_offsets, _ = self.get_watermark_offsets(partitions, mode=LOW_WATERMARK)
+
+        # Fetch partition disk sizes from DescribeLogDirs
+        partition_sizes = self._get_partition_disk_sizes()
+
+        for (topic, partition), high in highwater_offsets.items():
+            low = lowwater_offsets.get((topic, partition))
+            size = partition_sizes.get((topic, partition))
+            if low is None or size is None:
+                continue
+            store.update(topic, partition, low, high, size)
+
+        self._save_byte_position_store()
+
+    def _get_partition_disk_sizes(self) -> dict[tuple[str, int], int]:
+        """Get partition sizes in bytes from DescribeLogDirs, taking the max across brokers."""
+        sizes: dict[tuple[str, int], int] = {}
+        broker_log_dirs = self.client.describe_log_dirs()
+        for _broker_id, log_dirs in broker_log_dirs.items():
+            for logdir in log_dirs:
+                if logdir.error is not None:
+                    continue
+                for topic_desc in logdir.topics:
+                    for part in topic_desc.partitions:
+                        key = (topic_desc.topic, part.partition)
+                        sizes[key] = max(sizes.get(key, 0), part.size)
+        return sizes
 
     def send_event(self, title, text, tags, event_type, aggregation_key, severity='info'):
         """Emit an event to the Datadog Event Stream."""

--- a/kafka_consumer/metadata.csv
+++ b/kafka_consumer/metadata.csv
@@ -16,6 +16,7 @@ kafka.consumer_group.count,gauge,,item,,Total number of consumer groups.,0,kafka
 kafka.consumer_group.member.partitions,gauge,,item,,Number of partitions assigned to this consumer group member.,0,kafka_consumer,member partitions,,
 kafka.consumer_group.members,gauge,,item,,Number of members in the consumer group.,0,kafka_consumer,group members,,
 kafka.consumer_lag,gauge,,message,,Lag in messages between consumer and broker.,-1,kafka_consumer,consumer lag,,
+kafka.consumer_lag_bytes,gauge,,byte,,Estimated lag in bytes between consumer and broker.,-1,kafka_consumer,consumer lag bytes,,
 kafka.consumer_offset,gauge,,offset,,Current message offset on consumer.,0,kafka_consumer,consumer offset,,
 kafka.estimated_consumer_lag,gauge,,second,,Lag in seconds between consumer and broker. This metric is provided through Data Streams Monitoring. Additional charges may apply.,-1,kafka_consumer,consumer time lag,,
 kafka.partition.beginning_offset,gauge,,offset,,The earliest offset in the partition.,0,kafka_consumer,beginning offset,,


### PR DESCRIPTION
## Summary
- Introduce `BytePositionStore` with leveled thinning to track cumulative byte positions per topic-partition across check runs
- Use linear interpolation on stored (offset, byte_position) points to estimate consumer lag in bytes (`kafka.consumer_lag_bytes`)
- Gate behind `collect_consumer_lag_bytes` instance config option (default: disabled)
- Persist byte position data via `read/write_persistent_cache` to survive agent restarts

## Test plan
- [ ] Unit tests for `BytePositionStore` (serialization, interpolation, leveled thinning, pruning)
- [ ] Unit tests for `_update_byte_position_store` and `_get_partition_disk_sizes`
- [ ] Integration test verifying `consumer_lag_bytes` metric is emitted when enabled
- [ ] Verify metric not emitted when `collect_consumer_lag_bytes` is false

🤖 Generated with [Claude Code](https://claude.com/claude-code)