### PR TITLE
Add context compaction to AI framework

### DIFF
--- a/ddev/src/ddev/ai/agent/anthropic_client.py
+++ b/ddev/src/ddev/ai/agent/anthropic_client.py
@@ -41,11 +41,8 @@ class AnthropicAgent(BaseAgent[MessageParam]):
             programmatic_tool_calling: Whether to allow programmatic tool calling.
         """
 
-        super().__init__()
+        super().__init__(name=name, system_prompt=system_prompt, tools=tools)
         self._client = client
-        self._tools = tools
-        self._system_prompt = system_prompt
-        self.name = name
         self._model = model
         self._max_tokens = max_tokens
         self._programmatic_tool_calling = programmatic_tool_calling

--- a/ddev/src/ddev/ai/agent/base.py
+++ b/ddev/src/ddev/ai/agent/base.py
@@ -4,20 +4,41 @@
 
 from abc import ABC, abstractmethod
 from copy import deepcopy
+from typing import Final
 
 from ddev.ai.agent.types import AgentResponse, ToolResultMessage
+from ddev.ai.tools.core.registry import ToolRegistry
+
+_COMPACT_SYSTEM_PROMPT: Final[str] = """\
+You are summarizing an agentic conversation to free up context space.
+Produce a dense, structured summary that covers ALL of the following:
+  1. The original task given to the agent
+  2. Every tool call made and the key finding or result from each
+  3. Any decisions, conclusions, or hypotheses the agent reached
+  4. What has been completed and what work remains
+
+Rules:
+- Be exhaustive on facts and findings; omit raw data already consumed
+- Use bullet points, not prose
+- The agent will read ONLY this summary to continue — it must be self-sufficient
+"""
+
+_COMPACT_REQUEST: Final[str] = "Summarize the conversation so far following your instructions."
 
 
 class BaseAgent[TMessage](ABC):
     """Abstract base class for all agent implementations.
 
-    Provides shared, provider-agnostic history management. The message type
-    TMessage is supplied by each concrete provider (e.g. MessageParam for Anthropic).
-    Subclasses must implement send().
+    Provides shared, provider-agnostic history management and compaction.
+    The message type TMessage is supplied by each concrete provider
+    (e.g. MessageParam for Anthropic). Subclasses must implement send().
     """
 
-    def __init__(self) -> None:
+    def __init__(self, name: str, system_prompt: str, tools: ToolRegistry) -> None:
         self._history: list[TMessage] = []
+        self.name = name
+        self._system_prompt = system_prompt
+        self._tools = tools
 
     @property
     def history(self) -> list[TMessage]:
@@ -27,6 +48,25 @@ class BaseAgent[TMessage](ABC):
     def reset(self) -> None:
         """Clear conversation history to start a new conversation."""
         self._history = []
+
+    async def compact(self) -> None:
+        """Collapse history to 2 messages: original task + LLM summary. No-op if already ≤ 2."""
+        if len(self._history) <= 2:
+            return
+
+        original_prompt = self._history[0]
+        original_system = self._system_prompt
+
+        self._system_prompt = _COMPACT_SYSTEM_PROMPT
+        try:
+            await self.send(_COMPACT_REQUEST, allowed_tools=[])
+        finally:
+            self._system_prompt = original_system  # restore even if send() raises
+
+        compact_response = self._history[-1]  # summary message added by send()
+
+        self.reset()
+        self._history = [original_prompt, compact_response]
 
     @abstractmethod
     async def send(

--- a/ddev/src/ddev/ai/agent/base.py
+++ b/ddev/src/ddev/ai/agent/base.py
@@ -49,17 +49,21 @@ class BaseAgent[TMessage](ABC):
         """Clear conversation history to start a new conversation."""
         self._history = []
 
-    async def compact(self) -> None:
-        """Collapse history to 2 messages: original task + LLM summary. No-op if already ≤ 2."""
+    async def compact(self) -> AgentResponse | None:
+        """Collapse history to 2 messages: original task + LLM summary.
+
+        Returns the AgentResponse from the compaction call so callers can
+        account for its token usage. Returns None if history is already ≤ 2.
+        """
         if len(self._history) <= 2:
-            return
+            return None
 
         original_prompt = self._history[0]
         original_system = self._system_prompt
 
         self._system_prompt = _COMPACT_SYSTEM_PROMPT
         try:
-            await self.send(_COMPACT_REQUEST, allowed_tools=[])
+            response = await self.send(_COMPACT_REQUEST, allowed_tools=[])
         finally:
             self._system_prompt = original_system  # restore even if send() raises
 
@@ -67,6 +71,27 @@ class BaseAgent[TMessage](ABC):
 
         self.reset()
         self._history = [original_prompt, compact_response]
+        return response
+
+    async def compact_preserving_last_turn(self) -> AgentResponse | None:
+        """Compact history while keeping the last user+assistant pair intact.
+
+        Used mid-ReAct loop where the last assistant message contains unresolved
+        tool calls that still need a tool-result response. After compaction the
+        preserved pair re-anchors the pending turn so the next send(tool_results)
+        produces a valid alternating message sequence. No-op if history is ≤ 3
+        messages (too short to compact without corrupting the sequence).
+
+        Returns the AgentResponse from the compaction call, or None if no
+        compaction occurred.
+        """
+        if len(self._history) <= 3:
+            return None
+
+        last_turn = self._history[-2:]  # [user(tool_results_N), assistant(tool_use_N+1)]
+        response = await self.compact()
+        self._history.extend(last_turn)
+        return response
 
     @abstractmethod
     async def send(

--- a/ddev/src/ddev/ai/react/callbacks.py
+++ b/ddev/src/ddev/ai/react/callbacks.py
@@ -33,6 +33,18 @@ class OnErrorCallback(Protocol):
     async def __call__(self, error: BaseException) -> None: ...
 
 
+class OnBeforeCompactCallback(Protocol):
+    """Called immediately before the agent's history is compacted."""
+
+    async def __call__(self) -> None: ...
+
+
+class OnAfterCompactCallback(Protocol):
+    """Called immediately after the agent's history has been compacted."""
+
+    async def __call__(self) -> None: ...
+
+
 class CallbackSet:
     """Decorator-based registry for ReAct lifecycle event handlers.
 
@@ -50,6 +62,8 @@ class CallbackSet:
         self._on_tool_call: list[OnToolCallCallback] = []
         self._on_complete: list[OnCompleteCallback] = []
         self._on_error: list[OnErrorCallback] = []
+        self._on_before_compact: list[OnBeforeCompactCallback] = []
+        self._on_after_compact: list[OnAfterCompactCallback] = []
 
     def on_agent_response(self, func: OnAgentResponseCallback) -> OnAgentResponseCallback:
         """Register a handler fired after every agent response."""
@@ -69,6 +83,16 @@ class CallbackSet:
     def on_error(self, func: OnErrorCallback) -> OnErrorCallback:
         """Register a handler fired when the loop aborts."""
         self._on_error.append(func)
+        return func
+
+    def on_before_compact(self, func: OnBeforeCompactCallback) -> OnBeforeCompactCallback:
+        """Register a handler fired just before compaction runs."""
+        self._on_before_compact.append(func)
+        return func
+
+    def on_after_compact(self, func: OnAfterCompactCallback) -> OnAfterCompactCallback:
+        """Register a handler fired just after compaction completes."""
+        self._on_after_compact.append(func)
         return func
 
     async def fire_agent_response(self, response: AgentResponse, iteration: int) -> None:
@@ -96,5 +120,19 @@ class CallbackSet:
         for handler in self._on_error:
             try:
                 await handler(error)
+            except Exception:
+                pass
+
+    async def fire_before_compact(self) -> None:
+        for handler in self._on_before_compact:
+            try:
+                await handler()
+            except Exception:
+                pass
+
+    async def fire_after_compact(self) -> None:
+        for handler in self._on_after_compact:
+            try:
+                await handler()
             except Exception:
                 pass

--- a/ddev/src/ddev/ai/react/callbacks.py
+++ b/ddev/src/ddev/ai/react/callbacks.py
@@ -33,13 +33,13 @@ class OnErrorCallback(Protocol):
     async def __call__(self, error: BaseException) -> None: ...
 
 
-class OnBeforeCompactCallback(Protocol):
+class BeforeCompactCallback(Protocol):
     """Called immediately before the agent's history is compacted."""
 
     async def __call__(self) -> None: ...
 
 
-class OnAfterCompactCallback(Protocol):
+class AfterCompactCallback(Protocol):
     """Called immediately after the agent's history has been compacted."""
 
     async def __call__(self) -> None: ...
@@ -62,8 +62,8 @@ class CallbackSet:
         self._on_tool_call: list[OnToolCallCallback] = []
         self._on_complete: list[OnCompleteCallback] = []
         self._on_error: list[OnErrorCallback] = []
-        self._on_before_compact: list[OnBeforeCompactCallback] = []
-        self._on_after_compact: list[OnAfterCompactCallback] = []
+        self._before_compact: list[BeforeCompactCallback] = []
+        self._after_compact: list[AfterCompactCallback] = []
 
     def on_agent_response(self, func: OnAgentResponseCallback) -> OnAgentResponseCallback:
         """Register a handler fired after every agent response."""
@@ -85,14 +85,14 @@ class CallbackSet:
         self._on_error.append(func)
         return func
 
-    def on_before_compact(self, func: OnBeforeCompactCallback) -> OnBeforeCompactCallback:
+    def on_before_compact(self, func: BeforeCompactCallback) -> BeforeCompactCallback:
         """Register a handler fired just before compaction runs."""
-        self._on_before_compact.append(func)
+        self._before_compact.append(func)
         return func
 
-    def on_after_compact(self, func: OnAfterCompactCallback) -> OnAfterCompactCallback:
+    def on_after_compact(self, func: AfterCompactCallback) -> AfterCompactCallback:
         """Register a handler fired just after compaction completes."""
-        self._on_after_compact.append(func)
+        self._after_compact.append(func)
         return func
 
     async def fire_agent_response(self, response: AgentResponse, iteration: int) -> None:
@@ -124,14 +124,14 @@ class CallbackSet:
                 pass
 
     async def fire_before_compact(self) -> None:
-        for handler in self._on_before_compact:
+        for handler in self._before_compact:
             try:
                 await handler()
             except Exception:
                 pass
 
     async def fire_after_compact(self) -> None:
-        for handler in self._on_after_compact:
+        for handler in self._after_compact:
             try:
                 await handler()
             except Exception:

--- a/ddev/src/ddev/ai/react/process.py
+++ b/ddev/src/ddev/ai/react/process.py
@@ -48,7 +48,11 @@ class ReActProcess:
 
     async def compact(self) -> None:
         """Compact the agent's conversation history unconditionally."""
-        await self._fire_compact()
+        for cb_set in self._callback_sets:
+            await cb_set.fire_before_compact()
+        await self._agent.compact()
+        for cb_set in self._callback_sets:
+            await cb_set.fire_after_compact()
 
     def _should_compact(self, response: AgentResponse) -> bool:
         if self._compact_threshold_pct is None:
@@ -57,13 +61,6 @@ class ReActProcess:
         if ctx is None:
             return False
         return ctx.context_pct >= self._compact_threshold_pct
-
-    async def _fire_compact(self) -> None:
-        for cb_set in self._callback_sets:
-            await cb_set.fire_before_compact()
-        await self._agent.compact()
-        for cb_set in self._callback_sets:
-            await cb_set.fire_after_compact()
 
     async def start(self, prompt: str, allowed_tools: list[str] | None = None) -> ReActResult:
         """
@@ -119,7 +116,7 @@ class ReActProcess:
                     await cb_set.fire_agent_response(response, iterations)
 
                 if self._should_compact(response):
-                    await self._fire_compact()
+                    await self.compact()
 
             react_result = ReActResult(
                 final_response=response,

--- a/ddev/src/ddev/ai/react/process.py
+++ b/ddev/src/ddev/ai/react/process.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from ddev.ai.agent.base import BaseAgent
 from ddev.ai.agent.exceptions import AgentError
-from ddev.ai.agent.types import StopReason, ToolResultMessage
+from ddev.ai.agent.types import AgentResponse, StopReason, ToolResultMessage
 from ddev.ai.react.callbacks import CallbackSet
 from ddev.ai.react.types import ReActResult
 from ddev.ai.tools.core.registry import ToolRegistry
@@ -27,16 +27,43 @@ class ReActProcess:
         agent: BaseAgent[Any],
         tool_registry: ToolRegistry,
         callback_sets: list[CallbackSet] | None = None,
+        compact_threshold_pct: float | None = 75.0,
     ) -> None:
         """
         Args:
             agent: A BaseAgent subclass (e.g. AnthropicAgent).
             tool_registry: Registry of tools available in this loop.
             callback_sets: Optional CallbackSet instances to observe loop events.
+            compact_threshold_pct: Context usage percentage at which the loop auto-compacts.
+                None disables auto-compaction entirely.
         """
         self._agent = agent
         self._tool_registry = tool_registry
         self._callback_sets: list[CallbackSet] = callback_sets or []
+        self._compact_threshold_pct = compact_threshold_pct
+
+    def reset(self) -> None:
+        """Clear the agent's conversation history."""
+        self._agent.reset()
+
+    async def compact(self) -> None:
+        """Compact the agent's conversation history unconditionally."""
+        await self._fire_compact()
+
+    def _should_compact(self, response: AgentResponse) -> bool:
+        if self._compact_threshold_pct is None:
+            return False
+        ctx = response.usage.context_usage
+        if ctx is None:
+            return False
+        return ctx.context_pct >= self._compact_threshold_pct
+
+    async def _fire_compact(self) -> None:
+        for cb_set in self._callback_sets:
+            await cb_set.fire_before_compact()
+        await self._agent.compact()
+        for cb_set in self._callback_sets:
+            await cb_set.fire_after_compact()
 
     async def start(self, prompt: str, allowed_tools: list[str] | None = None) -> ReActResult:
         """
@@ -90,6 +117,9 @@ class ReActProcess:
 
                 for cb_set in self._callback_sets:
                     await cb_set.fire_agent_response(response, iterations)
+
+                if self._should_compact(response):
+                    await self._fire_compact()
 
             react_result = ReActResult(
                 final_response=response,

--- a/ddev/src/ddev/ai/react/process.py
+++ b/ddev/src/ddev/ai/react/process.py
@@ -47,20 +47,34 @@ class ReActProcess:
         self._agent.reset()
 
     async def compact(self) -> None:
-        """Compact the agent's conversation history unconditionally."""
+        """Compact the agent's conversation history unconditionally.
+        Compaction does not preserve the last user+assistant pair."""
         for cb_set in self._callback_sets:
             await cb_set.fire_before_compact()
         await self._agent.compact()
         for cb_set in self._callback_sets:
             await cb_set.fire_after_compact()
 
-    def _should_compact(self, response: AgentResponse) -> bool:
+    async def _compact_if_needed(self, response: AgentResponse) -> tuple[int, int]:
+        """Compact mid-loop if the context threshold is exceeded.
+
+        Returns (input_tokens, output_tokens) from the compaction call so the
+        caller can add them to the running totals. Returns (0, 0) if no
+        compaction occurred.
+        """
         if self._compact_threshold_pct is None:
-            return False
+            return 0, 0
         ctx = response.usage.context_usage
-        if ctx is None:
-            return False
-        return ctx.context_pct >= self._compact_threshold_pct
+        if ctx is None or ctx.context_pct < self._compact_threshold_pct:
+            return 0, 0
+        for cb_set in self._callback_sets:
+            await cb_set.fire_before_compact()
+        compact_response = await self._agent.compact_preserving_last_turn()
+        for cb_set in self._callback_sets:
+            await cb_set.fire_after_compact()
+        if compact_response is None:
+            return 0, 0
+        return compact_response.usage.input_tokens, compact_response.usage.output_tokens
 
     async def start(self, prompt: str, allowed_tools: list[str] | None = None) -> ReActResult:
         """
@@ -115,8 +129,9 @@ class ReActProcess:
                 for cb_set in self._callback_sets:
                     await cb_set.fire_agent_response(response, iterations)
 
-                if self._should_compact(response):
-                    await self.compact()
+                compact_in, compact_out = await self._compact_if_needed(response)
+                total_input += compact_in
+                total_output += compact_out
 
             react_result = ReActResult(
                 final_response=response,

--- a/ddev/src/ddev/ai/react/process.py
+++ b/ddev/src/ddev/ai/react/process.py
@@ -46,46 +46,37 @@ class ReActProcess:
         """Clear the agent's conversation history."""
         self._agent.reset()
 
-    async def compact(self) -> tuple[int, int]:
+    async def compact(self, response: AgentResponse | None = None) -> tuple[int, int]:
         """Compact the agent's conversation history unconditionally.
 
-        Compaction does not preserve the last user+assistant pair.
+        Args:
+            response: The last agent response. If None, compaction is unconditional.
+
         Returns (input_tokens, output_tokens) from the compaction API call.
         Returns (0, 0) if history was already compact and no API call was made.
         """
         for cb_set in self._callback_sets:
             await cb_set.fire_before_compact()
-        response = await self._agent.compact()
-        for cb_set in self._callback_sets:
-            await cb_set.fire_after_compact()
-        if response is None:
-            return 0, 0
-        return response.usage.input_tokens, response.usage.output_tokens
 
-    async def _compact_if_needed(self, response: AgentResponse) -> tuple[int, int]:
-        """Compact mid-loop if the context threshold is exceeded.
-
-        Returns (input_tokens, output_tokens) from the compaction call so the
-        caller can add them to the running totals. Returns (0, 0) if no
-        compaction occurred.
-        """
-        if self._compact_threshold_pct is None:
-            return 0, 0
-        ctx = response.usage.context_usage
-        if ctx is None or ctx.context_pct < self._compact_threshold_pct:
-            return 0, 0
-        for cb_set in self._callback_sets:
-            await cb_set.fire_before_compact()
         compact_response = None
-        if response.stop_reason == StopReason.TOOL_USE:
-            compact_response = await self._agent.compact_preserving_last_turn()
-        else:
+        if response is None or response.stop_reason != StopReason.TOOL_USE:
             compact_response = await self._agent.compact()
+        else:
+            compact_response = await self._agent.compact_preserving_last_turn()
+
         for cb_set in self._callback_sets:
             await cb_set.fire_after_compact()
         if compact_response is None:
             return 0, 0
         return compact_response.usage.input_tokens, compact_response.usage.output_tokens
+
+    def _is_compact_needed(self, response: AgentResponse) -> bool:
+        if self._compact_threshold_pct is None:
+            return False
+        ctx = response.usage.context_usage
+        if ctx is None or ctx.context_pct < self._compact_threshold_pct:
+            return False
+        return True
 
     async def start(self, prompt: str, allowed_tools: list[str] | None = None) -> ReActResult:
         """
@@ -140,9 +131,10 @@ class ReActProcess:
                 for cb_set in self._callback_sets:
                     await cb_set.fire_agent_response(response, iterations)
 
-                compact_in, compact_out = await self._compact_if_needed(response)
-                total_input += compact_in
-                total_output += compact_out
+                if self._is_compact_needed(response):
+                    compact_in, compact_out = await self.compact(response)
+                    total_input += compact_in
+                    total_output += compact_out
 
             react_result = ReActResult(
                 final_response=response,

--- a/ddev/src/ddev/ai/react/process.py
+++ b/ddev/src/ddev/ai/react/process.py
@@ -46,14 +46,21 @@ class ReActProcess:
         """Clear the agent's conversation history."""
         self._agent.reset()
 
-    async def compact(self) -> None:
+    async def compact(self) -> tuple[int, int]:
         """Compact the agent's conversation history unconditionally.
-        Compaction does not preserve the last user+assistant pair."""
+
+        Compaction does not preserve the last user+assistant pair.
+        Returns (input_tokens, output_tokens) from the compaction API call.
+        Returns (0, 0) if history was already compact and no API call was made.
+        """
         for cb_set in self._callback_sets:
             await cb_set.fire_before_compact()
-        await self._agent.compact()
+        response = await self._agent.compact()
         for cb_set in self._callback_sets:
             await cb_set.fire_after_compact()
+        if response is None:
+            return 0, 0
+        return response.usage.input_tokens, response.usage.output_tokens
 
     async def _compact_if_needed(self, response: AgentResponse) -> tuple[int, int]:
         """Compact mid-loop if the context threshold is exceeded.

--- a/ddev/src/ddev/ai/react/process.py
+++ b/ddev/src/ddev/ai/react/process.py
@@ -76,7 +76,11 @@ class ReActProcess:
             return 0, 0
         for cb_set in self._callback_sets:
             await cb_set.fire_before_compact()
-        compact_response = await self._agent.compact_preserving_last_turn()
+        compact_response = None
+        if response.stop_reason == StopReason.TOOL_USE:
+            compact_response = await self._agent.compact_preserving_last_turn()
+        else:
+            compact_response = await self._agent.compact()
         for cb_set in self._callback_sets:
             await cb_set.fire_after_compact()
         if compact_response is None:

--- a/ddev/tests/ai/agent/test_base.py
+++ b/ddev/tests/ai/agent/test_base.py
@@ -156,3 +156,60 @@ async def test_compact_leaves_history_unchanged_on_send_error() -> None:
     with pytest.raises(RuntimeError):
         await agent.compact()
     assert agent._history == original_history
+
+
+# ---------------------------------------------------------------------------
+# compact_preserving_last_turn() — guard: history too short
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n_messages", [0, 1, 2, 3])
+async def test_compact_preserving_last_turn_does_nothing_when_history_is_short(n_messages: int) -> None:
+    agent = ConcreteAgent()
+    agent._history = make_history(n_messages)
+    await agent.compact_preserving_last_turn()
+    assert len(agent.send_calls) == 0
+    assert len(agent._history) == n_messages
+
+
+# ---------------------------------------------------------------------------
+# compact_preserving_last_turn() — collapses middle, keeps last two
+# ---------------------------------------------------------------------------
+
+
+async def test_compact_preserving_last_turn_keeps_last_two_messages() -> None:
+    agent = ConcreteAgent(responses=["summary"])
+    agent._history = make_history(6)
+    last_two = agent._history[-2:]
+    await agent.compact_preserving_last_turn()
+    assert agent.history[-2:] == last_two
+
+
+async def test_compact_preserving_last_turn_first_message_is_original_task() -> None:
+    agent = ConcreteAgent(responses=["summary"])
+    original = make_history(6)[0]
+    agent._history = make_history(6)
+    await agent.compact_preserving_last_turn()
+    assert agent.history[0] == original
+
+
+async def test_compact_preserving_last_turn_produces_four_messages() -> None:
+    agent = ConcreteAgent(responses=["summary"])
+    agent._history = make_history(6)
+    await agent.compact_preserving_last_turn()
+    # original + summary + last user + last assistant
+    assert len(agent.history) == 4
+
+
+# ---------------------------------------------------------------------------
+# compact_preserving_last_turn() — error leaves history unchanged
+# ---------------------------------------------------------------------------
+
+
+async def test_compact_preserving_last_turn_leaves_history_unchanged_on_error() -> None:
+    agent = ConcreteAgent(responses=[RuntimeError("api failure")])
+    original_history = make_history(6)
+    agent._history = list(original_history)
+    with pytest.raises(RuntimeError):
+        await agent.compact_preserving_last_turn()
+    assert agent._history == original_history

--- a/ddev/tests/ai/agent/test_base.py
+++ b/ddev/tests/ai/agent/test_base.py
@@ -159,6 +159,27 @@ async def test_compact_leaves_history_unchanged_on_send_error() -> None:
 
 
 # ---------------------------------------------------------------------------
+# compact() — return value
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n_messages", [0, 1, 2])
+async def test_compact_returns_none_when_history_too_short(n_messages: int) -> None:
+    agent = ConcreteAgent()
+    agent._history = make_history(n_messages)
+    result = await agent.compact()
+    assert result is None
+
+
+async def test_compact_returns_response_when_compaction_occurs() -> None:
+    agent = ConcreteAgent(responses=["the summary"])
+    agent._history = make_history(4)
+    result = await agent.compact()
+    assert result is not None
+    assert result.text == "the summary"
+
+
+# ---------------------------------------------------------------------------
 # compact_preserving_last_turn() — guard: history too short
 # ---------------------------------------------------------------------------
 

--- a/ddev/tests/ai/agent/test_base.py
+++ b/ddev/tests/ai/agent/test_base.py
@@ -1,0 +1,156 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import pytest
+
+from ddev.ai.agent.base import _COMPACT_SYSTEM_PROMPT, BaseAgent
+from ddev.ai.agent.types import AgentResponse, StopReason, TokenUsage, ToolResultMessage
+from ddev.ai.tools.core.registry import ToolRegistry
+
+# ---------------------------------------------------------------------------
+# Minimal concrete agent for testing BaseAgent
+# ---------------------------------------------------------------------------
+
+
+class ConcreteAgent(BaseAgent[dict]):
+    """Minimal BaseAgent subclass that records send() calls and replays configured responses."""
+
+    def __init__(self, responses: list[str | Exception] | None = None) -> None:
+        super().__init__(name="test", system_prompt="original", tools=ToolRegistry([]))
+        self._responses = list(responses or [])
+        self._idx = 0
+        self.send_calls: list[dict] = []
+
+    async def send(
+        self,
+        content: str | list[ToolResultMessage],
+        allowed_tools: list[str] | None = None,
+    ) -> AgentResponse:
+        self.send_calls.append(
+            {"content": content, "allowed_tools": allowed_tools, "system_prompt": self._system_prompt}
+        )
+        if self._idx < len(self._responses):
+            resp = self._responses[self._idx]
+            self._idx += 1
+            if isinstance(resp, Exception):
+                raise resp
+            text = resp
+        else:
+            text = "default summary"
+            self._idx += 1
+
+        # Simulate what a real provider does: append user + assistant messages.
+        self._history.extend(
+            [
+                {"role": "user", "content": content},
+                {"role": "assistant", "content": text},
+            ]
+        )
+        return AgentResponse(
+            stop_reason=StopReason.END_TURN,
+            text=text,
+            tool_calls=[],
+            usage=TokenUsage(input_tokens=0, output_tokens=0, cache_read_input_tokens=0, cache_creation_input_tokens=0),
+        )
+
+
+def make_history(n_messages: int) -> list[dict]:
+    """Build n_messages alternating user/assistant dicts for seeding _history directly."""
+    return [{"role": "user" if i % 2 == 0 else "assistant", "content": f"msg-{i}"} for i in range(n_messages)]
+
+
+# ---------------------------------------------------------------------------
+# compact() — guard: history too short
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n_messages", [0, 1, 2])
+async def test_compact_does_nothing_when_history_is_short(n_messages: int) -> None:
+    agent = ConcreteAgent()
+    agent._history = make_history(n_messages)
+    await agent.compact()
+    assert len(agent.send_calls) == 0
+    assert len(agent._history) == n_messages
+
+
+# ---------------------------------------------------------------------------
+# compact() — collapses history
+# ---------------------------------------------------------------------------
+
+
+async def test_compact_collapses_history_to_two_messages() -> None:
+    agent = ConcreteAgent(responses=["summary"])
+    agent._history = make_history(4)
+    await agent.compact()
+    assert len(agent.history) == 2
+
+
+async def test_compact_first_message_is_original_task() -> None:
+    agent = ConcreteAgent(responses=["summary"])
+    original = make_history(4)[0]
+    agent._history = make_history(4)
+    await agent.compact()
+    assert agent.history[0] == original
+
+
+async def test_compact_second_message_is_summary_response() -> None:
+    agent = ConcreteAgent(responses=["the summary text"])
+    agent._history = make_history(4)
+    await agent.compact()
+    summary_msg = agent.history[1]
+    assert summary_msg["role"] == "assistant"
+    assert summary_msg["content"] == "the summary text"
+
+
+# ---------------------------------------------------------------------------
+# compact() — system prompt swap
+# ---------------------------------------------------------------------------
+
+
+async def test_compact_uses_compaction_system_prompt() -> None:
+    agent = ConcreteAgent(responses=["summary"])
+    agent._history = make_history(4)
+    await agent.compact()
+    assert agent.send_calls[0]["system_prompt"] == _COMPACT_SYSTEM_PROMPT
+
+
+async def test_compact_restores_original_system_prompt() -> None:
+    agent = ConcreteAgent(responses=["summary"])
+    agent._history = make_history(4)
+    await agent.compact()
+    assert agent._system_prompt == "original"
+
+
+async def test_compact_restores_system_prompt_on_send_error() -> None:
+    agent = ConcreteAgent(responses=[RuntimeError("api failure")])
+    agent._history = make_history(4)
+    with pytest.raises(RuntimeError):
+        await agent.compact()
+    assert agent._system_prompt == "original"
+
+
+# ---------------------------------------------------------------------------
+# compact() — send() called with no tools
+# ---------------------------------------------------------------------------
+
+
+async def test_compact_send_uses_no_tools() -> None:
+    agent = ConcreteAgent(responses=["summary"])
+    agent._history = make_history(4)
+    await agent.compact()
+    assert agent.send_calls[0]["allowed_tools"] == []
+
+
+# ---------------------------------------------------------------------------
+# compact() — error leaves history unchanged
+# ---------------------------------------------------------------------------
+
+
+async def test_compact_leaves_history_unchanged_on_send_error() -> None:
+    agent = ConcreteAgent(responses=[RuntimeError("api failure")])
+    original_history = make_history(4)
+    agent._history = list(original_history)
+    with pytest.raises(RuntimeError):
+        await agent.compact()
+    assert agent._history == original_history

--- a/ddev/tests/ai/agent/test_base.py
+++ b/ddev/tests/ai/agent/test_base.py
@@ -8,6 +8,9 @@ from ddev.ai.agent.base import _COMPACT_SYSTEM_PROMPT, BaseAgent
 from ddev.ai.agent.types import AgentResponse, StopReason, TokenUsage, ToolResultMessage
 from ddev.ai.tools.core.registry import ToolRegistry
 
+_AGENT_NAME: str = "test"
+_AGENT_SYSTEM_PROMPT: str = "original"
+
 # ---------------------------------------------------------------------------
 # Minimal concrete agent for testing BaseAgent
 # ---------------------------------------------------------------------------
@@ -17,7 +20,7 @@ class ConcreteAgent(BaseAgent[dict]):
     """Minimal BaseAgent subclass that records send() calls and replays configured responses."""
 
     def __init__(self, responses: list[str | Exception] | None = None) -> None:
-        super().__init__(name="test", system_prompt="original", tools=ToolRegistry([]))
+        super().__init__(name=_AGENT_NAME, system_prompt=_AGENT_SYSTEM_PROMPT, tools=ToolRegistry([]))
         self._responses = list(responses or [])
         self._idx = 0
         self.send_calls: list[dict] = []
@@ -61,29 +64,28 @@ def make_history(n_messages: int) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
-# compact() — guard: history too short
+# compact() — history length after compact (guard cases + collapse)
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("n_messages", [0, 1, 2])
-async def test_compact_does_nothing_when_history_is_short(n_messages: int) -> None:
-    agent = ConcreteAgent()
+@pytest.mark.parametrize(
+    "n_messages, responses, expected_len",
+    [
+        (0, None, 0),
+        (1, None, 1),
+        (2, None, 2),
+        (4, ["summary"], 2),
+    ],
+)
+async def test_compact_history_length(
+    n_messages: int,
+    responses: list[str] | None,
+    expected_len: int,
+) -> None:
+    agent = ConcreteAgent(responses=responses)
     agent._history = make_history(n_messages)
     await agent.compact()
-    assert len(agent.send_calls) == 0
-    assert len(agent._history) == n_messages
-
-
-# ---------------------------------------------------------------------------
-# compact() — collapses history
-# ---------------------------------------------------------------------------
-
-
-async def test_compact_collapses_history_to_two_messages() -> None:
-    agent = ConcreteAgent(responses=["summary"])
-    agent._history = make_history(4)
-    await agent.compact()
-    assert len(agent.history) == 2
+    assert len(agent.history) == expected_len
 
 
 async def test_compact_first_message_is_original_task() -> None:
@@ -119,7 +121,7 @@ async def test_compact_restores_original_system_prompt() -> None:
     agent = ConcreteAgent(responses=["summary"])
     agent._history = make_history(4)
     await agent.compact()
-    assert agent._system_prompt == "original"
+    assert agent._system_prompt == _AGENT_SYSTEM_PROMPT
 
 
 async def test_compact_restores_system_prompt_on_send_error() -> None:
@@ -127,7 +129,7 @@ async def test_compact_restores_system_prompt_on_send_error() -> None:
     agent._history = make_history(4)
     with pytest.raises(RuntimeError):
         await agent.compact()
-    assert agent._system_prompt == "original"
+    assert agent._system_prompt == _AGENT_SYSTEM_PROMPT
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/ai/react/test_callbacks.py
+++ b/ddev/tests/ai/react/test_callbacks.py
@@ -182,3 +182,73 @@ async def test_fire_error_swallows_handler_exception() -> None:
 
     await cb.fire_error(ValueError("original error"))
     assert fired == [True]
+
+
+# ---------------------------------------------------------------------------
+# before_compact and after_compact
+# ---------------------------------------------------------------------------
+
+
+async def test_before_compact_registered_and_fired() -> None:
+    cb = CallbackSet()
+    fired: list[bool] = []
+
+    @cb.on_before_compact
+    async def h() -> None:
+        fired.append(True)
+
+    await cb.fire_before_compact()
+    assert fired == [True]
+
+
+async def test_after_compact_registered_and_fired() -> None:
+    cb = CallbackSet()
+    fired: list[bool] = []
+
+    @cb.on_after_compact
+    async def h() -> None:
+        fired.append(True)
+
+    await cb.fire_after_compact()
+    assert fired == [True]
+
+
+async def test_compact_callback_exception_is_swallowed() -> None:
+    cb = CallbackSet()
+    fired: list[bool] = []
+
+    @cb.on_before_compact
+    async def bad() -> None:
+        raise RuntimeError("boom")
+
+    @cb.on_before_compact
+    async def good() -> None:
+        fired.append(True)
+
+    await cb.fire_before_compact()
+    assert fired == [True]
+
+
+async def test_multiple_compact_handlers_all_fired() -> None:
+    cb = CallbackSet()
+    fired: list[str] = []
+
+    @cb.on_before_compact
+    async def b1() -> None:
+        fired.append("before-1")
+
+    @cb.on_before_compact
+    async def b2() -> None:
+        fired.append("before-2")
+
+    @cb.on_after_compact
+    async def a1() -> None:
+        fired.append("after-1")
+
+    @cb.on_after_compact
+    async def a2() -> None:
+        fired.append("after-2")
+
+    await cb.fire_before_compact()
+    await cb.fire_after_compact()
+    assert fired == ["before-1", "before-2", "after-1", "after-2"]

--- a/ddev/tests/ai/react/test_process.py
+++ b/ddev/tests/ai/react/test_process.py
@@ -16,6 +16,8 @@ from ddev.ai.react.types import ReActResult
 from ddev.ai.tools.core.registry import ToolRegistry
 from ddev.ai.tools.core.types import ToolResult
 
+_TOOL_RESULT_DATA: str = "ok"
+
 # ---------------------------------------------------------------------------
 # Mock helpers
 # ---------------------------------------------------------------------------
@@ -51,7 +53,7 @@ class MockToolRegistry:
     """Minimal tool registry that always returns a configurable ToolResult."""
 
     def __init__(self, result: ToolResult | None = None) -> None:
-        self._result = result or ToolResult(success=True, data="ok")
+        self._result = result or ToolResult(success=True, data=_TOOL_RESULT_DATA)
         self.run_calls: list[tuple[str, dict]] = []
 
     async def run(self, name: str, raw: dict[str, object]) -> ToolResult:
@@ -206,7 +208,7 @@ async def test_single_tool_call_executes_tool_and_returns() -> None:
     assert agent.send_calls[0] == "Do something"
     assert isinstance(agent.send_calls[1], list)
     assert agent.send_calls[1][0].tool_call_id == "tc_01"
-    assert agent.send_calls[1][0].result.data == "ok"
+    assert agent.send_calls[1][0].result.data == _TOOL_RESULT_DATA
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/ai/react/test_process.py
+++ b/ddev/tests/ai/react/test_process.py
@@ -13,6 +13,7 @@ from ddev.ai.agent.types import AgentResponse, ContextUsage, StopReason, TokenUs
 from ddev.ai.react.callbacks import CallbackSet
 from ddev.ai.react.process import ReActProcess
 from ddev.ai.react.types import ReActResult
+from ddev.ai.tools.core.registry import ToolRegistry
 from ddev.ai.tools.core.types import ToolResult
 
 # ---------------------------------------------------------------------------
@@ -24,9 +25,11 @@ class MockAgent(BaseAgent[Any]):
     """Minimal BaseAgent implementation that replays a fixed list of responses."""
 
     def __init__(self, responses: list[AgentResponse]) -> None:
-        super().__init__()
+        super().__init__(name="mock", system_prompt="", tools=ToolRegistry([]))
         self._responses = iter(responses)
         self.send_calls: list[str | list[ToolResultMessage]] = []
+        self.compact_calls: int = 0
+        self.reset_calls: int = 0
 
     async def send(
         self,
@@ -35,6 +38,13 @@ class MockAgent(BaseAgent[Any]):
     ) -> AgentResponse:
         self.send_calls.append(content)
         return next(self._responses)
+
+    async def compact(self) -> None:
+        self.compact_calls += 1
+
+    def reset(self) -> None:
+        super().reset()
+        self.reset_calls += 1
 
 
 class MockToolRegistry:
@@ -84,6 +94,8 @@ class CallbackRecorder:
         self.tool_calls_seen: list[tuple[ToolCall, ToolResult, int]] = []
         self.complete_results: list[ReActResult] = []
         self.errors: list[BaseException] = []
+        self.before_compacts: int = 0
+        self.after_compacts: int = 0
 
         self.callback_set = CallbackSet()
 
@@ -102,6 +114,14 @@ class CallbackRecorder:
         @self.callback_set.on_error
         async def _record_error(error: BaseException) -> None:
             self.errors.append(error)
+
+        @self.callback_set.on_before_compact
+        async def _record_before_compact() -> None:
+            self.before_compacts += 1
+
+        @self.callback_set.on_after_compact
+        async def _record_after_compact() -> None:
+            self.after_compacts += 1
 
 
 def make_response(
@@ -135,11 +155,13 @@ def make_process(
     agent: MockAgent,
     registry: MockToolRegistry | None = None,
     callback_sets: list[CallbackSet] | None = None,
+    compact_threshold_pct: float | None = None,
 ) -> ReActProcess:
     return ReActProcess(
         agent=agent,
         tool_registry=registry or MockToolRegistry(),
         callback_sets=callback_sets,
+        compact_threshold_pct=compact_threshold_pct,
     )
 
 
@@ -363,6 +385,9 @@ async def test_two_callback_sets_both_notified() -> None:
 
 
 class ErrorAgent(BaseAgent[Any]):
+    def __init__(self) -> None:
+        super().__init__(name="error", system_prompt="", tools=ToolRegistry([]))
+
     async def send(
         self, content: str | list[ToolResultMessage], allowed_tools: list[str] | None = None
     ) -> AgentResponse:
@@ -387,6 +412,9 @@ async def test_agent_error_notifies_and_reraises() -> None:
 
 
 class InterruptAgent(BaseAgent[Any]):
+    def __init__(self) -> None:
+        super().__init__(name="interrupt", system_prompt="", tools=ToolRegistry([]))
+
     async def send(
         self, content: str | list[ToolResultMessage], allowed_tools: list[str] | None = None
     ) -> AgentResponse:
@@ -410,6 +438,9 @@ async def test_keyboard_interrupt_notifies_and_reraises() -> None:
 
 
 class CancelledAgent(BaseAgent[Any]):
+    def __init__(self) -> None:
+        super().__init__(name="cancelled", system_prompt="", tools=ToolRegistry([]))
+
     async def send(
         self, content: str | list[ToolResultMessage], allowed_tools: list[str] | None = None
     ) -> AgentResponse:
@@ -470,3 +501,95 @@ async def test_context_usage_propagated(context_usage: ContextUsage | None) -> N
 
     assert result.context_usage is context_usage
     assert result.final_response.usage.context_usage is context_usage
+
+
+# ---------------------------------------------------------------------------
+# reset() and compact() — delegation
+# ---------------------------------------------------------------------------
+
+
+async def test_reset_delegates_to_agent() -> None:
+    agent = MockAgent([])
+    make_process(agent).reset()
+    assert agent.reset_calls == 1
+    assert agent.history == []
+
+
+async def test_compact_delegates_to_agent() -> None:
+    agent = MockAgent([])
+    await make_process(agent).compact()
+    assert agent.compact_calls == 1
+
+
+async def test_compact_fires_before_and_after_callbacks() -> None:
+    agent = MockAgent([])
+    recorder = CallbackRecorder()
+    await make_process(agent, callback_sets=[recorder.callback_set]).compact()
+    assert recorder.before_compacts == 1
+    assert recorder.after_compacts == 1
+
+
+# ---------------------------------------------------------------------------
+# Auto-compact inside the ReAct loop
+# ---------------------------------------------------------------------------
+
+
+def make_context_usage(pct: float, window: int = 200_000) -> ContextUsage:
+    return ContextUsage(window_size=window, used_tokens=int(window * pct / 100))
+
+
+async def test_auto_compact_triggers_when_threshold_exceeded() -> None:
+    tc = make_tool_call()
+    responses = [
+        make_response(StopReason.TOOL_USE, tool_calls=[tc]),
+        make_response(StopReason.END_TURN, context_usage=make_context_usage(80.0)),
+    ]
+    agent = MockAgent(responses)
+    await make_process(agent, compact_threshold_pct=75.0).start("task")
+    assert agent.compact_calls == 1
+
+
+async def test_auto_compact_fires_callbacks() -> None:
+    tc = make_tool_call()
+    responses = [
+        make_response(StopReason.TOOL_USE, tool_calls=[tc]),
+        make_response(StopReason.END_TURN, context_usage=make_context_usage(80.0)),
+    ]
+    agent = MockAgent(responses)
+    recorder = CallbackRecorder()
+    await make_process(agent, callback_sets=[recorder.callback_set], compact_threshold_pct=75.0).start("task")
+    assert recorder.before_compacts == 1
+    assert recorder.after_compacts == 1
+
+
+async def test_auto_compact_does_not_trigger_below_threshold() -> None:
+    tc = make_tool_call()
+    responses = [
+        make_response(StopReason.TOOL_USE, tool_calls=[tc]),
+        make_response(StopReason.END_TURN, context_usage=make_context_usage(50.0)),
+    ]
+    agent = MockAgent(responses)
+    await make_process(agent, compact_threshold_pct=75.0).start("task")
+    assert agent.compact_calls == 0
+
+
+async def test_auto_compact_disabled_when_threshold_is_none() -> None:
+    tc = make_tool_call()
+    responses = [
+        make_response(StopReason.TOOL_USE, tool_calls=[tc]),
+        make_response(StopReason.END_TURN, context_usage=make_context_usage(99.9)),
+    ]
+    agent = MockAgent(responses)
+    await make_process(agent, compact_threshold_pct=None).start("task")
+    assert agent.compact_calls == 0
+
+
+async def test_auto_compact_skipped_when_context_usage_is_none() -> None:
+    tc = make_tool_call()
+    responses = [
+        make_response(StopReason.TOOL_USE, tool_calls=[tc]),
+        make_response(StopReason.END_TURN, context_usage=None),
+    ]
+    agent = MockAgent(responses)
+    await make_process(agent, compact_threshold_pct=75.0).start("task")
+    assert agent.compact_calls == 0

--- a/ddev/tests/ai/react/test_process.py
+++ b/ddev/tests/ai/react/test_process.py
@@ -31,6 +31,8 @@ class MockAgent(BaseAgent[Any]):
         self._responses = iter(responses)
         self.send_calls: list[str | list[ToolResultMessage]] = []
         self.compact_calls: int = 0
+        self.compact_preserving_turn_calls: int = 0
+        self.compact_token_response: AgentResponse | None = None
         self.reset_calls: int = 0
 
     async def send(
@@ -41,8 +43,13 @@ class MockAgent(BaseAgent[Any]):
         self.send_calls.append(content)
         return next(self._responses)
 
-    async def compact(self) -> None:
+    async def compact(self) -> AgentResponse | None:
         self.compact_calls += 1
+        return None
+
+    async def compact_preserving_last_turn(self) -> AgentResponse | None:
+        self.compact_preserving_turn_calls += 1
+        return self.compact_token_response
 
     def reset(self) -> None:
         super().reset()
@@ -548,7 +555,7 @@ async def test_auto_compact_triggers_when_threshold_exceeded() -> None:
     ]
     agent = MockAgent(responses)
     await make_process(agent, compact_threshold_pct=75.0).start("task")
-    assert agent.compact_calls == 1
+    assert agent.compact_preserving_turn_calls == 1
 
 
 async def test_auto_compact_fires_callbacks() -> None:
@@ -572,7 +579,7 @@ async def test_auto_compact_does_not_trigger_below_threshold() -> None:
     ]
     agent = MockAgent(responses)
     await make_process(agent, compact_threshold_pct=75.0).start("task")
-    assert agent.compact_calls == 0
+    assert agent.compact_preserving_turn_calls == 0
 
 
 async def test_auto_compact_disabled_when_threshold_is_none() -> None:
@@ -583,7 +590,7 @@ async def test_auto_compact_disabled_when_threshold_is_none() -> None:
     ]
     agent = MockAgent(responses)
     await make_process(agent, compact_threshold_pct=None).start("task")
-    assert agent.compact_calls == 0
+    assert agent.compact_preserving_turn_calls == 0
 
 
 async def test_auto_compact_skipped_when_context_usage_is_none() -> None:
@@ -594,4 +601,19 @@ async def test_auto_compact_skipped_when_context_usage_is_none() -> None:
     ]
     agent = MockAgent(responses)
     await make_process(agent, compact_threshold_pct=75.0).start("task")
-    assert agent.compact_calls == 0
+    assert agent.compact_preserving_turn_calls == 0
+
+
+async def test_auto_compact_tokens_included_in_result() -> None:
+    tc = make_tool_call()
+    responses = [
+        make_response(StopReason.TOOL_USE, tool_calls=[tc], input_tokens=100, output_tokens=50),
+        make_response(StopReason.END_TURN, context_usage=make_context_usage(80.0), input_tokens=200, output_tokens=80),
+    ]
+    agent = MockAgent(responses)
+    agent.compact_token_response = make_response(StopReason.END_TURN, input_tokens=30, output_tokens=10)
+
+    result = await make_process(agent, compact_threshold_pct=75.0).start("task")
+
+    assert result.total_input_tokens == 100 + 200 + 30
+    assert result.total_output_tokens == 50 + 80 + 10

--- a/ddev/tests/ai/react/test_process.py
+++ b/ddev/tests/ai/react/test_process.py
@@ -32,6 +32,7 @@ class MockAgent(BaseAgent[Any]):
         self.send_calls: list[str | list[ToolResultMessage]] = []
         self.compact_calls: int = 0
         self.compact_preserving_turn_calls: int = 0
+        self.compact_response: AgentResponse | None = None
         self.compact_token_response: AgentResponse | None = None
         self.reset_calls: int = 0
 
@@ -45,7 +46,7 @@ class MockAgent(BaseAgent[Any]):
 
     async def compact(self) -> AgentResponse | None:
         self.compact_calls += 1
-        return None
+        return self.compact_response
 
     async def compact_preserving_last_turn(self) -> AgentResponse | None:
         self.compact_preserving_turn_calls += 1
@@ -524,10 +525,20 @@ async def test_reset_delegates_to_agent() -> None:
     assert agent.history == []
 
 
-async def test_compact_delegates_to_agent() -> None:
-    agent = MockAgent([])
-    await make_process(agent).compact()
+async def test_compact_delegates_to_agent_returns_zero_when_no_op() -> None:
+    agent = MockAgent([])  # compact_response is None — no compaction occurred
+    compact_in, compact_out = await make_process(agent).compact()
     assert agent.compact_calls == 1
+    assert compact_in == 0
+    assert compact_out == 0
+
+
+async def test_compact_returns_tokens_when_compaction_occurs() -> None:
+    agent = MockAgent([])
+    agent.compact_response = make_response(StopReason.END_TURN, input_tokens=40, output_tokens=15)
+    compact_in, compact_out = await make_process(agent).compact()
+    assert compact_in == 40
+    assert compact_out == 15
 
 
 async def test_compact_fires_before_and_after_callbacks() -> None:

--- a/ddev/tests/ai/react/test_process.py
+++ b/ddev/tests/ai/react/test_process.py
@@ -566,7 +566,7 @@ async def test_auto_compact_triggers_when_threshold_exceeded() -> None:
     ]
     agent = MockAgent(responses)
     await make_process(agent, compact_threshold_pct=75.0).start("task")
-    assert agent.compact_preserving_turn_calls == 1
+    assert agent.compact_calls == 1
 
 
 async def test_auto_compact_fires_callbacks() -> None:
@@ -622,7 +622,7 @@ async def test_auto_compact_tokens_included_in_result() -> None:
         make_response(StopReason.END_TURN, context_usage=make_context_usage(80.0), input_tokens=200, output_tokens=80),
     ]
     agent = MockAgent(responses)
-    agent.compact_token_response = make_response(StopReason.END_TURN, input_tokens=30, output_tokens=10)
+    agent.compact_response = make_response(StopReason.END_TURN, input_tokens=30, output_tokens=10)
 
     result = await make_process(agent, compact_threshold_pct=75.0).start("task")
 


### PR DESCRIPTION
### What does this PR do?

Adds context compaction to the AI agent framework. When a long-running ReAct loop approaches the model's context window limit, the agent can now compress its entire conversation history into a 2-message seed (original task + LLM-generated summary) and continue working without losing semantic context.

Key changes:

- **`BaseAgent`** — promoted `name`, `system_prompt`, and `tools` from `AnthropicAgent` to the base class, making them universal fields. Added a concrete `compact()` method that temporarily swaps to a dedicated summarization system prompt, calls `send()` to generate a summary, then collapses `_history` to 2 messages. Fully model-agnostic — no provider-specific code needed.
- **`AnthropicAgent`** — `__init__` now delegates the three universal fields to `super().__init__()`. No other changes.
- **`ReActProcess`** — added `reset()` and `compact()` as manual pass-throughs for the Phase layer. Added auto-compaction inside the ReAct loop via a configurable `compact_threshold_pct` (default 75% of context window). Added `_fire_compact()` so callbacks fire consistently whether compaction is triggered manually or automatically.
- **`CallbackSet`** — added `on_before_compact` and `on_after_compact` lifecycle hooks so observers are notified around every compaction event.

### Motivation

Long agentic workflows (e.g. generating a full integration) accumulate tool results and reasoning across many iterations. Without compaction, the context window fills up and the loop either fails or degrades. This change lets the framework continue indefinitely by summarising its own history when needed, while keeping the implementation fully model-agnostic and testable.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged