### PR TITLE
kafka_actions: Fix filter type coercion for numeric string comparisons

### DIFF
--- a/kafka_actions/changelog.d/23162.fixed
+++ b/kafka_actions/changelog.d/23162.fixed
@@ -1,0 +1,1 @@
+Fix filter type coercion for numeric comparisons on protobuf int64 fields

--- a/kafka_actions/datadog_checks/kafka_actions/check.py
+++ b/kafka_actions/datadog_checks/kafka_actions/check.py
@@ -453,6 +453,8 @@ class KafkaActionsCheck(AgentCheck):
                 left_value = self._get_field_from_path(left, context)
                 right_value = self._parse_literal(right)
 
+                left_value, right_value = self._coerce_types(left_value, right_value)
+
                 if op == '==':
                     return left_value == right_value
                 elif op == '!=':
@@ -497,6 +499,26 @@ class KafkaActionsCheck(AgentCheck):
                 return None
 
         return current
+
+    @staticmethod
+    def _coerce_types(left, right):
+        """Coerce mismatched types for comparison (e.g., str vs int from protobuf int64)."""
+        if type(left) is type(right):
+            return left, right
+
+        # If one side is a numeric string and the other is a number, convert the string
+        if isinstance(left, str) and isinstance(right, (int, float)):
+            try:
+                return (float(left) if '.' in left else int(left)), right
+            except ValueError:
+                pass
+        elif isinstance(right, str) and isinstance(left, (int, float)):
+            try:
+                return left, (float(right) if '.' in right else int(right))
+            except ValueError:
+                pass
+
+        return left, right
 
     def _parse_literal(self, value_str: str):
         """Parse a literal value from string.

--- a/kafka_actions/datadog_checks/kafka_actions/check.py
+++ b/kafka_actions/datadog_checks/kafka_actions/check.py
@@ -506,13 +506,14 @@ class KafkaActionsCheck(AgentCheck):
         if type(left) is type(right):
             return left, right
 
-        # If one side is a numeric string and the other is a number, convert the string
-        if isinstance(left, str) and isinstance(right, (int, float)):
+        # If one side is a numeric string and the other is a number, convert the string.
+        # Exclude bools since bool is a subclass of int in Python.
+        if isinstance(left, str) and isinstance(right, (int, float)) and not isinstance(right, bool):
             try:
                 return (float(left) if '.' in left else int(left)), right
             except ValueError:
                 pass
-        elif isinstance(right, str) and isinstance(left, (int, float)):
+        elif isinstance(right, str) and isinstance(left, (int, float)) and not isinstance(left, bool):
             try:
                 return left, (float(right) if '.' in right else int(right))
             except ValueError:

--- a/kafka_actions/tests/test_message_filtering.py
+++ b/kafka_actions/tests/test_message_filtering.py
@@ -603,6 +603,21 @@ class TestTypeCoercion:
         msg = self.create_message({'name': 'alice'})
         assert self.check._evaluate_filter('.value.name == 42', msg) is False
 
+    def test_boolean_not_coerced_with_string(self):
+        """Ensure bool fields don't coerce strings (bool is subclass of int in Python)."""
+        msg = self.create_message({'flag': '1'})
+        assert self.check._evaluate_filter('.value.flag == true', msg) is False
+
+        msg = self.create_message({'flag': '0'})
+        assert self.check._evaluate_filter('.value.flag == false', msg) is False
+
+    def test_boolean_equality_still_works(self):
+        msg = self.create_message({'flag': True})
+        assert self.check._evaluate_filter('.value.flag == true', msg) is True
+
+        msg = self.create_message({'flag': False})
+        assert self.check._evaluate_filter('.value.flag == false', msg) is True
+
 
 if __name__ == '__main__':
     pytest.main([__file__, '-vv'])

--- a/kafka_actions/tests/test_message_filtering.py
+++ b/kafka_actions/tests/test_message_filtering.py
@@ -558,5 +558,51 @@ class TestLiteralParsing:
         assert check._evaluate_filter('.headers.nonexistent == "x"', msg) is False
 
 
+class TestTypeCoercion:
+    """Test type coercion for comparisons (e.g., protobuf int64 serialized as string)."""
+
+    def setup_method(self):
+        self.log = MagicMock()
+        self.deserializer = MessageDeserializer(self.log)
+        self.instance = {
+            'remote_config_id': 'test',
+            'kafka_connect_str': 'localhost:9092',
+            'read_messages': {'cluster': 'test', 'topic': 'test'},
+        }
+        self.check = KafkaActionsCheck('kafka_actions', {}, [self.instance])
+
+    def create_message(self, value_dict):
+        value_bytes = json.dumps(value_dict).encode('utf-8')
+        kafka_msg = MockKafkaMessage(key=b'test-key', value=value_bytes)
+        config = {'key_format': 'string', 'value_format': 'json', 'value_uses_schema_registry': False}
+        return DeserializedMessage(kafka_msg, self.deserializer, config)
+
+    def test_string_field_equals_int_literal(self):
+        """Test that string field values match numeric literals (protobuf int64 case)."""
+        msg = self.create_message({'orderDate': '1775237391227'})
+        assert self.check._evaluate_filter('.value.orderDate == 1775237391227', msg) is True
+
+    def test_string_field_not_equals_int_literal(self):
+        msg = self.create_message({'orderDate': '1775237391227'})
+        assert self.check._evaluate_filter('.value.orderDate != 9999', msg) is True
+
+    def test_string_field_greater_than_int_literal(self):
+        msg = self.create_message({'orderDate': '200'})
+        assert self.check._evaluate_filter('.value.orderDate > 100', msg) is True
+
+    def test_int_field_equals_int_literal(self):
+        """Verify normal int == int still works."""
+        msg = self.create_message({'orderDate': 1775237391227})
+        assert self.check._evaluate_filter('.value.orderDate == 1775237391227', msg) is True
+
+    def test_string_field_equals_float_literal(self):
+        msg = self.create_message({'price': '99.99'})
+        assert self.check._evaluate_filter('.value.price == 99.99', msg) is True
+
+    def test_non_numeric_string_does_not_match_int(self):
+        msg = self.create_message({'name': 'alice'})
+        assert self.check._evaluate_filter('.value.name == 42', msg) is False
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-vv'])


### PR DESCRIPTION
## Summary
- Protobuf's `MessageToJson` serializes `int64` fields as strings (e.g., `"1775237391227"` instead of `1775237391227`). This caused equality/comparison filters like `.value.orderDate == 1775237391227` to silently fail because Python's `"1775237391227" == 1775237391227` is `False`.
- Added `_coerce_types` to convert numeric strings to numbers (and vice versa) before comparisons, so filters work regardless of whether the field was deserialized as a string or int.
- Added tests covering string-vs-int, string-vs-float, normal int-vs-int, and non-numeric string cases.

## Test plan
- [x] All existing filtering tests pass (30/30)
- [x] New `TestTypeCoercion` tests cover the protobuf int64 scenario
- [ ] Manual verification with protobuf-serialized Kafka messages using int64 fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)