### PR TITLE
Apply `ignore_tags` filtering to dynamic tags in OpenMetrics v2

### DIFF
--- a/datadog_checks_base/changelog.d/23328.fixed
+++ b/datadog_checks_base/changelog.d/23328.fixed
@@ -1,0 +1,1 @@
+Apply ignore_tags filtering to dynamic tags in OpenMetrics v2 scraper.

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper/base_scraper.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper/base_scraper.py
@@ -192,8 +192,10 @@ class OpenMetricsScraper:
         # some tags can still generate unwanted metric contexts (e.g pod annotations as tags).
         ignore_tags = config.get('ignore_tags', [])
         if ignore_tags:
-            ignored_tags_re = re.compile('|'.join(set(ignore_tags)))
-            custom_tags = [tag for tag in custom_tags if not ignored_tags_re.search(tag)]
+            self.ignored_tags_re = re.compile('|'.join(set(ignore_tags)))
+            custom_tags = [tag for tag in custom_tags if not self.ignored_tags_re.search(tag)]
+        else:
+            self.ignored_tags_re = None
 
         self.static_tags = copy(custom_tags)
         if is_affirmative(self.config.get('tag_by_endpoint', True)):
@@ -469,6 +471,8 @@ class OpenMetricsScraper:
         """
         Set dynamic tags.
         """
+        if self.ignored_tags_re is not None:
+            tags = [tag for tag in tags if not self.ignored_tags_re.search(tag)]
 
         self.tags = tuple(chain(self.static_tags, tags))
 

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_options.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_options.py
@@ -941,11 +941,13 @@ class TestIgnoreTags:
             go_memstats_alloc_bytes 6.396288e+06
             """
         )
-        check = get_check({
-            'metrics': ['go_memstats_alloc_bytes'],
-            'tags': ['kept:tag'],
-            'ignore_tags': ['kube_replica_set:.*', 'pod_name:.*'],
-        })
+        check = get_check(
+            {
+                'metrics': ['go_memstats_alloc_bytes'],
+                'tags': ['kept:tag'],
+                'ignore_tags': ['kube_replica_set:.*', 'pod_name:.*'],
+            }
+        )
         dd_run_check(check)
         aggregator.reset()
 

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_options.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_options.py
@@ -931,3 +931,32 @@ class TestIgnoreTags:
         )
 
         aggregator.assert_all_metrics_covered()
+
+    def test_dynamic_tags(self, aggregator, dd_run_check, mock_http_response):
+        """Dynamic tags set after init (e.g. from Kubernetes autodiscovery) are also filtered by ignore_tags."""
+        mock_http_response(
+            """
+            # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+            # TYPE go_memstats_alloc_bytes gauge
+            go_memstats_alloc_bytes 6.396288e+06
+            """
+        )
+        check = get_check({
+            'metrics': ['go_memstats_alloc_bytes'],
+            'tags': ['kept:tag'],
+            'ignore_tags': ['kube_replica_set:.*', 'pod_name:.*'],
+        })
+        dd_run_check(check)
+        aggregator.reset()
+
+        check.set_dynamic_tags('kube_replica_set:my-app-6dcc699cc6', 'pod_name:my-pod-abc', 'kube_namespace:default')
+        dd_run_check(check)
+
+        aggregator.assert_metric(
+            'test.go_memstats_alloc_bytes',
+            6396288,
+            metric_type=aggregator.GAUGE,
+            tags=['endpoint:test', 'kept:tag', 'kube_namespace:default'],
+        )
+
+        aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
## Summary

- **Bug:** `ignore_tags` in the OpenMetrics v2 scraper only filtered static tags (from the `tags` config option) at init time. Dynamic tags set via `set_dynamic_tags()` — such as Kubernetes autodiscovery tags like `kube_replica_set`, `host`, `name` — bypassed the filter entirely.
- **Fix:** Store the compiled `ignore_tags` regex as an instance attribute and apply it in `set_dynamic_tags()` as well.
- **Test:** Added a test confirming dynamic tags matching `ignore_tags` patterns are properly excluded.

Fixes https://github.com/DataDog/integrations-core/issues/21026

🤖 Generated with [Claude Code](https://claude.com/claude-code)