### PR TITLE
[DOCS-13084] Fix wrong links and heading levels in OpenAI integration…

### DIFF
--- a/openai/README.md
+++ b/openai/README.md
@@ -4,8 +4,6 @@
 
 Monitor, troubleshoot, and evaluate your LLM-powered applications, such as chatbots or data extraction tools, using [OpenAI][1]. With LLM Observability, you can investigate the root cause of issues, monitor operational performance, and evaluate the quality, privacy, and safety of your LLM applications.
 
-[LLM Obs tracing view video][16]
-
 Get cost estimation, prompt and completion sampling, error tracking, performance metrics, and more out of [OpenAI][1] account-level, Python, Node.js, and PHP library requests using Datadog metrics and APM.
 
 ## Setup
@@ -19,22 +17,20 @@ Get cost estimation, prompt and completion sampling, error tracking, performance
 
 ### Installation
 
-# Configuring OpenAI Integration for Datadog
-
-## Overview
+#### Overview
 
 Datadog's OpenAI integration allows you to collect usage metrics, cost data, and enables [LLM Observability][19] to monitor your OpenAI models. Follow the steps below to generate an OpenAI API key and configure the integration.
 
-## Prerequisites
+#### Prerequisites
 
 - An **OpenAI account** with admin write permissions
 - A **valid OpenAI API key**:
   - **For Cloud Cost Management (CCM) and usage metrics**: An **admin-scoped API key is mandatory**. Project-scoped keys cannot collect this data.
   - **For LLM Observability only**: A standard API key with write permissions for model capabilities is sufficient.
 
-## Setup
+#### Setup
 
-### 1. Generate an OpenAI API key
+##### 1. Generate an OpenAI API key
 
 **For Cloud Cost Management and usage metrics**, you must create an **admin-scoped API key**:
 
@@ -51,7 +47,7 @@ Datadog's OpenAI integration allows you to collect usage metrics, cost data, and
    - Ensure that the API key has **write** permission for **model capabilities** to invoke models in your LLM account.
 4. Copy the created API Key to your clipboard.
 
-### 2. Configure Datadog's OpenAI integration
+##### 2. Configure Datadog's OpenAI integration
 
 1. Navigate Datadog's [OpenAI integration tile][11] and open the **Configuration** tab.
 2. Click **Add Account**.
@@ -60,14 +56,14 @@ Datadog's OpenAI integration allows you to collect usage metrics, cost data, and
    - **Collect Cost Data**: If enabled, cost data is visible in [Cloud Cost Management][14] within 24 hours. **Requires an admin-scoped API key.** See ([collected data][15]).
    - **Use this API key to evaluate your LLM applications**: If enabled, evaluations are run through this API key in LLM Observability.
 
-### Additional Notes
+##### Additional Notes
 
 - **Admin-scoped API key requirement**: An admin-scoped API key is **mandatory** for collecting usage metrics and Cloud Cost Management data. This integration only collects `audio_speeches`, `audio_transcriptions`, `code_interpreter_sessions`, `completions`, `embeddings`, `images`, `moderations`, and `vector_stores` metrics when an admin-scoped API key is provided.
 - If you enable Cloud Cost Management for OpenAI without an admin-scoped API key, cost metrics are not available.
 
-## Additional Resources
+#### Additional Resources
 
-- [OpenAI API Documentation][17]
+- [OpenAI API Documentation][21]
 - [Generating an API Token][18]
 
 
@@ -532,8 +528,7 @@ Additional helpful documentation, links, and articles:
 [13]: https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
 [14]: /cost
 [15]: https://docs.datadoghq.com/cloud_cost_management/saas_costs/?tab=openai#data-collected
-[16]: https://imgix.datadoghq.com/video/products/llm-observability/expedite-troubleshooting.mp4?fm=webm&fit=max
-[17]: https://platform.openai.com/docs/
 [18]: https://platform.openai.com/
+[21]: https://platform.openai.com/docs/
 [19]: https://www.datadoghq.com/product/llm-observability/
 [20]: https://platform.openai.com/settings/organization/admin-keys


### PR DESCRIPTION
### What does this PR do?
Two link reference bugs caused by duplicate reference numbers:
- [16] was defined twice: once for the PHP library install URL and once for a video URL. The video placeholder line in the Overview was a leftover that served no purpose as a text link, so it was removed along with its duplicate [16] definition.
- [17] was defined twice: once in the PHP tab for the PHP library config URL and once at the bottom for the OpenAI API docs URL. The "OpenAI API Documentation" link in the API Key tab was incorrectly resolving to the PHP library docs. Fixed by assigning the OpenAI API docs URL to a new reference [21].

Also demoted heading levels in the API Key tab from h1/h2/h3 to h4/h4/h5 to match the existing heading hierarchy (Installation is h3).

### Motivation
Fixes DOCS-13084

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
