### PR TITLE
[NDM] [Cisco ACI] Remove docs on sending tenant faults as events

### DIFF
--- a/cisco_aci/README.md
+++ b/cisco_aci/README.md
@@ -150,10 +150,6 @@ The Cisco ACI config `.yaml` file can be set up to collect one or both of the fo
 | [send_faultinst_faults][13]     | Set to `true` to enable collection of Cisco ACI `faultInst` faults as logs. |
 | [send_faultdelegate_faults][14] | Set to `true` to enable collection of Cisco ACI `faultDelegate` faults as logs. |
 
-### Events
-
-The Cisco ACI check sends tenant faults as events.
-
 ### Service Checks
 
 See [service_checks.json][8] for a list of service checks provided by this integration.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
i forgor to update the docs with the changes from https://github.com/DataDog/integrations-core/pull/23350

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
