### PR TITLE
Use default instead of display_default for clickhouse password

### DIFF
--- a/clickhouse/assets/configuration/spec.yaml
+++ b/clickhouse/assets/configuration/spec.yaml
@@ -41,7 +41,7 @@ files:
       secret: true
       value:
         type: string
-        display_default: ''
+        default: ''
     - name: db
       description: The database to connect to.
       fleet_configurable: true


### PR DESCRIPTION
### What does this PR do?
Switch the clickhouse `password` field in `spec.yaml` from `display_default: ''` to `default: ''`, so the empty-string default is declared through the proper `default` key rather than relying on `display_default` to implicitly drive the generated `instance_password()` default.

### Motivation
PR #23015 fixed a regression where `password` ended up as `None` at runtime (sending `"default:None"` as credentials) by making the config model generator emit `instance_password()` returning `''`. That default currently comes from `display_default: ''`, which is a side effect of how the default system happens to work rather than an explicit declaration. This change makes the intent explicit: `default: ''` is the source of truth for the runtime default, and `display_default` goes back to being purely a documentation concern.

Generated config models and `conf.yaml.example` are unchanged, so behavior is identical; this is just a correctness cleanup of the spec.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged