### PR TITLE
Add test for using embedded nfsiostat

### DIFF
--- a/nfsstat/tests/common.py
+++ b/nfsstat/tests/common.py
@@ -19,8 +19,15 @@ E2E_METADATA = {
     'start_commands': [
         'apt-get update',
         'apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y docker.io',
+        # Remove default binary to ensure the check uses the embedded one
+        'rm -f /usr/local/sbin/nfsiostat',
     ],
     'docker_volumes': ['/var/run/docker.sock:/var/run/docker.sock'],
+}
+
+CONFIG_BUNDLED_BINARY = {
+    "init_config": {},
+    "instances": [{}],
 }
 
 METRICS = [

--- a/nfsstat/tests/test_e2e.py
+++ b/nfsstat/tests/test_e2e.py
@@ -5,7 +5,7 @@ import pytest
 
 from datadog_checks.dev.utils import get_metadata_metrics
 
-from .common import CONFIG, METRICS
+from .common import CONFIG, CONFIG_BUNDLED_BINARY, METRICS
 
 
 @pytest.mark.e2e
@@ -17,3 +17,11 @@ def test_e2e(dd_agent_check):
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())
+
+
+@pytest.mark.e2e
+def test_e2e_bundled_binary_no_mounts(dd_agent_check):
+    """Verify the agent's bundled nfsiostat binary exists and the check handles no NFS mounts gracefully."""
+    aggregator = dd_agent_check(CONFIG_BUNDLED_BINARY)
+
+    aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?
Adds and e2e test for embedded nfsiostat
### Motivation
We want to catch a scenario where the embedded nfsiostat is missing or broken:  https://github.com/DataDog/datadog-agent/issues/49058
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
