### PR TITLE
[Kubernetes] Update OOMKill OOTB Dashboards 

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_clusters.json
+++ b/kubernetes/assets/dashboards/kubernetes_clusters.json
@@ -4524,14 +4524,19 @@
                                     "formulas": [
                                         {
                                             "alias": "OOM killed",
-                                            "formula": "query1"
+                                            "formula": "clamp_min(diff(query1), 0) * query2"
                                         }
                                     ],
                                     "queries": [
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes.containers.state.terminated{$cluster,reason:oomkilled,$scope} by {pod_name}"
+                                            "query": "sum:kubernetes.containers.restarts{$cluster,$scope} by {pod_name,kube_container_name}.fill(last)"
+                                        },
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query2",
+                                            "query": "sum:kubernetes.containers.last_state.terminated{$cluster,reason:oomkilled,$scope} by {pod_name,kube_container_name}.rollup(max)"
                                         }
                                     ],
                                     "response_format": "timeseries",

--- a/kubernetes/assets/dashboards/kubernetes_pods.json
+++ b/kubernetes/assets/dashboards/kubernetes_pods.json
@@ -911,11 +911,21 @@
                                 {
                                     "on_right_yaxis": false,
                                     "response_format": "timeseries",
+                                    "formulas": [
+                                        {
+                                            "formula": "clamp_min(diff(query1), 0) * query2"
+                                        }
+                                    ],
                                     "queries": [
                                         {
-                                            "query": "sum:kubernetes.containers.state.terminated{$cluster,$namespace,$deployment,reason:oomkilled,$scope,$statefulset,$daemonset,$job} by {pod_name}",
+                                            "query": "sum:kubernetes.containers.restarts{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {pod_name,kube_container_name}.fill(last)",
                                             "data_source": "metrics",
                                             "name": "query1"
+                                        },
+                                        {
+                                            "query": "sum:kubernetes.containers.last_state.terminated{$cluster,$namespace,$deployment,reason:oomkilled,$scope,$statefulset,$daemonset,$job} by {pod_name,kube_container_name}.rollup(max)",
+                                            "data_source": "metrics",
+                                            "name": "query2"
                                         }
                                     ],
                                     "style": {


### PR DESCRIPTION
### What does this PR do?
Updates the "Containers OOM Killed" widget on the Kubernetes Pods and Kubernetes Clusters OOTB dashboards. Replaces the old graphed metric with `clamp_min(diff(restarts), 0) * last_state.terminated{reason:oomkilled}`, using `restarts` as the event trigger and `last_state.terminated` as an "OOM filter". 

This also meant that we need to group by both `pod_name` and `kube_container_name`, because otherwise we get situations where a pod with many containers can see massive overcounting for a single OOM kill (`n` OOM kills can be overcounted to `n(n-1)/2`). 

The fractional values sometimes visible are a known artifact of the kubelet check not reporting restarts during a container's restart window, which means that there is a small metric gap. Thus taking the diff/derivative over that spreads the increment in restart over multiple points.

### Motivation
[CONTINT-5192](https://datadoghq.atlassian.net/browse/CONTINT-5192), [FSCONS-1115](https://datadoghq.atlassian.net/browse/FRCONS-1115)

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [x] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[CONTINT-5192]: https://datadoghq.atlassian.net/browse/CONTINT-5192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ