### PR TITLE
[FA] Set display_priority in cassandra spec.yaml

### DIFF
--- a/cassandra/assets/configuration/spec.yaml
+++ b/cassandra/assets/configuration/spec.yaml
@@ -9,6 +9,7 @@ files:
   - template: instances
     options:
     - name: cassandra_aliasing
+      display_priority: 1
       description: |
         Must be set to true to comply with CASSANDRA-4009.
         Learn more: https://issues.apache.org/jira/browse/CASSANDRA-4009

--- a/cassandra/changelog.d/23274.fixed
+++ b/cassandra/changelog.d/23274.fixed
@@ -1,0 +1,1 @@
+Re-order configuration fields based on real-world usage data.

--- a/cassandra/datadog_checks/cassandra/data/conf.yaml.example
+++ b/cassandra/datadog_checks/cassandra/data/conf.yaml.example
@@ -53,21 +53,21 @@ init_config:
 #
 instances:
 
+    ## @param cassandra_aliasing - boolean - required
+    ## Must be set to true to comply with CASSANDRA-4009.
+    ## Learn more: https://issues.apache.org/jira/browse/CASSANDRA-4009
+    #
+  - cassandra_aliasing: true
+
     ## @param host - string - required
     ## JMX hostname to connect to.
     #
-  - host: localhost
+    host: localhost
 
     ## @param port - integer - required
     ## JMX port to connect to.
     #
     port: 7199
-
-    ## @param cassandra_aliasing - boolean - required
-    ## Must be set to true to comply with CASSANDRA-4009.
-    ## Learn more: https://issues.apache.org/jira/browse/CASSANDRA-4009
-    #
-    cassandra_aliasing: true
 
     ## @param user - string - optional
     ## User to use when connecting to JMX.


### PR DESCRIPTION
## Summary
- Set `display_priority` in `cassandra` `spec.yaml` based on real-world field usage data
- Fields with >10% usage are ranked by usage (descending); fields with ≤10% usage get `display_priority: 0`
- Regenerated `conf.yaml.example` to reflect the new ordering

## Test plan
- [ ] Verify `conf.yaml.example` field ordering matches expected usage-based ordering
- [ ] Validate spec with `ddev validate config -s cassandra`

🤖 Generated with [Claude Code](https://claude.com/claude-code)