### PR TITLE
Use parameterized queries for table names in MySQL schema collection

### DIFF
--- a/mysql/changelog.d/23366.fixed
+++ b/mysql/changelog.d/23366.fixed
@@ -1,0 +1,1 @@
+Use parameterized queries for table names in schema collection.

--- a/mysql/datadog_checks/mysql/databases_data.py
+++ b/mysql/datadog_checks/mysql/databases_data.py
@@ -148,11 +148,10 @@ class DatabasesData:
         self._data_submitter.submit()
 
     def _cursor_run(self, cursor, query, params=None):
-        """
-        Run and log the query. If provided, obfuscated params are logged in place of the regular params.
-        """
+        """Run the query, log it, and emit a metric on database error."""
         try:
-            self._log.debug("Running query [{}] params={}".format(query, params))
+            params_repr = "({} params)".format(len(params)) if isinstance(params, list) else params
+            self._log.debug("Running query [{}] params={}".format(query, params_repr))
             cursor.execute(query, params)
         except pymysql.DatabaseError as e:
             self._check.count(
@@ -321,21 +320,30 @@ class DatabasesData:
         table_name_to_table_index = {}
         for i, table in enumerate(table_list):
             table_name_to_table_index[table["name"]] = i
-        table_names = ','.join(f'"{str(table["name"])}"' for table in table_list)
+        table_name_list = [str(table["name"]) for table in table_list]
+        placeholders = ','.join(['%s'] * len(table_name_list))
         total_columns_number = self._populate_with_columns_data(
-            table_name_to_table_index, table_list, table_names, db_name, cursor
+            table_name_to_table_index, table_list, table_name_list, placeholders, db_name, cursor
         )
-        self._populate_with_partitions_data(table_name_to_table_index, table_list, table_names, db_name, cursor)
-        self._populate_with_foreign_keys_data(table_name_to_table_index, table_list, table_names, db_name, cursor)
-        self._populate_with_index_data(table_name_to_table_index, table_list, table_names, db_name, cursor)
+        self._populate_with_partitions_data(
+            table_name_to_table_index, table_list, table_name_list, placeholders, db_name, cursor
+        )
+        self._populate_with_foreign_keys_data(
+            table_name_to_table_index, table_list, table_name_list, placeholders, db_name, cursor
+        )
+        self._populate_with_index_data(
+            table_name_to_table_index, table_list, table_name_list, placeholders, db_name, cursor
+        )
         return total_columns_number, table_list
 
     @tracked_method(agent_check_getter=agent_check_getter)
-    def _populate_with_columns_data(self, table_name_to_table_index, table_list, table_names, db_name, cursor):
+    def _populate_with_columns_data(
+        self, table_name_to_table_index, table_list, table_name_list, placeholders, db_name, cursor
+    ):
         self._cursor_run(
             cursor,
-            query=SQL_COLUMNS.format(table_names),
-            params=db_name,
+            query=SQL_COLUMNS.format(placeholders),
+            params=[db_name] + table_name_list,
         )
         rows = cursor.fetchall()
         for row in rows:
@@ -354,9 +362,11 @@ class DatabasesData:
         return len(rows)
 
     @tracked_method(agent_check_getter=agent_check_getter)
-    def _populate_with_index_data(self, table_name_to_table_index, table_list, table_names, db_name, cursor):
-        query = get_indexes_query(self._check.version, self._check.is_mariadb, table_names)
-        self._cursor_run(cursor, query=query, params=db_name)
+    def _populate_with_index_data(
+        self, table_name_to_table_index, table_list, table_name_list, placeholders, db_name, cursor
+    ):
+        query = get_indexes_query(self._check.version, self._check.is_mariadb, placeholders)
+        self._cursor_run(cursor, query=query, params=[db_name] + table_name_list)
         rows = cursor.fetchall()
         if not rows:
             return
@@ -394,8 +404,10 @@ class DatabasesData:
             table_list[table_name_to_table_index[table_name]]["indexes"] = list(index_dict.values())
 
     @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
-    def _populate_with_foreign_keys_data(self, table_name_to_table_index, table_list, table_names, db_name, cursor):
-        self._cursor_run(cursor, query=SQL_FOREIGN_KEYS.format(table_names), params=db_name)
+    def _populate_with_foreign_keys_data(
+        self, table_name_to_table_index, table_list, table_name_list, placeholders, db_name, cursor
+    ):
+        self._cursor_run(cursor, query=SQL_FOREIGN_KEYS.format(placeholders), params=[db_name] + table_name_list)
         rows = cursor.fetchall()
         for row in rows:
             table_name = row["table_name"]
@@ -403,8 +415,10 @@ class DatabasesData:
             table_list[table_name_to_table_index[table_name]]["foreign_keys"].append(row)
 
     @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
-    def _populate_with_partitions_data(self, table_name_to_table_index, table_list, table_names, db_name, cursor):
-        self._cursor_run(cursor, query=SQL_PARTITION.format(table_names), params=db_name)
+    def _populate_with_partitions_data(
+        self, table_name_to_table_index, table_list, table_name_list, placeholders, db_name, cursor
+    ):
+        self._cursor_run(cursor, query=SQL_PARTITION.format(placeholders), params=[db_name] + table_name_list)
         rows = cursor.fetchall()
         if not rows:
             return

--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -274,13 +274,13 @@ def show_replica_status_query(version, is_mariadb, channel=''):
         return "{0};".format(base_query)
 
 
-def get_indexes_query(version, is_mariadb, table_names):
+def get_indexes_query(version, is_mariadb, placeholders):
     """
     Get the appropriate indexes query based on MySQL version and flavor.
     The EXPRESSION column was introduced in MySQL 8.0.13 for functional indexes.
     MariaDB doesn't support functional indexes.
     """
     if not is_mariadb and version.version_compatible((8, 0, 13)):
-        return SQL_INDEXES_8_0_13.format(table_names)
+        return SQL_INDEXES_8_0_13.format(placeholders)
     else:
-        return SQL_INDEXES.format(table_names)
+        return SQL_INDEXES.format(placeholders)

--- a/mysql/tests/test_unit.py
+++ b/mysql/tests/test_unit.py
@@ -433,6 +433,37 @@ def test_submit_is_called_if_too_many_columns():
         assert mocked_submit.call_count == 2
 
 
+def test_get_tables_data_uses_parameterized_queries():
+    """Table names must be passed as query parameters, not interpolated into SQL strings."""
+    check = MySql(common.CHECK_NAME, {}, instances=[{'server': 'localhost', 'user': 'datadog'}])
+    databases_data = DatabasesData({}, check, check._config)
+
+    table_list = [{"name": 'normal_table'}, {"name": 'bad"table'}, {"name": "x\") UNION SELECT user()#"}]
+    execute_calls = []
+
+    class MockCursor:
+        def execute(self, query, params=None):
+            execute_calls.append((query, params))
+
+        def fetchall(self):
+            return []
+
+    def fake_index_query(v, m, p):
+        return "SELECT 1 WHERE s = %s AND n IN ({})".format(p)
+
+    with mock.patch('datadog_checks.mysql.databases_data.get_indexes_query', side_effect=fake_index_query):
+        databases_data._get_tables_data(table_list, "mydb", MockCursor())
+
+    table_name_list = [str(t["name"]) for t in table_list]
+
+    assert execute_calls, "Expected at least one query to be executed"
+    for query, params in execute_calls:
+        assert isinstance(params, list)
+        assert params[0] == "mydb"
+        assert params[1:] == table_name_list
+        assert query.count('%s') == len(table_list) + 1
+
+
 def test_exception_handling_by_do_for_dbs():
     check = MySql(common.CHECK_NAME, {}, instances=[{'server': 'localhost', 'user': 'datadog'}])
     databases_data = DatabasesData({}, check, check._config)


### PR DESCRIPTION
## Summary

- Replace string interpolation of table names in `IN (...)` clauses with `%s` parameterized placeholders across the four schema collection query methods (columns, indexes, foreign keys, partitions)
- Table names from `information_schema.TABLES` are now passed as query parameters via `pymysql` rather than being formatted directly into the SQL string

## Test plan

- [x] Run existing MySQL schema collection unit tests: `ddev --no-interactive test mysql -- -k schema`
- [ ] Start E2E environment and verify schema collection still works end-to-end: `ddev env start --dev mysql` / `ddev env test --dev mysql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)