### PR TITLE
Fix rabbitmq tests: remove dead assertions inside pytest.raises blocks

### DIFF
--- a/rabbitmq/tests/test_unit.py
+++ b/rabbitmq/tests/test_unit.py
@@ -28,12 +28,10 @@ def test__get_data(check):
     r = mock.MagicMock()
     with mock.patch('datadog_checks.base.utils.http.requests.Session', return_value=r):
         r.get.side_effect = [requests.exceptions.HTTPError, ValueError]
-        with pytest.raises(RabbitMQException) as e:
+        with pytest.raises(RabbitMQException):
             check._get_data('')
-            assert isinstance(e, RabbitMQException)
-        with pytest.raises(RabbitMQException) as e:
+        with pytest.raises(RabbitMQException):
             check._get_data('')
-            assert isinstance(e, RabbitMQException)
 
 
 def test_status_check(check, aggregator):
@@ -87,9 +85,8 @@ def test__check_aliveness(check, aggregator):
 
     # in case of connection errors, this check should stay silent
     check._get_data.side_effect = RabbitMQException
-    with pytest.raises(RabbitMQException) as e:
+    with pytest.raises(RabbitMQException):
         check._get_vhosts(instance, '')
-        assert isinstance(e, RabbitMQException)
 
 
 def test__get_metrics(check, aggregator):


### PR DESCRIPTION
## Motivation

Three `assert isinstance(e, RabbitMQException)` lines in `rabbitmq/tests/test_unit.py` are placed after raising calls inside `pytest.raises` blocks. Python exits the context as soon as the expected exception is raised, so these lines never run. They provide no safety net and give a false sense of coverage.

Found during the requests → httpx migration audit (PR #22722).

## Approach

Remove the three dead assertion lines. `pytest.raises(RabbitMQException)` already verifies the exception type at block exit. Writing replacement `isinstance(e.value, ...)` assertions would be redundant for the same reason.

## Verification

`ddev test -fs rabbitmq` clean. Test-only change, no changelog required.