### PR TITLE
Fix sonatype_nexus test: dict.update() returns None, mock has no body

### DIFF
--- a/sonatype_nexus/tests/test_check.py
+++ b/sonatype_nexus/tests/test_check.py
@@ -12,26 +12,32 @@ from datadog_checks.sonatype_nexus.errors import EmptyResponseError
 from .conftest import instance
 
 
-@pytest.fixture
-def mock_http_response(mocker):
-    yield lambda *args, **kwargs: mocker.patch(
-        kwargs.pop("method", "requests.Session.get"), return_value=MockResponse(*args, **kwargs)
-    )
+def test_successful_metrics_collection(dd_run_check, mock_http_response_per_endpoint, aggregator):
+    status_response_data = {key: {"healthy": True} for key in constants.STATUS_METRICS_MAP.keys()}
+    analytics_response_data = {
+        "gauges": {
+            "jvm.memory.heap.used": {"value": 123456789},
+            "nexus.analytics.bytes_transferred_by_format": {"value": []},
+            "nexus.analytics.blobstore_type_counts": {"value": {}},
+        }
+    }
 
-
-def test_successful_metrics_collection(dd_run_check, mock_http_response, aggregator):
-    status_metrics_response_data = {key: {"healthy": True} for key in constants.STATUS_METRICS_MAP.keys()}
-
-    mock_http_response(
-        "https://example.com/service/rest/v1/status/check",
-        status_code=200,
-        json_data=status_metrics_response_data.update({"gauges": {"jvm.memory.heap.used": {"value": 123456789}}}),
+    mock_http_response_per_endpoint(
+        {
+            "https://example.com/service/rest/v1/status/check": [
+                MockResponse(status_code=200, json_data=status_response_data)
+            ],
+            "https://example.com/service/metrics/data": [
+                MockResponse(status_code=200, json_data=analytics_response_data)
+            ],
+        }
     )
 
     check = SonatypeNexusCheck("sonatype_nexus", {}, [instance])
     dd_run_check(check)
 
-    aggregator.assert_all_metrics_covered()
+    aggregator.assert_metric("sonatype_nexus.status.available_cpus_health", value=1.0)
+    aggregator.assert_metric("sonatype_nexus.analytics.jvm.heap_memory_used", value=123456789)
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 
 

--- a/sonatype_nexus/tests/test_check.py
+++ b/sonatype_nexus/tests/test_check.py
@@ -37,6 +37,7 @@ def test_successful_metrics_collection(dd_run_check, mock_http_response_per_endp
     dd_run_check(check)
 
     aggregator.assert_metric("sonatype_nexus.status.available_cpus_health", value=1.0)
+    aggregator.assert_metric("sonatype_nexus.status.scheduler_health", value=1.0)
     aggregator.assert_metric("sonatype_nexus.analytics.jvm.heap_memory_used", value=123456789)
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 


### PR DESCRIPTION
## Motivation

Discovered during the [requests → httpx migration](https://datadoghq.atlassian.net/wiki/spaces/AI/pages/6214681547/RFC+2026-02-11+-+Migrate+the+HTTP+layer+from+requests+to+httpx) while auditing HTTP-layer call sites. Pre-existing bug on master, split out so the migration PR stays focused on transport changes.

`test_successful_metrics_collection` passed vacuously with zero metrics emitted. The failure chain:

1. `dict.update()` returns `None`, so `json_data=None` in the `mock_http_response` call
2. `MockResponse` falls back to using the URL string as the response body
3. `response.json()` raises `JSONDecodeError` on that string
4. Both `generate_and_yield_status_metrics` and `generate_and_yield_analytics_metrics` catch the error and return early
5. `assert_all_metrics_covered()` and `assert_metrics_using_metadata()` pass with nothing to check

## Approach

- Removed local `mock_http_response` fixture that shadowed the identical global one from `datadog_checks_dev`
- Switched to `mock_http_response_per_endpoint` so the status and analytics endpoints each get their own realistic response (the global `mock_http_response` patches all calls to return the same mock, which requires an awkward combined payload for a two-endpoint check)
- Built the status response dict correctly before passing it
- Added 3 explicit `assert_metric` spot-checks (2 status, 1 analytics) so the test fails if either code path stops emitting
- Dropped `assert_all_metrics_covered()`: it tracks coverage via `assert_metric` calls only, and `assert_metrics_using_metadata` does not satisfy it

## Verification

- `ddev --no-interactive test sonatype_nexus`: 13 passed, 1 skipped (E2E)
- `ddev test -fs sonatype_nexus`: no formatting changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)