### PR TITLE
[DBMON-6479] Harden SQL Server XML plan parsing

### DIFF
--- a/sqlserver/changelog.d/23382.fixed
+++ b/sqlserver/changelog.d/23382.fixed
@@ -1,0 +1,1 @@
+Harden SQL Server XML plan parsing

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -222,6 +222,8 @@ XML_PLAN_OBFUSCATION_ATTRS = frozenset(
     }
 )
 
+XML_PLAN_PARSER = ET.XMLParser(resolve_entities=False, load_dtd=False, no_network=True)
+
 
 def agent_check_getter(self):
     return self._check
@@ -236,7 +238,7 @@ def obfuscate_xml_plan(raw_plan, obfuscator_options=None):
     Obfuscates SQL text & Parameters from the provided SQL Server XML Plan
     Also strips unnecessary whitespace
     """
-    tree = ET.fromstring(raw_plan)
+    tree = ET.fromstring(raw_plan, parser=XML_PLAN_PARSER)
     for e in tree.iter():
         if e.text:
             e.text = e.text.strip()

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -222,9 +222,6 @@ XML_PLAN_OBFUSCATION_ATTRS = frozenset(
     }
 )
 
-XML_PLAN_PARSER = ET.XMLParser(resolve_entities=False, load_dtd=False, no_network=True)
-
-
 def agent_check_getter(self):
     return self._check
 
@@ -238,7 +235,8 @@ def obfuscate_xml_plan(raw_plan, obfuscator_options=None):
     Obfuscates SQL text & Parameters from the provided SQL Server XML Plan
     Also strips unnecessary whitespace
     """
-    tree = ET.fromstring(raw_plan, parser=XML_PLAN_PARSER)
+    parser = ET.XMLParser(resolve_entities=False, load_dtd=False, no_network=True)
+    tree = ET.fromstring(raw_plan, parser=parser)
     for e in tree.iter():
         if e.text:
             e.text = e.text.strip()

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -222,6 +222,7 @@ XML_PLAN_OBFUSCATION_ATTRS = frozenset(
     }
 )
 
+
 def agent_check_getter(self):
     return self._check
 


### PR DESCRIPTION
### What does this PR do?
Modifies the xml parser used for SQL Server XML explain plans to restrict abilities to resolve entities and block network access.

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-6479

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
