### PR TITLE
[mongo] Include database_instance tag in mongodb.can_connect service check

### DIFF
--- a/mongo/changelog.d/23476.fixed
+++ b/mongo/changelog.d/23476.fixed
@@ -1,0 +1,1 @@
+Include `database_instance` tag in `mongodb.can_connect` service check.

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -296,11 +296,11 @@ class MongoDb(AgentCheck):
                 self._schemas.run_job_loop(tags=self._get_tags(include_internal_resource_tags=True))
                 self._query_metrics.run_job_loop(tags=self._get_tags(include_internal_resource_tags=True))
         except CRITICAL_FAILURE as e:
-            self.service_check(SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=self._config.service_check_tags)
+            self.service_check(SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=self._get_service_check_tags())
             self._unset_metadata()
             raise e  # Let exception bubble up to global handler and show full error in the logs.
         else:
-            self.service_check(SERVICE_CHECK_NAME, AgentCheck.OK, tags=self._config.service_check_tags)
+            self.service_check(SERVICE_CHECK_NAME, AgentCheck.OK, tags=self._get_service_check_tags())
 
     def _refresh_metadata(self):
         if self._mongo_version is None or self._mongo_modules is None:
@@ -323,7 +323,6 @@ class MongoDb(AgentCheck):
     def _unset_metadata(self):
         self.log.debug('Due to connection failure we will need to reset the metadata.')
         self._mongo_version = None
-        self._resolved_hostname = None
 
     def _collect_metrics(self):
         deployment = self.deployment_type

--- a/mongo/tests/test_integration_shard.py
+++ b/mongo/tests/test_integration_shard.py
@@ -17,7 +17,12 @@ def test_mongo_arbiter(aggregator, check, instance_arbiter, dd_run_check):
     check = check(instance_arbiter)
     dd_run_check(check)
 
-    tags = [f'host:{common.HOST}', f'port:{common.PORT_ARBITER}', 'db:admin']
+    tags = [
+        f'host:{common.HOST}',
+        f'port:{common.PORT_ARBITER}',
+        'db:admin',
+        f'database_instance:{check._resolved_hostname}',
+    ]
     aggregator.assert_service_check('mongodb.can_connect', status=MongoDb.OK, tags=tags)
 
     metric_names = aggregator.metric_names

--- a/mongo/tests/test_integration_standalone.py
+++ b/mongo/tests/test_integration_standalone.py
@@ -56,7 +56,7 @@ def test_mongo_db_test(aggregator, check, instance_user, dd_run_check):
     check = check(instance_user)
     dd_run_check(check)
 
-    tags = [f'host:{common.HOST}', f'port:{common.PORT1}', 'db:test']
+    tags = [f'host:{common.HOST}', f'port:{common.PORT1}', 'db:test', f'database_instance:{check._resolved_hostname}']
     aggregator.assert_service_check('mongodb.can_connect', status=MongoDb.OK, tags=tags)
 
     metric_names = aggregator.metric_names
@@ -289,5 +289,6 @@ def test_propagate_agent_tags(
                 f'host:{common.HOST}',
                 f'port:{common.PORT1}',
                 'db:test',
+                f'database_instance:{check._resolved_hostname}',
             ] + agent_tags
             aggregator.assert_service_check('mongodb.can_connect', status=MongoDb.OK, tags=expected_tags)


### PR DESCRIPTION
## Summary

- `service_check()` calls in `check()` were using `self._config.service_check_tags` directly, bypassing `_get_service_check_tags()` which appends the `database_instance:<resolved_hostname>` tag
- Both the `CRITICAL` and `OK` paths now call `self._get_service_check_tags()` instead
- Removed `self._resolved_hostname = None` from `_unset_metadata()` so the tag remains stable across consecutive CRITICAL checks during a sustained outage (the hostname cannot change without a config change; no other DBM integration clears it on failure)
- Updated tag assertions in `test_integration_standalone.py` and `test_integration_shard.py` to include the new tag (read dynamically from `check._resolved_hostname` post-run)

## Test plan

- [x] `ddev --no-interactive test mongo -- -k test_emits_critical_service_check_when_service_is_not_available` — CRITICAL before hostname resolved, no `database_instance` tag emitted
- [x] `ddev --no-interactive test mongo -- -k test_emits_ok_service_check_when_service_is_available` — OK path includes `database_instance` tag
- [x] `ddev --no-interactive test mongo -- -k test_service_check_critical_when_connection_dies` — CRITICAL path includes `database_instance` tag on first and all subsequent failures
- [ ] Integration tests: `ddev env test mongo` covering `test_mongo_db_test`, `test_propagate_agent_tags`, and `test_mongo_arbiter`

Relates-to: SDBM-2530

🤖 Generated with [Claude Code](https://claude.com/claude-code)