### PR TITLE
Make wheel storage argument optional for disk usage commands

### DIFF
--- a/.github/workflows/measure-disk-usage-master.yml
+++ b/.github/workflows/measure-disk-usage-master.yml
@@ -16,6 +16,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.13"
+  INTEGRATIONS_WHEELS_STORAGE: "stable"
 
 jobs:
   measure-disk-usage:

--- a/ddev/src/ddev/cli/size/utils/common_params.py
+++ b/ddev/src/ddev/cli/size/utils/common_params.py
@@ -27,7 +27,7 @@ def common_params(func: Callable) -> Callable:
     @click.option(
         "--wheels-storage",
         type=click.Choice(["dev", "stable"]),
-        required=True,
+        default='dev',  # 'dev' is a strict superset of 'stable', so we're more likely to find wheels there.
         envvar="INTEGRATIONS_WHEELS_STORAGE",
         help=(
             "Which wheel storage tier to resolve dependency URLs against. "


### PR DESCRIPTION

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Also fix master workflow by pointing it explicitly at the stable storage.

Note that we're not adding a changelog entry because this tweaks an unreleased ddev change.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
