### PR TITLE
[Cisco ACI] Remove tenant faults as events

### DIFF
--- a/cisco_aci/changelog.d/23350.removed
+++ b/cisco_aci/changelog.d/23350.removed
@@ -1,0 +1,1 @@
+[Cisco ACI] Remove tenant faults as events, faults are now only to send as logs

--- a/cisco_aci/datadog_checks/cisco_aci/api.py
+++ b/cisco_aci/datadog_checks/cisco_aci/api.py
@@ -224,16 +224,6 @@ class Api:
         # return only the list of stats
         return self._parse_response(response)
 
-    def get_tenant_events(self, tenant, page=0, page_size=15):
-        query1 = 'rsp-subtree-include=event-logs,no-scoped,subtree'
-        query2 = 'order-by=eventRecord.created|desc'
-        query3 = 'page={}&page-size={}'.format(page, page_size)
-        query = '{}&{}&{}'.format(query1, query2, query3)
-        path = "/api/node/mo/uni/tn-{}.json?{}".format(tenant, query)
-        response = self.make_request(path)
-        # return only the list of stats
-        return self._parse_response(response)
-
     def get_fabric_pods(self):
         path = '/api/mo/topology.json?query-target=subtree&target-subtree-class=fabricPod'
         response = self.make_request(path)

--- a/cisco_aci/datadog_checks/cisco_aci/cisco.py
+++ b/cisco_aci/datadog_checks/cisco_aci/cisco.py
@@ -26,7 +26,6 @@ class CiscoACICheck(AgentCheck):
     def __init__(self, name, init_config, instances):
         super(CiscoACICheck, self).__init__(name, init_config, instances)
         self.tenant_metrics = make_tenant_metrics()
-        self.last_events_ts = {}
         self.external_host_tags = {}
         self._api_cache = {}
         self.check_tags = ['cisco']

--- a/cisco_aci/datadog_checks/cisco_aci/helpers.py
+++ b/cisco_aci/datadog_checks/cisco_aci/helpers.py
@@ -113,33 +113,6 @@ def _get_value_from_dn(regex, dn):
         return None
 
 
-def get_event_tags_from_dn(dn):
-    """
-    This grabs the event tags from the dn designator. They look like this:
-    uni/tn-DataDog/ap-DtDg-AP1-EcommerceApp/epg-DtDg-Ecomm/HDl2IngrPktsAg1h
-    """
-    tags = []
-    node = get_node_from_dn(dn)
-    if node:
-        tags.append("node:" + node)
-    app = get_app_from_dn(dn)
-    if app:
-        tags.append("app:" + app)
-    bd = get_bd_from_dn(dn)
-    if bd:
-        tags.append("bd:" + bd)
-    cep = get_cep_from_dn(dn)
-    if cep:
-        tags.append("mac:" + cep)
-    ip = get_ip_from_dn(dn)
-    if ip:
-        tags.append("ip:" + ip)
-    epg = get_epg_from_dn(dn)
-    if epg:
-        tags.append("epg:" + epg)
-    return tags
-
-
 def get_hostname_from_dn(dn):
     """
     This parses the hostname from a dn designator. They look like this:

--- a/cisco_aci/datadog_checks/cisco_aci/tenant.py
+++ b/cisco_aci/datadog_checks/cisco_aci/tenant.py
@@ -2,10 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-import datetime
-import re
-import time
-
 from . import exceptions, helpers
 
 
@@ -58,10 +54,6 @@ class Tenant:
             except (exceptions.APIConnectionException, exceptions.APIParsingException):
                 pass
             self._submit_ten_data(t)
-            try:
-                self.collect_events(t)
-            except (exceptions.APIConnectionException, exceptions.APIParsingException):
-                pass
 
     def _submit_app_data(self, tenant, app):
         a = app.get('fvAp', {})
@@ -120,74 +112,3 @@ class Tenant:
                         metrics[dd_metric] = mval
 
             self.submit_metrics(metrics, tags, instance=self.instance)
-
-    def collect_events(self, tenant, page=0, page_size=15):
-        # If there are too many events, it'll break the agent
-        # stop sending after it reaches page 10 (150 events per tenant)
-        if page >= 10:
-            return
-
-        event_list = self.api.get_tenant_events(tenant, page=page, page_size=15)
-
-        now = int(time.time())
-        prior_ts = self.last_events_ts.get(tenant)
-        time_window = 600
-        if prior_ts:
-            time_window = now - prior_ts
-
-        self.last_events_ts[tenant] = now
-
-        log_line = "Fetched: {} events".format(len(event_list))
-        if len(event_list) > 0:
-            created = event_list[0].get('eventRecord', {}).get('attributes', {}).get('created')
-            log_line += ", most recent is from: {}".format(created)
-        self.log.info(log_line)
-
-        for event in event_list:
-            ev = event.get('eventRecord', {}).get('attributes', {})
-            created = ev.get('created')
-            create_date = re.search(r'\d{4}-\d{2}-\d{1,2}T\d{2}:\d{2}:\d{2}', created).group(0)
-
-            self.log.debug("ev time: %s", created)
-            strptime = datetime.datetime.strptime(create_date, '%Y-%m-%dT%H:%M:%S')
-            timestamp = (strptime - datetime.datetime(1970, 1, 1)).total_seconds()
-            if now - timestamp > time_window:
-                return
-
-            self.log.debug("sending an event!")
-
-            title = "The resource: " + ev['affected'] + " emitted an event"
-            dn_tags = helpers.get_event_tags_from_dn(ev['dn'])
-            tags = ["tenant:" + tenant]
-            tags = tags + self.user_tags + self.check_tags
-            if 'code' in ev:
-                tags.append("code:" + ev['code'])
-            if 'user' in ev:
-                tags.append("user:" + ev['user'])
-            if 'cause' in ev:
-                tags.append("cause:" + ev['cause'])
-            if 'severity' in ev:
-                tags.append("severity:" + ev['severity'])
-            self.check.event(
-                {
-                    'timestamp': timestamp,
-                    'event_type': 'cisco_aci',
-                    'msg_title': title,
-                    'msg_text': ev['descr'],
-                    "tags": tags + dn_tags,
-                    "aggregation_key": ev['id'],
-                    'host': self.check.hostname,
-                }
-            )
-
-        # if we get to the end without running out of new events, move onto the next page
-        # there is a bug when sometimes it'll return 30 events despite the page size setting
-        if len(event_list) != 0 and len(event_list) % 15 == 0:
-            self.collect_events(tenant, page=page + 1, page_size=15)
-
-    @property
-    def last_events_ts(self):
-        if self.instance_hash not in self.check.last_events_ts:
-            self.check.last_events_ts[self.instance_hash] = {}
-
-        return self.check.last_events_ts[self.instance_hash]

--- a/cisco_aci/tests/common.py
+++ b/cisco_aci/tests/common.py
@@ -170,8 +170,6 @@ FIXTURE_LIST = [
     # 0d6ca781810665156211b355129ba2f1 - Api.get_eqpt_capacity
     '_api_mo_topology_json_query_target_subtree_target_subtree_class_fabricPod',
     # 643d217904f09445fbc9f7b43cd131f0 - Api.get_fabric_pods
-    '_api_node_mo_uni_tn_DataDog_json_rsp_subtree_include_event_logs_no_scoped_subtree_order_by_eventRecord_created_desc_page_0_page_size_15',  # noqa: E501
-    # d0260e4832537b43b1acb38bcfa58063 - Api.get_tenant_events
     '_api_mo_uni_tn_DataDog_json_query_target_subtree_target_subtree_class_fvAp',
     # 4efe80304d50330f5ed0f79252ef0a84 - Api.get_apps
     '_api_mo_uni_tn_DataDog_json_rsp_subtree_include_stats_no_scoped',

--- a/cisco_aci/tests/test_helpers.py
+++ b/cisco_aci/tests/test_helpers.py
@@ -11,7 +11,6 @@ from datadog_checks.cisco_aci.helpers import (
     get_bd_from_dn,
     get_cep_from_dn,
     get_epg_from_dn,
-    get_event_tags_from_dn,
     get_hostname_from_dn,
     get_ip_from_dn,
     get_node_from_dn,
@@ -115,27 +114,6 @@ def test_parse_capacity_tags():
     assert all(a == b for a, b in zip(res, ['node_id:2']))
     res = parse_capacity_tags("aa/pod-1/node-/aa")
     assert all(a == b for a, b in zip(res, ['fabric_pod_id:1']))
-
-
-def test_get_event_tags_from_dn():
-    assert get_event_tags_from_dn(None) == []
-    assert get_event_tags_from_dn("") == []
-    res = get_event_tags_from_dn("aa/ap-AA/epg-BB/pod-1/node-2/ip-CC/cep-DD/BD-EE/aa")
-    assert all(
-        a == b
-        for a, b in zip(
-            res,
-            [
-                'node:2',
-                'app:AA',
-                'bd:EE',
-                'mac:DD',
-                'ip:CC',
-                'epg:BB',
-                'pod:1',
-            ],
-        )
-    )
 
 
 def test_get_hostname_from_dn():

--- a/cisco_aci/tests/test_tenant.py
+++ b/cisco_aci/tests/test_tenant.py
@@ -41,9 +41,6 @@ class ApiMock:
             {"other": {"attributes": {"attr": "3"}}},
         ]
 
-    def get_tenant_events(self, tenant, page=0, page_size=15):
-        return []
-
     def get_epg_meta(self, tenant, app, epg):
         return [{"fvCEp": {"attributes": {"ip": "ip1", "mac": "mac1", "encap": "encap1"}}}]
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
**changes made**
* in the `tenant.py` - remove collecting tenant faults and emitting as events
* clean up references to the fault sent as events, etc.


### Motivation
<!-- What inspired you to submit this pull request? -->
https://datadoghq.atlassian.net/browse/AGENT-15715?focusedCommentId=3157922
* customer is seeing tenant faults coming in / costing monies
  * these are an old artifact from before we inherited the integration - specifically sent as **events**
  * why did we implement as logs?
    * trying to consolidate standards for NDM (snmp traps come in as logs)
* lets remove them because we have all encompassing faults (tenants, nodes, etc.) coming in as logs now

**reference docs:**
* [Cisco ACI faults](https://datadoghq.atlassian.net/wiki/spaces/II/pages/4632543381/Cisco+ACI+Faults)

**qa steps**
[QA for Cisco ACI documentation
](https://datadoghq.atlassian.net/wiki/spaces/II/pages/4013621409/QA+for+Cisco+ACI+integration+public+private+sandbox#Using-ddev)

todo

- [x] `ddev env start --base cisco_aci py3.13`
- [x] `ddev env config edit cisco_aci py3.13`
- [x] add config:
```
instances:
  - aci_url: https://sandboxapicdc.cisco.com/
    username: admin
    pwd: "!v3G@!4@Y"
    tls_verify: false
    namespace: zoe-qa-apic
    send_ndm_metadata: true
    tenant:
      - infra
      - Heroes # <-- this should have some tenant faults
```
- [x] `ddev env reload cisco_aci py3.13`
- [x] `ddev env agent cisco_aci py3.13 check > remove-fault-events.txt`

output snippet:
```
  Running Checks
  ==============
    
    cisco_aci (4.14.1)
    ------------------
      Instance ID: cisco_aci:zoe-qa-remove-events:24aed0e8f5a3aa7f [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/cisco_aci.d/cisco_aci.yaml[0]
      Total Runs: 1
      Metric Samples: Last Run: 897, Total: 897
      Events: Last Run: 0, Total: 0
      Network Devices Metadata: Last Run: 6, Total: 6
      Service Checks: Last Run: 1, Total: 1
      Average Execution Time : 6.283s
      Last Execution Date : 2026-04-20 17:49:13.998 UTC (1776707353998)
      Last Successful Execution Date : 2026-04-20 17:49:13 UTC (1776707353000)
```
* you can see there is `Events: Last Run: 0, Total: 0` - meaning no events were generated from the tenants we configured that should have tenant faults

evidence that there should be events generating (aka there are tenant faults)
```
curl --location 'https://sandboxapicdc.cisco.com/api/node/mo/uni/tn-Heroes.json?rsp-subtree-include=faults%2Cno-scoped%2Csubtree&order-by=faultInfo.severity%7Cdesc&page=0&page-size=15' 

{
    "totalCount": "2",
    "imdata": [
        {
            "faultInst": {
                "attributes": {
                    "ack": "no",
                    "alert": "no",
                    "annotation": "",
                    "cause": "threshold-crossed",
                    "changeSet": "dropRate:107997",
                    "childAction": "deleteNonPresent",
                    "code": "F110473",
                    "created": "2026-04-20T13:59:04.977+02:00",
                    "delegated": "no",
                    "descr": "TCA: ingress drop bytes rate(l2IngrBytesAg15min:dropRate) value 107997 raised above threshold 100000",
                    "dn": "uni/tn-Heroes/BD-Hero_Land/fault-F110473",
                    "domain": "infra",
                    "extMngdBy": "",
                    "highestSeverity": "warning",
                    "lastTransition": "2026-04-20T13:59:04.977+02:00",
                    "lc": "raised",
                    "modTs": "never",
                    "occur": "1",
                    "origSeverity": "warning",
                    "prevSeverity": "warning",
                    "rule": "tca-l2-ingr-bytes-ag15min-drop-rate",
                    "severity": "warning",
                    "status": "",
                    "subject": "counter",
                    "title": "",
                    "type": "operational",
                    "uid": "0",
                    "userdom": ""
                }
            }
        },
        {
            "faultInst": {
                "attributes": {
                    "ack": "no",
                    "alert": "no",
                    "annotation": "",
                    "cause": "threshold-crossed",
                    "changeSet": "dropRate:107997",
                    "childAction": "deleteNonPresent",
                    "code": "F110473",
                    "created": "2026-04-20T13:59:04.975+02:00",
                    "delegated": "no",
                    "descr": "TCA: ingress drop bytes rate(l2IngrBytesAg15min:dropRate) value 107997 raised above threshold 100000",
                    "dn": "uni/tn-Heroes/ctx-Heroes_Only/fault-F110473",
                    "domain": "infra",
                    "extMngdBy": "",
                    "highestSeverity": "warning",
                    "lastTransition": "2026-04-20T13:59:04.975+02:00",
                    "lc": "raised",
                    "modTs": "never",
                    "occur": "1",
                    "origSeverity": "warning",
                    "prevSeverity": "warning",
                    "rule": "tca-l2-ingr-bytes-ag15min-drop-rate",
                    "severity": "warning",
                    "status": "",
                    "subject": "counter",
                    "title": "",
                    "type": "operational",
                    "uid": "0",
                    "userdom": ""
                }
            }
        }
    ]
}
```



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
