### PR TITLE
[FA] Set display_priority in redis spec.yaml

### DIFF
--- a/redisdb/assets/configuration/spec.yaml
+++ b/redisdb/assets/configuration/spec.yaml
@@ -25,6 +25,19 @@ files:
         type: integer
         example: 6379
       fleet_configurable: true
+    - name: username
+      display_priority: 2
+      description: The username for the connection. Redis 6+ only.
+      value:
+          type: string
+      fleet_configurable: true
+    - name: password
+      display_priority: 1
+      description: The password for the connection.
+      secret: true
+      value:
+        type: string
+      fleet_configurable: true
     - name: unix_socket_path
       display_priority: 0
       description: Connect through a unix socket instead of using a `host` and `port`.
@@ -44,19 +57,6 @@ files:
       value:
         type: integer
         example: 0
-      fleet_configurable: true
-    - name: username
-      display_priority: 2
-      description: The username for the connection. Redis 6+ only.
-      value:
-          type: string
-      fleet_configurable: true
-    - name: password
-      display_priority: 1
-      description: The password for the connection.
-      secret: true
-      value:
-        type: string
       fleet_configurable: true
     - name: collect_client_metrics
       display_priority: 0

--- a/redisdb/assets/configuration/spec.yaml
+++ b/redisdb/assets/configuration/spec.yaml
@@ -9,7 +9,7 @@ files:
   - template: instances
     options:
     - name: host
-      display_priority: 3
+      display_priority: 4
       required: true
       description: Enter the host to connect to.
       value:
@@ -17,7 +17,7 @@ files:
         example: localhost
       fleet_configurable: true
     - name: port
-      display_priority: 2
+      display_priority: 3
       required: true
       description: Enter the port of the host to connect to.
       formats: ["port"]
@@ -46,7 +46,7 @@ files:
         example: 0
       fleet_configurable: true
     - name: username
-      display_priority: 0
+      display_priority: 2
       description: The username for the connection. Redis 6+ only.
       value:
           type: string

--- a/redisdb/assets/configuration/spec.yaml
+++ b/redisdb/assets/configuration/spec.yaml
@@ -9,6 +9,7 @@ files:
   - template: instances
     options:
     - name: host
+      display_priority: 3
       required: true
       description: Enter the host to connect to.
       value:
@@ -16,6 +17,7 @@ files:
         example: localhost
       fleet_configurable: true
     - name: port
+      display_priority: 2
       required: true
       description: Enter the port of the host to connect to.
       formats: ["port"]
@@ -24,6 +26,7 @@ files:
         example: 6379
       fleet_configurable: true
     - name: unix_socket_path
+      display_priority: 0
       description: Connect through a unix socket instead of using a `host` and `port`.
       value:
         type: string
@@ -32,6 +35,7 @@ files:
         display_default: null
       fleet_configurable: true
     - name: db
+      display_priority: 0
       description: |
         The index of the database (keyspace) to use.
         The default is index 0. Any other index results in a SELECT command sent upon connection
@@ -42,17 +46,20 @@ files:
         example: 0
       fleet_configurable: true
     - name: username
+      display_priority: 0
       description: The username for the connection. Redis 6+ only.
       value:
           type: string
       fleet_configurable: true
     - name: password
+      display_priority: 1
       description: The password for the connection.
       secret: true
       value:
         type: string
       fleet_configurable: true
     - name: collect_client_metrics
+      display_priority: 0
       description: |
         Collects metrics using the `CLIENT` command.
         This requires the Redis CLIENT command to be available on your servers.
@@ -61,18 +68,21 @@ files:
         example: false
       fleet_configurable: true
     - name: socket_timeout
+      display_priority: 0
       description: Custom timeout for the check request.
       value:
         type: integer
         example: 5
       fleet_configurable: true
     - name: ssl
+      display_priority: 0
       description: Enable SSL/TLS encryption for the check.
       value:
         type: boolean
         example: false
       fleet_configurable: true
     - name: ssl_keyfile
+      display_priority: 0
       description: The path to the client-side private keyfile.
       value:
         type: string
@@ -80,6 +90,7 @@ files:
         example: "<CERT_KEY_PATH>"
       fleet_configurable: true
     - name: ssl_certfile
+      display_priority: 0
       description: The path to the client-side certificate file.
       value:
         type: string
@@ -87,6 +98,7 @@ files:
         example: "<CERT_PEM_PATH>"
       fleet_configurable: true
     - name: ssl_ca_certs
+      display_priority: 0
       description:  The path to the CA certs file.
       value:
         type: string
@@ -94,6 +106,7 @@ files:
         example: "<CERT_PATH>"
       fleet_configurable: true
     - name: ssl_cert_reqs
+      display_priority: 0
       description: |
         Specifies whether a certificate is required from the
         other side of the connection, and whether it's validated if provided.
@@ -106,6 +119,7 @@ files:
         example: 2
       fleet_configurable: true
     - name: ssl_check_hostname
+      display_priority: 0
       description: |
         Verify the server's SSL certificate hostname matches the connection target.
         Redis-py 6.0+ defaults this to true. Set to false if your certificate
@@ -115,6 +129,7 @@ files:
         example: true
       fleet_configurable: true
     - name: keys
+      display_priority: 0
       description: |
         Enter the list of keys to collect the lengths from.
         The length is 1 for strings.
@@ -129,6 +144,7 @@ files:
           - "<KEY_PATTERN>"
       fleet_configurable: true
     - name: warn_on_missing_keys
+      display_priority: 0
       description: |
         If you provide a list of 'keys', set this to true to have the Agent log a warning
         when keys are missing.
@@ -137,6 +153,7 @@ files:
         example: true
       fleet_configurable: true
     - name: slowlog-max-len
+      display_priority: 0
       description: |
         Set the maximum number of entries to fetch from the slow query log.
         By default, the check reads this value from the redis config, but is limited to 128.
@@ -147,12 +164,14 @@ files:
         type: integer
         example: 128
     - name: command_stats
+      display_priority: 0
       description: Collect INFO COMMANDSTATS output as metrics.
       value:
         type: boolean
         example: false
       fleet_configurable: true
     - name: disable_connection_cache
+      display_priority: 0
       description: |
         Enable the connections cache so the check attempts to reuse the same Redis connections
         at every collection cycle. If disabled, this prevents stale connections.

--- a/redisdb/changelog.d/23270.fixed
+++ b/redisdb/changelog.d/23270.fixed
@@ -1,0 +1,1 @@
+Re-order configuration fields based on real-world usage data.

--- a/redisdb/datadog_checks/redisdb/data/conf.yaml.example
+++ b/redisdb/datadog_checks/redisdb/data/conf.yaml.example
@@ -23,6 +23,11 @@ instances:
     #
     port: 6379
 
+    ## @param username - string - optional
+    ## The username for the connection. Redis 6+ only.
+    #
+    # username: <USERNAME>
+
     ## @param password - string - optional
     ## The password for the connection.
     #
@@ -40,11 +45,6 @@ instances:
     ## used as in rc.
     #
     # db: 0
-
-    ## @param username - string - optional
-    ## The username for the connection. Redis 6+ only.
-    #
-    # username: <USERNAME>
 
     ## @param collect_client_metrics - boolean - optional - default: false
     ## Collects metrics using the `CLIENT` command.

--- a/redisdb/datadog_checks/redisdb/data/conf.yaml.example
+++ b/redisdb/datadog_checks/redisdb/data/conf.yaml.example
@@ -23,6 +23,11 @@ instances:
     #
     port: 6379
 
+    ## @param password - string - optional
+    ## The password for the connection.
+    #
+    # password: <PASSWORD>
+
     ## @param unix_socket_path - string - optional
     ## Connect through a unix socket instead of using a `host` and `port`.
     #
@@ -40,11 +45,6 @@ instances:
     ## The username for the connection. Redis 6+ only.
     #
     # username: <USERNAME>
-
-    ## @param password - string - optional
-    ## The password for the connection.
-    #
-    # password: <PASSWORD>
 
     ## @param collect_client_metrics - boolean - optional - default: false
     ## Collects metrics using the `CLIENT` command.


### PR DESCRIPTION
## Summary
- Set `display_priority` in `redis` `spec.yaml` based on real-world field usage data
- Fields with >10% usage are ranked by usage (descending); fields with ≤10% usage get `display_priority: 0`
- Regenerated `conf.yaml.example` to reflect the new ordering

## Test plan
- [ ] Verify `conf.yaml.example` field ordering matches expected usage-based ordering
- [ ] Validate spec with `ddev validate config -s redisdb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)