### PR TITLE
Set display_priority in krakend spec.yaml based on field usage

### DIFF
--- a/krakend/assets/configuration/spec.yaml
+++ b/krakend/assets/configuration/spec.yaml
@@ -7,6 +7,7 @@ files:
     options:
     - template: init_config/openmetrics
     - name: go_metrics
+      display_priority: 0
       description: |
         Collect Go runtime metrics exposed by KrakenD's Prometheus endpoint.
 
@@ -19,6 +20,7 @@ files:
         type: boolean
         example: true
     - name: process_metrics
+      display_priority: 0
       description: |
         Collect process metrics exposed by KrakenD's Prometheus endpoint.
 
@@ -34,7 +36,11 @@ files:
   - template: instances
     options:
     - template: instances/openmetrics
+      overrides:
+        openmetrics_endpoint.display_priority: 3
+        enable_health_service_check.display_priority: 1
     - name: go_metrics
+      display_priority: 0
       description: |
         Collect Go runtime metrics exposed by KrakenD's Prometheus endpoint.
 
@@ -49,6 +55,7 @@ files:
         type: boolean
         example: true
     - name: process_metrics
+      display_priority: 0
       description: |
         Collect process metrics exposed by KrakenD's Prometheus endpoint.
 

--- a/krakend/changelog.d/23324.fixed
+++ b/krakend/changelog.d/23324.fixed
@@ -1,0 +1,1 @@
+Re-order configuration fields by usage frequency.

--- a/krakend/changelog.d/23340.fixed
+++ b/krakend/changelog.d/23340.fixed
@@ -1,0 +1,1 @@
+Re-order configuration fields by usage frequency.

--- a/krakend/changelog.d/23340.fixed
+++ b/krakend/changelog.d/23340.fixed
@@ -1,1 +1,0 @@
-Re-order configuration fields by usage frequency.

--- a/krakend/datadog_checks/krakend/data/conf.yaml.example
+++ b/krakend/datadog_checks/krakend/data/conf.yaml.example
@@ -70,6 +70,12 @@ instances:
     #
   - openmetrics_endpoint: <OPENMETRICS_ENDPOINT>
 
+    ## @param enable_health_service_check - boolean - optional - default: true
+    ## Whether or not to send a service check named `<NAMESPACE>.openmetrics.health` which reports
+    ## the health of the `openmetrics_endpoint`.
+    #
+    # enable_health_service_check: true
+
     ## @param raw_metric_prefix - string - optional
     ## A prefix that is removed from all exposed metric names, if present.
     ## All configuration options will use the prefix-less name.
@@ -182,12 +188,6 @@ instances:
     # rename_labels:
     #   <LABEL_NAME_1>: <NEW_LABEL_NAME_1>
     #   <LABEL_NAME_2>: <NEW_LABEL_NAME_2>
-
-    ## @param enable_health_service_check - boolean - optional - default: true
-    ## Whether or not to send a service check named `<NAMESPACE>.openmetrics.health` which reports
-    ## the health of the `openmetrics_endpoint`.
-    #
-    # enable_health_service_check: true
 
     ## @param ignore_connection_errors - boolean - optional - default: false
     ## Whether or not to ignore connection errors when scraping `openmetrics_endpoint`.


### PR DESCRIPTION
## Summary

- Set `display_priority` on configuration fields for the `krakend` integration based on real-world field usage data.
- Fields used by >10% of instances are ranked by usage frequency; remaining fields default to `display_priority: 0`.
- Fields in related groups (`host`/`port`, `username`/`password`) are kept adjacent and in canonical order.

## Test plan

- [ ] `conf.yaml.example` renders fields in the expected order
- [ ] `ddev validate config -s krakend` passes
