### PR TITLE
Set async jobs to None on cancel

### DIFF
--- a/clickhouse/changelog.d/23191.fixed
+++ b/clickhouse/changelog.d/23191.fixed
@@ -1,0 +1,1 @@
+Set async jobs to None on cancel

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -470,6 +470,10 @@ class ClickhouseCheck(DatabaseCheck):
         if self.query_completions and self.query_completions._job_loop_future:
             self.query_completions._job_loop_future.result()
 
+        self.statement_metrics = None
+        self.statement_samples = None
+        self.query_completions = None
+
         # Close main client
         if self._client:
             try:

--- a/mongo/changelog.d/23191.fixed
+++ b/mongo/changelog.d/23191.fixed
@@ -1,0 +1,1 @@
+Set async jobs to None on cancel

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -415,6 +415,11 @@ class MongoDb(AgentCheck):
             self._operation_samples.cancel()
             self._slow_operations.cancel()
             self._query_metrics.cancel()
+            self._schemas.cancel()
+            self._operation_samples = None
+            self._slow_operations = None
+            self._query_metrics = None
+            self._schemas = None
 
     def _get_rs_deployment_from_status_payload(self, repl_set_payload, is_master_payload, cluster_role, hosting_type):
         replset_name = repl_set_payload["set"]

--- a/mysql/changelog.d/23191.fixed
+++ b/mysql/changelog.d/23191.fixed
@@ -1,0 +1,1 @@
+Set async jobs to None on cancel

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -444,6 +444,10 @@ class MySql(DatabaseCheck):
         self._statement_metrics.cancel()
         self._query_activity.cancel()
         self._mysql_metadata.cancel()
+        self._statement_samples = None
+        self._statement_metrics = None
+        self._query_activity = None
+        self._mysql_metadata = None
 
     def _new_query_executor(self, queries):
         return QueryExecutor(

--- a/postgres/changelog.d/23191.fixed
+++ b/postgres/changelog.d/23191.fixed
@@ -1,0 +1,1 @@
+Set async jobs to None on cancel

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -477,6 +477,9 @@ class PostgreSql(DatabaseCheck):
                 self.statement_samples._job_loop_future.result()
             if self.metadata_samples._job_loop_future:
                 self.metadata_samples._job_loop_future.result()
+            self.statement_samples = None
+            self.statement_metrics = None
+            self.metadata_samples = None
         self._close_db_pool()
 
     def _clean_state(self):

--- a/sqlserver/changelog.d/23191.fixed
+++ b/sqlserver/changelog.d/23191.fixed
@@ -1,0 +1,1 @@
+Set async jobs to None on cancel

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -212,6 +212,12 @@ class SQLServer(DatabaseCheck):
         self.sql_metadata.cancel()
         self.deadlocks.cancel()
         self.agent_history.cancel()
+        self.statement_metrics = None
+        self.procedure_metrics = None
+        self.activity = None
+        self.sql_metadata = None
+        self.deadlocks = None
+        self.agent_history = None
 
         # Cancel all XE session handlers
         for handler in self.xe_session_handlers:
@@ -219,6 +225,7 @@ class SQLServer(DatabaseCheck):
                 handler.cancel()
             except Exception as e:
                 self.log.error("Error canceling XE session handler for %s: %s", handler.session_name, e)
+        self.xe_session_handlers = []
 
     def config_checks(self):
         if self._config.autodiscovery and self.instance.get("database"):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Clears the referenced `DBMAsyncJob` objects for the DBM check when the check is cancelled.

### Motivation
<!-- What inspired you to submit this pull request? -->
These jobs can have relatively large caches. The core check may take some time to be fully released, setting these jobs to None when the cancel is complete may help release their memory earlier and more reliably.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
