### PR TITLE
[kafka_consumer] Fix consumer leak when offsets_for_times times out

### DIFF
--- a/kafka_consumer/changelog.d/23241.fixed
+++ b/kafka_consumer/changelog.d/23241.fixed
@@ -1,0 +1,1 @@
+Fix consumer leak when offsets_for_times() times out, preventing a potential librdkafka crash

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -411,12 +411,6 @@ class KafkaCheck(AgentCheck):
         try:
             cluster_id, _ = self.client.consumer_get_cluster_id_and_list_topics(dd_consumer_group)
 
-            self.log.debug(
-                'Querying %s %s offsets',
-                len(topic_partitions_to_check),
-                'highwater' if mode == HIGH_WATERMARK else 'lowwater',
-            )
-
             result = {}
             for topic, partition, offset in self.client.consumer_offsets_for_times(
                 partitions=topic_partitions_to_check, offset=mode

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -411,6 +411,12 @@ class KafkaCheck(AgentCheck):
         try:
             cluster_id, _ = self.client.consumer_get_cluster_id_and_list_topics(dd_consumer_group)
 
+            self.log.debug(
+                'Querying %s %s offsets',
+                len(topic_partitions_to_check),
+                'highwater' if mode == HIGH_WATERMARK else 'lowwater',
+            )
+
             result = {}
             for topic, partition, offset in self.client.consumer_offsets_for_times(
                 partitions=topic_partitions_to_check, offset=mode

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -408,21 +408,22 @@ class KafkaCheck(AgentCheck):
 
         # Open consumer once for both cluster_id and offset fetching
         self.client.open_consumer(dd_consumer_group)
-        cluster_id, _ = self.client.consumer_get_cluster_id_and_list_topics(dd_consumer_group)
+        try:
+            cluster_id, _ = self.client.consumer_get_cluster_id_and_list_topics(dd_consumer_group)
 
-        self.log.debug(
-            'Querying %s %s offsets',
-            len(topic_partitions_to_check),
-            'highwater' if mode == HIGH_WATERMARK else 'lowwater',
-        )
+            self.log.debug(
+                'Querying %s %s offsets',
+                len(topic_partitions_to_check),
+                'highwater' if mode == HIGH_WATERMARK else 'lowwater',
+            )
 
-        result = {}
-        for topic, partition, offset in self.client.consumer_offsets_for_times(
-            partitions=topic_partitions_to_check, offset=mode
-        ):
-            result[(topic, partition)] = offset
-
-        self.client.close_consumer()
+            result = {}
+            for topic, partition, offset in self.client.consumer_offsets_for_times(
+                partitions=topic_partitions_to_check, offset=mode
+            ):
+                result[(topic, partition)] = offset
+        finally:
+            self.client.close_consumer()
 
         self.log.debug('Got %s %s offsets', len(result), 'highwater' if mode == HIGH_WATERMARK else 'lowwater')
         return result, cluster_id


### PR DESCRIPTION
## Summary

- Fix a consumer leak in `get_watermark_offsets()` — when `offsets_for_times()` throws (e.g., timeout), `close_consumer()` was skipped because the exception jumped over it. The consumer is now closed in a `finally` block.

**How the leak happens:** `open_consumer()` is called at line 410, but if `offsets_for_times()` at line 420 raises a `KafkaException` (timeout), execution jumps to the caller's `except` block, skipping `close_consumer()`. On the next check run, `open_consumer()` overwrites `self._consumer` with a new instance, and the old one is only cleaned up by GC.

## Test plan

- [ ] Existing unit/integration tests pass
- [ ] Verify `close_consumer()` is called even when `offsets_for_times()` throws by reviewing the try/finally structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)