### PR TITLE
Add conditional message filtering to EventBusOrchestrator

### DIFF
--- a/ddev/changelog.d/23344.added
+++ b/ddev/changelog.d/23344.added
@@ -1,0 +1,1 @@
+Add conditional message filtering to EventBusOrchestrator

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -41,6 +41,9 @@ class BaseProcessor[T: BaseMessage]:
             raise ProcessorQueueError("This processor has not been added to an active event bus")
         self.queue.put_nowait(message)
 
+    def should_process_message(self, message: BaseMessage) -> bool:
+        return True
+
 
 class AsyncProcessor[T: BaseMessage](BaseProcessor[T], ABC):
     @abstractmethod
@@ -329,6 +332,7 @@ class EventBusOrchestrator(ABC):
         running_tasks.update(
             asyncio.create_task(self._task_wrapper(processor, msg))
             for processor in self._subscribers.get(type(msg), [])
+            if processor.should_process_message(msg)
         )
 
     async def _task_wrapper(self, processor: Processor, message: BaseMessage):

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -157,6 +157,12 @@ def manager() -> Manager:
 
 
 @pytest.fixture
+def bare_orchestrator() -> MockOrchestrator:
+    logger = logging.getLogger("test")
+    return MockOrchestrator(logger, grace_period=0.1)
+
+
+@pytest.fixture
 def orchestrator(secretary: Secretary, analyst: Analyst, manager: Manager) -> MockOrchestrator:
     logger = logging.getLogger("test_orchestrator")
     # Use a short grace_period for tests to speed them up (0.1s instead of default 10s)
@@ -521,3 +527,58 @@ def test_fatal_processing_error_stops_orchestrator(
     # Assert that only the first message was processed/received by the hook
     assert len(orchestrator.received_messages) == 1
     assert orchestrator.received_messages[0].id == "fatal_msg"
+
+
+def test_should_process_message_conditional_filtering(bare_orchestrator: MockOrchestrator) -> None:
+    """Processor processes only messages matching a custom predicate on message attributes."""
+
+    class HighPriorityAnalyst(AsyncProcessor[TaskAssignment]):
+        def __init__(self, name: str, min_priority: int):
+            super().__init__(name)
+            self.min_priority = min_priority
+            self.processed: list[TaskAssignment] = []
+
+        def should_process_message(self, message: BaseMessage) -> bool:
+            return isinstance(message, TaskAssignment) and message.priority >= self.min_priority
+
+        async def process_message(self, message: TaskAssignment) -> None:
+            self.processed.append(message)
+
+    analyst = HighPriorityAnalyst("high_priority_analyst", min_priority=10)
+    bare_orchestrator.register_processor(analyst, [TaskAssignment])
+
+    bare_orchestrator.submit_message(TaskAssignment("low_task", priority=1))
+    bare_orchestrator.submit_message(TaskAssignment("high_task", priority=100))
+    bare_orchestrator.run()
+
+    assert len(analyst.processed) == 1
+    assert analyst.processed[0].id == "high_task"
+
+
+def test_should_process_message_is_independent_per_processor(
+    bare_orchestrator: MockOrchestrator, secretary: Secretary
+) -> None:
+    """Each processor filters independently — one skipping a message does not affect the others."""
+
+    class UrgentMemosOnlyProcessor(AsyncProcessor[Memo]):
+        def __init__(self, name: str):
+            super().__init__(name)
+            self.processed: list[Memo] = []
+
+        def should_process_message(self, message: BaseMessage) -> bool:
+            return isinstance(message, Memo) and message.subject == "urgent"
+
+        async def process_message(self, message: Memo) -> None:
+            self.processed.append(message)
+
+    urgent_proc = UrgentMemosOnlyProcessor("urgent_only")
+    bare_orchestrator.register_processor(secretary, [Memo])
+    bare_orchestrator.register_processor(urgent_proc, [Memo])
+
+    bare_orchestrator.submit_message(Memo("memo1", subject="regular"))
+    bare_orchestrator.submit_message(Memo("memo2", subject="urgent"))
+    bare_orchestrator.run()
+
+    assert len(secretary.delivered_memos) == 2
+    assert len(urgent_proc.processed) == 1
+    assert urgent_proc.processed[0].id == "memo2"


### PR DESCRIPTION
### What does this PR do?

Adds a `should_process_message` method to `BaseProcessor` that can be overridden to conditionally skip message processing beyond type-based subscription. By default it returns `True` (no change in behavior). The `_handle_message` loop checks this predicate before spawning a task for each processor.

Also adds tests covering: attribute-based filtering and per-processor independence.

### Motivation

The upcoming AI integration-builder project drives phases through an `EventBusOrchestrator` pipeline. Phases will need to filter messages not just by type but by message content. This hook makes that possible without requiring separate message types or external coordination logic.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged