### PR TITLE
Set display_priority in iis spec.yaml based on field usage

### DIFF
--- a/iis/assets/configuration/spec.yaml
+++ b/iis/assets/configuration/spec.yaml
@@ -10,6 +10,7 @@ files:
   - template: instances
     options:
     - name: sites
+      display_priority: 2
       description: |
         The `sites` parameter allows you to specify a list of sites you want to
         read metrics from. With sites specified, metrics are tagged with the
@@ -43,6 +44,7 @@ files:
             items:
               type: string
     - name: app_pools
+      display_priority: 0
       description: |
         The `app_pools` parameter allows you to specify a list of application pools you want to
         read metrics from. With application pools specified, metrics are tagged with the
@@ -82,7 +84,11 @@ files:
             name: httpd_request_method
             counters:
             - CGI Requests/sec: cgi
+        username.display_priority: 4
+        password.display_priority: 3
     - template: instances/pdh_legacy
+      overrides:
+        host.display_priority: 5
       hidden: true
     - template: instances/default
   - template: logs

--- a/iis/changelog.d/23323.fixed
+++ b/iis/changelog.d/23323.fixed
@@ -1,0 +1,1 @@
+Re-order configuration fields by usage frequency.

--- a/iis/changelog.d/23340.fixed
+++ b/iis/changelog.d/23340.fixed
@@ -1,0 +1,1 @@
+Re-order configuration fields by usage frequency.

--- a/iis/changelog.d/23340.fixed
+++ b/iis/changelog.d/23340.fixed
@@ -1,1 +1,0 @@
-Re-order configuration fields by usage frequency.

--- a/iis/datadog_checks/iis/data/conf.yaml.example
+++ b/iis/datadog_checks/iis/data/conf.yaml.example
@@ -19,7 +19,16 @@ init_config:
 #
 instances:
 
-  -
+    ## @param username - string - optional
+    ## The username used to connect to the `server`.
+    #
+    # username: <USERNAME>
+
+    ## @param password - string - optional
+    ## The password of `username`.
+    #
+    # password: <PASSWORD>
+
     ## @param sites - list of strings or mapping - optional
     ## The `sites` parameter allows you to specify a list of sites you want to
     ## read metrics from. With sites specified, metrics are tagged with the
@@ -60,16 +69,6 @@ instances:
     ## The server with which to connect, defaulting to the local machine.
     #
     # server: <SERVER>
-
-    ## @param username - string - optional
-    ## The username used to connect to the `server`.
-    #
-    # username: <USERNAME>
-
-    ## @param password - string - optional
-    ## The password of `username`.
-    #
-    # password: <PASSWORD>
 
     ## @param enable_health_service_check - boolean - optional - default: true
     ## Whether or not to send a service check named `<NAMESPACE>.windows.perf.health`, which reports


### PR DESCRIPTION
## Summary

- Set `display_priority` on configuration fields for the `iis` integration based on real-world field usage data.
- Fields used by >10% of instances are ranked by usage frequency; remaining fields default to `display_priority: 0`.
- Fields in related groups (`host`/`port`, `username`/`password`) are kept adjacent and in canonical order.

## Test plan

- [ ] `conf.yaml.example` renders fields in the expected order
- [ ] `ddev validate config -s iis` passes
