### PR TITLE
Add ENTITY-MIB chassis metadata to SNMP _base profile

### DIFF
--- a/docs/developer/tutorials/snmp/profile-format.md
+++ b/docs/developer/tutorials/snmp/profile-format.md
@@ -68,6 +68,14 @@ extends:
   - _base.yaml
 ```
 
+#### Vendor mixins that `extend` `_base.yaml`
+
+Some underscore mixins (for example `_hp.yaml`, `_dell.yaml`, `_juniper.yaml`, `_opengear.yaml`, `_palo-alto.yaml`, `_ubiquiti.yaml`, `_vertiv.yaml`, `_apc.yaml`) list only `_base.yaml` under `extends` plus a `vendor` (or similar) field. Expanding that mixin still pulls in **`_base.yaml`’s full device metadata** (for example `serial_number` and `version` from ENTITY-MIB).
+
+Because metadata merge is **first wins**, any other mixin or profile fragment that defines the **same** metadata keys with vendor-specific OIDs must appear **before** that vendor bridge mixin in the device profile’s `extends` list. Otherwise ENTITY values from `_base.yaml` win and the vendor-specific sources are never used (for example list `_hp-base.yaml` before `_hp.yaml` on HP server profiles).
+
+Conversely, list the vendor bridge mixin **after** generic metric mixins that do not define overlapping device metadata, and keep an explicit **`_base.yaml` last** on the top-level profile when you include it, so shared fields remain fallbacks.
+
 ### `metrics`
 
 _(Required)_

--- a/docs/developer/tutorials/snmp/profile-format.md
+++ b/docs/developer/tutorials/snmp/profile-format.md
@@ -53,15 +53,19 @@ _(Optional)_
 
 This field can be used to include metrics and metric tags from other so-called _base profiles_. Base profiles can derive from other base profiles to build a hierarchy of reusable profile mixins.
 
+For device **`metadata`**, **`extends`** order is **first wins, later fallbacks**—same model as [Value from multiple OIDs (symbols)](#value-from-multiple-oids-symbols).
+
 !!! important
     All device profiles should extend from the `_base.yaml` profile, which defines items that should be collected for all devices.
+    List **`_base.yaml` last** in **`extends`** so vendor-specific fragments merged earlier override shared metadata from base.
 
 Example:
 
 ```yaml
 extends:
-  - _base.yaml
+  - device-specific-profile.yaml  # Vendor or device overrides (metadata, metrics, …).
   - _generic-if.yaml  # Include basic metrics from IF-MIB.
+  - _base.yaml
 ```
 
 ### `metrics`
@@ -608,6 +612,7 @@ metadata:
 
 All OID values are fetched, even if they might not be used in the end. In the example above, both `1.3.6.100.0` and `1.3.6.101.0` are retrieved.
 
+Merged **`metadata`** across **`extends`** follows the same first-wins / later-fallback ordering; see [`extends`](#extends).
 
 ### Symbol modifiers
 

--- a/snmp/changelog.d/23369.fixed
+++ b/snmp/changelog.d/23369.fixed
@@ -1,1 +1,0 @@
-Refactor Cisco Catalyst serial_number metadata to use a symbols list with CISCO-STACK and ENTITY-MIB fallbacks and updated Circitor links.

--- a/snmp/changelog.d/23369.fixed
+++ b/snmp/changelog.d/23369.fixed
@@ -1,0 +1,1 @@
+Refactor Cisco Catalyst serial_number metadata to use a symbols list with CISCO-STACK and ENTITY-MIB fallbacks and updated Circitor links.

--- a/snmp/changelog.d/23370.added
+++ b/snmp/changelog.d/23370.added
@@ -1,0 +1,1 @@
+List the shared SNMP base profile last in extends across default profiles so device metadata merges in the correct order; align ENTITY-MIB-based serial metadata on Cisco Catalyst and Arista with that base definition.

--- a/snmp/changelog.d/23370.fixed
+++ b/snmp/changelog.d/23370.fixed
@@ -1,1 +1,0 @@
-Add ENTITY-MIB chassis metadata to SNMP `_base.yaml`, deduplicate `_arista-metadata.yaml`, and use CISCO-STACK serial on Catalyst with ENTITY fallback from `_base`.

--- a/snmp/changelog.d/23370.fixed
+++ b/snmp/changelog.d/23370.fixed
@@ -1,0 +1,1 @@
+Add ENTITY-MIB chassis metadata to SNMP `_base.yaml`, deduplicate `_arista-metadata.yaml`, and use CISCO-STACK serial on Catalyst with ENTITY fallback from `_base`.

--- a/snmp/datadog_checks/snmp/data/default_profiles/3com.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/3com.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/_arista-metadata.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_arista-metadata.yaml
@@ -1,13 +1,16 @@
 # Arista-specific device metadata. ENTITY-MIB chassis fields (serial_number, version,
 # product_name, primary model) are defined in _base.yaml.
 #
-# Model fallback: when entPhysicalModelName is empty, parse the product from sysDescr
+# Model: try ENTITY-MIB entPhysicalModelName first; if empty, parse from sysDescr
 # (see Arista profile examples in arista.yaml).
 metadata:
   device:
     fields:
       model:
         symbols:
+          - OID: 1.3.6.1.2.1.47.1.1.1.1.13.1  # entPhysicalModelName OID at index `1`
+            name: entPhysicalModelName
+            # Examples: `DCS-7504`
           - OID: 1.3.6.1.2.1.1.1.0
             name: sysDescr
             match_pattern: 'running on an Arista Networks ([\w-]+)'

--- a/snmp/datadog_checks/snmp/data/default_profiles/_arista-metadata.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_arista-metadata.yaml
@@ -1,29 +1,13 @@
-# Note related to use of index `1` of entPhysicalTable columns:
-# Based on snmpwalks of Arista, the main/chassis hardware have the index `1`
-# Librennms is also using index `1`: https://github.com/librenms/librenms/blob/1ac60e3b1d90616119f3c4adc28213e3c35c2477/includes/definitions/discovery/arista_eos.yaml#L4
+# Arista-specific device metadata. ENTITY-MIB chassis fields (serial_number, version,
+# product_name, primary model) are defined in _base.yaml.
+#
+# Model fallback: when entPhysicalModelName is empty, parse the product from sysDescr
+# (see Arista profile examples in arista.yaml).
 metadata:
   device:
     fields:
-      serial_number:
-        symbol:
-          OID: 1.3.6.1.2.1.47.1.1.1.1.11.1  # entPhysicalSerialNum OID at index `1`
-          name: entPhysicalSerialNum
-          # Examples: `HSH16195058`
-      version:
-        symbol:
-          OID: 1.3.6.1.2.1.47.1.1.1.1.8.1  # entPhysicalHardwareRev OID at index `1`
-          name: entPhysicalHardwareRev
-          # Examples: `12.00`
-      product_name:
-        symbol:
-          OID: 1.3.6.1.2.1.47.1.1.1.1.2.1  # entPhysicalDescr OID at index `1`
-          name: entPhysicalDescr
-          # Examples: `DCS-7504 Chassis`
       model:
         symbols:
-          - OID: 1.3.6.1.2.1.47.1.1.1.1.13.1  # entPhysicalModelName OID at index `1`
-            name: entPhysicalModelName
-            # Examples: `DCS-7504`
           - OID: 1.3.6.1.2.1.1.1.0
             name: sysDescr
             match_pattern: 'running on an Arista Networks ([\w-]+)'

--- a/snmp/datadog_checks/snmp/data/default_profiles/_base.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_base.yaml
@@ -1,4 +1,6 @@
-# Base profile that should only contain any items we want to provide for all profiles.
+# Base profile for all devices. Vendor-only mixins extend this file and inherit all metadata
+# below; merge order with sibling mixins is documented in
+# docs/developer/tutorials/snmp/profile-format.md (`extends`, vendor mixins that extend `_base.yaml`).
 
 metric_tags:
   - OID: 1.3.6.1.2.1.1.5.0

--- a/snmp/datadog_checks/snmp/data/default_profiles/_base.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_base.yaml
@@ -27,3 +27,19 @@ metadata:
         symbol:
           OID: 1.3.6.1.2.1.1.6.0
           name: sysLocation
+      serial_number:
+        symbol:
+          OID: 1.3.6.1.2.1.47.1.1.1.1.11.1
+          name: entPhysicalSerialNum
+      version:
+        symbol:
+          OID: 1.3.6.1.2.1.47.1.1.1.1.8.1
+          name: entPhysicalHardwareRev
+      product_name:
+        symbol:
+          OID: 1.3.6.1.2.1.47.1.1.1.1.2.1
+          name: entPhysicalDescr
+      model:
+        symbol:
+          OID: 1.3.6.1.2.1.47.1.1.1.1.13.1
+          name: entPhysicalModelName

--- a/snmp/datadog_checks/snmp/data/default_profiles/_base_cisco.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_base_cisco.yaml
@@ -1,4 +1,4 @@
 # Backward compatibility shim, in case users referenced this in their own profiles before the rename.
 extends:
-  - _base.yaml
   - _cisco-generic.yaml
+  - _base.yaml

--- a/snmp/datadog_checks/snmp/data/default_profiles/_base_cisco_voice.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_base_cisco_voice.yaml
@@ -1,5 +1,5 @@
 # Backward compatibility shim, in case users referenced this in their own profiles before the rename.
 extends:
-  - _base.yaml
   - _cisco-generic.yaml
   - _cisco-voice.yaml
+  - _base.yaml

--- a/snmp/datadog_checks/snmp/data/default_profiles/_cisco-catalyst.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_cisco-catalyst.yaml
@@ -9,15 +9,18 @@ metadata:
   device:
     fields:
       serial_number:
-        symbol:
-          # Cisco Catalyst devices are using CISCO-STACK-MIB
-          # Source1: http://www.circitor.fr/Mibs/Html/C/CISCO-STACK-MIB.php
-          #   "This MIB provides configuration and runtime status for chassis, modules, ports, etc. on the Catalyst systems."
-          # Source2: chassisSerialNumberString is present for this device:
+        symbols:
+          # CISCO-STACK-MIB: chassisSerialNumberString — primary chassis serial on classic Catalyst.
+          # Source 1: https://circitor.fr/Mibs/Html/CISCO-STACK-MIB.php
+          # Source 2: chassisSerialNumberString is present for this device:
           #   Cisco Systems WS-C6509.Cisco Catalyst Operating System Software, Version 5.5(8).Copyright (c) 1995-2001 by Cisco Systems.
-          MIB: CISCO-STACK-MIB
-          OID: 1.3.6.1.4.1.9.5.1.2.19.0
-          name: chassisSerialNumberString
+          - OID: 1.3.6.1.4.1.9.5.1.2.19.0
+            name: chassisSerialNumberString
+          # ENTITY-MIB: entPhysicalSerialNum at entPhysicalIndex 1 — fallback when stack MIB data is missing.
+          # Source: https://circitor.fr/Mibs/Html/ENTITY-MIB.php
+          # Stacked members often use x000 indexes (1000, 2000, …); add more list entries if you need them.
+          - OID: 1.3.6.1.2.1.47.1.1.1.1.11.1
+            name: entPhysicalSerialNum
 
 metrics:
   - MIB: CISCO-ENTITY-SENSOR-MIB

--- a/snmp/datadog_checks/snmp/data/default_profiles/_cisco-catalyst.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_cisco-catalyst.yaml
@@ -9,18 +9,15 @@ metadata:
   device:
     fields:
       serial_number:
-        symbols:
-          # CISCO-STACK-MIB: chassisSerialNumberString — primary chassis serial on classic Catalyst.
-          # Source 1: https://circitor.fr/Mibs/Html/CISCO-STACK-MIB.php
-          # Source 2: chassisSerialNumberString is present for this device:
+        symbol:
+          # Cisco Catalyst devices are using CISCO-STACK-MIB
+          # Source1: http://www.circitor.fr/Mibs/Html/C/CISCO-STACK-MIB.php
+          #   "This MIB provides configuration and runtime status for chassis, modules, ports, etc. on the Catalyst systems."
+          # Source2: chassisSerialNumberString is present for this device:
           #   Cisco Systems WS-C6509.Cisco Catalyst Operating System Software, Version 5.5(8).Copyright (c) 1995-2001 by Cisco Systems.
-          - OID: 1.3.6.1.4.1.9.5.1.2.19.0
-            name: chassisSerialNumberString
-          # ENTITY-MIB: entPhysicalSerialNum at entPhysicalIndex 1 — fallback when stack MIB data is missing.
-          # Source: https://circitor.fr/Mibs/Html/ENTITY-MIB.php
-          # Stacked members often use x000 indexes (1000, 2000, …); add more list entries if you need them.
-          - OID: 1.3.6.1.2.1.47.1.1.1.1.11.1
-            name: entPhysicalSerialNum
+          MIB: CISCO-STACK-MIB
+          OID: 1.3.6.1.4.1.9.5.1.2.19.0
+          name: chassisSerialNumberString
 
 metrics:
   - MIB: CISCO-ENTITY-SENSOR-MIB

--- a/snmp/datadog_checks/snmp/data/default_profiles/_huawei.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_huawei.yaml
@@ -1,6 +1,6 @@
 extends:
- - _base.yaml
  - _generic-if.yaml
+ - _base.yaml
 metadata:
   device:
     fields:

--- a/snmp/datadog_checks/snmp/data/default_profiles/a10.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/a10.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/alcatel-lucent.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/alcatel-lucent.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/anue.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/anue.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/arista-switch.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/arista-switch.yaml
@@ -1,12 +1,12 @@
 extends:
   - _arista.yaml
   - _arista-queue.yaml
-  - _base.yaml
   - _generic-bgp4.yaml
   - _generic-entity-sensor.yaml
   - _generic-if.yaml
   - _generic-lldp.yaml
   - _generic-ospf.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/arista.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/arista.yaml
@@ -13,7 +13,6 @@ extends:
   - _arista.yaml
   - _arista-metadata.yaml
   - _arista-queue.yaml
-  - _base.yaml
   - _generic-if.yaml
   - _generic-ip.yaml
   - _generic-host-resources.yaml
@@ -21,6 +20,7 @@ extends:
   - _generic-bgp4.yaml
   - _generic-tcp.yaml
   - _generic-udp.yaml
+  - _base.yaml
 
 # The OID `1.3.6.1.4.1.30065.1`/`aristaProducts` is the root object identifier from
 # which sysObjectID values are assigned. Values are defined in ARISTA-PRODUCTS-MIB.

--- a/snmp/datadog_checks/snmp/data/default_profiles/aruba-access-point.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/aruba-access-point.yaml
@@ -8,10 +8,10 @@
 #     1.3.6.1.4.1.14823.1.2.82           ArubaOS (MODEL: 315), Version 8.5.0.5-8.5.0.5
 
 extends:
-  - _base.yaml
   - _aruba-base.yaml
   - _generic-if.yaml
   - _generic-ospf.yaml
+  - _base.yaml
 
 # All Access Point Products (apProducts/1.3.6.1.4.1.14823.1.2) from ARUBA-MIB
 sysobjectid: 1.3.6.1.4.1.14823.1.2.*

--- a/snmp/datadog_checks/snmp/data/default_profiles/aruba-mobility-controller.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/aruba-mobility-controller.yaml
@@ -1,7 +1,7 @@
 extends:
   - _aruba-base.yaml
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 sysobjectid:
   - 1.3.6.1.4.1.14823.1.1.50

--- a/snmp/datadog_checks/snmp/data/default_profiles/aruba-switch.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/aruba-switch.yaml
@@ -14,11 +14,11 @@
 #     1.3.6.1.4.1.14823.1.1.40           ArubaOS (MODEL: Aruba7010-US), Version 6.5.1.4 (58698)
 
 extends:
-  - _base.yaml
   - _aruba-base.yaml
   - _generic-if.yaml
   - _generic-ospf.yaml
   - _aruba-switch-cpu-memory.yaml
+  - _base.yaml
 
 # All Switch Products (switchProducts/1.3.6.1.4.1.14823.1.1) from ARUBA-MIB
 sysobjectid: 1.3.6.1.4.1.14823.1.1.*

--- a/snmp/datadog_checks/snmp/data/default_profiles/aruba-wireless-controller.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/aruba-wireless-controller.yaml
@@ -1,7 +1,7 @@
 extends:
   - _aruba-base.yaml
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 sysobjectid:
   - 1.3.6.1.4.1.14823.1.1.1

--- a/snmp/datadog_checks/snmp/data/default_profiles/aruba.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/aruba.yaml
@@ -8,7 +8,7 @@ device:
   vendor: "aruba"
 
 extends:
-  - _base.yaml
   - _aruba-base.yaml
   - _generic-if.yaml
   - _generic-ospf.yaml
+  - _base.yaml

--- a/snmp/datadog_checks/snmp/data/default_profiles/audiocodes-mediant-sbc.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/audiocodes-mediant-sbc.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 sysobjectid:
   - 1.3.6.1.4.1.5003.8.1.1.71

--- a/snmp/datadog_checks/snmp/data/default_profiles/avaya-media-gateway.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/avaya-media-gateway.yaml
@@ -1,9 +1,9 @@
 extends:
-  - _base.yaml
   - _generic-entity-sensor.yaml
   - _generic-if.yaml
   - _generic-ospf.yaml
   - avaya.yaml
+  - _base.yaml
 
 sysobjectid:
   - 1.3.6.1.4.1.6889.1.45.103.8 # G450 Media Gateway

--- a/snmp/datadog_checks/snmp/data/default_profiles/avaya-nortel-ethernet-routing-switch.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/avaya-nortel-ethernet-routing-switch.yaml
@@ -1,7 +1,7 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
   - avaya.yaml
+  - _base.yaml
 
 sysobjectid:
   - 1.3.6.1.4.1.45.3.71.10 # 4526T

--- a/snmp/datadog_checks/snmp/data/default_profiles/avocent-acs.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/avocent-acs.yaml
@@ -1,7 +1,7 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
   - _generic-ucd.yaml
+  - _base.yaml
 
 sysobjectid:
   - 1.3.6.1.4.1.10418.26.1.* # Avocent Console Server

--- a/snmp/datadog_checks/snmp/data/default_profiles/barracuda.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/barracuda.yaml
@@ -1,7 +1,7 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
   - _generic-ucd.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/bluecat-server.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/bluecat-server.yaml
@@ -1,8 +1,8 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
   - _generic-host-resources-base.yaml
   - _generic-ucd.yaml
+  - _base.yaml
 
 sysobjectid:
   - 1.3.6.1.4.1.13315.2.*

--- a/snmp/datadog_checks/snmp/data/default_profiles/brocade.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/brocade.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/checkpoint.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/checkpoint.yaml
@@ -6,12 +6,12 @@
 # - 1.3.6.1.4.1.2620.1.6.123.1.56   Linux host3 2.6.18-92cpx86_64 #1 SMP Tue May 16 12:09:46 IDT 2017 x86_64"
 
 extends:
-  - _base.yaml
   - _generic-if.yaml
   - _generic-tcp.yaml
   - _generic-udp.yaml
   - _generic-ip.yaml
   - _checkpoint-firewall-cpu-memory.yaml
+  - _base.yaml
 
 device:
   vendor: "checkpoint"

--- a/snmp/datadog_checks/snmp/data/default_profiles/cisco-3850.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cisco-3850.yaml
@@ -2,9 +2,9 @@
 # Profile for Cisco 3850 devices
 
 extends:
-  - _base.yaml
   - _cisco-generic.yaml
   - _cisco-catalyst.yaml
+  - _base.yaml
 
 sysobjectid: 1.3.6.1.4.1.9.1.1745 # cat38xxstack
 

--- a/snmp/datadog_checks/snmp/data/default_profiles/cisco-asa-5525.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cisco-asa-5525.yaml
@@ -6,8 +6,8 @@
 #   "Cisco Adaptive Security Appliance Version 9.12(3)12"
 
 extends:
-  - _base.yaml
   - _cisco-asa.yaml
+  - _base.yaml
 
 device:
   vendor: "cisco"

--- a/snmp/datadog_checks/snmp/data/default_profiles/cisco-asa.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cisco-asa.yaml
@@ -1,8 +1,8 @@
 # Profile for Cisco ASA devices
 
 extends:
-  - _base.yaml
   - _cisco-asa.yaml
+  - _base.yaml
 
 device:
   vendor: "cisco"

--- a/snmp/datadog_checks/snmp/data/default_profiles/cisco-asr.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cisco-asr.yaml
@@ -1,8 +1,8 @@
 # Profile for Cisco ASR devices
 
 extends:
-  - _base.yaml
   - _cisco-generic.yaml
+  - _base.yaml
 
 device:
   vendor: "cisco"

--- a/snmp/datadog_checks/snmp/data/default_profiles/cisco-catalyst-wlc.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cisco-catalyst-wlc.yaml
@@ -2,10 +2,10 @@
 # This profile is only compatible with the core SNMP integration
 
 extends:
-  - _base.yaml
   - _cisco-generic.yaml
   - _cisco-catalyst.yaml
   - _cisco-wlc.yaml
+  - _base.yaml
 
 device:
   vendor: "cisco"

--- a/snmp/datadog_checks/snmp/data/default_profiles/cisco-catalyst.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cisco-catalyst.yaml
@@ -1,9 +1,9 @@
 # Profile for Cisco Catalyst devices
 
 extends:
-  - _base.yaml
   - _cisco-generic.yaml
   - _cisco-catalyst.yaml
+  - _base.yaml
 
 device:
   vendor: "cisco"

--- a/snmp/datadog_checks/snmp/data/default_profiles/cisco-csr1000v.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cisco-csr1000v.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _cisco-generic.yaml
+  - _base.yaml
 
 sysobjectid: 1.3.6.1.4.1.9.1.1537
 

--- a/snmp/datadog_checks/snmp/data/default_profiles/cisco-firepower-asa.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cisco-firepower-asa.yaml
@@ -1,8 +1,8 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
   - _cisco-metadata.yaml
   # This profile does not import cisco.yaml on purpose
+  - _base.yaml
 sysobjectid:
   - 1.3.6.1.4.1.9.1.1902           # Cisco VASA (Cisco Firepower Threat Defense, Version 6.7.0.2)
   - 1.3.6.1.4.1.9.1.1903           # Cisco VASA System Context

--- a/snmp/datadog_checks/snmp/data/default_profiles/cisco-firepower.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cisco-firepower.yaml
@@ -1,8 +1,8 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
   - _cisco-metadata.yaml
   # This profile does not import cisco.yaml on purpose
+  - _base.yaml
 sysobjectid:
   - 1.3.6.1.4.1.9.1.2404           # Cisco FPR 2110td
   - 1.3.6.1.4.1.9.1.2405           # Cisco FPR 2120td

--- a/snmp/datadog_checks/snmp/data/default_profiles/cisco-ironport-email.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cisco-ironport-email.yaml
@@ -1,8 +1,8 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
   - _cisco-metadata.yaml
   # This profile does not import cisco.yaml on purpose
+  - _base.yaml
 sysobjectid:
   - 1.3.6.1.4.1.15497.1.*    # IronPort Email Security Appliance
   - 1.3.6.1.4.1.15497.1.2    # IronPort S300V

--- a/snmp/datadog_checks/snmp/data/default_profiles/cisco-ise.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cisco-ise.yaml
@@ -1,9 +1,9 @@
 extends:
-  - _base.yaml
   - _generic-host-resources.yaml
   - _generic-if.yaml
   - _generic-ucd.yaml
   # This profile does not import cisco.yaml on purpose
+  - _base.yaml
 sysobjectid:
   - 1.3.6.1.4.1.9.1.2785
   - 1.3.6.1.4.1.9.1.1426

--- a/snmp/datadog_checks/snmp/data/default_profiles/cisco-isr.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cisco-isr.yaml
@@ -1,8 +1,8 @@
 # Profile for Cisco ISR devices
 
 extends:
-  - _base.yaml
   - _cisco-generic.yaml
+  - _base.yaml
 
 device:
   vendor: "cisco"

--- a/snmp/datadog_checks/snmp/data/default_profiles/cisco-legacy-wlc.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cisco-legacy-wlc.yaml
@@ -2,12 +2,12 @@
 # This profile is only compatible with the core SNMP integration
 
 extends:
-  - _base.yaml
   - _generic-if.yaml
   - _generic-tcp.yaml
   - _generic-udp.yaml
   - _cisco-wlc.yaml
   - _cisco-metadata.yaml
+  - _base.yaml
 
 device:
   vendor: "cisco"

--- a/snmp/datadog_checks/snmp/data/default_profiles/cisco-nexus.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cisco-nexus.yaml
@@ -1,8 +1,8 @@
 # Profile for Cisco Nexus devices
 
 extends:
-  - _base.yaml
   - _cisco-generic.yaml
+  - _base.yaml
 
 device:
   vendor: "cisco"

--- a/snmp/datadog_checks/snmp/data/default_profiles/cisco-sb.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cisco-sb.yaml
@@ -1,7 +1,7 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
   # This profile does not import cisco.yaml on purpose
+  - _base.yaml
 sysobjectid:
   - 1.3.6.1.4.1.9.6.1.*         # Cisco Small Business
   - 1.3.6.1.4.1.9.6.1.88.26.1   # Cisco SG200-26

--- a/snmp/datadog_checks/snmp/data/default_profiles/cisco-ucs.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cisco-ucs.yaml
@@ -1,7 +1,7 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
   # This profile does not import cisco.yaml on purpose
+  - _base.yaml
 sysobjectid:
   - 1.3.6.1.4.1.9.1.1683           # UCS C240
   - 1.3.6.1.4.1.9.1.2178           # UCS C220 M4

--- a/snmp/datadog_checks/snmp/data/default_profiles/cisco_icm.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cisco_icm.yaml
@@ -1,7 +1,7 @@
 extends:
-  - _base.yaml
   - _cisco-generic.yaml
   - _cisco-voice.yaml
+  - _base.yaml
 
 sysobjectid: 1.3.6.1.4.1.9.1.693
 

--- a/snmp/datadog_checks/snmp/data/default_profiles/cisco_isr_4431.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cisco_isr_4431.yaml
@@ -1,7 +1,7 @@
 extends:
-  - _base.yaml
   - _cisco-generic.yaml
   - _cisco-voice.yaml
+  - _base.yaml
 
 device:
   vendor: "cisco"

--- a/snmp/datadog_checks/snmp/data/default_profiles/cisco_uc_virtual_machine.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cisco_uc_virtual_machine.yaml
@@ -1,7 +1,7 @@
 extends:
-  - _base.yaml
   - _cisco-generic.yaml
   - _cisco-voice.yaml
+  - _base.yaml
 
 device:
   vendor: "cisco"

--- a/snmp/datadog_checks/snmp/data/default_profiles/cradlepoint.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cradlepoint.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 metadata:
   device:
     fields:

--- a/snmp/datadog_checks/snmp/data/default_profiles/dialogic-media-gateway.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/dialogic-media-gateway.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/dlink.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/dlink.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/exagrid.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/exagrid.yaml
@@ -1,7 +1,7 @@
 extends:
-  - _base.yaml
   - _generic-host-resources.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 sysobjectid:
   - 1.3.6.1.4.1.14941.3.*

--- a/snmp/datadog_checks/snmp/data/default_profiles/extreme-switching.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/extreme-switching.yaml
@@ -1,7 +1,7 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
   - _generic-entity-sensor.yaml
+  - _base.yaml
 
 sysobjectid:
   - 1.3.6.1.4.1.1916.2.89

--- a/snmp/datadog_checks/snmp/data/default_profiles/f5-big-ip.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/f5-big-ip.yaml
@@ -6,7 +6,6 @@
 #   BIG-IP Virtual Edition : Linux 3.10.0-862.14.4.el7.ve.x86_64 : BIG-IP software release 15.0.1, build 0.0.11
 
 extends:
-  - _base.yaml
   - _generic-if.yaml # F5-specific variants of the other metrics are provided in this profile.
   - _generic-bgp4.yaml
   - _generic-ospf.yaml
@@ -14,6 +13,7 @@ extends:
   - _generic-udp.yaml
   - _generic-ip.yaml
   - _f5-big-ip-cpu-memory.yaml
+  - _base.yaml
 
 device:
   vendor: "f5"

--- a/snmp/datadog_checks/snmp/data/default_profiles/fireeye.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/fireeye.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/fortinet-appliance.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/fortinet-appliance.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - fortinet.yaml
+  - _base.yaml
 
 sysobjectid:
   - 1.3.6.1.4.1.12356.103.1.*          # Fortinet FortiManager

--- a/snmp/datadog_checks/snmp/data/default_profiles/fortinet-fortigate.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/fortinet-fortigate.yaml
@@ -3,10 +3,10 @@
 # For Fortinet FortiGate devices, the sysDescr is not a reliable source of info.
 
 extends:
-  - _base.yaml
   - _generic-if.yaml
   - _fortinet-fortigate-cpu-memory.yaml
   - _fortinet-fortigate-vpn-tunnel.yaml
+  - _base.yaml
 
 device:
   vendor: "fortinet"

--- a/snmp/datadog_checks/snmp/data/default_profiles/fortinet.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/fortinet.yaml
@@ -2,8 +2,8 @@
 # For Fortinet FortiGate devices, a separate fortinet-fortigate profile is used
 
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/generic-device.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/generic-device.yaml
@@ -1,11 +1,11 @@
 # Generic profile for network devices
 
 extends:
-  - _base.yaml
   - _generic-if.yaml
   - _generic-ip.yaml
   - _generic-tcp.yaml
   - _generic-udp.yaml
   - _generic-ospf.yaml
+  - _base.yaml
 
 sysobjectid: 1.3.6.1.4.*

--- a/snmp/datadog_checks/snmp/data/default_profiles/generic-ups.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/generic-ups.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-ups.yaml
+  - _base.yaml
 
 sysobjectid:
   - 1.3.6.1.2.1.33

--- a/snmp/datadog_checks/snmp/data/default_profiles/gigamon.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/gigamon.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/hp-ilo.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/hp-ilo.yaml
@@ -5,8 +5,8 @@
 # For more information, check: https://support.hpe.com/hpesc/public/docDisplay?docId=a00129448en_us&docLocale=en_US
 
 extends:
-  - _hp.yaml
   - _hp-base.yaml
+  - _hp.yaml
   - _hp-compaq-health.yaml
   - _hp-driver-stats.yaml
 

--- a/snmp/datadog_checks/snmp/data/default_profiles/hpe-bladesystem-enclosure.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/hpe-bladesystem-enclosure.yaml
@@ -1,7 +1,7 @@
 extends:
   - _generic-ucd.yaml
-  - _hp.yaml
   - _hp-base.yaml
+  - _hp.yaml
 sysobjectid:
   - 1.3.6.1.4.1.11.5.7.1.2
 metrics:

--- a/snmp/datadog_checks/snmp/data/default_profiles/hpe-msa.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/hpe-msa.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _hp.yaml
   - _hp-base.yaml
+  - _hp.yaml
 sysobjectid:
   - 1.3.6.1.4.1.11.2.51
 metadata:

--- a/snmp/datadog_checks/snmp/data/default_profiles/hpe-proliant.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/hpe-proliant.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _hp.yaml
   - _hp-base.yaml
+  - _hp.yaml
   - _hp-compaq-health.yaml
   - _hp-driver-stats.yaml
   - _generic-tcp.yaml

--- a/snmp/datadog_checks/snmp/data/default_profiles/infinera-coriant-groove.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/infinera-coriant-groove.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 sysobjectid: 1.3.6.1.4.1.42229.1.2 # Groove GX Series
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/infoblox-ipam.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/infoblox-ipam.yaml
@@ -1,8 +1,8 @@
 extends:
-  - _base.yaml
   - _generic-host-resources-base.yaml
   - _generic-if.yaml
   - _generic-ucd-base.yaml
+  - _base.yaml
 sysobjectid:
   - 1.3.6.1.4.1.7779.1.1004    # Virtual Device
   - 1.3.6.1.4.1.7779.1.1204    # IB-1552

--- a/snmp/datadog_checks/snmp/data/default_profiles/isilon.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/isilon.yaml
@@ -2,10 +2,10 @@
 # - device-name-3 263829375 Isilon OneFS v8.2.0.0
 # - device-name-5 2316163007 Isilon OneFS v8.1.2.0
 extends:
-  - _base.yaml
   - _generic-ip.yaml
   - _generic-tcp.yaml
   - _generic-udp.yaml
+  - _base.yaml
 
 device:
   vendor: "dell"

--- a/snmp/datadog_checks/snmp/data/default_profiles/ixsystems-truenas.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/ixsystems-truenas.yaml
@@ -7,10 +7,10 @@
 #       that can be extended in by ixsystems-truenas.yaml but also a new FreeNAS profile (with sysobjectid 1.3.6.1.4.1.50536.3.1 FreeNAS).
 
 extends:
-  - _base.yaml
   - _generic-host-resources-base.yaml
   - _generic-if.yaml
   - _generic-ucd.yaml
+  - _base.yaml
 
 sysobjectid: 1.3.6.1.4.1.50536.3.2  # TrueNAS
 

--- a/snmp/datadog_checks/snmp/data/default_profiles/linksys.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/linksys.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 metadata:
   device:
     fields:

--- a/snmp/datadog_checks/snmp/data/default_profiles/mcafee-web-gateway.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/mcafee-web-gateway.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 sysobjectid:
   - 1.3.6.1.4.1.1230.2.7.1.1
 metadata:

--- a/snmp/datadog_checks/snmp/data/default_profiles/meraki-cloud-controller.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/meraki-cloud-controller.yaml
@@ -2,8 +2,8 @@
 #
 # We don't extend from base for now, as sysName is useless for meraki.
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 device:
   vendor: "meraki"

--- a/snmp/datadog_checks/snmp/data/default_profiles/meraki.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/meraki.yaml
@@ -4,8 +4,8 @@
 #
 # We don't extend from base for now, as sysName is useless for meraki.
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 device:
   vendor: "meraki"

--- a/snmp/datadog_checks/snmp/data/default_profiles/mikrotik-router.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/mikrotik-router.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 metadata:
   device:
     fields:

--- a/snmp/datadog_checks/snmp/data/default_profiles/nasuni-filer.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/nasuni-filer.yaml
@@ -1,7 +1,7 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
   - _generic-ucd.yaml
+  - _base.yaml
 sysobjectid:
   - 1.3.6.1.4.1.42040.1.1.0
 metadata:

--- a/snmp/datadog_checks/snmp/data/default_profiles/nec-univerge.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/nec-univerge.yaml
@@ -1,7 +1,7 @@
 extends:
-  - _base.yaml
   - _generic-bgp4.yaml
   - _generic-if.yaml
+  - _base.yaml
 sysobjectid:
   - 1.3.6.1.4.1.119.1.*        # NEC
   - 1.3.6.1.4.1.119.1.84.18    # NEC IX Series IX2207

--- a/snmp/datadog_checks/snmp/data/default_profiles/netgear.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/netgear.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 sysobjectid: 1.3.6.1.4.1.4526.*
 

--- a/snmp/datadog_checks/snmp/data/default_profiles/nvidia.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/nvidia.yaml
@@ -1,7 +1,7 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
   - _generic-entity-sensor.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/omron-cj-ethernet-ip.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/omron-cj-ethernet-ip.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/peplink.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/peplink.yaml
@@ -1,7 +1,7 @@
 extends:
-  - _base.yaml
   - _generic-host-resources-base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 sysobjectid:
   - 1.3.6.1.4.1.23695

--- a/snmp/datadog_checks/snmp/data/default_profiles/pf-sense.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/pf-sense.yaml
@@ -1,8 +1,8 @@
 extends:
-  - _base.yaml
   - _generic-host-resources-base.yaml
   - _generic-if.yaml
   - _generic-ucd.yaml
+  - _base.yaml
 
 sysobjectid: 1.3.6.1.4.1.12325.*
 

--- a/snmp/datadog_checks/snmp/data/default_profiles/raritan-dominion.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/raritan-dominion.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/riverbed.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/riverbed.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/ruckus.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/ruckus.yaml
@@ -1,7 +1,7 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
   - _generic-ucd.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/server-iron-switch.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/server-iron-switch.yaml
@@ -1,7 +1,7 @@
 extends:
-  - _base.yaml
   - _generic-host-resources-base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/silverpeak-edgeconnect.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/silverpeak-edgeconnect.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/sophos-xgs-firewall.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/sophos-xgs-firewall.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 sysobjectid:
   - 1.3.6.1.4.1.2604.5
 metadata:

--- a/snmp/datadog_checks/snmp/data/default_profiles/synology-disk-station.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/synology-disk-station.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/tp-link.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/tp-link.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/velocloud-edge.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/velocloud-edge.yaml
@@ -1,7 +1,7 @@
 extends:
-  - _base.yaml
   - _generic-host-resources-base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/vmware-esx.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/vmware-esx.yaml
@@ -1,7 +1,7 @@
 extends:
-  - _base.yaml
   - _generic-host-resources-base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/watchguard.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/watchguard.yaml
@@ -1,7 +1,7 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
   - _generic-host-resources-base.yaml
+  - _base.yaml
 
 sysobjectid:
   - 1.3.6.1.4.1.3097.1.5.*

--- a/snmp/datadog_checks/snmp/data/default_profiles/western-digital-mycloud-ex2-ultra.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/western-digital-mycloud-ex2-ultra.yaml
@@ -1,7 +1,7 @@
 extends:
-  - _base.yaml
   - _generic-host-resources-base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/default_profiles/zyxel-switch.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/zyxel-switch.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/tests/fixtures/user_profiles/abstract-generic-ups.yaml
+++ b/snmp/tests/fixtures/user_profiles/abstract-generic-ups.yaml
@@ -1,5 +1,5 @@
 extends:
-  - _base.yaml
   - _generic-ups.yaml
+  - _base.yaml
 
 sysobjectid: 1.2.3.4.5.6.7.8.999

--- a/snmp/tests/fixtures/user_profiles/checkpoint-firewall-cpu-memory.yaml
+++ b/snmp/tests/fixtures/user_profiles/checkpoint-firewall-cpu-memory.yaml
@@ -1,5 +1,5 @@
 extends:
-  - _base.yaml
   - _checkpoint-firewall-cpu-memory.yaml
+  - _base.yaml
 
 sysobjectid: 1.2.3.1006

--- a/snmp/tests/fixtures/user_profiles/cisco-generic.yaml
+++ b/snmp/tests/fixtures/user_profiles/cisco-generic.yaml
@@ -1,6 +1,6 @@
 extends:
-  - _base.yaml
   - _cisco-generic.yaml
+  - _base.yaml
 
 metadata:
   device:

--- a/snmp/tests/fixtures/user_profiles/cisco-ipsec-flow-monitor.yaml
+++ b/snmp/tests/fixtures/user_profiles/cisco-ipsec-flow-monitor.yaml
@@ -1,5 +1,5 @@
 extends:
-  - _base.yaml
   - _cisco-ipsec-flow-monitor.yaml
+  - _base.yaml
 
 sysobjectid: 1.2.3.1008.123

--- a/snmp/tests/fixtures/user_profiles/dell-rac.yaml
+++ b/snmp/tests/fixtures/user_profiles/dell-rac.yaml
@@ -1,5 +1,5 @@
 extends:
-  - _base.yaml
   - _dell-rac.yaml
+  - _base.yaml
 
 sysobjectid: 1.2.3.1003

--- a/snmp/tests/fixtures/user_profiles/generic-bgp4.yaml
+++ b/snmp/tests/fixtures/user_profiles/generic-bgp4.yaml
@@ -1,5 +1,5 @@
 extends:
-  - _base.yaml
   - _generic-bgp4.yaml
+  - _base.yaml
 
 sysobjectid: 1.2.3.1007

--- a/snmp/tests/fixtures/user_profiles/generic-entity-sensor.yaml
+++ b/snmp/tests/fixtures/user_profiles/generic-entity-sensor.yaml
@@ -1,5 +1,5 @@
 extends:
-  - _base.yaml
   - _generic-entity-sensor.yaml
+  - _base.yaml
 
 sysobjectid: 1.2.3.1002

--- a/snmp/tests/fixtures/user_profiles/generic-lldp.yaml
+++ b/snmp/tests/fixtures/user_profiles/generic-lldp.yaml
@@ -1,5 +1,5 @@
 extends:
-  - _base.yaml
   - _generic-lldp.yaml
+  - _base.yaml
 
 sysobjectid: 1.2.3.99999

--- a/snmp/tests/fixtures/user_profiles/generic-ospf.yaml
+++ b/snmp/tests/fixtures/user_profiles/generic-ospf.yaml
@@ -1,5 +1,5 @@
 extends:
-  - _base.yaml
   - _generic-ospf.yaml
+  - _base.yaml
 
 sysobjectid: 1.2.3.3294.1281

--- a/snmp/tests/fixtures/user_profiles/generic-rtp.yaml
+++ b/snmp/tests/fixtures/user_profiles/generic-rtp.yaml
@@ -1,5 +1,5 @@
 extends:
-  - _base.yaml
   - _generic-rtp.yaml
+  - _base.yaml
 
 sysobjectid: 1.2.3.1009.123

--- a/snmp/tests/fixtures/user_profiles/generic-sip.yaml
+++ b/snmp/tests/fixtures/user_profiles/generic-sip.yaml
@@ -1,5 +1,5 @@
 extends:
-  - _base.yaml
   - _generic-sip.yaml
+  - _base.yaml
 
 sysobjectid: 1.2.3.1010.123

--- a/snmp/tests/fixtures/user_profiles/generic-ucd-base.yaml
+++ b/snmp/tests/fixtures/user_profiles/generic-ucd-base.yaml
@@ -1,5 +1,5 @@
 extends:
-  - _base.yaml
   - _generic-ucd-base.yaml
+  - _base.yaml
 
 sysobjectid: 1.2.3.40

--- a/snmp/tests/fixtures/user_profiles/generic-ucd-cpu-mem.yaml
+++ b/snmp/tests/fixtures/user_profiles/generic-ucd-cpu-mem.yaml
@@ -1,5 +1,5 @@
 extends:
-  - _base.yaml
   - _generic-ucd-cpu-mem.yaml
+  - _base.yaml
 
 sysobjectid: 1.2.3.41

--- a/snmp/tests/fixtures/user_profiles/generic-ucd.yaml
+++ b/snmp/tests/fixtures/user_profiles/generic-ucd.yaml
@@ -1,5 +1,5 @@
 extends:
-  - _base.yaml
   - _generic-ucd.yaml
+  - _base.yaml
 
 sysobjectid: 1.2.3.1001

--- a/snmp/tests/fixtures/user_profiles/hp-compaq-health.yaml
+++ b/snmp/tests/fixtures/user_profiles/hp-compaq-health.yaml
@@ -1,5 +1,5 @@
 extends:
-  - _base.yaml
   - _hp-compaq-health.yaml
+  - _base.yaml
 
 sysobjectid: 1.2.3.1004

--- a/snmp/tests/test_e2e_core_metadata.py
+++ b/snmp/tests/test_e2e_core_metadata.py
@@ -339,6 +339,7 @@ def test_e2e_core_metadata_hp_ilo4(dd_agent_check):
         'profile': 'hp-ilo4',
         'status': 1,
         'sys_object_id': '1.3.6.1.4.1.232.9.4.10',
+        'version': 'A04-08/12/2018',
         'tags': [
             'agent_host:' + common.get_agent_hostname(),
             'device_id:' + device_id,
@@ -351,6 +352,7 @@ def test_e2e_core_metadata_hp_ilo4(dd_agent_check):
             'snmp_profile:hp-ilo4',
         ],
         'vendor': 'hp',
+        'serial_number': 'dXPEdPBE5yKtjW9xx3',
         'device_type': 'server',
         'integration': 'snmp',
     }
@@ -386,6 +388,7 @@ def test_e2e_core_metadata_hpe_proliant(dd_agent_check):
         'os_name': 'RHEL',
         'os_version': '3.10.0-862.15.4.el7.ve.x86_64',
         'product_name': 'ProLiant',
+        'version': 'A04-08/12/2019',
         'sys_object_id': '1.3.6.1.4.1.232.1.2',
         'tags': [
             'agent_host:' + common.get_agent_hostname(),
@@ -399,6 +402,7 @@ def test_e2e_core_metadata_hpe_proliant(dd_agent_check):
             'snmp_profile:hpe-proliant',
         ],
         'vendor': 'hp',
+        'serial_number': 'dLPEdPBE5yKtjW9xx3',
         'device_type': 'other',
         'integration': 'snmp',
     }

--- a/snmp/tests/test_e2e_core_metadata.py
+++ b/snmp/tests/test_e2e_core_metadata.py
@@ -221,6 +221,7 @@ def test_e2e_core_metadata_cisco_3850(dd_agent_check):
         'location': '4th floor',
         'name': 'Cat-3850-4th-Floor.companyname.local',
         'os_name': 'IOS',
+        'product_name': 'c38xx Stack',
         'profile': 'cisco-3850',
         'status': 1,
         'sys_object_id': '1.3.6.1.4.1.9.1.1745',
@@ -338,7 +339,6 @@ def test_e2e_core_metadata_hp_ilo4(dd_agent_check):
         'profile': 'hp-ilo4',
         'status': 1,
         'sys_object_id': '1.3.6.1.4.1.232.9.4.10',
-        'version': 'A04-08/12/2018',
         'tags': [
             'agent_host:' + common.get_agent_hostname(),
             'device_id:' + device_id,
@@ -351,7 +351,6 @@ def test_e2e_core_metadata_hp_ilo4(dd_agent_check):
             'snmp_profile:hp-ilo4',
         ],
         'vendor': 'hp',
-        'serial_number': 'dXPEdPBE5yKtjW9xx3',
         'device_type': 'server',
         'integration': 'snmp',
     }
@@ -387,7 +386,6 @@ def test_e2e_core_metadata_hpe_proliant(dd_agent_check):
         'os_name': 'RHEL',
         'os_version': '3.10.0-862.15.4.el7.ve.x86_64',
         'product_name': 'ProLiant',
-        'version': 'A04-08/12/2019',
         'sys_object_id': '1.3.6.1.4.1.232.1.2',
         'tags': [
             'agent_host:' + common.get_agent_hostname(),
@@ -401,7 +399,6 @@ def test_e2e_core_metadata_hpe_proliant(dd_agent_check):
             'snmp_profile:hpe-proliant',
         ],
         'vendor': 'hp',
-        'serial_number': 'dLPEdPBE5yKtjW9xx3',
         'device_type': 'other',
         'integration': 'snmp',
     }

--- a/snmp/tests/test_e2e_core_profiles/test_profile_hp_ilo.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_hp_ilo.py
@@ -174,7 +174,6 @@ def test_e2e_profile_hp_ilo(dd_agent_check):
         'profile': 'hp-ilo',
         'status': 1,
         'sys_object_id': '1.3.6.1.4.1.232.9.4.11',
-        'version': 'A04-08/12/2018',
         'tags': [
             'device_id:default:' + ip_address,
             'agent_host:' + common.get_agent_hostname(),
@@ -186,7 +185,6 @@ def test_e2e_profile_hp_ilo(dd_agent_check):
             'snmp_profile:hp-ilo',
         ],
         'vendor': 'hp',
-        'serial_number': 'dXPEdPBE5yKtjW9xx3',
         'device_type': 'server',
         'integration': 'snmp',
     }

--- a/snmp/tests/test_e2e_core_profiles/test_profile_hp_ilo.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_hp_ilo.py
@@ -174,6 +174,7 @@ def test_e2e_profile_hp_ilo(dd_agent_check):
         'profile': 'hp-ilo',
         'status': 1,
         'sys_object_id': '1.3.6.1.4.1.232.9.4.11',
+        'version': 'A04-08/12/2018',
         'tags': [
             'device_id:default:' + ip_address,
             'agent_host:' + common.get_agent_hostname(),
@@ -185,6 +186,7 @@ def test_e2e_profile_hp_ilo(dd_agent_check):
             'snmp_profile:hp-ilo',
         ],
         'vendor': 'hp',
+        'serial_number': 'dXPEdPBE5yKtjW9xx3',
         'device_type': 'server',
         'integration': 'snmp',
     }

--- a/snmp/tests/test_e2e_core_profiles/test_profile_hpe_msa.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_hpe_msa.py
@@ -100,7 +100,6 @@ def test_e2e_profile_hpe_msa(dd_agent_check):
         'os_name': 'Jaded forward oxen zombies Jaded',
         'os_version': 'quaintly oxen',
         'profile': 'hpe-msa',
-        'serial_number': 'kept Jaded driving',
         'status': 1,
         'sys_object_id': '1.3.6.1.4.1.11.2.51',
         'vendor': 'hp',

--- a/snmp/tests/test_e2e_core_profiles/test_profile_hpe_msa.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_hpe_msa.py
@@ -100,6 +100,7 @@ def test_e2e_profile_hpe_msa(dd_agent_check):
         'os_name': 'Jaded forward oxen zombies Jaded',
         'os_version': 'quaintly oxen',
         'profile': 'hpe-msa',
+        'serial_number': 'kept Jaded driving',
         'status': 1,
         'sys_object_id': '1.3.6.1.4.1.11.2.51',
         'vendor': 'hp',

--- a/snmp/tests/test_e2e_snmp_listener.py
+++ b/snmp/tests/test_e2e_snmp_listener.py
@@ -32,6 +32,20 @@ def _build_device_ip(container_ip, last_digit='1'):
     return snmp_device
 
 
+def _snmp_device_from_profile_metrics(aggregator, profile, loader):
+    """Resolve snmp_device tag from autodiscovery metrics (host octet varies with snmpsim layout)."""
+    for stub in aggregator._metrics.get('datadog.snmp.check_duration', []):
+        tags = list(stub.tags or [])
+        if 'snmp_profile:{}'.format(profile) not in tags:
+            continue
+        if 'loader:{}'.format(loader) not in tags:
+            continue
+        for tag in tags:
+            if tag.startswith('snmp_device:'):
+                return tag.partition(':')[2]
+    return None
+
+
 @common.snmp_listener_only
 def test_e2e_snmp_listener(dd_agent_check, container_ip, autodiscovery_ready):
     """
@@ -105,8 +119,10 @@ def test_e2e_snmp_listener(dd_agent_check, container_ip, autodiscovery_ready):
                 aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.COUNT, tags=tags, count=1)
 
     # ==== apc_ups profile ===
+    apc_snmp_device = _snmp_device_from_profile_metrics(aggregator, 'apc_ups', loader='python')
+    assert apc_snmp_device is not None, 'expected apc_ups datadog.snmp.check_duration with loader python'
     common_tags = [
-        'snmp_device:{}'.format(snmp_device),
+        'snmp_device:{}'.format(apc_snmp_device),
         'autodiscovery_subnet:{}.0/28'.format(subnet_prefix),
         'snmp_profile:apc_ups',
         'model:APC Smart-UPS 600',

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -122,10 +122,10 @@ def run_profile_check(recording_name, profile_name=None):
 @pytest.mark.parametrize(
     'definition_file, equivalent_definition',
     [
-        pytest.param('_base_cisco.yaml', {'extends': ['_base.yaml', '_cisco-generic.yaml']}, id='generic'),
+        pytest.param('_base_cisco.yaml', {'extends': ['_cisco-generic.yaml', '_base.yaml']}, id='generic'),
         pytest.param(
             '_base_cisco_voice.yaml',
-            {'extends': ['_base.yaml', '_cisco-generic.yaml', '_cisco-voice.yaml']},
+            {'extends': ['_cisco-generic.yaml', '_cisco-voice.yaml', '_base.yaml']},
             id='voice',
         ),
     ],


### PR DESCRIPTION
**Supersedes:** #23369 (same work; that PR could not be retargeted after renaming the head branch on GitHub).

### What does this PR do?

- **`_base.yaml`** — Adds shared **`metadata.device.fields`** from **ENTITY-MIB** at **`entPhysicalIndex` 1**:
  - **`serial_number`** (`entPhysicalSerialNum`)
  - **`version`** (`entPhysicalHardwareRev`)
  - **`product_name`** (`entPhysicalDescr`)
  - **`model`** (`entPhysicalModelName`)

- **`_arista-metadata.yaml`** — Removes definitions that duplicate **`_base`**; keeps Arista-only **`model`** fallback from **`sysDescr`**, plus **`os_name`** and **`os_version`**.
- **`_cisco-catalyst.yaml`** — **`serial_number`** uses **CISCO-STACK-MIB** `chassisSerialNumberString` only; ENTITY serial is covered by **`_base`** for profiles that extend it, avoiding a second copy of the same fallback here.
- **`extends` ordering** — In every profile that lists **`_base.yaml`**, it is now the **last** `extends` entry. Device metadata resolution follows **first resolved value wins**: the walk stops once a field has a value, and only then falls through to later sources. Listing **`_base.yaml`** last keeps shared ENTITY-MIB fields as the **fallback** layer after vendor-specific fragments (for example Arista metadata or Cisco stack serial) that appear earlier in `extends`.
- **`docs/developer/tutorials/snmp/profile-format.md`** — Documents **`extends`** merge order for **`metadata`** (first-wins / later fallbacks, linked to multi-OID symbols), **`_base.yaml` last** in the important callout, and an example that includes **`device-specific-profile.yaml`** before generic and base mixins.

### Motivation

- Use **`_base.yaml`** as the single place for common ENTITY chassis metadata so vendor fragments only carry deltas (Arista **`sysDescr`** parsing, Cisco stack serial, and so on).
- AGENT-15682

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
