### PR TITLE
Fix gitlab conftest: json.loads for version response, remove dead /-/health branch

### DIFF
--- a/gitlab/tests/conftest.py
+++ b/gitlab/tests/conftest.py
@@ -148,15 +148,13 @@ def mocked_requests_get(*args, **kwargs):
                 iter_lines=lambda **kwargs: text_data.split("\n"),
                 headers={'Content-Type': "text/plain"},
             )
-    elif url == "http://{}:{}/api/v4/version".format(HOST, GITLAB_LOCAL_PORT) or url == "http://{}:{}/-/health".format(
-        HOST, GITLAB_LOCAL_PORT
-    ):
+    elif url == "http://{}:{}/api/v4/version".format(HOST, GITLAB_LOCAL_PORT):
         f_name = os.path.join(os.path.dirname(__file__), 'fixtures', 'version.json')
         with open(f_name, 'r') as f:
             text_data = f.read()
             response = mock.MagicMock()
             response.status_code = 200
-            response.json.return_value = text_data
+            response.json.return_value = json.loads(text_data)
             return response
 
     pytest.fail("url `{}` not registered".format(args[0]))

--- a/gitlab/tests/test_unit.py
+++ b/gitlab/tests/test_unit.py
@@ -12,7 +12,9 @@ from .common import (
     CUSTOM_TAGS,
     GITALY_METRICS,
     GITLAB_GITALY_PROMETHEUS_ENDPOINT,
+    GITLAB_LOCAL_PORT,
     GITLAB_TAGS,
+    HOST,
     V1_METRICS,
     V2_METRICS,
     assert_check,
@@ -173,3 +175,11 @@ def test_parse_readiness_service_checks(
         )
 
     assert len(aggregator.service_check_names) == 13
+
+
+def test_version_mock_returns_parsed_dict(mock_data):
+    import requests
+
+    session = requests.Session()
+    response = session.get("http://{}:{}/api/v4/version".format(HOST, GITLAB_LOCAL_PORT))
+    assert response.json() == {"version": "1.2.3"}

--- a/gitlab/tests/test_unit.py
+++ b/gitlab/tests/test_unit.py
@@ -12,9 +12,7 @@ from .common import (
     CUSTOM_TAGS,
     GITALY_METRICS,
     GITLAB_GITALY_PROMETHEUS_ENDPOINT,
-    GITLAB_LOCAL_PORT,
     GITLAB_TAGS,
-    HOST,
     V1_METRICS,
     V2_METRICS,
     assert_check,
@@ -175,11 +173,3 @@ def test_parse_readiness_service_checks(
         )
 
     assert len(aggregator.service_check_names) == 13
-
-
-def test_version_mock_returns_parsed_dict(mock_data):
-    import requests
-
-    session = requests.Session()
-    response = session.get("http://{}:{}/api/v4/version".format(HOST, GITLAB_LOCAL_PORT))
-    assert response.json() == {"version": "1.2.3"}


### PR DESCRIPTION
## Motivation

Two bugs in `gitlab/tests/conftest.py::mocked_requests_get`, found during the requests to httpx migration audit (PR #22710).

**Bug 1: version endpoint mock returns a raw string.**

```python
text_data = f.read()
response.json.return_value = text_data  # raw string, not a dict
```

The check calls `response.json().get('version')`. Strings have no `.get()` method, so an `AttributeError` is raised and silently swallowed in `get_gitlab_version`'s try/except. Version metadata is never collected. Other branches in the same function correctly use `json.loads(text_data)`.

**Bug 2: dead duplicate `/-/health` condition.**

```python
# First branch — always catches /-/health
elif url == ".../liveness" or url == ".../-/health":
    ...

# Later branch — /-/health is unreachable here
elif url == ".../api/v4/version" or url == ".../-/health":
    # returns version.json content — wrong for a health endpoint
```

The first branch wins, so the second `/-/health` condition is dead code that would return the wrong response type if ever reached.

## Approach

- Bug 1: `response.json.return_value = json.loads(text_data)`
- Bug 2: Remove the dead `or url == ".../-/health"` from the version branch

## Verification

`ddev test -fs gitlab` clean (15 unit tests pass).