### PR TITLE
Add ENTITY-MIB chassis metadata to SNMP _base profile

### DIFF
--- a/snmp/changelog.d/23369.fixed
+++ b/snmp/changelog.d/23369.fixed
@@ -1,0 +1,1 @@
+Refactor Cisco Catalyst serial_number metadata to use a symbols list with CISCO-STACK and ENTITY-MIB fallbacks and updated Circitor links.

--- a/snmp/datadog_checks/snmp/data/default_profiles/_cisco-catalyst.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_cisco-catalyst.yaml
@@ -9,15 +9,18 @@ metadata:
   device:
     fields:
       serial_number:
-        symbol:
-          # Cisco Catalyst devices are using CISCO-STACK-MIB
-          # Source1: http://www.circitor.fr/Mibs/Html/C/CISCO-STACK-MIB.php
-          #   "This MIB provides configuration and runtime status for chassis, modules, ports, etc. on the Catalyst systems."
-          # Source2: chassisSerialNumberString is present for this device:
+        symbols:
+          # CISCO-STACK-MIB: chassisSerialNumberString — primary chassis serial on classic Catalyst.
+          # Source 1: https://circitor.fr/Mibs/Html/CISCO-STACK-MIB.php
+          # Source 2: chassisSerialNumberString is present for this device:
           #   Cisco Systems WS-C6509.Cisco Catalyst Operating System Software, Version 5.5(8).Copyright (c) 1995-2001 by Cisco Systems.
-          MIB: CISCO-STACK-MIB
-          OID: 1.3.6.1.4.1.9.5.1.2.19.0
-          name: chassisSerialNumberString
+          - OID: 1.3.6.1.4.1.9.5.1.2.19.0
+            name: chassisSerialNumberString
+          # ENTITY-MIB: entPhysicalSerialNum at entPhysicalIndex 1 — fallback when stack MIB data is missing.
+          # Source: https://circitor.fr/Mibs/Html/ENTITY-MIB.php
+          # Stacked members often use x000 indexes (1000, 2000, …); add more list entries if you need them.
+          - OID: 1.3.6.1.2.1.47.1.1.1.1.11.1
+            name: entPhysicalSerialNum
 
 metrics:
   - MIB: CISCO-ENTITY-SENSOR-MIB


### PR DESCRIPTION
### What does this PR do?

- **`_base.yaml`** — Adds shared **`metadata.device.fields`** from **ENTITY-MIB** at **`entPhysicalIndex` 1**: **`serial_number`** (`entPhysicalSerialNum`), **`version`** (`entPhysicalHardwareRev`), **`product_name`** (`entPhysicalDescr`), and **`model`** (`entPhysicalModelName`).
- **`_arista-metadata.yaml`** — Removes definitions that duplicate **`_base`**; keeps Arista-only **`model`** fallback from **`sysDescr`**, plus **`os_name`** and **`os_version`**.
- **`_cisco-catalyst.yaml`** — **`serial_number`** uses **CISCO-STACK-MIB** `chassisSerialNumberString` only; ENTITY serial is covered by **`_base`** for profiles that extend it, avoiding a second copy of the same fallback here.

### Motivation

- Use **`_base.yaml`** as the single place for common ENTITY chassis metadata so vendor fragments only carry deltas (Arista **`sysDescr`** parsing, Cisco stack serial, and so on).
- AGENT-15682

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
