### PR TITLE
[kafka_consumer] Filter errored partitions from offsets_for_times results

### DIFF
--- a/kafka_consumer/changelog.d/23242.fixed
+++ b/kafka_consumer/changelog.d/23242.fixed
@@ -1,0 +1,1 @@
+Filter out errored partitions from offsets_for_times results to prevent invalid offset reporting

--- a/kafka_consumer/datadog_checks/kafka_consumer/client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client.py
@@ -153,12 +153,20 @@ class KafkaClient:
             TopicPartition(topic=topic, partition=partition, offset=offset)
             for topic, partition in partitions
         ]
-        return [
-            (tp.topic, tp.partition, tp.offset)
-            for tp in self._consumer.offsets_for_times(
-                partitions=topicpartitions_for_querying, timeout=self.config._request_timeout
-            )
-        ]
+        results = []
+        for tp in self._consumer.offsets_for_times(
+            partitions=topicpartitions_for_querying, timeout=self.config._request_timeout
+        ):
+            if tp.error:
+                self.log.debug(
+                    "Failed to get offset for topic %s partition %s: %s",
+                    tp.topic,
+                    tp.partition,
+                    tp.error,
+                )
+                continue
+            results.append((tp.topic, tp.partition, tp.offset))
+        return results
 
     def _list_topics(self):
         if self._cluster_metadata:


### PR DESCRIPTION
## Summary

- When brokers are temporarily unavailable, `offsets_for_times()` returns `TopicPartition` objects with `tp.error` set for partitions on those brokers. The offset value for errored partitions is invalid (the original input value, not a real offset).
- This causes invalid offset values stored in `highwater_offsets`, incorrect `broker_offset` metrics, and potentially negative consumer lag calculations.
- Filter out partitions with errors from `consumer_offsets_for_times()` results and log a debug message for the failed partitions.

## Test plan

- [ ] Verify unit tests pass: `ddev test kafka_consumer`
- [ ] Confirm that partitions returning errors from `offsets_for_times()` are excluded from results
- [ ] Confirm debug log message is emitted for each errored partition

🤖 Generated with [Claude Code](https://claude.com/claude-code)