### PR TITLE
[openmetrics] Add option to include raw endpoint response in Agent flares

### DIFF
--- a/datadog_checks_base/changelog.d/23341.added
+++ b/datadog_checks_base/changelog.d/23341.added
@@ -1,0 +1,1 @@
+Add `collect_endpoint_data_for_flare` option on `OpenMetricsBaseCheckV2` to capture raw endpoint HTTP response in Agent flares

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
@@ -7,10 +7,15 @@ from contextlib import contextmanager
 from requests.exceptions import RequestException
 
 from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.config import is_affirmative
 from datadog_checks.base.errors import ConfigurationError
 from datadog_checks.base.utils.tracing import traced_class
 
 from .scraper import OpenMetricsScraper
+
+# Maximum number of response body bytes captured per endpoint when collecting
+# flare data.  Keeps flares from becoming excessively large for busy endpoints.
+_FLARE_MAX_BODY_SIZE = 10_000
 
 
 class OpenMetricsBaseCheckV2(AgentCheck):
@@ -53,6 +58,9 @@ class OpenMetricsBaseCheckV2(AgentCheck):
         self.scrapers = {}
 
         self.check_initializations.append(self.configure_scrapers)
+
+        if is_affirmative(self.instance.get('collect_endpoint_data_for_flare', False)):
+            self.diagnosis.register(self._collect_endpoint_flare_data)
 
     def check(self, _):
         """
@@ -99,6 +107,50 @@ class OpenMetricsBaseCheckV2(AgentCheck):
         Subclasses can override to return a custom scraper based on instance configuration.
         """
         return OpenMetricsScraper(self, self.get_config_with_defaults(config))
+
+    def _collect_endpoint_flare_data(self):
+        """Fetch the raw HTTP response from each configured OpenMetrics endpoint
+        and record it as a diagnosis entry so it is included in Agent flares.
+
+        Registered as a diagnosis callback when ``collect_endpoint_data_for_flare``
+        is enabled in the instance configuration.  Each endpoint produces one
+        entry containing the status line, response headers, and up to
+        ``_FLARE_MAX_BODY_SIZE`` bytes of the response body — the equivalent of
+        running ``curl -v <endpoint>``.
+        """
+        if not self.scrapers:
+            self.diagnosis.warning(
+                'endpoint_flare_data',
+                'No scrapers initialised yet. Run the check at least once before generating a flare.',
+                category='flare',
+            )
+            return
+
+        for endpoint, scraper in self.scrapers.items():
+            name = 'endpoint_flare_data[{}]'.format(endpoint)
+            try:
+                response = scraper.http.get(endpoint, stream=False)
+                response.raise_for_status()
+
+                status_line = 'HTTP {} {}'.format(response.status_code, response.reason)
+                headers_text = '\n'.join('{}: {}'.format(k, v) for k, v in response.headers.items())
+                body = response.text
+                if len(body) > _FLARE_MAX_BODY_SIZE:
+                    body = body[:_FLARE_MAX_BODY_SIZE] + '\n[... response truncated at {} bytes ...]'.format(
+                        _FLARE_MAX_BODY_SIZE
+                    )
+
+                self.diagnosis.success(
+                    name,
+                    '{}\n{}\n\n{}'.format(status_line, headers_text, body),
+                    category='flare',
+                )
+            except Exception as e:
+                self.diagnosis.fail(
+                    name,
+                    'Failed to fetch {}: {}'.format(endpoint, e),
+                    category='flare',
+                )
 
     def set_dynamic_tags(self, *tags):
         for scraper in self.scrapers.values():

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_flare.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_flare.py
@@ -1,0 +1,179 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Tests for the `collect_endpoint_data_for_flare` option on OpenMetricsBaseCheckV2."""
+
+import json
+
+import pytest
+from mock import MagicMock, patch
+
+from datadog_checks.base.checks.openmetrics.v2.base import _FLARE_MAX_BODY_SIZE
+from datadog_checks.base.utils.diagnose import Diagnosis
+
+from .utils import get_check
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors the helpers in test_diagnose.py)
+# ---------------------------------------------------------------------------
+
+
+def get_diagnoses(check):
+    return json.loads(check.get_diagnoses())
+
+
+def diagnose_dict(result, name, diagnosis, category=None, description=None, remediation=None, rawerror=None):
+    return {
+        "result": result,
+        "name": name,
+        "diagnosis": diagnosis,
+        "category": category,
+        "description": description,
+        "remediation": remediation,
+        "rawerror": rawerror,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+
+class TestCollectEndpointDataForFlare:
+    """Tests for the ``collect_endpoint_data_for_flare`` instance option."""
+
+    PROMETHEUS_PAYLOAD = (
+        "# HELP go_memstats_alloc_bytes Number of bytes allocated.\n"
+        "# TYPE go_memstats_alloc_bytes gauge\n"
+        "go_memstats_alloc_bytes 6.396288e+06\n"
+    )
+
+    def test_disabled_by_default_no_flare_diagnoses(self, dd_run_check, mock_http_response):
+        """No flare-category diagnosis entries are produced when option is not set."""
+        mock_http_response(self.PROMETHEUS_PAYLOAD)
+        check = get_check({'metrics': ['.+']})
+        dd_run_check(check)
+
+        flare_entries = [d for d in get_diagnoses(check) if d.get('category') == 'flare']
+        assert flare_entries == []
+
+    def test_enabled_captures_status_and_headers(self, dd_run_check, mock_http_response):
+        """A success entry is created containing the HTTP status line and headers."""
+        mock_http_response(self.PROMETHEUS_PAYLOAD)
+        check = get_check({'metrics': ['.+'], 'collect_endpoint_data_for_flare': True})
+        dd_run_check(check)
+
+        flare_entries = [d for d in get_diagnoses(check) if d.get('category') == 'flare']
+
+        assert len(flare_entries) == 1
+        entry = flare_entries[0]
+        assert entry['result'] == Diagnosis.DIAGNOSIS_SUCCESS
+        assert entry['name'] == 'endpoint_flare_data[test]'
+        assert 'HTTP 200' in entry['diagnosis']
+
+    def test_enabled_captures_response_body(self, dd_run_check, mock_http_response):
+        """The raw response body is included in the diagnosis content."""
+        mock_http_response(self.PROMETHEUS_PAYLOAD)
+        check = get_check({'metrics': ['.+'], 'collect_endpoint_data_for_flare': True})
+        dd_run_check(check)
+
+        flare_entries = [d for d in get_diagnoses(check) if d.get('category') == 'flare']
+
+        assert len(flare_entries) == 1
+        assert self.PROMETHEUS_PAYLOAD in flare_entries[0]['diagnosis']
+
+    def test_response_body_truncated_at_limit(self, dd_run_check, mock_http_response):
+        """Bodies larger than _FLARE_MAX_BODY_SIZE are truncated with a notice."""
+        # Create a payload that exceeds the limit
+        large_payload = "# TYPE foo gauge\n" + ("foo{id=\"x\"} 1\n" * 1000)
+        assert len(large_payload) > _FLARE_MAX_BODY_SIZE, "Pre-condition: payload must exceed the limit"
+
+        mock_http_response(large_payload)
+        check = get_check({'metrics': ['.+'], 'collect_endpoint_data_for_flare': True})
+        dd_run_check(check)
+
+        flare_entries = [d for d in get_diagnoses(check) if d.get('category') == 'flare']
+
+        assert len(flare_entries) == 1
+        diagnosis_text = flare_entries[0]['diagnosis']
+        assert '[... response truncated at {} bytes ...]'.format(_FLARE_MAX_BODY_SIZE) in diagnosis_text
+        # Verify we didn't include the full payload
+        assert len(diagnosis_text) < len(large_payload)
+
+    def test_body_not_truncated_when_under_limit(self, dd_run_check, mock_http_response):
+        """Bodies within the size limit are included in full."""
+        assert len(self.PROMETHEUS_PAYLOAD) < _FLARE_MAX_BODY_SIZE, "Pre-condition: payload must be under the limit"
+
+        mock_http_response(self.PROMETHEUS_PAYLOAD)
+        check = get_check({'metrics': ['.+'], 'collect_endpoint_data_for_flare': True})
+        dd_run_check(check)
+
+        flare_entries = [d for d in get_diagnoses(check) if d.get('category') == 'flare']
+
+        assert len(flare_entries) == 1
+        assert 'truncated' not in flare_entries[0]['diagnosis']
+
+    def test_http_error_recorded_as_fail(self, dd_run_check, mock_http_response):
+        """An HTTP error response from the endpoint produces a fail diagnosis."""
+        mock_http_response('Forbidden', status_code=403)
+        check = get_check({'metrics': ['.+'], 'collect_endpoint_data_for_flare': True})
+
+        # The check run itself will raise (403), but the flare diagnosis should
+        # still record the failure gracefully.
+        with pytest.raises(Exception):
+            dd_run_check(check)
+
+        flare_entries = [d for d in get_diagnoses(check) if d.get('category') == 'flare']
+
+        assert len(flare_entries) == 1
+        assert flare_entries[0]['result'] == Diagnosis.DIAGNOSIS_FAIL
+        assert flare_entries[0]['name'] == 'endpoint_flare_data[test]'
+
+    def test_connection_error_recorded_as_fail(self, dd_run_check, mock_http_response):
+        """A connection error to the endpoint produces a fail diagnosis."""
+        mock_http_response(Exception("Connection refused"))
+        check = get_check({'metrics': ['.+'], 'collect_endpoint_data_for_flare': True})
+
+        with pytest.raises(Exception):
+            dd_run_check(check)
+
+        flare_entries = [d for d in get_diagnoses(check) if d.get('category') == 'flare']
+
+        assert len(flare_entries) == 1
+        assert flare_entries[0]['result'] == Diagnosis.DIAGNOSIS_FAIL
+        assert 'Connection refused' in flare_entries[0]['diagnosis']
+
+    def test_warns_when_no_scrapers_initialised(self):
+        """A warning is emitted if a flare is generated before the check has run."""
+        # Do not call dd_run_check — scrapers are not yet initialised
+        check = get_check({'metrics': ['.+'], 'collect_endpoint_data_for_flare': True})
+
+        flare_entries = [d for d in get_diagnoses(check) if d.get('category') == 'flare']
+
+        assert len(flare_entries) == 1
+        assert flare_entries[0]['result'] == Diagnosis.DIAGNOSIS_WARNING
+        assert flare_entries[0]['name'] == 'endpoint_flare_data'
+
+    def test_multiple_endpoints_produce_separate_entries(self, dd_run_check, mock_http_response):
+        """Each scraper endpoint produces an independent flare diagnosis entry."""
+        mock_http_response(self.PROMETHEUS_PAYLOAD)
+        check = get_check({'metrics': ['.+'], 'collect_endpoint_data_for_flare': True})
+        dd_run_check(check)
+
+        # Inject a second scraper after the first run to simulate multi-endpoint config
+        second_endpoint = 'http://other-host:9090/metrics'
+        mock_scraper = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.reason = 'OK'
+        mock_response.headers = {'Content-Type': 'text/plain'}
+        mock_response.text = '# TYPE bar gauge\nbar 2\n'
+        mock_scraper.http.get.return_value = mock_response
+        check.scrapers[second_endpoint] = mock_scraper
+
+        flare_entries = [d for d in get_diagnoses(check) if d.get('category') == 'flare']
+
+        assert len(flare_entries) == 2
+        names = {e['name'] for e in flare_entries}
+        assert 'endpoint_flare_data[test]' in names
+        assert 'endpoint_flare_data[{}]'.format(second_endpoint) in names

--- a/openmetrics/CHANGELOG.md
+++ b/openmetrics/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 <!-- towncrier release notes start -->
 
+## Unreleased
+
+***Added***:
+
+* Add `collect_endpoint_data_for_flare` instance option. When enabled, the raw HTTP response
+  from each `openmetrics_endpoint` (equivalent to `curl -v <endpoint>`) is captured and included
+  in Agent flares to aid in troubleshooting scraping issues. Response bodies are truncated to 10 KB.
+  See [#XXXXX](https://github.com/DataDog/integrations-core/pull/XXXXX).
+
 ## 7.1.1 / 2025-10-31
 
 ***Fixed***:

--- a/openmetrics/CHANGELOG.md
+++ b/openmetrics/CHANGELOG.md
@@ -2,15 +2,6 @@
 
 <!-- towncrier release notes start -->
 
-## Unreleased
-
-***Added***:
-
-* Add `collect_endpoint_data_for_flare` instance option. When enabled, the raw HTTP response
-  from each `openmetrics_endpoint` (equivalent to `curl -v <endpoint>`) is captured and included
-  in Agent flares to aid in troubleshooting scraping issues. Response bodies are truncated to 10 KB.
-  See [#XXXXX](https://github.com/DataDog/integrations-core/pull/XXXXX).
-
 ## 7.1.1 / 2025-10-31
 
 ***Fixed***:

--- a/openmetrics/assets/configuration/spec.yaml
+++ b/openmetrics/assets/configuration/spec.yaml
@@ -17,6 +17,20 @@ files:
             tag_by_endpoint.example: false
             tag_by_endpoint.hidden: false
             tag_by_endpoint.enabled: true
+        - name: collect_endpoint_data_for_flare
+          description: |
+            When enabled, the check performs an additional HTTP GET request to each
+            configured `openmetrics_endpoint` at flare generation time and includes
+            the raw response (status line, response headers, and up to 10 KB of body)
+            in the flare. This is equivalent to running `curl -v <endpoint>` and is
+            useful for diagnosing scraping issues without requiring direct access to
+            the host.
+
+            This option is disabled by default and has no effect during normal check
+            runs.
+          value:
+            type: boolean
+            example: false
         - template: instances/openmetrics_legacy_base
           hidden: true
           overrides:

--- a/openmetrics/changelog.d/23341.added
+++ b/openmetrics/changelog.d/23341.added
@@ -1,0 +1,1 @@
+Add `collect_endpoint_data_for_flare` option to include raw OpenMetrics endpoint response in Agent flares

--- a/openmetrics/datadog_checks/openmetrics/config_models/instance.py
+++ b/openmetrics/datadog_checks/openmetrics/config_models/instance.py
@@ -113,6 +113,7 @@ class InstanceConfig(BaseModel):
     cache_metric_wildcards: Optional[bool] = None
     cache_shared_labels: Optional[bool] = None
     collect_counters_with_distributions: Optional[bool] = None
+    collect_endpoint_data_for_flare: Optional[bool] = None
     collect_histogram_buckets: Optional[bool] = None
     connect_timeout: Optional[float] = None
     disable_generic_tags: Optional[bool] = None


### PR DESCRIPTION
## What does this PR do?

Adds a new `collect_endpoint_data_for_flare` boolean instance option to all
integrations built on `OpenMetricsBaseCheckV2`. When enabled, the check
registers a diagnosis callback that performs an HTTP GET to each configured
`openmetrics_endpoint` at flare generation time, and records the raw response
in the flare under a `flare` category diagnosis entry.

This is equivalent to a `curl -v <endpoint>` and gives support engineers
direct visibility into what the endpoint is returning — without requiring
manual steps from the customer.

## Motivation

When troubleshooting OpenMetrics scraping issues (parse errors, missing
metrics, auth failures, unexpected content types), Datadog support currently
needs customers to run `curl` manually and share the output. This option
automates that collection at flare time, reducing back-and-forth and speeding
up investigations.

## Changes

| File | Change |
|---|---|
| `datadog_checks_base/.../openmetrics/v2/base.py` | Add `_FLARE_MAX_BODY_SIZE` constant, import `is_affirmative`, register diagnosis callback in `__init__` when option is set, implement `_collect_endpoint_flare_data` |
| `openmetrics/assets/configuration/spec.yaml` | Document the new option |
| `openmetrics/.../config_models/instance.py` | Add `collect_endpoint_data_for_flare` field (autogenerated) |
| `datadog_checks_base/tests/.../test_v2/test_flare.py` | Full test coverage (new file) |
| `openmetrics/CHANGELOG.md` | Changelog entry |

## Usage

```yaml
instances:
  - openmetrics_endpoint: http://localhost:9090/metrics
    namespace: myapp
    metrics:
      - .+
    collect_endpoint_data_for_flare: true  # include curl output in flares
```

## Behaviour details

- **Opt-in**, defaults to `false` — no change in behaviour for existing configs.
- A separate HTTP request is made per endpoint **only at flare generation time**, not during normal check runs.
- Response bodies are **truncated at 10 KB** to keep flares manageable.
- Errors (connection failures, HTTP errors) are recorded as `DIAGNOSIS_FAIL` entries rather than raising, so a failing endpoint doesn't block the rest of the flare.
- If a flare is generated before the check has run (scrapers not yet initialised), a `DIAGNOSIS_WARNING` is emitted instead.
- Applies to **all** integrations built on `OpenMetricsBaseCheckV2` — not just the generic `openmetrics` check.

## Testing

```bash
# Run new tests
cd datadog_checks_base
hatch -e py3.12 run pytest tests/base/checks/openmetrics/test_v2/test_flare.py -v
```