### PR TITLE
[builders] Patch librdkafka use-after-free in admin coord_request error path

### DIFF
--- a/.builders/images/linux-aarch64/build_script.sh
+++ b/.builders/images/linux-aarch64/build_script.sh
@@ -23,6 +23,7 @@ if [[ "${DD_BUILD_PYTHON_VERSION}" == "3" ]]; then
         VERSION="${kafka_version}" \
         SHA256="14972092e4115f6e99f798a7cb420cbf6daa0c73502b3c52ae42fb5b418eea8f" \
         RELATIVE_PATH="librdkafka-{{version}}" \
+        PATCHES="librdkafka-fix-coord-request-uaf.patch" \
         bash install-from-source.sh --enable-sasl --enable-curl --enable-zstd
     always_build+=("confluent-kafka")
 

--- a/.builders/images/linux-x86_64/build_script.sh
+++ b/.builders/images/linux-x86_64/build_script.sh
@@ -20,6 +20,7 @@ if [[ "${DD_BUILD_PYTHON_VERSION}" == "3" ]]; then
         VERSION="${kafka_version}" \
         SHA256="14972092e4115f6e99f798a7cb420cbf6daa0c73502b3c52ae42fb5b418eea8f" \
         RELATIVE_PATH="librdkafka-{{version}}" \
+        PATCHES="librdkafka-fix-coord-request-uaf.patch" \
         bash install-from-source.sh --enable-sasl --enable-curl --enable-zstd
     always_build+=("confluent-kafka")
 

--- a/.builders/patches/librdkafka-fix-coord-request-uaf.patch
+++ b/.builders/patches/librdkafka-fix-coord-request-uaf.patch
@@ -1,5 +1,5 @@
 diff --git a/src/rdkafka_admin.c b/src/rdkafka_admin.c
-index 7986371afe..71eac0eee7 100644
+index 7986371a..552c10c0 100644
 --- a/src/rdkafka_admin.c
 +++ b/src/rdkafka_admin.c
 @@ -480,7 +480,6 @@ rd_kafka_admin_coord_request(rd_kafka_broker_t *rkb,
@@ -13,7 +13,7 @@ index 7986371afe..71eac0eee7 100644
 @@ -499,13 +498,17 @@ rd_kafka_admin_coord_request(rd_kafka_broker_t *rkb,
              &rko->rko_u.admin_request.options, errstr, sizeof(errstr), replyq,
              rd_kafka_admin_handle_response, eonce);
-
+ 
 -        if (err) {
 -                rd_kafka_admin_result_fail(
 -                    rko, err, "%s worker failed to send request: %s",
@@ -31,6 +31,43 @@ index 7986371afe..71eac0eee7 100644
 +         * Calling worker_destroy() here would free the eonce while the
 +         * caller still holds a reference to it, leading to a
 +         * use-after-free / assertion failure in
-+         * rd_kafka_enq_once_del_source_return(). See #4605, #3663. */
++         * rd_kafka_enq_once_del_source_return(). */
          return err;
  }
+ 
+diff --git a/src/rdkafka_coord.c b/src/rdkafka_coord.c
+index a880f23a..e57b3ef7 100644
+--- a/src/rdkafka_coord.c
++++ b/src/rdkafka_coord.c
+@@ -316,6 +316,14 @@ static void rd_kafka_coord_req_fail(rd_kafka_t *rk,
+         rd_kafka_op_t *reply;
+         rd_kafka_buf_t *rkbuf;
+ 
++        if (!creq->creq_reply_opaque) {
++                /* The admin operation has already timed out and been
++                 * destroyed.  The eonce (creq_reply_opaque) may be
++                 * freed.  Do not enqueue a response referencing it. */
++                rd_kafka_coord_req_destroy(rk, creq, rd_true /*done*/);
++                return;
++        }
++
+         reply         = rd_kafka_op_new(RD_KAFKA_OP_RECV_BUF);
+         reply->rko_rk = rk; /* Set rk since the rkbuf will not have a rkb
+                              * to reach it. */
+@@ -495,7 +503,15 @@ static void rd_kafka_coord_req_fsm(rd_kafka_t *rk, rd_kafka_coord_req_t *creq) {
+                                                      replyq, creq->creq_resp_cb,
+                                                      creq->creq_reply_opaque);
+ 
+-                        if (err) {
++                        if (err == RD_KAFKA_RESP_ERR__DESTROY) {
++                                /* Admin op already timed out.  Clear
++                                 * opaque to prevent coord_req_fail from
++                                 * using freed eonce. */
++                                creq->creq_reply_opaque = NULL;
++                                rd_kafka_replyq_destroy(&replyq);
++                                rd_kafka_coord_req_destroy(rk, creq,
++                                                           rd_true /*done*/);
++                        } else if (err) {
+                                 /* Permanent error, e.g., request not
+                                  *  supported by broker. */
+                                 rd_kafka_replyq_destroy(&replyq);

--- a/.builders/patches/librdkafka-fix-coord-request-uaf.patch
+++ b/.builders/patches/librdkafka-fix-coord-request-uaf.patch
@@ -1,0 +1,36 @@
+diff --git a/src/rdkafka_admin.c b/src/rdkafka_admin.c
+index 7986371afe..71eac0eee7 100644
+--- a/src/rdkafka_admin.c
++++ b/src/rdkafka_admin.c
+@@ -480,7 +480,6 @@ rd_kafka_admin_coord_request(rd_kafka_broker_t *rkb,
+                              rd_kafka_replyq_t replyq,
+                              rd_kafka_resp_cb_t *resp_cb,
+                              void *opaque) {
+-        rd_kafka_t *rk             = rkb->rkb_rk;
+         rd_kafka_enq_once_t *eonce = opaque;
+         rd_kafka_op_t *rko;
+         char errstr[512];
+@@ -499,13 +498,17 @@ rd_kafka_admin_coord_request(rd_kafka_broker_t *rkb,
+             &rko->rko_u.admin_request.options, errstr, sizeof(errstr), replyq,
+             rd_kafka_admin_handle_response, eonce);
+
+-        if (err) {
+-                rd_kafka_admin_result_fail(
+-                    rko, err, "%s worker failed to send request: %s",
+-                    rd_kafka_op2str(rko->rko_type), errstr);
+-                rd_kafka_admin_common_worker_destroy(rk, rko,
+-                                                     rd_true /*destroy*/);
+-        }
++        /* On error, do not call worker_destroy() here.
++         * The caller (rd_kafka_coord_req_fsm) will call coord_req_fail()
++         * which enqueues a dummy error response carrying the eonce as
++         * opaque. coord_response_parse() will then retrieve the rko via
++         * del_source_return("coordinator response"), see the error, and
++         * call worker_destroy() itself.
++         *
++         * Calling worker_destroy() here would free the eonce while the
++         * caller still holds a reference to it, leading to a
++         * use-after-free / assertion failure in
++         * rd_kafka_enq_once_del_source_return(). See #4605, #3663. */
+         return err;
+ }


### PR DESCRIPTION
## Summary

- Apply upstream fix ([confluentinc/librdkafka#5397](https://github.com/confluentinc/librdkafka/pull/5397)) as a build-time patch for Linux x86_64 and aarch64
- Fixes a use-after-free bug in `rd_kafka_admin_coord_request()` that causes process abort with `rd_kafka_enq_once_del_source_return: Assertion 'eonce->refcnt > 0' failed`
- Affects coordinator-targeted Admin API operations: `DescribeConsumerGroups`, `DeleteConsumerGroupOffsets`, `ListConsumerGroupOffsets`, etc.

## Motivation

The bug triggers when a coordinator-targeted admin request fails to send (API version mismatch or connection disruption). The error path prematurely frees the `eonce` object while the caller still holds a reference, leading to use-after-free and assertion failure.

This is not yet included in a released librdkafka version, so we apply it as a patch during the build using the existing `install-from-source.sh` `PATCHES` mechanism.

## Changes

- `.builders/patches/librdkafka-fix-coord-request-uaf.patch` — the upstream fix from confluentinc/librdkafka#5397
- `.builders/images/linux-x86_64/build_script.sh` — apply patch during librdkafka build
- `.builders/images/linux-aarch64/build_script.sh` — same

## Test plan

- [ ] Verify Linux x86_64 builder applies the patch and compiles librdkafka successfully
- [ ] Verify Linux aarch64 builder applies the patch and compiles librdkafka successfully
- [ ] Confirm kafka_consumer integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)