### PR TITLE
Fix nutanix test mock: unregistered URLs silently pass

### DIFF
--- a/nutanix/tests/conftest.py
+++ b/nutanix/tests/conftest.py
@@ -348,9 +348,6 @@ def mock_http_get(mocker):
             mock_resp.json = mocker.Mock(return_value=response_data)
             return mock_resp
 
-        print(f"[MOCK ERROR] No matching endpoint for URL: {url}")
-        mock_resp.status_code = 404
-        mock_resp.raise_for_status = mocker.Mock(side_effect=Exception("404 Not Found"))
-        return mock_resp
+        pytest.fail(f"url `{url}` not registered")
 
     return mocker.patch('requests.Session.get', side_effect=mock_response)


### PR DESCRIPTION
## Summary

- Replace `print()` + 404 response fallthrough with `pytest.fail()` for unregistered URLs in `nutanix/tests/conftest.py`

**Bug:** The `mock_http_get` fixture's fallthrough for unregistered URLs uses `print()` (swallowed by pytest) and returns a 404 mock response. If production code only checks `status_code` without calling `raise_for_status()`, unregistered URLs pass silently -- masking test issues. Other integrations (kubevirt_api, strimzi, couchbase, gitlab) already use `pytest.fail()` for this pattern.

## Test plan

- [x] `ddev --no-interactive test nutanix` -- all 114 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)