### PR TITLE
AI-6670 Add recommended monitors for NiFi integration

### DIFF
--- a/nifi/assets/monitors/can_connect.json
+++ b/nifi/assets/monitors/can_connect.json
@@ -1,0 +1,32 @@
+{
+  "version": 2,
+  "created_at": "2026-04-13",
+  "last_updated_at": "2026-04-13",
+  "title": "NiFi instance is unreachable",
+  "tags": [
+    "integration:nifi"
+  ],
+  "description": "The Datadog Agent cannot reach or authenticate with the NiFi REST API. When this check fails, all NiFi metrics stop flowing. This typically indicates NiFi is down, the API URL is misconfigured, or credentials have expired.",
+  "definition": {
+    "name": "[NiFi] Instance unreachable on {{host.name}}",
+    "type": "service check",
+    "query": "\"nifi.can_connect\".over(\"*\").by(\"host\").last(3).count_by_status()",
+    "message": "{{#is_alert}}\n\n## What's happening?\nThe NiFi instance on {{host.name}} has failed consecutive connectivity checks.\n\nAll NiFi metrics have stopped flowing. Verify that:\n- The NiFi process is running\n- The API URL is reachable from the Agent host\n- Credentials have not expired or been rotated\n\n{{/is_alert}}\n\n{{#is_recovery}}\nNiFi connectivity has been restored on {{host.name}}.\n{{/is_recovery}}",
+    "tags": [
+      "integration:nifi"
+    ],
+    "options": {
+      "thresholds": {
+        "critical": 2,
+        "ok": 1
+      },
+      "notify_audit": false,
+      "notify_no_data": false,
+      "renotify_interval": 0,
+      "timeout_h": 0,
+      "include_tags": true,
+      "new_group_delay": 30
+    },
+    "priority": null
+  }
+}

--- a/nifi/assets/monitors/connection_backpressure.json
+++ b/nifi/assets/monitors/connection_backpressure.json
@@ -1,0 +1,36 @@
+{
+  "version": 2,
+  "created_at": "2026-04-13",
+  "last_updated_at": "2026-04-13",
+  "title": "Connection backpressure is high",
+  "tags": [
+    "integration:nifi"
+  ],
+  "description": "NiFi connections have configurable backpressure thresholds. When a connection reaches 100% of its threshold, the upstream processor is forced to stop producing data. This monitor alerts before that hard stop occurs. Requires `collect_connection_metrics: true` in the integration configuration.",
+  "definition": {
+    "message": "{{#is_alert}}\n\n## What's happening?\nConnection backpressure on NiFi host {{host.name}} has exceeded 80% for connection {{connection_name.name}}.\n\nAt 100%, the upstream processor will be forced to stop. Investigate:\n- Whether the downstream processor is running and healthy\n- Whether the backpressure threshold needs to be increased\n- Whether the downstream processor needs more concurrent tasks\n\n{{/is_alert}}\n\n{{#is_warning}}\nConnection backpressure on {{host.name}} for {{connection_name.name}} has exceeded 60%.\n{{/is_warning}}\n\n{{#is_recovery}}\nConnection backpressure on {{host.name}} for {{connection_name.name}} has returned to normal.\n{{/is_recovery}}",
+    "name": "[NiFi] Connection backpressure is high on {{host.name}}",
+    "options": {
+      "escalation_message": "",
+      "include_tags": true,
+      "locked": false,
+      "new_host_delay": 300,
+      "no_data_timeframe": null,
+      "notify_audit": false,
+      "notify_no_data": false,
+      "renotify_interval": 0,
+      "require_full_window": true,
+      "thresholds": {
+        "critical": 0.8,
+        "warning": 0.6
+      },
+      "timeout_h": 0
+    },
+    "priority": null,
+    "query": "avg(last_10m):max:nifi.connection.percent_use_count{*} by {host,connection_name} > 0.8",
+    "tags": [
+      "integration:nifi"
+    ],
+    "type": "query alert"
+  }
+}

--- a/nifi/assets/monitors/content_repo_utilization.json
+++ b/nifi/assets/monitors/content_repo_utilization.json
@@ -1,0 +1,36 @@
+{
+  "version": 2,
+  "created_at": "2026-04-13",
+  "last_updated_at": "2026-04-13",
+  "title": "Content repository disk utilization is high",
+  "tags": [
+    "integration:nifi"
+  ],
+  "description": "The NiFi content repository stores FlowFile payloads on disk. When it reaches capacity, NiFi stops accepting new data and all flow processing halts. This monitor tracks disk utilization of the content repository.",
+  "definition": {
+    "message": "{{#is_alert}}\n\n## What's happening?\nContent repository utilization on NiFi host {{host.name}} has exceeded 85% over the last 15 minutes.\n\nWhen the content repository fills completely, NiFi stops accepting new data. Consider:\n- Clearing completed FlowFiles that are no longer needed\n- Adding additional content repository directories in `nifi.properties`\n- Investigating stuck flows that may be accumulating data\n\n{{/is_alert}}\n\n{{#is_warning}}\nContent repository utilization on NiFi host {{host.name}} has exceeded 75%.\n{{/is_warning}}\n\n{{#is_recovery}}\nContent repository utilization on {{host.name}} has returned to normal.\n{{/is_recovery}}",
+    "name": "[NiFi] Content repository disk utilization is high on {{host.name}}",
+    "options": {
+      "escalation_message": "",
+      "include_tags": true,
+      "locked": false,
+      "new_host_delay": 300,
+      "no_data_timeframe": null,
+      "notify_audit": false,
+      "notify_no_data": false,
+      "renotify_interval": 0,
+      "require_full_window": true,
+      "thresholds": {
+        "critical": 0.85,
+        "warning": 0.75
+      },
+      "timeout_h": 0
+    },
+    "priority": null,
+    "query": "avg(last_15m):avg:nifi.system.content_repo.utilization{*} by {host} > 0.85",
+    "tags": [
+      "integration:nifi"
+    ],
+    "type": "query alert"
+  }
+}

--- a/nifi/assets/monitors/invalid_processors.json
+++ b/nifi/assets/monitors/invalid_processors.json
@@ -1,0 +1,35 @@
+{
+  "version": 2,
+  "created_at": "2026-04-13",
+  "last_updated_at": "2026-04-13",
+  "title": "Invalid processors detected",
+  "tags": [
+    "integration:nifi"
+  ],
+  "description": "NiFi processors enter an invalid state when they have missing or misconfigured properties, broken controller service references, or incompatible settings. Invalid processors cannot run and silently break data flows.",
+  "definition": {
+    "message": "{{#is_alert}}\n\n## What's happening?\nNiFi host {{host.name}} has one or more invalid processors.\n\nInvalid processors cannot process data and will break any flow that depends on them. Open the NiFi UI to identify the invalid processors and resolve their configuration issues.\n\n{{/is_alert}}\n\n{{#is_recovery}}\nAll processors on NiFi host {{host.name}} are now valid.\n{{/is_recovery}}",
+    "name": "[NiFi] Invalid processors detected on {{host.name}}",
+    "options": {
+      "escalation_message": "",
+      "include_tags": true,
+      "locked": false,
+      "new_host_delay": 300,
+      "no_data_timeframe": null,
+      "notify_audit": false,
+      "notify_no_data": false,
+      "renotify_interval": 0,
+      "require_full_window": true,
+      "thresholds": {
+        "critical": 0
+      },
+      "timeout_h": 0
+    },
+    "priority": null,
+    "query": "avg(last_5m):avg:nifi.flow.invalid_count{*} by {host} > 0",
+    "tags": [
+      "integration:nifi"
+    ],
+    "type": "query alert"
+  }
+}

--- a/nifi/assets/monitors/jvm_heap_utilization.json
+++ b/nifi/assets/monitors/jvm_heap_utilization.json
@@ -1,0 +1,36 @@
+{
+  "version": 2,
+  "created_at": "2026-04-13",
+  "last_updated_at": "2026-04-13",
+  "title": "JVM heap utilization is high",
+  "tags": [
+    "integration:nifi"
+  ],
+  "description": "NiFi runs on the JVM and heap exhaustion causes OutOfMemoryError crashes or severe garbage collection pauses that stall data flow processing. This monitor tracks JVM heap usage as a percentage of the configured maximum.",
+  "definition": {
+    "message": "{{#is_alert}}\n\n## What's happening?\nJVM heap utilization on NiFi host {{host.name}} has exceeded 85% over the last 15 minutes.\n\nSustained high heap usage can lead to long GC pauses, flow stalls, or an OutOfMemoryError crash. Consider:\n- Increasing the JVM heap size in `bootstrap.conf` (`java.arg.Xmx`)\n- Reducing flow concurrency or disabling unnecessary processors\n- Investigating processors with large FlowFile content in memory\n\n{{/is_alert}}\n\n{{#is_warning}}\nJVM heap utilization on NiFi host {{host.name}} has exceeded 75%.\n{{/is_warning}}\n\n{{#is_recovery}}\nJVM heap utilization on {{host.name}} has returned to normal.\n{{/is_recovery}}",
+    "name": "[NiFi] JVM heap utilization is high on {{host.name}}",
+    "options": {
+      "escalation_message": "",
+      "include_tags": true,
+      "locked": false,
+      "new_host_delay": 300,
+      "no_data_timeframe": null,
+      "notify_audit": false,
+      "notify_no_data": false,
+      "renotify_interval": 0,
+      "require_full_window": true,
+      "thresholds": {
+        "critical": 0.85,
+        "warning": 0.75
+      },
+      "timeout_h": 0
+    },
+    "priority": null,
+    "query": "avg(last_15m):avg:nifi.system.jvm.heap_utilization{*} by {host} > 0.85",
+    "tags": [
+      "integration:nifi"
+    ],
+    "type": "query alert"
+  }
+}

--- a/nifi/manifest.json
+++ b/nifi/manifest.json
@@ -52,7 +52,13 @@
     "dashboards": {
       "NiFi Overview": "assets/dashboards/nifi_overview.json"
     },
-    "monitors": {},
+    "monitors": {
+      "NiFi instance is unreachable": "assets/monitors/can_connect.json",
+      "JVM heap utilization is high": "assets/monitors/jvm_heap_utilization.json",
+      "Connection backpressure is high": "assets/monitors/connection_backpressure.json",
+      "Content repository disk utilization is high": "assets/monitors/content_repo_utilization.json",
+      "Invalid processors detected": "assets/monitors/invalid_processors.json"
+    },
     "saved_views": {}
   },
   "author": {


### PR DESCRIPTION
**Jira:** [AI-6670](https://datadoghq.atlassian.net/browse/AI-6670)
**Epic:** [AI-6662](https://datadoghq.atlassian.net/browse/AI-6662)
**Stacks on:** #23110

## Summary

- Add 5 recommended monitors for the NiFi integration covering key operational failure modes
- Thresholds calibrated against a survey of 406 existing monitors across the repo

## Monitors

| Monitor | Type | Critical | Warning | Metric |
|---------|------|----------|---------|--------|
| Instance unreachable | service check | 2 consecutive failures | — | `nifi.can_connect` |
| JVM heap utilization high | query alert | 85% | 75% | `nifi.system.jvm.heap_utilization` |
| Connection backpressure high | query alert | 80% | 60% | `nifi.connection.percent_use_count` |
| Content repo disk high | query alert | 85% | 75% | `nifi.system.content_repo.utilization` |
| Invalid processors detected | query alert | >0 | — | `nifi.flow.invalid_count` |

## Threshold rationale

- **JVM heap 85/75**: Matches JVM convention (sonatype_nexus uses 80%); NiFi heap is spikier so 80% would be noisy
- **Backpressure 80/60**: NiFi backpressure at 100% is a hard stop (not graceful degradation like connection pools at 90/80), so earlier warning is needed
- **Content repo 85/75**: 100% halts all flow processing; tighter than generic disk (80%) but less noisy than ActiveMQ's 95%
- **Invalid processors >0**: Matches system-critical count pattern (k8s crashes, Kafka offline partitions); invalid processors don't self-heal
- **Service check critical=2**: Matches Consul pattern; suppresses transient network blips

## Test plan

- [x] `ddev validate config -s nifi` passes
- [x] `ddev validate models -s nifi` passes
- [x] All monitor JSON files are valid v2 schema with correct tags
- [x] All manifest.json paths resolve to existing files
- [ ] APW validator passes (runs as GitHub check)

[AI-6670]: https://datadoghq.atlassian.net/browse/AI-6670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AI-6662]: https://datadoghq.atlassian.net/browse/AI-6662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ