### PR TITLE
Fix brand names: "Checkpoint" → "Check Point", "Ping Federate" → "PingFederate"

### DIFF
--- a/checkpoint_quantum_firewall/README.md
+++ b/checkpoint_quantum_firewall/README.md
@@ -10,7 +10,7 @@ This integration ingests URL Filtering logs, Anti Bot logs, Application Control,
 
 ### Installation
 
-To install the Checkpoint Quantum Firewall integration, follow the steps below:
+To install the Check Point Quantum Firewall integration, follow the steps below:
 
 **Note**: This step is not necessary for Agent version >= 7.52.0.
 
@@ -20,7 +20,7 @@ To install the Checkpoint Quantum Firewall integration, follow the steps below:
 
 #### Log collection
 
-**Checkpoint Quantum Firewall:**
+**Check Point Quantum Firewall:**
 
 1. Collecting logs is disabled by default in the Datadog Agent. Enable it in the `datadog.yaml` file:
 
@@ -28,7 +28,7 @@ To install the Checkpoint Quantum Firewall integration, follow the steps below:
    logs_enabled: true
    ```
 
-2. Add this configuration block to your `checkpoint_quantum_firewall.d/conf.yaml` file to start collecting your Checkpoint Quantum Firewall logs.
+2. Add this configuration block to your `checkpoint_quantum_firewall.d/conf.yaml` file to start collecting your Check Point Quantum Firewall logs.
 
    See the [sample checkpoint_quantum_firewall.d/conf.yaml][6] for available configuration options.
 
@@ -42,7 +42,7 @@ To install the Checkpoint Quantum Firewall integration, follow the steps below:
 
 3. [Restart the Agent][1].
 
-4. Configure Syslog Message Forwarding from Checkpoint Quantum Firewall:
+4. Configure Syslog Message Forwarding from Check Point Quantum Firewall:
    1. Connect to the command line on the Management Server / Log Server.
    2. Login to the Expert mode. Enter your administrative credentials (after entering credentials, expert mode is enabled).
    3. In order to configure a new target for the exported logs, enter the following commands:
@@ -52,7 +52,7 @@ To install the Checkpoint Quantum Firewall integration, follow the steps below:
       - In the commands above, specify the following Syslog Server Details:
  
         - name: The Name of the syslog server. For example: `datadog_syslog`.
-        - target-server: The destination where you want to send the Checkpoint Quantum Firewall logs.
+        - target-server: The destination where you want to send the Check Point Quantum Firewall logs.
         - target-port: The port on which the syslog server is listening (typically 514).
         - protocol: The protocol name, or which protocol will be used to send logs (TCP/UDP).
         - format: Format must be 'json'.
@@ -60,7 +60,7 @@ To install the Checkpoint Quantum Firewall integration, follow the steps below:
       ```yaml
       cp_log_export restart name <Name of Log Exporter Configuration>
       ```
-   5. For more information about configuring syslog, see the [official Checkpoint documentation][4].
+   5. For more information about configuring syslog, see the [official Check Point documentation][4].
 
 ### Validation
 
@@ -70,23 +70,23 @@ To install the Checkpoint Quantum Firewall integration, follow the steps below:
 
 ### Logs
 
-The Checkpoint Quantum Firewall integration collects Firewall, URL Filtering, IPS, Identity Awareness, Application Control, Threat Emulation, Audit, Anti Ransomware, Anti Spam & Email Security, Anti Exploit, Anti Bot, Anti Virus, HTTPS Inspection, DLP, and Anti Malware logs.
+The Check Point Quantum Firewall integration collects Firewall, URL Filtering, IPS, Identity Awareness, Application Control, Threat Emulation, Audit, Anti Ransomware, Anti Spam & Email Security, Anti Exploit, Anti Bot, Anti Virus, HTTPS Inspection, DLP, and Anti Malware logs.
 
 ### Metrics
 
-The Checkpoint Quantum Firewall integration does not include any metrics.
+The Check Point Quantum Firewall integration does not include any metrics.
 
 ### Events
 
-The Checkpoint Quantum Firewall integration does not include any events.
+The Check Point Quantum Firewall integration does not include any events.
 
 ### Service Checks
 
-The Checkpoint Quantum Firewall integration does not include any service checks.
+The Check Point Quantum Firewall integration does not include any service checks.
 
 ## Troubleshooting
 
-**Checkpoint Quantum Firewall:**
+**Check Point Quantum Firewall:**
 
 #### Permission denied while port binding
 
@@ -124,7 +124,7 @@ Make sure that traffic is bypassed from the configured port if the firewall is e
 
 If you see the **Port <PORT-NO\> Already in Use** error, see the following instructions. The example below is for PORT-NO = 514:
 
-On systems using Syslog, if the Agent listens for Checkpoint Quantum Firewall logs on port 514, the following error can appear in the Agent logs: `Can't start UDP forwarder on port 514: listen udp :514: bind: address already in use`.
+On systems using Syslog, if the Agent listens for Check Point Quantum Firewall logs on port 514, the following error can appear in the Agent logs: `Can't start UDP forwarder on port 514: listen udp :514: bind: address already in use`.
 
 This error occurs because by default, Syslog listens on port 514. To resolve this error, take **one** of the following steps:
 

--- a/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_anti_bot.json
+++ b/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_anti_bot.json
@@ -1,5 +1,5 @@
 {
-    "title": "Checkpoint Quantum Firewall - Anti Bot",
+    "title": "Check Point Quantum Firewall - Anti Bot",
     "description": "- This dashboard gives insights about anti-bot related logs.",
     "widgets": [
         {

--- a/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_anti_exploit.json
+++ b/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_anti_exploit.json
@@ -1,5 +1,5 @@
 {
-    "title": "Checkpoint Quantum Firewall - Anti Exploit",
+    "title": "Check Point Quantum Firewall - Anti Exploit",
     "description": "- This dashboard gives insights about anti-exploits related logs.",
     "widgets": [
         {

--- a/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_anti_malware.json
+++ b/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_anti_malware.json
@@ -1,5 +1,5 @@
 {
-    "title": "Checkpoint Quantum Firewall - Anti Malware",
+    "title": "Check Point Quantum Firewall - Anti Malware",
     "description": "- This dashboard gives insights about anti-malware related logs.",
     "widgets": [
         {

--- a/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_anti_ransomware.json
+++ b/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_anti_ransomware.json
@@ -1,5 +1,5 @@
 {
-    "title": "Checkpoint Quantum Firewall - Anti Ransomware",
+    "title": "Check Point Quantum Firewall - Anti Ransomware",
     "description": "- This dashboard gives insights about anti-ransomware related logs.",
     "widgets": [
         {

--- a/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_anti_spam_and_email_security.json
+++ b/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_anti_spam_and_email_security.json
@@ -1,5 +1,5 @@
 {
-    "title": "Checkpoint Quantum Firewall - Anti Spam & Email Security",
+    "title": "Check Point Quantum Firewall - Anti Spam & Email Security",
     "description": "- This dashboard gives insight about anti-spam and email security related logs.",
     "widgets": [
         {

--- a/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_anti_virus.json
+++ b/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_anti_virus.json
@@ -1,5 +1,5 @@
 {
-    "title": "Checkpoint Quantum Firewall - Anti Virus",
+    "title": "Check Point Quantum Firewall - Anti Virus",
     "description": "- This dashboard gives insights about anti-virus related logs.",
     "widgets": [
         {

--- a/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_application_control.json
+++ b/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_application_control.json
@@ -1,5 +1,5 @@
 {
-    "title": "Checkpoint Quantum Firewall - Application Control",
+    "title": "Check Point Quantum Firewall - Application Control",
     "description": "- This dashboard gives insights about application control related logs.",
     "widgets": [
         {

--- a/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_audit.json
+++ b/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_audit.json
@@ -1,5 +1,5 @@
 {
-    "title": "Checkpoint Quantum Firewall - Audit",
+    "title": "Check Point Quantum Firewall - Audit",
     "description": "- This dashboard gives insights about audit log details.",
     "widgets": [
         {

--- a/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_dlp.json
+++ b/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_dlp.json
@@ -1,5 +1,5 @@
 {
-    "title": "Checkpoint Quantum Firewall - DLP",
+    "title": "Check Point Quantum Firewall - DLP",
     "description": "- This dashboard gives insights about Data Loss Prevention (DLP) related logs.",
     "widgets": [
         {

--- a/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_firewall.json
+++ b/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_firewall.json
@@ -1,5 +1,5 @@
 {
-    "title": "Checkpoint Quantum Firewall - Firewall",
+    "title": "Check Point Quantum Firewall - Firewall",
     "description": "- This dashboard gives insights about firewall related logs.",
     "widgets": [
         {

--- a/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_https_inspection.json
+++ b/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_https_inspection.json
@@ -1,5 +1,5 @@
 {
-    "title": "Checkpoint Quantum Firewall - HTTPS Inspection",
+    "title": "Check Point Quantum Firewall - HTTPS Inspection",
     "description": "- This dashboard gives insights about HTTPS Inspection type of logs.",
     "widgets": [
         {

--- a/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_identity_awareness.json
+++ b/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_identity_awareness.json
@@ -1,5 +1,5 @@
 {
-    "title": "Checkpoint Quantum Firewall - Identity Awareness",
+    "title": "Check Point Quantum Firewall - Identity Awareness",
     "description": "- This dashboard gives insights about identity awareness related logs.",
     "widgets": [
         {

--- a/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_ips.json
+++ b/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_ips.json
@@ -1,5 +1,5 @@
 {
-    "title": "Checkpoint Quantum Firewall - IPS",
+    "title": "Check Point Quantum Firewall - IPS",
     "description": "- This dashboard gives insights about Intrusion Prevention System (IPS) related logs.",
     "widgets": [
         {

--- a/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_threat_emulation.json
+++ b/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_threat_emulation.json
@@ -1,5 +1,5 @@
 {
-    "title": "Checkpoint Quantum Firewall - Threat Emulation",
+    "title": "Check Point Quantum Firewall - Threat Emulation",
     "description": "- This dashboard gives insights about threat emulation related logs.",
     "widgets": [
         {

--- a/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_url_filtering.json
+++ b/checkpoint_quantum_firewall/assets/dashboards/checkpoint_quantum_firewall_url_filtering.json
@@ -1,5 +1,5 @@
 {
-    "title": "Checkpoint Quantum Firewall - URL Filtering",
+    "title": "Check Point Quantum Firewall - URL Filtering",
     "description": "- This dashboard gives insights about URL filtering related logs.",
     "widgets": [
         {

--- a/checkpoint_quantum_firewall/assets/logs/checkpoint-quantum-firewall.yaml
+++ b/checkpoint_quantum_firewall/assets/logs/checkpoint-quantum-firewall.yaml
@@ -100,21 +100,21 @@ facets:
     source: log
   - facetType: list
     groups:
-      - Checkpoint Quantum Firewall
+      - Check Point Quantum Firewall
     name: Application Name
     path: checkpoint.quantum.firewall.appi_name
     source: log
     type: string
   - facetType: list
     groups:
-      - Checkpoint Quantum Firewall
+      - Check Point Quantum Firewall
     name: Application Risk
     path: checkpoint.quantum.firewall.app_risk_str
     source: log
     type: string
   - facetType: range
     groups:
-      - Checkpoint Quantum Firewall
+      - Check Point Quantum Firewall
     name: Client Inbound Bytes
     path: checkpoint.quantum.firewall.client_inbound_bytes
     source: log
@@ -124,14 +124,14 @@ facets:
       name: byte
   - facetType: range
     groups:
-      - Checkpoint Quantum Firewall
+      - Check Point Quantum Firewall
     name: Client Inbound Packets
     path: checkpoint.quantum.firewall.client_inbound_packets
     source: log
     type: integer
   - facetType: range
     groups:
-      - Checkpoint Quantum Firewall
+      - Check Point Quantum Firewall
     name: Client Outbound Bytes
     path: checkpoint.quantum.firewall.client_outbound_bytes
     source: log
@@ -141,28 +141,28 @@ facets:
       name: byte
   - facetType: range
     groups:
-      - Checkpoint Quantum Firewall
+      - Check Point Quantum Firewall
     name: Client Outbound Packets
     path: checkpoint.quantum.firewall.client_outbound_packets
     source: log
     type: integer
   - facetType: range
     groups:
-      - Checkpoint Quantum Firewall
+      - Check Point Quantum Firewall
     name: Server Inbound Packets
     path: checkpoint.quantum.firewall.server_inbound_packets
     source: log
     type: integer
   - facetType: range
     groups:
-      - Checkpoint Quantum Firewall
+      - Check Point Quantum Firewall
     name: Server Outbound Packets
     path: checkpoint.quantum.firewall.server_outbound_packets
     source: log
     type: integer
   - facetType: range
     groups:
-      - Checkpoint Quantum Firewall
+      - Check Point Quantum Firewall
     name: Total Bytes
     path: checkpoint.quantum.firewall.bytes
     source: log
@@ -172,7 +172,7 @@ facets:
       name: byte
 pipeline:
   type: pipeline
-  name: Checkpoint Quantum Firewall
+  name: Check Point Quantum Firewall
   enabled: true
   filter:
     query: "source:checkpoint-quantum-firewall"

--- a/checkpoint_quantum_firewall/manifest.json
+++ b/checkpoint_quantum_firewall/manifest.json
@@ -9,46 +9,46 @@
     "configuration": "README.md#Setup",
     "support": "README.md#Support",
     "changelog": "CHANGELOG.md",
-    "description": "Gain insights into Checkpoint Quantum Firewall logs",
-    "title": "Checkpoint Quantum Firewall",
+    "description": "Gain insights into Check Point Quantum Firewall logs",
+    "title": "Check Point Quantum Firewall",
     "media": [
       {
-        "caption": "Checkpoint Quantum Firewall - Audit",
+        "caption": "Check Point Quantum Firewall - Audit",
         "image_url": "images/checkpoint_quantum_firewall_audit.png",
         "media_type": "image"
       },
       {
-        "caption": "Checkpoint Quantum Firewall - Application Control",
+        "caption": "Check Point Quantum Firewall - Application Control",
         "image_url": "images/checkpoint_quantum_firewall_application_control.png",
         "media_type": "image"
       },
       {
-        "caption": "Checkpoint Quantum Firewall - URL Filtering",
+        "caption": "Check Point Quantum Firewall - URL Filtering",
         "image_url": "images/checkpoint_quantum_firewall_url_filtering.png",
         "media_type": "image"
       },
       {
-        "caption": "Checkpoint Quantum Firewall - Identity Awareness",
+        "caption": "Check Point Quantum Firewall - Identity Awareness",
         "image_url": "images/checkpoint_quantum_firewall_identity_awareness.png",
         "media_type": "image"
       },
       {
-        "caption": "Checkpoint Quantum Firewall - IPS",
+        "caption": "Check Point Quantum Firewall - IPS",
         "image_url": "images/checkpoint_quantum_firewall_ips.png",
         "media_type": "image"
       },
       {
-        "caption": "Checkpoint Quantum Firewall - Firewall",
+        "caption": "Check Point Quantum Firewall - Firewall",
         "image_url": "images/checkpoint_quantum_firewall_firewall.png",
         "media_type": "image"
       },
       {
-        "caption": "Checkpoint Quantum Firewall - Threat Emulation",
+        "caption": "Check Point Quantum Firewall - Threat Emulation",
         "image_url": "images/checkpoint_quantum_firewall_threat_emulation.png",
         "media_type": "image"
       },
       {
-        "caption": "Checkpoint Quantum Firewall - Anti Bot",
+        "caption": "Check Point Quantum Firewall - Anti Bot",
         "image_url": "images/checkpoint_quantum_firewall_anti_bot.png",
         "media_type": "image"
       }
@@ -79,21 +79,21 @@
       }
     },
     "dashboards": {
-      "Checkpoint Quantum Firewall: Audit": "assets/dashboards/checkpoint_quantum_firewall_audit.json",
-      "Checkpoint Quantum Firewall: Application Control": "assets/dashboards/checkpoint_quantum_firewall_application_control.json",
-      "Checkpoint Quantum Firewall: URL Filtering": "assets/dashboards/checkpoint_quantum_firewall_url_filtering.json",
-      "Checkpoint Quantum Firewall: Identity Awareness": "assets/dashboards/checkpoint_quantum_firewall_identity_awareness.json",
-      "Checkpoint Quantum Firewall: DLP": "assets/dashboards/checkpoint_quantum_firewall_dlp.json",
-      "Checkpoint Quantum Firewall: IPS": "assets/dashboards/checkpoint_quantum_firewall_ips.json",
-      "Checkpoint Quantum Firewall: Anti Spam & Email Security": "assets/dashboards/checkpoint_quantum_firewall_anti_spam_and_email_security.json",
-      "Checkpoint Quantum Firewall: Anti Exploit": "assets/dashboards/checkpoint_quantum_firewall_anti_exploit.json",
-      "Checkpoint Quantum Firewall: Firewall": "assets/dashboards/checkpoint_quantum_firewall_firewall.json",
-      "Checkpoint Quantum Firewall: Anti Ransomware": "assets/dashboards/checkpoint_quantum_firewall_anti_ransomware.json",
-      "Checkpoint Quantum Firewall: Threat Emulation": "assets/dashboards/checkpoint_quantum_firewall_threat_emulation.json",
-      "Checkpoint Quantum Firewall: Anti Virus": "assets/dashboards/checkpoint_quantum_firewall_anti_virus.json",
-      "Checkpoint Quantum Firewall: HTTPS Inspection": "assets/dashboards/checkpoint_quantum_firewall_https_inspection.json",
-      "Checkpoint Quantum Firewall: Anti Bot": "assets/dashboards/checkpoint_quantum_firewall_anti_bot.json",
-      "Checkpoint Quantum Firewall: Anti Malware": "assets/dashboards/checkpoint_quantum_firewall_anti_malware.json"
+      "Check Point Quantum Firewall: Audit": "assets/dashboards/checkpoint_quantum_firewall_audit.json",
+      "Check Point Quantum Firewall: Application Control": "assets/dashboards/checkpoint_quantum_firewall_application_control.json",
+      "Check Point Quantum Firewall: URL Filtering": "assets/dashboards/checkpoint_quantum_firewall_url_filtering.json",
+      "Check Point Quantum Firewall: Identity Awareness": "assets/dashboards/checkpoint_quantum_firewall_identity_awareness.json",
+      "Check Point Quantum Firewall: DLP": "assets/dashboards/checkpoint_quantum_firewall_dlp.json",
+      "Check Point Quantum Firewall: IPS": "assets/dashboards/checkpoint_quantum_firewall_ips.json",
+      "Check Point Quantum Firewall: Anti Spam & Email Security": "assets/dashboards/checkpoint_quantum_firewall_anti_spam_and_email_security.json",
+      "Check Point Quantum Firewall: Anti Exploit": "assets/dashboards/checkpoint_quantum_firewall_anti_exploit.json",
+      "Check Point Quantum Firewall: Firewall": "assets/dashboards/checkpoint_quantum_firewall_firewall.json",
+      "Check Point Quantum Firewall: Anti Ransomware": "assets/dashboards/checkpoint_quantum_firewall_anti_ransomware.json",
+      "Check Point Quantum Firewall: Threat Emulation": "assets/dashboards/checkpoint_quantum_firewall_threat_emulation.json",
+      "Check Point Quantum Firewall: Anti Virus": "assets/dashboards/checkpoint_quantum_firewall_anti_virus.json",
+      "Check Point Quantum Firewall: HTTPS Inspection": "assets/dashboards/checkpoint_quantum_firewall_https_inspection.json",
+      "Check Point Quantum Firewall: Anti Bot": "assets/dashboards/checkpoint_quantum_firewall_anti_bot.json",
+      "Check Point Quantum Firewall: Anti Malware": "assets/dashboards/checkpoint_quantum_firewall_anti_malware.json"
     }
   },
   "author": {

--- a/ping_federate/README.md
+++ b/ping_federate/README.md
@@ -62,7 +62,7 @@ Linux command
 
 ### Logs
 
-The Ping Federate integration collects the following log types.
+The PingFederate integration collects the following log types.
 
 | Format     | Event Types    |
 | ---------  | -------------- |
@@ -95,15 +95,15 @@ Additional field log format:
 
 ### Metrics
 
-The Ping Federate does not include any metrics.
+The PingFederate does not include any metrics.
 
 ### Events
 
-The Ping Federate integration does not include any events.
+The PingFederate integration does not include any events.
 
 ### Service Checks
 
-The Ping Federate integration does not include any service checks.
+The PingFederate integration does not include any service checks.
 
 ## Troubleshooting
 

--- a/ping_federate/assets/dashboards/ping_federate_audit.json
+++ b/ping_federate/assets/dashboards/ping_federate_audit.json
@@ -230,7 +230,7 @@
           {
             "definition": {
               "background_color": "vivid_blue",
-              "content": "\nDatadog Cloud SIEM analyzes and correlates Ping Federate Audit logs to detect threats to your environment in real time. If you don't see signals please make sure you've enabled [Datadog Cloud SIEM](/security?query=source%3Aping-federate%20service%3Aaudit%20). ",
+              "content": "\nDatadog Cloud SIEM analyzes and correlates PingFederate Audit logs to detect threats to your environment in real time. If you don't see signals please make sure you've enabled [Datadog Cloud SIEM](/security?query=source%3Aping-federate%20service%3Aaudit%20). ",
               "font_size": "14",
               "has_padding": true,
               "show_tick": false,


### PR DESCRIPTION
## Summary
- Fix "Checkpoint Quantum Firewall" → "Check Point Quantum Firewall" across manifest, README, 15 dashboards, and logs YAML
- Fix "Ping Federate" → "PingFederate" in README and audit dashboard

## Changes
- `checkpoint_quantum_firewall/manifest.json` — title, description, 8 media captions, 15 dashboard names
- `checkpoint_quantum_firewall/README.md` — 12 occurrences
- `checkpoint_quantum_firewall/assets/logs/checkpoint-quantum-firewall.yaml` — 10 facet group names + pipeline name
- 15 dashboard JSONs — dashboard title in each
- `ping_federate/README.md` — 4 occurrences
- `ping_federate/assets/dashboards/ping_federate_audit.json` — 1 occurrence

## Notes
- `$Checkpoint_Server` template variable names intentionally left unchanged (programmatic identifiers; renaming would break existing dashboards)
- All changes are asset/config only — no Python code changes, no changelog needed
- Existing customer orgs keep old dashboard titles; new installs get corrected titles

## Test plan
- [ ] Verify no remaining "Checkpoint Quantum" (without space) in user-visible strings
- [ ] Verify no remaining "Ping Federate" (with space) in user-visible strings
- [ ] Confirm `$Checkpoint_Server` template variables still work in dashboards

🤖 Generated with [Claude Code](https://claude.com/claude-code)