### PR TITLE
[builders] Add zstd compression support to librdkafka

### DIFF
--- a/.builders/images/linux-aarch64/Dockerfile
+++ b/.builders/images/linux-aarch64/Dockerfile
@@ -126,14 +126,7 @@ RUN \
  --sysconfdir=/opt/datadog-agent/embedded/etc
 
 # zstd for librdkafka compression support
-RUN \
- CFLAGS="${CFLAGS} -fPIC" \
- DOWNLOAD_URL="https://github.com/facebook/zstd/releases/download/v{{version}}/zstd-{{version}}.tar.gz" \
- VERSION="1.5.7" \
- SHA256="eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3" \
- RELATIVE_PATH="zstd-{{version}}" \
- CONFIGURE_SCRIPT="true" \
- bash install-from-source.sh
+RUN yum install -y epel-release && yum install -y libzstd-devel
 
 # Dependencies needed to build librdkafka (and thus, confluent-kafka) with kerberos support
 RUN \

--- a/.builders/images/linux-aarch64/Dockerfile
+++ b/.builders/images/linux-aarch64/Dockerfile
@@ -125,6 +125,16 @@ RUN \
  # This is the folder where unixODBC searches for driver config and where we ask customers to copy their config to
  --sysconfdir=/opt/datadog-agent/embedded/etc
 
+# zstd for librdkafka compression support
+RUN \
+ CFLAGS="${CFLAGS} -fPIC" \
+ DOWNLOAD_URL="https://github.com/facebook/zstd/releases/download/v{{version}}/zstd-{{version}}.tar.gz" \
+ VERSION="1.5.7" \
+ SHA256="eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3" \
+ RELATIVE_PATH="zstd-{{version}}" \
+ CONFIGURE_SCRIPT="true" \
+ bash install-from-source.sh
+
 # Dependencies needed to build librdkafka (and thus, confluent-kafka) with kerberos support
 RUN \
  DOWNLOAD_URL="https://github.com/LMDB/lmdb/archive/LMDB_{{version}}.tar.gz" \

--- a/.builders/images/linux-aarch64/build_script.sh
+++ b/.builders/images/linux-aarch64/build_script.sh
@@ -23,7 +23,7 @@ if [[ "${DD_BUILD_PYTHON_VERSION}" == "3" ]]; then
         VERSION="${kafka_version}" \
         SHA256="14972092e4115f6e99f798a7cb420cbf6daa0c73502b3c52ae42fb5b418eea8f" \
         RELATIVE_PATH="librdkafka-{{version}}" \
-        bash install-from-source.sh --enable-sasl --enable-curl
+        bash install-from-source.sh --enable-sasl --enable-curl --enable-zstd
     always_build+=("confluent-kafka")
 
     # The version of pyodbc is dynamically linked against a version of the odbc which doesn't come included in the wheel

--- a/.builders/images/linux-x86_64/Dockerfile
+++ b/.builders/images/linux-x86_64/Dockerfile
@@ -130,14 +130,7 @@ RUN \
  --sysconfdir=/opt/datadog-agent/embedded/etc
 
 # zstd for librdkafka compression support
-RUN \
- CFLAGS="${CFLAGS} -fPIC" \
- DOWNLOAD_URL="https://github.com/facebook/zstd/releases/download/v{{version}}/zstd-{{version}}.tar.gz" \
- VERSION="1.5.7" \
- SHA256="eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3" \
- RELATIVE_PATH="zstd-{{version}}" \
- CONFIGURE_SCRIPT="true" \
- bash install-from-source.sh
+RUN yum install -y epel-release && yum install -y libzstd-devel
 
 # Dependencies needed to build librdkafka (and thus, confluent-kafka) with kerberos support
 RUN \

--- a/.builders/images/linux-x86_64/Dockerfile
+++ b/.builders/images/linux-x86_64/Dockerfile
@@ -129,6 +129,16 @@ RUN \
  # This is the folder where unixODBC searches for driver config and where we ask customers to copy their config to
  --sysconfdir=/opt/datadog-agent/embedded/etc
 
+# zstd for librdkafka compression support
+RUN \
+ CFLAGS="${CFLAGS} -fPIC" \
+ DOWNLOAD_URL="https://github.com/facebook/zstd/releases/download/v{{version}}/zstd-{{version}}.tar.gz" \
+ VERSION="1.5.7" \
+ SHA256="eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3" \
+ RELATIVE_PATH="zstd-{{version}}" \
+ CONFIGURE_SCRIPT="true" \
+ bash install-from-source.sh
+
 # Dependencies needed to build librdkafka (and thus, confluent-kafka) with kerberos support
 RUN \
  DOWNLOAD_URL="https://github.com/LMDB/lmdb/archive/LMDB_{{version}}.tar.gz" \

--- a/.builders/images/linux-x86_64/build_script.sh
+++ b/.builders/images/linux-x86_64/build_script.sh
@@ -20,7 +20,7 @@ if [[ "${DD_BUILD_PYTHON_VERSION}" == "3" ]]; then
         VERSION="${kafka_version}" \
         SHA256="14972092e4115f6e99f798a7cb420cbf6daa0c73502b3c52ae42fb5b418eea8f" \
         RELATIVE_PATH="librdkafka-{{version}}" \
-        bash install-from-source.sh --enable-sasl --enable-curl
+        bash install-from-source.sh --enable-sasl --enable-curl --enable-zstd
     always_build+=("confluent-kafka")
 
     # The version of pyodbc is dynamically linked against a version of the odbc which doesn't come included in the wheel

--- a/.builders/images/macos/builder_setup.sh
+++ b/.builders/images/macos/builder_setup.sh
@@ -103,6 +103,15 @@ RELATIVE_PATH="postgresql-{{version}}" \
 # Add paths to pg_config and to the library
 echo PATH="${DD_PREFIX_PATH}/bin:${PATH:-}" >> "$DD_ENV_FILE"
 
+# zstd for librdkafka compression support
+DOWNLOAD_URL="https://github.com/facebook/zstd/releases/download/v{{version}}/zstd-{{version}}.tar.gz" \
+VERSION="1.5.7" \
+SHA256="eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3" \
+RELATIVE_PATH="zstd-{{version}}" \
+CONFIGURE_SCRIPT="true" \
+INSTALL_COMMAND="make prefix=${DD_PREFIX_PATH} install" \
+  install-from-source
+
 # Dependencies needed to build librdkafka (and thus, confluent-kafka) with kerberos support
 DOWNLOAD_URL="https://github.com/LMDB/lmdb/archive/LMDB_{{version}}.tar.gz" \
 VERSION="0.9.29" \

--- a/.builders/images/macos/builder_setup.sh
+++ b/.builders/images/macos/builder_setup.sh
@@ -111,6 +111,8 @@ RELATIVE_PATH="zstd-{{version}}" \
 CONFIGURE_SCRIPT="true" \
 INSTALL_COMMAND="make prefix=${DD_PREFIX_PATH} install" \
   install-from-source
+# Fix install name so delocate can bundle it from the correct path
+install_name_tool -id "${DD_PREFIX_PATH}/lib/libzstd.1.dylib" "${DD_PREFIX_PATH}/lib/libzstd.1.dylib"
 
 # Dependencies needed to build librdkafka (and thus, confluent-kafka) with kerberos support
 DOWNLOAD_URL="https://github.com/LMDB/lmdb/archive/LMDB_{{version}}.tar.gz" \

--- a/.builders/images/macos/builder_setup.sh
+++ b/.builders/images/macos/builder_setup.sh
@@ -104,6 +104,7 @@ RELATIVE_PATH="postgresql-{{version}}" \
 echo PATH="${DD_PREFIX_PATH}/bin:${PATH:-}" >> "$DD_ENV_FILE"
 
 # zstd for librdkafka compression support
+# Keep version in sync with github.com/DataDog/datadog-agent/deps/repos.MODULE.bazel
 DOWNLOAD_URL="https://github.com/facebook/zstd/releases/download/v{{version}}/zstd-{{version}}.tar.gz" \
 VERSION="1.5.7" \
 SHA256="eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3" \

--- a/.builders/images/macos/extra_build.sh
+++ b/.builders/images/macos/extra_build.sh
@@ -20,6 +20,7 @@ if [[ "${DD_BUILD_PYTHON_VERSION}" == "3" ]]; then
     # lmdb doesnt't get the actual full path in its install name which means delocate won't find it
     # Luckily we can patch it here so that it does.
     install_name_tool -change liblmdb.so "${DD_PREFIX_PATH}/lib/liblmdb.so" "${DD_PREFIX_PATH}/lib/librdkafka.1.dylib"
+    install_name_tool -change /usr/local/lib/libzstd.1.dylib "${DD_PREFIX_PATH}/lib/libzstd.1.dylib" "${DD_PREFIX_PATH}/lib/librdkafka.1.dylib"
     always_build+=("confluent-kafka")
 fi
 

--- a/.builders/images/macos/extra_build.sh
+++ b/.builders/images/macos/extra_build.sh
@@ -9,15 +9,6 @@ if [[ "${DD_BUILD_PYTHON_VERSION}" == "3" ]]; then
     # confluent-kafka and librdkafka need to be compiled from source to get kerberos support
     # The librdkafka version needs to stay in sync with the confluent-kafka version,
     # thus we extract the version from the requirements file.
-    # zstd for librdkafka compression support
-    DOWNLOAD_URL="https://github.com/facebook/zstd/releases/download/v{{version}}/zstd-{{version}}.tar.gz" \
-      VERSION="1.5.7" \
-      SHA256="eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3" \
-      RELATIVE_PATH="zstd-{{version}}" \
-      CONFIGURE_SCRIPT="true" \
-      INSTALL_COMMAND="make PREFIX=${DD_PREFIX_PATH} install" \
-      bash install-from-source.sh
-
     kafka_version=$(grep 'confluent-kafka==' "${DD_MOUNT_DIR}/requirements.in" | sed -E 's/^.*([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+).*$/\1/')
     LDFLAGS="${LDFLAGS} -L${DD_PREFIX_PATH}/lib -lgssapi_krb5 -llmdb" \
     DOWNLOAD_URL="https://github.com/confluentinc/librdkafka/archive/refs/tags/v{{version}}.tar.gz" \

--- a/.builders/images/macos/extra_build.sh
+++ b/.builders/images/macos/extra_build.sh
@@ -9,13 +9,22 @@ if [[ "${DD_BUILD_PYTHON_VERSION}" == "3" ]]; then
     # confluent-kafka and librdkafka need to be compiled from source to get kerberos support
     # The librdkafka version needs to stay in sync with the confluent-kafka version,
     # thus we extract the version from the requirements file.
+    # zstd for librdkafka compression support
+    DOWNLOAD_URL="https://github.com/facebook/zstd/releases/download/v{{version}}/zstd-{{version}}.tar.gz" \
+      VERSION="1.5.7" \
+      SHA256="eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3" \
+      RELATIVE_PATH="zstd-{{version}}" \
+      CONFIGURE_SCRIPT="true" \
+      INSTALL_COMMAND="make PREFIX=${DD_PREFIX_PATH} install" \
+      bash install-from-source.sh
+
     kafka_version=$(grep 'confluent-kafka==' "${DD_MOUNT_DIR}/requirements.in" | sed -E 's/^.*([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+).*$/\1/')
     LDFLAGS="${LDFLAGS} -L${DD_PREFIX_PATH}/lib -lgssapi_krb5 -llmdb" \
     DOWNLOAD_URL="https://github.com/confluentinc/librdkafka/archive/refs/tags/v{{version}}.tar.gz" \
       VERSION="${kafka_version}" \
       SHA256="14972092e4115f6e99f798a7cb420cbf6daa0c73502b3c52ae42fb5b418eea8f" \
       RELATIVE_PATH="librdkafka-{{version}}" \
-      bash install-from-source.sh --prefix="${DD_PREFIX_PATH}" --enable-sasl --enable-curl
+      bash install-from-source.sh --prefix="${DD_PREFIX_PATH}" --enable-sasl --enable-curl --enable-zstd
 
     # lmdb doesnt't get the actual full path in its install name which means delocate won't find it
     # Luckily we can patch it here so that it does.

--- a/.ddev/ci/scripts/kafka_consumer/linux/32_install_kerberos.sh
+++ b/.ddev/ci/scripts/kafka_consumer/linux/32_install_kerberos.sh
@@ -3,7 +3,7 @@
 set -ex
 
 sudo apt update
-sudo apt install -y --no-install-recommends build-essential libkrb5-dev wget software-properties-common lsb-release gcc make python3 python3-pip python3-dev libsasl2-modules-gssapi-mit krb5-user
+sudo apt install -y --no-install-recommends build-essential libkrb5-dev libzstd-dev wget software-properties-common lsb-release gcc make python3 python3-pip python3-dev libsasl2-modules-gssapi-mit krb5-user
 
 # Install librdkafka from source since no binaries are available for the distribution we use on the CI:
 git clone https://github.com/confluentinc/librdkafka


### PR DESCRIPTION
## Summary
- Install `libzstd-devel` from EPEL in the Linux x86_64 and aarch64 builder Docker images
- Build zstd 1.5.7 from source in the macOS builder before compiling librdkafka
- Pass `--enable-zstd` to librdkafka's `./configure` on all three platforms so the build fails if zstd is missing, rather than silently omitting the codec
- Add `libzstd-dev` to the CI Kerberos install script so CI tests also get zstd support
- Windows already has zstd via vcpkg — no changes needed there

Without this, the agent cannot decompress Kafka messages produced with zstd compression (codec `0x4`), resulting in `KafkaError{code=_NOT_IMPLEMENTED}` at read time.

## Test plan
- [ ] Verify Linux x86_64 builder image builds successfully with zstd
- [ ] Verify Linux aarch64 builder image builds successfully with zstd
- [ ] Verify macOS builder builds librdkafka with zstd
- [ ] Confirm `librdkafka` reports zstd support enabled (`builtin.features` includes `zstd`)
- [ ] Test reading zstd-compressed Kafka messages no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)