### PR TITLE
Parameterize explain statement queries in postgres integration

### DIFF
--- a/postgres/changelog.d/23392.fixed
+++ b/postgres/changelog.d/23392.fixed
@@ -1,0 +1,1 @@
+Fix explain statement query construction when statement text contains dollar-quote delimiters.

--- a/postgres/datadog_checks/postgres/explain_parameterized_queries.py
+++ b/postgres/datadog_checks/postgres/explain_parameterized_queries.py
@@ -24,7 +24,7 @@ SELECT CARDINALITY(parameter_types) FROM pg_prepared_statements WHERE name = 'dd
 
 EXECUTE_PREPARED_STATEMENT_QUERY = 'EXECUTE dd_{prepared_statement}{parameters}'
 
-EXPLAIN_QUERY = 'SELECT {explain_function}($stmt${statement}$stmt$)'
+EXPLAIN_QUERY = 'SELECT {explain_function}(%s)'
 
 
 def agent_check_getter(self):
@@ -157,10 +157,8 @@ class ExplainParameterizedQueries:
             prepared_statement_query = self._generate_prepared_statement_query(conn, query_signature)
             return self._execute_query_and_fetch_rows(
                 conn,
-                EXPLAIN_QUERY.format(
-                    explain_function=self._explain_function,
-                    statement=prepared_statement_query,
-                ),
+                EXPLAIN_QUERY.format(explain_function=self._explain_function),
+                (prepared_statement_query,),
             )
         except Exception as e:
             logged_statement = obfuscated_statement
@@ -189,9 +187,9 @@ class ExplainParameterizedQueries:
             logger.debug('Executing query=[%s]', query)
             cursor.execute(query, ignore_query_metric=True)
 
-    def _execute_query_and_fetch_rows(self, conn, query):
+    def _execute_query_and_fetch_rows(self, conn, query, params=None):
         with conn.cursor() as cursor:
-            cursor.execute(query, ignore_query_metric=True)
+            cursor.execute(query, params, ignore_query_metric=True)
             return cursor.fetchall()
 
     def _is_parameterized_query(self, statement: str) -> bool:

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -725,9 +725,8 @@ class PostgresStatementSamples(DBMAsyncJob):
                     "Running query on dbname=%s: %s(%s)", dbname, self._explain_function, obfuscated_statement
                 )
                 cursor.execute(
-                    """SELECT {explain_function}($stmt${statement}$stmt$)""".format(
-                        explain_function=self._explain_function, statement=statement
-                    ),
+                    "SELECT {}(%s)".format(self._explain_function),
+                    (statement,),
                     ignore_query_metric=True,
                 )
                 result = cursor.fetchone()


### PR DESCRIPTION
## Summary

- Replace string interpolation with psycopg bound parameters when calling the explain function in `_run_explain` (`statement_samples.py`) and `_explain_prepared_statement` (`explain_parameterized_queries.py`)
- Eliminates a class of query construction issues where statement text containing the dollar-quote tag `$stmt$` would cause the SQL to be malformed, resulting in a failed explain and no execution plan being collected

## Test plan

- [x] Existing statement tests pass: `ddev test postgres:py3.13-16.0-UTF8 -- -k test_statement --skip-env`
- [x] Existing explain parameterized query tests pass: `ddev test postgres:py3.13-16.0-UTF8 -- -k test_explain_parameterized --skip-env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)