### PR TITLE
Fix nutanix conftest: pytest.fail on unregistered URLs instead of silent 404

### DIFF
--- a/nutanix/tests/conftest.py
+++ b/nutanix/tests/conftest.py
@@ -348,9 +348,6 @@ def mock_http_get(mocker):
             mock_resp.json = mocker.Mock(return_value=response_data)
             return mock_resp
 
-        print(f"[MOCK ERROR] No matching endpoint for URL: {url}")
-        mock_resp.status_code = 404
-        mock_resp.raise_for_status = mocker.Mock(side_effect=Exception("404 Not Found"))
-        return mock_resp
+        pytest.fail(f"url `{url}` not registered")
 
     return mocker.patch('requests.Session.get', side_effect=mock_response)

--- a/nutanix/tests/test_configuration.py
+++ b/nutanix/tests/test_configuration.py
@@ -4,6 +4,7 @@
 
 
 import pytest
+import requests
 
 from datadog_checks.nutanix import NutanixCheck
 
@@ -113,7 +114,5 @@ def test_category_tags_with_prefix_for_system_and_user_types(dd_run_check, aggre
 
 
 def test_mock_fails_on_unregistered_url(mock_http_get):
-    import requests
-
     with pytest.raises(pytest.fail.Exception, match="not registered"):
         requests.Session().get("http://10.0.0.197:9440/api/nonexistent/v1/endpoint")

--- a/nutanix/tests/test_configuration.py
+++ b/nutanix/tests/test_configuration.py
@@ -110,3 +110,10 @@ def test_category_tags_with_prefix_for_system_and_user_types(dd_run_check, aggre
         category_tags = [t for t in metric.tags if "Environment:" in t or "Team:" in t]
         unprefixed_tags = [t for t in category_tags if not t.startswith("ntnx_")]
         assert not unprefixed_tags, f"Category tags must have ntnx_ prefix, found without: {unprefixed_tags}"
+
+
+def test_mock_fails_on_unregistered_url(mock_http_get):
+    import requests
+
+    with pytest.raises(pytest.fail.Exception, match="not registered"):
+        requests.Session().get("http://10.0.0.197:9440/api/nonexistent/v1/endpoint")

--- a/nutanix/tests/test_configuration.py
+++ b/nutanix/tests/test_configuration.py
@@ -4,7 +4,6 @@
 
 
 import pytest
-import requests
 
 from datadog_checks.nutanix import NutanixCheck
 
@@ -111,8 +110,3 @@ def test_category_tags_with_prefix_for_system_and_user_types(dd_run_check, aggre
         category_tags = [t for t in metric.tags if "Environment:" in t or "Team:" in t]
         unprefixed_tags = [t for t in category_tags if not t.startswith("ntnx_")]
         assert not unprefixed_tags, f"Category tags must have ntnx_ prefix, found without: {unprefixed_tags}"
-
-
-def test_mock_fails_on_unregistered_url(mock_http_get):
-    with pytest.raises(pytest.fail.Exception, match="not registered"):
-        requests.Session().get("http://10.0.0.197:9440/api/nonexistent/v1/endpoint")


### PR DESCRIPTION
## Motivation

The fallthrough handler in `nutanix/tests/conftest.py` uses `print()` to log unmatched URLs. Pytest swallows stdout by default, so the message never appears. The 404 response is returned silently. Tests that only check `status_code` pass without error when an unregistered URL is hit. This can mask missing mock registrations for the lifetime of the integration. Other integrations (strimzi, couchbase, gitlab, torchserve) use `pytest.fail()` for this case.

This bug was found during the [requests to httpx migration](https://github.com/DataDog/integrations-core/pull/22676) audit of HTTP-layer call sites.

## Approach

Replace the three-line fallthrough with a single `pytest.fail()` call:

```python
pytest.fail(f"url `{url}` not registered")
```

No response object is returned. The test stops immediately with the unmatched URL in the failure message. The intentional 404 for missing alert UUIDs (lines 292-294) is not touched.

## Verification

`ddev test -fs nutanix` passes (114/114).