### PR TITLE
[Backport 7.78.x] Test shipped version of the integration when running test agent workflows  (#23378)

### DIFF
--- a/.github/actions/setup-test-target-scripts/src/run-e2e-tests.sh
+++ b/.github/actions/setup-test-target-scripts/src/run-e2e-tests.sh
@@ -21,8 +21,10 @@ else
   export DDEV_TEST_ENABLE_TRACING="0"
 fi
 
-# Set E2E flags based on repo (latest always uses --base --new-env)
-if [[ "$INPUT_REPO" == 'core' || "$INPUT_IS_LATEST" == 'true' ]]; then
+# Set E2E flags based on context and repo
+if [[ "$INPUT_CONTEXT" == test-agent* ]]; then
+  E2E_FLAGS="--new-env"
+elif [[ "$INPUT_REPO" == 'core' || "$INPUT_IS_LATEST" == 'true' ]]; then
   E2E_FLAGS="--base --new-env"
 else
   E2E_FLAGS="--dev"

--- a/.github/actions/setup-test-target-scripts/src/setup-test-env.sh
+++ b/.github/actions/setup-test-target-scripts/src/setup-test-env.sh
@@ -115,6 +115,7 @@ fi
   echo "INPUT_MINIMUM_BASE_PACKAGE=${INPUT_MINIMUM_BASE_PACKAGE:-false}"
   echo "INPUT_PYTEST_ARGS=${INPUT_PYTEST_ARGS:-}"
   echo "INPUT_IS_FORK=${INPUT_IS_FORK:-false}"
+  echo "INPUT_CONTEXT=${INPUT_CONTEXT:-standard}"
 } >> "$GITHUB_ENV"
 
 # Override with custom vars if provided


### PR DESCRIPTION
### What does this PR do?
backports https://github.com/DataDog/integrations-core/pull/23378 to 7.78.x to verify agent release artifact
### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
