### PR TITLE
Print applied tags in tag-job action

### DIFF
--- a/.github/actions/tag-job/action.yml
+++ b/.github/actions/tag-job/action.yml
@@ -73,3 +73,8 @@ runs:
         done
 
         datadog-ci tag --level job $TAGS_ARGS
+
+        echo "Tags added to the job:"
+        for tag in "${TAG_ARRAY[@]}"; do
+          echo "  - $tag"
+        done


### PR DESCRIPTION
### What does this PR do?
Adds a small reporting step to the `tag-job` composite action so it logs the tags applied to the job after `datadog-ci tag` runs.

### Motivation
Make it easier to see at a glance which tags were added to a job when inspecting the action logs in CI.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged