### PR TITLE
Fix bentoml tests: remove patch override of mock_http_response, add METRICS assertions

### DIFF
--- a/bentoml/tests/test_unit.py
+++ b/bentoml/tests/test_unit.py
@@ -1,13 +1,11 @@
 # (C) Datadog, Inc. 2025-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from unittest.mock import Mock, patch
-
 import pytest
-import requests
 
 from datadog_checks.base.constants import ServiceCheck
 from datadog_checks.bentoml import BentomlCheck
+from datadog_checks.dev.http import MockResponse
 from datadog_checks.dev.utils import get_metadata_metrics
 
 from .common import (
@@ -21,26 +19,20 @@ from .common import (
 def test_bentoml_mock_metrics(dd_run_check, aggregator, mock_http_response):
     mock_http_response(file_path=get_fixture_path('metrics.txt'))
 
-    with patch('datadog_checks.bentoml.check.BentomlCheck.http') as mock_http:
-        mock_response = type('MockResponse', (), {'status_code': 200})()
-        mock_http.get.return_value = mock_response
-        mock_http.get.return_value.raise_for_status = lambda: None
+    check = BentomlCheck('bentoml', {}, [OM_MOCKED_INSTANCE])
+    dd_run_check(check)
 
-        check = BentomlCheck('bentoml', {}, [OM_MOCKED_INSTANCE])
-        dd_run_check(check)
+    for metric in METRICS:
+        aggregator.assert_metric(metric)
 
-        for metric in METRICS:
-            aggregator.assert_metric(metric)
+    for metric in ENDPOINT_METRICS:
+        aggregator.assert_metric(metric, value=1, tags=['test:tag', 'status_code:200'])
 
-        for metric in ENDPOINT_METRICS:
-            aggregator.assert_metric(metric, value=1, tags=['test:tag', 'status_code:200'])
-
-        aggregator.assert_all_metrics_covered()
-        assert mock_http.get.call_count == 2
-        aggregator.assert_metrics_using_metadata(get_metadata_metrics())
-        aggregator.assert_all_metrics_covered()
-        aggregator.assert_metric_has_tag('bentoml.service.request.count', 'bentoml_endpoint:/summarize')
-        aggregator.assert_service_check('bentoml.openmetrics.health', ServiceCheck.OK)
+    aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
+    aggregator.assert_all_metrics_covered()
+    aggregator.assert_metric_has_tag('bentoml.service.request.count', 'bentoml_endpoint:/summarize')
+    aggregator.assert_service_check('bentoml.openmetrics.health', ServiceCheck.OK)
 
 
 def test_bentoml_mock_invalid_endpoint(dd_run_check, aggregator, mock_http_response):
@@ -52,22 +44,22 @@ def test_bentoml_mock_invalid_endpoint(dd_run_check, aggregator, mock_http_respo
     aggregator.assert_service_check('bentoml.openmetrics.health', ServiceCheck.CRITICAL)
 
 
-def test_bentoml_mock_valid_endpoint_invalid_health(dd_run_check, aggregator, mock_http_response):
-    mock_http_response(file_path=get_fixture_path('metrics.txt'))
+def test_bentoml_mock_valid_endpoint_invalid_health(dd_run_check, aggregator, mock_http_response_per_endpoint):
+    mock_http_response_per_endpoint(
+        {
+            'http://bentoml:3000/metrics': [MockResponse(file_path=get_fixture_path('metrics.txt'))],
+            'http://bentoml:3000//livez': [MockResponse(status_code=500)],
+            'http://bentoml:3000//readyz': [MockResponse(status_code=500)],
+        }
+    )
 
-    _err = Mock()
-    _err.status_code = 500
-    _http_err = requests.HTTPError("500 Internal Server Error")
-    _http_err.response = _err
-    _err.raise_for_status.side_effect = _http_err
+    check = BentomlCheck('bentoml', {}, [OM_MOCKED_INSTANCE])
+    dd_run_check(check)
 
-    with patch('datadog_checks.bentoml.check.BentomlCheck.http') as mock_http:
-        mock_http.get.return_value = _err
+    for metric in METRICS:
+        aggregator.assert_metric(metric)
 
-        check = BentomlCheck('bentoml', {}, [OM_MOCKED_INSTANCE])
-        dd_run_check(check)
+    for metric in ENDPOINT_METRICS:
+        aggregator.assert_metric(metric, value=0, tags=['test:tag', 'status_code:500'])
 
-        for metric in ENDPOINT_METRICS:
-            aggregator.assert_metric(metric, value=0, tags=['test:tag', 'status_code:500'])
-
-        aggregator.assert_service_check('bentoml.openmetrics.health', ServiceCheck.OK)
+    aggregator.assert_service_check('bentoml.openmetrics.health', ServiceCheck.OK)


### PR DESCRIPTION
## Motivation

Two test correctness bugs in `bentoml/tests/test_unit.py`, found during the requests→httpx migration audit (PR #22710).

Both tests call `mock_http_response(file_path=...)` and then immediately override `BentomlCheck.http` with `patch()`. The key insight: `OpenMetricsScraper` has its own `RequestsWrapper` created independently in `__init__`, so patching `BentomlCheck.http` never affected the scraper. Both the scraper and the health endpoint checks ultimately call `requests.Session.get`, which `mock_http_response` already patches.

**`test_bentoml_mock_metrics`**
- The inner `patch(BentomlCheck.http)` block is dead weight. `mock_http_response` already serves health endpoint calls.
- `assert mock_http.get.call_count == 2` is an implementation detail assertion that breaks if endpoints are added or removed.

**`test_bentoml_mock_valid_endpoint_invalid_health`**
- Achieves URL routing by accident via two independent mock layers that happen to target different code paths.
- No assertions on OpenMetrics metrics, so a regression in the primary check output would go undetected.

## Approach

- `test_bentoml_mock_metrics`: Remove the inner `patch()` block and `assert call_count == 2`.
- `test_bentoml_mock_valid_endpoint_invalid_health`: Replace with `mock_http_response_per_endpoint` for explicit URL routing. `MockResponse(status_code=500).raise_for_status()` raises `HTTPError` naturally. Add `METRICS` assertions.

## Verification

- Added `METRICS` assertions to `test_bentoml_mock_valid_endpoint_invalid_health` before refactoring; confirmed they passed with the old mock (scraper was already emitting metrics correctly).
- `ddev test -fs bentoml` clean, 3/3 pass.