### PR TITLE
Fix bentoml tests: mock overwrites fixture data

### DIFF
--- a/bentoml/changelog.d/23422.fixed
+++ b/bentoml/changelog.d/23422.fixed
@@ -1,0 +1,1 @@
+Fix double-slash in health endpoint URLs from _extract_base_url

--- a/bentoml/datadog_checks/bentoml/check.py
+++ b/bentoml/datadog_checks/bentoml/check.py
@@ -21,7 +21,7 @@ class BentomlCheck(OpenMetricsBaseCheckV2):
         parsed = urlparse(endpoint)
         path = parsed.path.rstrip('/')
         base_path = path.rsplit('/', 1)[0] if '/' in path else ''
-        return urlunparse(parsed._replace(path=base_path or '/'))
+        return urlunparse(parsed._replace(path=base_path))
 
     def get_default_config(self):
         return {

--- a/bentoml/tests/test_unit.py
+++ b/bentoml/tests/test_unit.py
@@ -1,10 +1,7 @@
 # (C) Datadog, Inc. 2025-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from unittest.mock import Mock, patch
-
 import pytest
-import requests
 
 from datadog_checks.base.constants import ServiceCheck
 from datadog_checks.bentoml import BentomlCheck
@@ -20,27 +17,19 @@ from .common import (
 
 def test_bentoml_mock_metrics(dd_run_check, aggregator, mock_http_response):
     mock_http_response(file_path=get_fixture_path('metrics.txt'))
+    check = BentomlCheck('bentoml', {}, [OM_MOCKED_INSTANCE])
+    dd_run_check(check)
 
-    with patch('datadog_checks.bentoml.check.BentomlCheck.http') as mock_http:
-        mock_response = type('MockResponse', (), {'status_code': 200})()
-        mock_http.get.return_value = mock_response
-        mock_http.get.return_value.raise_for_status = lambda: None
+    for metric in METRICS:
+        aggregator.assert_metric(metric)
 
-        check = BentomlCheck('bentoml', {}, [OM_MOCKED_INSTANCE])
-        dd_run_check(check)
+    for metric in ENDPOINT_METRICS:
+        aggregator.assert_metric(metric, value=1, tags=['test:tag', 'status_code:200'])
 
-        for metric in METRICS:
-            aggregator.assert_metric(metric)
-
-        for metric in ENDPOINT_METRICS:
-            aggregator.assert_metric(metric, value=1, tags=['test:tag', 'status_code:200'])
-
-        aggregator.assert_all_metrics_covered()
-        assert mock_http.get.call_count == 2
-        aggregator.assert_metrics_using_metadata(get_metadata_metrics())
-        aggregator.assert_all_metrics_covered()
-        aggregator.assert_metric_has_tag('bentoml.service.request.count', 'bentoml_endpoint:/summarize')
-        aggregator.assert_service_check('bentoml.openmetrics.health', ServiceCheck.OK)
+    aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
+    aggregator.assert_metric_has_tag('bentoml.service.request.count', 'bentoml_endpoint:/summarize')
+    aggregator.assert_service_check('bentoml.openmetrics.health', ServiceCheck.OK)
 
 
 def test_bentoml_mock_invalid_endpoint(dd_run_check, aggregator, mock_http_response):
@@ -52,22 +41,21 @@ def test_bentoml_mock_invalid_endpoint(dd_run_check, aggregator, mock_http_respo
     aggregator.assert_service_check('bentoml.openmetrics.health', ServiceCheck.CRITICAL)
 
 
-def test_bentoml_mock_valid_endpoint_invalid_health(dd_run_check, aggregator, mock_http_response):
-    mock_http_response(file_path=get_fixture_path('metrics.txt'))
+def test_bentoml_mock_valid_endpoint_invalid_health(dd_run_check, aggregator, mock_http_response_per_endpoint):
+    from datadog_checks.dev.http import MockResponse
 
-    _err = Mock()
-    _err.status_code = 500
-    _http_err = requests.HTTPError("500 Internal Server Error")
-    _http_err.response = _err
-    _err.raise_for_status.side_effect = _http_err
+    mock_http_response_per_endpoint(
+        {
+            'http://bentoml:3000/metrics': [MockResponse(file_path=get_fixture_path('metrics.txt'))],
+            'http://bentoml:3000/livez': [MockResponse(status_code=500)],
+            'http://bentoml:3000/readyz': [MockResponse(status_code=500)],
+        },
+    )
 
-    with patch('datadog_checks.bentoml.check.BentomlCheck.http') as mock_http:
-        mock_http.get.return_value = _err
+    check = BentomlCheck('bentoml', {}, [OM_MOCKED_INSTANCE])
+    dd_run_check(check)
 
-        check = BentomlCheck('bentoml', {}, [OM_MOCKED_INSTANCE])
-        dd_run_check(check)
+    for metric in ENDPOINT_METRICS:
+        aggregator.assert_metric(metric, value=0, tags=['test:tag', 'status_code:500'])
 
-        for metric in ENDPOINT_METRICS:
-            aggregator.assert_metric(metric, value=0, tags=['test:tag', 'status_code:500'])
-
-        aggregator.assert_service_check('bentoml.openmetrics.health', ServiceCheck.OK)
+    aggregator.assert_service_check('bentoml.openmetrics.health', ServiceCheck.OK)

--- a/bentoml/tests/test_unit.py
+++ b/bentoml/tests/test_unit.py
@@ -5,6 +5,7 @@ import pytest
 
 from datadog_checks.base.constants import ServiceCheck
 from datadog_checks.bentoml import BentomlCheck
+from datadog_checks.dev.http import MockResponse
 from datadog_checks.dev.utils import get_metadata_metrics
 
 from .common import (
@@ -42,13 +43,13 @@ def test_bentoml_mock_invalid_endpoint(dd_run_check, aggregator, mock_http_respo
 
 
 def test_bentoml_mock_valid_endpoint_invalid_health(dd_run_check, aggregator, mock_http_response_per_endpoint):
-    from datadog_checks.dev.http import MockResponse
-
+    endpoint = OM_MOCKED_INSTANCE['openmetrics_endpoint']
+    base_url = BentomlCheck._extract_base_url(None, endpoint)
     mock_http_response_per_endpoint(
         {
-            'http://bentoml:3000/metrics': [MockResponse(file_path=get_fixture_path('metrics.txt'))],
-            'http://bentoml:3000/livez': [MockResponse(status_code=500)],
-            'http://bentoml:3000/readyz': [MockResponse(status_code=500)],
+            endpoint: [MockResponse(file_path=get_fixture_path('metrics.txt'))],
+            f'{base_url}/livez': [MockResponse(status_code=500)],
+            f'{base_url}/readyz': [MockResponse(status_code=500)],
         },
     )
 


### PR DESCRIPTION
## Summary
- `test_bentoml_mock_metrics`: inner `patch('...BentomlCheck.http')` overwrote the `mock_http_response` fixture with a bare status-200 mock — scraper parsed empty payload. Removed the redundant patch.
- `test_bentoml_mock_valid_endpoint_invalid_health`: same pattern — error mock applied to ALL URLs including metrics. Switched to `mock_http_response_per_endpoint` to dispatch by URL.
- `_extract_base_url` returned trailing slash for root-level paths (`http://host:3000/`), causing double-slash health URLs (`//livez`). Removed `or '/'` fallback.

## Test plan
- [x] `ddev --no-interactive test bentoml` — all 3 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)