### PR TITLE
[DOCS-13851] Windows Crash Detection clarification 

### DIFF
--- a/wincrashdetect/README.md
+++ b/wincrashdetect/README.md
@@ -38,7 +38,7 @@ No metrics are collected by this integration.
 
 ### Events
 
-The Windows crash detection integration submits an event when a previously unreported crash is detected at agent startup.  The integration will report one event per crash.
+The Windows Crash Detection integration submits an event when it detects a previously unreported system crash (BSOD) at Agent startup. The integration submits one event per crash.
 
 ### Service Checks
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes DOCS-13851

- Updates the Windows Crash Detection integration's Events description to clarify it reports system crashes (BSOD).
- Makes additional changes to match style guide
    - Changes passive voice to active voice
    - Removes temporal "will" word 


### Motivation
DOCS-13851

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
