### PR TITLE
postgres: improve robustness of database name handling in schema collection

### DIFF
--- a/postgres/changelog.d/23389.fixed
+++ b/postgres/changelog.d/23389.fixed
@@ -1,0 +1,1 @@
+Fix database name handling in schema collection query construction.

--- a/postgres/datadog_checks/postgres/schemas.py
+++ b/postgres/datadog_checks/postgres/schemas.py
@@ -162,7 +162,7 @@ SELECT db.oid::text                  AS id,
 FROM   pg_catalog.pg_database db
        JOIN pg_roles a
          ON datdba = a.oid
-        WHERE datname NOT LIKE 'template%'
+        WHERE datname NOT LIKE 'template%%'
 """
 
 
@@ -223,7 +223,7 @@ class PostgresSchemaCollector(SchemaCollector):
                         query += f" AND datname IN ({placeholders})"
                         params.extend(autodiscovery_databases)
 
-                cursor.execute(query, params or None)
+                cursor.execute(query, params)
                 return [dict(row) for row in cursor.fetchall()]
 
     @contextlib.contextmanager

--- a/postgres/datadog_checks/postgres/schemas.py
+++ b/postgres/datadog_checks/postgres/schemas.py
@@ -201,28 +201,27 @@ class PostgresSchemaCollector(SchemaCollector):
         return "pg_databases"
 
     def _get_databases(self):
+        query = DATABASE_INFORMATION_QUERY
+        params: list[str] = []
+
+        for exclude_regex in self._config.exclude_databases:
+            query += " AND datname !~ %s"
+            params.append(exclude_regex)
+
+        if self._config.include_databases:
+            or_clause = " OR ".join(["datname ~ %s"] * len(self._config.include_databases))
+            query += f" AND ({or_clause})"
+            params.extend(self._config.include_databases)
+
+        # Autodiscovery trumps exclude and include
+        autodiscovery_databases = self._check.autodiscovery.get_items() if self._check.autodiscovery else []
+        if autodiscovery_databases:
+            in_clause = ", ".join(["%s"] * len(autodiscovery_databases))
+            query += f" AND datname IN ({in_clause})"
+            params.extend(autodiscovery_databases)
+
         with self._check._get_main_db() as conn:
             with conn.cursor(row_factory=dict_row) as cursor:
-                query = DATABASE_INFORMATION_QUERY
-                params: list[str] = []
-
-                for exclude_regex in self._config.exclude_databases:
-                    query += " AND datname !~ %s"
-                    params.append(exclude_regex)
-
-                if self._config.include_databases:
-                    placeholders = " OR ".join("datname ~ %s" for _ in self._config.include_databases)
-                    query += f" AND ({placeholders})"
-                    params.extend(self._config.include_databases)
-
-                # Autodiscovery trumps exclude and include
-                if self._check.autodiscovery:
-                    autodiscovery_databases = self._check.autodiscovery.get_items()
-                    if autodiscovery_databases:
-                        placeholders = ", ".join("%s" for _ in autodiscovery_databases)
-                        query += f" AND datname IN ({placeholders})"
-                        params.extend(autodiscovery_databases)
-
                 cursor.execute(query, params)
                 return [dict(row) for row in cursor.fetchall()]
 

--- a/postgres/datadog_checks/postgres/schemas.py
+++ b/postgres/datadog_checks/postgres/schemas.py
@@ -204,20 +204,26 @@ class PostgresSchemaCollector(SchemaCollector):
         with self._check._get_main_db() as conn:
             with conn.cursor(row_factory=dict_row) as cursor:
                 query = DATABASE_INFORMATION_QUERY
+                params: list[str] = []
+
                 for exclude_regex in self._config.exclude_databases:
-                    query += " AND datname !~ '{}'".format(exclude_regex)
+                    query += " AND datname !~ %s"
+                    params.append(exclude_regex)
+
                 if self._config.include_databases:
-                    query += f" AND ({
-                        ' OR '.join(f"datname ~ '{include_regex}'" for include_regex in self._config.include_databases)
-                    })"
+                    placeholders = " OR ".join("datname ~ %s" for _ in self._config.include_databases)
+                    query += f" AND ({placeholders})"
+                    params.extend(self._config.include_databases)
 
                 # Autodiscovery trumps exclude and include
                 if self._check.autodiscovery:
                     autodiscovery_databases = self._check.autodiscovery.get_items()
                     if autodiscovery_databases:
-                        query += " AND datname IN ({})".format(", ".join(f"'{db}'" for db in autodiscovery_databases))
+                        placeholders = ", ".join("%s" for _ in autodiscovery_databases)
+                        query += f" AND datname IN ({placeholders})"
+                        params.extend(autodiscovery_databases)
 
-                cursor.execute(query)
+                cursor.execute(query, params or None)
                 return [dict(row) for row in cursor.fetchall()]
 
     @contextlib.contextmanager


### PR DESCRIPTION
## Summary

- `_get_databases` in the schema collector was building SQL query strings by formatting values directly into the query via f-strings and `.format()` calls
- Switch to `%s` parameterized placeholders passed as the second argument to `cursor.execute`, consistent with how other query methods in this codebase handle dynamic values
- Applies to all three dynamic filter paths in the method: `exclude_databases` regexes, `include_databases` regexes, and the autodiscovery `IN` clause

## Test plan

- [ ] Existing integration tests in `tests/test_schemas.py` cover the filtering behavior end-to-end (`test_get_databases`, `test_databases_filters`)
- [ ] Run `ddev --no-interactive test postgres -- -k test_databases` to verify filters still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)