### PR TITLE
Set display_priority in twistlock spec.yaml based on field usage

### DIFF
--- a/twistlock/assets/configuration/spec.yaml
+++ b/twistlock/assets/configuration/spec.yaml
@@ -10,6 +10,7 @@ files:
   - template: instances
     options:
     - name: url
+      display_priority: 3
       fleet_configurable: true
       formats: ["url"]
       required: true
@@ -18,6 +19,7 @@ files:
         example: 'http://localhost:8081'
         type: string
     - name: project
+      display_priority: 1
       description: |
         The Twistlock project if enabled.
         See https://cdn.twistlock.com/docs/api/twistlock_api.html
@@ -32,4 +34,6 @@ files:
         password.description: |
           The password to use if services are behind basic or NTLM auth.
           In the case of SaaS version this is your Prisma Cloud Secret Key.
+        username.display_priority: 5
+        password.display_priority: 4
     - template: instances/default

--- a/twistlock/changelog.d/23321.fixed
+++ b/twistlock/changelog.d/23321.fixed
@@ -1,0 +1,1 @@
+Re-order configuration fields by usage frequency.

--- a/twistlock/changelog.d/23340.fixed
+++ b/twistlock/changelog.d/23340.fixed
@@ -1,0 +1,1 @@
+Re-order configuration fields by usage frequency.

--- a/twistlock/changelog.d/23340.fixed
+++ b/twistlock/changelog.d/23340.fixed
@@ -1,1 +1,0 @@
-Re-order configuration fields by usage frequency.

--- a/twistlock/datadog_checks/twistlock/data/conf.yaml.example
+++ b/twistlock/datadog_checks/twistlock/data/conf.yaml.example
@@ -45,10 +45,23 @@ init_config:
 #
 instances:
 
+  -
+    ## @param username - string - optional
+    ## The username to use if services are behind basic or digest auth.
+    ## In the case of SaaS version this is your Prisma Cloud API access key ID.
+    #
+    # username: <USERNAME>
+
+    ## @param password - string - optional
+    ## The password to use if services are behind basic or NTLM auth.
+    ## In the case of SaaS version this is your Prisma Cloud Secret Key.
+    #
+    # password: <PASSWORD>
+
     ## @param url - string - required
     ## The Prisma Cloud url to connect to.
     #
-  - url: http://localhost:8081
+    url: http://localhost:8081
 
     ## @param project - string - optional
     ## The Twistlock project if enabled.
@@ -122,18 +135,6 @@ instances:
     ## When `auth_type` is set to `basic`, this determines whether to encode as `latin1` rather than `utf-8`.
     #
     # use_legacy_auth_encoding: true
-
-    ## @param username - string - optional
-    ## The username to use if services are behind basic or digest auth.
-    ## In the case of SaaS version this is your Prisma Cloud API access key ID.
-    #
-    # username: <USERNAME>
-
-    ## @param password - string - optional
-    ## The password to use if services are behind basic or NTLM auth.
-    ## In the case of SaaS version this is your Prisma Cloud Secret Key.
-    #
-    # password: <PASSWORD>
 
     ## @param ntlm_domain - string - optional
     ## If your services use NTLM authentication, specify


### PR DESCRIPTION
## Summary

- Set `display_priority` on configuration fields for the `twistlock` integration based on real-world field usage data.
- Fields used by >10% of instances are ranked by usage frequency; remaining fields default to `display_priority: 0`.
- Fields in related groups (`host`/`port`, `username`/`password`) are kept adjacent and in canonical order.

## Test plan

- [ ] `conf.yaml.example` renders fields in the expected order
- [ ] `ddev validate config -s twistlock` passes
