### PR TITLE
[DBMON-6430] Add explain plan collection for ClickHouse DBM

### DIFF
--- a/clickhouse/assets/configuration/spec.yaml
+++ b/clickhouse/assets/configuration/spec.yaml
@@ -237,6 +237,7 @@ files:
           value:
             type: number
             default: 60
+            minimum: 1
         - name: explained_queries_cache_maxsize
           hidden: true
           description: |

--- a/clickhouse/assets/configuration/spec.yaml
+++ b/clickhouse/assets/configuration/spec.yaml
@@ -236,7 +236,7 @@ files:
             This rate limits EXPLAIN PLAN execution to avoid overhead on frequently executed queries.
           value:
             type: number
-            default: 1
+            default: 60
         - name: explained_queries_cache_maxsize
           hidden: true
           description: |

--- a/clickhouse/assets/configuration/spec.yaml
+++ b/clickhouse/assets/configuration/spec.yaml
@@ -229,6 +229,21 @@ files:
           value:
             type: number
             default: 1000
+        - name: explained_queries_per_hour_per_query
+          hidden: true
+          description: |
+            Set the maximum number of explain plans to collect per hour per unique query signature.
+            This rate limits EXPLAIN PLAN execution to avoid overhead on frequently executed queries.
+          value:
+            type: number
+            default: 1
+        - name: explained_queries_cache_maxsize
+          hidden: true
+          description: |
+            Set the max size of the cache used for rate limiting explain plan collection.
+          value:
+            type: number
+            default: 5000
         - name: run_sync
           hidden: true
           description: |

--- a/clickhouse/changelog.d/23286.fixed
+++ b/clickhouse/changelog.d/23286.fixed
@@ -1,1 +1,1 @@
-Fix plan deduplication key to scope per database so the same query in different databases each emit their own plan event.
+Add support for ClickHouse explain plans.

--- a/clickhouse/changelog.d/23286.fixed
+++ b/clickhouse/changelog.d/23286.fixed
@@ -1,0 +1,1 @@
+Fix plan deduplication key to scope per database so the same query in different databases each emit their own plan event.

--- a/clickhouse/datadog_checks/clickhouse/config.py
+++ b/clickhouse/datadog_checks/clickhouse/config.py
@@ -261,6 +261,11 @@ def _apply_features(config: InstanceConfig, validation_result: ValidationResult)
         None if config.dbm else "Requires `dbm: true`",
     )
     validation_result.add_feature(
+        FeatureKey.EXPLAIN_PLANS,
+        config.query_completions.enabled and config.dbm,
+        None if config.dbm else "Requires `dbm: true`",
+    )
+    validation_result.add_feature(
         FeatureKey.QUERY_ERRORS,
         config.query_errors.enabled and config.dbm,
         None if config.dbm else "Requires `dbm: true`",

--- a/clickhouse/datadog_checks/clickhouse/config_models/dict_defaults.py
+++ b/clickhouse/datadog_checks/clickhouse/config_models/dict_defaults.py
@@ -40,7 +40,7 @@ def instance_query_completions():
         samples_per_hour_per_query=15,
         seen_samples_cache_maxsize=10000,
         max_samples_per_collection=1000,
-        explained_queries_per_hour_per_query=1,
+        explained_queries_per_hour_per_query=60,
         explained_queries_cache_maxsize=5000,
         run_sync=False,
     )

--- a/clickhouse/datadog_checks/clickhouse/config_models/dict_defaults.py
+++ b/clickhouse/datadog_checks/clickhouse/config_models/dict_defaults.py
@@ -40,6 +40,8 @@ def instance_query_completions():
         samples_per_hour_per_query=15,
         seen_samples_cache_maxsize=10000,
         max_samples_per_collection=1000,
+        explained_queries_per_hour_per_query=1,
+        explained_queries_cache_maxsize=5000,
         run_sync=False,
     )
 

--- a/clickhouse/datadog_checks/clickhouse/config_models/instance.py
+++ b/clickhouse/datadog_checks/clickhouse/config_models/instance.py
@@ -12,13 +12,12 @@ from __future__ import annotations
 from types import MappingProxyType
 from typing import Any, Optional
 
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
 
 from . import defaults, validators
-
 
 SECURE_FIELD_NAMES = frozenset(['tls_ca_cert'])
 
@@ -60,7 +59,7 @@ class QueryCompletions(BaseModel):
     collection_interval: Optional[float] = None
     enabled: Optional[bool] = None
     explained_queries_cache_maxsize: Optional[float] = None
-    explained_queries_per_hour_per_query: Optional[float] = None
+    explained_queries_per_hour_per_query: Optional[float] = Field(None, ge=1.0)
     max_samples_per_collection: Optional[float] = None
     run_sync: Optional[bool] = None
     samples_per_hour_per_query: Optional[float] = None

--- a/clickhouse/datadog_checks/clickhouse/config_models/instance.py
+++ b/clickhouse/datadog_checks/clickhouse/config_models/instance.py
@@ -19,6 +19,7 @@ from datadog_checks.base.utils.models import validation
 
 from . import defaults, validators
 
+
 SECURE_FIELD_NAMES = frozenset(['tls_ca_cert'])
 
 

--- a/clickhouse/datadog_checks/clickhouse/config_models/instance.py
+++ b/clickhouse/datadog_checks/clickhouse/config_models/instance.py
@@ -19,7 +19,6 @@ from datadog_checks.base.utils.models import validation
 
 from . import defaults, validators
 
-
 SECURE_FIELD_NAMES = frozenset(['tls_ca_cert'])
 
 
@@ -59,6 +58,8 @@ class QueryCompletions(BaseModel):
     )
     collection_interval: Optional[float] = None
     enabled: Optional[bool] = None
+    explained_queries_cache_maxsize: Optional[float] = None
+    explained_queries_per_hour_per_query: Optional[float] = None
     max_samples_per_collection: Optional[float] = None
     run_sync: Optional[bool] = None
     samples_per_hour_per_query: Optional[float] = None

--- a/clickhouse/datadog_checks/clickhouse/explain_plans.py
+++ b/clickhouse/datadog_checks/clickhouse/explain_plans.py
@@ -30,6 +30,42 @@ _CLICKHOUSE_PLAN_STATS_KEYS = frozenset(
     }
 )
 
+# Keys whose string values always contain SQL expressions and may embed literal values.
+_CLICKHOUSE_PLAN_EXPRESSION_KEYS = frozenset(
+    {
+        'Filter Column',  # e.g. "notLike(query, '%secret%'_String)"
+        'Condition',  # e.g. "equals(user_id, 12345)" in Index nodes
+        'Clauses',  # e.g. "[(__table1.sku) = (__table2.sku)]" in Join nodes
+    }
+)
+
+# Action node types whose Result Name embeds the full expression with literals.
+_CLICKHOUSE_EXPRESSION_ACTION_TYPES = frozenset({'COLUMN', 'FUNCTION'})
+
+
+def _obfuscate_clickhouse_plan(node: object) -> object:
+    """Recursively redact expression fields that may contain literal values."""
+    if isinstance(node, list):
+        return [_obfuscate_clickhouse_plan(item) for item in node]
+    if isinstance(node, dict):
+        node_type = node.get('Node Type', '')
+        result = {}
+        for k, v in node.items():
+            if k in _CLICKHOUSE_PLAN_EXPRESSION_KEYS:
+                result[k] = '?'
+            elif k == 'Result Name' and node_type in _CLICKHOUSE_EXPRESSION_ACTION_TYPES:
+                result[k] = '?'
+            elif k == 'Name' and isinstance(v, str) and ("'" in v or '(' in v):
+                # Input/Output Name derived from an expression, e.g.
+                # "notLike(query, '%secret%'_String)" or "equals(user_id, 12345)".
+                # ClickHouse uses the expression itself as the column name when
+                # no alias is given, embedding both string and numeric literals.
+                result[k] = '?'
+            else:
+                result[k] = _obfuscate_clickhouse_plan(v)
+        return result
+    return node
+
 
 def _normalize_clickhouse_plan(node: object) -> object:
     """Recursively strip cost/stats fields from a ClickHouse plan node."""
@@ -140,7 +176,7 @@ class ClickhouseExplainPlans:
 
         if plan_dict is not None:
             try:
-                obfuscated_plan = json.dumps(plan_dict)
+                obfuscated_plan = json.dumps(_obfuscate_clickhouse_plan(plan_dict))
                 if isinstance(obfuscated_plan, bytes):
                     obfuscated_plan = obfuscated_plan.decode('utf-8')
                 normalized_plan = json.dumps(_normalize_clickhouse_plan(plan_dict))

--- a/clickhouse/datadog_checks/clickhouse/explain_plans.py
+++ b/clickhouse/datadog_checks/clickhouse/explain_plans.py
@@ -1,0 +1,177 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+import json as stdlib_json
+from enum import Enum
+from typing import TYPE_CHECKING, Callable, Iterator
+
+if TYPE_CHECKING:
+    from datadog_checks.clickhouse import ClickhouseCheck
+
+try:
+    import datadog_agent
+except ImportError:
+    from datadog_checks.base.stubs import datadog_agent
+
+from datadog_checks.base.utils.db.sql import compute_exec_plan_signature
+from datadog_checks.base.utils.db.utils import RateLimitingTTLCache
+from datadog_checks.base.utils.serialization import json
+
+SUPPORTED_EXPLAIN_STATEMENTS = frozenset({'select', 'insert', 'with'})
+
+_SECONDS_PER_HOUR = 60 * 60
+
+
+class DBExplainError(Enum):
+    connection_error = 'connection_error'
+    no_plans_possible = 'no_plans_possible'
+    query_truncated = 'query_truncated'
+    unknown_error = 'unknown_error'
+    invalid_result = 'invalid_result'
+    database_error = 'database_error'
+
+
+class ClickhouseExplainPlans:
+    """Collects execution plans for completed ClickHouse queries."""
+
+    def __init__(self, check: ClickhouseCheck, config, execute_query_fn: Callable) -> None:
+        self._check = check
+        self._config = config
+        self._log = check.log
+        self._execute_query_fn = execute_query_fn
+
+        plan_ttl = _SECONDS_PER_HOUR / float(config.explained_queries_per_hour_per_query)
+
+        # Gates EXPLAIN execution per query_signature
+        self._explained_statements_ratelimiter = RateLimitingTTLCache(
+            maxsize=int(config.explained_queries_cache_maxsize),
+            ttl=plan_ttl,
+        )
+        # Deduplicates per (query_signature, plan_signature) to avoid re-emitting unchanged plans
+        self._seen_samples_ratelimiter = RateLimitingTTLCache(
+            maxsize=int(config.seen_samples_cache_maxsize),
+            ttl=plan_ttl,
+        )
+
+    def _can_explain_statement(self, statement: str) -> bool:
+        """Return True if this statement type supports EXPLAIN PLAN."""
+        if not statement:
+            return False
+        first_token = statement.strip().split()[0].lower()
+        return first_token in SUPPORTED_EXPLAIN_STATEMENTS
+
+    def _run_explain(self, statement: str) -> dict:
+        """Execute EXPLAIN PLAN json = 1 and return the parsed plan as a dict."""
+        explain_query = "EXPLAIN PLAN json = 1 " + statement
+        rows = self._execute_query_fn(explain_query)
+        if not rows:
+            raise ValueError("EXPLAIN PLAN returned no rows")
+        # ClickHouse returns the JSON plan across one or more text rows; join and parse
+        plan_text = '\n'.join(str(row[0]) for row in rows if row)
+        return stdlib_json.loads(plan_text)
+
+    def _run_explain_safe(self, row: dict) -> tuple[dict | None, DBExplainError | None, str | None]:
+        """
+        Run EXPLAIN for a row, returning (plan_dict, error_code, error_msg).
+
+        Uses the obfuscated statement to check supportability and the raw query for execution.
+        """
+        obfuscated_statement = row.get('statement', '')
+        if not self._can_explain_statement(obfuscated_statement):
+            return None, DBExplainError.no_plans_possible, None
+
+        raw_query = row.get('query', '')
+        try:
+            plan_dict = self._run_explain(raw_query)
+            return plan_dict, None, None
+        except Exception as e:
+            self._log.debug(
+                "Failed to collect explain plan for query_signature=%s: %s",
+                row.get('query_signature', ''),
+                e,
+            )
+            return None, DBExplainError.database_error, str(type(e))
+
+    def _collect_plan_for_statement(self, row: dict, tags_no_db: list[str]) -> dict | None:
+        """
+        Build a plan event dict for a row.
+
+        Returns None if the plan should not be emitted (unsupported, rate limited, or obfuscation failed).
+        """
+        plan_dict, error_code, error_msg = self._run_explain_safe(row)
+
+        if error_code == DBExplainError.no_plans_possible:
+            return None
+
+        collection_errors: list[dict] = []
+        obfuscated_plan: str | None = None
+        plan_signature: str | None = None
+
+        if plan_dict is not None:
+            raw_plan = json.dumps(plan_dict)
+            if isinstance(raw_plan, bytes):
+                raw_plan = raw_plan.decode('utf-8')
+            try:
+                obfuscated_plan = datadog_agent.obfuscate_sql_exec_plan(raw_plan)
+                normalized_plan = datadog_agent.obfuscate_sql_exec_plan(raw_plan, normalize=True)
+                plan_signature = compute_exec_plan_signature(normalized_plan)
+            except Exception as e:
+                self._log.debug("Failed to obfuscate explain plan: %s", e)
+                collection_errors.append({'code': DBExplainError.invalid_result.value, 'message': str(e)})
+        elif error_code is not None:
+            collection_errors.append({'code': error_code.value, 'message': error_msg or ''})
+
+        if plan_signature:
+            statement_plan_sig = (row.get('query_signature', ''), plan_signature)
+            if not self._seen_samples_ratelimiter.acquire(statement_plan_sig):
+                return None
+
+        return {
+            'host': self._check.reported_hostname,
+            'database_instance': self._check.database_identifier,
+            'ddsource': 'clickhouse',
+            'ddagentversion': datadog_agent.get_version(),
+            'dbm_type': 'plan',
+            'timestamp': row.get('event_time_microseconds', 0) / 1000,
+            'ddtags': ','.join(tags_no_db),
+            'db': {
+                'instance': row.get('databases', ''),
+                'query_signature': row.get('query_signature', ''),
+                'statement': row.get('statement', ''),
+                'plan': {
+                    'definition': obfuscated_plan,
+                    'signature': plan_signature,
+                    'collection_errors': collection_errors if collection_errors else None,
+                },
+                'metadata': {
+                    'tables': row.get('dd_tables'),
+                    'commands': row.get('dd_commands'),
+                },
+            },
+            'clickhouse': {
+                'user': row.get('user', ''),
+                'query_kind': row.get('query_kind', ''),
+                'query_duration_ms': row.get('query_duration_ms', 0),
+            },
+        }
+
+    def _collect_plans(self, rows: list[dict], tags_no_db: list[str]) -> Iterator[dict]:
+        """
+        Yield plan events for rows that pass rate limiting.
+
+        Uses two caches:
+        - _explained_statements_ratelimiter: limits EXPLAIN execution per query_signature
+        - _seen_samples_ratelimiter: deduplicates per (query_signature, plan_signature)
+        """
+        for row in rows:
+            query_signature = row.get('query_signature', '')
+            if not query_signature:
+                continue
+            if not self._explained_statements_ratelimiter.acquire(query_signature):
+                continue
+
+            plan_event = self._collect_plan_for_statement(row, tags_no_db)
+            if plan_event is not None:
+                yield plan_event

--- a/clickhouse/datadog_checks/clickhouse/explain_plans.py
+++ b/clickhouse/datadog_checks/clickhouse/explain_plans.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import annotations
 
-import json as stdlib_json
 import re
 from enum import Enum
 from typing import TYPE_CHECKING, Callable, Iterator
@@ -99,7 +98,7 @@ class ClickhouseExplainPlans:
         self._log = check.log
         self._execute_query_fn = execute_query_fn
 
-        plan_ttl = _SECONDS_PER_HOUR / float(config.explained_queries_per_hour_per_query)
+        plan_ttl = _SECONDS_PER_HOUR / max(1.0, float(config.explained_queries_per_hour_per_query))
 
         self._explained_statements_ratelimiter = RateLimitingTTLCache(
             maxsize=int(config.explained_queries_cache_maxsize),
@@ -130,7 +129,7 @@ class ClickhouseExplainPlans:
         if not rows:
             raise ValueError("EXPLAIN PLAN returned no rows")
         plan_text = '\n'.join(str(row[0]) for row in rows if row)
-        result = stdlib_json.loads(plan_text)
+        result = json.loads(plan_text)
         if isinstance(result, list):
             if not result:
                 raise ValueError("EXPLAIN PLAN returned empty JSON array")

--- a/clickhouse/datadog_checks/clickhouse/explain_plans.py
+++ b/clickhouse/datadog_checks/clickhouse/explain_plans.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json as stdlib_json
+import re
 from enum import Enum
 from typing import TYPE_CHECKING, Callable, Iterator
 
@@ -19,7 +20,27 @@ from datadog_checks.base.utils.db.sql import compute_exec_plan_signature
 from datadog_checks.base.utils.db.utils import RateLimitingTTLCache
 from datadog_checks.base.utils.serialization import json
 
-SUPPORTED_EXPLAIN_STATEMENTS = frozenset({'select', 'insert', 'with'})
+SUPPORTED_EXPLAIN_STATEMENTS = frozenset({'select', 'with'})
+
+_CLICKHOUSE_PLAN_STATS_KEYS = frozenset(
+    {
+        'Estimated Rows',
+        'Estimated Cost',
+        'Estimated Total Rows',
+    }
+)
+
+
+def _normalize_clickhouse_plan(node: object) -> object:
+    """Recursively strip cost/stats fields from a ClickHouse plan node."""
+    if isinstance(node, dict):
+        return {k: _normalize_clickhouse_plan(v) for k, v in node.items() if k not in _CLICKHOUSE_PLAN_STATS_KEYS}
+    if isinstance(node, list):
+        return [_normalize_clickhouse_plan(item) for item in node]
+    return node
+
+
+_FORMAT_SUFFIX_RE = re.compile(r'\s+FORMAT\s+\w+\s*$', re.IGNORECASE)
 
 _SECONDS_PER_HOUR = 60 * 60
 
@@ -44,12 +65,10 @@ class ClickhouseExplainPlans:
 
         plan_ttl = _SECONDS_PER_HOUR / float(config.explained_queries_per_hour_per_query)
 
-        # Gates EXPLAIN execution per query_signature
         self._explained_statements_ratelimiter = RateLimitingTTLCache(
             maxsize=int(config.explained_queries_cache_maxsize),
             ttl=plan_ttl,
         )
-        # Deduplicates per (query_signature, plan_signature) to avoid re-emitting unchanged plans
         self._seen_samples_ratelimiter = RateLimitingTTLCache(
             maxsize=int(config.seen_samples_cache_maxsize),
             ttl=plan_ttl,
@@ -62,15 +81,25 @@ class ClickhouseExplainPlans:
         first_token = statement.strip().split()[0].lower()
         return first_token in SUPPORTED_EXPLAIN_STATEMENTS
 
+    @staticmethod
+    def _strip_format_clause(query: str) -> str:
+        """Strip trailing FORMAT clause that clickhouse_connect appends to queries."""
+        return _FORMAT_SUFFIX_RE.sub('', query)
+
     def _run_explain(self, statement: str) -> dict:
         """Execute EXPLAIN PLAN json = 1 and return the parsed plan as a dict."""
-        explain_query = "EXPLAIN PLAN json = 1 " + statement
+        statement = self._strip_format_clause(statement)
+        explain_query = "EXPLAIN PLAN json = 1, indexes = 1, actions = 1 " + statement
         rows = self._execute_query_fn(explain_query)
         if not rows:
             raise ValueError("EXPLAIN PLAN returned no rows")
-        # ClickHouse returns the JSON plan across one or more text rows; join and parse
         plan_text = '\n'.join(str(row[0]) for row in rows if row)
-        return stdlib_json.loads(plan_text)
+        result = stdlib_json.loads(plan_text)
+        if isinstance(result, list):
+            if not result:
+                raise ValueError("EXPLAIN PLAN returned empty JSON array")
+            return result[0]
+        return result
 
     def _run_explain_safe(self, row: dict) -> tuple[dict | None, DBExplainError | None, str | None]:
         """
@@ -110,21 +139,22 @@ class ClickhouseExplainPlans:
         plan_signature: str | None = None
 
         if plan_dict is not None:
-            raw_plan = json.dumps(plan_dict)
-            if isinstance(raw_plan, bytes):
-                raw_plan = raw_plan.decode('utf-8')
             try:
-                obfuscated_plan = datadog_agent.obfuscate_sql_exec_plan(raw_plan)
-                normalized_plan = datadog_agent.obfuscate_sql_exec_plan(raw_plan, normalize=True)
+                obfuscated_plan = json.dumps(plan_dict)
+                if isinstance(obfuscated_plan, bytes):
+                    obfuscated_plan = obfuscated_plan.decode('utf-8')
+                normalized_plan = json.dumps(_normalize_clickhouse_plan(plan_dict))
+                if isinstance(normalized_plan, bytes):
+                    normalized_plan = normalized_plan.decode('utf-8')
                 plan_signature = compute_exec_plan_signature(normalized_plan)
             except Exception as e:
-                self._log.debug("Failed to obfuscate explain plan: %s", e)
+                self._log.debug("Failed to serialize explain plan: %s", e)
                 collection_errors.append({'code': DBExplainError.invalid_result.value, 'message': str(e)})
         elif error_code is not None:
             collection_errors.append({'code': error_code.value, 'message': error_msg or ''})
 
         if plan_signature:
-            statement_plan_sig = (row.get('query_signature', ''), plan_signature)
+            statement_plan_sig = (row.get('databases', ''), row.get('query_signature', ''), plan_signature)
             if not self._seen_samples_ratelimiter.acquire(statement_plan_sig):
                 return None
 
@@ -162,14 +192,17 @@ class ClickhouseExplainPlans:
         Yield plan events for rows that pass rate limiting.
 
         Uses two caches:
-        - _explained_statements_ratelimiter: limits EXPLAIN execution per query_signature
-        - _seen_samples_ratelimiter: deduplicates per (query_signature, plan_signature)
+        - _explained_statements_ratelimiter: limits EXPLAIN execution per (databases, query_signature)
+        - _seen_samples_ratelimiter: deduplicates per (databases, query_signature, plan_signature)
         """
         for row in rows:
             query_signature = row.get('query_signature', '')
             if not query_signature:
                 continue
-            if not self._explained_statements_ratelimiter.acquire(query_signature):
+            if not self._can_explain_statement(row.get('statement', '')):
+                continue
+            rate_limit_key = (row.get('databases', ''), query_signature)
+            if not self._explained_statements_ratelimiter.acquire(rate_limit_key):
                 continue
 
             plan_event = self._collect_plan_for_statement(row, tags_no_db)

--- a/clickhouse/datadog_checks/clickhouse/explain_plans.py
+++ b/clickhouse/datadog_checks/clickhouse/explain_plans.py
@@ -234,6 +234,8 @@ class ClickhouseExplainPlans:
             query_signature = row.get('query_signature', '')
             if not query_signature:
                 continue
+            if row.get('query_kind', '').lower() != 'select':
+                continue
             if not self._can_explain_statement(row.get('statement', '')):
                 continue
             rate_limit_key = (row.get('databases', ''), query_signature)

--- a/clickhouse/datadog_checks/clickhouse/features.py
+++ b/clickhouse/datadog_checks/clickhouse/features.py
@@ -21,6 +21,7 @@ class FeatureKey(Enum):
     QUERY_METRICS = "query_metrics"
     QUERY_SAMPLES = "query_samples"
     QUERY_COMPLETIONS = "query_completions"
+    EXPLAIN_PLANS = "explain_plans"
     QUERY_ERRORS = "query_errors"
     SINGLE_ENDPOINT_MODE = "single_endpoint_mode"
 
@@ -31,6 +32,7 @@ FeatureNames = {
     FeatureKey.QUERY_SAMPLES: 'Query Samples',
     FeatureKey.QUERY_COMPLETIONS: 'Query Completions',
     FeatureKey.QUERY_ERRORS: 'Query Errors',
+    FeatureKey.EXPLAIN_PLANS: 'Explain Plans',
     FeatureKey.SINGLE_ENDPOINT_MODE: 'Single Endpoint Mode',
 }
 

--- a/clickhouse/datadog_checks/clickhouse/query_completions.py
+++ b/clickhouse/datadog_checks/clickhouse/query_completions.py
@@ -17,6 +17,7 @@ except ImportError:
 from datadog_checks.base.utils.db.utils import RateLimitingTTLCache, default_json_event_encoding
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
+from datadog_checks.clickhouse.explain_plans import ClickhouseExplainPlans
 from datadog_checks.clickhouse.query_log_job import ClickhouseQueryLogJob, agent_check_getter
 
 # Query to fetch individual completed queries from system.query_log.
@@ -85,6 +86,8 @@ class ClickhouseQueryCompletions(ClickhouseQueryLogJob):
         # Maximum number of samples to collect per run
         self._max_samples_per_collection = int(config.max_samples_per_collection)
 
+        self._explain_plans = ClickhouseExplainPlans(check, config, self._execute_query)
+
     @tracked_method(agent_check_getter=agent_check_getter)
     def _collect_and_submit(self):
         """
@@ -105,14 +108,22 @@ class ClickhouseQueryCompletions(ClickhouseQueryLogJob):
                 self._log.debug("No new completed queries")
                 return
 
-            # Step 2: Apply rate limiting and create payload
+            # Step 2: Collect and submit explain plans (independent of completion rate limiting)
+            try:
+                for plan_event in self._explain_plans._collect_plans(rows, self._tags_no_db or []):
+                    plan_data = json.dumps(plan_event, default=default_json_event_encoding)
+                    self._check.database_monitoring_query_sample(plan_data)
+            except Exception:
+                self._log.exception("Failed to collect explain plans")
+
+            # Step 3: Apply rate limiting and create payload
             payload = self._create_batched_payload(rows)
 
             if not payload or not payload.get('clickhouse_query_completions'):
                 self._log.debug("No query completions after rate limiting")
                 return
 
-            # Step 3: Submit payload
+            # Step 4: Submit payload
             payload_data = json.dumps(payload, default=default_json_event_encoding)
             num_completions = len(payload.get('clickhouse_query_completions', []))
             self._log.debug(

--- a/clickhouse/tests/test_config_defaults.py
+++ b/clickhouse/tests/test_config_defaults.py
@@ -56,7 +56,7 @@ EXPECTED_DEFAULTS = {
         'samples_per_hour_per_query': 15,
         'seen_samples_cache_maxsize': 10000,
         'max_samples_per_collection': 1000,
-        'explained_queries_per_hour_per_query': 1,
+        'explained_queries_per_hour_per_query': 60,
         'explained_queries_cache_maxsize': 5000,
         'run_sync': False,
     },

--- a/clickhouse/tests/test_config_defaults.py
+++ b/clickhouse/tests/test_config_defaults.py
@@ -56,6 +56,8 @@ EXPECTED_DEFAULTS = {
         'samples_per_hour_per_query': 15,
         'seen_samples_cache_maxsize': 10000,
         'max_samples_per_collection': 1000,
+        'explained_queries_per_hour_per_query': 1,
+        'explained_queries_cache_maxsize': 5000,
         'run_sync': False,
     },
     # === DBM: Query errors ===

--- a/clickhouse/tests/test_dbm_integration.py
+++ b/clickhouse/tests/test_dbm_integration.py
@@ -361,6 +361,158 @@ def test_query_completions_data(aggregator, instance, dd_run_check, datadog_agen
     assert details['event_time_microseconds'] > 0
 
 
+def test_explain_plan_collected(aggregator, instance, dd_run_check, datadog_agent):
+    """
+    Run a known SELECT query, then verify that:
+    1. A dbm-samples event with dbm_type='plan' is emitted
+    2. The plan event has required top-level fields: host, database_instance, ddsource, etc.
+    3. db.plan.definition is valid JSON with a ClickHouse Plan structure (Node Type, etc.)
+    4. db.plan.signature is set and db.plan.collection_errors is None
+    5. clickhouse.query_kind is 'Select'
+    """
+    instance_config = deepcopy(instance)
+    instance_config['dbm'] = True
+    instance_config['query_metrics'] = {'enabled': False}
+    instance_config['query_samples'] = {'enabled': False}
+    instance_config['query_completions'] = {
+        'enabled': True,
+        'run_sync': True,
+        'collection_interval': 10,
+    }
+
+    check = ClickhouseCheck('clickhouse', {}, [instance_config])
+    client = _get_clickhouse_client(instance_config)
+
+    query = "SELECT name, engine FROM system.databases ORDER BY name"
+    client.command(query)
+    client.command('SYSTEM FLUSH LOGS')
+
+    dd_run_check(check)
+    dd_run_check(check)
+
+    expected_obfuscated = obfuscate_sql_with_metadata(query, check.query_completions._obfuscate_options)['query']
+
+    sample_events = aggregator.get_event_platform_events("dbm-samples")
+    plan_events = [e for e in sample_events if e.get('dbm_type') == 'plan']
+    matching_plans = [e for e in plan_events if e['db']['statement'] == expected_obfuscated]
+    assert len(matching_plans) >= 1, (
+        f"Expected at least 1 plan event for query: {query!r}.\n"
+        f"Expected obfuscated: {expected_obfuscated!r}\n"
+        f"Found {len(matching_plans)} matching plan events.\n"
+        f"All plan events: {[e['db']['statement'] for e in plan_events]}"
+    )
+
+    plan_event = matching_plans[0]
+    assert plan_event['ddsource'] == 'clickhouse'
+    assert plan_event['host'] is not None
+    assert plan_event['database_instance'] is not None
+    assert plan_event['ddagentversion'] == datadog_agent.get_version()
+    assert plan_event['timestamp'] > 0
+
+    db = plan_event['db']
+    assert db['query_signature'] is not None
+    assert db['statement'] == expected_obfuscated
+
+    plan = db['plan']
+    assert plan['definition'] is not None
+    assert plan['signature'] is not None
+    assert plan['collection_errors'] is None
+
+    plan_dict = json.loads(plan['definition'])
+    assert 'Plan' in plan_dict, f"Expected 'Plan' key in plan definition, got: {list(plan_dict.keys())}"
+    assert 'Node Type' in plan_dict['Plan'], (
+        f"Expected 'Node Type' in top-level Plan node, got: {list(plan_dict['Plan'].keys())}"
+    )
+
+    ch = plan_event['clickhouse']
+    assert ch['user'] is not None
+    assert ch['query_kind'] == 'Select'
+    assert ch['query_duration_ms'] >= 0
+
+
+def test_explain_plan_deduplication(aggregator, instance, dd_run_check, datadog_agent):
+    """
+    Run the same SELECT query twice; only one plan event should be emitted.
+
+    The _explained_statements_ratelimiter prevents re-running EXPLAIN for the same
+    query_signature within the rate-limit TTL. Both rows appear in the same collection
+    batch but only the first acquires the rate limiter slot.
+    """
+    instance_config = deepcopy(instance)
+    instance_config['dbm'] = True
+    instance_config['query_metrics'] = {'enabled': False}
+    instance_config['query_samples'] = {'enabled': False}
+    instance_config['query_completions'] = {
+        'enabled': True,
+        'run_sync': True,
+        'collection_interval': 10,
+    }
+
+    check = ClickhouseCheck('clickhouse', {}, [instance_config])
+    client = _get_clickhouse_client(instance_config)
+
+    query = "SELECT name, engine FROM system.tables ORDER BY name"
+    client.command(query)
+    client.command(query)  # same query a second time — produces two rows in query_log
+    client.command('SYSTEM FLUSH LOGS')
+
+    dd_run_check(check)
+    dd_run_check(check)
+
+    expected_obfuscated = obfuscate_sql_with_metadata(query, check.query_completions._obfuscate_options)['query']
+
+    sample_events = aggregator.get_event_platform_events("dbm-samples")
+    plan_events = [e for e in sample_events if e.get('dbm_type') == 'plan']
+    matching_plans = [e for e in plan_events if e['db']['statement'] == expected_obfuscated]
+
+    assert len(matching_plans) == 1, (
+        f"Expected exactly 1 plan event for query: {query!r} despite two executions.\n"
+        f"Found {len(matching_plans)} plan events — rate limiting may not be working."
+    )
+
+
+def test_explain_plan_not_collected_for_insert(aggregator, instance, dd_run_check):
+    """
+    Verify no explain plan is collected for INSERT statements.
+
+    INSERT does not support EXPLAIN PLAN. The completions pipeline skips INSERT rows
+    in _collect_plans because _can_explain_statement returns False for non-SELECT/WITH
+    statements. Runs a SELECT alongside the INSERT to confirm the pipeline is active.
+    """
+    instance_config = deepcopy(instance)
+    instance_config['dbm'] = True
+    instance_config['query_metrics'] = {'enabled': False}
+    instance_config['query_samples'] = {'enabled': False}
+    instance_config['query_completions'] = {
+        'enabled': True,
+        'run_sync': True,
+        'collection_interval': 10,
+    }
+
+    check = ClickhouseCheck('clickhouse', {}, [instance_config])
+    client = _get_clickhouse_client(instance_config)
+
+    # Run a SELECT alongside the INSERT so we can confirm the pipeline collected queries
+    client.command("SELECT count() FROM system.tables")
+    client.command("INSERT INTO tableau VALUES (222)")
+    client.command('SYSTEM FLUSH LOGS')
+
+    dd_run_check(check)
+    dd_run_check(check)
+
+    sample_events = aggregator.get_event_platform_events("dbm-samples")
+    plan_events = [e for e in sample_events if e.get('dbm_type') == 'plan']
+
+    # At least one plan event from the SELECT confirms the pipeline ran
+    assert len(plan_events) > 0, "Expected at least one plan event from the SELECT query"
+
+    # INSERT should never generate a plan event
+    insert_plan_events = [e for e in plan_events if e.get('clickhouse', {}).get('query_kind') == 'Insert']
+    assert len(insert_plan_events) == 0, (
+        f"Expected no plan events for INSERT statements, but found {len(insert_plan_events)}"
+    )
+
+
 def test_query_samples_data(aggregator, instance, dd_run_check):
     """
     Start a long-running query in the background so it appears in system.processes,

--- a/clickhouse/tests/test_explain_plans.py
+++ b/clickhouse/tests/test_explain_plans.py
@@ -7,7 +7,12 @@ from unittest import mock
 import pytest
 
 from datadog_checks.clickhouse import ClickhouseCheck
-from datadog_checks.clickhouse.explain_plans import ClickhouseExplainPlans, DBExplainError, _normalize_clickhouse_plan
+from datadog_checks.clickhouse.explain_plans import (
+    ClickhouseExplainPlans,
+    DBExplainError,
+    _normalize_clickhouse_plan,
+    _obfuscate_clickhouse_plan,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -570,6 +575,129 @@ def test_plan_definition_preserves_descriptions(mock_agent, explain_plans):
     assert top_plan['Description'] == 'Project names + Projection'
     assert top_plan['Plans'][0]['Description'] == 'WHERE + Change column names to column identifiers'
     assert top_plan['Plans'][0]['Plans'][0]['Description'] == 'default.inventory_items'
+
+
+def test_obfuscate_clickhouse_plan_redacts_filter_column():
+    """Filter Column containing a predicate expression is redacted."""
+    plan = {
+        'Plan': {
+            'Node Type': 'Filter',
+            'Node Id': 'Filter_1',
+            'Description': 'WHERE',
+            'Filter Column': "notLike(query, '%secret%'_String)",
+            'Plans': [],
+        }
+    }
+    result = _obfuscate_clickhouse_plan(plan)
+    assert result['Plan']['Filter Column'] == '?'
+    assert result['Plan']['Description'] == 'WHERE'
+    assert result['Plan']['Node Type'] == 'Filter'
+
+
+def test_obfuscate_clickhouse_plan_redacts_index_condition():
+    """Condition in Index nodes containing a predicate expression is redacted."""
+    plan = {
+        'Plan': {
+            'Node Type': 'ReadFromMergeTree',
+            'Node Id': 'ReadFromMergeTree_0',
+            'Description': 'default.orders',
+            'Indexes': [
+                {
+                    'Type': 'PrimaryKey',
+                    'Condition': 'equals(user_id, 12345)',
+                    'Initial Parts': 4,
+                    'Selected Parts': 1,
+                }
+            ],
+        }
+    }
+    result = _obfuscate_clickhouse_plan(plan)
+    assert result['Plan']['Indexes'][0]['Condition'] == '?'
+    assert result['Plan']['Indexes'][0]['Type'] == 'PrimaryKey'
+    assert result['Plan']['Indexes'][0]['Initial Parts'] == 4
+
+
+def test_obfuscate_clickhouse_plan_redacts_join_clauses():
+    """Clauses in Join nodes is redacted."""
+    plan = {
+        'Plan': {
+            'Node Type': 'Join',
+            'Node Id': 'Join_1',
+            'Description': 'JOIN FillRightFirst',
+            'Clauses': '[(__table1.sku) = (__table2.sku)]',
+        }
+    }
+    result = _obfuscate_clickhouse_plan(plan)
+    assert result['Plan']['Clauses'] == '?'
+    assert result['Plan']['Description'] == 'JOIN FillRightFirst'
+
+
+def test_obfuscate_clickhouse_plan_redacts_column_and_function_result_names():
+    """Result Name in COLUMN and FUNCTION action nodes is redacted; INPUT/ALIAS are kept."""
+    plan = {
+        'Plan': {
+            'Node Type': 'Expression',
+            'Expression': {
+                'Actions': [
+                    {'Node Type': 'INPUT', 'Result Name': 'user_id', 'Result Type': 'UInt64'},
+                    {'Node Type': 'COLUMN', 'Result Name': "'%secret%'_String", 'Result Type': 'String'},
+                    {'Node Type': 'FUNCTION', 'Result Name': "notLike(query, '%secret%'_String)", 'Result Type': 'UInt8'},
+                    {'Node Type': 'ALIAS', 'Result Name': 'filtered_query', 'Result Type': 'UInt8'},
+                ]
+            },
+        }
+    }
+    result = _obfuscate_clickhouse_plan(plan)
+    actions = result['Plan']['Expression']['Actions']
+    assert actions[0]['Result Name'] == 'user_id'           # INPUT kept
+    assert actions[1]['Result Name'] == '?'                  # COLUMN redacted
+    assert actions[2]['Result Name'] == '?'                  # FUNCTION redacted
+    assert actions[3]['Result Name'] == 'filtered_query'     # ALIAS kept
+
+
+def test_obfuscate_clickhouse_plan_redacts_expression_names_in_outputs():
+    """Name in Inputs/Outputs is redacted when it contains a quote (string literal) or paren (expression)."""
+    plan = {
+        'Plan': {
+            'Node Type': 'Expression',
+            'Expression': {
+                'Inputs': [
+                    {'Name': 'user_id', 'Type': 'UInt64'},
+                    {'Name': "notLike(query, '%secret%'_String)", 'Type': 'UInt8'},
+                    {'Name': 'equals(user_id, 12345)', 'Type': 'UInt8'},
+                ],
+                'Outputs': [
+                    {'Name': 'user_id', 'Type': 'UInt64'},
+                    {'Name': "notLike(query, '%secret%'_String)", 'Type': 'UInt8'},
+                ],
+            },
+        }
+    }
+    result = _obfuscate_clickhouse_plan(plan)
+    inputs = result['Plan']['Expression']['Inputs']
+    assert inputs[0]['Name'] == 'user_id'    # plain column name, kept
+    assert inputs[1]['Name'] == '?'           # string literal in expression, redacted
+    assert inputs[2]['Name'] == '?'           # numeric literal in expression (has paren), redacted
+
+    outputs = result['Plan']['Expression']['Outputs']
+    assert outputs[0]['Name'] == 'user_id'
+    assert outputs[1]['Name'] == '?'
+
+
+def test_obfuscate_clickhouse_plan_preserves_structural_fields():
+    """Structural fields (Node Type, Node Id, Description, numeric values) are untouched."""
+    result = _obfuscate_clickhouse_plan(SAMPLE_PLAN_WITH_INDEXES)
+    plan = result['Plan']
+    assert plan['Node Type'] == 'Expression'
+    assert plan['Node Id'] == 'Expression_1'
+    assert plan['Description'] == 'Project names + Projection'
+    read_node = plan['Plans'][0]
+    assert read_node['Description'] == 'default.orders'
+    # Condition is redacted, but other index fields are kept
+    assert read_node['Indexes'][0]['Type'] == 'PrimaryKey'
+    assert read_node['Indexes'][0]['Condition'] == '?'
+    assert read_node['Indexes'][0]['Parts'] == 3
+    assert read_node['Indexes'][0]['Granules'] == 12
 
 
 def test_default_config_values(instance_with_dbm):

--- a/clickhouse/tests/test_explain_plans.py
+++ b/clickhouse/tests/test_explain_plans.py
@@ -320,6 +320,33 @@ def test_collect_plans_rate_limiting(mock_agent, explain_plans):
 
 
 @mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
+def test_collect_plans_skips_cte_insert(mock_agent, explain_plans):
+    """WITH ... INSERT queries pass _can_explain_statement but are skipped via query_kind."""
+    mock_agent.get_version.return_value = '7.64.0'
+    explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN),)])
+
+    rows = [
+        {
+            'query': 'WITH foo AS (SELECT 1) INSERT INTO t SELECT * FROM foo',
+            'statement': 'WITH foo AS (SELECT ?) INSERT INTO t SELECT * FROM foo',
+            'query_signature': 'cte_insert_sig',
+            'databases': 'default',
+            'user': 'default',
+            'query_kind': 'Insert',
+            'query_duration_ms': 10.0,
+            'event_time_microseconds': 1746205423150500,
+            'dd_tables': [],
+            'dd_commands': ['INSERT'],
+        }
+    ]
+
+    plans = list(explain_plans._collect_plans(rows, ['test:tag']))
+
+    assert len(plans) == 0
+    explain_plans._execute_query_fn.assert_not_called()
+
+
+@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
 def test_collect_plans_skips_missing_signature(mock_agent, explain_plans):
     """Rows without a query_signature are skipped."""
     mock_agent.get_version.return_value = '7.64.0'

--- a/clickhouse/tests/test_explain_plans.py
+++ b/clickhouse/tests/test_explain_plans.py
@@ -1,0 +1,292 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+from unittest import mock
+
+import pytest
+
+from datadog_checks.clickhouse import ClickhouseCheck
+from datadog_checks.clickhouse.explain_plans import ClickhouseExplainPlans, DBExplainError
+
+pytestmark = pytest.mark.unit
+
+SAMPLE_PLAN = {
+    "Plan": {
+        "Node Type": "Expression",
+        "Description": "",
+        "Plans": [{"Node Type": "ReadFromStorage", "Description": "SystemTables"}],
+    }
+}
+
+
+@pytest.fixture
+def instance_with_dbm():
+    return {
+        'server': 'localhost',
+        'port': 9000,
+        'username': 'default',
+        'password': '',
+        'db': 'default',
+        'dbm': True,
+        'query_completions': {
+            'enabled': True,
+            'collection_interval': 10,
+            'samples_per_hour_per_query': 15,
+            'seen_samples_cache_maxsize': 10000,
+            'max_samples_per_collection': 1000,
+            'explained_queries_per_hour_per_query': 1,
+            'explained_queries_cache_maxsize': 5000,
+            'run_sync': False,
+        },
+        'tags': ['test:clickhouse'],
+    }
+
+
+@pytest.fixture
+def check_with_dbm(instance_with_dbm):
+    return ClickhouseCheck('clickhouse', {}, [instance_with_dbm])
+
+
+@pytest.fixture
+def explain_plans(check_with_dbm):
+    """Return the ClickhouseExplainPlans instance from the check's query completions."""
+    return check_with_dbm.query_completions._explain_plans
+
+
+def test_explain_plans_initialized(check_with_dbm):
+    """ClickhouseExplainPlans is initialized when query_completions is enabled."""
+    assert check_with_dbm.query_completions is not None
+    assert check_with_dbm.query_completions._explain_plans is not None
+    assert isinstance(check_with_dbm.query_completions._explain_plans, ClickhouseExplainPlans)
+
+
+@pytest.mark.parametrize(
+    "statement,expected",
+    [
+        ("SELECT * FROM users", True),
+        ("select count() FROM system.tables", True),
+        ("INSERT INTO events VALUES (?)", True),
+        ("WITH cte AS (SELECT 1) SELECT * FROM cte", True),
+        ("UPDATE users SET name = ?", False),
+        ("DELETE FROM users WHERE id = 1", False),
+        ("CREATE TABLE foo (id Int64)", False),
+        ("DROP TABLE foo", False),
+        ("", False),
+    ],
+)
+def test_can_explain_statement(explain_plans, statement, expected):
+    assert explain_plans._can_explain_statement(statement) is expected
+
+
+def test_run_explain_safe_no_plans_possible(explain_plans):
+    """Unsupported statement types return no_plans_possible without running EXPLAIN."""
+    row = {
+        'query': 'UPDATE users SET name = ?',
+        'statement': 'UPDATE users SET name = ?',
+        'query_signature': 'abc123',
+    }
+    plan_dict, error_code, error_msg = explain_plans._run_explain_safe(row)
+    assert plan_dict is None
+    assert error_code == DBExplainError.no_plans_possible
+    assert error_msg is None
+
+
+def test_run_explain_safe_database_error(explain_plans):
+    """Database errors from EXPLAIN are caught and returned as database_error."""
+    explain_plans._execute_query_fn = mock.MagicMock(side_effect=Exception("ClickHouse error"))
+
+    row = {
+        'query': 'SELECT * FROM users',
+        'statement': 'SELECT * FROM users',
+        'query_signature': 'abc123',
+    }
+    plan_dict, error_code, error_msg = explain_plans._run_explain_safe(row)
+    assert plan_dict is None
+    assert error_code == DBExplainError.database_error
+    assert error_msg is not None
+
+
+def test_run_explain_safe_success(explain_plans):
+    """A successful EXPLAIN call returns the parsed plan dict."""
+    explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN),)])
+
+    row = {
+        'query': 'SELECT * FROM system.tables',
+        'statement': 'SELECT * FROM system.tables',
+        'query_signature': 'abc123',
+    }
+    plan_dict, error_code, error_msg = explain_plans._run_explain_safe(row)
+    assert plan_dict == SAMPLE_PLAN
+    assert error_code is None
+    assert error_msg is None
+
+
+def test_collect_plan_for_statement_no_plans_possible(explain_plans):
+    """Statements that cannot be explained return None."""
+    row = {
+        'query': 'UPDATE users SET x = 1',
+        'statement': 'UPDATE users SET x = ?',
+        'query_signature': 'abc123',
+    }
+    result = explain_plans._collect_plan_for_statement(row, ['test:tag'])
+    assert result is None
+
+
+@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
+def test_plan_event_structure(mock_agent, explain_plans):
+    """A successful plan event has the required fields and correct dbm_type."""
+    mock_agent.get_version.return_value = '7.64.0'
+    mock_agent.obfuscate_sql_exec_plan.return_value = json.dumps(SAMPLE_PLAN)
+
+    explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN),)])
+
+    row = {
+        'query': 'SELECT * FROM system.tables',
+        'statement': 'SELECT * FROM system.tables',
+        'query_signature': 'sig001',
+        'databases': 'default',
+        'user': 'default_user',
+        'query_kind': 'Select',
+        'query_duration_ms': 100.0,
+        'event_time_microseconds': 1746205423150500,
+        'dd_tables': ['tables'],
+        'dd_commands': ['SELECT'],
+    }
+    event = explain_plans._collect_plan_for_statement(row, ['test:tag'])
+
+    assert event is not None
+    assert event['dbm_type'] == 'plan'
+    assert event['ddsource'] == 'clickhouse'
+    assert event['ddagentversion'] == '7.64.0'
+    assert event['host'] is not None
+    assert event['database_instance'] is not None
+    assert event['timestamp'] == 1746205423150500 / 1000
+    assert event['ddtags'] == 'test:tag'
+
+    db = event['db']
+    assert db['query_signature'] == 'sig001'
+    assert db['statement'] == 'SELECT * FROM system.tables'
+    assert db['plan']['definition'] is not None
+    assert db['plan']['signature'] is not None
+    assert db['metadata']['tables'] == ['tables']
+    assert db['metadata']['commands'] == ['SELECT']
+
+    ch = event['clickhouse']
+    assert ch['user'] == 'default_user'
+    assert ch['query_kind'] == 'Select'
+    assert ch['query_duration_ms'] == 100.0
+
+
+@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
+def test_collect_plans_rate_limiting(mock_agent, explain_plans):
+    """The same query_signature is only explained once within the rate-limit TTL."""
+    mock_agent.get_version.return_value = '7.64.0'
+    mock_agent.obfuscate_sql_exec_plan.return_value = json.dumps(SAMPLE_PLAN)
+
+    explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN),)])
+
+    rows = [
+        {
+            'query': 'SELECT * FROM system.tables',
+            'statement': 'SELECT * FROM system.tables',
+            'query_signature': 'same_sig',
+            'databases': 'default',
+            'user': 'default',
+            'query_kind': 'Select',
+            'query_duration_ms': 50.0,
+            'event_time_microseconds': 1746205423150500,
+            'dd_tables': [],
+            'dd_commands': ['SELECT'],
+        },
+        {
+            'query': 'SELECT * FROM system.tables',
+            'statement': 'SELECT * FROM system.tables',
+            'query_signature': 'same_sig',
+            'databases': 'default',
+            'user': 'default',
+            'query_kind': 'Select',
+            'query_duration_ms': 60.0,
+            'event_time_microseconds': 1746205423200000,
+            'dd_tables': [],
+            'dd_commands': ['SELECT'],
+        },
+    ]
+
+    plans = list(explain_plans._collect_plans(rows, ['test:tag']))
+
+    # Only one plan emitted despite two rows with the same query_signature
+    assert len(plans) == 1
+    # EXPLAIN was also only called once
+    assert explain_plans._execute_query_fn.call_count == 1
+
+
+@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
+def test_collect_plans_skips_missing_signature(mock_agent, explain_plans):
+    """Rows without a query_signature are skipped."""
+    mock_agent.get_version.return_value = '7.64.0'
+
+    rows = [
+        {
+            'query': 'SELECT 1',
+            'statement': 'SELECT ?',
+            'query_signature': '',  # missing
+            'databases': 'default',
+        }
+    ]
+
+    plans = list(explain_plans._collect_plans(rows, ['test:tag']))
+    assert len(plans) == 0
+
+
+@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
+def test_collect_plans_error_event(mock_agent, explain_plans):
+    """When EXPLAIN fails, the error is recorded in collection_errors."""
+    mock_agent.get_version.return_value = '7.64.0'
+    explain_plans._execute_query_fn = mock.MagicMock(side_effect=Exception("DB error"))
+
+    rows = [
+        {
+            'query': 'SELECT * FROM users',
+            'statement': 'SELECT * FROM users',
+            'query_signature': 'errorsig',
+            'databases': 'default',
+            'user': 'default',
+            'query_kind': 'Select',
+            'query_duration_ms': 10.0,
+            'event_time_microseconds': 1746205423150500,
+            'dd_tables': [],
+            'dd_commands': ['SELECT'],
+        }
+    ]
+
+    plans = list(explain_plans._collect_plans(rows, ['test:tag']))
+
+    assert len(plans) == 1
+    plan_event = plans[0]
+    assert plan_event['dbm_type'] == 'plan'
+    assert plan_event['db']['plan']['definition'] is None
+    assert plan_event['db']['plan']['signature'] is None
+    errors = plan_event['db']['plan']['collection_errors']
+    assert errors is not None
+    assert len(errors) == 1
+    assert errors[0]['code'] == DBExplainError.database_error.value
+
+
+def test_default_config_values(instance_with_dbm):
+    """Default config values for explain plans are applied correctly."""
+    instance = {
+        'server': 'localhost',
+        'port': 9000,
+        'username': 'default',
+        'password': '',
+        'db': 'default',
+        'dbm': True,
+        'query_completions': {'enabled': True},
+        'tags': ['test:clickhouse'],
+    }
+    check = ClickhouseCheck('clickhouse', {}, [instance])
+    cfg = check._config.query_completions
+
+    assert cfg.explained_queries_per_hour_per_query == 1
+    assert cfg.explained_queries_cache_maxsize == 5000

--- a/clickhouse/tests/test_explain_plans.py
+++ b/clickhouse/tests/test_explain_plans.py
@@ -7,15 +7,95 @@ from unittest import mock
 import pytest
 
 from datadog_checks.clickhouse import ClickhouseCheck
-from datadog_checks.clickhouse.explain_plans import ClickhouseExplainPlans, DBExplainError
+from datadog_checks.clickhouse.explain_plans import ClickhouseExplainPlans, DBExplainError, _normalize_clickhouse_plan
 
 pytestmark = pytest.mark.unit
 
 SAMPLE_PLAN = {
     "Plan": {
         "Node Type": "Expression",
-        "Description": "",
-        "Plans": [{"Node Type": "ReadFromStorage", "Description": "SystemTables"}],
+        "Node Id": "Expression_1",
+        "Description": "Project names + Projection",
+        "Plans": [
+            {
+                "Node Type": "Expression",
+                "Node Id": "Expression_0",
+                "Description": "WHERE + Change column names to column identifiers",
+                "Plans": [
+                    {
+                        "Node Type": "ReadFromMergeTree",
+                        "Node Id": "ReadFromMergeTree_0",
+                        "Description": "default.inventory_items",
+                    }
+                ],
+            }
+        ],
+    }
+}
+
+SAMPLE_PLAN_WITH_INDEXES = {
+    "Plan": {
+        "Node Type": "Expression",
+        "Node Id": "Expression_1",
+        "Description": "Project names + Projection",
+        "Plans": [
+            {
+                "Node Type": "ReadFromMergeTree",
+                "Node Id": "ReadFromMergeTree_0",
+                "Description": "default.orders",
+                "Indexes": [
+                    {
+                        "Type": "PrimaryKey",
+                        "Keys": ["order_date"],
+                        "Condition": "(order_date in [2024-01-01, +Inf))",
+                        "Parts": 3,
+                        "Granules": 12,
+                    }
+                ],
+            }
+        ],
+    }
+}
+
+SAMPLE_PLAN_WITH_ACTIONS = {
+    "Plan": {
+        "Node Type": "Expression",
+        "Node Id": "Expression_1",
+        "Description": "Project names + Projection",
+        "Actions": {
+            "Inputs": [{"Name": "order_id", "Type": "UInt64"}, {"Name": "amount", "Type": "Float64"}],
+            "Actions": [
+                {"Type": "INPUT", "Result Name": "order_id", "Result Type": "UInt64", "Arguments": []},
+                {"Type": "INPUT", "Result Name": "amount", "Result Type": "Float64", "Arguments": []},
+            ],
+            "Outputs": [{"Name": "order_id", "Type": "UInt64"}, {"Name": "amount", "Type": "Float64"}],
+        },
+        "Plans": [
+            {
+                "Node Type": "ReadFromMergeTree",
+                "Node Id": "ReadFromMergeTree_0",
+                "Description": "default.orders",
+            }
+        ],
+    }
+}
+
+SAMPLE_PLAN_WITH_STATS = {
+    "Plan": {
+        "Node Type": "Expression",
+        "Node Id": "Expression_1",
+        "Description": "Project names + Projection",
+        "Estimated Rows": 1000,
+        "Estimated Cost": 42.5,
+        "Plans": [
+            {
+                "Node Type": "ReadFromMergeTree",
+                "Node Id": "ReadFromMergeTree_0",
+                "Description": "default.inventory_items",
+                "Estimated Rows": 1000,
+                "Estimated Total Rows": 50000,
+            }
+        ],
     }
 }
 
@@ -35,7 +115,7 @@ def instance_with_dbm():
             'samples_per_hour_per_query': 15,
             'seen_samples_cache_maxsize': 10000,
             'max_samples_per_collection': 1000,
-            'explained_queries_per_hour_per_query': 1,
+            'explained_queries_per_hour_per_query': 60,
             'explained_queries_cache_maxsize': 5000,
             'run_sync': False,
         },
@@ -66,7 +146,7 @@ def test_explain_plans_initialized(check_with_dbm):
     [
         ("SELECT * FROM users", True),
         ("select count() FROM system.tables", True),
-        ("INSERT INTO events VALUES (?)", True),
+        ("INSERT INTO events VALUES (?)", False),
         ("WITH cte AS (SELECT 1) SELECT * FROM cte", True),
         ("UPDATE users SET name = ?", False),
         ("DELETE FROM users WHERE id = 1", False),
@@ -122,6 +202,21 @@ def test_run_explain_safe_success(explain_plans):
     assert error_msg is None
 
 
+def test_run_explain_safe_success_array_wrapped(explain_plans):
+    """Some ClickHouse versions wrap the plan in a top-level JSON array; it is unwrapped."""
+    explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps([SAMPLE_PLAN]),)])
+
+    row = {
+        'query': 'SELECT * FROM system.tables',
+        'statement': 'SELECT * FROM system.tables',
+        'query_signature': 'abc123',
+    }
+    plan_dict, error_code, error_msg = explain_plans._run_explain_safe(row)
+    assert plan_dict == SAMPLE_PLAN
+    assert error_code is None
+    assert error_msg is None
+
+
 def test_collect_plan_for_statement_no_plans_possible(explain_plans):
     """Statements that cannot be explained return None."""
     row = {
@@ -137,7 +232,6 @@ def test_collect_plan_for_statement_no_plans_possible(explain_plans):
 def test_plan_event_structure(mock_agent, explain_plans):
     """A successful plan event has the required fields and correct dbm_type."""
     mock_agent.get_version.return_value = '7.64.0'
-    mock_agent.obfuscate_sql_exec_plan.return_value = json.dumps(SAMPLE_PLAN)
 
     explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN),)])
 
@@ -182,7 +276,6 @@ def test_plan_event_structure(mock_agent, explain_plans):
 def test_collect_plans_rate_limiting(mock_agent, explain_plans):
     """The same query_signature is only explained once within the rate-limit TTL."""
     mock_agent.get_version.return_value = '7.64.0'
-    mock_agent.obfuscate_sql_exec_plan.return_value = json.dumps(SAMPLE_PLAN)
 
     explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN),)])
 
@@ -273,6 +366,212 @@ def test_collect_plans_error_event(mock_agent, explain_plans):
     assert errors[0]['code'] == DBExplainError.database_error.value
 
 
+@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
+def test_collect_plans_unsupported_statements_skip_rate_limiter(mock_agent, explain_plans):
+    """Unsupported statements are skipped before acquiring a rate limit slot."""
+    mock_agent.get_version.return_value = '7.64.0'
+    explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN),)])
+
+    # Fill the cache with DDL queries up to maxsize so any further acquire would fail
+    maxsize = explain_plans._explained_statements_ratelimiter.maxsize
+    for i in range(maxsize):
+        explain_plans._explained_statements_ratelimiter.acquire(('db', f'ddl_sig_{i}'))
+
+    rows = [
+        {
+            'query': 'SELECT * FROM system.tables',
+            'statement': 'SELECT * FROM system.tables',
+            'query_signature': 'select_sig',
+            'databases': 'default',
+            'user': 'default',
+            'query_kind': 'Select',
+            'query_duration_ms': 10.0,
+            'event_time_microseconds': 1746205423150500,
+            'dd_tables': [],
+            'dd_commands': ['SELECT'],
+        },
+        {
+            'query': 'DELETE FROM users WHERE id = 1',
+            'statement': 'DELETE FROM users WHERE id = ?',
+            'query_signature': 'delete_sig',
+            'databases': 'default',
+            'user': 'default',
+            'query_kind': 'Delete',
+            'query_duration_ms': 5.0,
+            'event_time_microseconds': 1746205423160000,
+            'dd_tables': [],
+            'dd_commands': ['DELETE'],
+        },
+    ]
+
+    plans = list(explain_plans._collect_plans(rows, ['test:tag']))
+
+    # The DDL row is skipped before touching the rate limiter; SELECT is also blocked since cache is full
+    assert len(plans) == 0
+    # EXPLAIN was never called for the DDL row
+    explain_plans._execute_query_fn.assert_not_called()
+
+
+@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
+def test_collect_plans_different_databases_explained_separately(mock_agent, explain_plans):
+    """Same query_signature in different databases each get an EXPLAIN."""
+    mock_agent.get_version.return_value = '7.64.0'
+    explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN),)])
+
+    rows = [
+        {
+            'query': 'SELECT * FROM system.tables',
+            'statement': 'SELECT * FROM system.tables',
+            'query_signature': 'same_sig',
+            'databases': 'db_a',
+            'user': 'default',
+            'query_kind': 'Select',
+            'query_duration_ms': 10.0,
+            'event_time_microseconds': 1746205423150500,
+            'dd_tables': [],
+            'dd_commands': ['SELECT'],
+        },
+        {
+            'query': 'SELECT * FROM system.tables',
+            'statement': 'SELECT * FROM system.tables',
+            'query_signature': 'same_sig',
+            'databases': 'db_b',
+            'user': 'default',
+            'query_kind': 'Select',
+            'query_duration_ms': 10.0,
+            'event_time_microseconds': 1746205423160000,
+            'dd_tables': [],
+            'dd_commands': ['SELECT'],
+        },
+    ]
+
+    plans = list(explain_plans._collect_plans(rows, ['test:tag']))
+
+    assert len(plans) == 2
+    assert explain_plans._execute_query_fn.call_count == 2
+
+
+def test_run_explain_uses_indexes_and_actions(explain_plans):
+    """EXPLAIN query includes json=1, indexes=1, and actions=1."""
+    explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN),)])
+
+    explain_plans._run_explain("SELECT * FROM orders")
+
+    call_args = explain_plans._execute_query_fn.call_args[0][0]
+    assert "json = 1" in call_args
+    assert "indexes = 1" in call_args
+    assert "actions = 1" in call_args
+
+
+@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
+def test_plan_definition_preserves_indexes(mock_agent, explain_plans):
+    """Plan definition keeps Indexes fields intact."""
+    mock_agent.get_version.return_value = '7.64.0'
+    explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN_WITH_INDEXES),)])
+
+    row = {
+        'query': 'SELECT * FROM orders WHERE order_date > ?',
+        'statement': 'SELECT * FROM orders WHERE order_date > ?',
+        'query_signature': 'idx_sig',
+        'databases': 'default',
+        'user': 'default',
+        'query_kind': 'Select',
+        'query_duration_ms': 5.0,
+        'event_time_microseconds': 1746205423150500,
+        'dd_tables': ['orders'],
+        'dd_commands': ['SELECT'],
+    }
+    event = explain_plans._collect_plan_for_statement(row, ['test:tag'])
+
+    assert event is not None
+    definition = json.loads(event['db']['plan']['definition'])
+    read_node = definition['Plan']['Plans'][0]
+    assert 'Indexes' in read_node
+    assert read_node['Indexes'][0]['Type'] == 'PrimaryKey'
+    assert read_node['Indexes'][0]['Keys'] == ['order_date']
+
+
+@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
+def test_plan_definition_preserves_actions(mock_agent, explain_plans):
+    """Plan definition keeps Actions fields intact."""
+    mock_agent.get_version.return_value = '7.64.0'
+    explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN_WITH_ACTIONS),)])
+
+    row = {
+        'query': 'SELECT order_id, amount FROM orders',
+        'statement': 'SELECT order_id, amount FROM orders',
+        'query_signature': 'act_sig',
+        'databases': 'default',
+        'user': 'default',
+        'query_kind': 'Select',
+        'query_duration_ms': 5.0,
+        'event_time_microseconds': 1746205423150500,
+        'dd_tables': ['orders'],
+        'dd_commands': ['SELECT'],
+    }
+    event = explain_plans._collect_plan_for_statement(row, ['test:tag'])
+
+    assert event is not None
+    definition = json.loads(event['db']['plan']['definition'])
+    top_plan = definition['Plan']
+    assert 'Actions' in top_plan
+    assert top_plan['Actions']['Inputs'][0]['Name'] == 'order_id'
+    assert top_plan['Actions']['Outputs'][1]['Name'] == 'amount'
+
+
+def test_normalize_clickhouse_plan_preserves_indexes_and_actions():
+    """_normalize_clickhouse_plan does not strip Indexes or Actions — they are structural."""
+    normalized_with_indexes = _normalize_clickhouse_plan(SAMPLE_PLAN_WITH_INDEXES)
+    read_node = normalized_with_indexes['Plan']['Plans'][0]
+    assert 'Indexes' in read_node
+    assert read_node['Indexes'][0]['Type'] == 'PrimaryKey'
+
+    normalized_with_actions = _normalize_clickhouse_plan(SAMPLE_PLAN_WITH_ACTIONS)
+    assert 'Actions' in normalized_with_actions['Plan']
+    assert normalized_with_actions['Plan']['Actions']['Inputs'][0]['Name'] == 'order_id'
+
+
+def test_normalize_clickhouse_plan_strips_stats():
+    """_normalize_clickhouse_plan removes cost/stats keys but keeps structural fields."""
+    normalized = _normalize_clickhouse_plan(SAMPLE_PLAN_WITH_STATS)
+    plan = normalized['Plan']
+    assert 'Estimated Rows' not in plan
+    assert 'Estimated Cost' not in plan
+    assert plan['Description'] == 'Project names + Projection'
+    child = plan['Plans'][0]
+    assert 'Estimated Rows' not in child
+    assert 'Estimated Total Rows' not in child
+    assert child['Description'] == 'default.inventory_items'
+
+
+@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
+def test_plan_definition_preserves_descriptions(mock_agent, explain_plans):
+    """Plan definition keeps ClickHouse Description fields intact (not replaced with '?')."""
+    mock_agent.get_version.return_value = '7.64.0'
+    explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN),)])
+
+    row = {
+        'query': 'SELECT * FROM inventory_items WHERE sku = ?',
+        'statement': 'SELECT * FROM inventory_items WHERE sku = ?',
+        'query_signature': 'desc_sig',
+        'databases': 'default',
+        'user': 'default',
+        'query_kind': 'Select',
+        'query_duration_ms': 5.0,
+        'event_time_microseconds': 1746205423150500,
+        'dd_tables': ['inventory_items'],
+        'dd_commands': ['SELECT'],
+    }
+    event = explain_plans._collect_plan_for_statement(row, ['test:tag'])
+
+    assert event is not None
+    definition = json.loads(event['db']['plan']['definition'])
+    top_plan = definition['Plan']
+    assert top_plan['Description'] == 'Project names + Projection'
+    assert top_plan['Plans'][0]['Description'] == 'WHERE + Change column names to column identifiers'
+    assert top_plan['Plans'][0]['Plans'][0]['Description'] == 'default.inventory_items'
+
+
 def test_default_config_values(instance_with_dbm):
     """Default config values for explain plans are applied correctly."""
     instance = {
@@ -288,5 +587,5 @@ def test_default_config_values(instance_with_dbm):
     check = ClickhouseCheck('clickhouse', {}, [instance])
     cfg = check._config.query_completions
 
-    assert cfg.explained_queries_per_hour_per_query == 1
+    assert cfg.explained_queries_per_hour_per_query == 60
     assert cfg.explained_queries_cache_maxsize == 5000

--- a/clickhouse/tests/test_explain_plans.py
+++ b/clickhouse/tests/test_explain_plans.py
@@ -641,7 +641,11 @@ def test_obfuscate_clickhouse_plan_redacts_column_and_function_result_names():
                 'Actions': [
                     {'Node Type': 'INPUT', 'Result Name': 'user_id', 'Result Type': 'UInt64'},
                     {'Node Type': 'COLUMN', 'Result Name': "'%secret%'_String", 'Result Type': 'String'},
-                    {'Node Type': 'FUNCTION', 'Result Name': "notLike(query, '%secret%'_String)", 'Result Type': 'UInt8'},
+                    {
+                        'Node Type': 'FUNCTION',
+                        'Result Name': "notLike(query, '%secret%'_String)",
+                        'Result Type': 'UInt8',
+                    },
                     {'Node Type': 'ALIAS', 'Result Name': 'filtered_query', 'Result Type': 'UInt8'},
                 ]
             },
@@ -649,10 +653,10 @@ def test_obfuscate_clickhouse_plan_redacts_column_and_function_result_names():
     }
     result = _obfuscate_clickhouse_plan(plan)
     actions = result['Plan']['Expression']['Actions']
-    assert actions[0]['Result Name'] == 'user_id'           # INPUT kept
-    assert actions[1]['Result Name'] == '?'                  # COLUMN redacted
-    assert actions[2]['Result Name'] == '?'                  # FUNCTION redacted
-    assert actions[3]['Result Name'] == 'filtered_query'     # ALIAS kept
+    assert actions[0]['Result Name'] == 'user_id'  # INPUT kept
+    assert actions[1]['Result Name'] == '?'  # COLUMN redacted
+    assert actions[2]['Result Name'] == '?'  # FUNCTION redacted
+    assert actions[3]['Result Name'] == 'filtered_query'  # ALIAS kept
 
 
 def test_obfuscate_clickhouse_plan_redacts_expression_names_in_outputs():
@@ -675,9 +679,9 @@ def test_obfuscate_clickhouse_plan_redacts_expression_names_in_outputs():
     }
     result = _obfuscate_clickhouse_plan(plan)
     inputs = result['Plan']['Expression']['Inputs']
-    assert inputs[0]['Name'] == 'user_id'    # plain column name, kept
-    assert inputs[1]['Name'] == '?'           # string literal in expression, redacted
-    assert inputs[2]['Name'] == '?'           # numeric literal in expression (has paren), redacted
+    assert inputs[0]['Name'] == 'user_id'  # plain column name, kept
+    assert inputs[1]['Name'] == '?'  # string literal in expression, redacted
+    assert inputs[2]['Name'] == '?'  # numeric literal in expression (has paren), redacted
 
     outputs = result['Plan']['Expression']['Outputs']
     assert outputs[0]['Name'] == 'user_id'
@@ -698,6 +702,109 @@ def test_obfuscate_clickhouse_plan_preserves_structural_fields():
     assert read_node['Indexes'][0]['Condition'] == '?'
     assert read_node['Indexes'][0]['Parts'] == 3
     assert read_node['Indexes'][0]['Granules'] == 12
+
+
+@pytest.mark.parametrize(
+    "query,expected",
+    [
+        ("SELECT * FROM orders FORMAT JSON", "SELECT * FROM orders"),
+        ("SELECT 1 FORMAT TabSeparated", "SELECT 1"),
+        ("SELECT 1   FORMAT TSV  ", "SELECT 1"),
+        ("select * from t format JSONEachRow", "select * from t"),
+        ("SELECT * FROM orders", "SELECT * FROM orders"),
+        ("SELECT FORMAT FROM t", "SELECT FORMAT FROM t"),
+    ],
+)
+def test_strip_format_clause(explain_plans, query, expected):
+    assert explain_plans._strip_format_clause(query) == expected
+
+
+def test_run_explain_empty_rows(explain_plans):
+    """_run_explain raises ValueError when the query returns no rows."""
+    explain_plans._execute_query_fn = mock.MagicMock(return_value=[])
+    with pytest.raises(ValueError, match="no rows"):
+        explain_plans._run_explain("SELECT 1")
+
+
+def test_run_explain_empty_json_array(explain_plans):
+    """_run_explain raises ValueError when the JSON response is an empty array."""
+    explain_plans._execute_query_fn = mock.MagicMock(return_value=[('[]',)])
+    with pytest.raises(ValueError, match="empty JSON array"):
+        explain_plans._run_explain("SELECT 1")
+
+
+def test_run_explain_invalid_json(explain_plans):
+    """_run_explain raises an error when the response is not valid JSON."""
+    explain_plans._execute_query_fn = mock.MagicMock(return_value=[('not valid json',)])
+    with pytest.raises(Exception):
+        explain_plans._run_explain("SELECT 1")
+
+
+def test_run_explain_safe_captures_empty_rows_as_database_error(explain_plans):
+    """Empty rows from EXPLAIN are surfaced as database_error via _run_explain_safe."""
+    explain_plans._execute_query_fn = mock.MagicMock(return_value=[])
+    row = {'query': 'SELECT 1', 'statement': 'SELECT ?', 'query_signature': 'sig'}
+    plan_dict, error_code, error_msg = explain_plans._run_explain_safe(row)
+    assert plan_dict is None
+    assert error_code == DBExplainError.database_error
+
+
+@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
+def test_collect_plan_for_statement_serialization_failure(mock_agent, explain_plans):
+    """A serialization failure during plan obfuscation is recorded as invalid_result."""
+    mock_agent.get_version.return_value = '7.64.0'
+
+    explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN),)])
+
+    row = {
+        'query': 'SELECT * FROM system.tables',
+        'statement': 'SELECT * FROM system.tables',
+        'query_signature': 'serial_sig',
+        'databases': 'default',
+        'user': 'default',
+        'query_kind': 'Select',
+        'query_duration_ms': 10.0,
+        'event_time_microseconds': 1746205423150500,
+        'dd_tables': [],
+        'dd_commands': ['SELECT'],
+    }
+
+    with mock.patch('datadog_checks.clickhouse.explain_plans.json') as mock_json:
+        mock_json.loads.return_value = SAMPLE_PLAN
+        mock_json.dumps.side_effect = Exception("serialization failed")
+        event = explain_plans._collect_plan_for_statement(row, ['test:tag'])
+
+    assert event is not None
+    errors = event['db']['plan']['collection_errors']
+    assert errors is not None
+    assert len(errors) == 1
+    assert errors[0]['code'] == DBExplainError.invalid_result.value
+    assert event['db']['plan']['definition'] is None
+    assert event['db']['plan']['signature'] is None
+
+
+@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
+def test_collect_plan_for_statement_no_collection_errors_on_success(mock_agent, explain_plans):
+    """collection_errors is None (not an empty list) when the plan is collected successfully."""
+    mock_agent.get_version.return_value = '7.64.0'
+    explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN),)])
+
+    row = {
+        'query': 'SELECT * FROM system.tables',
+        'statement': 'SELECT * FROM system.tables',
+        'query_signature': 'ok_sig',
+        'databases': 'default',
+        'user': 'default',
+        'query_kind': 'Select',
+        'query_duration_ms': 10.0,
+        'event_time_microseconds': 1746205423150500,
+        'dd_tables': [],
+        'dd_commands': ['SELECT'],
+    }
+    event = explain_plans._collect_plan_for_statement(row, ['test:tag'])
+
+    assert event is not None
+    assert event['db']['plan']['collection_errors'] is None
 
 
 def test_default_config_values(instance_with_dbm):


### PR DESCRIPTION
- Add explain_plans.py with ClickhouseExplainPlans class: `EXPLAIN PLAN json=1, , indexes=1, actions=1` execution, DBExplainError enum, two rate-limit TTL caches (_explained_statements_ratelimiter per query_signature at 1/hr default, _seen_samples_ratelimiter per (query_signature, plan_signature)) default of 60 queries / hr
- Integrate into query_completions.py: collect plans after each batch of completed queries, emit via database_monitoring_query_sample
- Add explained_queries_per_hour_per_query and explained_queries_cache_maxsize config options to query_completions spec.yaml; regenerate config models
- Add `EXPLAIN_PLANS` feature key to features.py and wire into config.py
- Add 19 unit tests in test_explain_plans.py

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add support for ClickHouse Explain plans

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
