### PR TITLE
[kafka_consumer] Send cluster monitoring heartbeat via data streams messages

### DIFF
--- a/kafka_consumer/changelog.d/23281.added
+++ b/kafka_consumer/changelog.d/23281.added
@@ -1,0 +1,1 @@
+Send cluster monitoring heartbeat via data streams messages with context count and limit.

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -143,6 +143,8 @@ class KafkaCheck(AgentCheck):
         return sum(len(offsets) for offsets in consumer_offsets.values())
 
     def _send_cluster_monitoring_heartbeat(self, total_contexts: int, cluster_id: str) -> None:
+        if not cluster_id and self.client._cluster_metadata:
+            cluster_id = self.client._cluster_metadata.cluster_id or ""
         payload = {
             'collection_timestamp': int(time() * 1000),
             'kafka_cluster_id': cluster_id,

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -130,7 +130,7 @@ class KafkaCheck(AgentCheck):
 
         # Collect cluster metadata if enabled
         if self.config._cluster_monitoring_enabled:
-            self._send_cluster_monitoring_heartbeat(total_contexts)
+            self._send_cluster_monitoring_heartbeat(total_contexts, cluster_id)
             try:
                 self.metadata_collector.collect_all_metadata(highwater_offsets)
             except Exception as e:
@@ -142,14 +142,7 @@ class KafkaCheck(AgentCheck):
     def count_consumer_contexts(self, consumer_offsets):
         return sum(len(offsets) for offsets in consumer_offsets.values())
 
-    def _send_cluster_monitoring_heartbeat(self, total_contexts: int) -> None:
-        cluster_id = self.config._kafka_cluster_id_override or ""
-        auto_detected_id = ""
-        cluster_metadata = getattr(self.client, '_cluster_metadata', None)
-        if cluster_metadata:
-            auto_detected_id = cluster_metadata.cluster_id or ""
-        if not cluster_id:
-            cluster_id = auto_detected_id
+    def _send_cluster_monitoring_heartbeat(self, total_contexts: int, cluster_id: str) -> None:
         payload = {
             'collection_timestamp': int(time() * 1000),
             'kafka_cluster_id': cluster_id,
@@ -158,7 +151,7 @@ class KafkaCheck(AgentCheck):
             'contexts_limit': self._context_limit,
         }
         if self.config._kafka_cluster_id_override:
-            payload['original_kafka_cluster_id'] = auto_detected_id
+            payload['original_kafka_cluster_id'] = self.config._auto_detected_cluster_id
         self.event_platform_event(json.dumps(payload), "data-streams-message")
 
     def get_consumer_offsets(self):

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -130,6 +130,7 @@ class KafkaCheck(AgentCheck):
 
         # Collect cluster metadata if enabled
         if self.config._cluster_monitoring_enabled:
+            self._send_cluster_monitoring_heartbeat(total_contexts, cluster_id)
             try:
                 self.metadata_collector.collect_all_metadata(highwater_offsets)
             except Exception as e:
@@ -140,6 +141,18 @@ class KafkaCheck(AgentCheck):
 
     def count_consumer_contexts(self, consumer_offsets):
         return sum(len(offsets) for offsets in consumer_offsets.values())
+
+    def _send_cluster_monitoring_heartbeat(self, total_contexts: int, cluster_id: str) -> None:
+        payload = {
+            'collection_timestamp': int(time() * 1000),
+            'kafka_cluster_id': cluster_id,
+            'config_type': 'heartbeat',
+            'contexts': total_contexts,
+            'contexts_limit': self._context_limit,
+        }
+        if self.config._kafka_cluster_id_override:
+            payload['original_kafka_cluster_id'] = self.config._auto_detected_cluster_id
+        self.event_platform_event(json.dumps(payload), "data-streams-message")
 
     def get_consumer_offsets(self):
         # {(consumer_group, topic, partition): offset}

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -130,7 +130,7 @@ class KafkaCheck(AgentCheck):
 
         # Collect cluster metadata if enabled
         if self.config._cluster_monitoring_enabled:
-            self._send_cluster_monitoring_heartbeat(total_contexts, cluster_id)
+            self._send_cluster_monitoring_heartbeat(total_contexts)
             try:
                 self.metadata_collector.collect_all_metadata(highwater_offsets)
             except Exception as e:
@@ -142,9 +142,13 @@ class KafkaCheck(AgentCheck):
     def count_consumer_contexts(self, consumer_offsets):
         return sum(len(offsets) for offsets in consumer_offsets.values())
 
-    def _send_cluster_monitoring_heartbeat(self, total_contexts: int, cluster_id: str) -> None:
-        if not cluster_id and self.client._cluster_metadata:
-            cluster_id = self.client._cluster_metadata.cluster_id or ""
+    def _send_cluster_monitoring_heartbeat(self, total_contexts: int) -> None:
+        cluster_id = self.config._kafka_cluster_id_override or ""
+        auto_detected_id = ""
+        if self.client._cluster_metadata:
+            auto_detected_id = self.client._cluster_metadata.cluster_id or ""
+        if not cluster_id:
+            cluster_id = auto_detected_id
         payload = {
             'collection_timestamp': int(time() * 1000),
             'kafka_cluster_id': cluster_id,
@@ -153,7 +157,7 @@ class KafkaCheck(AgentCheck):
             'contexts_limit': self._context_limit,
         }
         if self.config._kafka_cluster_id_override:
-            payload['original_kafka_cluster_id'] = self.config._auto_detected_cluster_id
+            payload['original_kafka_cluster_id'] = auto_detected_id
         self.event_platform_event(json.dumps(payload), "data-streams-message")
 
     def get_consumer_offsets(self):

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -145,8 +145,9 @@ class KafkaCheck(AgentCheck):
     def _send_cluster_monitoring_heartbeat(self, total_contexts: int) -> None:
         cluster_id = self.config._kafka_cluster_id_override or ""
         auto_detected_id = ""
-        if self.client._cluster_metadata:
-            auto_detected_id = self.client._cluster_metadata.cluster_id or ""
+        cluster_metadata = getattr(self.client, '_cluster_metadata', None)
+        if cluster_metadata:
+            auto_detected_id = cluster_metadata.cluster_id or ""
         if not cluster_id:
             cluster_id = auto_detected_id
         payload = {


### PR DESCRIPTION
## Summary
- When `enable_cluster_monitoring` is enabled, send a heartbeat via `data-streams-message` on every check run
- The heartbeat includes the current total context count and the configured context limit, so we can determine if a customer is hitting the ceiling

## Test plan
- [x] Existing unit tests pass (114/114)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)