### PR TITLE
fix(release): enable dry-run=false by default for wheel release trigger

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -26,8 +26,7 @@ on:
           or triggering downstream wheel builds.
         required: false
         type: boolean
-        # TODO: flip back to false once agent-integration-wheels-release is updated to handle the new payload
-        default: true
+        default: false
       ddev-version:
         description: "ddev version, pinned by default."
         required: false

--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -31,8 +31,7 @@ on:
         description: "Print what would be released without pushing tags or starting builds"
         required: false
         type: boolean
-        # TODO: flip back to false once agent-integration-wheels-release is updated to handle the new payload
-        default: true
+        default: false
       ddev-version:
         description: "ddev version, pinned by default."
         required: false
@@ -63,7 +62,7 @@ jobs:
       source-repo: integrations-core
       packages: ${{ inputs.packages || '' }}
       source-repo-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.source-repo-ref || github.sha }}
-      dry-run: ${{ inputs.dry-run || true }}  # TODO: flip back to false
+      dry-run: ${{ inputs.dry-run || false }}
       ddev-version: ${{ inputs.ddev-version || '' }}
       is-stable-release: ${{ needs.context.outputs.is-stable-release }}
     permissions:


### PR DESCRIPTION
## Summary

- `release-trigger.yml` and `release-dispatch.yml` had `dry-run` defaulting to `true` with a TODO to flip it back once `agent-integration-wheels-release` was updated to handle the new payload format
- That blocked push-triggered runs on `master` and `X.Y.x` branches from ever dispatching wheel builds (the `dispatch` job was always skipped)
- This PR flips the default back to `false` and removes the TODO comments

## Test plan

- [ ] Verify next release commit on `master` or a `X.Y.x` branch triggers the `dispatch` job and creates a deployment in the `release` environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)