### PR TITLE
DDS: Supply Chain Firewall Updates

### DIFF
--- a/supply_chain_firewall/assets/dashboards/supply_chain_firewall_events.json
+++ b/supply_chain_firewall/assets/dashboards/supply_chain_firewall_events.json
@@ -4232,7 +4232,7 @@
                                             },
                                             "group_by": [],
                                             "search": {
-                                                "query": "source:scfw status:critical"
+                                                "query": "source:supply-chain-firewall status:critical"
                                             }
                                         }
                                     ],
@@ -4283,7 +4283,7 @@
                                             },
                                             "group_by": [],
                                             "search": {
-                                                "query": "source:scfw status:high"
+                                                "query": "source:supply-chain-firewall status:high"
                                             }
                                         }
                                     ],
@@ -4339,7 +4339,7 @@
                                                 }
                                             ],
                                             "search": {
-                                                "query": "source:scfw status:critical"
+                                                "query": "source:supply-chain-firewall status:critical"
                                             }
                                         }
                                     ],
@@ -4404,7 +4404,7 @@
                                             },
                                             "group_by": [],
                                             "search": {
-                                                "query": "source:scfw status:medium"
+                                                "query": "source:supply-chain-firewall status:medium"
                                             }
                                         }
                                     ],
@@ -4455,7 +4455,7 @@
                                             },
                                             "group_by": [],
                                             "search": {
-                                                "query": "source:scfw status:low"
+                                                "query": "source:supply-chain-firewall status:low"
                                             }
                                         }
                                     ],
@@ -4506,7 +4506,7 @@
                                             },
                                             "group_by": [],
                                             "search": {
-                                                "query": "source:scfw status:info"
+                                                "query": "source:supply-chain-firewall status:info"
                                             }
                                         }
                                     ],
@@ -4559,7 +4559,7 @@
                                                 }
                                             ],
                                             "search": {
-                                                "query": "source:scfw status:high"
+                                                "query": "source:supply-chain-firewall status:high"
                                             }
                                         }
                                     ],
@@ -4626,7 +4626,7 @@
                                                 }
                                             ],
                                             "search": {
-                                                "query": "source:scfw status:medium"
+                                                "query": "source:supply-chain-firewall status:medium"
                                             }
                                         }
                                     ],


### PR DESCRIPTION
### What does this PR do?
This PR updates the Dashboard Cloud SIEM panel query source from `source:scfw` to `source:supply-chain-firewall`.

Previously, `source:scfw` was used in the query to align with older detection rules tags ([PR](https://github.com/DataDog/security-monitoring/pull/7577) reference). We are not moving forward with those rules, and all active detection rules now rely on `source:supply-chain-firewall`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
