### PR TITLE
[DBMON-6427] Bump `datadog-checks-base` to `>=37.34.1` in DBM integrations 

### DIFF
--- a/clickhouse/changelog.d/23282.fixed
+++ b/clickhouse/changelog.d/23282.fixed
@@ -1,1 +1,2 @@
-Bump `datadog-checks-base` to `>=37.34.1`
+Bump `datadog-checks-base` to `>=37.34.1`. Notable changes:
+  - Reduce allocations in `StatementMetrics` by deferring dict construction and updating the previous-statements cache in place. ([#23075](https://github.com/DataDog/integrations-core/pull/23075))

--- a/clickhouse/changelog.d/23282.fixed
+++ b/clickhouse/changelog.d/23282.fixed
@@ -1,0 +1,1 @@
+Bump `datadog-checks-base` to `>=37.34.1`

--- a/clickhouse/pyproject.toml
+++ b/clickhouse/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.33.0",
+    "datadog-checks-base>=37.34.1",
 ]
 dynamic = [
     "version",

--- a/mongo/changelog.d/23282.fixed
+++ b/mongo/changelog.d/23282.fixed
@@ -1,1 +1,2 @@
-Bump `datadog-checks-base` to `>=37.34.1`
+Bump `datadog-checks-base` to `>=37.34.1`. Notable changes:
+  - Reduce allocations in `StatementMetrics` by deferring dict construction and updating the previous-statements cache in place. ([#23075](https://github.com/DataDog/integrations-core/pull/23075))

--- a/mongo/changelog.d/23282.fixed
+++ b/mongo/changelog.d/23282.fixed
@@ -1,0 +1,1 @@
+Bump `datadog-checks-base` to `>=37.34.1`

--- a/mongo/pyproject.toml
+++ b/mongo/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.33.0",
+    "datadog-checks-base>=37.34.1",
 ]
 dynamic = [
     "version",

--- a/mysql/changelog.d/23282.fixed
+++ b/mysql/changelog.d/23282.fixed
@@ -1,1 +1,4 @@
-Bump `datadog-checks-base` to `>=37.34.1`
+Bump `datadog-checks-base` to `>=37.34.1`. Notable changes:
+  - Fix schema collection silently dropping all collected metadata when the last discovered database has no tables. ([#22880](https://github.com/DataDog/integrations-core/pull/22880))
+  - Reduce allocations in `StatementMetrics` by deferring dict construction and updating the previous-statements cache in place. ([#23075](https://github.com/DataDog/integrations-core/pull/23075))
+  - Improve compile-time error messages for invalid syntax in DB query extras expressions. ([#23140](https://github.com/DataDog/integrations-core/pull/23140))

--- a/mysql/changelog.d/23282.fixed
+++ b/mysql/changelog.d/23282.fixed
@@ -1,0 +1,1 @@
+Bump `datadog-checks-base` to `>=37.34.1`

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.33.0",
+    "datadog-checks-base>=37.34.1",
 ]
 dynamic = [
     "version",

--- a/postgres/changelog.d/23282.fixed
+++ b/postgres/changelog.d/23282.fixed
@@ -1,1 +1,4 @@
-Bump `datadog-checks-base` to `>=37.34.1`
+Bump `datadog-checks-base` to `>=37.34.1`. Notable changes:
+  - Fix schema collection silently dropping all collected metadata when the last discovered database has no tables. ([#22880](https://github.com/DataDog/integrations-core/pull/22880))
+  - Reduce allocations in `StatementMetrics` by deferring dict construction and updating the previous-statements cache in place. ([#23075](https://github.com/DataDog/integrations-core/pull/23075))
+  - Improve compile-time error messages for invalid syntax in DB query extras expressions. ([#23140](https://github.com/DataDog/integrations-core/pull/23140))

--- a/postgres/changelog.d/23282.fixed
+++ b/postgres/changelog.d/23282.fixed
@@ -1,0 +1,1 @@
+Bump `datadog-checks-base` to `>=37.34.1`

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.33.0",
+    "datadog-checks-base>=37.34.1",
 ]
 dynamic = [
     "version",

--- a/sqlserver/changelog.d/23282.fixed
+++ b/sqlserver/changelog.d/23282.fixed
@@ -1,1 +1,4 @@
-Bump `datadog-checks-base` to `>=37.34.1`
+Bump `datadog-checks-base` to `>=37.34.1`. Notable changes:
+  - Fix schema collection silently dropping all collected metadata when the last discovered database has no tables. ([#22880](https://github.com/DataDog/integrations-core/pull/22880))
+  - Reduce allocations in `StatementMetrics` by deferring dict construction and updating the previous-statements cache in place. ([#23075](https://github.com/DataDog/integrations-core/pull/23075))
+  - Improve compile-time error messages for invalid syntax in DB query extras expressions. ([#23140](https://github.com/DataDog/integrations-core/pull/23140))

--- a/sqlserver/changelog.d/23282.fixed
+++ b/sqlserver/changelog.d/23282.fixed
@@ -1,0 +1,1 @@
+Bump `datadog-checks-base` to `>=37.34.1`

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.33.0",
+    "datadog-checks-base>=37.34.1",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?
Updates `datadog-checks-base` to `>=37.34.1` in DBM integrations. This includes significant improvements to `StatementMetrics` tracking as well as schema collection fixes and improvements for a few of the integrations called out in changelogs

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
