### PR TITLE
Patch ddev to fully support the new lockfile format

### DIFF
--- a/.github/workflows/measure-disk-usage.yml
+++ b/.github/workflows/measure-disk-usage.yml
@@ -8,6 +8,7 @@ on:
       - completed
 env:
   PYTHON_VERSION: "3.13"
+  INTEGRATIONS_WHEELS_STORAGE: "stable"
 
 jobs:
 

--- a/ddev/changelog.d/23063.added
+++ b/ddev/changelog.d/23063.added
@@ -1,1 +1,2 @@
-Support size computation for lockfiles in both new and old formats.
+- Support size computation for lockfiles in both new and old formats. New CLI param (and envvar) to switch between storage locations.
+- Command to trigger the promotion of wheels for PRs that bump dependencies.

--- a/ddev/src/ddev/cli/size/diff.py
+++ b/ddev/src/ddev/cli/size/diff.py
@@ -49,6 +49,7 @@ def diff(
     compressed: bool,
     format: list[str],
     show_gui: bool,
+    wheels_storage: Optional[str],
 ) -> None:
     """
     Compare the size of integrations and dependencies between two commits.
@@ -107,6 +108,7 @@ def diff(
                         "compressed": compressed,
                         "format": format,
                         "show_gui": show_gui,
+                        "wheels_storage": wheels_storage,
                     }
                     modules_plat_ver.extend(
                         diff_mode(
@@ -133,7 +135,14 @@ def diff_mode(
     progress: Progress,
 ) -> list[FileDataEntryPlatformVersion]:
     files_b, dependencies_b, files_a, dependencies_a = get_repo_info(
-        gitRepo, params["platform"], params["version"], first_commit, second_commit, params["compressed"], progress
+        gitRepo,
+        params["platform"],
+        params["version"],
+        first_commit,
+        second_commit,
+        params["compressed"],
+        params["wheels_storage"],
+        progress,
     )
 
     integrations = get_diff(files_b, files_a, "Integration")
@@ -178,6 +187,7 @@ def get_repo_info(
     first_commit: str,
     second_commit: str,
     compressed: bool,
+    wheels_storage: Optional[str],
     progress: Progress,
 ) -> tuple[list[FileDataEntry], list[FileDataEntry], list[FileDataEntry], list[FileDataEntry]]:
     with progress:
@@ -205,13 +215,13 @@ def get_repo_info(
         task = progress.add_task("[cyan]Calculating sizes for the first commit...", total=None)
         gitRepo.checkout_commit(first_commit)
         files_b = get_files(repo, compressed, version)
-        dependencies_b = get_dependencies(repo, platform, version, compressed)
+        dependencies_b = get_dependencies(repo, platform, version, compressed, wheels_storage)
         progress.remove_task(task)
 
         task = progress.add_task("[cyan]Calculating sizes for the second commit...", total=None)
         gitRepo.checkout_commit(second_commit)
         files_a = get_files(repo, compressed, version)
-        dependencies_a = get_dependencies(repo, platform, version, compressed)
+        dependencies_a = get_dependencies(repo, platform, version, compressed, wheels_storage)
         progress.remove_task(task)
 
     return files_b, dependencies_b, files_a, dependencies_a

--- a/ddev/src/ddev/cli/size/diff.py
+++ b/ddev/src/ddev/cli/size/diff.py
@@ -49,7 +49,7 @@ def diff(
     compressed: bool,
     format: list[str],
     show_gui: bool,
-    wheels_storage: Optional[str],
+    wheels_storage: str,
 ) -> None:
     """
     Compare the size of integrations and dependencies between two commits.
@@ -187,7 +187,7 @@ def get_repo_info(
     first_commit: str,
     second_commit: str,
     compressed: bool,
-    wheels_storage: Optional[str],
+    wheels_storage: str,
     progress: Progress,
 ) -> tuple[list[FileDataEntry], list[FileDataEntry], list[FileDataEntry], list[FileDataEntry]]:
     with progress:

--- a/ddev/src/ddev/cli/size/status.py
+++ b/ddev/src/ddev/cli/size/status.py
@@ -35,6 +35,7 @@ def status(
     compressed: bool,
     format: list[str],
     show_gui: bool,
+    wheels_storage: str | None,
     to_dd_org: str | None,
     to_dd_key: str | None,
     dependency_sizes: Path | None,
@@ -91,6 +92,7 @@ def status(
                 "compressed": compressed,
                 "format": format,
                 "show_gui": show_gui,
+                "wheels_storage": wheels_storage,
             }
             modules_plat_ver.extend(
                 status_mode(
@@ -179,7 +181,7 @@ def status_mode(
                 f"Getting dependencies from lockfiles for {params['platform']} {params['version']}"
             )
             modules = get_files(repo_path, params["compressed"], params["version"]) + get_dependencies(
-                repo_path, params["platform"], params["version"], params["compressed"]
+                repo_path, params["platform"], params["version"], params["compressed"], params["wheels_storage"]
             )
 
     formatted_modules = format_modules(modules, params["platform"], params["version"])

--- a/ddev/src/ddev/cli/size/status.py
+++ b/ddev/src/ddev/cli/size/status.py
@@ -35,7 +35,7 @@ def status(
     compressed: bool,
     format: list[str],
     show_gui: bool,
-    wheels_storage: str | None,
+    wheels_storage: str,
     to_dd_org: str | None,
     to_dd_key: str | None,
     dependency_sizes: Path | None,

--- a/ddev/src/ddev/cli/size/timeline.py
+++ b/ddev/src/ddev/cli/size/timeline.py
@@ -30,6 +30,7 @@ from .utils.common_funcs import (
     is_correct_dependency,
     is_valid_integration_file,
     print_table,
+    resolve_wheel_url,
     save_csv,
     save_json,
     save_markdown,
@@ -71,6 +72,7 @@ def timeline(
     compressed: bool,
     format: Optional[list[str]],
     show_gui: bool,
+    wheels_storage: Optional[str],
 ) -> None:
     """
     Show the size evolution of a module (integration or dependency) over time.
@@ -174,6 +176,7 @@ def timeline(
                                 "show_gui": show_gui,
                                 "first_commit": None,
                                 "platform": plat,
+                                "wheels_storage": wheels_storage,
                             }
 
                             modules_plat.extend(
@@ -196,6 +199,7 @@ def timeline(
                             "show_gui": show_gui,
                             "first_commit": None,
                             "platform": platform,
+                            "wheels_storage": wheels_storage,
                         }
                         modules_plat.extend(
                             timeline_mode(
@@ -220,6 +224,7 @@ def timeline(
                         "show_gui": show_gui,
                         "first_commit": first_commit,
                         "platform": None,
+                        "wheels_storage": wheels_storage,
                     }
                     progress.remove_task(task)
                     modules.extend(
@@ -388,6 +393,7 @@ def process_commits(
                 author,
                 message,
                 params["compressed"],
+                params["wheels_storage"],
             )
             if result:
                 file_data.append(result)
@@ -492,6 +498,7 @@ def get_dependencies(
     author: str,
     message: str,
     compressed: bool,
+    wheels_storage: Optional[str],
 ) -> Optional[CommitEntry]:
     """
     Returns the size and metadata of a dependency for a given commit and platform.
@@ -515,7 +522,7 @@ def get_dependencies(
     for filename in paths:
         file_path = os.path.join(resolved_path, filename)
         if os.path.isfile(file_path) and is_correct_dependency(platform, version, filename):
-            download_url, dep_version = get_dependency_data(file_path, module)
+            download_url, dep_version = get_dependency_data(file_path, module, wheels_storage)
             return (
                 get_dependency_size(download_url, dep_version, commit, date, author, message, compressed)
                 if download_url and dep_version is not None
@@ -524,7 +531,9 @@ def get_dependencies(
     return None
 
 
-def get_dependency_data(file_path: str, module: str) -> tuple[Optional[str], Optional[str]]:
+def get_dependency_data(
+    file_path: str, module: str, wheels_storage: Optional[str]
+) -> tuple[Optional[str], Optional[str]]:
     """
     Parses a dependency file and extracts the dependency name, download URL, and version.
 
@@ -545,7 +554,7 @@ def get_dependency_data(file_path: str, module: str) -> tuple[Optional[str], Opt
                 raise WrongDependencyFormat("The dependency format 'name @ link' is no longer supported.")
             name, url = match.groups()
             if name == module:
-                url = url.replace("${INTEGRATIONS_WHEELS_STORAGE}", "stable")
+                url = resolve_wheel_url(url, wheels_storage)
                 version_match = re.search(rf"{re.escape(name)}/[^/]+?-([0-9]+(?:\.[0-9]+)*)-", url)
                 version = version_match.group(1) if version_match else ""
                 return url, version

--- a/ddev/src/ddev/cli/size/timeline.py
+++ b/ddev/src/ddev/cli/size/timeline.py
@@ -72,7 +72,7 @@ def timeline(
     compressed: bool,
     format: Optional[list[str]],
     show_gui: bool,
-    wheels_storage: Optional[str],
+    wheels_storage: str,
 ) -> None:
     """
     Show the size evolution of a module (integration or dependency) over time.
@@ -498,7 +498,7 @@ def get_dependencies(
     author: str,
     message: str,
     compressed: bool,
-    wheels_storage: Optional[str],
+    wheels_storage: str,
 ) -> Optional[CommitEntry]:
     """
     Returns the size and metadata of a dependency for a given commit and platform.
@@ -531,9 +531,7 @@ def get_dependencies(
     return None
 
 
-def get_dependency_data(
-    file_path: str, module: str, wheels_storage: Optional[str]
-) -> tuple[Optional[str], Optional[str]]:
+def get_dependency_data(file_path: str, module: str, wheels_storage: str) -> tuple[Optional[str], Optional[str]]:
     """
     Parses a dependency file and extracts the dependency name, download URL, and version.
 

--- a/ddev/src/ddev/cli/size/utils/common_funcs.py
+++ b/ddev/src/ddev/cli/size/utils/common_funcs.py
@@ -73,6 +73,7 @@ class CLIParameters(TypedDict):
     compressed: bool  # Whether to analyze compressed file sizes
     format: Optional[list[str]]  # Output format options (png, csv, markdown, json)
     show_gui: bool  # Whether to display interactive visualization
+    wheels_storage: Optional[str]  # Storage tier (dev/stable) for new-style lockfile URLs
 
 
 class CLIParametersTimeline(TypedDict):
@@ -82,6 +83,7 @@ class CLIParametersTimeline(TypedDict):
     compressed: bool  # Whether to analyze compressed file sizes
     format: Optional[list[str]]  # Output format options (png, csv, markdown, json)
     show_gui: bool  # Whether to display interactive visualization
+    wheels_storage: Optional[str]  # Storage tier (dev/stable) for new-style lockfile URLs
 
 
 class InitialParametersTimelineIntegration(CLIParametersTimeline):
@@ -300,7 +302,31 @@ def extract_version_from_about_py(path: str) -> str:
     return ""
 
 
-def get_dependencies(repo_path: str | Path, platform: str, version: str, compressed: bool) -> list[FileDataEntry]:
+WHEELS_STORAGE_PLACEHOLDER = "${INTEGRATIONS_WHEELS_STORAGE}"
+
+
+def resolve_wheel_url(url: str, wheels_storage: str | None) -> str:
+    """
+    Substitute the wheels storage tier into a lockfile URL.
+
+    Old-style lockfiles hard-code the storage tier in the domain and contain no placeholder,
+    so they ignore ``wheels_storage``. New-style lockfiles template the tier via
+    ``${INTEGRATIONS_WHEELS_STORAGE}`` and require a value to resolve.
+    """
+    if WHEELS_STORAGE_PLACEHOLDER not in url:
+        return url
+    if wheels_storage is None:
+        raise ValueError(
+            "This lockfile templates the wheel storage tier via ${INTEGRATIONS_WHEELS_STORAGE} "
+            "but no tier was provided. Pass --wheels-storage=dev|stable or set the "
+            "INTEGRATIONS_WHEELS_STORAGE environment variable."
+        )
+    return url.replace(WHEELS_STORAGE_PLACEHOLDER, wheels_storage)
+
+
+def get_dependencies(
+    repo_path: str | Path, platform: str, version: str, compressed: bool, wheels_storage: str | None
+) -> list[FileDataEntry]:
     """
     Gets the list of dependencies for a given platform and Python version and returns a FileDataEntry that includes:
     Name, Version, Size_Bytes, Size, and Type.
@@ -311,12 +337,12 @@ def get_dependencies(repo_path: str | Path, platform: str, version: str, compres
         file_path = os.path.join(resolved_path, filename)
 
         if os.path.isfile(file_path) and is_correct_dependency(platform, version, filename):
-            deps, download_urls, versions = get_dependencies_list(file_path)
+            deps, download_urls, versions = get_dependencies_list(file_path, wheels_storage)
             return get_dependencies_sizes(deps, download_urls, versions, compressed)
     return []
 
 
-def get_dependencies_list(file_path: str) -> tuple[list[str], list[str], list[str]]:
+def get_dependencies_list(file_path: str, wheels_storage: str | None) -> tuple[list[str], list[str], list[str]]:
     """
     Parses a dependency file and extracts the dependency names, download URLs, and versions.
     """
@@ -331,7 +357,7 @@ def get_dependencies_list(file_path: str) -> tuple[list[str], list[str], list[st
             if not match:
                 raise WrongDependencyFormat("The dependency format 'name @ link' is no longer supported.")
             name = match.group(1)
-            url = match.group(2).replace("${INTEGRATIONS_WHEELS_STORAGE}", "stable")
+            url = resolve_wheel_url(match.group(2), wheels_storage)
 
             deps.append(name)
             download_urls.append(url)

--- a/ddev/src/ddev/cli/size/utils/common_funcs.py
+++ b/ddev/src/ddev/cli/size/utils/common_funcs.py
@@ -73,7 +73,7 @@ class CLIParameters(TypedDict):
     compressed: bool  # Whether to analyze compressed file sizes
     format: Optional[list[str]]  # Output format options (png, csv, markdown, json)
     show_gui: bool  # Whether to display interactive visualization
-    wheels_storage: Optional[str]  # Storage tier (dev/stable) for new-style lockfile URLs
+    wheels_storage: str  # Storage tier (dev/stable) for new-style lockfile URLs
 
 
 class CLIParametersTimeline(TypedDict):
@@ -83,7 +83,7 @@ class CLIParametersTimeline(TypedDict):
     compressed: bool  # Whether to analyze compressed file sizes
     format: Optional[list[str]]  # Output format options (png, csv, markdown, json)
     show_gui: bool  # Whether to display interactive visualization
-    wheels_storage: Optional[str]  # Storage tier (dev/stable) for new-style lockfile URLs
+    wheels_storage: str  # Storage tier (dev/stable) for new-style lockfile URLs
 
 
 class InitialParametersTimelineIntegration(CLIParametersTimeline):
@@ -305,27 +305,13 @@ def extract_version_from_about_py(path: str) -> str:
 WHEELS_STORAGE_PLACEHOLDER = "${INTEGRATIONS_WHEELS_STORAGE}"
 
 
-def resolve_wheel_url(url: str, wheels_storage: str | None) -> str:
-    """
-    Substitute the wheels storage tier into a lockfile URL.
-
-    Old-style lockfiles hard-code the storage tier in the domain and contain no placeholder,
-    so they ignore ``wheels_storage``. New-style lockfiles template the tier via
-    ``${INTEGRATIONS_WHEELS_STORAGE}`` and require a value to resolve.
-    """
-    if WHEELS_STORAGE_PLACEHOLDER not in url:
-        return url
-    if wheels_storage is None:
-        raise ValueError(
-            "This lockfile templates the wheel storage tier via ${INTEGRATIONS_WHEELS_STORAGE} "
-            "but no tier was provided. Pass --wheels-storage=dev|stable or set the "
-            "INTEGRATIONS_WHEELS_STORAGE environment variable."
-        )
+def resolve_wheel_url(url: str, wheels_storage: str) -> str:
+    """Substitute the wheels storage tier into a lockfile URL."""
     return url.replace(WHEELS_STORAGE_PLACEHOLDER, wheels_storage)
 
 
 def get_dependencies(
-    repo_path: str | Path, platform: str, version: str, compressed: bool, wheels_storage: str | None
+    repo_path: str | Path, platform: str, version: str, compressed: bool, wheels_storage: str
 ) -> list[FileDataEntry]:
     """
     Gets the list of dependencies for a given platform and Python version and returns a FileDataEntry that includes:
@@ -342,7 +328,7 @@ def get_dependencies(
     return []
 
 
-def get_dependencies_list(file_path: str, wheels_storage: str | None) -> tuple[list[str], list[str], list[str]]:
+def get_dependencies_list(file_path: str, wheels_storage: str) -> tuple[list[str], list[str], list[str]]:
     """
     Parses a dependency file and extracts the dependency names, download URLs, and versions.
     """

--- a/ddev/src/ddev/cli/size/utils/common_params.py
+++ b/ddev/src/ddev/cli/size/utils/common_params.py
@@ -21,14 +21,34 @@ def common_params(func: Callable) -> Callable:
         is_flag=True,
         help="Display a pop-up window with a treemap showing the current size distribution of modules.",
     )
+    @click.option(
+        "--wheels-storage",
+        type=click.Choice(["dev", "stable"]),
+        default=None,
+        envvar="INTEGRATIONS_WHEELS_STORAGE",
+        help=(
+            "Which wheel storage tier to resolve dependency URLs against. "
+            "Only required for new-style lockfiles that template the storage tier into the URL "
+            "via ${INTEGRATIONS_WHEELS_STORAGE}. Old-style lockfiles hard-code the domain and "
+            "ignore this option. Can also be set via the INTEGRATIONS_WHEELS_STORAGE env var."
+        ),
+    )
     @click.pass_context
     def wrapper(
-        ctx: click.Context, platform: str, compressed: bool, format: list[str], show_gui: bool, *args, **kwargs
+        ctx: click.Context,
+        platform: str,
+        compressed: bool,
+        format: list[str],
+        show_gui: bool,
+        wheels_storage: str | None,
+        *args,
+        **kwargs,
     ):
         kwargs["platform"] = platform
         kwargs["compressed"] = compressed
         kwargs["format"] = format
         kwargs["show_gui"] = show_gui
+        kwargs["wheels_storage"] = wheels_storage
         return ctx.invoke(func, *args, **kwargs)
 
     return wrapper

--- a/ddev/src/ddev/cli/size/utils/common_params.py
+++ b/ddev/src/ddev/cli/size/utils/common_params.py
@@ -21,16 +21,17 @@ def common_params(func: Callable) -> Callable:
         is_flag=True,
         help="Display a pop-up window with a treemap showing the current size distribution of modules.",
     )
+    # An option rather than a positional argument so it can bind to the
+    # INTEGRATIONS_WHEELS_STORAGE env var (Click only supports envvar on options).
+    # This keeps CI invocations aligned with the GitLab variable of the same name.
     @click.option(
         "--wheels-storage",
         type=click.Choice(["dev", "stable"]),
-        default=None,
+        required=True,
         envvar="INTEGRATIONS_WHEELS_STORAGE",
         help=(
             "Which wheel storage tier to resolve dependency URLs against. "
-            "Only required for new-style lockfiles that template the storage tier into the URL "
-            "via ${INTEGRATIONS_WHEELS_STORAGE}. Old-style lockfiles hard-code the domain and "
-            "ignore this option. Can also be set via the INTEGRATIONS_WHEELS_STORAGE env var."
+            "Can also be set via the INTEGRATIONS_WHEELS_STORAGE env var."
         ),
     )
     @click.pass_context
@@ -40,7 +41,7 @@ def common_params(func: Callable) -> Callable:
         compressed: bool,
         format: list[str],
         show_gui: bool,
-        wheels_storage: str | None,
+        wheels_storage: str,
         *args,
         **kwargs,
     ):

--- a/ddev/tests/cli/size/conftest.py
+++ b/ddev/tests/cli/size/conftest.py
@@ -8,3 +8,8 @@ def mock_matplotlib_globally(mocker: pytest_mock.MockerFixture):
     mocker.patch("matplotlib.pyplot.show")
     mocker.patch("matplotlib.pyplot.savefig")
     mocker.patch("matplotlib.pyplot.figure")
+
+
+@pytest.fixture(autouse=True)
+def default_wheels_storage(monkeypatch):
+    monkeypatch.setenv("INTEGRATIONS_WHEELS_STORAGE", "stable")

--- a/ddev/tests/size/test_common.py
+++ b/ddev/tests/size/test_common.py
@@ -148,7 +148,7 @@ def test_get_dependencies_list():
     file_content = "dependency1 @ https://example.com/dependency1/dependency1-1.1.1-.whl\ndependency2 @ https://example.com/dependency2/dependency2-1.1.1-.whl"
     mock_open_obj = mock_open(read_data=file_content)
     with patch("builtins.open", mock_open_obj):
-        deps, urls, versions = get_dependencies_list("fake_path")
+        deps, urls, versions = get_dependencies_list("fake_path", None)
     assert deps == ["dependency1", "dependency2"]
     assert urls == [
         "https://example.com/dependency1/dependency1-1.1.1-.whl",

--- a/ddev/tests/size/test_common.py
+++ b/ddev/tests/size/test_common.py
@@ -148,7 +148,7 @@ def test_get_dependencies_list():
     file_content = "dependency1 @ https://example.com/dependency1/dependency1-1.1.1-.whl\ndependency2 @ https://example.com/dependency2/dependency2-1.1.1-.whl"
     mock_open_obj = mock_open(read_data=file_content)
     with patch("builtins.open", mock_open_obj):
-        deps, urls, versions = get_dependencies_list("fake_path", None)
+        deps, urls, versions = get_dependencies_list("fake_path", "stable")
     assert deps == ["dependency1", "dependency2"]
     assert urls == [
         "https://example.com/dependency1/dependency1-1.1.1-.whl",

--- a/ddev/tests/size/test_timeline.py
+++ b/ddev/tests/size/test_timeline.py
@@ -108,7 +108,7 @@ def test_get_dependency():
     content = """dep1 @ https://example.com/dep1/dep1-1.1.1-.whl
 dep2 @ https://example.com/dep2/dep2-1.1.2-.whl"""
     with patch("ddev.cli.size.timeline.open", mock_open(read_data=content)):
-        url, version = get_dependency_data(Path("some") / "path" / "file.txt", "dep2", None)
+        url, version = get_dependency_data(Path("some") / "path" / "file.txt", "dep2", "stable")
         assert (url, version) == ("https://example.com/dep2/dep2-1.1.2-.whl", "1.1.2")
 
 
@@ -163,7 +163,7 @@ def test_get_compressed_dependencies():
             "auth",
             "Added dep1",
             True,
-            None,
+            "stable",
         )
         assert result == {
             "Size_Bytes": 12345,

--- a/ddev/tests/size/test_timeline.py
+++ b/ddev/tests/size/test_timeline.py
@@ -108,7 +108,7 @@ def test_get_dependency():
     content = """dep1 @ https://example.com/dep1/dep1-1.1.1-.whl
 dep2 @ https://example.com/dep2/dep2-1.1.2-.whl"""
     with patch("ddev.cli.size.timeline.open", mock_open(read_data=content)):
-        url, version = get_dependency_data(Path("some") / "path" / "file.txt", "dep2")
+        url, version = get_dependency_data(Path("some") / "path" / "file.txt", "dep2", None)
         assert (url, version) == ("https://example.com/dep2/dep2-1.1.2-.whl", "1.1.2")
 
 
@@ -155,7 +155,15 @@ def test_get_compressed_dependencies():
         patch("ddev.cli.size.timeline.requests.head", return_value=make_mock_response("12345")),
     ):
         result = get_dependencies(
-            "fake_repo", "dep1", "linux-x86_64", "abc1234", datetime(2025, 4, 4).date(), "auth", "Added dep1", True
+            "fake_repo",
+            "dep1",
+            "linux-x86_64",
+            "abc1234",
+            datetime(2025, 4, 4).date(),
+            "auth",
+            "Added dep1",
+            True,
+            None,
         )
         assert result == {
             "Size_Bytes": 12345,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Full functionality to support the new lockfile format.

What we were missing in https://github.com/DataDog/integrations-core/pull/23063 was a way to tell the size command which storage to pull the wheels from.

### Motivation
<!-- What inspired you to submit this pull request? -->

The linked PR was getting big and complex enough that we decided to complete in a follow-up PR.
That's why this PR doesn't have a separate changelog entry but modifies the previous PR's changelog.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
