### PR TITLE
[kafka_actions] Fix Avro deserialization for schemas with logical types

### DIFF
--- a/kafka_actions/changelog.d/23224.fixed
+++ b/kafka_actions/changelog.d/23224.fixed
@@ -1,0 +1,1 @@
+Fix Avro deserialization for schemas with logical types (decimal, uuid, date, time, timestamp) that caused "Object of type ... is not JSON serializable" errors.

--- a/kafka_actions/datadog_checks/kafka_actions/message_deserializer.py
+++ b/kafka_actions/datadog_checks/kafka_actions/message_deserializer.py
@@ -4,8 +4,11 @@
 """Message deserialization for Kafka messages."""
 
 import base64
+import datetime
+import decimal
 import hashlib
 import json
+import uuid
 from io import BytesIO
 
 from bson import decode as bson_decode
@@ -15,6 +18,23 @@ from google.protobuf import descriptor_pb2, descriptor_pool, message_factory
 from google.protobuf.json_format import MessageToJson
 
 SCHEMA_REGISTRY_MAGIC_BYTE = 0x00
+
+
+class _AvroJSONEncoder(json.JSONEncoder):
+    """JSON encoder that handles types returned by fastavro for Avro logical types."""
+
+    def default(self, obj):
+        if isinstance(obj, decimal.Decimal):
+            return float(obj)
+        if isinstance(obj, datetime.datetime):
+            return obj.isoformat()
+        if isinstance(obj, datetime.date):
+            return obj.isoformat()
+        if isinstance(obj, uuid.UUID):
+            return str(obj)
+        if isinstance(obj, bytes):
+            return base64.b64encode(obj).decode('ascii')
+        return super().default(obj)
 
 
 def _read_varint(data):
@@ -305,7 +325,7 @@ class MessageDeserializer:
                     f"Read {bytes_read} bytes, but message has {total_bytes} bytes."
                 )
 
-            return json.dumps(data)
+            return json.dumps(data, cls=_AvroJSONEncoder)
         except Exception as e:
             raise ValueError(f"Failed to deserialize Avro message: {e}")
 

--- a/kafka_actions/datadog_checks/kafka_actions/message_deserializer.py
+++ b/kafka_actions/datadog_checks/kafka_actions/message_deserializer.py
@@ -30,6 +30,8 @@ class _AvroJSONEncoder(json.JSONEncoder):
             return obj.isoformat()
         if isinstance(obj, datetime.date):
             return obj.isoformat()
+        if isinstance(obj, datetime.time):
+            return obj.isoformat()
         if isinstance(obj, uuid.UUID):
             return str(obj)
         if isinstance(obj, bytes):

--- a/kafka_actions/datadog_checks/kafka_actions/message_deserializer.py
+++ b/kafka_actions/datadog_checks/kafka_actions/message_deserializer.py
@@ -25,7 +25,7 @@ class _AvroJSONEncoder(json.JSONEncoder):
 
     def default(self, obj):
         if isinstance(obj, decimal.Decimal):
-            return float(obj)
+            return str(obj)
         if isinstance(obj, datetime.datetime):
             return obj.isoformat()
         if isinstance(obj, datetime.date):

--- a/kafka_actions/tests/test_message_deserializer.py
+++ b/kafka_actions/tests/test_message_deserializer.py
@@ -325,6 +325,43 @@ class TestMessageDeserializer:
         assert deserialized_msg_sr.value['title'] == 'The Go Programming Language'
         assert deserialized_msg_sr.value_schema_id == 350
 
+    def test_avro_logical_types_decimal_timestamp_uuid(self):
+        """Test that Avro messages with logical types (decimal, timestamp-millis, date, uuid) deserialize correctly."""
+        log = MagicMock()
+        deserializer = MessageDeserializer(log)
+
+        avro_schema = json.dumps({
+            "type": "record",
+            "name": "Payment",
+            "fields": [
+                {"name": "id", "type": "long"},
+                {"name": "amount", "type": {"type": "bytes", "logicalType": "decimal", "precision": 18, "scale": 4}},
+                {"name": "created_at", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+                {"name": "due_date", "type": {"type": "int", "logicalType": "date"}},
+                {"name": "tx_id", "type": {"type": "string", "logicalType": "uuid"}},
+                {"name": "memo", "type": "string"},
+            ],
+        })
+
+        # Payment: id=42, amount=99.9500, created_at=2024-06-15T12:00:00Z, due_date=2024-07-01,
+        #          tx_id=550e8400-e29b-41d4-a716-446655440000, memo="Test payment"
+        avro_message = (
+            b'T\x06\x0f@L\x80\xa8\xa6\xbc\x83d\x82\xb7\x02'
+            b'H550e8400-e29b-41d4-a716-446655440000\x18Test payment'
+        )
+
+        result_str, schema_id = deserializer.deserialize_message(avro_message, 'avro', avro_schema, False)
+        assert result_str is not None
+        assert schema_id is None
+
+        result = json.loads(result_str)
+        assert result['id'] == 42
+        assert result['amount'] == 99.95
+        assert '2024-06-15' in result['created_at']
+        assert result['due_date'] == '2024-07-01'
+        assert result['tx_id'] == '550e8400-e29b-41d4-a716-446655440000'
+        assert result['memo'] == 'Test payment'
+
     def test_protobuf_explicit_schema_registry_configuration(self):
         """Test that explicit Protobuf schema registry configuration is enforced."""
         log = MagicMock()

--- a/kafka_actions/tests/test_message_deserializer.py
+++ b/kafka_actions/tests/test_message_deserializer.py
@@ -326,7 +326,7 @@ class TestMessageDeserializer:
         assert deserialized_msg_sr.value_schema_id == 350
 
     def test_avro_logical_types_decimal_timestamp_uuid(self):
-        """Test that Avro messages with logical types (decimal, timestamp-millis, date, uuid) deserialize correctly."""
+        """Test that Avro messages with all logical types deserialize correctly."""
         log = MagicMock()
         deserializer = MessageDeserializer(log)
 
@@ -338,15 +338,17 @@ class TestMessageDeserializer:
                 {"name": "amount", "type": {"type": "bytes", "logicalType": "decimal", "precision": 18, "scale": 4}},
                 {"name": "created_at", "type": {"type": "long", "logicalType": "timestamp-millis"}},
                 {"name": "due_date", "type": {"type": "int", "logicalType": "date"}},
+                {"name": "due_time", "type": {"type": "int", "logicalType": "time-millis"}},
                 {"name": "tx_id", "type": {"type": "string", "logicalType": "uuid"}},
                 {"name": "memo", "type": "string"},
             ],
         })
 
         # Payment: id=42, amount=99.9500, created_at=2024-06-15T12:00:00Z, due_date=2024-07-01,
-        #          tx_id=550e8400-e29b-41d4-a716-446655440000, memo="Test payment"
+        #          due_time=14:30:00, tx_id=550e8400-e29b-41d4-a716-446655440000, memo="Test payment"
         avro_message = (
             b'T\x06\x0f@L\x80\xa8\xa6\xbc\x83d\x82\xb7\x02'
+            b'\x80\x89\xe41'
             b'H550e8400-e29b-41d4-a716-446655440000\x18Test payment'
         )
 
@@ -359,6 +361,7 @@ class TestMessageDeserializer:
         assert result['amount'] == 99.95
         assert '2024-06-15' in result['created_at']
         assert result['due_date'] == '2024-07-01'
+        assert result['due_time'] == '14:30:00'
         assert result['tx_id'] == '550e8400-e29b-41d4-a716-446655440000'
         assert result['memo'] == 'Test payment'
 

--- a/kafka_actions/tests/test_message_deserializer.py
+++ b/kafka_actions/tests/test_message_deserializer.py
@@ -330,19 +330,24 @@ class TestMessageDeserializer:
         log = MagicMock()
         deserializer = MessageDeserializer(log)
 
-        avro_schema = json.dumps({
-            "type": "record",
-            "name": "Payment",
-            "fields": [
-                {"name": "id", "type": "long"},
-                {"name": "amount", "type": {"type": "bytes", "logicalType": "decimal", "precision": 18, "scale": 4}},
-                {"name": "created_at", "type": {"type": "long", "logicalType": "timestamp-millis"}},
-                {"name": "due_date", "type": {"type": "int", "logicalType": "date"}},
-                {"name": "due_time", "type": {"type": "int", "logicalType": "time-millis"}},
-                {"name": "tx_id", "type": {"type": "string", "logicalType": "uuid"}},
-                {"name": "memo", "type": "string"},
-            ],
-        })
+        avro_schema = json.dumps(
+            {
+                "type": "record",
+                "name": "Payment",
+                "fields": [
+                    {"name": "id", "type": "long"},
+                    {
+                        "name": "amount",
+                        "type": {"type": "bytes", "logicalType": "decimal", "precision": 18, "scale": 4},
+                    },
+                    {"name": "created_at", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+                    {"name": "due_date", "type": {"type": "int", "logicalType": "date"}},
+                    {"name": "due_time", "type": {"type": "int", "logicalType": "time-millis"}},
+                    {"name": "tx_id", "type": {"type": "string", "logicalType": "uuid"}},
+                    {"name": "memo", "type": "string"},
+                ],
+            }
+        )
 
         # Payment: id=42, amount=99.9500, created_at=2024-06-15T12:00:00Z, due_date=2024-07-01,
         #          due_time=14:30:00, tx_id=550e8400-e29b-41d4-a716-446655440000, memo="Test payment"

--- a/kafka_actions/tests/test_message_deserializer.py
+++ b/kafka_actions/tests/test_message_deserializer.py
@@ -363,7 +363,7 @@ class TestMessageDeserializer:
 
         result = json.loads(result_str)
         assert result['id'] == 42
-        assert result['amount'] == 99.95
+        assert result['amount'] == '99.9500'
         assert '2024-06-15' in result['created_at']
         assert result['due_date'] == '2024-07-01'
         assert result['due_time'] == '14:30:00'


### PR DESCRIPTION
## Summary
- `fastavro.schemaless_reader` returns Python-native types for Avro logical types (`decimal.Decimal`, `datetime.datetime`, `datetime.date`, `uuid.UUID`, `bytes`), but `json.dumps()` in `_deserialize_avro` cannot serialize any of them
- This caused `"Failed to deserialize Avro message: Object of type Decimal is not JSON serializable"` errors for schemas using `bytes`/`decimal`, `timestamp-millis`, `date`, or `uuid` logical types — both with inline schemas and Schema Registry
- Adds `_AvroJSONEncoder` custom encoder that handles all fastavro logical type return values
- Adds test covering all affected logical types (decimal, timestamp-millis, date, uuid)

## Test plan
- [x] New test `test_avro_logical_types_decimal_timestamp_uuid` passes
- [x] All 26 existing deserializer tests pass
- [ ] Manually verify with a real Kafka topic that has `bytes`/`decimal` fields (e.g. `enriched_spend_events`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)