### PR TITLE
Clean up integrations that were mistakenly not shipped with the agents

### DIFF
--- a/.ddev/config.toml
+++ b/.ddev/config.toml
@@ -243,6 +243,7 @@ __pycache__ = false
 # removed.
 # This is a temporary fix while we implement a metadata.json file that we can add to each integration
 # that replaces the manifest.
+# Used here: https://github.com/DataDog/datadog-agent/blob/main/tasks/agent.py
 # Use manifest-like platforms
 [overrides.manifest.platforms]
 krakend = ["linux", "windows", "mac_os"]

--- a/AGENT_INTEGRATIONS.md
+++ b/AGENT_INTEGRATIONS.md
@@ -50,7 +50,6 @@
 * datadog-cockroachdb: 6.4.0
 * datadog-confluent-platform: 3.3.0
 * datadog-consul: 5.4.0
-* datadog-control-m: 1.1.0
 * datadog-coredns: 6.4.0
 * datadog-couch: 9.4.0
 * datadog-couchbase: 6.5.0
@@ -124,7 +123,6 @@
 * datadog-keda: 2.4.0
 * datadog-keycloak: 1.2.0
 * datadog-kong: 6.4.0
-* datadog-krakend: 1.4.0
 * datadog-kube-apiserver-metrics: 7.5.0
 * datadog-kube-controller-manager: 8.4.0
 * datadog-kube-dns: 7.4.0
@@ -146,7 +144,6 @@
 * datadog-linux-audit-logs: 1.2.0
 * datadog-linux-proc-extras: 4.3.0
 * datadog-litellm: 2.4.0
-* datadog-lustre: 1.5.0
 * datadog-mac-audit-logs: 1.4.0
 * datadog-mapr: 3.4.0
 * datadog-mapreduce: 7.4.0
@@ -160,7 +157,6 @@
 * datadog-milvus: 2.5.0
 * datadog-mongo: 10.9.0
 * datadog-mysql: 15.15.1
-* datadog-n8n: 1.1.0
 * datadog-nagios: 3.4.0
 * datadog-network: 5.7.0
 * datadog-nfsstat: 3.5.0
@@ -185,7 +181,6 @@
 * datadog-postfix: 3.4.0
 * datadog-postgres: 23.6.0
 * datadog-powerdns-recursor: 5.4.0
-* datadog-prefect: 1.0.0
 * datadog-presto: 3.4.0
 * datadog-process: 5.5.0
 * datadog-prometheus: 6.3.0
@@ -382,7 +377,6 @@
 * datadog-keda: 2.3.0
 * datadog-keycloak: 1.2.0
 * datadog-kong: 6.3.0
-* datadog-krakend: 1.3.0
 * datadog-kube-apiserver-metrics: 7.4.0
 * datadog-kube-controller-manager: 8.3.0
 * datadog-kube-dns: 7.3.0
@@ -404,7 +398,6 @@
 * datadog-linux-audit-logs: 1.2.0
 * datadog-linux-proc-extras: 4.3.0
 * datadog-litellm: 2.3.0
-* datadog-lustre: 1.4.0
 * datadog-mac-audit-logs: 1.3.0
 * datadog-mapr: 3.3.0
 * datadog-mapreduce: 7.3.0
@@ -639,7 +632,6 @@
 * datadog-keda: 2.3.0
 * datadog-keycloak: 1.2.0
 * datadog-kong: 6.3.0
-* datadog-krakend: 1.3.0
 * datadog-kube-apiserver-metrics: 7.4.0
 * datadog-kube-controller-manager: 8.3.0
 * datadog-kube-dns: 7.3.0
@@ -661,7 +653,6 @@
 * datadog-linux-audit-logs: 1.2.0
 * datadog-linux-proc-extras: 4.3.0
 * datadog-litellm: 2.3.0
-* datadog-lustre: 1.4.0
 * datadog-mac-audit-logs: 1.3.0
 * datadog-mapr: 3.3.0
 * datadog-mapreduce: 7.3.0
@@ -896,7 +887,6 @@
 * datadog-keda: 2.3.0
 * datadog-keycloak: 1.2.0
 * datadog-kong: 6.3.0
-* datadog-krakend: 1.3.0
 * datadog-kube-apiserver-metrics: 7.4.0
 * datadog-kube-controller-manager: 8.3.0
 * datadog-kube-dns: 7.3.0
@@ -918,7 +908,6 @@
 * datadog-linux-audit-logs: 1.2.0
 * datadog-linux-proc-extras: 4.3.0
 * datadog-litellm: 2.3.0
-* datadog-lustre: 1.4.0
 * datadog-mac-audit-logs: 1.3.0
 * datadog-mapr: 3.3.0
 * datadog-mapreduce: 7.3.0
@@ -1153,7 +1142,6 @@
 * datadog-keda: 2.3.0
 * datadog-keycloak: 1.2.0
 * datadog-kong: 6.3.0
-* datadog-krakend: 1.3.0
 * datadog-kube-apiserver-metrics: 7.4.0
 * datadog-kube-controller-manager: 8.3.0
 * datadog-kube-dns: 7.3.0
@@ -1175,7 +1163,6 @@
 * datadog-linux-audit-logs: 1.2.0
 * datadog-linux-proc-extras: 4.3.0
 * datadog-litellm: 2.3.0
-* datadog-lustre: 1.4.0
 * datadog-mac-audit-logs: 1.3.0
 * datadog-mapr: 3.3.0
 * datadog-mapreduce: 7.3.0
@@ -1407,7 +1394,6 @@
 * datadog-keda: 2.2.0
 * datadog-keycloak: 1.2.0
 * datadog-kong: 6.2.0
-* datadog-krakend: 1.2.0
 * datadog-kube-apiserver-metrics: 7.3.0
 * datadog-kube-controller-manager: 8.2.0
 * datadog-kube-dns: 7.2.0
@@ -1429,7 +1415,6 @@
 * datadog-linux-audit-logs: 1.2.0
 * datadog-linux-proc-extras: 4.2.0
 * datadog-litellm: 2.2.0
-* datadog-lustre: 1.3.0
 * datadog-mac-audit-logs: 1.2.0
 * datadog-mapr: 3.2.0
 * datadog-mapreduce: 7.2.0
@@ -1661,7 +1646,6 @@
 * datadog-keda: 2.2.0
 * datadog-keycloak: 1.2.0
 * datadog-kong: 6.2.0
-* datadog-krakend: 1.2.0
 * datadog-kube-apiserver-metrics: 7.3.0
 * datadog-kube-controller-manager: 8.2.0
 * datadog-kube-dns: 7.2.0
@@ -1683,7 +1667,6 @@
 * datadog-linux-audit-logs: 1.2.0
 * datadog-linux-proc-extras: 4.2.0
 * datadog-litellm: 2.2.0
-* datadog-lustre: 1.3.0
 * datadog-mac-audit-logs: 1.2.0
 * datadog-mapr: 3.2.0
 * datadog-mapreduce: 7.2.0
@@ -1915,7 +1898,6 @@
 * datadog-keda: 2.2.0
 * datadog-keycloak: 1.2.0
 * datadog-kong: 6.2.0
-* datadog-krakend: 1.2.0
 * datadog-kube-apiserver-metrics: 7.3.0
 * datadog-kube-controller-manager: 8.2.0
 * datadog-kube-dns: 7.2.0
@@ -1937,7 +1919,6 @@
 * datadog-linux-audit-logs: 1.2.0
 * datadog-linux-proc-extras: 4.2.0
 * datadog-litellm: 2.2.0
-* datadog-lustre: 1.3.0
 * datadog-mac-audit-logs: 1.2.0
 * datadog-mapr: 3.2.0
 * datadog-mapreduce: 7.2.0
@@ -2169,7 +2150,6 @@
 * datadog-keda: 2.2.0
 * datadog-keycloak: 1.2.0
 * datadog-kong: 6.2.0
-* datadog-krakend: 1.2.0
 * datadog-kube-apiserver-metrics: 7.3.0
 * datadog-kube-controller-manager: 8.2.0
 * datadog-kube-dns: 7.2.0
@@ -2191,7 +2171,6 @@
 * datadog-linux-audit-logs: 1.2.0
 * datadog-linux-proc-extras: 4.2.0
 * datadog-litellm: 2.2.0
-* datadog-lustre: 1.3.0
 * datadog-mac-audit-logs: 1.2.0
 * datadog-mapr: 3.2.0
 * datadog-mapreduce: 7.2.0
@@ -2423,7 +2402,6 @@
 * datadog-keda: 2.2.0
 * datadog-keycloak: 1.2.0
 * datadog-kong: 6.2.0
-* datadog-krakend: 1.2.0
 * datadog-kube-apiserver-metrics: 7.3.0
 * datadog-kube-controller-manager: 8.2.0
 * datadog-kube-dns: 7.2.0
@@ -2445,7 +2423,6 @@
 * datadog-linux-audit-logs: 1.2.0
 * datadog-linux-proc-extras: 4.2.0
 * datadog-litellm: 2.2.0
-* datadog-lustre: 1.3.0
 * datadog-mac-audit-logs: 1.2.0
 * datadog-mapr: 3.2.0
 * datadog-mapreduce: 7.2.0
@@ -2676,7 +2653,6 @@
 * datadog-keda: 2.2.0
 * datadog-keycloak: 1.2.0
 * datadog-kong: 6.2.0
-* datadog-krakend: 1.2.0
 * datadog-kube-apiserver-metrics: 7.3.0
 * datadog-kube-controller-manager: 8.2.0
 * datadog-kube-dns: 7.2.0
@@ -2698,7 +2674,6 @@
 * datadog-linux-audit-logs: 1.2.0
 * datadog-linux-proc-extras: 4.2.0
 * datadog-litellm: 2.2.0
-* datadog-lustre: 1.3.0
 * datadog-mac-audit-logs: 1.2.0
 * datadog-mapr: 3.2.0
 * datadog-mapreduce: 7.2.0
@@ -2929,7 +2904,6 @@
 * datadog-keda: 2.2.0
 * datadog-keycloak: 1.2.0
 * datadog-kong: 6.2.0
-* datadog-krakend: 1.2.0
 * datadog-kube-apiserver-metrics: 7.3.0
 * datadog-kube-controller-manager: 8.2.0
 * datadog-kube-dns: 7.2.0
@@ -2951,7 +2925,6 @@
 * datadog-linux-audit-logs: 1.2.0
 * datadog-linux-proc-extras: 4.2.0
 * datadog-litellm: 2.2.0
-* datadog-lustre: 1.3.0
 * datadog-mac-audit-logs: 1.2.0
 * datadog-mapr: 3.2.0
 * datadog-mapreduce: 7.2.0
@@ -3182,7 +3155,6 @@
 * datadog-keda: 2.2.0
 * datadog-keycloak: 1.2.0
 * datadog-kong: 6.2.0
-* datadog-krakend: 1.2.0
 * datadog-kube-apiserver-metrics: 7.3.0
 * datadog-kube-controller-manager: 8.2.0
 * datadog-kube-dns: 7.2.0
@@ -3204,7 +3176,6 @@
 * datadog-linux-audit-logs: 1.2.0
 * datadog-linux-proc-extras: 4.2.0
 * datadog-litellm: 2.2.0
-* datadog-lustre: 1.3.0
 * datadog-mac-audit-logs: 1.2.0
 * datadog-mapr: 3.2.0
 * datadog-mapreduce: 7.2.0
@@ -3435,7 +3406,6 @@
 * datadog-keda: 2.2.0
 * datadog-keycloak: 1.2.0
 * datadog-kong: 6.2.0
-* datadog-krakend: 1.2.0
 * datadog-kube-apiserver-metrics: 7.3.0
 * datadog-kube-controller-manager: 8.2.0
 * datadog-kube-dns: 7.2.0
@@ -3457,7 +3427,6 @@
 * datadog-linux-audit-logs: 1.2.0
 * datadog-linux-proc-extras: 4.2.0
 * datadog-litellm: 2.2.0
-* datadog-lustre: 1.3.0
 * datadog-mac-audit-logs: 1.2.0
 * datadog-mapr: 3.2.0
 * datadog-mapreduce: 7.2.0
@@ -3687,7 +3656,6 @@
 * datadog-keda: 2.2.0
 * datadog-keycloak: 1.2.0
 * datadog-kong: 6.2.0
-* datadog-krakend: 1.2.0
 * datadog-kube-apiserver-metrics: 7.3.0
 * datadog-kube-controller-manager: 8.2.0
 * datadog-kube-dns: 7.2.0
@@ -3709,7 +3677,6 @@
 * datadog-linux-audit-logs: 1.2.0
 * datadog-linux-proc-extras: 4.2.0
 * datadog-litellm: 2.2.0
-* datadog-lustre: 1.3.0
 * datadog-mac-audit-logs: 1.2.0
 * datadog-mapr: 3.2.0
 * datadog-mapreduce: 7.2.0


### PR DESCRIPTION
### What does this PR do?
Some integrations were mistakenly not shipped when they were supposed to. This fixes the catalog. Also include a comment in the ddev config to where the manifest like entries are used.
