### PR TITLE
Add octo-sts trust policy for validation PR comments

### DIFF
--- a/.github/chainguard/self.validate.pull-request.sts.yaml
+++ b/.github/chainguard/self.validate.pull-request.sts.yaml
@@ -1,0 +1,35 @@
+# Trust policy for the validation workflow in DataDog/integrations-core
+#
+# This policy grants the workflow permission to post PR comments with
+# validation results when any validation fails.
+#
+# Naming convention:
+#   self:          Only this repository (DataDog/integrations-core) can use this policy
+#   validate:      Grants permissions for the validate workflow
+#   pull-request:  Intended for workflows triggered by pull_request events
+#
+# Security model:
+#   - Workflow runs on pull_request events from any branch
+#   - job_workflow_ref is matched by pattern since PR events reference refs/pull/N/merge
+#   - No ref_protected constraint — PRs originate from any branch
+#
+# Permissions granted:
+#   - pull_requests: write  - Post a comment on the pull request with validation results
+#
+# Usage in workflows:
+#   - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+#     with:
+#       scope: DataDog/integrations-core
+#       policy: self.validate.pull-request
+
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: repo:DataDog/integrations-core:pull_request
+
+claim_pattern:
+  event_name: pull_request
+  job_workflow_ref: DataDog/integrations-core/\.github/workflows/run-validations\.yml@.*
+  repository: DataDog/integrations-core
+
+permissions:
+  pull_requests: write


### PR DESCRIPTION
### What does this PR do?

Adds an octo-sts trust policy (`self.validate.pull-request.sts.yaml`) that grants the validation workflow permission to post PR comments with validation results.

This policy is a prerequisite for #23249, which replaces the 25 sequential validation steps with a parallel `ddev validate all` command that posts structured failure reports as PR comments.

### Motivation

The validation workflow needs `pull_requests: write` to post comments on PRs. The octo-sts action exchanges an OIDC token for a scoped GitHub token using this trust policy, which is more secure than using `secrets.GITHUB_TOKEN` with broad permissions.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged