### PR TITLE
Share ownership of dependency building

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,7 +17,7 @@ manifest.json         @DataDog/documentation @DataDog/agent-integrations
 
 # Dependencies
 /.deps/                            @DataDog/agent-integrations @DataDog/agent-build
-/.builders/                        @DataDog/agent-build
+/.builders/                        @DataDog/agent-integrations @DataDog/agent-build
 /.builders/images/                 @DataDog/agent-integrations @DataDog/agent-build
 /.builders/patches/                @DataDog/agent-integrations @DataDog/agent-build
 
@@ -810,7 +810,7 @@ docs/developer/process/integration-release.md                         @DataDog/a
 # As well as the pipelines.
 /.github/chainguard/                                                  @DataDog/agent-integrations
 /.github/workflows/                                                   @DataDog/agent-integrations
-/.github/workflows/resolve-build-deps.yml                             @DataDog/agent-build
+/.github/workflows/resolve-build-deps.yml                             @DataDog/agent-integrations @DataDog/agent-build
 /.gitlab-ci.yml                                                       @DataDog/agent-integrations
 /.github/CODEOWNERS                                                   @DataDog/agent-integrations @DataDog/saas-integrations
 /.github/workflows/config/labeler.yml                                 @DataDog/agent-integrations @DataDog/saas-integrations


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
#### Before
PRs changing .builders scripts and the github workflow for building dependencies would block on review from agent-build

#### After
Review from agent-integrations is enough to unblock a PR.

### Motivation
<!-- What inspired you to submit this pull request? -->
Agent ints is doing some work on this, so our knowledge is deepening and we don't want to ping agent-build for every small change.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
