### PR TITLE
[Backport 7.78.x] Bump cryptography from 46.0.6 to 46.0.7 (#23403)

### DIFF
--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -10,7 +10,7 @@ cachetools==7.0.1
 clickhouse-connect==0.11.0
 cm-client==45.0.4
 confluent-kafka==2.13.2
-cryptography==46.0.6
+cryptography==46.0.7
 ddtrace==3.19.5
 dnspython==2.8.0
 fastavro==1.12.1

--- a/cisco_aci/changelog.d/23403.fixed
+++ b/cisco_aci/changelog.d/23403.fixed
@@ -1,0 +1,1 @@
+Bump cryptography from 46.0.6 to 46.0.7 to address CVE-2026-39892.

--- a/cisco_aci/pyproject.toml
+++ b/cisco_aci/pyproject.toml
@@ -36,7 +36,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "cryptography==46.0.6",
+    "cryptography==46.0.7",
 ]
 
 [project.urls]

--- a/datadog_checks_base/changelog.d/23403.fixed
+++ b/datadog_checks_base/changelog.d/23403.fixed
@@ -1,0 +1,1 @@
+Bump cryptography from 46.0.6 to 46.0.7 to address CVE-2026-39892.

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -36,7 +36,7 @@ db = [
 deps = [
     "binary==1.0.2",
     "cachetools==7.0.1",
-    "cryptography==46.0.6",
+    "cryptography==46.0.7",
     "ddtrace==3.19.5",
     "jellyfish==1.2.1",
     "lazy-loader==0.4",

--- a/http_check/changelog.d/23403.fixed
+++ b/http_check/changelog.d/23403.fixed
@@ -1,0 +1,1 @@
+Bump cryptography from 46.0.6 to 46.0.7 to address CVE-2026-39892.

--- a/http_check/pyproject.toml
+++ b/http_check/pyproject.toml
@@ -36,7 +36,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "cryptography==46.0.6",
+    "cryptography==46.0.7",
     "pysocks==1.7.1",
     "requests-ntlm==1.3.0",
 ]

--- a/mysql/changelog.d/23403.fixed
+++ b/mysql/changelog.d/23403.fixed
@@ -1,0 +1,1 @@
+Bump cryptography from 46.0.6 to 46.0.7 to address CVE-2026-39892.

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -38,7 +38,7 @@ license = "BSD-3-Clause"
 deps = [
     "boto3==1.42.54",
     "cachetools==7.0.1",
-    "cryptography==46.0.6",
+    "cryptography==46.0.7",
     "pymysql==1.1.2",
 ]
 

--- a/tls/changelog.d/23403.fixed
+++ b/tls/changelog.d/23403.fixed
@@ -1,0 +1,1 @@
+Bump cryptography from 46.0.6 to 46.0.7 to address CVE-2026-39892.

--- a/tls/pyproject.toml
+++ b/tls/pyproject.toml
@@ -36,7 +36,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "cryptography==46.0.6",
+    "cryptography==46.0.7",
     "service-identity[idna]==24.2.0",
 ]
 


### PR DESCRIPTION
Backport of #23403 to `7.78.x`.

Addresses CVE-2026-39892 (VULN-62136).

## Conflicts resolved

- `datadog_checks_base/pyproject.toml`, `mysql/pyproject.toml`: kept 7.78.x versions of unrelated deps (`cachetools==7.0.1`, `boto3==1.42.54`), bumped only `cryptography` to `46.0.7`.
- `.deps/resolved/*.txt` and `.deps/metadata.json`: reverted to 7.78.x state. These will be regenerated by the dependency-resolution bot after merge (per the established backport pattern — see #23225/#23235).

## Test plan

- [ ] CI passes on the backport
- [ ] Dependency-resolution bot regenerates lockfiles on `7.78.x` post-merge