### PR TITLE
chore(bentoml): drop redundant assert_all_metrics_covered() call

### DIFF
--- a/bentoml/tests/test_unit.py
+++ b/bentoml/tests/test_unit.py
@@ -30,7 +30,6 @@ def test_bentoml_mock_metrics(dd_run_check, aggregator, mock_http_response):
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())
-    aggregator.assert_all_metrics_covered()
     aggregator.assert_metric_has_tag('bentoml.service.request.count', 'bentoml_endpoint:/summarize')
     aggregator.assert_service_check('bentoml.openmetrics.health', ServiceCheck.OK)
 


### PR DESCRIPTION
## Summary

Cleanup: remove redundant `aggregator.assert_all_metrics_covered()` call in `test_bentoml_mock_metrics`.

The duplicate dates back to the original integration commit (PR #21232). The second call brackets `assert_metrics_using_metadata`, which doesn't submit or assert metrics, so the asserted-metric set is unchanged between the two calls — second invocation is a no-op. Flagged by NouemanKHAL in PR #22676.

No behavior change. Test coverage unchanged.

## Test plan

- [ ] `ddev test bentoml` passes