### PR TITLE
[DBMON-6568] Add support for ClickHouse metadata with schema and views collection

### DIFF
--- a/clickhouse/assets/configuration/spec.yaml
+++ b/clickhouse/assets/configuration/spec.yaml
@@ -313,6 +313,127 @@ files:
           value:
             type: boolean
             example: false
+    - name: collect_schemas
+      description: |
+        Configure collection of ClickHouse catalog metadata (databases,
+        tables, views, columns) for Database Monitoring's Schema Explorer.
+        Requires `dbm: true`.
+      options:
+        - name: enabled
+          description: |
+            Enable collection of catalog metadata. When enabled, the agent
+            polls `system.tables`, `system.columns`, and
+            `system.view_refreshes` (ClickHouse 24.3+) and emits one
+            `kind=clickhouse_databases` payload per cycle.
+          value:
+            type: boolean
+            example: true
+        - name: collection_interval
+          description: |
+            Set the schema collection interval (in seconds). Catalog data
+            changes slowly; 600s (10 min) is a reasonable default.
+          value:
+            type: number
+            example: 600
+        - name: max_tables
+          description: |
+            Maximum number of tables plus views to collect per cycle
+            across all databases.
+          value:
+            type: integer
+            example: 300
+        - name: max_columns
+          description: |
+            Maximum number of columns to collect per table/view.
+          value:
+            type: integer
+            example: 1000
+        - name: max_query_duration
+          description: |
+            Maximum duration of the schema collection queries in seconds.
+            Applied to each query via the `max_execution_time` ClickHouse setting.
+          value:
+            type: integer
+            example: 60
+        - name: include_databases
+          description: |
+            A list of regex patterns to include databases. Any database whose
+            name matches any one of these patterns will be included. If empty,
+            all databases (other than those excluded) are included.
+          value:
+            type: array
+            items:
+              type: string
+            example:
+              - "mydb"
+        - name: exclude_databases
+          description: |
+            A list of regex patterns to exclude databases. Any database whose
+            name matches any one of these patterns will be excluded. The
+            ClickHouse system databases (`system`, `INFORMATION_SCHEMA`,
+            `information_schema`) are always excluded regardless of this setting.
+          value:
+            type: array
+            items:
+              type: string
+            example:
+              - "tmp_.*"
+        - name: include_tables
+          description: |
+            A list of regex patterns to include tables. Any table whose name
+            matches any one of these patterns will be included. If empty, all
+            tables (other than those excluded) are included.
+          value:
+            type: array
+            items:
+              type: string
+            example:
+              - "events.*"
+        - name: exclude_tables
+          description: |
+            A list of regex patterns to exclude tables. Any table whose name
+            matches any one of these patterns will be excluded.
+          value:
+            type: array
+            items:
+              type: string
+            example:
+              - ".*_tmp"
+        - name: run_sync
+          hidden: true
+          description: |
+            Run the metadata collection synchronously. For testing only.
+          value:
+            type: boolean
+            example: false
+    - name: schema_metrics
+      description: |
+        Configure per-table size and per-view refresh gauges derived from
+        `system.tables` and `system.view_refreshes`. Independent of
+        `collect_schemas` (which controls catalog structure collection)
+        so users can dashboard table sizes without enabling Schema Explorer.
+        Requires `dbm: true`.
+      options:
+        - name: enabled
+          description: |
+            Enable collection of per-table size and per-view refresh gauges.
+          value:
+            type: boolean
+            example: false
+        - name: collection_interval
+          description: |
+            Set the schema metrics collection interval (in seconds). These
+            gauges change continuously, so 60s is a reasonable default.
+          value:
+            type: number
+            example: 60
+        - name: run_sync
+          hidden: true
+          description: |
+            Run the schema metrics collection synchronously. For testing only.
+          value:
+            type: boolean
+            example: false
     - name: parts_and_merges
       description: Configure parts and merges monitoring
       options:

--- a/clickhouse/changelog.d/23390.added
+++ b/clickhouse/changelog.d/23390.added
@@ -1,0 +1,1 @@
+Add ClickHouse metadata collection: catalog payload (databases, tables, views, columns) under collect_schemas with include/exclude regex filters for databases and tables; per-table size gauges and per-view refresh gauges under schema_metrics.

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -40,6 +40,7 @@ SELECT
     database,
     view,
     status,
+    exception,
     toInt64(toUnixTimestamp(last_success_time)) AS last_refresh_time,
     toInt64(toUnixTimestamp(next_refresh_time)) AS next_refresh_time,
     toInt64(written_rows) AS written_rows,
@@ -399,13 +400,14 @@ class ClickhouseCheck(DatabaseCheck):
 
         base_tags = list(self.tags)
         seen: set[tuple[str, str]] = set()
-        for database, view_name, status, last_time, next_time, written_rows, written_bytes in rows:
+        for database, view_name, status, exception, last_time, next_time, written_rows, written_bytes in rows:
             if (database, view_name) in seen:
                 continue
             seen.add((database, view_name))
             view_tags = base_tags + [f'db:{database}', f'view:{view_name}']
             sc_status = _VIEW_REFRESH_STATUS_MAP.get(status, AgentCheck.UNKNOWN)
-            self.service_check(self.SERVICE_CHECK_VIEW_REFRESH, sc_status, tags=view_tags, message=status)
+            sc_msg = (exception or '').split('\n')[0] or status
+            self.service_check(self.SERVICE_CHECK_VIEW_REFRESH, sc_status, tags=view_tags, message=sc_msg)
             self.gauge('view.refresh.last_time', int(last_time or 0), tags=view_tags)
             self.gauge('view.refresh.next_time', int(next_time or 0), tags=view_tags)
             self.gauge('view.refresh.rows', int(written_rows or 0), tags=view_tags)

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -32,7 +32,7 @@ except ImportError:
     from datadog_checks.base.stubs import datadog_agent
 
 
-# Database instance collection interval in seconds (not user-configurable)
+# Not user-configurable; controls how often database_instance metadata is emitted.
 DATABASE_INSTANCE_COLLECTION_INTERVAL = 300
 
 
@@ -43,28 +43,21 @@ class ClickhouseCheck(DatabaseCheck):
     def __init__(self, name, init_config, instances):
         super(ClickhouseCheck, self).__init__(name, init_config, instances)
 
-        # Build typed configuration
         config, validation_result = build_config(self)
         self._config = config
         self._validation_result = validation_result
 
-        # Initialize health event handler for DBM
         self.health = ClickhouseHealth(self)
 
-        # Log validation warnings (errors will be raised in validate_config)
         for warning in validation_result.warnings:
             self.log.warning(warning)
 
-        # DBM-related properties (computed lazily)
         self._resolved_hostname = None
         self._database_identifier = None
         self._agent_hostname = None
         self._dbms_version = None
-
-        # Track last emission time for database instance metadata (rate limiting)
         self._database_instance_last_emitted = 0
 
-        # Initialize TagManager for tag management (similar to MySQL)
         self.tag_manager = TagManager()
         self.tag_manager.set_tags_from_list(self._config.tags, replace=True)
         self._add_core_tags()
@@ -72,12 +65,7 @@ class ClickhouseCheck(DatabaseCheck):
         self._error_sanitizer = ErrorSanitizer(self._config.password)
         self.check_initializations.append(self.validate_config)
         self.check_initializations.append(advanced_queries.warm_cache)
-
-        # Submit health event with config validation result
-        # Tags are now available so health events will include them
         self._submit_config_health_event()
-
-        # We'll connect on the first check run
         self._client = None
 
         # Cache query manager per server version to avoid recompiling on every check run
@@ -95,30 +83,41 @@ class ClickhouseCheck(DatabaseCheck):
             ca_cert=self._config.tls_ca_cert,
         )
 
-        # Initialize DBM components if enabled
+        self._query_manager = QueryManager(
+            self,
+            self.execute_query_raw,
+            queries=[
+                queries.SystemMetrics,
+                queries.SystemEventsToDeprecate,
+                queries.SystemEvents,
+                queries.SystemAsynchronousMetrics,
+                queries.SystemParts,
+                queries.SystemReplicas,
+                queries.SystemDictionaries,
+            ],
+            tags=self.tags,
+            error_handler=self._error_sanitizer.clean,
+        )
+        self.check_initializations.append(self._query_manager.compile_queries)
+
         self._init_dbm_components()
 
     def _init_dbm_components(self):
-        """Initialize DBM components based on typed configuration."""
-        # Initialize query metrics (from system.query_log - analogous to pg_stat_statements)
         if self._config.dbm and self._config.query_metrics.enabled:
             self.statement_metrics = ClickhouseStatementMetrics(self, self._config.query_metrics)
         else:
             self.statement_metrics = None
 
-        # Initialize query samples (from system.processes - analogous to pg_stat_activity)
         if self._config.dbm and self._config.query_samples.enabled:
             self.statement_samples = ClickhouseStatementSamples(self, self._config.query_samples)
         else:
             self.statement_samples = None
 
-        # Initialize query completions (from system.query_log - completed queries)
         if self._config.dbm and self._config.query_completions.enabled:
             self.query_completions = ClickhouseQueryCompletions(self, self._config.query_completions)
         else:
             self.query_completions = None
 
-        # Initialize query errors (from system.query_log - failed queries)
         if self._config.dbm and self._config.query_errors.enabled:
             self.query_errors = ClickhouseQueryErrors(self, self._config.query_errors)
         else:
@@ -141,14 +140,9 @@ class ClickhouseCheck(DatabaseCheck):
 
     @property
     def tags(self) -> list[str]:
-        """Return the current list of tags from the TagManager."""
         return list(self.tag_manager.get_tags())
 
     def _add_core_tags(self):
-        """
-        Add tags that should be attached to every metric/event.
-        These are core identification tags for the ClickHouse instance.
-        """
         self.tag_manager.set_tag("server", self._config.server, replace=True)
         self.tag_manager.set_tag("port", str(self._config.port), replace=True)
         self.tag_manager.set_tag("db", self._config.db, replace=True)
@@ -156,10 +150,6 @@ class ClickhouseCheck(DatabaseCheck):
         self.tag_manager.set_tag("database_instance", self.database_identifier, replace=True)
 
     def validate_config(self):
-        """
-        Validate the configuration and raise an error if invalid.
-        This is called during check initialization.
-        """
         from datadog_checks.base import ConfigurationError
 
         if not self._validation_result.valid:
@@ -169,18 +159,7 @@ class ClickhouseCheck(DatabaseCheck):
                 raise ConfigurationError(str(self._validation_result.errors[0]))
 
     def _submit_config_health_event(self):
-        """
-        Submit a health event with the configuration validation result.
-
-        This event reports the initialization status to DBM, including:
-        - Configuration errors (if any)
-        - Configuration warnings (if any)
-        - DBM feature enablement status
-
-        Uses a 6-hour cooldown to avoid spamming health events.
-        """
         try:
-            # Determine health status based on validation result
             if not self._validation_result.valid:
                 status = HealthStatus.ERROR
             elif self._validation_result.warnings:
@@ -202,14 +181,11 @@ class ClickhouseCheck(DatabaseCheck):
                 },
             )
         except Exception as e:
-            # Health event submission should not break the check initialization
             self.log.debug("Failed to submit config health event: %s", e)
 
     def _send_database_instance_metadata(self):
-        """Send database instance metadata to the metadata intake."""
         current_time = time()
         if current_time - self._database_instance_last_emitted >= DATABASE_INSTANCE_COLLECTION_INTERVAL:
-            # Get the version for the metadata (and cache it)
             try:
                 version_result = list(self.execute_query_raw('SELECT version()'))[0][0]
                 self._dbms_version = version_result
@@ -217,7 +193,6 @@ class ClickhouseCheck(DatabaseCheck):
                 self.log.debug("Unable to fetch version for metadata: %s", e)
                 self._dbms_version = "unknown"
 
-            # Get tags without db: prefix for metadata
             tags_no_db = [t for t in self.tags if not t.startswith('db:')]
 
             event = {
@@ -251,33 +226,20 @@ class ClickhouseCheck(DatabaseCheck):
             self._query_manager_version = self._server_version
         self._query_manager.execute()
         self.set_version_metadata(self._server_version)
-
-        # Send database instance metadata
         self._send_database_instance_metadata()
 
-        # Run query metrics collection if DBM is enabled (from system.query_log)
         if self.statement_metrics:
             self.statement_metrics.run_job_loop(self.tags)
-
-        # Run query samples collection if DBM is enabled (from system.processes)
         if self.statement_samples:
             self.statement_samples.run_job_loop(self.tags)
-
-        # Run query completions if DBM is enabled (from system.query_log)
         if self.query_completions:
             self.query_completions.run_job_loop(self.tags)
-
-        # Run query errors if DBM is enabled (from system.query_log - failed queries)
         if self.query_errors:
             self.query_errors.run_job_loop(self.tags)
-
         if self.metadata:
             self.metadata.run_job_loop(self.tags)
-
         if self.table_metrics:
             self.table_metrics.run_job_loop(self.tags)
-
-        # Run parts and merges monitoring if enabled
         if self.parts_and_merges:
             self.parts_and_merges.run_job_loop(self.tags)
 
@@ -336,7 +298,6 @@ class ClickhouseCheck(DatabaseCheck):
         return self._client.query(query).result_rows
 
     def _get_debug_tags(self):
-        """Return debug tags for metrics"""
         return ['server:{}'.format(self._config.server)]
 
     @property
@@ -350,22 +311,16 @@ class ClickhouseCheck(DatabaseCheck):
 
     @property
     def agent_hostname(self):
-        """Get the agent hostname."""
         if self._agent_hostname is None:
             self._agent_hostname = datadog_agent.get_hostname()
         return self._agent_hostname
 
     @property
     def database_identifier(self) -> str:
-        """
-        Get a unique identifier for this database instance.
-        Uses the database_identifier template from config, defaulting to "$server:$port:$db".
-        """
         if self._database_identifier is None:
             template = Template(self._config.database_identifier.template)
             tag_dict = {}
             tags = self.tags.copy()
-            # Sort tags to ensure consistent ordering
             tags.sort()
             for t in tags:
                 if ':' in t:
@@ -374,7 +329,6 @@ class ClickhouseCheck(DatabaseCheck):
                         tag_dict[key] += f",{value}"
                     else:
                         tag_dict[key] = value
-            # Add connection parameters to the template variables
             tag_dict['server'] = str(self._config.server)
             tag_dict['port'] = str(self._config.port)
             tag_dict['db'] = str(self._config.db)
@@ -387,54 +341,23 @@ class ClickhouseCheck(DatabaseCheck):
 
     @property
     def dbms_version(self) -> str:
-        """Get the ClickHouse server version."""
         if self._dbms_version is None:
             return "unknown"
         return self._dbms_version
 
     @property
     def cloud_metadata(self) -> dict:
-        """Get cloud provider metadata if available."""
-        # TODO: Populate with cloud metadata when available (e.g., ClickHouse Cloud)
         return {}
 
     @property
     def is_single_endpoint_mode(self):
-        """
-        Returns True if single endpoint mode is enabled.
-
-        When True, DBM components should use clusterAllReplicas() to query system tables
-        across all nodes in the cluster, since replicas are abstracted behind a single
-        endpoint (e.g., load balancer or managed service like ClickHouse Cloud).
-        """
         return self._config.single_endpoint_mode
 
     def get_system_table(self, table_name):
-        """
-        Get the appropriate system table reference based on deployment type.
-
-        For single endpoint mode: Returns clusterAllReplicas('default', system.<table>)
-        For direct connection: Returns system.<table>
-
-        Args:
-            table_name: The system table name (e.g., 'query_log', 'processes')
-
-        Returns:
-            str: The table reference to use in SQL queries
-
-        Example:
-            >>> self.get_system_table('query_log')
-            "clusterAllReplicas('default', system.query_log)"  # Single endpoint mode
-            >>> self.get_system_table('query_log')
-            "system.query_log"  # Direct connection
-        """
+        """Return the system table reference, using clusterAllReplicas in single_endpoint_mode."""
         if self._config.single_endpoint_mode:
-            # Single endpoint mode: Use clusterAllReplicas to query all nodes
-            # The cluster name is 'default' for ClickHouse Cloud and most setups
             return f"clusterAllReplicas('default', system.{table_name})"
-        else:
-            # Direct connection: Query the local system table directly
-            return f"system.{table_name}"
+        return f"system.{table_name}"
 
     def ping_clickhouse(self):
         return self._client.ping()
@@ -457,7 +380,6 @@ class ClickhouseCheck(DatabaseCheck):
                 self._client = None
 
         try:
-            # Convert compression None to False for get_client
             compress = self._config.compression if self._config.compression else False
             client = clickhouse_connect.get_client(
                 # https://clickhouse.com/docs/integrations/python#connection-arguments
@@ -477,7 +399,6 @@ class ClickhouseCheck(DatabaseCheck):
                 autogenerate_session_id=False,
                 # https://clickhouse.com/docs/integrations/python#settings-argument
                 settings={},
-                # Use shared connection pool for efficiency
                 pool_mgr=self._pool_manager,
             )
         except Exception as e:
@@ -491,16 +412,7 @@ class ClickhouseCheck(DatabaseCheck):
             self._client = client
 
     def create_dbm_client(self):
-        """
-        Create a ClickHouse client for DBM async jobs.
-
-        Each DBM job gets its own client for isolation, but all clients share
-        the same HTTP connection pool for efficiency.
-
-        See: https://clickhouse.com/docs/integrations/language-clients/python/advanced-usage#customizing-the-http-connection-pool
-        """
         try:
-            # Convert compression None to False for get_client
             compress = self._config.compression if self._config.compression else False
             client = clickhouse_connect.get_client(
                 host=self._config.server,
@@ -515,11 +427,9 @@ class ClickhouseCheck(DatabaseCheck):
                 compress=compress,
                 ca_cert=self._config.tls_ca_cert,
                 verify=self._config.verify,
-                # Disable session IDs for multi-threaded safety
-                # See: https://clickhouse.com/docs/integrations/language-clients/python/advanced-usage#managing-clickhouse-session-ids
+                # https://clickhouse.com/docs/integrations/language-clients/python/advanced-usage#managing-clickhouse-session-ids
                 autogenerate_session_id=False,
                 settings={},
-                # Use shared connection pool for efficiency
                 pool_mgr=self._pool_manager,
             )
             return client
@@ -531,13 +441,6 @@ class ClickhouseCheck(DatabaseCheck):
             raise
 
     def cancel(self):
-        """
-        Cancel DBM async jobs and clean up connections.
-        This is called when the check is being shut down.
-        """
-        self.log.debug("Cancelling ClickHouse check and cleaning up connections")
-
-        # Cancel DBM async jobs
         if self.statement_metrics:
             self.statement_metrics.cancel()
         if self.statement_samples:
@@ -553,7 +456,6 @@ class ClickhouseCheck(DatabaseCheck):
         if self.parts_and_merges:
             self.parts_and_merges.cancel()
 
-        # Wait for job loops to finish
         if self.statement_metrics and self.statement_metrics._job_loop_future:
             self.statement_metrics._job_loop_future.result()
         if self.statement_samples and self.statement_samples._job_loop_future:
@@ -569,7 +471,6 @@ class ClickhouseCheck(DatabaseCheck):
         if self.parts_and_merges and self.parts_and_merges._job_loop_future:
             self.parts_and_merges._job_loop_future.result()
 
-        # Close main client
         if self._client:
             try:
                 self._client.close()
@@ -577,8 +478,6 @@ class ClickhouseCheck(DatabaseCheck):
                 self.log.debug("Error closing main client: %s", e)
             self._client = None
 
-        # Clear the shared pool manager
-        # Note: urllib3 pool connections are automatically closed when idle
         self._pool_manager = None
 
     def version_lt(self, version: str) -> bool:

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -17,11 +17,13 @@ from . import advanced_queries, queries, utils
 from .__about__ import __version__
 from .config import build_config, sanitize
 from .health import ClickhouseHealth, HealthEvent, HealthStatus
+from .metadata import ClickhouseMetadata
 from .parts_and_merges import ClickhousePartsAndMerges
 from .query_completions import ClickhouseQueryCompletions
 from .query_errors import ClickhouseQueryErrors
 from .statement_samples import ClickhouseStatementSamples
 from .statements import ClickhouseStatementMetrics
+from .table_metrics import ClickhouseTableMetrics
 from .utils import ErrorSanitizer
 
 try:
@@ -122,7 +124,16 @@ class ClickhouseCheck(DatabaseCheck):
         else:
             self.query_errors = None
 
-        # Initialize parts and merges monitoring (from system.parts, merges, mutations, replication_queue)
+        if self._config.dbm and self._config.collect_schemas and self._config.collect_schemas.enabled:
+            self.metadata = ClickhouseMetadata(self)
+        else:
+            self.metadata = None
+
+        if self._config.dbm and self._config.schema_metrics and self._config.schema_metrics.enabled:
+            self.table_metrics = ClickhouseTableMetrics(self, self._config.schema_metrics)
+        else:
+            self.table_metrics = None
+
         if self._config.dbm and self._config.parts_and_merges.enabled:
             self.parts_and_merges = ClickhousePartsAndMerges(self, self._config.parts_and_merges)
         else:
@@ -260,6 +271,12 @@ class ClickhouseCheck(DatabaseCheck):
         if self.query_errors:
             self.query_errors.run_job_loop(self.tags)
 
+        if self.metadata:
+            self.metadata.run_job_loop(self.tags)
+
+        if self.table_metrics:
+            self.table_metrics.run_job_loop(self.tags)
+
         # Run parts and merges monitoring if enabled
         if self.parts_and_merges:
             self.parts_and_merges.run_job_loop(self.tags)
@@ -363,6 +380,10 @@ class ClickhouseCheck(DatabaseCheck):
             tag_dict['db'] = str(self._config.db)
             self._database_identifier = template.safe_substitute(**tag_dict)
         return self._database_identifier
+
+    @property
+    def dbms(self) -> str:
+        return "clickhouse"
 
     @property
     def dbms_version(self) -> str:
@@ -525,6 +546,10 @@ class ClickhouseCheck(DatabaseCheck):
             self.query_completions.cancel()
         if self.query_errors:
             self.query_errors.cancel()
+        if self.metadata:
+            self.metadata.cancel()
+        if self.table_metrics:
+            self.table_metrics.cancel()
         if self.parts_and_merges:
             self.parts_and_merges.cancel()
 
@@ -537,6 +562,10 @@ class ClickhouseCheck(DatabaseCheck):
             self.query_completions._job_loop_future.result()
         if self.query_errors and self.query_errors._job_loop_future:
             self.query_errors._job_loop_future.result()
+        if self.metadata and self.metadata._job_loop_future:
+            self.metadata._job_loop_future.result()
+        if self.table_metrics and self.table_metrics._job_loop_future:
+            self.table_metrics._job_loop_future.result()
         if self.parts_and_merges and self.parts_and_merges._job_loop_future:
             self.parts_and_merges._job_loop_future.result()
 

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -408,6 +408,7 @@ class ClickhouseCheck(DatabaseCheck):
             sc_status = _VIEW_REFRESH_STATUS_MAP.get(status, AgentCheck.UNKNOWN)
             sc_msg = '' if sc_status == AgentCheck.OK else ((exception or '').split('\n')[0] or status)
             self.service_check(self.SERVICE_CHECK_VIEW_REFRESH, sc_status, tags=view_tags, message=sc_msg)
+            self.gauge('view.refresh.status', sc_status, tags=view_tags)
             self.gauge('view.refresh.last_time', int(last_time or 0), tags=view_tags)
             self.gauge('view.refresh.next_time', int(next_time or 0), tags=view_tags)
             self.gauge('view.refresh.rows', int(written_rows or 0), tags=view_tags)

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -35,10 +35,31 @@ except ImportError:
 # Not user-configurable; controls how often database_instance metadata is emitted.
 DATABASE_INSTANCE_COLLECTION_INTERVAL = 300
 
+_VIEW_REFRESHES_QUERY = """\
+SELECT
+    database,
+    view,
+    status,
+    toInt64(toUnixTimestamp(last_success_time)) AS last_refresh_time,
+    toInt64(toUnixTimestamp(next_refresh_time)) AS next_refresh_time,
+    toInt64(written_rows) AS written_rows,
+    toInt64(written_bytes) AS written_bytes
+FROM {view_refreshes_table}
+"""
+
+_VIEW_REFRESH_STATUS_MAP = {
+    'Scheduled': AgentCheck.OK,
+    'Running': AgentCheck.OK,
+    'WaitingForDependencies': AgentCheck.WARNING,
+    'Disabled': AgentCheck.UNKNOWN,
+    'Error': AgentCheck.CRITICAL,
+}
+
 
 class ClickhouseCheck(DatabaseCheck):
     __NAMESPACE__ = 'clickhouse'
     SERVICE_CHECK_CONNECT = 'can_connect'
+    SERVICE_CHECK_VIEW_REFRESH = 'view.refresh'
 
     def __init__(self, name, init_config, instances):
         super(ClickhouseCheck, self).__init__(name, init_config, instances)
@@ -61,6 +82,10 @@ class ClickhouseCheck(DatabaseCheck):
         self.tag_manager = TagManager()
         self.tag_manager.set_tags_from_list(self._config.tags, replace=True)
         self._add_core_tags()
+
+        self._view_refreshes_unsupported_logged = False
+        self._view_refreshes_permission_logged = False
+        self._view_refreshes_skip = False
 
         self._error_sanitizer = ErrorSanitizer(self._config.password)
         self.check_initializations.append(self.validate_config)
@@ -242,6 +267,8 @@ class ClickhouseCheck(DatabaseCheck):
             self.table_metrics.run_job_loop(self.tags)
         if self.parts_and_merges:
             self.parts_and_merges.run_job_loop(self.tags)
+        if self._config.dbm:
+            self._collect_view_refresh_metrics()
 
     def get_queries(self) -> list[dict]:
         query_list = []
@@ -358,6 +385,51 @@ class ClickhouseCheck(DatabaseCheck):
         if self._config.single_endpoint_mode:
             return f"clusterAllReplicas('default', system.{table_name})"
         return f"system.{table_name}"
+
+    def _collect_view_refresh_metrics(self) -> None:
+        if self._view_refreshes_skip:
+            return
+        try:
+            rows = self.execute_query_raw(
+                _VIEW_REFRESHES_QUERY.format(view_refreshes_table=self.get_system_table('view_refreshes'))
+            )
+        except Exception as e:
+            self._handle_view_refreshes_error(e)
+            return
+
+        base_tags = list(self.tags)
+        seen: set[tuple[str, str]] = set()
+        for database, view_name, status, last_time, next_time, written_rows, written_bytes in rows:
+            if (database, view_name) in seen:
+                continue
+            seen.add((database, view_name))
+            view_tags = base_tags + [f'db:{database}', f'view:{view_name}']
+            sc_status = _VIEW_REFRESH_STATUS_MAP.get(status, AgentCheck.UNKNOWN)
+            self.service_check(self.SERVICE_CHECK_VIEW_REFRESH, sc_status, tags=view_tags, message=status)
+            self.gauge('view.refresh.last_time', int(last_time or 0), tags=view_tags)
+            self.gauge('view.refresh.next_time', int(next_time or 0), tags=view_tags)
+            self.gauge('view.refresh.rows', int(written_rows or 0), tags=view_tags)
+            self.gauge('view.refresh.bytes', int(written_bytes or 0), tags=view_tags)
+
+    def _handle_view_refreshes_error(self, e: Exception) -> None:
+        lowered = str(e).lower()
+        if 'unknown table' in lowered or 'unknowntable' in lowered:
+            if not self._view_refreshes_unsupported_logged:
+                self.log.info(
+                    "system.view_refreshes not present (ClickHouse < 24.3); refresh status will not be populated."
+                )
+                self._view_refreshes_unsupported_logged = True
+            self._view_refreshes_skip = True
+        elif 'not enough privileges' in lowered or 'access_denied' in lowered:
+            if not self._view_refreshes_permission_logged:
+                self.log.warning(
+                    "Agent user lacks SELECT on system.view_refreshes; refresh status will not be populated. "
+                    "Grant with: GRANT SELECT ON system.view_refreshes TO <agent_user>"
+                )
+                self._view_refreshes_permission_logged = True
+            self._view_refreshes_skip = True
+        else:
+            self.log.exception("Unexpected error querying system.view_refreshes")
 
     def ping_clickhouse(self):
         return self._client.ping()

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -415,7 +415,7 @@ class ClickhouseCheck(DatabaseCheck):
 
     def _handle_view_refreshes_error(self, e: Exception) -> None:
         lowered = str(e).lower()
-        if 'unknown table' in lowered or 'unknowntable' in lowered:
+        if 'unknown table' in lowered or 'unknowntable' in lowered or 'unknown_table' in lowered:
             if not self._view_refreshes_unsupported_logged:
                 self.log.info(
                     "system.view_refreshes not present (ClickHouse < 24.3); refresh status will not be populated."

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -406,7 +406,7 @@ class ClickhouseCheck(DatabaseCheck):
             seen.add((database, view_name))
             view_tags = base_tags + [f'db:{database}', f'view:{view_name}']
             sc_status = _VIEW_REFRESH_STATUS_MAP.get(status, AgentCheck.UNKNOWN)
-            sc_msg = (exception or '').split('\n')[0] or status
+            sc_msg = '' if sc_status == AgentCheck.OK else ((exception or '').split('\n')[0] or status)
             self.service_check(self.SERVICE_CHECK_VIEW_REFRESH, sc_status, tags=view_tags, message=sc_msg)
             self.gauge('view.refresh.last_time', int(last_time or 0), tags=view_tags)
             self.gauge('view.refresh.next_time', int(next_time or 0), tags=view_tags)

--- a/clickhouse/datadog_checks/clickhouse/config.py
+++ b/clickhouse/datadog_checks/clickhouse/config.py
@@ -128,6 +128,14 @@ def build_config(check: ClickhouseCheck) -> Tuple[InstanceConfig, ValidationResu
                 **dict_defaults.instance_parts_and_merges().model_dump(),
                 **(instance.get('parts_and_merges', {})),
             },
+            "collect_schemas": {
+                **dict_defaults.instance_collect_schemas().model_dump(),
+                **(instance.get('collect_schemas', {})),
+            },
+            "schema_metrics": {
+                **dict_defaults.instance_schema_metrics().model_dump(),
+                **(instance.get('schema_metrics', {})),
+            },
             # Tags - ensure we have a list, not None
             "tags": list(instance.get('tags', [])),
             # Other settings

--- a/clickhouse/datadog_checks/clickhouse/config_models/dict_defaults.py
+++ b/clickhouse/datadog_checks/clickhouse/config_models/dict_defaults.py
@@ -57,6 +57,29 @@ def instance_query_errors():
     )
 
 
+def instance_collect_schemas():
+    return instance.CollectSchemas(
+        enabled=False,
+        collection_interval=600,
+        max_tables=300,
+        max_columns=1000,
+        max_query_duration=60,
+        include_databases=(),
+        exclude_databases=(),
+        include_tables=(),
+        exclude_tables=(),
+        run_sync=False,
+    )
+
+
+def instance_schema_metrics():
+    return instance.SchemaMetrics(
+        enabled=False,
+        collection_interval=60,
+        run_sync=False,
+    )
+
+
 def instance_parts_and_merges():
     return instance.PartsAndMerges(
         enabled=True,

--- a/clickhouse/datadog_checks/clickhouse/config_models/instance.py
+++ b/clickhouse/datadog_checks/clickhouse/config_models/instance.py
@@ -175,8 +175,8 @@ class InstanceConfig(BaseModel):
     query_metrics: Optional[QueryMetrics] = None
     query_samples: Optional[QuerySamples] = None
     read_timeout: Optional[int] = None
-    schema_metrics: Optional[SchemaMetrics] = None
     reported_hostname: Optional[str] = None
+    schema_metrics: Optional[SchemaMetrics] = None
     server: str
     service: Optional[str] = None
     single_endpoint_mode: Optional[bool] = None

--- a/clickhouse/datadog_checks/clickhouse/config_models/instance.py
+++ b/clickhouse/datadog_checks/clickhouse/config_models/instance.py
@@ -23,6 +23,23 @@ from . import defaults, validators
 SECURE_FIELD_NAMES = frozenset(['tls_ca_cert'])
 
 
+class CollectSchemas(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    collection_interval: Optional[float] = None
+    enabled: Optional[bool] = None
+    exclude_databases: Optional[tuple[str, ...]] = None
+    exclude_tables: Optional[tuple[str, ...]] = None
+    include_databases: Optional[tuple[str, ...]] = None
+    include_tables: Optional[tuple[str, ...]] = None
+    max_columns: Optional[int] = None
+    max_query_duration: Optional[int] = None
+    max_tables: Optional[int] = None
+    run_sync: Optional[bool] = None
+
+
 class CustomQuery(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -121,12 +138,23 @@ class QuerySamples(BaseModel):
     run_sync: Optional[bool] = None
 
 
+class SchemaMetrics(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    collection_interval: Optional[float] = None
+    enabled: Optional[bool] = None
+    run_sync: Optional[bool] = None
+
+
 class InstanceConfig(BaseModel):
     model_config = ConfigDict(
         validate_default=True,
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    collect_schemas: Optional[CollectSchemas] = None
     compression: Optional[str] = None
     connect_timeout: Optional[int] = None
     custom_queries: Optional[tuple[CustomQuery, ...]] = None
@@ -147,6 +175,7 @@ class InstanceConfig(BaseModel):
     query_metrics: Optional[QueryMetrics] = None
     query_samples: Optional[QuerySamples] = None
     read_timeout: Optional[int] = None
+    schema_metrics: Optional[SchemaMetrics] = None
     reported_hostname: Optional[str] = None
     server: str
     service: Optional[str] = None

--- a/clickhouse/datadog_checks/clickhouse/data/conf.yaml.example
+++ b/clickhouse/datadog_checks/clickhouse/data/conf.yaml.example
@@ -214,6 +214,94 @@ instances:
         #
         # samples_per_hour_per_query: 60
 
+    ## Configure collection of ClickHouse catalog metadata (databases,
+    ## tables, views, columns) for Database Monitoring's Schema Explorer.
+    ## Requires `dbm: true`.
+    #
+    # collect_schemas:
+
+        ## @param enabled - boolean - optional - default: true
+        ## Enable collection of catalog metadata. When enabled, the agent
+        ## polls `system.tables`, `system.columns`, and
+        ## `system.view_refreshes` (ClickHouse 24.3+) and emits one
+        ## `kind=clickhouse_databases` payload per cycle.
+        #
+        # enabled: true
+
+        ## @param collection_interval - number - optional - default: 600
+        ## Set the schema collection interval (in seconds). Catalog data
+        ## changes slowly; 600s (10 min) is a reasonable default.
+        #
+        # collection_interval: 600
+
+        ## @param max_tables - integer - optional - default: 300
+        ## Maximum number of tables plus views to collect per cycle
+        ## across all databases.
+        #
+        # max_tables: 300
+
+        ## @param max_columns - integer - optional - default: 1000
+        ## Maximum number of columns to collect per table/view.
+        #
+        # max_columns: 1000
+
+        ## @param max_query_duration - integer - optional - default: 60
+        ## Maximum duration of the schema collection queries in seconds.
+        ## Applied to each query via the `max_execution_time` ClickHouse setting.
+        #
+        # max_query_duration: 60
+
+        ## @param include_databases - list of strings - optional
+        ## A list of regex patterns to include databases. Any database whose
+        ## name matches any one of these patterns will be included. If empty,
+        ## all databases (other than those excluded) are included.
+        #
+        # include_databases:
+        #   - mydb
+
+        ## @param exclude_databases - list of strings - optional
+        ## A list of regex patterns to exclude databases. Any database whose
+        ## name matches any one of these patterns will be excluded. The
+        ## ClickHouse system databases (`system`, `INFORMATION_SCHEMA`,
+        ## `information_schema`) are always excluded regardless of this setting.
+        #
+        # exclude_databases:
+        #   - tmp_.*
+
+        ## @param include_tables - list of strings - optional
+        ## A list of regex patterns to include tables. Any table whose name
+        ## matches any one of these patterns will be included. If empty, all
+        ## tables (other than those excluded) are included.
+        #
+        # include_tables:
+        #   - events.*
+
+        ## @param exclude_tables - list of strings - optional
+        ## A list of regex patterns to exclude tables. Any table whose name
+        ## matches any one of these patterns will be excluded.
+        #
+        # exclude_tables:
+        #   - .*_tmp
+
+    ## Configure per-table size and per-view refresh gauges derived from
+    ## `system.tables` and `system.view_refreshes`. Independent of
+    ## `collect_schemas` (which controls catalog structure collection)
+    ## so users can dashboard table sizes without enabling Schema Explorer.
+    ## Requires `dbm: true`.
+    #
+    # schema_metrics:
+
+        ## @param enabled - boolean - optional - default: false
+        ## Enable collection of per-table size and per-view refresh gauges.
+        #
+        # enabled: false
+
+        ## @param collection_interval - number - optional - default: 60
+        ## Set the schema metrics collection interval (in seconds). These
+        ## gauges change continuously, so 60s is a reasonable default.
+        #
+        # collection_interval: 60
+
     ## Configure parts and merges monitoring
     #
     # parts_and_merges:

--- a/clickhouse/datadog_checks/clickhouse/features.py
+++ b/clickhouse/datadog_checks/clickhouse/features.py
@@ -23,6 +23,8 @@ class FeatureKey(Enum):
     QUERY_COMPLETIONS = "query_completions"
     EXPLAIN_PLANS = "explain_plans"
     QUERY_ERRORS = "query_errors"
+    COLLECT_SCHEMAS = "collect_schemas"
+    SCHEMA_METRICS = "schema_metrics"
     PARTS_AND_MERGES = "parts_and_merges"
     SINGLE_ENDPOINT_MODE = "single_endpoint_mode"
 
@@ -34,6 +36,8 @@ FeatureNames = {
     FeatureKey.QUERY_COMPLETIONS: 'Query Completions',
     FeatureKey.QUERY_ERRORS: 'Query Errors',
     FeatureKey.EXPLAIN_PLANS: 'Explain Plans',
+    FeatureKey.COLLECT_SCHEMAS: 'Collect Schemas',
+    FeatureKey.SCHEMA_METRICS: 'Schema Metrics',
     FeatureKey.PARTS_AND_MERGES: 'Parts and Merges',
     FeatureKey.SINGLE_ENDPOINT_MODE: 'Single Endpoint Mode',
 }

--- a/clickhouse/datadog_checks/clickhouse/metadata.py
+++ b/clickhouse/datadog_checks/clickhouse/metadata.py
@@ -1,0 +1,52 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from clickhouse_connect.driver.exceptions import DatabaseError
+
+if TYPE_CHECKING:
+    from datadog_checks.clickhouse import ClickhouseCheck
+
+from datadog_checks.base.utils.db.utils import DBMAsyncJob
+from datadog_checks.base.utils.tracking import tracked_method
+
+from .schemas import ClickhouseSchemaCollector
+
+
+def agent_check_getter(self):
+    return self._check
+
+
+class ClickhouseMetadata(DBMAsyncJob):
+    """Top-level DBM job that drives the schema collector on its configured cadence."""
+
+    def __init__(self, check: ClickhouseCheck):
+        collection_interval = check._config.collect_schemas.collection_interval
+        super(ClickhouseMetadata, self).__init__(
+            check,
+            rate_limit=1 / collection_interval,
+            run_sync=check._config.collect_schemas.run_sync,
+            enabled=check._config.collect_schemas.enabled,
+            dbms='clickhouse',
+            min_collection_interval=check._config.min_collection_interval,
+            expected_db_exceptions=(DatabaseError,),
+            job_name='clickhouse-metadata',
+        )
+        self._check = check
+        self._collection_interval = collection_interval
+        self._schema_collector = ClickhouseSchemaCollector(check)
+        self._schema_collector._cancel_event = self._cancel_event
+
+    def cancel(self):
+        super(ClickhouseMetadata, self).cancel()
+        self._schema_collector.close()
+
+    @tracked_method(agent_check_getter=agent_check_getter)
+    def run_job(self):
+        try:
+            self._schema_collector.collect_schemas()
+        except Exception:
+            self._log.exception("Schema collection failed")

--- a/clickhouse/datadog_checks/clickhouse/schemas.py
+++ b/clickhouse/datadog_checks/clickhouse/schemas.py
@@ -172,8 +172,9 @@ class ClickhouseSchemaCollector(SchemaCollector):
                 'db_filters': db_filters,
                 'table_filters': table_filters,
             }
-            rows = self._execute_query(_TABLES_COLUMNS_QUERY.format(**fmt))
-            yield iter(rows)
+            self._check_cancelled()
+            with self._db_client.query_rows_stream(_TABLES_COLUMNS_QUERY.format(**fmt)) as stream:
+                yield stream
         finally:
             self._refreshable_views = set()
             self.close()

--- a/clickhouse/datadog_checks/clickhouse/schemas.py
+++ b/clickhouse/datadog_checks/clickhouse/schemas.py
@@ -71,17 +71,6 @@ GROUP BY
 ORDER BY t.database, t.name
 """
 
-_VIEW_REFRESHES_QUERY = """\
-SELECT
-    database,
-    view,
-    exception
-FROM {view_refreshes_table}
-WHERE database NOT IN ({system_dbs})
-  {db_filters}
-LIMIT 1 BY (database, view)
-"""
-
 
 class ClickhouseSchemaCollectorConfig(SchemaCollectorConfig):
     max_tables: int
@@ -113,10 +102,6 @@ class ClickhouseSchemaCollector(SchemaCollector):
         super().__init__(check, config)
         self._db_client = None
         self._cancel_event = None
-        self._view_refreshes_unsupported_logged = False
-        self._view_refreshes_permission_logged = False
-        self._view_refreshes_skip = False
-        self._refreshable_views: set[tuple[str, str]] = set()
 
     @property
     def kind(self) -> str:
@@ -140,10 +125,6 @@ class ClickhouseSchemaCollector(SchemaCollector):
         if self._cancel_event is not None and self._cancel_event.is_set():
             raise Exception("Job loop cancelled. Aborting query.")
 
-    def _execute_query(self, query: str) -> list:
-        self._check_cancelled()
-        return self._db_client.query(query).result_rows
-
     def _get_databases(self) -> list[dict[str, str]]:
         return [_CLUSTER_STUB]
 
@@ -156,9 +137,6 @@ class ClickhouseSchemaCollector(SchemaCollector):
                 'database', self._config.include_databases, self._config.exclude_databases
             )
             table_filters = _build_match_clauses('name', self._config.include_tables, self._config.exclude_tables)
-
-            refresh_rows = self._collect_view_refreshes(db_filters)
-            self._refreshable_views = {(row[0], row[1]) for row in refresh_rows}
 
             fmt = {
                 'tables_table': self._check.get_system_table('tables'),
@@ -174,7 +152,6 @@ class ClickhouseSchemaCollector(SchemaCollector):
             with self._db_client.query_rows_stream(_TABLES_COLUMNS_QUERY.format(**fmt)) as stream:
                 yield stream
         finally:
-            self._refreshable_views = set()
             self.close()
 
     def _get_next(self, cursor) -> tuple | None:
@@ -222,40 +199,9 @@ class ClickhouseSchemaCollector(SchemaCollector):
             'create_query': create_query,
             'columns': cols,
             'metadata_modified_at': int(metadata_modified_at or 0),
-            'is_refreshable': (database, name) in self._refreshable_views,
+            'is_refreshable': 'REFRESH' in (create_query or '').upper(),
         }
 
-    def _collect_view_refreshes(self, db_filters: str) -> list:
-        if self._view_refreshes_skip:
-            return []
-        try:
-            return self._execute_query(
-                _VIEW_REFRESHES_QUERY.format(
-                    view_refreshes_table=self._check.get_system_table('view_refreshes'),
-                    system_dbs=", ".join(_SYSTEM_DATABASE_NAMES),
-                    db_filters=db_filters,
-                )
-            )
-        except Exception as e:
-            lowered = str(e).lower()
-            if 'unknown table' in lowered or 'unknowntable' in lowered:
-                if not self._view_refreshes_unsupported_logged:
-                    self._log.info(
-                        "system.view_refreshes not present (ClickHouse < 24.3); refresh status will not be populated."
-                    )
-                    self._view_refreshes_unsupported_logged = True
-                self._view_refreshes_skip = True
-            elif 'not enough privileges' in lowered or 'access_denied' in lowered:
-                if not self._view_refreshes_permission_logged:
-                    self._log.warning(
-                        "Agent user lacks SELECT on system.view_refreshes; refresh status will not be populated. "
-                        "Grant with: GRANT SELECT ON system.view_refreshes TO <agent_user>"
-                    )
-                    self._view_refreshes_permission_logged = True
-                self._view_refreshes_skip = True
-            else:
-                self._log.exception("Unexpected error querying system.view_refreshes")
-            return []
 
 
 def _build_match_clauses(

--- a/clickhouse/datadog_checks/clickhouse/schemas.py
+++ b/clickhouse/datadog_checks/clickhouse/schemas.py
@@ -162,16 +162,16 @@ class ClickhouseSchemaCollector(SchemaCollector):
             refresh_rows = self._collect_view_refreshes(db_filters)
             self._refreshable_views = {(row[0], row[1]) for row in refresh_rows}
 
-            fmt = dict(
-                tables_table=self._check.get_system_table('tables'),
-                columns_table=self._check.get_system_table('columns'),
-                system_dbs=", ".join(_SYSTEM_DATABASE_NAMES),
-                max_tables=self._config.max_tables,
-                max_columns=self._config.max_columns,
-                limit_columns=self._config.max_tables * self._config.max_columns,
-                db_filters=db_filters,
-                table_filters=table_filters,
-            )
+            fmt = {
+                'tables_table': self._check.get_system_table('tables'),
+                'columns_table': self._check.get_system_table('columns'),
+                'system_dbs': ", ".join(_SYSTEM_DATABASE_NAMES),
+                'max_tables': self._config.max_tables,
+                'max_columns': self._config.max_columns,
+                'limit_columns': self._config.max_tables * self._config.max_columns,
+                'db_filters': db_filters,
+                'table_filters': table_filters,
+            }
             rows = self._execute_query(_TABLES_COLUMNS_QUERY.format(**fmt))
             yield iter(rows)
         finally:

--- a/clickhouse/datadog_checks/clickhouse/schemas.py
+++ b/clickhouse/datadog_checks/clickhouse/schemas.py
@@ -203,7 +203,6 @@ class ClickhouseSchemaCollector(SchemaCollector):
         }
 
 
-
 def _build_match_clauses(
     column: str,
     include_patterns: tuple[str, ...],

--- a/clickhouse/datadog_checks/clickhouse/schemas.py
+++ b/clickhouse/datadog_checks/clickhouse/schemas.py
@@ -13,6 +13,8 @@ from datadog_checks.base.utils.db.schemas import SchemaCollector, SchemaCollecto
 
 _SYSTEM_DATABASE_NAMES = ("'system'", "'INFORMATION_SCHEMA'", "'information_schema'")
 
+_VIEW_ENGINES = frozenset(['View', 'MaterializedView', 'LiveView', 'WindowView'])
+
 # Single stub so the base-class loop runs exactly once; actual database names
 # come from the `database` column of each cursor row.
 _CLUSTER_STUB = {'name': '_cluster_'}
@@ -159,10 +161,11 @@ class ClickhouseSchemaCollector(SchemaCollector):
 
     def _map_row(self, _database: dict[str, str], cursor_row: tuple) -> dict[str, Any]:
         actual_db_name = cursor_row[0]
-        return {
-            'name': actual_db_name,
-            'tables': [self._build_item(cursor_row)],
-        }
+        engine = cursor_row[2]
+        item = self._build_item(cursor_row)
+        if engine in _VIEW_ENGINES:
+            return {'name': actual_db_name, 'tables': [], 'views': [item]}
+        return {'name': actual_db_name, 'tables': [item], 'views': []}
 
     def _build_item(self, row: tuple) -> dict[str, Any]:
         (

--- a/clickhouse/datadog_checks/clickhouse/schemas.py
+++ b/clickhouse/datadog_checks/clickhouse/schemas.py
@@ -1,0 +1,316 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from datadog_checks.clickhouse import ClickhouseCheck
+
+from datadog_checks.base.utils.db.schemas import SchemaCollector, SchemaCollectorConfig
+
+_VIEW_ENGINES = frozenset(['View', 'MaterializedView', 'LiveView', 'WindowView'])
+
+# Internal ClickHouse schemas we never want to surface as user databases.
+_SYSTEM_DATABASE_NAMES = ("'system'", "'INFORMATION_SCHEMA'", "'information_schema'")
+
+# Single stub passed to the base-class loop so it runs exactly once.
+# Actual database names come from the `database` column of each cursor row.
+_CLUSTER_STUB = {'name': '_cluster_'}
+
+_TABLES_COLUMNS_QUERY = """\
+WITH
+tables AS (
+    SELECT
+        database,
+        name,
+        engine,
+        toString(uuid) AS uuid,
+        create_table_query,
+        sorting_key,
+        partition_key,
+        primary_key,
+        sampling_key,
+        toInt64(toUnixTimestamp(metadata_modification_time)) AS metadata_modified_at
+    FROM {tables_table}
+    WHERE database NOT IN ({system_dbs})
+      {db_filters}
+      {table_filters}
+    ORDER BY database, name
+    LIMIT 1 BY (database, name)
+    LIMIT {max_tables}
+),
+columns AS (
+    SELECT database, table, name, type, default_expression, comment, toInt32(position) AS position
+    FROM {columns_table}
+    WHERE (database, table) IN (SELECT database, name FROM tables)
+    ORDER BY database, table, position
+    LIMIT 1 BY (database, table, name)
+    LIMIT {limit_columns}
+)
+SELECT
+    t.database,
+    t.name,
+    t.engine,
+    t.uuid,
+    t.create_table_query,
+    t.sorting_key,
+    t.partition_key,
+    t.primary_key,
+    t.sampling_key,
+    t.metadata_modified_at,
+    groupArrayIf({max_columns})(
+        tuple(c.name, c.type, c.default_expression, c.comment, c.position),
+        c.name IS NOT NULL
+    ) AS columns
+FROM tables t
+LEFT JOIN columns c ON t.database = c.database AND t.name = c.table
+GROUP BY
+    t.database, t.name, t.engine, t.uuid, t.create_table_query,
+    t.sorting_key, t.partition_key, t.primary_key, t.sampling_key,
+    t.metadata_modified_at
+ORDER BY t.database, t.name
+"""
+
+_VIEW_REFRESHES_QUERY = """\
+SELECT
+    database,
+    view,
+    exception
+FROM {view_refreshes_table}
+WHERE database NOT IN ({system_dbs})
+  {db_filters}
+LIMIT 1 BY (database, view)
+"""
+
+
+class ClickhouseSchemaCollectorConfig(SchemaCollectorConfig):
+    max_tables: int
+    max_columns: int
+    max_query_duration: int
+    include_databases: tuple[str, ...]
+    exclude_databases: tuple[str, ...]
+    include_tables: tuple[str, ...]
+    exclude_tables: tuple[str, ...]
+
+
+class ClickhouseSchemaCollector(SchemaCollector):
+    """ClickHouse implementation of the shared schema collector.
+
+    Uses a single connection for the full collection cycle. _get_databases
+    returns a single stub so the base loop runs exactly once. The main query
+    is a CTE that joins tables and columns server-side via groupArrayIf,
+    returning one fully-assembled row per table. view_refreshes is a separate
+    optional query for version compatibility. _map_row extracts the actual
+    database name from each cursor row.
+    """
+
+    _check: ClickhouseCheck
+    _config: ClickhouseSchemaCollectorConfig
+
+    def __init__(self, check: ClickhouseCheck):
+        config = ClickhouseSchemaCollectorConfig()
+        config.collection_interval = check._config.collect_schemas.collection_interval
+        config.max_tables = check._config.collect_schemas.max_tables
+        config.max_columns = check._config.collect_schemas.max_columns
+        config.max_query_duration = check._config.collect_schemas.max_query_duration
+        config.include_databases = tuple(check._config.collect_schemas.include_databases or ())
+        config.exclude_databases = tuple(check._config.collect_schemas.exclude_databases or ())
+        config.include_tables = tuple(check._config.collect_schemas.include_tables or ())
+        config.exclude_tables = tuple(check._config.collect_schemas.exclude_tables or ())
+
+        super().__init__(check, config)
+        self._db_client = None
+        self._cancel_event = None
+        self._view_refreshes_unsupported_logged = False
+        self._view_refreshes_permission_logged = False
+        self._view_refreshes_skip = False
+        self._refreshable_views: set[tuple[str, str]] = set()
+
+    @property
+    def kind(self) -> str:
+        return 'clickhouse_databases'
+
+    @property
+    def base_event(self) -> dict[str, Any]:
+        event = super().base_event
+        event['collector_id'] = self._check.check_id
+        return event
+
+    def close(self) -> None:
+        if self._db_client:
+            try:
+                self._db_client.close()
+            except Exception as e:
+                self._log.debug("Error closing schema collector client: %s", e)
+            self._db_client = None
+
+    def _check_cancelled(self) -> None:
+        if self._cancel_event is not None and self._cancel_event.is_set():
+            raise Exception("Job loop cancelled. Aborting query.")
+
+    def _execute_query(self, query: str) -> list:
+        self._check_cancelled()
+        return self._db_client.query(query).result_rows
+
+    def _get_databases(self) -> list[dict[str, str]]:
+        return [_CLUSTER_STUB]
+
+    @contextlib.contextmanager
+    def _get_cursor(self, _database_name: str):
+        self._db_client = self._check.create_dbm_client()
+        self._db_client.set_client_setting('max_execution_time', self._config.max_query_duration)
+        try:
+            db_filters = _build_match_clauses('database', self._config.include_databases, self._config.exclude_databases)
+            table_filters = _build_match_clauses('name', self._config.include_tables, self._config.exclude_tables)
+
+            refresh_rows = self._collect_view_refreshes(db_filters)
+            self._refreshable_views = {(row[0], row[1]) for row in refresh_rows}
+
+            fmt = dict(
+                tables_table=self._check.get_system_table('tables'),
+                columns_table=self._check.get_system_table('columns'),
+                system_dbs=", ".join(_SYSTEM_DATABASE_NAMES),
+                max_tables=self._config.max_tables,
+                max_columns=self._config.max_columns,
+                limit_columns=self._config.max_tables * self._config.max_columns,
+                db_filters=db_filters,
+                table_filters=table_filters,
+            )
+            rows = self._execute_query(_TABLES_COLUMNS_QUERY.format(**fmt))
+            yield iter(rows)
+        finally:
+            self._refreshable_views = set()
+            self.close()
+
+    def _get_next(self, cursor) -> tuple | None:
+        return next(cursor, None)
+
+    def _map_row(self, _database: dict[str, str], cursor_row: tuple) -> dict[str, Any]:
+        item, bucket = self._build_table_or_view_item(cursor_row)
+        actual_db_name = cursor_row[0]
+        return {
+            'name': actual_db_name,
+            'tables': [item] if bucket == 'tables' else [],
+            'views': [item] if bucket == 'views' else [],
+        }
+
+    def _build_table_or_view_item(self, row: tuple) -> tuple[dict[str, Any], str]:
+        (
+            database,
+            name,
+            engine,
+            uuid_str,
+            create_query,
+            sorting_key,
+            partition_key,
+            primary_key,
+            sampling_key,
+            metadata_modified_at,
+            raw_columns,
+        ) = row
+        cols = [
+            {
+                'name': col[0],
+                'type': col[1],
+                'default': col[2] or '',
+                'comment': col[3] or '',
+                'position': int(col[4] or 0),
+            }
+            for col in (raw_columns or [])
+        ]
+        if engine in _VIEW_ENGINES:
+            item = self._make_view(
+                name=name,
+                engine=engine,
+                uuid_str=uuid_str,
+                create_query=create_query,
+                columns=cols,
+                metadata_modified_at=metadata_modified_at,
+                is_refreshable=(database, name) in self._refreshable_views,
+            )
+            return item, 'views'
+        item = {
+            'name': name,
+            'engine': engine,
+            'uuid': uuid_str,
+            'sorting_key': sorting_key or '',
+            'partition_key': partition_key or '',
+            'primary_key': primary_key or '',
+            'sampling_key': sampling_key or '',
+            'create_query': create_query,
+            'columns': cols,
+            'metadata_modified_at': int(metadata_modified_at or 0),
+        }
+        return item, 'tables'
+
+    def _make_view(
+        self,
+        name: str,
+        engine: str,
+        uuid_str: str,
+        create_query: str,
+        columns: list[dict[str, Any]],
+        metadata_modified_at: int | None,
+        is_refreshable: bool,
+    ) -> dict[str, Any]:
+        return {
+            'name': name,
+            'engine': engine,
+            'uuid': uuid_str,
+            'create_query': create_query,
+            'columns': columns,
+            'metadata_modified_at': int(metadata_modified_at or 0),
+            'is_refreshable': is_refreshable,
+        }
+
+    def _collect_view_refreshes(self, db_filters: str) -> list:
+        if self._view_refreshes_skip:
+            return []
+        try:
+            return self._execute_query(
+                _VIEW_REFRESHES_QUERY.format(
+                    view_refreshes_table=self._check.get_system_table('view_refreshes'),
+                    system_dbs=", ".join(_SYSTEM_DATABASE_NAMES),
+                    db_filters=db_filters,
+                )
+            )
+        except Exception as e:
+            lowered = str(e).lower()
+            if 'unknown table' in lowered or 'unknowntable' in lowered:
+                if not self._view_refreshes_unsupported_logged:
+                    self._log.info(
+                        "system.view_refreshes not present (ClickHouse < 24.3); refresh status will not be populated."
+                    )
+                    self._view_refreshes_unsupported_logged = True
+                self._view_refreshes_skip = True
+            elif 'not enough privileges' in lowered or 'access_denied' in lowered:
+                if not self._view_refreshes_permission_logged:
+                    self._log.warning(
+                        "Agent user lacks SELECT on system.view_refreshes; refresh status will not be populated. "
+                        "Grant with: GRANT SELECT ON system.view_refreshes TO <agent_user>"
+                    )
+                    self._view_refreshes_permission_logged = True
+                self._view_refreshes_skip = True
+            else:
+                self._log.exception("Unexpected error querying system.view_refreshes")
+            return []
+
+
+def _build_match_clauses(
+    column: str,
+    include_patterns: tuple[str, ...],
+    exclude_patterns: tuple[str, ...],
+) -> str:
+    def escape(p: str) -> str:
+        return p.replace("'", "''")
+
+    clauses: list[str] = []
+    for pattern in exclude_patterns:
+        clauses.append(f"AND NOT match({column}, '{escape(pattern)}')")
+    if include_patterns:
+        ors = " OR ".join(f"match({column}, '{escape(p)}')" for p in include_patterns)
+        clauses.append(f"AND ({ors})")
+    return "\n  ".join(clauses)

--- a/clickhouse/datadog_checks/clickhouse/schemas.py
+++ b/clickhouse/datadog_checks/clickhouse/schemas.py
@@ -154,7 +154,9 @@ class ClickhouseSchemaCollector(SchemaCollector):
         self._db_client = self._check.create_dbm_client()
         self._db_client.set_client_setting('max_execution_time', self._config.max_query_duration)
         try:
-            db_filters = _build_match_clauses('database', self._config.include_databases, self._config.exclude_databases)
+            db_filters = _build_match_clauses(
+                'database', self._config.include_databases, self._config.exclude_databases
+            )
             table_filters = _build_match_clauses('name', self._config.include_tables, self._config.exclude_tables)
 
             refresh_rows = self._collect_view_refreshes(db_filters)

--- a/clickhouse/datadog_checks/clickhouse/schemas.py
+++ b/clickhouse/datadog_checks/clickhouse/schemas.py
@@ -13,11 +13,10 @@ from datadog_checks.base.utils.db.schemas import SchemaCollector, SchemaCollecto
 
 _VIEW_ENGINES = frozenset(['View', 'MaterializedView', 'LiveView', 'WindowView'])
 
-# Internal ClickHouse schemas we never want to surface as user databases.
 _SYSTEM_DATABASE_NAMES = ("'system'", "'INFORMATION_SCHEMA'", "'information_schema'")
 
-# Single stub passed to the base-class loop so it runs exactly once.
-# Actual database names come from the `database` column of each cursor row.
+# Single stub so the base-class loop runs exactly once; actual database names
+# come from the `database` column of each cursor row.
 _CLUSTER_STUB = {'name': '_cluster_'}
 
 _TABLES_COLUMNS_QUERY = """\
@@ -97,15 +96,7 @@ class ClickhouseSchemaCollectorConfig(SchemaCollectorConfig):
 
 
 class ClickhouseSchemaCollector(SchemaCollector):
-    """ClickHouse implementation of the shared schema collector.
-
-    Uses a single connection for the full collection cycle. _get_databases
-    returns a single stub so the base loop runs exactly once. The main query
-    is a CTE that joins tables and columns server-side via groupArrayIf,
-    returning one fully-assembled row per table. view_refreshes is a separate
-    optional query for version compatibility. _map_row extracts the actual
-    database name from each cursor row.
-    """
+    """Collects ClickHouse schema metadata via a single CTE query per cycle."""
 
     _check: ClickhouseCheck
     _config: ClickhouseSchemaCollectorConfig

--- a/clickhouse/datadog_checks/clickhouse/schemas.py
+++ b/clickhouse/datadog_checks/clickhouse/schemas.py
@@ -11,8 +11,6 @@ if TYPE_CHECKING:
 
 from datadog_checks.base.utils.db.schemas import SchemaCollector, SchemaCollectorConfig
 
-_VIEW_ENGINES = frozenset(['View', 'MaterializedView', 'LiveView', 'WindowView'])
-
 _SYSTEM_DATABASE_NAMES = ("'system'", "'INFORMATION_SCHEMA'", "'information_schema'")
 
 # Single stub so the base-class loop runs exactly once; actual database names
@@ -183,15 +181,13 @@ class ClickhouseSchemaCollector(SchemaCollector):
         return next(cursor, None)
 
     def _map_row(self, _database: dict[str, str], cursor_row: tuple) -> dict[str, Any]:
-        item, bucket = self._build_table_or_view_item(cursor_row)
         actual_db_name = cursor_row[0]
         return {
             'name': actual_db_name,
-            'tables': [item] if bucket == 'tables' else [],
-            'views': [item] if bucket == 'views' else [],
+            'tables': [self._build_item(cursor_row)],
         }
 
-    def _build_table_or_view_item(self, row: tuple) -> tuple[dict[str, Any], str]:
+    def _build_item(self, row: tuple) -> dict[str, Any]:
         (
             database,
             name,
@@ -215,18 +211,7 @@ class ClickhouseSchemaCollector(SchemaCollector):
             }
             for col in (raw_columns or [])
         ]
-        if engine in _VIEW_ENGINES:
-            item = self._make_view(
-                name=name,
-                engine=engine,
-                uuid_str=uuid_str,
-                create_query=create_query,
-                columns=cols,
-                metadata_modified_at=metadata_modified_at,
-                is_refreshable=(database, name) in self._refreshable_views,
-            )
-            return item, 'views'
-        item = {
+        return {
             'name': name,
             'engine': engine,
             'uuid': uuid_str,
@@ -237,27 +222,7 @@ class ClickhouseSchemaCollector(SchemaCollector):
             'create_query': create_query,
             'columns': cols,
             'metadata_modified_at': int(metadata_modified_at or 0),
-        }
-        return item, 'tables'
-
-    def _make_view(
-        self,
-        name: str,
-        engine: str,
-        uuid_str: str,
-        create_query: str,
-        columns: list[dict[str, Any]],
-        metadata_modified_at: int | None,
-        is_refreshable: bool,
-    ) -> dict[str, Any]:
-        return {
-            'name': name,
-            'engine': engine,
-            'uuid': uuid_str,
-            'create_query': create_query,
-            'columns': columns,
-            'metadata_modified_at': int(metadata_modified_at or 0),
-            'is_refreshable': is_refreshable,
+            'is_refreshable': (database, name) in self._refreshable_views,
         }
 
     def _collect_view_refreshes(self, db_filters: str) -> list:

--- a/clickhouse/datadog_checks/clickhouse/table_metrics.py
+++ b/clickhouse/datadog_checks/clickhouse/table_metrics.py
@@ -98,4 +98,3 @@ class ClickhouseTableMetrics(DBMAsyncJob):
             entity_tags = base_tags + [f'db:{database}', f'table:{name}']
             self._check.gauge('table.rows', int(total_rows or 0), tags=entity_tags)
             self._check.gauge('table.bytes', int(total_bytes or 0), tags=entity_tags)
-

--- a/clickhouse/datadog_checks/clickhouse/table_metrics.py
+++ b/clickhouse/datadog_checks/clickhouse/table_metrics.py
@@ -27,25 +27,13 @@ FROM {tables_table}
 WHERE database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')
 """
 
-_VIEW_REFRESHES_QUERY = """\
-SELECT
-    database,
-    view,
-    status,
-    toInt64(toUnixTimestamp(last_success_time)) AS last_refresh_time,
-    toInt64(toUnixTimestamp(next_refresh_time)) AS next_refresh_time,
-    toInt64(written_rows) AS written_rows,
-    toInt64(written_bytes) AS written_bytes
-FROM {view_refreshes_table}
-"""
-
 
 def agent_check_getter(self):
     return self._check
 
 
 class ClickhouseTableMetrics(DBMAsyncJob):
-    """Per-table size gauges and per-view refresh-state gauges from system.tables and system.view_refreshes."""
+    """Per-table size gauges from system.tables."""
 
     def __init__(self, check: ClickhouseCheck, config: SchemaMetrics):
         collection_interval = config.collection_interval
@@ -66,9 +54,6 @@ class ClickhouseTableMetrics(DBMAsyncJob):
         self._config = config
         self._collection_interval = collection_interval
         self._db_client = None
-        self._view_refreshes_unsupported_logged = False
-        self._view_refreshes_permission_logged = False
-        self._view_refreshes_skip = False
 
     def cancel(self):
         super(ClickhouseTableMetrics, self).cancel()
@@ -85,6 +70,7 @@ class ClickhouseTableMetrics(DBMAsyncJob):
     def _execute_query(self, query: str) -> list:
         if self._db_client is None:
             self._db_client = self._check.create_dbm_client()
+            self._db_client.set_client_setting('max_execution_time', self._collection_interval)
         try:
             return self._db_client.query(query).result_rows
         except OperationalError as e:
@@ -95,7 +81,6 @@ class ClickhouseTableMetrics(DBMAsyncJob):
     @tracked_method(agent_check_getter=agent_check_getter)
     def run_job(self):
         self._emit_table_size_gauges()
-        self._emit_view_refresh_gauges()
 
     def _emit_table_size_gauges(self) -> None:
         try:
@@ -114,46 +99,3 @@ class ClickhouseTableMetrics(DBMAsyncJob):
             self._check.gauge('table.rows', int(total_rows or 0), tags=entity_tags)
             self._check.gauge('table.bytes', int(total_bytes or 0), tags=entity_tags)
 
-    def _emit_view_refresh_gauges(self) -> None:
-        if self._view_refreshes_skip:
-            return
-        try:
-            rows = self._execute_query(
-                _VIEW_REFRESHES_QUERY.format(view_refreshes_table=self._check.get_system_table('view_refreshes'))
-            )
-        except Exception as e:
-            self._handle_view_refreshes_error(e)
-            return
-
-        base_tags = list(self._check.tags)
-        seen: set[tuple[str, str]] = set()
-        for database, view_name, status, last_time, next_time, written_rows, written_bytes in rows:
-            if (database, view_name) in seen:
-                continue
-            seen.add((database, view_name))
-            view_tags = base_tags + [f'db:{database}', f'view:{view_name}']
-            self._check.gauge('view.refresh.status', 1, tags=view_tags + [f'status:{status or "Unknown"}'])
-            self._check.gauge('view.refresh.last_time', int(last_time or 0), tags=view_tags)
-            self._check.gauge('view.refresh.next_time', int(next_time or 0), tags=view_tags)
-            self._check.gauge('view.refresh.rows', int(written_rows or 0), tags=view_tags)
-            self._check.gauge('view.refresh.bytes', int(written_bytes or 0), tags=view_tags)
-
-    def _handle_view_refreshes_error(self, e: Exception) -> None:
-        lowered = str(e).lower()
-        if 'unknown table' in lowered or 'unknowntable' in lowered:
-            if not self._view_refreshes_unsupported_logged:
-                self._log.info(
-                    "system.view_refreshes not present (ClickHouse < 24.3); refresh status will not be populated."
-                )
-                self._view_refreshes_unsupported_logged = True
-            self._view_refreshes_skip = True
-        elif 'not enough privileges' in lowered or 'access_denied' in lowered:
-            if not self._view_refreshes_permission_logged:
-                self._log.warning(
-                    "Agent user lacks SELECT on system.view_refreshes; refresh status will not be populated. "
-                    "Grant with: GRANT SELECT ON system.view_refreshes TO <agent_user>"
-                )
-                self._view_refreshes_permission_logged = True
-            self._view_refreshes_skip = True
-        else:
-            self._log.exception("Unexpected error querying system.view_refreshes")

--- a/clickhouse/datadog_checks/clickhouse/table_metrics.py
+++ b/clickhouse/datadog_checks/clickhouse/table_metrics.py
@@ -1,0 +1,159 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from clickhouse_connect.driver.exceptions import OperationalError
+
+if TYPE_CHECKING:
+    from datadog_checks.clickhouse import ClickhouseCheck
+    from datadog_checks.clickhouse.config_models.instance import SchemaMetrics
+
+from datadog_checks.base.utils.db.utils import DBMAsyncJob
+from datadog_checks.base.utils.tracking import tracked_method
+
+_DEFAULT_COLLECTION_INTERVAL = 60
+
+
+_TABLE_SIZES_QUERY = """\
+SELECT
+    database,
+    name,
+    toInt64(total_rows) AS total_rows,
+    toInt64(total_bytes) AS total_bytes
+FROM {tables_table}
+WHERE database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')
+"""
+
+_VIEW_REFRESHES_QUERY = """\
+SELECT
+    database,
+    view,
+    status,
+    toInt64(toUnixTimestamp(last_success_time)) AS last_refresh_time,
+    toInt64(toUnixTimestamp(next_refresh_time)) AS next_refresh_time,
+    toInt64(written_rows) AS written_rows,
+    toInt64(written_bytes) AS written_bytes
+FROM {view_refreshes_table}
+"""
+
+
+def agent_check_getter(self):
+    return self._check
+
+
+class ClickhouseTableMetrics(DBMAsyncJob):
+    """Per-table size gauges and per-view refresh-state gauges from system.tables and system.view_refreshes."""
+
+    def __init__(self, check: ClickhouseCheck, config: SchemaMetrics):
+        collection_interval = config.collection_interval
+        if collection_interval is None or collection_interval <= 0:
+            collection_interval = _DEFAULT_COLLECTION_INTERVAL
+
+        super(ClickhouseTableMetrics, self).__init__(
+            check,
+            rate_limit=1 / collection_interval,
+            run_sync=config.run_sync,
+            enabled=config.enabled,
+            dbms='clickhouse',
+            min_collection_interval=check._config.min_collection_interval,
+            expected_db_exceptions=(Exception,),
+            job_name='clickhouse-table-metrics',
+        )
+        self._check = check
+        self._config = config
+        self._collection_interval = collection_interval
+        self._db_client = None
+        self._view_refreshes_unsupported_logged = False
+        self._view_refreshes_permission_logged = False
+        self._view_refreshes_skip = False
+
+    def cancel(self):
+        super(ClickhouseTableMetrics, self).cancel()
+        self._close_db_client()
+
+    def _close_db_client(self):
+        if self._db_client:
+            try:
+                self._db_client.close()
+            except Exception as e:
+                self._log.debug("Error closing table-metrics client: %s", e)
+            self._db_client = None
+
+    def _execute_query(self, query: str) -> list:
+        if self._db_client is None:
+            self._db_client = self._check.create_dbm_client()
+        try:
+            return self._db_client.query(query).result_rows
+        except OperationalError as e:
+            self._log.warning("Connection error on table-metrics query, will reconnect: %s", e)
+            self._close_db_client()
+            raise
+
+    @tracked_method(agent_check_getter=agent_check_getter)
+    def run_job(self):
+        self._emit_table_size_gauges()
+        self._emit_view_refresh_gauges()
+
+    def _emit_table_size_gauges(self) -> None:
+        try:
+            rows = self._execute_query(_TABLE_SIZES_QUERY.format(tables_table=self._check.get_system_table('tables')))
+        except Exception:
+            self._log.exception("Failed to collect clickhouse table sizes")
+            return
+
+        base_tags = list(self._check.tags)
+        seen: set[tuple[str, str]] = set()
+        for database, name, total_rows, total_bytes in rows:
+            if (database, name) in seen:
+                continue
+            seen.add((database, name))
+            entity_tags = base_tags + [f'db:{database}', f'table:{name}']
+            self._check.gauge('table.rows', int(total_rows or 0), tags=entity_tags)
+            self._check.gauge('table.bytes', int(total_bytes or 0), tags=entity_tags)
+
+    def _emit_view_refresh_gauges(self) -> None:
+        if self._view_refreshes_skip:
+            return
+        try:
+            rows = self._execute_query(
+                _VIEW_REFRESHES_QUERY.format(view_refreshes_table=self._check.get_system_table('view_refreshes'))
+            )
+        except Exception as e:
+            self._handle_view_refreshes_error(e)
+            return
+
+        base_tags = list(self._check.tags)
+        seen: set[tuple[str, str]] = set()
+        for database, view_name, status, last_time, next_time, written_rows, written_bytes in rows:
+            if (database, view_name) in seen:
+                continue
+            seen.add((database, view_name))
+            view_tags = base_tags + [f'db:{database}', f'view:{view_name}']
+            self._check.gauge('view.refresh.status', 1, tags=view_tags + [f'status:{status or "Unknown"}'])
+            self._check.gauge('view.refresh.last_time', int(last_time or 0), tags=view_tags)
+            self._check.gauge('view.refresh.next_time', int(next_time or 0), tags=view_tags)
+            self._check.gauge('view.refresh.rows', int(written_rows or 0), tags=view_tags)
+            self._check.gauge('view.refresh.bytes', int(written_bytes or 0), tags=view_tags)
+
+    def _handle_view_refreshes_error(self, e: Exception) -> None:
+        lowered = str(e).lower()
+        if 'unknown table' in lowered or 'unknowntable' in lowered:
+            if not self._view_refreshes_unsupported_logged:
+                self._log.info(
+                    "system.view_refreshes not present (ClickHouse < 24.3); refresh status will not be populated."
+                )
+                self._view_refreshes_unsupported_logged = True
+            self._view_refreshes_skip = True
+        elif 'not enough privileges' in lowered or 'access_denied' in lowered:
+            if not self._view_refreshes_permission_logged:
+                self._log.warning(
+                    "Agent user lacks SELECT on system.view_refreshes; refresh status will not be populated. "
+                    "Grant with: GRANT SELECT ON system.view_refreshes TO <agent_user>"
+                )
+                self._view_refreshes_permission_logged = True
+            self._view_refreshes_skip = True
+        else:
+            self._log.exception("Unexpected error querying system.view_refreshes")

--- a/clickhouse/tests/test_config_defaults.py
+++ b/clickhouse/tests/test_config_defaults.py
@@ -70,6 +70,25 @@ EXPECTED_DEFAULTS = {
         'max_samples_per_collection': 1000,
         'run_sync': False,
     },
+    # === DBM: Schema collector ===
+    'collect_schemas': {
+        'enabled': False,
+        'collection_interval': 600,
+        'max_tables': 300,
+        'max_columns': 1000,
+        'max_query_duration': 60,
+        'include_databases': (),
+        'exclude_databases': (),
+        'include_tables': (),
+        'exclude_tables': (),
+        'run_sync': False,
+    },
+    # === DBM: Schema metrics ===
+    'schema_metrics': {
+        'enabled': False,
+        'collection_interval': 60,
+        'run_sync': False,
+    },
     # === DBM: Parts and merges ===
     'parts_and_merges': {
         'enabled': True,

--- a/clickhouse/tests/test_metadata.py
+++ b/clickhouse/tests/test_metadata.py
@@ -278,7 +278,7 @@ def test_collect_emits_single_payload_when_small(check):
     assert 'collector_id' in p
 
 
-def test_collect_payload_contains_tables_and_views(check):
+def test_collect_payload_tables_list_includes_views(check):
     payloads = _run_collect(
         check,
         table_rows=[_table_row(name='events'), _view_row(name='events_mv')],
@@ -286,20 +286,19 @@ def test_collect_payload_contains_tables_and_views(check):
     )
     dbs = payloads[0]['metadata']
     table_names = {t['name'] for db in dbs for t in db['tables']}
-    view_names = {v['name'] for db in dbs for v in db['views']}
     assert 'events' in table_names
-    assert 'events_mv' in view_names
-    refreshable_view = next(v for db in dbs for v in db['views'] if v['name'] == 'events_mv')
+    assert 'events_mv' in table_names
+    refreshable_view = next(t for db in dbs for t in db['tables'] if t['name'] == 'events_mv')
     assert refreshable_view['is_refreshable'] is True
 
 
 @pytest.mark.parametrize('engine', ['View', 'LiveView', 'WindowView'])
-def test_collect_routes_other_view_engines(check, engine):
+def test_collect_view_engines_appear_in_tables(check, engine):
     payloads = _run_collect(check, table_rows=[_view_row(name='some_view', engine=engine)])
     dbs = payloads[0]['metadata']
-    views = [v for db in dbs for v in db['views']]
-    assert [v['name'] for v in views] == ['some_view']
-    assert views[0]['engine'] == engine
+    tables = [t for db in dbs for t in db['tables']]
+    assert [t['name'] for t in tables] == ['some_view']
+    assert tables[0]['engine'] == engine
 
 
 def test_collect_dedupes_replica_rows_via_sql(check):
@@ -331,7 +330,7 @@ def test_collect_marks_view_refreshable_only_when_refresh_row_present(check):
         ],
         refresh_rows=[_refresh_row(view='refreshable_mv')],
     )
-    by_name = {v['name']: v for db in payloads[0]['metadata'] for v in db['views']}
+    by_name = {t['name']: t for db in payloads[0]['metadata'] for t in db['tables']}
     assert by_name['refreshable_mv']['is_refreshable'] is True
     assert by_name['vanilla_view']['is_refreshable'] is False
 
@@ -346,7 +345,7 @@ def test_collect_columns_attached_to_correct_parent(check):
     )
     dbs = payloads[0]['metadata']
     table = next(t for db in dbs for t in db['tables'] if t['name'] == 'events')
-    view = next(v for db in dbs for v in db['views'] if v['name'] == 'events_mv')
+    view = next(t for db in dbs for t in db['tables'] if t['name'] == 'events_mv')
     assert [c['name'] for c in table['columns']] == ['id']
     assert [c['name'] for c in view['columns']] == ['count']
 
@@ -358,7 +357,7 @@ def test_collect_chunks_when_payload_chunk_size_exceeded(check):
     payloads = _run_collect(check, table_rows=rows)
 
     assert len(payloads) >= 2
-    emitted_total = sum(len(db['tables']) + len(db['views']) for p in payloads for db in p['metadata'])
+    emitted_total = sum(len(db['tables']) for p in payloads for db in p['metadata'])
     assert emitted_total == 12
 
 

--- a/clickhouse/tests/test_metadata.py
+++ b/clickhouse/tests/test_metadata.py
@@ -557,9 +557,7 @@ def test_max_execution_time_set_on_client(collector):
     with _patch_query(collector) as mock_client:
         collector.collect_schemas()
 
-    mock_client.set_client_setting.assert_called_once_with(
-        'max_execution_time', collector._config.max_query_duration
-    )
+    mock_client.set_client_setting.assert_called_once_with('max_execution_time', collector._config.max_query_duration)
 
 
 def test_main_query_failure_closes_client(collector):

--- a/clickhouse/tests/test_metadata.py
+++ b/clickhouse/tests/test_metadata.py
@@ -279,19 +279,20 @@ def test_collect_payload_tables_list_includes_views(check):
     )
     dbs = payloads[0]['metadata']
     table_names = {t['name'] for db in dbs for t in db['tables']}
+    view_names = {v['name'] for db in dbs for v in db.get('views', [])}
     assert 'events' in table_names
-    assert 'events_mv' in table_names
-    refreshable_view = next(t for db in dbs for t in db['tables'] if t['name'] == 'events_mv')
+    assert 'events_mv' in view_names
+    refreshable_view = next(v for db in dbs for v in db.get('views', []) if v['name'] == 'events_mv')
     assert refreshable_view['is_refreshable'] is True
 
 
 @pytest.mark.parametrize('engine', ['View', 'LiveView', 'WindowView'])
-def test_collect_view_engines_appear_in_tables(check, engine):
+def test_collect_view_engines_appear_in_views(check, engine):
     payloads = _run_collect(check, table_rows=[_view_row(name='some_view', engine=engine)])
     dbs = payloads[0]['metadata']
-    tables = [t for db in dbs for t in db['tables']]
-    assert [t['name'] for t in tables] == ['some_view']
-    assert tables[0]['engine'] == engine
+    views = [v for db in dbs for v in db.get('views', [])]
+    assert [v['name'] for v in views] == ['some_view']
+    assert views[0]['engine'] == engine
 
 
 def test_collect_dedupes_replica_rows_via_sql(check):
@@ -329,7 +330,7 @@ def test_collect_marks_view_refreshable_based_on_create_query(check):
             ),
         ],
     )
-    by_name = {t['name']: t for db in payloads[0]['metadata'] for t in db['tables']}
+    by_name = {v['name']: v for db in payloads[0]['metadata'] for v in db.get('views', [])}
     assert by_name['refreshable_mv']['is_refreshable'] is True
     assert by_name['vanilla_view']['is_refreshable'] is False
 
@@ -344,7 +345,7 @@ def test_collect_columns_attached_to_correct_parent(check):
     )
     dbs = payloads[0]['metadata']
     table = next(t for db in dbs for t in db['tables'] if t['name'] == 'events')
-    view = next(t for db in dbs for t in db['tables'] if t['name'] == 'events_mv')
+    view = next(v for db in dbs for v in db.get('views', []) if v['name'] == 'events_mv')
     assert [c['name'] for c in table['columns']] == ['id']
     assert [c['name'] for c in view['columns']] == ['count']
 

--- a/clickhouse/tests/test_metadata.py
+++ b/clickhouse/tests/test_metadata.py
@@ -269,7 +269,11 @@ def test_collect_payload_tables_list_includes_views(check):
             _table_row(name='events'),
             _view_row(
                 name='events_mv',
-                create_query='CREATE MATERIALIZED VIEW default.events_mv REFRESH EVERY 1 HOUR TO default.events_target AS SELECT * FROM default.events',
+                create_query=(
+                    'CREATE MATERIALIZED VIEW default.events_mv'
+                    ' REFRESH EVERY 1 HOUR TO default.events_target'
+                    ' AS SELECT * FROM default.events'
+                ),
             ),
         ],
     )
@@ -312,7 +316,11 @@ def test_collect_marks_view_refreshable_based_on_create_query(check):
         table_rows=[
             _view_row(
                 name='refreshable_mv',
-                create_query='CREATE MATERIALIZED VIEW default.refreshable_mv REFRESH EVERY 1 HOUR TO default.target AS SELECT * FROM default.src',
+                create_query=(
+                    'CREATE MATERIALIZED VIEW default.refreshable_mv'
+                    ' REFRESH EVERY 1 HOUR TO default.target'
+                    ' AS SELECT * FROM default.src'
+                ),
             ),
             _view_row(
                 name='vanilla_view',
@@ -371,7 +379,6 @@ def test_collect_all_chunks_share_collection_started_at(check):
 
     started_ats = {p['collection_started_at'] for p in payloads}
     assert len(started_ats) == 1
-
 
 
 def test_cancel_closes_db_client(check):
@@ -568,10 +575,7 @@ def test_payload_chunking(check, collector):
 
     # Every table appears exactly once across all payloads
     all_names = [
-        entry['tables'][0]['name']
-        for payload in captured
-        for entry in payload['metadata']
-        if entry.get('tables')
+        entry['tables'][0]['name'] for payload in captured for entry in payload['metadata'] if entry.get('tables')
     ]
     assert sorted(all_names) == sorted(f'tbl_{i}' for i in range(7))
 

--- a/clickhouse/tests/test_metadata.py
+++ b/clickhouse/tests/test_metadata.py
@@ -75,10 +75,6 @@ def _view_row(
     )
 
 
-def _refresh_row(database='default', view='events_mv', exception=''):
-    return (database, view, exception)
-
-
 @pytest.fixture
 def collect_schemas_instance():
     return {
@@ -121,26 +117,15 @@ def _make_query_result(rows):
 
 
 @contextlib.contextmanager
-def _patch_query(collector, table_rows=None, refresh_rows=None):
-    """Mocks the DBM client for the two cluster-wide queries.
-
-    - view_refreshes goes through client.query() → result_rows
-    - combined tables+columns CTE goes through client.query_rows_stream()
-    """
+def _patch_query(collector, table_rows=None):
+    """Mocks the DBM client for the combined tables+columns CTE query."""
     table_rows = table_rows or []
-    refresh_rows = refresh_rows or []
-
-    def fake_client_query(query, *args, **kwargs):
-        if 'view_refreshes' in query:
-            return _make_query_result(refresh_rows)
-        return _make_query_result([])
 
     @contextlib.contextmanager
     def fake_stream(query, *args, **kwargs):
         yield iter(table_rows)
 
     mock_client = mock.MagicMock()
-    mock_client.query.side_effect = fake_client_query
     mock_client.query_rows_stream.side_effect = fake_stream
 
     with mock.patch.object(collector._check, 'create_dbm_client', return_value=mock_client):
@@ -154,9 +139,9 @@ def _capture_payloads(check):
     return captured
 
 
-def _run_collect(check, table_rows=None, refresh_rows=None):
+def _run_collect(check, table_rows=None):
     captured = _capture_payloads(check)
-    with _patch_query(check.metadata._schema_collector, table_rows, refresh_rows):
+    with _patch_query(check.metadata._schema_collector, table_rows):
         check.metadata._schema_collector.collect_schemas()
     return captured
 
@@ -266,7 +251,6 @@ def test_collect_emits_single_payload_when_small(check):
             _table_row(name='events', columns=[_column_row(name='id')]),
             _view_row(name='events_mv'),
         ],
-        refresh_rows=[_refresh_row(view='events_mv')],
     )
     assert len(payloads) == 1
     p = payloads[0]
@@ -281,8 +265,13 @@ def test_collect_emits_single_payload_when_small(check):
 def test_collect_payload_tables_list_includes_views(check):
     payloads = _run_collect(
         check,
-        table_rows=[_table_row(name='events'), _view_row(name='events_mv')],
-        refresh_rows=[_refresh_row(view='events_mv')],
+        table_rows=[
+            _table_row(name='events'),
+            _view_row(
+                name='events_mv',
+                create_query='CREATE MATERIALIZED VIEW default.events_mv REFRESH EVERY 1 HOUR TO default.events_target AS SELECT * FROM default.events',
+            ),
+        ],
     )
     dbs = payloads[0]['metadata']
     table_names = {t['name'] for db in dbs for t in db['tables']}
@@ -317,18 +306,20 @@ def test_collect_emits_empty_snapshot_marker_when_no_tables(check):
     assert payloads[0]['collection_payloads_count'] == 1
 
 
-def test_collect_marks_view_refreshable_only_when_refresh_row_present(check):
+def test_collect_marks_view_refreshable_based_on_create_query(check):
     payloads = _run_collect(
         check,
         table_rows=[
-            _view_row(name='refreshable_mv'),
+            _view_row(
+                name='refreshable_mv',
+                create_query='CREATE MATERIALIZED VIEW default.refreshable_mv REFRESH EVERY 1 HOUR TO default.target AS SELECT * FROM default.src',
+            ),
             _view_row(
                 name='vanilla_view',
                 engine='View',
                 create_query='CREATE VIEW default.vanilla_view AS SELECT 1',
             ),
         ],
-        refresh_rows=[_refresh_row(view='refreshable_mv')],
     )
     by_name = {t['name']: t for db in payloads[0]['metadata'] for t in db['tables']}
     assert by_name['refreshable_mv']['is_refreshable'] is True
@@ -382,30 +373,6 @@ def test_collect_all_chunks_share_collection_started_at(check):
     assert len(started_ats) == 1
 
 
-def test_collect_view_refreshes_unknown_table_logs_once(collector):
-    collector._log = mock.MagicMock()
-    with mock.patch.object(collector, '_execute_query', side_effect=Exception('Unknown table system.view_refreshes')):
-        assert collector._collect_view_refreshes('') == []
-        assert collector._collect_view_refreshes('') == []
-    assert len(collector._log.info.call_args_list) == 1
-
-
-def test_collect_view_refreshes_permission_denied_logs_once(collector):
-    collector._log = mock.MagicMock()
-    with mock.patch.object(
-        collector, '_execute_query', side_effect=Exception('Not enough privileges to access system.view_refreshes')
-    ):
-        assert collector._collect_view_refreshes('') == []
-        assert collector._collect_view_refreshes('') == []
-    assert len(collector._log.warning.call_args_list) == 1
-
-
-def test_collect_view_refreshes_unexpected_error_logs_exception(collector):
-    collector._log = mock.MagicMock()
-    with mock.patch.object(collector, '_execute_query', side_effect=Exception('boom')):
-        assert collector._collect_view_refreshes('') == []
-    collector._log.exception.assert_called_once()
-
 
 def test_cancel_closes_db_client(check):
     fake_client = mock.MagicMock()
@@ -456,7 +423,6 @@ def test_collect_routes_through_cluster_all_replicas_in_single_endpoint_mode(col
     joined = '\n'.join(seen_queries)
     assert "clusterAllReplicas('default', system.tables)" in joined
     assert "clusterAllReplicas('default', system.columns)" in joined
-    assert "clusterAllReplicas('default', system.view_refreshes)" in joined
 
 
 def test_build_match_clauses_empty_returns_empty_string():
@@ -531,10 +497,8 @@ def test_all_cluster_fanout_queries_dedupe_replica_rows(check):
     with _capture_all_queries(check.metadata._schema_collector) as seen_queries:
         check.metadata._schema_collector.collect_schemas()
 
-    refreshes_query = next(q for q in seen_queries if 'system.view_refreshes' in q)
     combined_query = next(q for q in seen_queries if 'FROM system.tables' in q)
 
-    assert 'LIMIT 1 BY (database, view)' in refreshes_query
     assert 'LIMIT 1 BY (database, name)' in combined_query
     assert 'LIMIT 1 BY (database, table, name)' in combined_query
 
@@ -546,7 +510,7 @@ def test_system_databases_excluded_from_all_queries(collect_schemas_instance):
     with _capture_all_queries(check.metadata._schema_collector) as seen_queries:
         check.metadata._schema_collector.collect_schemas()
 
-    for kw in ('system.tables', 'system.columns', 'system.view_refreshes'):
+    for kw in ('system.tables', 'system.columns'):
         q = next(q for q in seen_queries if kw in q)
         assert "database NOT IN (" in q
 
@@ -560,7 +524,6 @@ def test_collect_uses_local_system_tables_in_direct_mode(check):
     assert 'clusterAllReplicas' not in joined
     assert 'FROM system.tables' in joined
     assert 'FROM system.columns' in joined
-    assert 'FROM system.view_refreshes' in joined
 
 
 def test_max_execution_time_set_on_client(collector):
@@ -572,13 +535,7 @@ def test_max_execution_time_set_on_client(collector):
 
 
 def test_main_query_failure_closes_client(collector):
-    def fake_query(query, *args, **kwargs):
-        if 'view_refreshes' in query:
-            return _make_query_result([])
-        return _make_query_result([])
-
     mock_client = mock.MagicMock()
-    mock_client.query.side_effect = fake_query
     mock_client.query_rows_stream.return_value.__enter__.side_effect = Exception("main query failed")
 
     _capture_payloads(collector._check)
@@ -627,9 +584,5 @@ def test_cancel_event_aborts_before_query(collector):
     collector._cancel_event = cancel_event
     cancel_event.set()
 
-    collector._db_client = mock.MagicMock()
-
     with pytest.raises(Exception, match="cancelled"):
-        collector._execute_query("SELECT 1")
-
-    collector._db_client.query.assert_not_called()
+        collector._check_cancelled()

--- a/clickhouse/tests/test_metadata.py
+++ b/clickhouse/tests/test_metadata.py
@@ -125,7 +125,7 @@ def _patch_query(collector, table_rows=None, refresh_rows=None):
     """Mocks the DBM client for the two cluster-wide queries.
 
     - view_refreshes goes through client.query() → result_rows
-    - combined tables+columns CTE goes through client.query() → result_rows
+    - combined tables+columns CTE goes through client.query_rows_stream()
     """
     table_rows = table_rows or []
     refresh_rows = refresh_rows or []
@@ -133,10 +133,15 @@ def _patch_query(collector, table_rows=None, refresh_rows=None):
     def fake_client_query(query, *args, **kwargs):
         if 'view_refreshes' in query:
             return _make_query_result(refresh_rows)
-        return _make_query_result(table_rows)
+        return _make_query_result([])
+
+    @contextlib.contextmanager
+    def fake_stream(query, *args, **kwargs):
+        yield iter(table_rows)
 
     mock_client = mock.MagicMock()
     mock_client.query.side_effect = fake_client_query
+    mock_client.query_rows_stream.side_effect = fake_stream
 
     with mock.patch.object(collector._check, 'create_dbm_client', return_value=mock_client):
         yield mock_client
@@ -165,8 +170,14 @@ def _capture_all_queries(collector):
         seen.append(query)
         return _make_query_result([])
 
+    @contextlib.contextmanager
+    def fake_stream(query, *args, **kwargs):
+        seen.append(query)
+        yield iter([])
+
     mock_client = mock.MagicMock()
     mock_client.query.side_effect = fake_client_query
+    mock_client.query_rows_stream.side_effect = fake_stream
 
     with mock.patch.object(collector._check, 'create_dbm_client', return_value=mock_client):
         yield seen
@@ -565,10 +576,11 @@ def test_main_query_failure_closes_client(collector):
     def fake_query(query, *args, **kwargs):
         if 'view_refreshes' in query:
             return _make_query_result([])
-        raise Exception("main query failed")
+        return _make_query_result([])
 
     mock_client = mock.MagicMock()
     mock_client.query.side_effect = fake_query
+    mock_client.query_rows_stream.return_value.__enter__.side_effect = Exception("main query failed")
 
     _capture_payloads(collector._check)
     with mock.patch.object(collector._check, 'create_dbm_client', return_value=mock_client):

--- a/clickhouse/tests/test_metadata.py
+++ b/clickhouse/tests/test_metadata.py
@@ -7,6 +7,7 @@ import threading
 from unittest import mock
 
 import pytest
+
 from datadog_checks.clickhouse import ClickhouseCheck
 from datadog_checks.clickhouse.metadata import ClickhouseMetadata
 from datadog_checks.clickhouse.schemas import (

--- a/clickhouse/tests/test_metadata.py
+++ b/clickhouse/tests/test_metadata.py
@@ -3,10 +3,10 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import contextlib
 import json
+import threading
 from unittest import mock
 
 import pytest
-
 from datadog_checks.clickhouse import ClickhouseCheck
 from datadog_checks.clickhouse.metadata import ClickhouseMetadata
 from datadog_checks.clickhouse.schemas import (
@@ -550,3 +550,44 @@ def test_collect_uses_local_system_tables_in_direct_mode(check):
     assert 'FROM system.tables' in joined
     assert 'FROM system.columns' in joined
     assert 'FROM system.view_refreshes' in joined
+
+
+def test_max_execution_time_set_on_client(collector):
+    _capture_payloads(collector._check)
+    with _patch_query(collector) as mock_client:
+        collector.collect_schemas()
+
+    mock_client.set_client_setting.assert_called_once_with(
+        'max_execution_time', collector._config.max_query_duration
+    )
+
+
+def test_main_query_failure_closes_client(collector):
+    def fake_query(query, *args, **kwargs):
+        if 'view_refreshes' in query:
+            return _make_query_result([])
+        raise Exception("main query failed")
+
+    mock_client = mock.MagicMock()
+    mock_client.query.side_effect = fake_query
+
+    _capture_payloads(collector._check)
+    with mock.patch.object(collector._check, 'create_dbm_client', return_value=mock_client):
+        with pytest.raises(Exception, match="main query failed"):
+            collector.collect_schemas()
+
+    mock_client.close.assert_called_once()
+    assert collector._db_client is None
+
+
+def test_cancel_event_aborts_before_query(collector):
+    cancel_event = threading.Event()
+    collector._cancel_event = cancel_event
+    cancel_event.set()
+
+    collector._db_client = mock.MagicMock()
+
+    with pytest.raises(Exception, match="cancelled"):
+        collector._execute_query("SELECT 1")
+
+    collector._db_client.query.assert_not_called()

--- a/clickhouse/tests/test_metadata.py
+++ b/clickhouse/tests/test_metadata.py
@@ -591,6 +591,38 @@ def test_main_query_failure_closes_client(collector):
     assert collector._db_client is None
 
 
+def test_payload_chunking(check, collector):
+    # Set a small chunk size so 7 tables produce 3 separate payloads.
+    collector._config.payload_chunk_size = 3
+    table_rows = [_table_row(name=f'tbl_{i}') for i in range(7)]
+    captured = _run_collect(check, table_rows=table_rows)
+
+    # Three payloads: rows 0-2, rows 3-5, row 6
+    assert len(captured) == 3
+
+    # Only the last payload carries collection_payloads_count (snapshot marker)
+    assert 'collection_payloads_count' not in captured[0]
+    assert 'collection_payloads_count' not in captured[1]
+    assert captured[2]['collection_payloads_count'] == 3
+
+    # Non-final chunks hold exactly chunk_size rows; final chunk holds the remainder
+    assert len(captured[0]['metadata']) == 3
+    assert len(captured[1]['metadata']) == 3
+    assert len(captured[2]['metadata']) == 1
+
+    # Every table appears exactly once across all payloads
+    all_names = [
+        entry['tables'][0]['name']
+        for payload in captured
+        for entry in payload['metadata']
+        if entry.get('tables')
+    ]
+    assert sorted(all_names) == sorted(f'tbl_{i}' for i in range(7))
+
+    # Schema kind is correct on every payload
+    assert all(p['kind'] == 'clickhouse_databases' for p in captured)
+
+
 def test_cancel_event_aborts_before_query(collector):
     cancel_event = threading.Event()
     collector._cancel_event = cancel_event

--- a/clickhouse/tests/test_metadata.py
+++ b/clickhouse/tests/test_metadata.py
@@ -1,0 +1,552 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import contextlib
+import json
+from unittest import mock
+
+import pytest
+
+from datadog_checks.clickhouse import ClickhouseCheck
+from datadog_checks.clickhouse.metadata import ClickhouseMetadata
+from datadog_checks.clickhouse.schemas import (
+    ClickhouseSchemaCollector,
+    _build_match_clauses,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _column_row(name='id', type_='UInt64', default='', comment='', position=1):
+    """Column tuple as returned by groupArrayIf in the combined CTE query."""
+    return (name, type_, default, comment, position)
+
+
+def _table_row(
+    database='default',
+    name='events',
+    engine='MergeTree',
+    uuid_str='uuid-1',
+    create_query='CREATE TABLE default.events (id UInt64) ENGINE = MergeTree ORDER BY id',
+    sorting_key='id',
+    partition_key='',
+    primary_key='id',
+    sampling_key='',
+    metadata_modified_at=1700000000,
+    columns=None,
+):
+    return (
+        database,
+        name,
+        engine,
+        uuid_str,
+        create_query,
+        sorting_key,
+        partition_key,
+        primary_key,
+        sampling_key,
+        metadata_modified_at,
+        columns or [],
+    )
+
+
+def _view_row(
+    database='default',
+    name='events_mv',
+    engine='MaterializedView',
+    uuid_str='uuid-2',
+    create_query='CREATE MATERIALIZED VIEW default.events_mv TO default.events_target AS SELECT * FROM default.events',
+    metadata_modified_at=1700001000,
+    columns=None,
+):
+    return _table_row(
+        database=database,
+        name=name,
+        engine=engine,
+        uuid_str=uuid_str,
+        create_query=create_query,
+        sorting_key='',
+        partition_key='',
+        primary_key='',
+        sampling_key='',
+        metadata_modified_at=metadata_modified_at,
+        columns=columns,
+    )
+
+
+def _refresh_row(database='default', view='events_mv', exception=''):
+    return (database, view, exception)
+
+
+@pytest.fixture
+def collect_schemas_instance():
+    return {
+        'server': 'localhost',
+        'port': 9000,
+        'username': 'default',
+        'password': '',
+        'db': 'default',
+        'dbm': True,
+        'collect_schemas': {
+            'enabled': True,
+            'collection_interval': 600,
+            'max_tables': 5000,
+            'max_columns': 1000,
+            'run_sync': True,
+        },
+        'tags': ['test:clickhouse'],
+    }
+
+
+@pytest.fixture
+def check(collect_schemas_instance):
+    return ClickhouseCheck('clickhouse', {}, [collect_schemas_instance])
+
+
+@pytest.fixture
+def collector(check) -> ClickhouseSchemaCollector:
+    return check.metadata._schema_collector
+
+
+def _make_query_result(rows):
+    rows = list(rows)
+    result = mock.MagicMock()
+    result.result_set = rows
+    result.result_rows = rows
+    result.column_names = ('c0',)
+    result.column_types = ()
+    result.summary = {}
+    return result
+
+
+@contextlib.contextmanager
+def _patch_query(collector, table_rows=None, refresh_rows=None):
+    """Mocks the DBM client for the two cluster-wide queries.
+
+    - view_refreshes goes through client.query() → result_rows
+    - combined tables+columns CTE goes through client.query() → result_rows
+    """
+    table_rows = table_rows or []
+    refresh_rows = refresh_rows or []
+
+    def fake_client_query(query, *args, **kwargs):
+        if 'view_refreshes' in query:
+            return _make_query_result(refresh_rows)
+        return _make_query_result(table_rows)
+
+    mock_client = mock.MagicMock()
+    mock_client.query.side_effect = fake_client_query
+
+    with mock.patch.object(collector._check, 'create_dbm_client', return_value=mock_client):
+        yield mock_client
+
+
+def _capture_payloads(check):
+    captured: list[dict] = []
+    check.database_monitoring_metadata = lambda raw: captured.append(json.loads(raw))
+    check.gauge = lambda *a, **kw: None
+    return captured
+
+
+def _run_collect(check, table_rows=None, refresh_rows=None):
+    captured = _capture_payloads(check)
+    with _patch_query(check.metadata._schema_collector, table_rows, refresh_rows):
+        check.metadata._schema_collector.collect_schemas()
+    return captured
+
+
+@contextlib.contextmanager
+def _capture_all_queries(collector):
+    """Records every SQL string sent through the DBM client."""
+    seen: list[str] = []
+
+    def fake_client_query(query, *args, **kwargs):
+        seen.append(query)
+        return _make_query_result([])
+
+    mock_client = mock.MagicMock()
+    mock_client.query.side_effect = fake_client_query
+
+    with mock.patch.object(collector._check, 'create_dbm_client', return_value=mock_client):
+        yield seen
+
+
+def test_initialization(check):
+    assert isinstance(check.metadata, ClickhouseMetadata)
+    assert isinstance(check.metadata._schema_collector, ClickhouseSchemaCollector)
+    assert check.metadata._collection_interval == 600
+    assert check.metadata._schema_collector._config.max_tables == 5000
+    assert check.metadata._schema_collector._config.max_columns == 1000
+
+
+def test_kind(collector):
+    assert collector.kind == 'clickhouse_databases'
+
+
+def test_init_collection_interval_omitted_uses_default():
+    check = ClickhouseCheck(
+        'clickhouse',
+        {},
+        [{'server': 'localhost', 'dbm': True, 'collect_schemas': {'enabled': True}}],
+    )
+    assert check.metadata is not None
+    assert check.metadata._collection_interval == 600
+
+
+def test_init_max_tables_omitted_uses_default():
+    check = ClickhouseCheck(
+        'clickhouse',
+        {},
+        [{'server': 'localhost', 'dbm': True, 'collect_schemas': {'enabled': True}}],
+    )
+    assert check.metadata._schema_collector._config.max_tables == 300
+
+
+def test_init_max_query_duration_omitted_uses_default():
+    check = ClickhouseCheck(
+        'clickhouse',
+        {},
+        [{'server': 'localhost', 'dbm': True, 'collect_schemas': {'enabled': True}}],
+    )
+    assert check.metadata._schema_collector._config.max_query_duration == 60
+
+
+def test_init_filters_omitted_default_to_empty_tuples():
+    check = ClickhouseCheck(
+        'clickhouse',
+        {},
+        [{'server': 'localhost', 'dbm': True, 'collect_schemas': {'enabled': True}}],
+    )
+    cfg = check.metadata._schema_collector._config
+    assert cfg.include_databases == ()
+    assert cfg.exclude_databases == ()
+    assert cfg.include_tables == ()
+    assert cfg.exclude_tables == ()
+
+
+def test_disabled_when_dbm_off():
+    check = ClickhouseCheck(
+        'clickhouse',
+        {},
+        [{'server': 'localhost', 'dbm': False, 'collect_schemas': {'enabled': True, 'collection_interval': 600}}],
+    )
+    assert check.metadata is None
+
+
+def test_disabled_by_default_when_dbm_on():
+    check = ClickhouseCheck('clickhouse', {}, [{'server': 'localhost', 'dbm': True}])
+    assert check.metadata is None
+
+
+def test_disabled_when_explicitly_opted_out():
+    check = ClickhouseCheck(
+        'clickhouse',
+        {},
+        [{'server': 'localhost', 'dbm': True, 'collect_schemas': {'enabled': False, 'collection_interval': 600}}],
+    )
+    assert check.metadata is None
+
+
+def test_collect_emits_single_payload_when_small(check):
+    payloads = _run_collect(
+        check,
+        table_rows=[
+            _table_row(name='events', columns=[_column_row(name='id')]),
+            _view_row(name='events_mv'),
+        ],
+        refresh_rows=[_refresh_row(view='events_mv')],
+    )
+    assert len(payloads) == 1
+    p = payloads[0]
+    assert p['kind'] == 'clickhouse_databases'
+    assert p['dbms'] == 'clickhouse'
+    assert p['collection_payloads_count'] == 1
+    assert p['collection_started_at'] > 0
+    assert 'host' in p
+    assert 'collector_id' in p
+
+
+def test_collect_payload_contains_tables_and_views(check):
+    payloads = _run_collect(
+        check,
+        table_rows=[_table_row(name='events'), _view_row(name='events_mv')],
+        refresh_rows=[_refresh_row(view='events_mv')],
+    )
+    dbs = payloads[0]['metadata']
+    table_names = {t['name'] for db in dbs for t in db['tables']}
+    view_names = {v['name'] for db in dbs for v in db['views']}
+    assert 'events' in table_names
+    assert 'events_mv' in view_names
+    refreshable_view = next(v for db in dbs for v in db['views'] if v['name'] == 'events_mv')
+    assert refreshable_view['is_refreshable'] is True
+
+
+@pytest.mark.parametrize('engine', ['View', 'LiveView', 'WindowView'])
+def test_collect_routes_other_view_engines(check, engine):
+    payloads = _run_collect(check, table_rows=[_view_row(name='some_view', engine=engine)])
+    dbs = payloads[0]['metadata']
+    views = [v for db in dbs for v in db['views']]
+    assert [v['name'] for v in views] == ['some_view']
+    assert views[0]['engine'] == engine
+
+
+def test_collect_dedupes_replica_rows_via_sql(check):
+    payloads = _run_collect(check, table_rows=[_table_row(name='events')])
+    dbs = payloads[0]['metadata']
+    table_names = [t['name'] for db in dbs for t in db['tables']]
+    assert table_names == ['events']
+
+
+def test_collect_emits_empty_snapshot_marker_when_no_tables(check):
+    # An empty run still emits one terminal payload so the backend receives a
+    # snapshot marker (collection_payloads_count) and can clear stale state.
+    payloads = _run_collect(check, table_rows=[])
+    assert len(payloads) == 1
+    assert payloads[0]['metadata'] == []
+    assert payloads[0]['collection_payloads_count'] == 1
+
+
+def test_collect_marks_view_refreshable_only_when_refresh_row_present(check):
+    payloads = _run_collect(
+        check,
+        table_rows=[
+            _view_row(name='refreshable_mv'),
+            _view_row(
+                name='vanilla_view',
+                engine='View',
+                create_query='CREATE VIEW default.vanilla_view AS SELECT 1',
+            ),
+        ],
+        refresh_rows=[_refresh_row(view='refreshable_mv')],
+    )
+    by_name = {v['name']: v for db in payloads[0]['metadata'] for v in db['views']}
+    assert by_name['refreshable_mv']['is_refreshable'] is True
+    assert by_name['vanilla_view']['is_refreshable'] is False
+
+
+def test_collect_columns_attached_to_correct_parent(check):
+    payloads = _run_collect(
+        check,
+        table_rows=[
+            _table_row(name='events', columns=[_column_row(name='id')]),
+            _view_row(name='events_mv', columns=[_column_row(name='count', type_='UInt64')]),
+        ],
+    )
+    dbs = payloads[0]['metadata']
+    table = next(t for db in dbs for t in db['tables'] if t['name'] == 'events')
+    view = next(v for db in dbs for v in db['views'] if v['name'] == 'events_mv')
+    assert [c['name'] for c in table['columns']] == ['id']
+    assert [c['name'] for c in view['columns']] == ['count']
+
+
+def test_collect_chunks_when_payload_chunk_size_exceeded(check):
+    check.metadata._schema_collector._config.payload_chunk_size = 5
+    rows = [_table_row(name=f'big_{i}') for i in range(12)]
+
+    payloads = _run_collect(check, table_rows=rows)
+
+    assert len(payloads) >= 2
+    emitted_total = sum(len(db['tables']) + len(db['views']) for p in payloads for db in p['metadata'])
+    assert emitted_total == 12
+
+
+def test_collect_collection_payloads_count_only_on_last(check):
+    check.metadata._schema_collector._config.payload_chunk_size = 5
+    rows = [_table_row(name=f'big_{i}') for i in range(12)]
+
+    payloads = _run_collect(check, table_rows=rows)
+
+    for intermediate in payloads[:-1]:
+        assert 'collection_payloads_count' not in intermediate
+    assert payloads[-1]['collection_payloads_count'] == len(payloads)
+
+
+def test_collect_all_chunks_share_collection_started_at(check):
+    check.metadata._schema_collector._config.payload_chunk_size = 5
+    rows = [_table_row(name=f'big_{i}') for i in range(12)]
+
+    payloads = _run_collect(check, table_rows=rows)
+
+    started_ats = {p['collection_started_at'] for p in payloads}
+    assert len(started_ats) == 1
+
+
+def test_collect_view_refreshes_unknown_table_logs_once(collector):
+    collector._log = mock.MagicMock()
+    with mock.patch.object(collector, '_execute_query', side_effect=Exception('Unknown table system.view_refreshes')):
+        assert collector._collect_view_refreshes('') == []
+        assert collector._collect_view_refreshes('') == []
+    assert len(collector._log.info.call_args_list) == 1
+
+
+def test_collect_view_refreshes_permission_denied_logs_once(collector):
+    collector._log = mock.MagicMock()
+    with mock.patch.object(
+        collector, '_execute_query', side_effect=Exception('Not enough privileges to access system.view_refreshes')
+    ):
+        assert collector._collect_view_refreshes('') == []
+        assert collector._collect_view_refreshes('') == []
+    assert len(collector._log.warning.call_args_list) == 1
+
+
+def test_collect_view_refreshes_unexpected_error_logs_exception(collector):
+    collector._log = mock.MagicMock()
+    with mock.patch.object(collector, '_execute_query', side_effect=Exception('boom')):
+        assert collector._collect_view_refreshes('') == []
+    collector._log.exception.assert_called_once()
+
+
+def test_cancel_closes_db_client(check):
+    fake_client = mock.MagicMock()
+    check.metadata._schema_collector._db_client = fake_client
+
+    check.metadata.cancel()
+
+    assert check.metadata._schema_collector._db_client is None
+    fake_client.close.assert_called_once()
+
+
+def test_combined_query_dedupes_replicas_before_limit(check):
+    _capture_payloads(check)
+    with _capture_all_queries(check.metadata._schema_collector) as seen_queries:
+        check.metadata._schema_collector.collect_schemas()
+
+    combined_query = next(q for q in seen_queries if 'FROM system.tables' in q)
+    dedup_idx = combined_query.find('LIMIT 1 BY (database, name)')
+    outer_limit_idx = combined_query.find('LIMIT 5000')
+    assert dedup_idx >= 0
+    assert outer_limit_idx >= 0
+    assert dedup_idx < outer_limit_idx
+
+
+def test_combined_query_joins_columns_and_caps_per_table(check):
+    _capture_payloads(check)
+    with _capture_all_queries(check.metadata._schema_collector) as seen_queries:
+        check.metadata._schema_collector.collect_schemas()
+
+    combined_query = next(q for q in seen_queries if 'FROM system.columns' in q)
+    assert '(database, table) IN (' in combined_query
+    assert 'FROM system.tables' in combined_query
+    assert 'LIMIT 1 BY (database, name)' in combined_query
+    assert 'LIMIT 1 BY (database, table, name)' in combined_query
+    # limit_columns = max_tables * max_columns = 5000 * 1000
+    assert 'LIMIT 5000000' in combined_query
+    # per-table cap via groupArrayIf
+    assert 'groupArrayIf(1000)' in combined_query
+
+
+def test_collect_routes_through_cluster_all_replicas_in_single_endpoint_mode(collect_schemas_instance):
+    collect_schemas_instance['single_endpoint_mode'] = True
+    check = ClickhouseCheck('clickhouse', {}, [collect_schemas_instance])
+    _capture_payloads(check)
+    with _capture_all_queries(check.metadata._schema_collector) as seen_queries:
+        check.metadata._schema_collector.collect_schemas()
+
+    joined = '\n'.join(seen_queries)
+    assert "clusterAllReplicas('default', system.tables)" in joined
+    assert "clusterAllReplicas('default', system.columns)" in joined
+    assert "clusterAllReplicas('default', system.view_refreshes)" in joined
+
+
+def test_build_match_clauses_empty_returns_empty_string():
+    assert _build_match_clauses('database', (), ()) == ''
+
+
+def test_build_match_clauses_excludes_only():
+    out = _build_match_clauses('database', (), ('tmp_.*', 'shadow_.*'))
+    assert "AND NOT match(database, 'tmp_.*')" in out
+    assert "AND NOT match(database, 'shadow_.*')" in out
+
+
+def test_build_match_clauses_includes_become_or_disjunction():
+    out = _build_match_clauses('name', ('events.*', 'orders.*'), ())
+    assert "AND (match(name, 'events.*') OR match(name, 'orders.*'))" in out
+
+
+def test_build_match_clauses_single_include_pattern():
+    out = _build_match_clauses('name', ('only_one.*',), ())
+    assert "AND (match(name, 'only_one.*'))" in out
+    assert " OR " not in out
+
+
+def test_build_match_clauses_excludes_appear_before_includes():
+    out = _build_match_clauses('database', ('keep_.*',), ('drop_.*',))
+    exclude_idx = out.find("AND NOT match(database, 'drop_.*')")
+    include_idx = out.find("AND (match(database, 'keep_.*'))")
+    assert exclude_idx >= 0 and include_idx >= 0
+    assert exclude_idx < include_idx
+
+
+def test_build_match_clauses_combines_includes_and_excludes():
+    out = _build_match_clauses('database', ('keep_.*',), ('drop_.*',))
+    assert "AND NOT match(database, 'drop_.*')" in out
+    assert "AND (match(database, 'keep_.*'))" in out
+
+
+def test_build_match_clauses_escapes_single_quotes():
+    out = _build_match_clauses('database', (), ("o'reilly_.*",))
+    assert "AND NOT match(database, 'o''reilly_.*')" in out
+
+
+def test_database_filters_appear_in_combined_query(collect_schemas_instance):
+    collect_schemas_instance['collect_schemas']['exclude_databases'] = ['tmp_.*']
+    collect_schemas_instance['collect_schemas']['include_databases'] = ['keep_.*']
+    check = ClickhouseCheck('clickhouse', {}, [collect_schemas_instance])
+    _capture_payloads(check)
+    with _capture_all_queries(check.metadata._schema_collector) as seen_queries:
+        check.metadata._schema_collector.collect_schemas()
+
+    combined_query = next(q for q in seen_queries if 'FROM system.tables' in q)
+    assert "AND NOT match(database, 'tmp_.*')" in combined_query
+    assert "AND (match(database, 'keep_.*'))" in combined_query
+
+
+def test_table_filters_appear_in_combined_query(collect_schemas_instance):
+    collect_schemas_instance['collect_schemas']['include_tables'] = ['events.*']
+    collect_schemas_instance['collect_schemas']['exclude_tables'] = ['tmp_.*']
+    check = ClickhouseCheck('clickhouse', {}, [collect_schemas_instance])
+    _capture_payloads(check)
+    with _capture_all_queries(check.metadata._schema_collector) as seen_queries:
+        check.metadata._schema_collector.collect_schemas()
+
+    combined_query = next(q for q in seen_queries if 'FROM system.tables' in q)
+    assert "AND NOT match(name, 'tmp_.*')" in combined_query
+    assert "AND (match(name, 'events.*'))" in combined_query
+
+
+def test_all_cluster_fanout_queries_dedupe_replica_rows(check):
+    """Every query that hits a system table needs LIMIT 1 BY to prevent replica fan-out duplicates."""
+    _capture_payloads(check)
+    with _capture_all_queries(check.metadata._schema_collector) as seen_queries:
+        check.metadata._schema_collector.collect_schemas()
+
+    refreshes_query = next(q for q in seen_queries if 'system.view_refreshes' in q)
+    combined_query = next(q for q in seen_queries if 'FROM system.tables' in q)
+
+    assert 'LIMIT 1 BY (database, view)' in refreshes_query
+    assert 'LIMIT 1 BY (database, name)' in combined_query
+    assert 'LIMIT 1 BY (database, table, name)' in combined_query
+
+
+def test_system_databases_excluded_from_all_queries(collect_schemas_instance):
+    """All cluster-wide queries hard-exclude ClickHouse's internal databases."""
+    check = ClickhouseCheck('clickhouse', {}, [collect_schemas_instance])
+    _capture_payloads(check)
+    with _capture_all_queries(check.metadata._schema_collector) as seen_queries:
+        check.metadata._schema_collector.collect_schemas()
+
+    for kw in ('system.tables', 'system.columns', 'system.view_refreshes'):
+        q = next(q for q in seen_queries if kw in q)
+        assert "database NOT IN (" in q
+
+
+def test_collect_uses_local_system_tables_in_direct_mode(check):
+    _capture_payloads(check)
+    with _capture_all_queries(check.metadata._schema_collector) as seen_queries:
+        check.metadata._schema_collector.collect_schemas()
+
+    joined = '\n'.join(seen_queries)
+    assert 'clusterAllReplicas' not in joined
+    assert 'FROM system.tables' in joined
+    assert 'FROM system.columns' in joined
+    assert 'FROM system.view_refreshes' in joined

--- a/clickhouse/tests/test_metadata_integration.py
+++ b/clickhouse/tests/test_metadata_integration.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 
 import clickhouse_connect
 import pytest
+
 from datadog_checks.base.utils.db.utils import DBMAsyncJob
 from datadog_checks.clickhouse import ClickhouseCheck
 

--- a/clickhouse/tests/test_metadata_integration.py
+++ b/clickhouse/tests/test_metadata_integration.py
@@ -6,7 +6,6 @@ from copy import deepcopy
 
 import clickhouse_connect
 import pytest
-
 from datadog_checks.base.utils.db.utils import DBMAsyncJob
 from datadog_checks.clickhouse import ClickhouseCheck
 
@@ -261,6 +260,56 @@ def test_metadata_disabled_emits_no_payload(aggregator, instance, dd_run_check):
     assert _catalog_events(aggregator) == [], (
         'Expected no clickhouse_databases payload when collect_schemas is disabled'
     )
+
+
+def test_metadata_exclude_tables_filter(aggregator, metadata_instance, dd_run_check):
+    client = _client(metadata_instance)
+    table_keep = 'dd_md_filter_keep'
+    table_drop = 'dd_md_filter_drop'
+    try:
+        for t in (table_keep, table_drop):
+            client.command(f'DROP TABLE IF EXISTS default.{t}')
+            client.command(f'CREATE TABLE default.{t} (id UInt64) ENGINE = MergeTree ORDER BY id')
+
+        instance = deepcopy(metadata_instance)
+        instance['collect_schemas']['exclude_tables'] = [f'^{table_drop}$']
+
+        check = ClickhouseCheck('clickhouse', {}, [instance])
+        dd_run_check(check)
+
+        db = _find_database(_catalog_events(aggregator), 'default')
+        assert db is not None
+        table_names = {t['name'] for t in db['tables']}
+        assert table_keep in table_names
+        assert table_drop not in table_names
+    finally:
+        for t in (table_keep, table_drop):
+            client.command(f'DROP TABLE IF EXISTS default.{t} SYNC')
+
+
+def test_metadata_include_tables_filter(aggregator, metadata_instance, dd_run_check):
+    client = _client(metadata_instance)
+    table_included = 'dd_md_include_target'
+    table_other = 'dd_md_include_other'
+    try:
+        for t in (table_included, table_other):
+            client.command(f'DROP TABLE IF EXISTS default.{t}')
+            client.command(f'CREATE TABLE default.{t} (id UInt64) ENGINE = MergeTree ORDER BY id')
+
+        instance = deepcopy(metadata_instance)
+        instance['collect_schemas']['include_tables'] = [f'^{table_included}$']
+
+        check = ClickhouseCheck('clickhouse', {}, [instance])
+        dd_run_check(check)
+
+        db = _find_database(_catalog_events(aggregator), 'default')
+        assert db is not None
+        table_names = {t['name'] for t in db['tables']}
+        assert table_included in table_names
+        assert table_other not in table_names
+    finally:
+        for t in (table_included, table_other):
+            client.command(f'DROP TABLE IF EXISTS default.{t} SYNC')
 
 
 @pytest.mark.skipif(

--- a/clickhouse/tests/test_metadata_integration.py
+++ b/clickhouse/tests/test_metadata_integration.py
@@ -1,0 +1,310 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from concurrent.futures.thread import ThreadPoolExecutor
+from copy import deepcopy
+
+import clickhouse_connect
+import pytest
+
+from datadog_checks.base.utils.db.utils import DBMAsyncJob
+from datadog_checks.clickhouse import ClickhouseCheck
+
+from .common import CLICKHOUSE_VERSION
+
+UNSUPPORTED_VERSIONS = {'18', '19', '20', '21.8', '22.7'}
+NO_VIEW_REFRESHES_VERSIONS = UNSUPPORTED_VERSIONS | {'23.2', '23.8'}
+
+
+def _is_supported():
+    if CLICKHOUSE_VERSION == 'latest':
+        return True
+    return CLICKHOUSE_VERSION not in UNSUPPORTED_VERSIONS
+
+
+def _supports_view_refreshes():
+    if CLICKHOUSE_VERSION == 'latest':
+        return True
+    return CLICKHOUSE_VERSION not in NO_VIEW_REFRESHES_VERSIONS
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.usefixtures('dd_environment'),
+    pytest.mark.skipif(
+        not _is_supported(),
+        reason='metadata collection requires DBM support (ClickHouse 21.8+)',
+    ),
+]
+
+
+@pytest.fixture
+def metadata_instance(instance):
+    instance['dbm'] = True
+    instance['collect_schemas'] = {
+        'enabled': True,
+        'run_sync': True,
+        'collection_interval': 60,
+        'max_tables': 5000,
+        'max_columns': 1000,
+    }
+    instance['schema_metrics'] = {
+        'enabled': True,
+        'run_sync': True,
+        'collection_interval': 60,
+    }
+    instance['query_metrics'] = {'enabled': False}
+    instance['query_samples'] = {'enabled': False}
+    instance['query_completions'] = {'enabled': False}
+    instance['query_errors'] = {'enabled': False}
+    instance['parts_and_merges'] = {'enabled': False}
+    return instance
+
+
+@pytest.fixture(autouse=True)
+def stop_orphaned_threads():
+    DBMAsyncJob.executor.shutdown(wait=True)
+    DBMAsyncJob.executor = ThreadPoolExecutor()
+
+
+def _client(instance_config):
+    return clickhouse_connect.get_client(
+        host=instance_config['server'],
+        port=instance_config['port'],
+        username=instance_config['username'],
+        password=instance_config['password'],
+    )
+
+
+def _catalog_events(aggregator):
+    return [e for e in aggregator.get_event_platform_events('dbm-metadata') if e.get('kind') == 'clickhouse_databases']
+
+
+def _databases(catalog_events):
+    out = []
+    for ev in catalog_events:
+        out.extend(ev.get('metadata') or [])
+    return out
+
+
+def _merged_database(catalog_events, name):
+    """Merge every per-row entry for `name` across events into one dict.
+
+    SchemaCollector emits one DatabaseObject per table/view; the same database
+    name appears multiple times across chunks. The backend dedupes on its side;
+    tests need to do the same to assert on the full set of tables/views.
+    """
+    tables: list[dict] = []
+    views: list[dict] = []
+    found = False
+    for db in _databases(catalog_events):
+        if db.get('name') != name:
+            continue
+        found = True
+        tables.extend(db.get('tables') or [])
+        views.extend(db.get('views') or [])
+    if not found:
+        return None
+    return {'name': name, 'tables': tables, 'views': views}
+
+
+_find_database = _merged_database
+
+
+def test_metadata_payload_emitted(aggregator, metadata_instance, dd_run_check):
+    client = _client(metadata_instance)
+    table = 'dd_md_payload_test'
+    try:
+        client.command(f'DROP TABLE IF EXISTS default.{table}')
+        client.command(f'CREATE TABLE default.{table} (id UInt64, ts DateTime) ENGINE = MergeTree ORDER BY id')
+
+        check = ClickhouseCheck('clickhouse', {}, [metadata_instance])
+        check.check_id = 'test-collector-id'
+        dd_run_check(check)
+
+        events = _catalog_events(aggregator)
+        assert events, 'Expected at least one clickhouse_databases event on dbm-metadata'
+
+        ev = events[-1]
+        assert ev['dbms'] == 'clickhouse'
+        assert ev['database_instance']
+        assert ev['agent_version']
+        assert ev['collection_started_at'] > 0
+        assert ev['collection_payloads_count'] == 1
+        assert ev['collector_id'] == 'test-collector-id'
+        assert ev['timestamp'] > 0
+
+        db = _find_database(events, 'default')
+        assert db is not None, "Expected the 'default' database to be present in payload"
+        assert any(t['name'] == table for t in db['tables']), (
+            f'Expected table {table} in catalog payload; got: {[t["name"] for t in db["tables"]]}'
+        )
+    finally:
+        client.command(f'DROP TABLE IF EXISTS default.{table} SYNC')
+
+
+def test_metadata_columns_collected(aggregator, metadata_instance, dd_run_check):
+    client = _client(metadata_instance)
+    table = 'dd_md_columns_test'
+    try:
+        client.command(f'DROP TABLE IF EXISTS default.{table}')
+        client.command(
+            f'CREATE TABLE default.{table} ('
+            'id UInt64, '
+            'event_name String, '
+            'created_at DateTime DEFAULT now()'
+            ') ENGINE = MergeTree ORDER BY id'
+        )
+
+        check = ClickhouseCheck('clickhouse', {}, [metadata_instance])
+        dd_run_check(check)
+
+        events = _catalog_events(aggregator)
+        db = _find_database(events, 'default')
+        assert db is not None
+
+        target = next((t for t in db['tables'] if t['name'] == table), None)
+        assert target is not None, f'Expected {table} in tables, got {[t["name"] for t in db["tables"]]}'
+
+        col_names = [c['name'] for c in target['columns']]
+        assert col_names == ['id', 'event_name', 'created_at'], col_names
+
+        types = {c['name']: c['type'] for c in target['columns']}
+        assert types['id'] == 'UInt64'
+        assert types['event_name'] == 'String'
+
+        defaults = {c['name']: c['default'] for c in target['columns']}
+        assert defaults['created_at'], 'DEFAULT expression should round-trip into payload'
+    finally:
+        client.command(f'DROP TABLE IF EXISTS default.{table} SYNC')
+
+
+def test_metadata_materialized_view_with_target(aggregator, metadata_instance, dd_run_check):
+    client = _client(metadata_instance)
+    src = 'dd_md_mv_src'
+    target = 'dd_md_mv_target'
+    mv = 'dd_md_mv_view'
+    try:
+        for obj in (mv, target, src):
+            client.command(f'DROP TABLE IF EXISTS default.{obj}')
+
+        client.command(f'CREATE TABLE default.{src} (id UInt64, val UInt64) ENGINE = MergeTree ORDER BY id')
+        client.command(f'CREATE TABLE default.{target} (id UInt64, total UInt64) ENGINE = MergeTree ORDER BY id')
+        client.command(
+            f'CREATE MATERIALIZED VIEW default.{mv} TO default.{target} AS SELECT id, val AS total FROM default.{src}'
+        )
+
+        check = ClickhouseCheck('clickhouse', {}, [metadata_instance])
+        dd_run_check(check)
+
+        events = _catalog_events(aggregator)
+        db = _find_database(events, 'default')
+        assert db is not None
+
+        view = next((v for v in db['views'] if v['name'] == mv), None)
+        assert view is not None, f'Expected view {mv} in payload; got: {[v["name"] for v in db["views"]]}'
+        assert view['engine'] == 'MaterializedView'
+        assert view['create_query']
+        assert f'TO default.{target}' in view['create_query']
+        assert f'FROM default.{src}' in view['create_query']
+    finally:
+        for obj in (mv, target, src):
+            client.command(f'DROP TABLE IF EXISTS default.{obj} SYNC')
+
+
+def test_metadata_emits_per_table_size_gauges(aggregator, metadata_instance, dd_run_check):
+    client = _client(metadata_instance)
+    table = 'dd_md_size_gauge_test'
+    try:
+        client.command(f'DROP TABLE IF EXISTS default.{table}')
+        client.command(f'CREATE TABLE default.{table} (id UInt64) ENGINE = MergeTree ORDER BY id')
+        client.command(f'INSERT INTO default.{table} SELECT number FROM numbers(100)')
+
+        check = ClickhouseCheck('clickhouse', {}, [metadata_instance])
+        dd_run_check(check)
+
+        required_tags = {'db:default', f'table:{table}'}
+
+        rows_metrics = [m for m in aggregator.metrics('clickhouse.table.rows') if required_tags.issubset(set(m.tags))]
+        assert rows_metrics, (
+            f'Expected clickhouse.table.rows for {table}. '
+            f'Got: {[(m.value, sorted(m.tags)) for m in aggregator.metrics("clickhouse.table.rows")]}'
+        )
+        assert rows_metrics[0].value == 100
+
+        bytes_metrics = [m for m in aggregator.metrics('clickhouse.table.bytes') if required_tags.issubset(set(m.tags))]
+        assert bytes_metrics, 'Expected clickhouse.table.bytes gauge'
+        assert bytes_metrics[0].value > 0
+    finally:
+        client.command(f'DROP TABLE IF EXISTS default.{table} SYNC')
+
+
+def test_metadata_skips_system_databases(aggregator, metadata_instance, dd_run_check):
+    check = ClickhouseCheck('clickhouse', {}, [metadata_instance])
+    dd_run_check(check)
+
+    db_names = {db['name'] for db in _databases(_catalog_events(aggregator))}
+    forbidden = {'system', 'INFORMATION_SCHEMA', 'information_schema'}
+    leaked = db_names & forbidden
+    assert not leaked, f'System databases leaked into payload: {leaked}'
+
+
+def test_metadata_disabled_emits_no_payload(aggregator, instance, dd_run_check):
+    instance_config = deepcopy(instance)
+    instance_config['dbm'] = True
+    instance_config['collect_schemas'] = {'enabled': False, 'collection_interval': 60}
+
+    check = ClickhouseCheck('clickhouse', {}, [instance_config])
+    assert check.metadata is None
+    dd_run_check(check)
+
+    assert _catalog_events(aggregator) == [], (
+        'Expected no clickhouse_databases payload when collect_schemas is disabled'
+    )
+
+
+@pytest.mark.skipif(
+    not _supports_view_refreshes(),
+    reason='system.view_refreshes requires ClickHouse 24.3+',
+)
+def test_metadata_refreshable_view_status_populated(aggregator, metadata_instance, dd_run_check):
+    client = _client(metadata_instance)
+    src = 'dd_md_refresh_src'
+    target = 'dd_md_refresh_target'
+    mv = 'dd_md_refreshable_mv'
+    try:
+        for obj in (mv, target, src):
+            client.command(f'DROP TABLE IF EXISTS default.{obj}')
+
+        client.command(f'CREATE TABLE default.{src} (id UInt64, val UInt64) ENGINE = MergeTree ORDER BY id')
+        client.command(f'CREATE TABLE default.{target} (id UInt64, total UInt64) ENGINE = MergeTree ORDER BY id')
+        client.command(
+            f'CREATE MATERIALIZED VIEW default.{mv} REFRESH EVERY 1 HOUR '
+            f'TO default.{target} AS SELECT id, val AS total FROM default.{src}',
+            settings={'allow_experimental_refreshable_materialized_view': 1},
+        )
+
+        check = ClickhouseCheck('clickhouse', {}, [metadata_instance])
+        check.check_id = 'test-collector-id'
+        dd_run_check(check)
+
+        events = _catalog_events(aggregator)
+        db = _find_database(events, 'default')
+        assert db is not None
+
+        view = next((v for v in db['views'] if v['name'] == mv), None)
+        assert view is not None, f'Expected refreshable view {mv} in payload'
+        assert view['is_refreshable'] is True
+
+        required_tags = {'db:default', f'view:{mv}'}
+        status_metrics = [
+            m for m in aggregator.metrics('clickhouse.view.refresh.status') if required_tags.issubset(set(m.tags))
+        ]
+        assert status_metrics, f'Expected clickhouse.view.refresh.status for {mv}'
+        next_time_metrics = [
+            m for m in aggregator.metrics('clickhouse.view.refresh.next_time') if required_tags.issubset(set(m.tags))
+        ]
+        assert next_time_metrics, f'Expected clickhouse.view.refresh.next_time for {mv}'
+    finally:
+        for obj in (mv, target, src):
+            client.command(f'DROP TABLE IF EXISTS default.{obj} SYNC')

--- a/clickhouse/tests/test_table_metrics.py
+++ b/clickhouse/tests/test_table_metrics.py
@@ -15,18 +15,6 @@ def _table_size_row(database='default', name='events', total_rows=1000, total_by
     return (database, name, total_rows, total_bytes)
 
 
-def _refresh_row(
-    database='default',
-    view='events_mv',
-    status='Ok',
-    last_refresh_time=1700001000,
-    next_refresh_time=1700001600,
-    written_rows=10,
-    written_bytes=512,
-):
-    return (database, view, status, last_refresh_time, next_refresh_time, written_rows, written_bytes)
-
-
 @pytest.fixture
 def schema_metrics_instance():
     return {
@@ -46,13 +34,10 @@ def check(schema_metrics_instance):
     return ClickhouseCheck('clickhouse', {}, [schema_metrics_instance])
 
 
-def _patch_query(job, table_rows=None, refresh_rows=None):
+def _patch_query(job, table_rows=None):
     table_rows = table_rows or []
-    refresh_rows = refresh_rows or []
 
     def fake_query(query):
-        if 'view_refreshes' in query:
-            return refresh_rows
         return table_rows
 
     return mock.patch.object(job, '_execute_query', side_effect=fake_query)
@@ -119,41 +104,6 @@ def test_run_job_emits_table_size_gauges(check):
     assert 'table:events' in tags
 
 
-def test_run_job_emits_view_refresh_gauges(check):
-    job = check.table_metrics
-    emitted = []
-    check.gauge = lambda name, value, tags=None: emitted.append((name, value, tags))
-
-    with _patch_query(
-        job,
-        refresh_rows=[
-            _refresh_row(status='Ok', last_refresh_time=100, next_refresh_time=700, written_rows=5, written_bytes=50)
-        ],
-    ):
-        job.run_job()
-
-    by_name = {n: (v, t) for n, v, t in emitted}
-    assert by_name['view.refresh.last_time'][0] == 100
-    assert by_name['view.refresh.next_time'][0] == 700
-    assert by_name['view.refresh.rows'][0] == 5
-    assert by_name['view.refresh.bytes'][0] == 50
-    status_tags = by_name['view.refresh.status'][1]
-    assert 'status:Ok' in status_tags
-    assert 'view:events_mv' in status_tags
-
-
-def test_run_job_view_refresh_unknown_status(check):
-    job = check.table_metrics
-    emitted = []
-    check.gauge = lambda name, value, tags=None: emitted.append((name, value, tags))
-
-    with _patch_query(job, refresh_rows=[_refresh_row(status=None)]):
-        job.run_job()
-
-    status_tags = next(t for n, _, t in emitted if n == 'view.refresh.status')
-    assert 'status:Unknown' in status_tags
-
-
 def test_run_job_dedupes_duplicate_table_rows(check):
     job = check.table_metrics
     emitted = []
@@ -165,48 +115,6 @@ def test_run_job_dedupes_duplicate_table_rows(check):
 
     rows_emissions = [m for m in emitted if m[0] == 'table.rows']
     assert len(rows_emissions) == 1
-
-
-def test_run_job_dedupes_duplicate_view_refresh_rows(check):
-    job = check.table_metrics
-    emitted = []
-    check.gauge = lambda name, value, tags=None: emitted.append((name, value, tags))
-
-    row = _refresh_row(view='events_mv')
-    with _patch_query(job, refresh_rows=[row, row, row]):
-        job.run_job()
-
-    status_emissions = [m for m in emitted if m[0] == 'view.refresh.status']
-    assert len(status_emissions) == 1
-
-
-def test_view_refreshes_unknown_table_logs_once(check):
-    job = check.table_metrics
-    job._log = mock.MagicMock()
-    check.gauge = lambda *a, **kw: None
-    with mock.patch.object(job, '_execute_query', side_effect=Exception('Unknown table system.view_refreshes')):
-        job._emit_view_refresh_gauges()
-        job._emit_view_refresh_gauges()
-    assert len(job._log.info.call_args_list) == 1
-
-
-def test_view_refreshes_permission_denied_logs_once(check):
-    job = check.table_metrics
-    job._log = mock.MagicMock()
-    check.gauge = lambda *a, **kw: None
-    with mock.patch.object(job, '_execute_query', side_effect=Exception('Not enough privileges')):
-        job._emit_view_refresh_gauges()
-        job._emit_view_refresh_gauges()
-    assert len(job._log.warning.call_args_list) == 1
-
-
-def test_view_refreshes_unexpected_error_logs_exception(check):
-    job = check.table_metrics
-    job._log = mock.MagicMock()
-    check.gauge = lambda *a, **kw: None
-    with mock.patch.object(job, '_execute_query', side_effect=Exception('boom')):
-        job._emit_view_refresh_gauges()
-    job._log.exception.assert_called_once()
 
 
 def test_cancel_closes_db_client(check):
@@ -235,4 +143,3 @@ def test_routes_through_cluster_all_replicas_in_single_endpoint_mode(schema_metr
 
     joined = '\n'.join(seen_queries)
     assert "clusterAllReplicas('default', system.tables)" in joined
-    assert "clusterAllReplicas('default', system.view_refreshes)" in joined

--- a/clickhouse/tests/test_table_metrics.py
+++ b/clickhouse/tests/test_table_metrics.py
@@ -1,0 +1,238 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from unittest import mock
+
+import pytest
+
+from datadog_checks.clickhouse import ClickhouseCheck
+from datadog_checks.clickhouse.table_metrics import ClickhouseTableMetrics
+
+pytestmark = pytest.mark.unit
+
+
+def _table_size_row(database='default', name='events', total_rows=1000, total_bytes=2048):
+    return (database, name, total_rows, total_bytes)
+
+
+def _refresh_row(
+    database='default',
+    view='events_mv',
+    status='Ok',
+    last_refresh_time=1700001000,
+    next_refresh_time=1700001600,
+    written_rows=10,
+    written_bytes=512,
+):
+    return (database, view, status, last_refresh_time, next_refresh_time, written_rows, written_bytes)
+
+
+@pytest.fixture
+def schema_metrics_instance():
+    return {
+        'server': 'localhost',
+        'port': 9000,
+        'username': 'default',
+        'password': '',
+        'db': 'default',
+        'dbm': True,
+        'schema_metrics': {'enabled': True, 'collection_interval': 60, 'run_sync': True},
+        'tags': ['test:clickhouse'],
+    }
+
+
+@pytest.fixture
+def check(schema_metrics_instance):
+    return ClickhouseCheck('clickhouse', {}, [schema_metrics_instance])
+
+
+def _patch_query(job, table_rows=None, refresh_rows=None):
+    table_rows = table_rows or []
+    refresh_rows = refresh_rows or []
+
+    def fake_query(query):
+        if 'view_refreshes' in query:
+            return refresh_rows
+        return table_rows
+
+    return mock.patch.object(job, '_execute_query', side_effect=fake_query)
+
+
+def test_initialization(check):
+    assert isinstance(check.table_metrics, ClickhouseTableMetrics)
+    assert check.table_metrics._collection_interval == 60
+
+
+def test_default_disabled_when_dbm_on():
+    check = ClickhouseCheck('clickhouse', {}, [{'server': 'localhost', 'dbm': True}])
+    assert check.table_metrics is None
+
+
+def test_disabled_when_dbm_off():
+    check = ClickhouseCheck(
+        'clickhouse',
+        {},
+        [{'server': 'localhost', 'dbm': False, 'schema_metrics': {'enabled': True}}],
+    )
+    assert check.table_metrics is None
+
+
+def test_disabled_when_explicitly_opted_out():
+    check = ClickhouseCheck(
+        'clickhouse',
+        {},
+        [{'server': 'localhost', 'dbm': True, 'schema_metrics': {'enabled': False}}],
+    )
+    assert check.table_metrics is None
+
+
+@pytest.mark.parametrize('bad_value', [None, 0, -1])
+def test_init_falls_back_when_collection_interval_is_invalid(bad_value):
+    check = ClickhouseCheck(
+        'clickhouse',
+        {},
+        [
+            {
+                'server': 'localhost',
+                'dbm': True,
+                'schema_metrics': {'enabled': True, 'collection_interval': bad_value},
+            }
+        ],
+    )
+    assert check.table_metrics is not None
+    assert check.table_metrics._collection_interval == 60
+
+
+def test_run_job_emits_table_size_gauges(check):
+    job = check.table_metrics
+    emitted = []
+    check.gauge = lambda name, value, tags=None: emitted.append((name, value, tags))
+
+    with _patch_query(job, table_rows=[_table_size_row(name='events', total_rows=1000, total_bytes=2048)]):
+        job.run_job()
+
+    by_name = {n: (v, t) for n, v, t in emitted}
+    assert by_name['table.rows'][0] == 1000
+    assert by_name['table.bytes'][0] == 2048
+    tags = by_name['table.rows'][1]
+    assert 'db:default' in tags
+    assert 'table:events' in tags
+
+
+def test_run_job_emits_view_refresh_gauges(check):
+    job = check.table_metrics
+    emitted = []
+    check.gauge = lambda name, value, tags=None: emitted.append((name, value, tags))
+
+    with _patch_query(
+        job,
+        refresh_rows=[
+            _refresh_row(status='Ok', last_refresh_time=100, next_refresh_time=700, written_rows=5, written_bytes=50)
+        ],
+    ):
+        job.run_job()
+
+    by_name = {n: (v, t) for n, v, t in emitted}
+    assert by_name['view.refresh.last_time'][0] == 100
+    assert by_name['view.refresh.next_time'][0] == 700
+    assert by_name['view.refresh.rows'][0] == 5
+    assert by_name['view.refresh.bytes'][0] == 50
+    status_tags = by_name['view.refresh.status'][1]
+    assert 'status:Ok' in status_tags
+    assert 'view:events_mv' in status_tags
+
+
+def test_run_job_view_refresh_unknown_status(check):
+    job = check.table_metrics
+    emitted = []
+    check.gauge = lambda name, value, tags=None: emitted.append((name, value, tags))
+
+    with _patch_query(job, refresh_rows=[_refresh_row(status=None)]):
+        job.run_job()
+
+    status_tags = next(t for n, _, t in emitted if n == 'view.refresh.status')
+    assert 'status:Unknown' in status_tags
+
+
+def test_run_job_dedupes_duplicate_table_rows(check):
+    job = check.table_metrics
+    emitted = []
+    check.gauge = lambda name, value, tags=None: emitted.append((name, value, tags))
+
+    row = _table_size_row(name='events')
+    with _patch_query(job, table_rows=[row, row, row]):
+        job.run_job()
+
+    rows_emissions = [m for m in emitted if m[0] == 'table.rows']
+    assert len(rows_emissions) == 1
+
+
+def test_run_job_dedupes_duplicate_view_refresh_rows(check):
+    job = check.table_metrics
+    emitted = []
+    check.gauge = lambda name, value, tags=None: emitted.append((name, value, tags))
+
+    row = _refresh_row(view='events_mv')
+    with _patch_query(job, refresh_rows=[row, row, row]):
+        job.run_job()
+
+    status_emissions = [m for m in emitted if m[0] == 'view.refresh.status']
+    assert len(status_emissions) == 1
+
+
+def test_view_refreshes_unknown_table_logs_once(check):
+    job = check.table_metrics
+    job._log = mock.MagicMock()
+    check.gauge = lambda *a, **kw: None
+    with mock.patch.object(job, '_execute_query', side_effect=Exception('Unknown table system.view_refreshes')):
+        job._emit_view_refresh_gauges()
+        job._emit_view_refresh_gauges()
+    assert len(job._log.info.call_args_list) == 1
+
+
+def test_view_refreshes_permission_denied_logs_once(check):
+    job = check.table_metrics
+    job._log = mock.MagicMock()
+    check.gauge = lambda *a, **kw: None
+    with mock.patch.object(job, '_execute_query', side_effect=Exception('Not enough privileges')):
+        job._emit_view_refresh_gauges()
+        job._emit_view_refresh_gauges()
+    assert len(job._log.warning.call_args_list) == 1
+
+
+def test_view_refreshes_unexpected_error_logs_exception(check):
+    job = check.table_metrics
+    job._log = mock.MagicMock()
+    check.gauge = lambda *a, **kw: None
+    with mock.patch.object(job, '_execute_query', side_effect=Exception('boom')):
+        job._emit_view_refresh_gauges()
+    job._log.exception.assert_called_once()
+
+
+def test_cancel_closes_db_client(check):
+    job = check.table_metrics
+    fake_client = mock.MagicMock()
+    job._db_client = fake_client
+
+    job.cancel()
+
+    assert job._db_client is None
+    fake_client.close.assert_called_once()
+
+
+def test_routes_through_cluster_all_replicas_in_single_endpoint_mode(schema_metrics_instance):
+    schema_metrics_instance['single_endpoint_mode'] = True
+    check = ClickhouseCheck('clickhouse', {}, [schema_metrics_instance])
+    seen_queries = []
+
+    def fake_query(query):
+        seen_queries.append(query)
+        return []
+
+    check.gauge = lambda *a, **kw: None
+    with mock.patch.object(check.table_metrics, '_execute_query', side_effect=fake_query):
+        check.table_metrics.run_job()
+
+    joined = '\n'.join(seen_queries)
+    assert "clusterAllReplicas('default', system.tables)" in joined
+    assert "clusterAllReplicas('default', system.view_refreshes)" in joined


### PR DESCRIPTION
### What does this PR do?

Adds an opt-in ClickHouse catalog collector to Database Monitoring. Each cycle the agent reads `system.tables`, `system.columns`, and `system.view_refreshes` (ClickHouse 24.3+) and emits a single payload describing each database with its tables, views, and columns, plus per-table size gauges and per-view refresh-status gauges.

### Motivation

Surfaces materialized views and table schemas as first-class resources in DBM so customers can browse their catalog (DDL, column definitions, refresh status, source/target lineage) and alert on refresh failures.

### Highlights

- Opt-in via `collect_schemas.enabled` (off by default). Defaults: `max_tables: 300`, `max_columns: 1000`, `collection_interval: 600s`.
- Catalog queries joined client-side; deduplicated by `(database, name)` to keep `clusterAllReplicas` fan-out from inflating the payload.
- View refresh status (`Scheduled` / `Running` / `Exception` / `Disabled` / etc.) pulled from `system.view_refreshes` on ClickHouse 24.3+. Older servers or missing privileges degrade silently, logged once per agent process.
- New metrics: `clickhouse.table.rows`, `clickhouse.table.bytes`, `clickhouse.view.refresh.status`, `clickhouse.view.refresh.last_time`, `clickhouse.view.refresh.next_time`, `clickhouse.view.refresh.rows`, `clickhouse.view.refresh.bytes`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
