### PR TITLE
[ECT-5327] airflow: set creates_events=true

### DIFF
--- a/airflow/manifest.json
+++ b/airflow/manifest.json
@@ -34,7 +34,7 @@
         "spec": "assets/configuration/spec.yaml"
       },
       "events": {
-        "creates_events": false
+        "creates_events": true
       },
       "metrics": {
         "prefix": "airflow.",


### PR DESCRIPTION
## Summary
- Sets `creates_events: true` in `airflow/manifest.json` to enable V2 event ingestion

Jira: ECT-5327

🤖 Generated with [Claude Code](https://claude.com/claude-code)