### PR TITLE
docs(airflow): surface DJM setup on tile Overview and Configuration tabs

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -3,8 +3,8 @@
 ## Overview
 
 <div class="alert alert-info">
-<a href="https://docs.datadoghq.com/data_observability/jobs_monitoring/">Data Observability: Jobs Monitoring</a> provides out-of-the-box tracing for Airflow DAG runs, helping you quickly troubleshoot problematic tasks, correlate DAG runs to logs, and understand complex pipelines with data lineage across DAGs.<br/><br/>
-<strong>Note</strong>: This page covers only the documentation for collecting Airflow integration metrics and logs using the Datadog Agent.
+<a href="https://docs.datadoghq.com/data_observability/jobs_monitoring/">Data Observability: Jobs Monitoring</a> provides out-of-the-box tracing, log correlation, and data lineage for Airflow DAG runs, helping you quickly troubleshoot problematic tasks and understand complex pipelines.<br/><br/>
+To enable Data Observability: Jobs Monitoring for this integration, see the <a href="https://docs.datadoghq.com/data_observability/jobs_monitoring/airflow/?tab=kubernetes">setup guide</a>.
 </div>
 
 The Datadog Agent collects many metrics from Airflow, including those for:
@@ -21,6 +21,16 @@ In addition to metrics, the Datadog Agent also sends service checks related to A
 **Minimum Agent version:** 7.17.0
 
 ## Setup
+
+<div class="alert alert-info">
+<a href="https://docs.datadoghq.com/data_observability/jobs_monitoring/">Data Observability: Jobs Monitoring</a> provides out-of-the-box tracing, log correlation, and data lineage for Airflow DAG runs, helping you quickly troubleshoot problematic tasks and understand complex pipelines.<br/><br/>
+To enable Data Observability: Jobs Monitoring for this integration, see the <a href="https://docs.datadoghq.com/data_observability/jobs_monitoring/airflow/?tab=kubernetes">setup guide</a>.
+</div>
+
+<div class="alert alert-warning">
+If your goal is only to enable Data Observability: Jobs Monitoring, you do <strong>not</strong> need to install the Datadog Agent or follow the configuration steps below. Follow the <a href="https://docs.datadoghq.com/data_observability/jobs_monitoring/airflow/?tab=kubernetes">Data Observability: Jobs Monitoring setup guide</a> instead.<br/><br/>
+<strong>Note</strong>: This page covers only the documentation for collecting Airflow integration metrics and logs using the Datadog Agent.
+</div>
 
 ### Installation
 


### PR DESCRIPTION
### What does this PR do?

Updates the Airflow integration tile README to promote **Data Observability: Jobs Monitoring** (DJM) as a lower-friction path for users who only need DAG-run observability. Two changes:

1. **Overview tab banner** — refined copy (tracing, log correlation, data lineage) and added a second link taking users directly to the DJM Airflow setup guide (`?tab=kubernetes`).
2. **Configuration tab** — added a duplicate blue info banner (so the DJM link is visible on this tab too) plus a new yellow warning banner that explicitly states the Agent install and configuration steps are **not** required if the goal is only to enable DJM.

### Motivation

Users landing on the Airflow tile today get a single-link mention of DJM inside a blue box, only on the Overview tab. If their goal is DJM they can waste time reading through Agent/StatsD configuration that they don't actually need. Making the DJM path clearer — and surfacing it on the Configuration tab too — reduces friction for that cohort.

### Review checklist (to be filled by reviewers)

- [ ] Docs-only change; no tests needed.
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] Verify banner copy and links render correctly on the docs preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)