### PR TITLE
[sqlserver] Add SQL Server 2025 to supported versions

### DIFF
--- a/sqlserver/README.md
+++ b/sqlserver/README.md
@@ -8,7 +8,7 @@ The SQL Server integration tracks the performance of your SQL Server instances. 
 
 Enable [Database Monitoring](https://docs.datadoghq.com/database_monitoring/setup_sql_server/) (DBM) for enhanced insight into query performance and database health. In addition to the standard integration, Datadog DBM provides query-level metrics, live and historical query snapshots, wait event analysis, database load, query explain plans, and blocking query insights.
 
-SQL Server 2012, 2014, 2016, 2017, 2019, and 2022 are supported.
+SQL Server 2012, 2014, 2016, 2017, 2019, 2022, and 2025 are supported.
 
 **Minimum Agent version:** 6.0.0
 

--- a/sqlserver/changelog.d/23395.added
+++ b/sqlserver/changelog.d/23395.added
@@ -1,0 +1,1 @@
+Add SQL Server 2025 to list of supported versions.


### PR DESCRIPTION
## What does this PR do? What is the motivation?

Adds SQL Server 2025 to the supported versions list in the SQL Server integration README.

SQL Server 2025 support confirmed in Agent 7.79+ via [integrations-core#22794](https://github.com/DataDog/integrations-core/pull/22794). DBM-specific docs updated separately in [DataDog/documentation#36110](https://github.com/DataDog/documentation/pull/36110).

## Additional Information

Documentation-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)