### PR TITLE
Harden dependency-wheel promotion workflow against untrusted PR code

### DIFF
--- a/.builders/promote.py
+++ b/.builders/promote.py
@@ -6,6 +6,7 @@ Invoked via ``ddev promote <PR_URL>`` which dispatches the promote workflow.
 """
 from __future__ import annotations
 
+import os
 import re
 import sys
 from pathlib import Path, PurePosixPath
@@ -54,13 +55,15 @@ def url_to_blob_path(url: str) -> str | None:
 
 def collect_relative_paths() -> list[str]:
     """Read all lockfiles and return relative wheel paths from ${INTEGRATIONS_WHEELS_STORAGE} entries."""
-    if not LOCK_FILE_DIR.is_dir():
-        print(f"No lockfile directory found at {LOCK_FILE_DIR}", file=sys.stderr)
+    lockfile_dir = Path(os.environ.get("PROMOTE_LOCKFILE_DIR", LOCK_FILE_DIR))
+
+    if not lockfile_dir.is_dir():
+        print(f"No lockfile directory found at {lockfile_dir}", file=sys.stderr)
         sys.exit(1)
 
-    lockfiles = list(LOCK_FILE_DIR.glob("*.txt"))
+    lockfiles = list(lockfile_dir.glob("*.txt"))
     if not lockfiles:
-        print(f"No lockfiles found in {LOCK_FILE_DIR}", file=sys.stderr)
+        print(f"No lockfiles found in {lockfile_dir}", file=sys.stderr)
         sys.exit(1)
 
     rel_paths: list[str] = []

--- a/.github/workflows/dependency-wheel-promotion.yaml
+++ b/.github/workflows/dependency-wheel-promotion.yaml
@@ -23,10 +23,17 @@ jobs:
       pull-requests: write
 
     steps:
-    - name: Checkout code
+    - name: Checkout trusted code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Checkout PR lockfiles only
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.head_sha }}
+        path: pr
+        sparse-checkout: |
+          .deps/resolved
+        sparse-checkout-cone-mode: false
 
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -44,6 +51,8 @@ jobs:
         workload_identity_provider: projects/574011472402/locations/global/workloadIdentityPools/github/providers/integrations-core
 
     - name: Promote wheels
+      env:
+        PROMOTE_LOCKFILE_DIR: pr/.deps/resolved
       run: python .builders/promote.py
 
     - name: Clean up credentials

--- a/ddev/changelog.d/23372.fixed
+++ b/ddev/changelog.d/23372.fixed
@@ -1,0 +1,1 @@
+Harden dependency-wheel promotion workflow against untrusted PR code.

--- a/ddev/src/ddev/cli/dep/promote.py
+++ b/ddev/src/ddev/cli/dep/promote.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
 PR_URL_RE = re.compile(r"https://github\.com/[^/]+/[^/]+/pull/(\d+)")
 PROMOTE_WORKFLOW = "dependency-wheel-promotion.yaml"
+PROMOTE_WORKFLOW_REF = "master"
 
 
 @click.command(short_help='Promote dependency wheels from dev to stable')
@@ -46,7 +47,7 @@ def promote(app: Application, pr_url: str):
     with app.status('Dispatching promote workflow...'):
         app.github.dispatch_workflow(
             workflow_id=PROMOTE_WORKFLOW,
-            ref=head_ref,
+            ref=PROMOTE_WORKFLOW_REF,
             inputs={'pr_number': str(pr_number), 'head_sha': head_sha},
         )
 


### PR DESCRIPTION
### Motivation

https://datadoghq.atlassian.net/browse/AI-6748
- The promotion workflow previously checked out the PR head and then obtained OIDC/GCS credentials before executing repository code from the PR, allowing attacker-controlled PR changes to run with sensitive permissions.
- The intent is to prevent untrusted PR code from executing with credentials while still allowing maintainers to promote PR lockfile changes.

### Description

- Run the promotion workflow definition from the trusted branch by dispatching the workflow on `master` instead of executing the workflow from the PR branch (`ddev` dispatch now uses a fixed ref `master`).
- Keep trusted repository code checked out at the workflow root and perform a sparse checkout of only the PR `.deps/resolved` lockfiles into a separate `pr/` directory in the workflow (`.github/workflows/dependency-wheel-promotion.yaml`).
- Teach the promotion script to read lockfiles from an override directory via the `PROMOTE_LOCKFILE_DIR` environment variable (defaulting to the existing `.deps/resolved`) so the workflow can promote PR-provided lockfiles without running PR-modified scripts (`.builders/promote.py`).

### Testing

- `python -m compileall .builders/promote.py ddev/src/ddev/cli/dep/promote.py` completed successfully.
- `python -m pytest .builders/tests/test_promote.py` failed during collection due to the environment missing the `google.cloud` dependency (`ModuleNotFoundError: No module named 'google'`).
- `ddev test -fs ddev` could not be run in this environment because `ddev` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e1079678ec83329b267ad7904b77af)