### PR TITLE
Use ConfigMixin for typed configuration access

### DIFF
--- a/nutanix/assets/configuration/spec.yaml
+++ b/nutanix/assets/configuration/spec.yaml
@@ -66,7 +66,7 @@ files:
               The actual backoff time uses exponential backoff: base * (2 ^ attempt) + jitter.
               Default is 1 second.
             value:
-              type: number
+              type: integer
               example: 1
           - name: pc_max_backoff_seconds
             description: |
@@ -74,7 +74,7 @@ files:
               This caps the exponential backoff calculation to prevent excessive wait times.
               Default is 30 seconds.
             value:
-              type: number
+              type: integer
               example: 30
           - name: resource_filters
             description: |

--- a/nutanix/changelog.d/23304.added
+++ b/nutanix/changelog.d/23304.added
@@ -1,0 +1,1 @@
+Improve configuration validation with stricter type checking and clearer error messages.

--- a/nutanix/datadog_checks/nutanix/activity_monitor.py
+++ b/nutanix/datadog_checks/nutanix/activity_monitor.py
@@ -76,7 +76,9 @@ class ActivityMonitor:
         start_time = last_time
         if not start_time:
             now = get_current_datetime()
-            start_time = (now - timedelta(seconds=self.check.sampling_interval)).isoformat().replace("+00:00", "Z")
+            start_time = (
+                (now - timedelta(seconds=self.check.config.min_collection_interval)).isoformat().replace("+00:00", "Z")
+            )
 
         self.check.log.debug("[%s] Collecting %ss since: %s", self._pc_label, activity_kind, start_time)
 
@@ -162,7 +164,7 @@ class ActivityMonitor:
 
     def collect_tasks(self) -> None:
         def _filter_subtasks(tasks: list[dict]) -> list[dict]:
-            if not self.check.collect_subtasks_enabled:
+            if not self.check.config.collect_subtasks:
                 return [t for t in tasks if not t.get("parentTask")]
             return tasks
 

--- a/nutanix/datadog_checks/nutanix/check.py
+++ b/nutanix/datadog_checks/nutanix/check.py
@@ -22,11 +22,10 @@ class NutanixCheck(AgentCheck, ConfigMixin):
     def __init__(self, name, init_config, instances):
         super().__init__(name, init_config, instances)
         # Insert after load_configuration_models but before __initialize_persistent_cache_key_prefix
-        # so that ActivityMonitor reads persistent cache with an empty prefix (matching AgentCheck lifecycle)
-        self.check_initializations.insert(1, self._initialize_check_attributes)
-        self.check_initializations.insert(1, self._parse_config)
+        # so that ActivityMonitor reads persistent cache with an empty prefix (preserving existing cache keys)
+        self.check_initializations.insert(1, self._initialize)
 
-    def _parse_config(self):
+    def _initialize(self):
         self.pc_ip = self.config.pc_ip
         self.pc_port = self.config.pc_port or 9440
         if ":" in self.pc_ip:
@@ -42,7 +41,6 @@ class NutanixCheck(AgentCheck, ConfigMixin):
             [rf.model_dump() for rf in (self.config.resource_filters or ())], self.log
         )
 
-    def _initialize_check_attributes(self):
         self.base_url = f"{self.pc_ip}:{self.pc_port}"
         if not self.base_url.startswith("http"):
             self.base_url = "https://" + self.base_url

--- a/nutanix/datadog_checks/nutanix/check.py
+++ b/nutanix/datadog_checks/nutanix/check.py
@@ -28,13 +28,13 @@ class NutanixCheck(AgentCheck, ConfigMixin):
 
     def _parse_config(self):
         self.pc_ip = self.config.pc_ip
-        self.pc_port = self.config.pc_port
+        self.pc_port = self.config.pc_port or 9440
         if ":" in self.pc_ip:
             host, _, port = self.pc_ip.rpartition(":")
             if port.isdigit():
                 if "pc_port" in self.instance:
                     raise ConfigurationError(
-                        f"Conflicting port configuration between pc_ip ({port}) and pc_port ({self.config.pc_port})"
+                        f"Conflicting port configuration between pc_ip ({port}) and pc_port ({self.pc_port})"
                     )
                 self.pc_ip, self.pc_port = host, int(port)
 

--- a/nutanix/datadog_checks/nutanix/check.py
+++ b/nutanix/datadog_checks/nutanix/check.py
@@ -27,7 +27,7 @@ class NutanixCheck(AgentCheck, ConfigMixin):
 
     def _initialize_check(self):
         self.pc_ip = self.config.pc_ip
-        self.pc_port = self.config.pc_port or 9440
+        self.pc_port = self.config.pc_port
         if ":" in self.pc_ip:
             host, _, port = self.pc_ip.rpartition(":")
             if port.isdigit():

--- a/nutanix/datadog_checks/nutanix/check.py
+++ b/nutanix/datadog_checks/nutanix/check.py
@@ -7,66 +7,40 @@ from datetime import datetime
 
 from requests.exceptions import ConnectionError, HTTPError, InvalidURL, Timeout
 
-from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
+from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.nutanix.activity_monitor import ActivityMonitor
+from datadog_checks.nutanix.config_models import ConfigMixin
 from datadog_checks.nutanix.infrastructure_monitor import InfrastructureMonitor
 from datadog_checks.nutanix.resource_filters import parse_resource_filters
 from datadog_checks.nutanix.utils import retry_on_rate_limit
 
 
-class NutanixCheck(AgentCheck):
+class NutanixCheck(AgentCheck, ConfigMixin):
     __NAMESPACE__ = 'nutanix'
+    HTTP_CONFIG_REMAPPER = {'pc_username': {'name': 'username'}, 'pc_password': {'name': 'password'}}
 
     def __init__(self, name, init_config, instances):
         super().__init__(name, init_config, instances)
-
-        self._parse_config()
-        self._initialize_check_attributes()
+        # Insert after load_configuration_models but before __initialize_persistent_cache_key_prefix
+        # so that ActivityMonitor reads persistent cache with an empty prefix (matching AgentCheck lifecycle)
+        self.check_initializations.insert(1, self._initialize_check_attributes)
+        self.check_initializations.insert(1, self._parse_config)
 
     def _parse_config(self):
-        # 120s proved reliable during testing — retrieves the majority of Cluster/VM stats
-        self.sampling_interval = self.instance.get("min_collection_interval", 120)
-        self.page_limit = self.instance.get("page_limit", 100)
-
-        # setup
-        self.pc_ip = self.instance.get("pc_ip")
-        if not self.pc_ip:
-            raise ConfigurationError("pc_ip is required")
-        self.pc_port = self.instance.get("pc_port")
-        if self.pc_ip and ":" in self.pc_ip:
+        self.pc_ip = self.config.pc_ip
+        self.pc_port = self.config.pc_port
+        if ":" in self.pc_ip:
             host, _, port = self.pc_ip.rpartition(":")
             if port.isdigit():
                 if "pc_port" in self.instance:
                     raise ConfigurationError(
-                        f"Conflicting port configuration between pc_ip ({port}) and pc_port ({self.pc_port})"
+                        f"Conflicting port configuration between pc_ip ({port}) and pc_port ({self.config.pc_port})"
                     )
                 self.pc_ip, self.pc_port = host, int(port)
-        self.pc_port = self.pc_port or 9440
 
-        # http auth
-        pc_username = self.instance.get("pc_username")
-        pc_password = self.instance.get("pc_password")
-
-        if pc_username and "username" not in self.instance:
-            self.instance["username"] = pc_username
-        if pc_password and "password" not in self.instance:
-            self.instance["password"] = pc_password
-
-        self.collect_events_enabled = is_affirmative(self.instance.get("collect_events", True))
-        self.collect_tasks_enabled = is_affirmative(self.instance.get("collect_tasks", True))
-        self.collect_audits_enabled = is_affirmative(self.instance.get("collect_audits", True))
-        self.collect_alerts_enabled = is_affirmative(self.instance.get("collect_alerts", True))
-        self.collect_subtasks_enabled = is_affirmative(self.instance.get("collect_subtasks", False))
-
-        self.batch_vm_collection = is_affirmative(self.instance.get("batch_vm_collection", True))
-
-        self.exclude_filtered_resources_from_cluster_capacity = is_affirmative(
-            self.instance.get("exclude_filtered_resources_from_cluster_capacity", False)
+        self.resource_filters = parse_resource_filters(
+            [rf.model_dump() for rf in (self.config.resource_filters or ())], self.log
         )
-
-        self.prefix_category_tags = is_affirmative(self.instance.get("prefix_category_tags", False))
-
-        self.resource_filters = parse_resource_filters(self.instance.get("resource_filters") or [], self.log)
 
     def _initialize_check_attributes(self):
         self.base_url = f"{self.pc_ip}:{self.pc_port}"
@@ -75,7 +49,7 @@ class NutanixCheck(AgentCheck):
 
         self.health_check_url = f"{self.base_url}/console"
 
-        self.base_tags = list(self.instance.get("tags", []))
+        self.base_tags = list(self.config.tags or ())
         self.base_tags.append("nutanix")
         self.base_tags.append(f"prism_central:{self.pc_ip}")
 
@@ -135,7 +109,7 @@ class NutanixCheck(AgentCheck):
                 value = category.get("value")
 
                 if key and value:
-                    if self.prefix_category_tags:
+                    if self.config.prefix_category_tags:
                         tags.append(f"ntnx_{key}:{value}")
                     else:
                         tags.append(f"{key}:{value}")
@@ -184,13 +158,13 @@ class NutanixCheck(AgentCheck):
 
     def _collect_activity(self) -> None:
         """Collect events, tasks, audits, and alerts if enabled."""
-        if self.collect_events_enabled:
+        if self.config.collect_events:
             self.activity_monitor.collect_events()
-        if self.collect_alerts_enabled:
+        if self.config.collect_alerts:
             self.activity_monitor.collect_alerts()
-        if self.collect_tasks_enabled:
+        if self.config.collect_tasks:
             self.activity_monitor.collect_tasks()
-        if self.collect_audits_enabled:
+        if self.config.collect_audits:
             self.activity_monitor.collect_audits()
 
     def _check_health(self):
@@ -281,7 +255,7 @@ class NutanixCheck(AgentCheck):
 
         # init pagination
         page = 0
-        limit = self.page_limit
+        limit = self.config.page_limit
 
         req_params = {} if params is None else params.copy()
         req_params["$page"] = page

--- a/nutanix/datadog_checks/nutanix/check.py
+++ b/nutanix/datadog_checks/nutanix/check.py
@@ -23,9 +23,9 @@ class NutanixCheck(AgentCheck, ConfigMixin):
         super().__init__(name, init_config, instances)
         # Insert after load_configuration_models but before __initialize_persistent_cache_key_prefix
         # so that ActivityMonitor reads persistent cache with an empty prefix (preserving existing cache keys)
-        self.check_initializations.insert(1, self._initialize)
+        self.check_initializations.insert(1, self._initialize_check)
 
-    def _initialize(self):
+    def _initialize_check(self):
         self.pc_ip = self.config.pc_ip
         self.pc_port = self.config.pc_port or 9440
         if ":" in self.pc_ip:

--- a/nutanix/datadog_checks/nutanix/config_models/instance.py
+++ b/nutanix/datadog_checks/nutanix/config_models/instance.py
@@ -103,9 +103,9 @@ class InstanceConfig(BaseModel):
     ntlm_domain: Optional[str] = None
     page_limit: Optional[int] = None
     password: Optional[str] = None
-    pc_base_backoff_seconds: Optional[float] = None
+    pc_base_backoff_seconds: Optional[int] = None
     pc_ip: str
-    pc_max_backoff_seconds: Optional[float] = None
+    pc_max_backoff_seconds: Optional[int] = None
     pc_max_retries: Optional[int] = None
     pc_password: str
     pc_port: Optional[int] = None

--- a/nutanix/datadog_checks/nutanix/data/conf.yaml.example
+++ b/nutanix/datadog_checks/nutanix/data/conf.yaml.example
@@ -54,14 +54,14 @@ instances:
     #
     # pc_max_retries: 3
 
-    ## @param pc_base_backoff_seconds - number - optional - default: 1
+    ## @param pc_base_backoff_seconds - integer - optional - default: 1
     ## The initial backoff duration in seconds when retrying rate-limited requests.
     ## The actual backoff time uses exponential backoff: base * (2 ^ attempt) + jitter.
     ## Default is 1 second.
     #
     # pc_base_backoff_seconds: 1
 
-    ## @param pc_max_backoff_seconds - number - optional - default: 30
+    ## @param pc_max_backoff_seconds - integer - optional - default: 30
     ## The maximum backoff duration in seconds when retrying rate-limited requests.
     ## This caps the exponential backoff calculation to prevent excessive wait times.
     ## Default is 30 seconds.

--- a/nutanix/datadog_checks/nutanix/infrastructure_monitor.py
+++ b/nutanix/datadog_checks/nutanix/infrastructure_monitor.py
@@ -118,7 +118,7 @@ class InfrastructureMonitor:
             if cluster_id and cluster_name:
                 self.cluster_names[cluster_id] = cluster_name
 
-        if self.check.batch_vm_collection:
+        if self.check.config.batch_vm_collection:
             try:
                 self._build_vms_by_host_cache()
                 self.check.log.info("[%s] Cached VMs for %d hosts", self._pc_label, len(self._vms_by_host))
@@ -256,7 +256,7 @@ class InfrastructureMonitor:
     def _report_cluster_capacity_metrics(self, hosts: list[dict], cluster_id: str, cluster_tags: list[str]) -> None:
         """Aggregate host and VM capacity for the cluster and report metrics."""
         self._cluster_capacity.reset()
-        exclude_filtered = self.check.exclude_filtered_resources_from_cluster_capacity
+        exclude_filtered = self.check.config.exclude_filtered_resources_from_cluster_capacity
 
         host_ids = set()
         for host in hosts:
@@ -568,7 +568,7 @@ class InfrastructureMonitor:
             "$startTime": start_time,
             "$endTime": end_time,
             "$statType": "AVG",
-            "$samplingInterval": self.check.sampling_interval,
+            "$samplingInterval": self.check.config.min_collection_interval,
         }
 
     def _get_stats(self, endpoint: str) -> dict:
@@ -602,6 +602,6 @@ class InfrastructureMonitor:
     def init_collection_time_window(self) -> None:
         """Calculate and set the collection time window for this check run."""
         now = datetime.now(timezone.utc)
-        end_time = now - timedelta(seconds=self.check.sampling_interval)
-        start_time = end_time - timedelta(seconds=self.check.sampling_interval)
+        end_time = now - timedelta(seconds=self.check.config.min_collection_interval)
+        start_time = end_time - timedelta(seconds=self.check.config.min_collection_interval)
         self.collection_time_window = start_time.isoformat(), end_time.isoformat()

--- a/nutanix/datadog_checks/nutanix/infrastructure_monitor.py
+++ b/nutanix/datadog_checks/nutanix/infrastructure_monitor.py
@@ -568,7 +568,7 @@ class InfrastructureMonitor:
             "$startTime": start_time,
             "$endTime": end_time,
             "$statType": "AVG",
-            "$samplingInterval": self.check.config.min_collection_interval,
+            "$samplingInterval": int(self.check.config.min_collection_interval),
         }
 
     def _get_stats(self, endpoint: str) -> dict:

--- a/nutanix/datadog_checks/nutanix/resource_filters.py
+++ b/nutanix/datadog_checks/nutanix/resource_filters.py
@@ -32,9 +32,8 @@ def _validate_filter_structure(f: dict[str, Any]) -> bool:
     """Check if filter has required 'resource', 'property', and 'patterns' fields."""
     return (
         isinstance(f, dict)
-        and 'resource' in f
-        and 'property' in f
-        and 'patterns' in f
+        and f.get('resource') is not None
+        and f.get('property') is not None
         and isinstance(f.get('patterns'), (list, tuple))
     )
 

--- a/nutanix/datadog_checks/nutanix/resource_filters.py
+++ b/nutanix/datadog_checks/nutanix/resource_filters.py
@@ -35,7 +35,7 @@ def _validate_filter_structure(f: dict[str, Any]) -> bool:
         and 'resource' in f
         and 'property' in f
         and 'patterns' in f
-        and isinstance(f.get('patterns'), list)
+        and isinstance(f.get('patterns'), (list, tuple))
     )
 
 

--- a/nutanix/datadog_checks/nutanix/utils.py
+++ b/nutanix/datadog_checks/nutanix/utils.py
@@ -27,8 +27,8 @@ def retry_on_rate_limit(method: Callable[..., Response]) -> Callable[..., Respon
     @wraps(method)
     def wrapper(self, *args, **kwargs) -> Response:
         max_retries: int = max(1, self.config.pc_max_retries)
-        base_backoff: float = self.config.pc_base_backoff_seconds
-        max_backoff: float = self.config.pc_max_backoff_seconds
+        base_backoff: int = self.config.pc_base_backoff_seconds
+        max_backoff: int = self.config.pc_max_backoff_seconds
 
         response = method(self, *args, **kwargs)
         for attempt in range(1, max_retries):

--- a/nutanix/datadog_checks/nutanix/utils.py
+++ b/nutanix/datadog_checks/nutanix/utils.py
@@ -26,9 +26,9 @@ def retry_on_rate_limit(method: Callable[..., Response]) -> Callable[..., Respon
 
     @wraps(method)
     def wrapper(self, *args, **kwargs) -> Response:
-        max_retries: int = max(1, self.instance.get('pc_max_retries', 3))
-        base_backoff: int = self.instance.get('pc_base_backoff_seconds', 1)
-        max_backoff: int = self.instance.get('pc_max_backoff_seconds', 30)
+        max_retries: int = max(1, self.config.pc_max_retries)
+        base_backoff: float = self.config.pc_base_backoff_seconds
+        max_backoff: float = self.config.pc_max_backoff_seconds
 
         response = method(self, *args, **kwargs)
         for attempt in range(1, max_retries):

--- a/nutanix/tests/test_clusters.py
+++ b/nutanix/tests/test_clusters.py
@@ -104,7 +104,7 @@ def test_pc_ip_with_port_raises_error(dd_run_check, mock_instance):
     instance = mock_instance.copy()
     instance['pc_ip'] = '10.0.0.197:9440'
 
-    with pytest.raises(Exception, match="Conflicting port configuration between pc_ip"):
+    with pytest.raises(Exception, match="Conflicting port configuration"):
         check = NutanixCheck('nutanix', {}, [instance])
         dd_run_check(check)
 

--- a/nutanix/tests/test_clusters.py
+++ b/nutanix/tests/test_clusters.py
@@ -7,7 +7,6 @@ import logging
 
 import pytest
 
-from datadog_checks.base import ConfigurationError
 from datadog_checks.nutanix import NutanixCheck
 from tests.constants import BASE_TAGS, CLUSTER_TAGS
 
@@ -93,29 +92,30 @@ def test_prism_central_cluster_skipped(dd_run_check, aggregator, mock_instance, 
     assert len(pc_metrics) == 0
 
 
-def test_missing_pc_ip_raises_error():
-    with pytest.raises(ConfigurationError, match="pc_ip is required"):
-        NutanixCheck('nutanix', {}, [{"pc_username": "admin", "pc_password": "secret"}])
+def test_missing_pc_ip_raises_error(dd_run_check):
+    with pytest.raises(Exception, match="(?s)pc_ip.*required"):
+        check = NutanixCheck('nutanix', {}, [{"pc_username": "admin", "pc_password": "secret"}])
+        dd_run_check(check)
 
 
-def test_pc_ip_with_port_raises_error(mock_instance):
+def test_pc_ip_with_port_raises_error(dd_run_check, mock_instance):
     """Test that ConfigurationError is raised when pc_ip contains a port."""
 
     instance = mock_instance.copy()
     instance['pc_ip'] = '10.0.0.197:9440'
 
-    with pytest.raises(ConfigurationError) as exc_info:
-        NutanixCheck('nutanix', {}, [instance])
+    with pytest.raises(Exception, match="Conflicting port configuration between pc_ip"):
+        check = NutanixCheck('nutanix', {}, [instance])
+        dd_run_check(check)
 
-    assert "Conflicting port configuration between pc_ip (9440) and pc_port (9440)" in str(exc_info.value)
 
-
-def test_pc_ip_without_port(mock_instance):
+def test_pc_ip_without_port(dd_run_check, mock_instance, mock_http_get):
     """Test that pc_port is used when pc_ip has no port."""
     instance = mock_instance.copy()
     instance['pc_ip'] = '10.0.0.197'
 
     check = NutanixCheck('nutanix', {}, [instance])
+    dd_run_check(check)
 
     assert check.pc_ip == '10.0.0.197'
     assert check.pc_port == 9440

--- a/nutanix/tests/test_configuration.py
+++ b/nutanix/tests/test_configuration.py
@@ -5,19 +5,19 @@
 
 import pytest
 
-from datadog_checks.base import ConfigurationError
 from datadog_checks.nutanix import NutanixCheck
 
 pytestmark = [pytest.mark.unit]
 
 
-def test_conflicting_port_configuration_raises_error(mock_instance):
+def test_conflicting_port_configuration_raises_error(dd_run_check, mock_instance):
     instance = mock_instance.copy()
     instance['pc_ip'] = '10.0.0.197:9441'
     instance['pc_port'] = 9440
 
-    with pytest.raises(ConfigurationError):
-        NutanixCheck('nutanix', {}, [instance])
+    with pytest.raises(Exception, match="Conflicting port configuration"):
+        check = NutanixCheck('nutanix', {}, [instance])
+        dd_run_check(check)
 
 
 def test_events_disabled_no_events_collected(dd_run_check, aggregator, mock_instance, mock_http_get):

--- a/nutanix/tests/test_metadata.py
+++ b/nutanix/tests/test_metadata.py
@@ -61,9 +61,12 @@ def test_version_metadata(dd_run_check, mock_instance, mock_http_get, datadog_ag
         ('pc.2024.3', '2024', '3'),
     ],
 )
-def test_version_metadata_formats(mock_instance, datadog_agent, version, expected_major, expected_minor):
+def test_version_metadata_formats(
+    dd_run_check, mock_instance, mock_http_get, datadog_agent, version, expected_major, expected_minor
+):
     check = NutanixCheck('nutanix', {}, [mock_instance])
     check.check_id = 'test:123'
+    dd_run_check(check)
 
     pc_cluster = {'config': {'buildInfo': {'version': version}, 'clusterFunction': ['PRISM_CENTRAL']}}
     check.infrastructure_monitor._collect_pc_version_metadata(pc_cluster)

--- a/nutanix/tests/test_retry.py
+++ b/nutanix/tests/test_retry.py
@@ -13,8 +13,11 @@ from datadog_checks.nutanix import NutanixCheck
 pytestmark = [pytest.mark.unit]
 
 
-def test_retry_on_rate_limit_success_no_retry(dd_run_check, aggregator, mock_instance, mocker):
+def test_retry_on_rate_limit_success_no_retry(dd_run_check, aggregator, mock_instance, mock_http_get, mocker):
     """Test successful request without needing retries."""
+    check = NutanixCheck('nutanix', {}, [mock_instance])
+    dd_run_check(check)
+
     mock_response = Mock(spec=Response)
     mock_response.status_code = 200
     mock_response.json.return_value = {"data": {"test": "data"}}
@@ -23,7 +26,6 @@ def test_retry_on_rate_limit_success_no_retry(dd_run_check, aggregator, mock_ins
 
     mock_get = mocker.patch('requests.Session.get', return_value=mock_response)
 
-    check = NutanixCheck('nutanix', {}, [mock_instance])
     result = check._get_request_data("api/test")
 
     assert result == {"test": "data"}
@@ -31,8 +33,11 @@ def test_retry_on_rate_limit_success_no_retry(dd_run_check, aggregator, mock_ins
     aggregator.assert_metric("nutanix.api.rate_limited", count=0)
 
 
-def test_retry_on_rate_limit_429_then_success(dd_run_check, aggregator, mock_instance, mocker):
+def test_retry_on_rate_limit_429_then_success(dd_run_check, aggregator, mock_instance, mock_http_get, mocker):
     """Test retry on 429 rate limit, then success."""
+    check = NutanixCheck('nutanix', {}, [mock_instance])
+    dd_run_check(check)
+
     # First response: 429 rate limited
     mock_response_429 = Mock(spec=Response)
     mock_response_429.status_code = 429
@@ -49,7 +54,6 @@ def test_retry_on_rate_limit_429_then_success(dd_run_check, aggregator, mock_ins
     mock_get = mocker.patch('requests.Session.get', side_effect=[mock_response_429, mock_response_200])
     mock_sleep = mocker.patch('time.sleep')
 
-    check = NutanixCheck('nutanix', {}, [mock_instance])
     result = check._get_request_data("api/test")
 
     assert result == {"test": "data"}
@@ -63,8 +67,13 @@ def test_retry_on_rate_limit_429_then_success(dd_run_check, aggregator, mock_ins
     aggregator.assert_metric("nutanix.api.rate_limited", value=1, tags=['nutanix', 'prism_central:10.0.0.197'])
 
 
-def test_retry_on_rate_limit_max_retries_exceeded(dd_run_check, aggregator, mock_instance, mocker):
+def test_retry_on_rate_limit_max_retries_exceeded(dd_run_check, aggregator, mock_instance, mock_http_get, mocker):
     """Test max retries exceeded with continuous 429 responses."""
+    mock_instance['pc_max_retries'] = 2
+
+    check = NutanixCheck('nutanix', {}, [mock_instance])
+    dd_run_check(check)
+
     mock_response_429 = Mock(spec=Response)
     mock_response_429.status_code = 429
     mock_response_429.raise_for_status.side_effect = HTTPError(response=mock_response_429)
@@ -72,11 +81,6 @@ def test_retry_on_rate_limit_max_retries_exceeded(dd_run_check, aggregator, mock
 
     mock_get = mocker.patch('requests.Session.get', return_value=mock_response_429)
     mock_sleep = mocker.patch('time.sleep')
-
-    # Set max_retries to 2 for faster test
-    mock_instance['pc_max_retries'] = 2
-
-    check = NutanixCheck('nutanix', {}, [mock_instance])
 
     with pytest.raises(HTTPError):
         check._get_request_data("api/test")
@@ -88,8 +92,11 @@ def test_retry_on_rate_limit_max_retries_exceeded(dd_run_check, aggregator, mock
     aggregator.assert_metric("nutanix.api.rate_limited", tags=['nutanix', 'prism_central:10.0.0.197'])
 
 
-def test_retry_on_non_429_error_no_retry(dd_run_check, aggregator, mock_instance, mocker):
+def test_retry_on_non_429_error_no_retry(dd_run_check, aggregator, mock_instance, mock_http_get, mocker):
     """Test that non-429 HTTP errors are not retried."""
+    check = NutanixCheck('nutanix', {}, [mock_instance])
+    dd_run_check(check)
+
     # 500 Internal Server Error
     mock_response_500 = Mock(spec=Response)
     mock_response_500.status_code = 500
@@ -98,8 +105,6 @@ def test_retry_on_non_429_error_no_retry(dd_run_check, aggregator, mock_instance
 
     mock_get = mocker.patch('requests.Session.get', return_value=mock_response_500)
     mock_sleep = mocker.patch('time.sleep')
-
-    check = NutanixCheck('nutanix', {}, [mock_instance])
 
     with pytest.raises(HTTPError):
         check._get_request_data("api/test")
@@ -111,12 +116,14 @@ def test_retry_on_non_429_error_no_retry(dd_run_check, aggregator, mock_instance
     aggregator.assert_metric("nutanix.api.rate_limited", count=0)
 
 
-def test_retry_with_custom_config(dd_run_check, aggregator, mock_instance, mocker):
+def test_retry_with_custom_config(dd_run_check, aggregator, mock_instance, mock_http_get, mocker):
     """Test retry with custom configuration parameters."""
-    # Configure custom retry parameters
     mock_instance['pc_max_retries'] = 5
     mock_instance['pc_base_backoff_seconds'] = 2
     mock_instance['pc_max_backoff_seconds'] = 10
+
+    check = NutanixCheck('nutanix', {}, [mock_instance])
+    dd_run_check(check)
 
     # First two responses: 429, then success
     mock_response_429 = Mock(spec=Response)
@@ -133,7 +140,6 @@ def test_retry_with_custom_config(dd_run_check, aggregator, mock_instance, mocke
     mock_get = mocker.patch('requests.Session.get', side_effect=[mock_response_429, mock_response_200])
     mock_sleep = mocker.patch('time.sleep')
 
-    check = NutanixCheck('nutanix', {}, [mock_instance])
     result = check._get_request_data("api/test")
 
     assert result == {"test": "data"}
@@ -144,12 +150,14 @@ def test_retry_with_custom_config(dd_run_check, aggregator, mock_instance, mocke
     assert 4.0 <= sleep_time <= 5.0
 
 
-def test_retry_exponential_backoff(dd_run_check, aggregator, mock_instance, mocker):
+def test_retry_exponential_backoff(dd_run_check, aggregator, mock_instance, mock_http_get, mocker):
     """Test exponential backoff calculation."""
-    # Configure to allow 4 retries
     mock_instance['pc_max_retries'] = 4
     mock_instance['pc_base_backoff_seconds'] = 1
     mock_instance['pc_max_backoff_seconds'] = 20
+
+    check = NutanixCheck('nutanix', {}, [mock_instance])
+    dd_run_check(check)
 
     # Four 429 responses, then success
     mock_response_429 = Mock(spec=Response)
@@ -168,7 +176,6 @@ def test_retry_exponential_backoff(dd_run_check, aggregator, mock_instance, mock
     )
     mock_sleep = mocker.patch('time.sleep')
 
-    check = NutanixCheck('nutanix', {}, [mock_instance])
     result = check._get_request_data("api/test")
 
     assert result == {"test": "data"}
@@ -188,9 +195,12 @@ def test_retry_exponential_backoff(dd_run_check, aggregator, mock_instance, mock
     assert 8.0 <= sleep_times[2] <= 9.0
 
 
-def test_retry_disabled_with_zero_max_retries(dd_run_check, aggregator, mock_instance, mocker):
+def test_retry_disabled_with_zero_max_retries(dd_run_check, aggregator, mock_instance, mock_http_get, mocker):
     """Test that setting max_retries to 0 disables retry logic."""
     mock_instance['pc_max_retries'] = 0
+
+    check = NutanixCheck('nutanix', {}, [mock_instance])
+    dd_run_check(check)
 
     mock_response_429 = Mock(spec=Response)
     mock_response_429.status_code = 429
@@ -199,8 +209,6 @@ def test_retry_disabled_with_zero_max_retries(dd_run_check, aggregator, mock_ins
 
     mock_get = mocker.patch('requests.Session.get', return_value=mock_response_429)
     mock_sleep = mocker.patch('time.sleep')
-
-    check = NutanixCheck('nutanix', {}, [mock_instance])
 
     with pytest.raises(HTTPError):
         check._get_request_data("api/test")
@@ -213,8 +221,11 @@ def test_retry_disabled_with_zero_max_retries(dd_run_check, aggregator, mock_ins
     aggregator.assert_metric("nutanix.api.rate_limited", count=0)
 
 
-def test_health_check_with_retry(dd_run_check, aggregator, mock_instance, mocker):
+def test_health_check_with_retry(dd_run_check, aggregator, mock_instance, mock_http_get, mocker):
     """Test health check endpoint uses retry logic."""
+    check = NutanixCheck('nutanix', {}, [mock_instance])
+    dd_run_check(check)
+
     # First response: 429 rate limited
     mock_response_429 = Mock(spec=Response)
     mock_response_429.status_code = 429
@@ -230,7 +241,6 @@ def test_health_check_with_retry(dd_run_check, aggregator, mock_instance, mocker
     mock_get = mocker.patch('requests.Session.get', side_effect=[mock_response_429, mock_response_200])
     mock_sleep = mocker.patch('time.sleep')
 
-    check = NutanixCheck('nutanix', {}, [mock_instance])
     result = check._check_health()
 
     assert result is True


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Replace raw self.instance.get() config access with typed self.config.* from ConfigMixin. Use check_initializations for deferred config parsing, HTTP_CONFIG_REMAPPER for credential passthrough, and direct config reads at call sites instead of cached boolean copies.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
