### PR TITLE
[FA] Set display_priority in gunicorn spec.yaml

### DIFF
--- a/gunicorn/assets/configuration/spec.yaml
+++ b/gunicorn/assets/configuration/spec.yaml
@@ -5,6 +5,7 @@ files:
   - template: init_config
     options:
       - name: gunicorn
+        display_priority: 0
         description: |
           Command or path to gunicorn (e.g. `/usr/local/bin/gunicorn` or `docker exec container gunicorn`)
           can be overwritten on an instance
@@ -16,6 +17,7 @@ files:
   - template: instances
     options:
     - name: proc_name
+      display_priority: 1
       required: true
       description: |
         The name of the gunicorn process. For the following gunicorn server:
@@ -27,6 +29,7 @@ files:
         type: string
       fleet_configurable: true
     - name: gunicorn
+      display_priority: 0
       description: Command or path to gunicorn (e.g. `/usr/local/bin/gunicorn` or `docker exec container gunicorn`)
       value:
         type: string


### PR DESCRIPTION
## Summary
- Set `display_priority` in `gunicorn` `spec.yaml` based on real-world field usage data
- Fields with >10% usage are ranked by usage (descending); fields with ≤10% usage get `display_priority: 0`
- Regenerated `conf.yaml.example` to reflect the new ordering

## Test plan
- [ ] Verify `conf.yaml.example` field ordering matches expected usage-based ordering
- [ ] Validate spec with `ddev validate config -s gunicorn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)