### PR TITLE
[AI-6672] Polish NiFi README for release

### DIFF
--- a/nifi/README.md
+++ b/nifi/README.md
@@ -4,7 +4,17 @@
 
 This check monitors [Apache NiFi][1] through the Datadog Agent.
 
-Apache NiFi is a data integration and automation platform for moving data between systems. This integration collects JVM health, flow throughput, queue backpressure, processor status, and bulletin events from the NiFi REST API, providing visibility into data pipeline health without requiring NiFi-side configuration.
+Apache NiFi is an open-source platform for routing, transforming, and automating data flow between systems. This check collects JVM health, flow throughput, queue backpressure, processor status, and bulletin events from the NiFi REST API. No NiFi-side reporting task or JMX exporter is required.
+
+With the Datadog NiFi integration, you can:
+
+- Monitor JVM memory, garbage collection, and thread activity.
+- Track flow throughput, queued flowfiles, and backpressure across process groups.
+- Surface processor status at configurable cardinality, with opt-in per-processor and per-connection metrics.
+- Receive NiFi bulletins (errors and warnings) as Datadog events.
+- Collect application, user, bootstrap, and request logs.
+
+**Minimum Agent version:** <!-- TODO(AI-6674): set to the first Agent release that ships the NiFi check before public release. -->
 
 ## Setup
 
@@ -12,14 +22,15 @@ Follow the instructions below to install and configure this check for an Agent r
 
 ### Installation
 
-The NiFi check is included in the [Datadog Agent][2] package.
-No additional installation is needed on your server.
+The NiFi check is included in the [Datadog Agent][2] package. No additional installation is needed on your server.
 
 ### Configuration
 
-1. Edit the `nifi.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your NiFi performance data. See the [sample nifi.d/conf.yaml][4] for all available configuration options.
+#### Host
 
-2. At minimum, configure the `api_url`, `username`, and `password`:
+1. Edit the `nifi.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample nifi.d/conf.yaml][4] for all available configuration options.
+
+2. At minimum, configure `api_url`, `username`, and `password`:
 
    ```yaml
    instances:
@@ -31,6 +42,28 @@ No additional installation is needed on your server.
 
 3. [Restart the Agent][5].
 
+#### Containerized (Autodiscovery)
+
+For containerized NiFi, apply the following annotations to the NiFi pod. Adjust the container name in the annotation key to match your deployment.
+
+```yaml
+ad.datadoghq.com/nifi.checks: |
+  {
+    "nifi": {
+      "instances": [
+        {
+          "api_url": "https://%%host%%:8443/nifi-api",
+          "username": "<NIFI_USERNAME>",
+          "password": "<NIFI_PASSWORD>",
+          "tls_verify": true
+        }
+      ]
+    }
+  }
+```
+
+Store credentials in Kubernetes secrets and reference them through standard secret-injection patterns rather than inline in annotations. For more information, see the [Autodiscovery Integration Templates][3].
+
 ### Validation
 
 [Run the Agent's status subcommand][6] and look for `nifi` under the Checks section.
@@ -39,28 +72,59 @@ No additional installation is needed on your server.
 
 ### Metrics
 
-See [metadata.csv][7] for a list of metrics provided by this integration.
+See [metadata.csv][7] for a list of metrics provided by this check.
 
 Per-connection and per-processor metrics are opt-in to control cardinality. Enable them with `collect_connection_metrics: true` and `collect_processor_metrics: true`. Use `max_connections` and `max_processors` to cap the number of entities monitored.
 
 ### Events
 
-NiFi bulletins (errors and warnings from processors and system components) are forwarded as Datadog events when `collect_bulletins` is enabled (default: true). Filter by severity with `bulletin_min_level` (default: WARNING).
+NiFi bulletins (errors and warnings from processors and system components) are forwarded as Datadog events when `collect_bulletins` is enabled (default: `true`). Filter by severity with `bulletin_min_level` (default: `WARNING`).
 
 ### Service Checks
 
-The NiFi integration does not include any service checks. Connectivity is reported via the `nifi.can_connect` gauge (1 = OK, 0 = unreachable).
+The NiFi check does not include any service checks. Connectivity is reported via the `nifi.can_connect` gauge (`1` = OK, `0` = unreachable).
 
 ## Troubleshooting
 
-Need help? Contact [Datadog support][8].
+### Authentication fails (`nifi.can_connect` = 0)
+
+The check authenticates to NiFi via `POST /access/token` (JWT bearer token). If authentication fails, the Agent log records an error from the `nifi` check. Common causes:
+
+- Wrong `username` or `password`.
+- The NiFi user lacks a policy granting access to the REST API. Grant **view the UI** and **access the controller** at minimum, plus read access on the process groups the check queries.
+- The configured NiFi identity provider (LDAP, Kerberos, certificates) rejects the credentials. Confirm the credentials work against the NiFi UI first.
+
+### TLS verification errors
+
+NiFi 2.x uses HTTPS by default, and most production deployments use an internal or self-signed CA. Point the check at your CA bundle:
+
+```yaml
+tls_ca_cert: /path/to/ca.pem
+```
+
+As a last resort (not recommended for production), set `tls_verify: false`.
+
+### Missing per-connection or per-processor metrics
+
+Per-connection and per-processor metrics are opt-in. Set `collect_connection_metrics: true` and `collect_processor_metrics: true`. The check truncates output to `max_connections` and `max_processors` (default `200` each), prioritizing the busiest entities by queue depth and task count.
+
+### Still stuck?
+
+Contact [Datadog support][8].
+
+## Further Reading
+
+- [Apache NiFi REST API documentation][9]
+- [Apache NiFi System Administrator's Guide][10]
 
 
 [1]: https://nifi.apache.org/
-[2]: https://app.datadoghq.com/account/settings/agent/latest
+[2]: /account/settings/agent/latest
 [3]: https://docs.datadoghq.com/containers/kubernetes/integrations/
 [4]: https://github.com/DataDog/integrations-core/blob/master/nifi/datadog_checks/nifi/data/conf.yaml.example
 [5]: https://docs.datadoghq.com/agent/configuration/agent-commands/#start-stop-and-restart-the-agent
 [6]: https://docs.datadoghq.com/agent/configuration/agent-commands/#agent-status-and-information
 [7]: https://github.com/DataDog/integrations-core/blob/master/nifi/metadata.csv
 [8]: https://docs.datadoghq.com/help/
+[9]: https://nifi.apache.org/docs/nifi-docs/rest-api/
+[10]: https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html

--- a/nifi/README.md
+++ b/nifi/README.md
@@ -88,7 +88,7 @@ The NiFi check does not include any service checks. Connectivity is reported wit
 
 ### Authentication fails (`nifi.can_connect` = 0)
 
-The check authenticates to NiFi via `POST /access/token` (JWT bearer token). If authentication fails, the Agent log records an error from the `nifi` check. Common causes:
+The check authenticates to NiFi with `POST /access/token` (JWT bearer token). If authentication fails, the Agent log records an error from the `nifi` check. Common causes:
 
 - Wrong `username` or `password`.
 - The NiFi user lacks sufficient permissions. The check reads `/flow/about`, `/flow/status`, `/flow/cluster/summary`, `/system-diagnostics`, `/flow/bulletin-board`, and `/flow/process-groups/{id}/status`. Grant the user read access on those resources. See the [NiFi System Administrator's Guide][10] for configuring access policies.

--- a/nifi/README.md
+++ b/nifi/README.md
@@ -82,7 +82,7 @@ NiFi bulletins (errors and warnings from processors and system components) are f
 
 ### Service Checks
 
-The NiFi check does not include any service checks. Connectivity is reported via the `nifi.can_connect` gauge (`1` = OK, `0` = unreachable).
+The NiFi check does not include any service checks. Connectivity is reported with the `nifi.can_connect` gauge (`1` = OK, `0` = unreachable).
 
 ## Troubleshooting
 

--- a/nifi/README.md
+++ b/nifi/README.md
@@ -91,7 +91,7 @@ The NiFi check does not include any service checks. Connectivity is reported via
 The check authenticates to NiFi via `POST /access/token` (JWT bearer token). If authentication fails, the Agent log records an error from the `nifi` check. Common causes:
 
 - Wrong `username` or `password`.
-- The NiFi user lacks a policy granting access to the REST API. Grant **view the UI** and **access the controller** at minimum, plus read access on the process groups the check queries.
+- The NiFi user lacks sufficient permissions. The check reads `/flow/about`, `/flow/status`, `/flow/cluster/summary`, `/system-diagnostics`, `/flow/bulletin-board`, and `/flow/process-groups/{id}/status`. Grant the user read access on those resources. See the [NiFi System Administrator's Guide][10] for configuring access policies.
 - The configured NiFi identity provider (LDAP, Kerberos, certificates) rejects the credentials. Confirm the credentials work against the NiFi UI first.
 
 ### TLS verification errors

--- a/nifi/README.md
+++ b/nifi/README.md
@@ -4,7 +4,7 @@
 
 This check monitors [Apache NiFi][1] through the Datadog Agent.
 
-Apache NiFi is an open-source platform for routing, transforming, and automating data flow between systems. This check collects JVM health, flow throughput, queue backpressure, processor status, and bulletin events from the NiFi REST API. No NiFi-side reporting task or JMX exporter is required.
+Apache NiFi is an open source platform for routing, transforming, and automating data flow between systems. This check collects JVM health, flow throughput, queue backpressure, processor status, and bulletin events from the NiFi REST API. No NiFi-side reporting task or JMX exporter is required.
 
 With the Datadog NiFi integration, you can:
 


### PR DESCRIPTION
## Summary

Pre-release polish of the NiFi Agent integration README ([AI-6672](https://datadoghq.atlassian.net/browse/AI-6672)). README-only change; no code, assets, or validators touched.

### What changed
- **Overview**: added a scannable capabilities list (matching the [kuma README](https://github.com/DataDog/integrations-core/blob/master/kuma/README.md) pattern) and rewrote the lead paragraph so the real differentiator — "no NiFi-side reporting task or JMX exporter" — is up front instead of buried.
- **Minimum Agent version**: added the `**Minimum Agent version:**` line with an HTML-comment TODO placeholder pointing at [AI-6674](https://datadoghq.atlassian.net/browse/AI-6674). **This PR must not merge to a release cut until AI-6674 fills in the version** — an empty `Minimum Agent version:` line would ship to docs otherwise.
- **Configuration**: split into `#### Host` and `#### Containerized (Autodiscovery)` subsections. The AD block gives customers a drop-in pod-annotation example and steers credentials to k8s secrets rather than inline.
- **Troubleshooting**: previously just "Contact Datadog support." Now covers:
  - Authentication failures (`nifi.can_connect = 0`): `POST /access/token` token-flow explanation (verified against `nifi/datadog_checks/nifi/api.py:30`), required REST API read access on the specific endpoints the check hits, and an identity-provider sanity check.
  - TLS verification: `tls_ca_cert` for internal CAs; `tls_verify: false` only as last resort.
  - Missing per-connection / per-processor metrics: reminder they're opt-in and the `max_*` truncation behavior.
- **Further Reading**: linked Apache NiFi REST API docs and System Administrator's Guide.
- **Small prose/style fixes**:
  - Relative agent-install link (`/account/settings/agent/latest`) so it renders on `.eu`, `.gov`, and `datad0g.com`.
  - Normalized "this check" over "this integration" to match kuma convention.
  - Tightened the `conf.yaml` editing sentence; collapsed the Installation two-liner into one sentence (rendered output unchanged).
  - Backticked default values and literal return values (e.g. `` `true` ``, `` `WARNING` ``, `` `1` ``, `` `0` ``).

### Scope notes
- The log-collection README section lives on `philip.lee/AI-6669` (not yet merged). Polishing it will be a follow-up PR after AI-6669 lands.
- No changelog entry required (README-only change; per `AGENTS.md`, changelogs are required only for Python changes under `datadog_checks/`).

### Review round 1 addressed
- Dropped unverified NiFi policy names ("view the UI", "access the controller") in favor of the specific REST API endpoints the check reads, with a pointer to the admin guide.
- Verified `POST /access/token` claim against the check source before asserting it in user docs.
- Fixed a non-ASCII em-dash rejected by `ddev validate readmes`.

### Related tickets
- [AI-6672](https://datadoghq.atlassian.net/browse/AI-6672) — this ticket (README)
- [AI-6668](https://datadoghq.atlassian.net/browse/AI-6668) — initial implementation + initial README (merged in [#23110](https://github.com/DataDog/integrations-core/pull/23110))
- [AI-6669](https://datadoghq.atlassian.net/browse/AI-6669) — Logs (in progress, has additional README content)
- [AI-6674](https://datadoghq.atlassian.net/browse/AI-6674) — Pre-release (must fill in the Min Agent version before release)

## Test plan

- [x] \`ddev validate readmes nifi\` passes
- [x] Rendered diff self-reviewed on GitHub; Autodiscovery code block renders correctly
- [x] Verified the \`POST /access/token\` claim against \`nifi/datadog_checks/nifi/api.py:30\`
- [ ] **Reviewer action**: confirm AI-6674 is tracked as a blocker for the release cut so the empty \`Minimum Agent version:\` line does not ship to public docs.

[AI-6672]: https://datadoghq.atlassian.net/browse/AI-6672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AI-6674]: https://datadoghq.atlassian.net/browse/AI-6674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AI-6672]: https://datadoghq.atlassian.net/browse/AI-6672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ