### PR TITLE
Fix post-pr-comment policy to request pull_requests:write

### DIFF
--- a/.github/chainguard/self.post-pr-comment.workflow-run.sts.yaml
+++ b/.github/chainguard/self.post-pr-comment.workflow-run.sts.yaml
@@ -18,16 +18,20 @@
 #     workflow_run-triggered workflows cannot reuse this policy.
 #
 # Permissions granted:
-#   - issues: write        - Create and update PR conversation comments
-#                            (PR conversation comments use the Issues API, which is
-#                            why the GitHub App scope is issues, not pull_requests).
+#   - pull_requests: write - Create and update PR conversation comments. Although
+#                            PR conversation comments are served by the Issues API
+#                            endpoint (/repos/.../issues/{n}/comments), the endpoint
+#                            accepts either issues:write or pull_requests:write, and
+#                            we only ever comment on pull requests, never on plain
+#                            issues. pull_requests:write is also what works in
+#                            practice for the DD Octo STS installation in this repo.
 #   - actions: read        - List and download the pr-comment artifact from the
 #                            triggering workflow_run.
-#   - pull_requests: read  - Resolve the open PR number from the workflow_run
-#                            head SHA (commits/{sha}/pulls endpoint).
 #
 # Granting reads to the STS token means the workflow uses a single ephemeral
-# credential end-to-end and never relies on GITHUB_TOKEN.
+# credential end-to-end and never relies on GITHUB_TOKEN. pull_requests:write
+# also subsumes the PR-number lookup (commits/{sha}/pulls) previously covered
+# by pull_requests:read.
 #
 # Usage in workflows:
 #   - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
@@ -47,6 +51,5 @@ claim_pattern:
   repository: DataDog/integrations-core
 
 permissions:
-  issues: write
+  pull_requests: write
   actions: read
-  pull_requests: read

--- a/.github/workflows/post-pr-comment.yml
+++ b/.github/workflows/post-pr-comment.yml
@@ -61,9 +61,9 @@ jobs:
     steps:
       # Mint the STS token first so every API call below uses a single
       # ephemeral, scoped credential. The policy grants actions: read +
-      # pull_requests: read + issues: write, covering all of: listing and
-      # downloading the artifact, resolving the PR number, finding and
-      # updating the comment.
+      # pull_requests: write, covering all of: listing and downloading the
+      # artifact, resolving the PR number, and finding and updating the
+      # comment.
       - name: Get token via dd-octo-sts
         uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         id: octo-sts


### PR DESCRIPTION
### What does this PR do?

Switches the `self.post-pr-comment.workflow-run` trust policy from `issues: write` + `pull_requests: read` to `pull_requests: write`.

### Motivation

The endpoint this workflow hits (`POST /repos/.../issues/{n}/comments`) advertises either `issues=write` or `pull_requests=write` as acceptable. `pull_requests: write` is what the sibling `self.validate.pull-request` policy already uses successfully in this repo, but we wanted to verify whether `issues: write` also worked here; empirically it does not — every run failed with `403 Resource not accessible by integration` ([example](https://github.com/DataDog/integrations-core/actions/runs/24828098318/job/72669212709)).

Switching to `pull_requests: write` is also semantically correct — this workflow only ever comments on PRs, never on plain issues — and subsumes the previous `pull_requests: read` used for the PR-number lookup.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged