### PR TITLE
Document Agent 7.79 NTP metric and tag breaking changes in README

### DIFF
--- a/ntp/README.md
+++ b/ntp/README.md
@@ -19,6 +19,25 @@ default to the NTP servers below:
 
 **Note:** NTP requests do not support proxy settings.
 
+## Agent version notes
+
+### Datadog Agent 7.79 — NTP metric and tag changes
+
+Agent **7.78** introduced **`ntp.offset`** for two signals, distinguished by a **`source`** tag:
+
+- **`source:intake`** — offset between the local clock and Datadog intake time (from the HTTP `Date` response header).
+- **`source:ntp`** — offset between the local clock and the configured NTP reference.
+
+Starting with Agent **7.79**:
+
+- The intake-derived series is renamed to **`ntp.intake_offset`** (it is no longer reported as **`ntp.offset`** with **`source:intake`**).
+- The NTP reference series remains **`ntp.offset`**, but the **`source:ntp` tag is removed**. That is a **breaking change** for any monitor, dashboard, or saved query that filters on **`ntp.offset` and `source:ntp`**.
+
+| If you match this today (Agent 7.78) | Use this after Agent 7.79 |
+|--------------------------------------|-----------------------------|
+| **`ntp.offset`** with **`source:intake`** | **`ntp.intake_offset`** |
+| **`ntp.offset`** with **`source:ntp`** | **`ntp.offset`** without a **`source`** filter |
+
 ## Setup
 
 ### Installation
@@ -66,7 +85,7 @@ For containerized environments, see the documentation concerning [Autodiscovery 
 
 ### Metrics
 
-See [metadata.csv][6] for a list of metrics provided by this check.
+See [metadata.csv][6] for a list of metrics provided by this check. If you upgrade from Agent 7.78 to 7.79 or later, read [Agent version notes](#agent-version-notes) above before updating monitors or dashboards.
 
 ### Events
 


### PR DESCRIPTION
### What does this PR do?

Adds an **Agent version notes** section to the NTP integration README describing Datadog Agent **7.79** behavior for customers upgrading from **7.78**: the intake-derived offset is emitted as **`ntp.intake_offset`** (instead of **`ntp.offset`** with **`source:intake`**), and **`ntp.offset`** for the NTP reference clock **no longer includes the `source:ntp` tag**. Includes a short migration table and a cross-link from **Data collected → Metrics**.

### Motivation

Agent 7.78 introduced **`ntp.offset`** with **`source:intake`** and **`source:ntp`**; 7.79 renames the intake series and removes **`source:ntp`** on the NTP reference series. That is a breaking change for monitors and dashboards that filter on those tags; the README should document the expected queries after upgrade.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
