### PR TITLE
Fix sonatype_nexus test: dict.update() returns None

### DIFF
--- a/sonatype_nexus/tests/test_check.py
+++ b/sonatype_nexus/tests/test_check.py
@@ -4,6 +4,7 @@
 import pytest
 
 from datadog_checks.dev.http import MockResponse
+from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.sonatype_nexus import constants
 from datadog_checks.sonatype_nexus.check import SonatypeNexusCheck
 from datadog_checks.sonatype_nexus.errors import EmptyResponseError
@@ -33,7 +34,7 @@ def test_successful_metrics_collection(dd_run_check, mocker, aggregator):
             return status_response
         if "metrics/data" in url:
             return analytics_response
-        raise ValueError(f"Unexpected URL: {url}")
+        pytest.fail(f"url `{url}` not registered")
 
     mocker.patch("requests.Session.get", side_effect=side_effect)
 
@@ -48,6 +49,7 @@ def test_successful_metrics_collection(dd_run_check, mocker, aggregator):
     aggregator.assert_metric("sonatype_nexus.analytics.downloaded_bytes_by_format", value=200, count=1)
     aggregator.assert_metric("sonatype_nexus.analytics.blob_store.count_by_type", value=5, count=1)
     aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 
 
 def test_create_metric_for_configs_int(mocker, aggregator):

--- a/sonatype_nexus/tests/test_check.py
+++ b/sonatype_nexus/tests/test_check.py
@@ -4,7 +4,6 @@
 import pytest
 
 from datadog_checks.dev.http import MockResponse
-from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.sonatype_nexus import constants
 from datadog_checks.sonatype_nexus.check import SonatypeNexusCheck
 from datadog_checks.sonatype_nexus.errors import EmptyResponseError
@@ -12,27 +11,43 @@ from datadog_checks.sonatype_nexus.errors import EmptyResponseError
 from .conftest import instance
 
 
-@pytest.fixture
-def mock_http_response(mocker):
-    yield lambda *args, **kwargs: mocker.patch(
-        kwargs.pop("method", "requests.Session.get"), return_value=MockResponse(*args, **kwargs)
-    )
+def test_successful_metrics_collection(dd_run_check, mocker, aggregator):
+    status_response_data = {key: {"healthy": True} for key in constants.STATUS_METRICS_MAP}
+    analytics_response_data = {
+        "gauges": {
+            "jvm.memory.heap.used": {"value": 123456789},
+            "nexus.analytics.bytes_transferred_by_format": {
+                "value": [{"maven": {"bytes_uploaded": 100, "bytes_downloaded": 200}}],
+            },
+            "nexus.analytics.blobstore_type_counts": {
+                "value": {"File": 5},
+            },
+        }
+    }
 
+    status_response = MockResponse(json_data=status_response_data, status_code=200)
+    analytics_response = MockResponse(json_data=analytics_response_data, status_code=200)
 
-def test_successful_metrics_collection(dd_run_check, mock_http_response, aggregator):
-    status_metrics_response_data = {key: {"healthy": True} for key in constants.STATUS_METRICS_MAP.keys()}
+    def side_effect(url, **kwargs):
+        if "status/check" in url:
+            return status_response
+        if "metrics/data" in url:
+            return analytics_response
+        raise ValueError(f"Unexpected URL: {url}")
 
-    mock_http_response(
-        "https://example.com/service/rest/v1/status/check",
-        status_code=200,
-        json_data=status_metrics_response_data.update({"gauges": {"jvm.memory.heap.used": {"value": 123456789}}}),
-    )
+    mocker.patch("requests.Session.get", side_effect=side_effect)
 
     check = SonatypeNexusCheck("sonatype_nexus", {}, [instance])
     dd_run_check(check)
 
+    for metric_name in constants.STATUS_METRICS_MAP.values():
+        aggregator.assert_metric(f"sonatype_nexus.{metric_name}", value=1, count=1)
+
+    aggregator.assert_metric("sonatype_nexus.analytics.jvm.heap_memory_used", value=123456789, count=1)
+    aggregator.assert_metric("sonatype_nexus.analytics.uploaded_bytes_by_format", value=100, count=1)
+    aggregator.assert_metric("sonatype_nexus.analytics.downloaded_bytes_by_format", value=200, count=1)
+    aggregator.assert_metric("sonatype_nexus.analytics.blob_store.count_by_type", value=5, count=1)
     aggregator.assert_all_metrics_covered()
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 
 
 def test_create_metric_for_configs_int(mocker, aggregator):


### PR DESCRIPTION
## Summary
`test_successful_metrics_collection` validated nothing — `dict.update()` returns `None`, so the mock had no response body. Assertions passed vacuously with zero metrics. Fixed by building response dicts properly and adding explicit `assert_metric` calls. Also removed a local `mock_http_response` fixture that shadowed the global one.

## Test plan
- [x] `ddev --no-interactive test sonatype_nexus` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)