### PR TITLE
Fix 'occured' -> 'occurred' typo in mysql databases_data error log

### DIFF
--- a/mysql/datadog_checks/mysql/databases_data.py
+++ b/mysql/datadog_checks/mysql/databases_data.py
@@ -275,14 +275,14 @@ class DatabasesData:
                 self._fetch_database_data(cursor, start_time, db_info['name'])
             except StopIteration as e:
                 self._log.error(
-                    "While executing fetch database data for database {}, the following exception occured {}".format(
+                    "While executing fetch database data for database {}, the following exception occurred {}".format(
                         db_info['name'], e
                     )
                 )
                 return
             except Exception as e:
                 self._log.error(
-                    "While executing fetch database data for database {}, the following exception occured {}".format(
+                    "While executing fetch database data for database {}, the following exception occurred {}".format(
                         db_info['name'], e
                     )
                 )


### PR DESCRIPTION
Two error log messages in `mysql/datadog_checks/mysql/databases_data.py` (lines 278 and 285) read `the following exception occured {}`. Both are emitted from the fetch-database-data path and are user-visible in mysql check error output. Python `ast.parse` stays clean against current `master`.