### PR TITLE
[DBMON-6422] Remove internal user filtering in metrics for ClickHouse

### DIFF
--- a/clickhouse/changelog.d/23258.changed
+++ b/clickhouse/changelog.d/23258.changed
@@ -1,0 +1,1 @@
+Remove internal user filtering from metrics and samples collection to collect data for all users

--- a/clickhouse/datadog_checks/clickhouse/query_log_job.py
+++ b/clickhouse/datadog_checks/clickhouse/query_log_job.py
@@ -11,7 +11,6 @@ This module provides shared functionality for:
 Both jobs share:
 - Checkpoint-based collection with persistent cache
 - Dedicated DB client management
-- Internal user filtering
 - Query obfuscation
 """
 
@@ -37,16 +36,6 @@ GET_CURRENT_TIME_QUERY = "SELECT toUnixTimestamp64Micro(now64(6))"
 # If a node's checkpoint is more than this far behind the most advanced node,
 # it is considered decommissioned
 _NODE_CHECKPOINT_STALENESS_THRESHOLD_US = 60 * 60 * 1_000_000  # 1 hour
-
-# List of internal Cloud users to exclude from query metrics/samples
-# These are Datadog Cloud internal service accounts
-INTERNAL_CLOUD_USERS = frozenset(
-    {
-        # Add internal Cloud user names here as needed
-        # 'internal_service_user',
-    }
-)
-
 
 def agent_check_getter(self):
     """Helper function for @tracked_method decorator to get the check instance."""
@@ -240,19 +229,6 @@ class ClickhouseQueryLogJob(DBMAsyncJob):
                 "Failed to save checkpoint to persistent cache: %s. Next collection will retry the same time window.",
                 str(e),
             )
-
-    def _get_internal_user_filter(self) -> str:
-        """
-        Build the SQL filter to exclude internal Cloud users.
-
-        Returns:
-            SQL fragment starting with "AND " to exclude internal users
-        """
-        filters = ["user NOT LIKE '%-internal'"]
-        if INTERNAL_CLOUD_USERS:
-            users_list = ", ".join(f"'{user}'" for user in INTERNAL_CLOUD_USERS)
-            filters.append(f"user NOT IN ({users_list})")
-        return "AND " + " AND ".join(filters)
 
     def _obfuscate_query(self, query_text: str) -> dict | None:
         """

--- a/clickhouse/datadog_checks/clickhouse/statements.py
+++ b/clickhouse/datadog_checks/clickhouse/statements.py
@@ -69,7 +69,6 @@ WHERE
     AND is_initial_query = 1
     AND query != ''
     AND normalized_query_hash != 0
-    {internal_user_filter}
 GROUP BY normalized_query_hash, server_node
 ORDER BY total_duration_ms DESC
 """
@@ -221,7 +220,6 @@ class ClickhouseStatementMetrics(ClickhouseQueryLogJob):
             query = (
                 STATEMENTS_QUERY.replace("{query_log_table}", query_log_table)
                 .replace("{checkpoint_filter}", checkpoint_filter)
-                .replace("{internal_user_filter}", self._get_internal_user_filter())
             )
             params["min_checkpoint_us"] = min_checkpoint
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
As part of this PR we want the agent to allow capture of metrics for cloud internal user queries. We want users to be able to view all queries running on CH - both internal and application user queries. 
The frontend will ensure proper grouping and filtering if users want to view this without creating noise

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
