### PR TITLE
fix(snmp_f5): apply snmp_device and snmp_host    template vars to # Nodes widget

### DIFF
--- a/snmp_f5/assets/dashboards/f5-networks.json
+++ b/snmp_f5/assets/dashboards/f5-networks.json
@@ -1839,7 +1839,7 @@
                             "requests": [
                                 {
                                     "aggregator": "last",
-                                    "q": "sum:snmp.ltmNodeAddrNumber{*}"
+                                    "q": "sum:snmp.ltmNodeAddrNumber{$snmp_device,$snmp_host}"
                                 }
                             ],
                             "title": "# Nodes ",


### PR DESCRIPTION
### What does this PR do?
Changes the # Nodes widget query in the F5 Networks OOTB dashboard from {*} to {$snmp_device,$snmp_host} so it respects the dashboard's template variable filters.

### Motivation
Customer bug (AGENT-16084): scoping the F5 Networks dashboard by $snmp_device or $snmp_host had no effect on the # Nodes widget — it always showed the total node count across all devices. The sibling # Virtual Servers and # Pools widgets already correctly use {$snmp_device,$snmp_host}.

Single character change in a JSON dashboard definition. Verified the corrected query matches the pattern used by the other count widgets in the same dashboard.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
