### PR TITLE
Add central workflow_run poster for PR comments

### DIFF
--- a/.github/chainguard/self.post-pr-comment.workflow-run.sts.yaml
+++ b/.github/chainguard/self.post-pr-comment.workflow-run.sts.yaml
@@ -1,0 +1,43 @@
+# Trust policy for the central PR-comment poster in DataDog/integrations-core
+#
+# This policy grants a scoped, ephemeral token for posting comments to pull
+# requests. It is only reachable from the post-pr-comment.yml workflow
+# committed to master; workflow_run always runs the default-branch version
+# of the workflow, so fork-PR modifications cannot reach this policy.
+#
+# Naming convention:
+#   self:              Only this repository (DataDog/integrations-core) can use this policy
+#   post-pr-comment:   Central poster workflow
+#   workflow-run:      Triggered by workflow_run events
+#
+# Security model:
+#   - event_name pinned to workflow_run (runs on master by design).
+#   - ref / ref_protected pinned to master so a rogue fork PR cannot mint this token
+#     even if it manages to invoke something else.
+#   - job_workflow_ref pinned to post-pr-comment.yml on master so unrelated
+#     workflow_run-triggered workflows cannot reuse this policy.
+#
+# Permissions granted:
+#   - issues: write  - Create and update PR conversation comments
+#                      (PR conversation comments use the Issues API, which is
+#                      why the GitHub App scope is issues, not pull_requests).
+#
+# Usage in workflows:
+#   - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+#     with:
+#       scope: DataDog/integrations-core
+#       policy: self.post-pr-comment.workflow-run
+
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/integrations-core:ref:refs/heads/master
+
+claim_pattern:
+  event_name: workflow_run
+  ref: refs/heads/master
+  ref_protected: "true"
+  job_workflow_ref: DataDog/integrations-core/\.github/workflows/post-pr-comment\.yml@refs/heads/master
+  repository: DataDog/integrations-core
+
+permissions:
+  issues: write

--- a/.github/chainguard/self.post-pr-comment.workflow-run.sts.yaml
+++ b/.github/chainguard/self.post-pr-comment.workflow-run.sts.yaml
@@ -18,9 +18,16 @@
 #     workflow_run-triggered workflows cannot reuse this policy.
 #
 # Permissions granted:
-#   - issues: write  - Create and update PR conversation comments
-#                      (PR conversation comments use the Issues API, which is
-#                      why the GitHub App scope is issues, not pull_requests).
+#   - issues: write        - Create and update PR conversation comments
+#                            (PR conversation comments use the Issues API, which is
+#                            why the GitHub App scope is issues, not pull_requests).
+#   - actions: read        - List and download the pr-comment artifact from the
+#                            triggering workflow_run.
+#   - pull_requests: read  - Resolve the open PR number from the workflow_run
+#                            head SHA (commits/{sha}/pulls endpoint).
+#
+# Granting reads to the STS token means the workflow uses a single ephemeral
+# credential end-to-end and never relies on GITHUB_TOKEN.
 #
 # Usage in workflows:
 #   - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
@@ -41,3 +48,5 @@ claim_pattern:
 
 permissions:
   issues: write
+  actions: read
+  pull_requests: read

--- a/.github/workflows/post-pr-comment.yml
+++ b/.github/workflows/post-pr-comment.yml
@@ -1,0 +1,127 @@
+name: 'Post PR comment'
+
+# Central privileged poster for PR comments produced by fork-safe upstream
+# workflows.
+#
+# Why this exists:
+#   pull_request events from forks cannot safely mint a writable token
+#   (attacker can modify the workflow YAML, exchange OIDC via dd-octo-sts,
+#   and get the policy-scoped token). workflow_run, in contrast, always
+#   runs the version of *this* workflow that lives on the default branch
+#   and is therefore invulnerable to fork-PR modification. The dd-octo-sts
+#   policy for this workflow pins ref=refs/heads/master, so only the
+#   master-committed version of this file can ever exchange for a token.
+#
+# Artifact contract (producer uploads; this workflow consumes):
+#   name: pr-comment
+#   files:
+#     body.md    Markdown body to post. Treated as opaque, attacker-controlled text.
+#     meta.json  {"marker": "<!-- xxx-comment -->"} — validated below.
+#
+# Trust boundaries enforced here:
+#   - PR number comes from the workflow_run event (head_sha -> commits/pulls
+#     API), never from the artifact. Prevents cross-PR comment injection.
+#   - Marker is validated against a strict regex before being used as a
+#     find-comment filter. Prevents hijacking of unrelated bot comments.
+#   - body.md is written directly to a file and passed via body-path.
+#     It is never shell-interpolated.
+#
+# Onboarding a new producer:
+#   1) Append the producer's workflow display name to on.workflow_run.workflows.
+#   2) Producer uploads an artifact matching the contract above.
+#   3) Pick a unique marker (format: "<!-- <slug>-comment -->").
+
+on:
+  workflow_run:
+    workflows:
+      - 'Validate skip QA label'
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read          # download artifact from the triggering run
+  pull-requests: read    # resolve PR number from the workflow_run head SHA
+  id-token: write        # dd-octo-sts OIDC exchange
+
+jobs:
+  post:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download comment artifact
+        id: download
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        continue-on-error: true
+        with:
+          name: pr-comment
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: pr-comment
+
+      - name: Skip if no artifact was produced
+        if: steps.download.outcome != 'success'
+        run: |
+          echo "Upstream workflow completed without a pr-comment artifact. Nothing to post."
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+        id: skip_no_artifact
+
+      - name: Validate marker
+        if: steps.skip_no_artifact.outputs.skip != 'true'
+        id: meta
+        env:
+          META_PATH: pr-comment/meta.json
+        run: |
+          set -euo pipefail
+          marker=$(python3 -c 'import json, os; print(json.load(open(os.environ["META_PATH"]))["marker"])')
+          if ! printf '%s' "$marker" | grep -Eq '^<!-- [a-z0-9][a-z0-9_-]{0,62}-comment -->$'; then
+            echo "Rejecting marker (format violation): $marker" >&2
+            exit 1
+          fi
+          # Echoing via GITHUB_OUTPUT is safe because the regex above has
+          # constrained the value to [a-z0-9_-] plus a fixed wrapper.
+          echo "marker=$marker" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve PR number from head SHA
+        if: steps.skip_no_artifact.outputs.skip != 'true'
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          number=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \
+            --jq '[.[] | select(.state == "open")][0].number // empty')
+          if [[ -z "$number" ]]; then
+            echo "No open PR matches head SHA ${HEAD_SHA}; nothing to post." >&2
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=$number" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Get token via dd-octo-sts
+        if: steps.skip_no_artifact.outputs.skip != 'true' && steps.pr.outputs.skip != 'true'
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        id: octo-sts
+        with:
+          scope: DataDog/integrations-core
+          policy: self.post-pr-comment.workflow-run
+
+      - name: Find existing comment
+        if: steps.skip_no_artifact.outputs.skip != 'true' && steps.pr.outputs.skip != 'true'
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
+        id: find_comment
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+          issue-number: ${{ steps.pr.outputs.number }}
+          body-includes: ${{ steps.meta.outputs.marker }}
+
+      - name: Post comment
+        if: steps.skip_no_artifact.outputs.skip != 'true' && steps.pr.outputs.skip != 'true'
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+          issue-number: ${{ steps.pr.outputs.number }}
+          body-path: pr-comment/body.md
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          edit-mode: replace

--- a/.github/workflows/post-pr-comment.yml
+++ b/.github/workflows/post-pr-comment.yml
@@ -56,25 +56,38 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
+      # A successful upstream run may legitimately not produce an artifact
+      # (e.g. the skip-qa producer only uploads when a comment is actually
+      # needed). Pre-check so the download step only runs when we know the
+      # artifact exists; that way a missing artifact is a clean skip rather
+      # than a failed step, and a real download failure remains a real
+      # failure we want to see.
+      - name: Check for comment artifact
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          count=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/artifacts" \
+            --jq '[.artifacts[] | select(.name == "pr-comment")] | length')
+          if [[ "$count" -eq 0 ]]; then
+            echo "Upstream run ${RUN_ID} did not upload a pr-comment artifact. Nothing to post."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Download comment artifact
-        id: download
+        if: steps.check.outputs.skip != 'true'
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
-        continue-on-error: true
         with:
           name: pr-comment
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
           path: pr-comment
 
-      - name: Skip if no artifact was produced
-        if: steps.download.outcome != 'success'
-        id: skip_no_artifact
-        run: |
-          echo "Upstream workflow completed without a pr-comment artifact. Nothing to post."
-          echo "skip=true" >> "$GITHUB_OUTPUT"
-
       - name: Derive marker and prepend to body
-        if: steps.skip_no_artifact.outputs.skip != 'true'
+        if: steps.check.outputs.skip != 'true'
         id: marker
         env:
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
@@ -96,7 +109,7 @@ jobs:
           echo "value=$marker" >> "$GITHUB_OUTPUT"
 
       - name: Resolve PR number from head SHA
-        if: steps.skip_no_artifact.outputs.skip != 'true'
+        if: steps.check.outputs.skip != 'true'
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
@@ -114,7 +127,7 @@ jobs:
           fi
 
       - name: Get token via dd-octo-sts
-        if: steps.skip_no_artifact.outputs.skip != 'true' && steps.pr.outputs.skip != 'true'
+        if: steps.check.outputs.skip != 'true' && steps.pr.outputs.skip != 'true'
         uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         id: octo-sts
         with:
@@ -122,7 +135,7 @@ jobs:
           policy: self.post-pr-comment.workflow-run
 
       - name: Find existing comment
-        if: steps.skip_no_artifact.outputs.skip != 'true' && steps.pr.outputs.skip != 'true'
+        if: steps.check.outputs.skip != 'true' && steps.pr.outputs.skip != 'true'
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find_comment
         with:
@@ -132,7 +145,7 @@ jobs:
           comment-author: 'dd-octo-sts[bot]'
 
       - name: Post comment
-        if: steps.skip_no_artifact.outputs.skip != 'true' && steps.pr.outputs.skip != 'true'
+        if: steps.check.outputs.skip != 'true' && steps.pr.outputs.skip != 'true'
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           token: ${{ steps.octo-sts.outputs.token }}

--- a/.github/workflows/post-pr-comment.yml
+++ b/.github/workflows/post-pr-comment.yml
@@ -33,6 +33,12 @@ name: 'Post PR comment'
 #   - find-comment is scoped to the dd-octo-sts[bot] author so a contributor
 #     comment cannot be hijacked even if it happens to contain the marker.
 #
+# Credentials:
+#   A single ephemeral dd-octo-sts token is used for every API call
+#   (artifact list/download, PR lookup, comment find/post). The workflow's
+#   only ambient permission is id-token: write, which is the prerequisite
+#   to minting the STS token; GITHUB_TOKEN itself carries no scopes.
+#
 # Onboarding a new producer:
 #   1) Append the producer's workflow display name to on.workflow_run.workflows.
 #   2) Producer uploads a 'pr-comment' artifact containing body.md.
@@ -46,16 +52,25 @@ on:
     types: [completed]
 
 permissions:
-  contents: read
-  actions: read          # download artifact from the triggering run
-  pull-requests: read    # resolve PR number from the workflow_run head SHA
-  id-token: write        # dd-octo-sts OIDC exchange
+  id-token: write   # required to call the OIDC endpoint for dd-octo-sts
 
 jobs:
   post:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
+      # Mint the STS token first so every API call below uses a single
+      # ephemeral, scoped credential. The policy grants actions: read +
+      # pull_requests: read + issues: write, covering all of: listing and
+      # downloading the artifact, resolving the PR number, finding and
+      # updating the comment.
+      - name: Get token via dd-octo-sts
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        id: octo-sts
+        with:
+          scope: DataDog/integrations-core
+          policy: self.post-pr-comment.workflow-run
+
       # A successful upstream run may legitimately not produce an artifact
       # (e.g. the skip-qa producer only uploads when a comment is actually
       # needed). Pre-check so the download step only runs when we know the
@@ -65,7 +80,7 @@ jobs:
       - name: Check for comment artifact
         id: check
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           RUN_ID: ${{ github.event.workflow_run.id }}
           REPO: ${{ github.repository }}
         run: |
@@ -83,7 +98,7 @@ jobs:
         with:
           name: pr-comment
           run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.octo-sts.outputs.token }}
           path: pr-comment
 
       - name: Derive marker and prepend to body
@@ -112,7 +127,7 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         id: pr
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           REPO: ${{ github.repository }}
         run: |
@@ -125,14 +140,6 @@ jobs:
           else
             echo "number=$number" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Get token via dd-octo-sts
-        if: steps.check.outputs.skip != 'true' && steps.pr.outputs.skip != 'true'
-        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
-        id: octo-sts
-        with:
-          scope: DataDog/integrations-core
-          policy: self.post-pr-comment.workflow-run
 
       - name: Find existing comment
         if: steps.check.outputs.skip != 'true' && steps.pr.outputs.skip != 'true'

--- a/.github/workflows/post-pr-comment.yml
+++ b/.github/workflows/post-pr-comment.yml
@@ -15,21 +15,29 @@ name: 'Post PR comment'
 # Artifact contract (producer uploads; this workflow consumes):
 #   name: pr-comment
 #   files:
-#     body.md    Markdown body to post. Treated as opaque, attacker-controlled text.
-#     meta.json  {"marker": "<!-- xxx-comment -->"} — validated below.
+#     body.md   Markdown body to post. Treated as opaque, attacker-controlled text.
+#
+# This workflow owns the hidden marker that lets find-comment locate the
+# previously-posted comment. The marker is derived from the triggering
+# workflow's display name (slugified), so producers cannot misconfigure it
+# and there is no attacker-controlled metadata to validate. The marker is
+# prepended to body.md before the comment is posted.
 #
 # Trust boundaries enforced here:
 #   - PR number comes from the workflow_run event (head_sha -> commits/pulls
 #     API), never from the artifact. Prevents cross-PR comment injection.
-#   - Marker is validated against a strict regex before being used as a
-#     find-comment filter. Prevents hijacking of unrelated bot comments.
+#   - Marker is derived from github.event.workflow_run.name (trusted GitHub
+#     event data), never from the artifact.
 #   - body.md is written directly to a file and passed via body-path.
 #     It is never shell-interpolated.
+#   - find-comment is scoped to the dd-octo-sts[bot] author so a contributor
+#     comment cannot be hijacked even if it happens to contain the marker.
 #
 # Onboarding a new producer:
 #   1) Append the producer's workflow display name to on.workflow_run.workflows.
-#   2) Producer uploads an artifact matching the contract above.
-#   3) Pick a unique marker (format: "<!-- <slug>-comment -->").
+#   2) Producer uploads a 'pr-comment' artifact containing body.md.
+#   3) Pick a workflow display name that slugifies to a stable, unique id;
+#      the derived marker is "<!-- pr-comment:<slug> -->".
 
 on:
   workflow_run:
@@ -60,26 +68,32 @@ jobs:
 
       - name: Skip if no artifact was produced
         if: steps.download.outcome != 'success'
+        id: skip_no_artifact
         run: |
           echo "Upstream workflow completed without a pr-comment artifact. Nothing to post."
           echo "skip=true" >> "$GITHUB_OUTPUT"
-        id: skip_no_artifact
 
-      - name: Validate marker
+      - name: Derive marker and prepend to body
         if: steps.skip_no_artifact.outputs.skip != 'true'
-        id: meta
+        id: marker
         env:
-          META_PATH: pr-comment/meta.json
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
         run: |
           set -euo pipefail
-          marker=$(python3 -c 'import json, os; print(json.load(open(os.environ["META_PATH"]))["marker"])')
-          if ! printf '%s' "$marker" | grep -Eq '^<!-- [a-z0-9][a-z0-9_-]{0,62}-comment -->$'; then
-            echo "Rejecting marker (format violation): $marker" >&2
+          slug=$(printf '%s' "$WORKFLOW_NAME" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' \
+            | cut -c1-64)
+          if [[ -z "$slug" ]]; then
+            echo "Workflow name did not produce a usable slug: ${WORKFLOW_NAME}" >&2
             exit 1
           fi
-          # Echoing via GITHUB_OUTPUT is safe because the regex above has
-          # constrained the value to [a-z0-9_-] plus a fixed wrapper.
-          echo "marker=$marker" >> "$GITHUB_OUTPUT"
+          marker="<!-- pr-comment:${slug} -->"
+          {
+            printf '%s\n\n' "$marker"
+            cat pr-comment/body.md
+          } > pr-comment/posted-body.md
+          echo "value=$marker" >> "$GITHUB_OUTPUT"
 
       - name: Resolve PR number from head SHA
         if: steps.skip_no_artifact.outputs.skip != 'true'
@@ -114,7 +128,8 @@ jobs:
         with:
           token: ${{ steps.octo-sts.outputs.token }}
           issue-number: ${{ steps.pr.outputs.number }}
-          body-includes: ${{ steps.meta.outputs.marker }}
+          body-includes: ${{ steps.marker.outputs.value }}
+          comment-author: 'dd-octo-sts[bot]'
 
       - name: Post comment
         if: steps.skip_no_artifact.outputs.skip != 'true' && steps.pr.outputs.skip != 'true'
@@ -122,6 +137,6 @@ jobs:
         with:
           token: ${{ steps.octo-sts.outputs.token }}
           issue-number: ${{ steps.pr.outputs.number }}
-          body-path: pr-comment/body.md
+          body-path: pr-comment/posted-body.md
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           edit-mode: replace


### PR DESCRIPTION
### What does this PR do?
Adds a central `workflow_run`-triggered workflow (`post-pr-comment.yml`) that posts or updates PR conversation comments on behalf of fork-safe upstream workflows, plus its dd-octo-sts trust policy.

### Artifact contract (single file)
Upstream workflows (running on `pull_request` with no secrets and no id-token) upload a `pr-comment` artifact that contains only:

- `body.md` — the rendered markdown body.

That is the entire producer-side contract. No metadata file, no marker, no coordination fields.

### What the central workflow does
1. Downloads the `pr-comment` artifact from the triggering run (skips cleanly if none was uploaded).
2. **Derives the hidden find-comment marker from `github.event.workflow_run.name`**, slugified: `"<!-- pr-comment:<slug> -->"`. The marker source is trusted GitHub event data, not artifact content, so no validation is needed beyond slug normalization. For `"Validate skip QA label"` the marker is `<!-- pr-comment:validate-skip-qa-label -->`.
3. Prepends the marker to `body.md` and writes `posted-body.md`, so the comment body the poster sees and the string `find-comment` searches for are always the same.
4. Resolves the PR number from `workflow_run.head_sha` via the commits/pulls API (never from the artifact) to prevent cross-PR comment injection.
5. Exchanges OIDC via dd-octo-sts (scope limited to `issues: write`, since PR conversation comments use the Issues API).
6. `peter-evans/find-comment` scoped to `comment-author: 'dd-octo-sts[bot]'` so a contributor comment cannot be hijacked even if it happens to contain the marker string.
7. `peter-evans/create-or-update-comment` with `body-path: posted-body.md`, `edit-mode: replace`.

### Trust boundaries
- STS policy pins `event_name=workflow_run`, `ref=refs/heads/master`, `ref_protected=true`, `job_workflow_ref=post-pr-comment.yml@refs/heads/master`. `workflow_run` always runs the default-branch version of the workflow file, so fork PRs cannot modify it or mint this token.
- The artifact's `body.md` is treated as opaque, attacker-controlled text — written to a file, never shell-interpolated.
- The marker is owned by the central workflow end-to-end. Producers cannot misconfigure it. Codex's "ensure posted bodies include the marker" concern is moot by construction — the post is literally constructed from `marker + body`.

### Onboarding a new producer
1. Append the producer's workflow display name to `on.workflow_run.workflows`.
2. Producer uploads a `pr-comment` artifact containing `body.md`.
3. Choose a workflow display name whose slug is stable and unique.

### Motivation
Follow-up to AI-6753. The finding's proposed fix (switch `validate-skip-qa.yml` from `pull_request_target` to `pull_request`) combined with dd-octo-sts reopened the same privilege-escalation class: on fork PRs the workflow YAML is attacker-modifiable and `id-token: write` is still reachable, so a malicious fork could mint the policy-scoped token directly.

`workflow_run` is the only trigger GitHub guarantees runs the default-branch version of the workflow file, which is what makes the privileged posting step safe here. The upstream `pull_request` workflow is kept credential-less so nothing a fork PR can do to it matters.

`validate-skip-qa.yml` will be refactored to use this contract in #23398, which depends on this PR merging first.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged