### PR TITLE
Fix flaky celery E2E test by waiting for Flower endpoint

### DIFF
--- a/celery/tests/common.py
+++ b/celery/tests/common.py
@@ -40,6 +40,7 @@ E2E_METADATA = {
     'env_vars': {
         'DD_LOGS_ENABLED': 'true',
         'DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL': 'true',
+        'DD_IGNORE_AUTOCONF': 'redisdb',
     },
     'docker_volumes': ['/var/run/docker.sock:/var/run/docker.sock:ro'],
 }

--- a/celery/tests/common.py
+++ b/celery/tests/common.py
@@ -36,11 +36,4 @@ METRICS = [
 ]
 
 
-E2E_METADATA = {
-    'env_vars': {
-        'DD_LOGS_ENABLED': 'true',
-        'DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL': 'true',
-        'DD_IGNORE_AUTOCONF': 'redisdb',
-    },
-    'docker_volumes': ['/var/run/docker.sock:/var/run/docker.sock:ro'],
-}
+E2E_METADATA = {}

--- a/celery/tests/conftest.py
+++ b/celery/tests/conftest.py
@@ -6,7 +6,7 @@ import copy
 import pytest
 
 from datadog_checks.dev import docker_run
-from datadog_checks.dev.conditions import CheckDockerLogs
+from datadog_checks.dev.conditions import CheckDockerLogs, CheckEndpoints
 
 from . import common
 
@@ -21,7 +21,8 @@ def dd_environment():
     with docker_run(
         compose_file,
         conditions=[
-            CheckDockerLogs('docker-redis-standalone-1', 'Ready to accept connections tcp'),
+            CheckDockerLogs(compose_file, 'Ready to accept connections tcp', service='redis-standalone'),
+            CheckEndpoints(common.MOCKED_INSTANCE['openmetrics_endpoint']),
         ],
     ):
         yield common.MOCKED_INSTANCE, common.E2E_METADATA


### PR DESCRIPTION
### What does this PR do?

Fixes the celery E2E test (`test_check_celery_e2e`) that fails with "Could not find valid check output".

**Root cause:** The `E2E_METADATA` mounted the Docker socket and enabled `DD_LOGS_ENABLED` + `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL`. This combination causes the agent to start multiple `DockerSocketTailer` goroutines in parallel (one per discovered container). Each tailer goroutine calls `GetBool("logs_config.auto_multi_line_detection_enabled")` during initialization, which calls `checkKnownKey` in `pkg/config/nodetreemodel/config.go`. That method writes to `c.unknownKeys` (a `map[string]struct{}`), but it's called under a read lock (`RLock`), not a write lock. When multiple goroutines hold the read lock simultaneously and all hit an unknown config key, they concurrently write to the same map, causing `fatal error: concurrent map writes` and crashing the agent. With the agent crashed, `agent check celery --json` returns empty output and the test fails.

**Why celery is uniquely affected:** celery was the only integration that combined all three settings in its `E2E_METADATA`:
- `DD_LOGS_ENABLED=true`
- `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true`
- Docker socket mount

Other integrations use either the Docker socket without log collection env vars (n8n, nfsstat), or log collection env vars without the Docker socket (tomcat, torchserve, ray), so they never start multiple `DockerSocketTailer` goroutines concurrently and don't trigger the race.

**Why these settings were unnecessary:** The celery check is a straightforward OpenMetrics scraper that hits Flower's `/metrics` endpoint. It has no log collection or parsing logic, and the E2E test doesn't test any log-related behavior. These settings were likely copied from a template without considering whether they were needed.

**Changes:**

`celery/tests/conftest.py`:
- Use `CheckDockerLogs` with compose file + `service` parameter instead of a hardcoded container name, avoiding log buffering issues with docker compose
- Add `CheckEndpoints` condition to wait for Flower's `/metrics` endpoint to be reachable before starting the agent

`celery/tests/common.py`:
- Remove `E2E_METADATA` entries (`DD_LOGS_ENABLED`, `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL`, Docker socket volume mount) since they are unnecessary for this integration and trigger the agent crash

### Motivation

The E2E test was failing because the agent crashed during startup. Additionally, the docker-compose readiness condition was only waiting for Redis instead of Flower (the actual service the celery check scrapes).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged