### PR TITLE
Fix renovate python ignore rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,7 @@
       "matchManagers": [
         "github-actions"
       ],
-      "matchPackageNames": [
+      "matchDepNames": [
         "python"
       ],
       "enabled": false


### PR DESCRIPTION
### What does this PR do?

Fixes the Renovate package rule that is supposed to disable Python version updates in GitHub Actions workflows.

The rule used `matchPackageNames: ["python"]`, but the actual `packageName` Renovate assigns to Python version dependencies is `actions/python-versions` (not `python`). The `depName` is `python`, so the correct matcher is `matchDepNames`.

Before this fix, the rule had no effect and Python was being updated from 3.13 to 3.14 in the `renovate/actions` PR despite the intent to disable it.

### Motivation

Renovate was picking up Python version updates (e.g. `python-version: "3.13"` → `"3.14"` in `setup-python` action inputs) and including them in the `renovate/actions` PR. The existing `enabled: false` rule was silently not matching due to using `matchPackageNames` instead of `matchDepNames`.