### PR TITLE
Harden kafka_consumer CI librdkafka install with SHA256 verification

### DIFF
--- a/.ddev/ci/scripts/kafka_consumer/linux/32_install_kerberos.sh
+++ b/.ddev/ci/scripts/kafka_consumer/linux/32_install_kerberos.sh
@@ -6,9 +6,14 @@ sudo apt update
 sudo apt install -y --no-install-recommends build-essential libkrb5-dev libzstd-dev wget software-properties-common lsb-release gcc make python3 python3-pip python3-dev libsasl2-modules-gssapi-mit krb5-user
 
 # Install librdkafka from source since no binaries are available for the distribution we use on the CI:
-git clone https://github.com/confluentinc/librdkafka
-cd librdkafka
-git checkout v2.13.2
+LIBRDKAFKA_VERSION="v2.13.2"
+LIBRDKAFKA_SHA256="14972092e4115f6e99f798a7cb420cbf6daa0c73502b3c52ae42fb5b418eea8f"
+LIBRDKAFKA_TARBALL="${LIBRDKAFKA_VERSION}.tar.gz"
+
+wget "https://github.com/confluentinc/librdkafka/archive/refs/tags/${LIBRDKAFKA_TARBALL}"
+echo "${LIBRDKAFKA_SHA256}  ${LIBRDKAFKA_TARBALL}" | sha256sum -c -
+tar -xzf "${LIBRDKAFKA_TARBALL}"
+cd "librdkafka-${LIBRDKAFKA_VERSION#v}"
 sudo ./configure --install-deps --prefix=/usr
 make
 sudo make install


### PR DESCRIPTION
### Motivation
- The CI script previously cloned `librdkafka` and ran `git checkout v2.13.2` before executing privileged build/install steps, creating a supply-chain risk if the tag or upstream repo were tampered with. 
- The change enforces artifact integrity verification so CI only builds from a known, pinned release artifact before running commands as root.

### Description
- Replace the `git clone` + `git checkout` flow with a pinned release tarball download using `LIBRDKAFKA_VERSION` and `LIBRDKAFKA_TARBALL` variables. 
- Add a `LIBRDKAFKA_SHA256` variable and verify the downloaded tarball with `sha256sum -c -` before extraction. 
- Preserve the existing build steps (`./configure --install-deps --prefix=/usr`, `make`, `make install`) after successful verification so behavior remains unchanged apart from the integrity gate.

### Testing
- Ran a shell syntax check with `bash -n .ddev/ci/scripts/kafka_consumer/linux/32_install_kerberos.sh`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e0b488fa508332a53398411d975a88)