### PR TITLE
Remove dead assertions in rabbitmq test_unit.py

### DIFF
--- a/rabbitmq/tests/test_unit.py
+++ b/rabbitmq/tests/test_unit.py
@@ -28,12 +28,10 @@ def test__get_data(check):
     r = mock.MagicMock()
     with mock.patch('datadog_checks.base.utils.http.requests.Session', return_value=r):
         r.get.side_effect = [requests.exceptions.HTTPError, ValueError]
-        with pytest.raises(RabbitMQException) as e:
+        with pytest.raises(RabbitMQException):
             check._get_data('')
-            assert isinstance(e, RabbitMQException)
-        with pytest.raises(RabbitMQException) as e:
+        with pytest.raises(RabbitMQException):
             check._get_data('')
-            assert isinstance(e, RabbitMQException)
 
 
 def test_status_check(check, aggregator):


### PR DESCRIPTION
## Summary

- Remove two dead `assert isinstance(e, RabbitMQException)` lines inside `pytest.raises` blocks in `test__get_data`

## Motivation

When `check._get_data('')` raises `RabbitMQException`, execution exits the `with pytest.raises(...)` block immediately. The `assert isinstance(...)` lines after the raising call are unreachable dead code. The `pytest.raises(RabbitMQException)` context manager already validates the exception type, so the assertions were redundant even if they could execute.

## Test plan

- [x] `ddev --no-interactive test rabbitmq -- -k test__get_data` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)