### PR TITLE
Turn off static analysis temporarily

### DIFF
--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -1,4 +1,7 @@
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - master
 
 name: Datadog Static Analysis
 

--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -1,7 +1,8 @@
+# Turning off while we investigate
 on:
   push:
     branches-ignore:
-      - master
+      - '**'
 
 name: Datadog Static Analysis
 


### PR DESCRIPTION
### What does this PR do?
Turns off static analysis while the team looks into it, as it is often failing now
https://github.com/DataDog/integrations-core/actions/runs/24411995914/job/71311027658
### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
