### PR TITLE
Harden macOS packaging workflow trigger to prevent Apple secrets exposure

### DIFF
--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -437,7 +437,7 @@ jobs:
 
   macos-packaging:
     name: Build macOS installer and sign/notarize artifacts
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'push'
     needs:
     - define-tags
     - binaries


### PR DESCRIPTION
### Motivation
https://datadoghq.atlassian.net/browse/AI-6754
- Prevent Apple signing/notarization secrets from being exposed to untrusted same-repo pull request code by narrowing the macOS packaging job trigger.

### Description
- Restrict the `macos-packaging` job trigger in `.github/workflows/build-ddev.yml` from `github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository` to only `github.event_name == 'push'`.

### Testing
- No automated tests were run because this change only updates a GitHub Actions workflow file and does not modify runtime code or test suites.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e0b029b23c83328d6a29ed7c9462f8)