### PR TITLE
Add out_of_sync_broker_id tag to partition metrics

### DIFF
--- a/kafka_consumer/changelog.d/23428.added
+++ b/kafka_consumer/changelog.d/23428.added
@@ -1,0 +1,1 @@
+Add an `out_of_sync_broker_id` tag to the `kafka.partition.*` metrics (when `enable_cluster_monitoring` is true) identifying each assigned replica that is not in the partition's ISR. Use it to attribute under-replicated partitions to specific broker IDs.

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -571,12 +571,17 @@ class ClusterMetadataCollector:
                     for replica in replicas:
                         partition_broker_tags.append(f'replica_broker_id:{replica}')
 
+                    isr_set = set(isrs)
+                    out_of_sync_broker_ids = [replica for replica in replicas if replica not in isr_set]
+                    for broker_id in out_of_sync_broker_ids:
+                        partition_broker_tags.append(f'out_of_sync_broker_id:{broker_id}')
+
                     self.check.gauge('partition.replicas', len(replicas), tags=partition_broker_tags)
                     self.check.gauge('partition.isr', len(isrs), tags=partition_broker_tags)
 
                     self.check.gauge('partition.size', partition_size, tags=partition_broker_tags)
 
-                    is_under_replicated = len(isrs) < len(replicas)
+                    is_under_replicated = len(out_of_sync_broker_ids) > 0
                     self.check.gauge(
                         'partition.under_replicated',
                         1 if is_under_replicated else 0,

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -572,7 +572,7 @@ class ClusterMetadataCollector:
                         partition_broker_tags.append(f'replica_broker_id:{replica}')
 
                     isr_set = set(isrs)
-                    out_of_sync_broker_ids = [replica for replica in replicas if replica not in isr_set]
+                    out_of_sync_broker_ids = [broker_id for broker_id in replicas if broker_id not in isr_set]
                     for broker_id in out_of_sync_broker_ids:
                         partition_broker_tags.append(f'out_of_sync_broker_id:{broker_id}')
 
@@ -581,7 +581,7 @@ class ClusterMetadataCollector:
 
                     self.check.gauge('partition.size', partition_size, tags=partition_broker_tags)
 
-                    is_under_replicated = len(out_of_sync_broker_ids) > 0
+                    is_under_replicated = bool(out_of_sync_broker_ids)
                     self.check.gauge(
                         'partition.under_replicated',
                         1 if is_under_replicated else 0,

--- a/kafka_consumer/tests/test_cluster_metadata.py
+++ b/kafka_consumer/tests/test_cluster_metadata.py
@@ -1351,3 +1351,66 @@ def test_schema_registry_url_encodes_subject_names(check):
     collector.http.get.assert_called_with(
         'http://localhost:8081/subjects/google%2Fprotobuf%2Ftimestamp.proto/versions/latest'
     )
+
+
+def test_partition_out_of_sync_broker_id_tag(check, dd_run_check, aggregator):
+    """Under-replicated partitions expose an ``out_of_sync_broker_id`` tag per replica missing from the ISR."""
+    instance = {
+        'kafka_connect_str': 'localhost:9092',
+        'enable_cluster_monitoring': True,
+        'tags': ['test_tag:test_value'],
+    }
+
+    kafka_consumer_check = check(instance)
+    mock_kafka_client = seed_mock_kafka_client()
+
+    # Mutate the seeded metadata so that partition 0 is under-replicated:
+    # replicas = [1, 2, 3], but only broker 1 is in-sync => brokers 2 and 3 are out-of-sync.
+    # Partition 1 remains fully replicated.
+    topic_metadata = mock_kafka_client.kafka_client.list_topics.return_value.topics['test-topic']
+    topic_metadata.partitions[0].replicas = [1, 2, 3]
+    topic_metadata.partitions[0].isrs = [1]
+
+    kafka_consumer_check.client = mock_kafka_client
+    kafka_consumer_check.metadata_collector.client = mock_kafka_client
+    mock_schema_registry_methods(kafka_consumer_check.metadata_collector)
+
+    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=None)
+    kafka_consumer_check.write_persistent_cache = mock.Mock()
+    kafka_consumer_check.event_platform_event = mock.Mock()
+
+    dd_run_check(kafka_consumer_check)
+
+    under_replicated_tags = [
+        'test_tag:test_value',
+        'kafka_cluster_id:test-cluster-id',
+        'topic:test-topic',
+        'partition:0',
+        'leader_broker_id:1',
+        'replica_broker_id:1',
+        'replica_broker_id:2',
+        'replica_broker_id:3',
+        'out_of_sync_broker_id:2',
+        'out_of_sync_broker_id:3',
+    ]
+
+    aggregator.assert_metric('kafka.partition.under_replicated', value=1, tags=under_replicated_tags)
+    aggregator.assert_metric('kafka.partition.replicas', value=3, tags=under_replicated_tags)
+    aggregator.assert_metric('kafka.partition.isr', value=1, tags=under_replicated_tags)
+
+    # Fully-replicated partitions must not carry an ``out_of_sync_broker_id`` tag.
+    in_sync_tags = [
+        'test_tag:test_value',
+        'kafka_cluster_id:test-cluster-id',
+        'topic:test-topic',
+        'partition:1',
+        'leader_broker_id:2',
+        'replica_broker_id:1',
+        'replica_broker_id:2',
+    ]
+    aggregator.assert_metric('kafka.partition.under_replicated', value=0, tags=in_sync_tags)
+    for metric in aggregator.metrics('kafka.partition.under_replicated'):
+        if 'partition:1' in metric.tags:
+            assert not any(tag.startswith('out_of_sync_broker_id:') for tag in metric.tags), (
+                f"Fully-replicated partition should not have out_of_sync_broker_id tags, got {metric.tags}"
+            )

--- a/kafka_consumer/tests/test_cluster_metadata.py
+++ b/kafka_consumer/tests/test_cluster_metadata.py
@@ -1353,7 +1353,19 @@ def test_schema_registry_url_encodes_subject_names(check):
     )
 
 
-def test_partition_out_of_sync_broker_id_tag(check, dd_run_check, aggregator):
+@pytest.mark.parametrize(
+    "replicas, isrs, expected_oos, expected_under",
+    [
+        pytest.param([1, 2], [1, 2], [], 0, id="fully_in_sync"),
+        pytest.param([1, 2], [1], [2], 1, id="single_oos"),
+        pytest.param([1, 2, 3], [1], [2, 3], 1, id="multiple_oos"),
+        pytest.param([1, 2], [], [1, 2], 1, id="empty_isr"),
+        pytest.param([1], [1], [], 0, id="single_replica"),
+    ],
+)
+def test_partition_out_of_sync_broker_id_tag(
+    check, dd_run_check, aggregator, replicas, isrs, expected_oos, expected_under
+):
     """Under-replicated partitions expose an ``out_of_sync_broker_id`` tag per replica missing from the ISR."""
     instance = {
         'kafka_connect_str': 'localhost:9092',
@@ -1364,12 +1376,9 @@ def test_partition_out_of_sync_broker_id_tag(check, dd_run_check, aggregator):
     kafka_consumer_check = check(instance)
     mock_kafka_client = seed_mock_kafka_client()
 
-    # Mutate the seeded metadata so that partition 0 is under-replicated:
-    # replicas = [1, 2, 3], but only broker 1 is in-sync => brokers 2 and 3 are out-of-sync.
-    # Partition 1 remains fully replicated.
     topic_metadata = mock_kafka_client.kafka_client.list_topics.return_value.topics['test-topic']
-    topic_metadata.partitions[0].replicas = [1, 2, 3]
-    topic_metadata.partitions[0].isrs = [1]
+    topic_metadata.partitions[0].replicas = replicas
+    topic_metadata.partitions[0].isrs = isrs
 
     kafka_consumer_check.client = mock_kafka_client
     kafka_consumer_check.metadata_collector.client = mock_kafka_client
@@ -1381,36 +1390,13 @@ def test_partition_out_of_sync_broker_id_tag(check, dd_run_check, aggregator):
 
     dd_run_check(kafka_consumer_check)
 
-    under_replicated_tags = [
+    expected_tags = [
         'test_tag:test_value',
         'kafka_cluster_id:test-cluster-id',
         'topic:test-topic',
         'partition:0',
         'leader_broker_id:1',
-        'replica_broker_id:1',
-        'replica_broker_id:2',
-        'replica_broker_id:3',
-        'out_of_sync_broker_id:2',
-        'out_of_sync_broker_id:3',
+        *(f'replica_broker_id:{r}' for r in replicas),
+        *(f'out_of_sync_broker_id:{b}' for b in expected_oos),
     ]
-
-    aggregator.assert_metric('kafka.partition.under_replicated', value=1, tags=under_replicated_tags)
-    aggregator.assert_metric('kafka.partition.replicas', value=3, tags=under_replicated_tags)
-    aggregator.assert_metric('kafka.partition.isr', value=1, tags=under_replicated_tags)
-
-    # Fully-replicated partitions must not carry an ``out_of_sync_broker_id`` tag.
-    in_sync_tags = [
-        'test_tag:test_value',
-        'kafka_cluster_id:test-cluster-id',
-        'topic:test-topic',
-        'partition:1',
-        'leader_broker_id:2',
-        'replica_broker_id:1',
-        'replica_broker_id:2',
-    ]
-    aggregator.assert_metric('kafka.partition.under_replicated', value=0, tags=in_sync_tags)
-    for metric in aggregator.metrics('kafka.partition.under_replicated'):
-        if 'partition:1' in metric.tags:
-            assert not any(tag.startswith('out_of_sync_broker_id:') for tag in metric.tags), (
-                f"Fully-replicated partition should not have out_of_sync_broker_id tags, got {metric.tags}"
-            )
+    aggregator.assert_metric('kafka.partition.under_replicated', value=expected_under, tags=expected_tags)

--- a/kafka_consumer/tests/test_cluster_metadata.py
+++ b/kafka_consumer/tests/test_cluster_metadata.py
@@ -1400,3 +1400,10 @@ def test_partition_out_of_sync_broker_id_tag(
         *(f'out_of_sync_broker_id:{b}' for b in expected_oos),
     ]
     aggregator.assert_metric('kafka.partition.under_replicated', value=expected_under, tags=expected_tags)
+    for metric in (
+        'kafka.partition.replicas',
+        'kafka.partition.isr',
+        'kafka.partition.size',
+        'kafka.partition.offline',
+    ):
+        aggregator.assert_metric(metric, tags=expected_tags)


### PR DESCRIPTION
### What does this PR do?

Adds a `out_of_sync_broker_id:<id>` tag on the `kafka.partition.*` metrics for each replica that is assigned to the partition but not present in the ISR.

### Motivation

Kafka cluster operators can identify when a topic has under-replicated partitions with the existing metrics. When they find a partition is under-replicated, they will likely want to know what specific broker is falling behind. They can query these tags to identify that information.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
