### PR TITLE
Fix traefik_mesh: version metadata never submitted in production

### DIFF
--- a/traefik_mesh/changelog.d/23421.fixed
+++ b/traefik_mesh/changelog.d/23421.fixed
@@ -1,0 +1,1 @@
+Fix `get_version()` signature so version metadata is actually submitted.

--- a/traefik_mesh/datadog_checks/traefik_mesh/check.py
+++ b/traefik_mesh/datadog_checks/traefik_mesh/check.py
@@ -84,7 +84,7 @@ class TraefikMeshCheck(OpenMetricsBaseCheckV2, ConfigMixin):
 
         return node_status
 
-    def get_version(self, url):
+    def get_version(self):
         """Fetches Traefik Proxy version from the Proxy API"""
 
         version_url = urljoin(self.traefik_proxy_api_endpoint, PROXY_VERSION)


### PR DESCRIPTION
## Summary
- `get_version(self, url)` takes a `url` param it never uses; caller `_submit_version()` passes zero args → TypeError → silently caught → version metadata never submitted. Fix: remove dead param.

## Test plan
- [x] All 8 traefik_mesh tests pass, including `test_submit_version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)