### PR TITLE
[DBMON-6322] SQL Server OOTB dashboard OTel support

### DIFF
--- a/sqlserver/assets/dashboards/SQLServer-Overview_dashboard.json
+++ b/sqlserver/assets/dashboards/SQLServer-Overview_dashboard.json
@@ -106,13 +106,15 @@
                       "query": "sum:sqlserver.server.cpu_count{$host} by {host}",
                       "data_source": "metrics",
                       "name": "query2",
-                      "aggregator": "last"
+                      "aggregator": "last",
+                      "semantic_mode": "combined"
                     },
                     {
                       "query": "sum:sqlserver.server.uptime{$host} by {host}",
                       "data_source": "metrics",
                       "name": "query1",
-                      "aggregator": "last"
+                      "aggregator": "last",
+                      "semantic_mode": "combined"
                     },
                     {
                       "query": "sum:sqlserver.server.committed_memory{$host} by {host}",
@@ -176,7 +178,8 @@
                       "query": "sum:sqlserver.server.uptime{$host}",
                       "data_source": "metrics",
                       "name": "query1",
-                      "aggregator": "last"
+                      "aggregator": "last",
+                      "semantic_mode": "combined"
                     }
                   ]
                 }
@@ -313,7 +316,8 @@
                     {
                       "query": "sum:sqlserver.stats.batch_requests{$host} by {host}",
                       "data_source": "metrics",
-                      "name": "query1"
+                      "name": "query1",
+                      "semantic_mode": "combined"
                     }
                   ],
                   "style": {
@@ -355,7 +359,8 @@
                     {
                       "query": "avg:sqlserver.stats.connections{$host} by {host}",
                       "data_source": "metrics",
-                      "name": "query1"
+                      "name": "query1",
+                      "semantic_mode": "combined"
                     }
                   ],
                   "style": {
@@ -397,7 +402,8 @@
                     {
                       "query": "sum:sqlserver.stats.sql_recompilations{$host} by {host}",
                       "data_source": "metrics",
-                      "name": "query1"
+                      "name": "query1",
+                      "semantic_mode": "combined"
                     }
                   ],
                   "style": {
@@ -481,7 +487,8 @@
                     {
                       "query": "sum:sqlserver.stats.sql_compilations{$host} by {host}",
                       "data_source": "metrics",
-                      "name": "query1"
+                      "name": "query1",
+                      "semantic_mode": "combined"
                     }
                   ],
                   "style": {
@@ -523,7 +530,8 @@
                     {
                       "query": "sum:sqlserver.database.write_transactions{$host} by {host}",
                       "data_source": "metrics",
-                      "name": "query1"
+                      "name": "query1",
+                      "semantic_mode": "combined"
                     }
                   ],
                   "style": {
@@ -565,7 +573,8 @@
                     {
                       "query": "sum:sqlserver.database.transactions{$host} by {host}",
                       "data_source": "metrics",
-                      "name": "query1"
+                      "name": "query1",
+                      "semantic_mode": "combined"
                     }
                   ],
                   "style": {
@@ -740,7 +749,8 @@
                     {
                       "query": "avg:sqlserver.access.page_splits{$host} by {host}",
                       "data_source": "metrics",
-                      "name": "query1"
+                      "name": "query1",
+                      "semantic_mode": "combined"
                     }
                   ],
                   "style": {
@@ -842,7 +852,8 @@
                     {
                       "query": "avg:sqlserver.buffer.page_life_expectancy{$host} by {host}",
                       "data_source": "metrics",
-                      "name": "query1"
+                      "name": "query1",
+                      "semantic_mode": "combined"
                     }
                   ],
                   "style": {
@@ -1260,12 +1271,14 @@
                     {
                       "query": "sum:sqlserver.files.read_io_stall{$host} by {host,db}.as_count()",
                       "data_source": "metrics",
-                      "name": "query1"
+                      "name": "query1",
+                      "semantic_mode": "combined"
                     },
                     {
                       "query": "sum:sqlserver.files.reads{$host} by {host,db}.as_count()",
                       "data_source": "metrics",
-                      "name": "query2"
+                      "name": "query2",
+                      "semantic_mode": "combined"
                     }
                   ],
                   "style": {
@@ -1287,12 +1300,14 @@
                     {
                       "query": "sum:sqlserver.files.write_io_stall{$host} by {host,db}.as_count()",
                       "data_source": "metrics",
-                      "name": "query0"
+                      "name": "query0",
+                      "semantic_mode": "combined"
                     },
                     {
                       "query": "sum:sqlserver.files.writes{$host} by {host,db}.as_count()",
                       "data_source": "metrics",
-                      "name": "query1"
+                      "name": "query1",
+                      "semantic_mode": "combined"
                     }
                   ],
                   "style": {
@@ -1346,7 +1361,8 @@
                     {
                       "query": "sum:sqlserver.files.read_bytes{$host} by {host,db}.as_rate()",
                       "data_source": "metrics",
-                      "name": "query1"
+                      "name": "query1",
+                      "semantic_mode": "combined"
                     }
                   ],
                   "style": {
@@ -1368,7 +1384,8 @@
                     {
                       "query": "sum:sqlserver.files.written_bytes{$host} by {host,db}.as_rate()",
                       "data_source": "metrics",
-                      "name": "query0"
+                      "name": "query0",
+                      "semantic_mode": "combined"
                     }
                   ],
                   "style": {
@@ -1449,25 +1466,29 @@
                       "query": "sum:sqlserver.files.reads{$host} by {host,logical_name,file_location,db}.as_rate()",
                       "data_source": "metrics",
                       "name": "query1",
-                      "aggregator": "avg"
+                      "aggregator": "avg",
+                      "semantic_mode": "combined"
                     },
                     {
                       "query": "sum:sqlserver.files.writes{$host} by {host,logical_name,file_location,db}.as_rate()",
                       "data_source": "metrics",
                       "name": "query2",
-                      "aggregator": "avg"
+                      "aggregator": "avg",
+                      "semantic_mode": "combined"
                     },
                     {
                       "query": "sum:sqlserver.files.read_bytes{$host} by {host,logical_name,file_location,db}.as_rate()",
                       "data_source": "metrics",
                       "name": "query3",
-                      "aggregator": "avg"
+                      "aggregator": "avg",
+                      "semantic_mode": "combined"
                     },
                     {
                       "query": "sum:sqlserver.files.written_bytes{$host} by {host,logical_name,file_location,db}.as_rate()",
                       "data_source": "metrics",
                       "name": "query4",
-                      "aggregator": "avg"
+                      "aggregator": "avg",
+                      "semantic_mode": "combined"
                     },
                     {
                       "query": "sum:sqlserver.files.size_on_disk{$host} by {host,logical_name,file_location,db}.as_count()",
@@ -1479,25 +1500,29 @@
                       "query": "sum:sqlserver.files.read_io_stall{$host} by {host,logical_name,file_location,db}.as_count()",
                       "data_source": "metrics",
                       "name": "query10",
-                      "aggregator": "sum"
+                      "aggregator": "sum",
+                      "semantic_mode": "combined"
                     },
                     {
                       "query": "sum:sqlserver.files.reads{$host} by {host,logical_name,file_location,db}.as_count()",
                       "data_source": "metrics",
                       "name": "query9",
-                      "aggregator": "sum"
+                      "aggregator": "sum",
+                      "semantic_mode": "combined"
                     },
                     {
                       "query": "sum:sqlserver.files.write_io_stall{$host} by {host,logical_name,file_location,db}.as_count()",
                       "data_source": "metrics",
                       "name": "query11",
-                      "aggregator": "sum"
+                      "aggregator": "sum",
+                      "semantic_mode": "combined"
                     },
                     {
                       "query": "sum:sqlserver.files.writes{$host} by {host,logical_name,file_location,db}.as_count()",
                       "data_source": "metrics",
                       "name": "query8",
-                      "aggregator": "sum"
+                      "aggregator": "sum",
+                      "semantic_mode": "combined"
                     }
                   ]
                 }
@@ -1566,7 +1591,8 @@
                       "query": "avg:sqlserver.buffer.cache_hit_ratio{$host}",
                       "data_source": "metrics",
                       "name": "query1",
-                      "aggregator": "avg"
+                      "aggregator": "avg",
+                      "semantic_mode": "combined"
                     }
                   ]
                 }
@@ -1606,7 +1632,8 @@
                     {
                       "query": "avg:sqlserver.buffer.cache_hit_ratio{$host} by {host}",
                       "data_source": "metrics",
-                      "name": "query1"
+                      "name": "query1",
+                      "semantic_mode": "combined"
                     }
                   ],
                   "style": {
@@ -1743,7 +1770,8 @@
                     {
                       "query": "avg:sqlserver.buffer.page_life_expectancy{$host} by {host}",
                       "data_source": "metrics",
-                      "name": "query1"
+                      "name": "query1",
+                      "semantic_mode": "combined"
                     }
                   ],
                   "style": {
@@ -1871,7 +1899,8 @@
                     {
                       "query": "avg:sqlserver.stats.procs_blocked{$host} by {host}",
                       "data_source": "metrics",
-                      "name": "query1"
+                      "name": "query1",
+                      "semantic_mode": "combined"
                     }
                   ],
                   "style": {
@@ -1913,7 +1942,8 @@
                     {
                       "query": "avg:sqlserver.stats.lock_waits{$host} by {host}",
                       "data_source": "metrics",
-                      "name": "query1"
+                      "name": "query1",
+                      "semantic_mode": "combined"
                     }
                   ],
                   "style": {

--- a/sqlserver/assets/dashboards/sqlserver_dashboard.json
+++ b/sqlserver/assets/dashboards/sqlserver_dashboard.json
@@ -19,7 +19,8 @@
                             {
                                 "data_source": "metrics",
                                 "name": "query1",
-                                "query": "sum:sqlserver.stats.connections{$scope}"
+                                "query": "sum:sqlserver.stats.connections{$scope}",
+                                "semantic_mode": "combined"
                             }
                         ],
                         "formulas": [
@@ -42,7 +43,8 @@
                             {
                                 "data_source": "metrics",
                                 "name": "query1",
-                                "query": "avg:sqlserver.buffer.cache_hit_ratio{$scope}"
+                                "query": "avg:sqlserver.buffer.cache_hit_ratio{$scope}",
+                                "semantic_mode": "combined"
                             }
                         ],
                         "formulas": [
@@ -65,7 +67,8 @@
                             {
                                 "data_source": "metrics",
                                 "name": "query1",
-                                "query": "sum:sqlserver.stats.procs_blocked{$scope}"
+                                "query": "sum:sqlserver.stats.procs_blocked{$scope}",
+                                "semantic_mode": "combined"
                             }
                         ],
                         "formulas": [
@@ -88,7 +91,8 @@
                             {
                                 "data_source": "metrics",
                                 "name": "query1",
-                                "query": "sum:sqlserver.access.page_splits{$scope}"
+                                "query": "sum:sqlserver.access.page_splits{$scope}",
+                                "semantic_mode": "combined"
                             }
                         ],
                         "formulas": [
@@ -111,7 +115,8 @@
                             {
                                 "data_source": "metrics",
                                 "name": "query1",
-                                "query": "sum:sqlserver.stats.batch_requests{$scope}"
+                                "query": "sum:sqlserver.stats.batch_requests{$scope}",
+                                "semantic_mode": "combined"
                             }
                         ],
                         "formulas": [
@@ -134,7 +139,8 @@
                             {
                                 "data_source": "metrics",
                                 "name": "query1",
-                                "query": "sum:sqlserver.stats.sql_compilations{$scope}"
+                                "query": "sum:sqlserver.stats.sql_compilations{$scope}",
+                                "semantic_mode": "combined"
                             }
                         ],
                         "formulas": [
@@ -157,7 +163,8 @@
                             {
                                 "data_source": "metrics",
                                 "name": "query1",
-                                "query": "sum:sqlserver.buffer.page_life_expectancy{$scope}"
+                                "query": "sum:sqlserver.buffer.page_life_expectancy{$scope}",
+                                "semantic_mode": "combined"
                             }
                         ],
                         "formulas": [
@@ -180,7 +187,8 @@
                             {
                                 "data_source": "metrics",
                                 "name": "query1",
-                                "query": "sum:sqlserver.stats.lock_waits{$scope}"
+                                "query": "sum:sqlserver.stats.lock_waits{$scope}",
+                                "semantic_mode": "combined"
                             }
                         ],
                         "formulas": [


### PR DESCRIPTION
### What does this PR do?
Adds support to SQL Server OOTB dashboards for mapping OTel metrics to dashboard widgets where equivalent metrics exist on the OTel side

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
