### PR TITLE
[FA] Set display_priority in rabbitmq spec.yaml

### DIFF
--- a/rabbitmq/assets/configuration/spec.yaml
+++ b/rabbitmq/assets/configuration/spec.yaml
@@ -14,6 +14,7 @@ files:
     multiple_instances_defined: true
     options:
     - name: OpenMetrics
+      display_priority: 0
       description: RabbitMQ Prometheus Plugin Example
       options:
       - name: prometheus_plugin
@@ -68,6 +69,7 @@ files:
           openmetrics_endpoint.required: false
           openmetrics_endpoint.hidden: true
     - name: RabbitMQ Management Plugin
+      display_priority: 0
       description: RabbitMQ Management Plugin Example
       options:
       - name: rabbitmq_api_url

--- a/rabbitmq/assets/configuration/spec.yaml
+++ b/rabbitmq/assets/configuration/spec.yaml
@@ -14,7 +14,6 @@ files:
     multiple_instances_defined: true
     options:
     - name: OpenMetrics
-      display_priority: 0
       description: RabbitMQ Prometheus Plugin Example
       options:
       - name: prometheus_plugin
@@ -70,7 +69,6 @@ files:
           openmetrics_endpoint.required: false
           openmetrics_endpoint.hidden: true
     - name: RabbitMQ Management Plugin
-      display_priority: 0
       description: RabbitMQ Management Plugin Example
       options:
       - name: rabbitmq_api_url

--- a/rabbitmq/assets/configuration/spec.yaml
+++ b/rabbitmq/assets/configuration/spec.yaml
@@ -18,6 +18,7 @@ files:
       description: RabbitMQ Prometheus Plugin Example
       options:
       - name: prometheus_plugin
+        display_priority: 0
         description: |
           Settings for talking to the Prometheus plugin of RabbitMQ.
           Specify this section to trigger metric collection from the Prometheus plugin endpoints.
@@ -73,6 +74,7 @@ files:
       description: RabbitMQ Management Plugin Example
       options:
       - name: rabbitmq_api_url
+        display_priority: 3
         description: |
           For every instance a 'rabbitmq_api_url' must be provided, pointing to the API
           URL of the RabbitMQ Management Plugin (http://www.rabbitmq.com/management.html).
@@ -82,12 +84,14 @@ files:
           type: string
           example: http://localhost:15672/api/
       - name: rabbitmq_user
+        display_priority: 2
         description: The username to use for the RabbitMQ Management Plugin
         fleet_configurable: true
         value:
           type: string
           example: guest
       - name: rabbitmq_pass
+        display_priority: 1
         description: The password to use for the RabbitMQ Management Plugin
         secret: true
         fleet_configurable: true
@@ -95,18 +99,21 @@ files:
           type: string
           example: guest
       - name: tag_families
+        display_priority: 0
         description: To tag queue "families" based on regex matching.
         fleet_configurable: true
         value:
           type: boolean
           example: false
       - name: collect_node_metrics
+        display_priority: 0
         description: Node metrics are collected by default. Setting this parameter to false skips node metric collection.
         fleet_configurable: true
         value:
           type: boolean
           example: true
       - name: nodes
+        display_priority: 0
         description: |
           Use the `nodes` parameters to specify the nodes you'd like to collect metrics on.
           The default maximum number of nodes is 100. Exceeding this limit can cause
@@ -119,6 +126,7 @@ files:
             - <NODE_NAME_1>
             - <NODE_NAME_2>
       - name: nodes_regexes
+        display_priority: 0
         description: |
           Use the `nodes_regexes` parameters to specify which nodes you would like to
           collect using one or multiple Python regular expressions. The same limit applies as
@@ -132,6 +140,7 @@ files:
           example:
             - <REGEX>
       - name: queues
+        display_priority: 0
         description: |
           Use the `queues` parameters to specify the queues you'd like to collect metrics on.
           The default maximum number of queues is 200. Exceeding this limit can cause
@@ -145,6 +154,7 @@ files:
             - <QUEUE_NAME_1>
             - <QUEUE_NAME_2>
       - name: queues_regexes
+        display_priority: 0
         description: |
           Use the `queues_regexes` parameters to specify which queues you would like to
           collect using one or multiple Python regular expressions.
@@ -167,6 +177,7 @@ files:
           example:
             - <REGEX>
       - name: exchanges
+        display_priority: 0
         description: |
           Use the `exchanges` parameters to specify the exchanges you'd like to collect metrics on.
           The default maximum number of exchanges is 50. Exceeding this limit can cause
@@ -180,6 +191,7 @@ files:
             - <EXCHANGE_1>
             - <EXCHANGE_2>
       - name: exchanges_regexes
+        display_priority: 0
         description: |
           Use the `exchanges_regexes` parameters to specify which exchanges you would like to
           collect using one or multiple Python regular expressions.
@@ -203,6 +215,7 @@ files:
           example:
             - <REGEX>
       - name: vhosts
+        display_priority: 0
         description: |
           Service checks and `rabbitmq.connections` metric:
           By default a list of all vhosts is fetched and each one is checked using the aliveness


### PR DESCRIPTION
## Summary
- Set `display_priority` in `rabbitmq` `spec.yaml` based on real-world field usage data
- Fields with >10% usage are ranked by usage (descending); fields with ≤10% usage get `display_priority: 0`
- Regenerated `conf.yaml.example` to reflect the new ordering

## Test plan
- [ ] Verify `conf.yaml.example` field ordering matches expected usage-based ordering
- [ ] Validate spec with `ddev validate config -s rabbitmq`

🤖 Generated with [Claude Code](https://claude.com/claude-code)