### PR TITLE
test: Add account_config.json for Plaid (validator testing)

### DIFF
--- a/plaid/assets/account_config.json
+++ b/plaid/assets/account_config.json
@@ -1,0 +1,36 @@
+{
+  "supported_auth_methods": [],
+  "additional_config_fields": [
+    {
+      "field_type": "text",
+      "field": {
+        "key": "api_base_url",
+        "label": "API base URL",
+        "help": "For example: production.plaid.com",
+        "editable": true,
+        "required": true,
+        "pattern": null
+      }
+    },
+    {
+      "field_type": "text",
+      "field": {
+        "key": "client_id",
+        "label": "Client ID",
+        "editable": true,
+        "required": true,
+        "pattern": null
+      }
+    },
+    {
+      "field_type": "password",
+      "field": {
+        "key": "secret",
+        "label": "Secret",
+        "editable": true,
+        "required": true
+      }
+    }
+  ],
+  "dataflow_config": []
+}


### PR DESCRIPTION
## Summary
Add `account_config.json` for Plaid integration to test the new account-config-validator in staging.

**This is a test PR** - the file intentionally has incomplete field definitions to verify that the APW validator correctly detects and reports validation errors.

## What's included
This PR adds `plaid/assets/account_config.json` with the following fields:
- ✅ `api_base_url` - API base URL (e.g., production.plaid.com)
- ✅ `client_id` - Client ID
- ✅ `secret` - Secret (password field)
- ❌ `access_token` - **Intentionally omitted for testing**

## Expected validator behavior
The account-config-validator should detect that the `access_token` field is:
- Present in the Plaid crawler's `account_config_fields()` definition (both metrics and logs crawlers)
- Missing from the `account_config.json` file

This should produce a validation error similar to:
```
Field 'access_token' from crawlers is missing in account_config.json
```

## Testing plan
1. Merge this PR to trigger APW validation in staging
2. Monitor delancie logs for account-config-validator execution:
   ```
   service:delancie-web-crawler
   @task_name:account-config-runtime-validator
   ```
3. Verify that the validator correctly identifies the missing `access_token` field
4. After successful validation, either:
   - Close this PR if it's for testing only
   - Add the missing `access_token` field in a follow-up commit

## Related
- account-config-validator implementation in dogweb repo (branch: `leandro.almeida/account-config-apw-validator`)
- Similar test PRs in integrations-internal-core: SAP HANA Cloud #3154, Plaid #3157, Shopify #3159
- Related to integrations-internal-core Plaid PR for cross-repo testing