### PR TITLE
[DBMON-6461] Conditionally look for host or hostname when filtering Postgres dashboard logs

### DIFF
--- a/postgres/assets/dashboards/postgresql_screenboard_dashboard.json
+++ b/postgres/assets/dashboards/postgresql_screenboard_dashboard.json
@@ -1612,7 +1612,7 @@
               "title_align": "left",
               "type": "log_stream",
               "indexes": [],
-              "query": "source:postgresql hostname:$host.value",
+              "query": "source:postgresql (host:$host.value OR hostname:$host.value)",
               "sort": {
                 "column": "time",
                 "order": "desc"


### PR DESCRIPTION
### What does this PR do?
Looking through git history we've swapped back and forth between filtering logs on the Postgres Overview widget between `host` and `hostname` due to issues sourcing the correct value. We're currently using `hostname` but OTel Postgres logs will only have `host` which breaks the current logic. This change adds a conditional looking for either of these values in order for us to support OTel Postgres logs on the dashboard.

### Motivation
With this filter update we'll properly be able to surface Postgres logs that are emitted from an OTel collector.
<img width="1863" height="599" alt="Screenshot 2026-04-15 at 2 51 37 PM" src="https://github.com/user-attachments/assets/77ed8720-08fc-4d58-b6d6-26c88aa730d1" />


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
