### PR TITLE
Fix gitlab test conftest: version check silently fails

### DIFF
--- a/gitlab/tests/conftest.py
+++ b/gitlab/tests/conftest.py
@@ -148,15 +148,13 @@ def mocked_requests_get(*args, **kwargs):
                 iter_lines=lambda **kwargs: text_data.split("\n"),
                 headers={'Content-Type': "text/plain"},
             )
-    elif url == "http://{}:{}/api/v4/version".format(HOST, GITLAB_LOCAL_PORT) or url == "http://{}:{}/-/health".format(
-        HOST, GITLAB_LOCAL_PORT
-    ):
+    elif url == "http://{}:{}/api/v4/version".format(HOST, GITLAB_LOCAL_PORT):
         f_name = os.path.join(os.path.dirname(__file__), 'fixtures', 'version.json')
         with open(f_name, 'r') as f:
             text_data = f.read()
             response = mock.MagicMock()
             response.status_code = 200
-            response.json.return_value = text_data
+            response.json.return_value = json.loads(text_data)
             return response
 
     pytest.fail("url `{}` not registered".format(args[0]))


### PR DESCRIPTION
## Summary

Fixes two test correctness bugs in `gitlab/tests/conftest.py`:

1. **`/api/v4/version` mock returns raw JSON string instead of parsed dict** — `response.json.return_value` was set to the raw string from `f.read()` instead of `json.loads(text_data)`. Production code calls `response.json().get('version')`, which silently fails because strings don't have `.get()`, caught by a bare `except Exception`.

2. **Dead `/-/health` URL branch in version handler** — The `/api/v4/version` elif also matched `/-/health`, but that URL is already handled by an earlier elif branch, making the condition unreachable dead code.

## Test plan

- [x] `ddev test -fs gitlab` passes (formatting/linting)
- [x] `ddev --no-interactive test gitlab` — all 15 unit tests pass (integration tests skipped, need docker)