### PR TITLE
[FA] Set display_priority in nginx spec.yaml

### DIFF
--- a/nginx/assets/configuration/spec.yaml
+++ b/nginx/assets/configuration/spec.yaml
@@ -12,7 +12,7 @@ files:
     - name: nginx_status_url
       fleet_configurable: true
       required: true
-      display_priority: 2
+      display_priority: 1
       formats: ["url"]
       description: |
         For every instance, you need an `nginx_status_url` and can optionally
@@ -30,6 +30,7 @@ files:
         example: http://localhost:81/nginx_status/
         type: string
     - name: use_plus_api
+      display_priority: 0
       description: |
         If you are using the commercial version of NGINX for releases R13 and above,
         there is a new API that replaces the extended status API.
@@ -40,6 +41,7 @@ files:
         type: boolean
         example: false
     - name: use_plus_api_stream
+      display_priority: 0
       description: |
        If you are using the commercial version of NGINX, for releases R13 and above,
        there is an API that replaces the extended status API.
@@ -52,12 +54,14 @@ files:
         example: false
         display_default: true
     - name: plus_api_version
+      display_priority: 0
       description: Specify the version of the Plus API to use. The check supports versions 1-7.
       fleet_configurable: true
       value:
         type: integer
         display_default: 2
     - name: only_query_enabled_endpoints
+      display_priority: 0
       description: |
         Enable this option if you would like the check to determine which API endpoints
         to query based on your NGINX Plus configuration.
@@ -68,6 +72,7 @@ files:
         display_default: false
       enabled: true
     - name: use_vts
+      display_priority: 0
       description: |
         Set this option to true if you are using the nginx vhost_traffic_status module.
         If you are using VTS, set the nginx_status_url to something like http://localhost/nginx_stats/format/json.


### PR DESCRIPTION
## Summary
- Set `display_priority` in `nginx` `spec.yaml` based on real-world field usage data
- Fields with >10% usage are ranked by usage (descending); fields with ≤10% usage get `display_priority: 0`
- Regenerated `conf.yaml.example` to reflect the new ordering

## Test plan
- [ ] Verify `conf.yaml.example` field ordering matches expected usage-based ordering
- [ ] Validate spec with `ddev validate config -s nginx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)