### PR TITLE
Exclude Python version updates from Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,15 @@
         "github-actions"
       ],
       "matchPackageNames": [
+        "python"
+      ],
+      "enabled": false
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
         "dtolnay/rust-toolchain"
       ],
       "groupName": "actions",


### PR DESCRIPTION
### What does this PR do?

Adds a Renovate rule to disable automatic Python version updates (the `python` package, type `uses-with`). Renovate was bumping hardcoded `python-version` values in `actions/setup-python` steps (e.g. `3.11`/`3.13` → `3.14`), which we handle separately via the dedicated upgrade workflow.

### Motivation

Renovate PR [#23289](https://github.com/DataDog/integrations-core/pull/23289) included unwanted Python version bumps alongside legitimate action updates. Python version upgrades are managed separately.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)