### PR TITLE
[TXP-77] Add webhook_config.json and api-key-picker for batch 2 integrations (integrations-core)

### DIFF
--- a/adyen/README.md
+++ b/adyen/README.md
@@ -16,7 +16,7 @@ Follow the instructions below to configure this integration for your Adyen accou
 
 Configure the Datadog endpoint to forward Adyen events as logs to Datadog. For more details, see [Adyen webhook overview][2].
 
-1. Copy the generated URL inside the **Configuration** tab on the Datadog [Adyen integration tile][4].
+1. {{< integration-api-key-picker >}}
 2. Sign in to your [Adyen][1] account with a user which has a **Merchant technical integrator** role along with default roles, and has access to **Company account and all associated merchant accounts**.
 3. Under the **Developers** section, click **Webhooks**.
 4. Click on **Create new webhook**.

--- a/adyen/README.md
+++ b/adyen/README.md
@@ -69,5 +69,4 @@ Additional helpful documentation, links, and articles:
 [1]: https://www.adyen.com/
 [2]: https://docs.adyen.com/development-resources/webhooks/
 [3]: https://docs.datadoghq.com/help/
-[4]: /integrations/adyen
 [5]: https://www.datadoghq.com/blog/monitor-adyen-payments/

--- a/adyen/README.md
+++ b/adyen/README.md
@@ -63,10 +63,10 @@ For further assistance, contact [Datadog Support][3].
 
 Additional helpful documentation, links, and articles:
 
-- [Monitor and optimize payment processing with Datadog's Adyen integration][5]
+- [Monitor and optimize payment processing with Datadog's Adyen integration][4]
 
 
 [1]: https://www.adyen.com/
 [2]: https://docs.adyen.com/development-resources/webhooks/
 [3]: https://docs.datadoghq.com/help/
-[5]: https://www.datadoghq.com/blog/monitor-adyen-payments/
+[4]: https://www.datadoghq.com/blog/monitor-adyen-payments/

--- a/adyen/README.md
+++ b/adyen/README.md
@@ -10,9 +10,7 @@ The Adyen integration collects transaction, dispute, and payout data using Adyen
 
 Follow the instructions below to configure this integration for your Adyen account.
 
-### Configuration
-
-#### Webhook Configuration
+### Webhook Configuration
 
 Configure the Datadog endpoint to forward Adyen events as logs to Datadog. For more details, see [Adyen webhook overview][2].
 

--- a/adyen/assets/webhook_config.json
+++ b/adyen/assets/webhook_config.json
@@ -1,0 +1,1 @@
+{"type": "url", "source": "adyen"}

--- a/beyondtrust_identity_security_insights/README.md
+++ b/beyondtrust_identity_security_insights/README.md
@@ -16,7 +16,7 @@ This integration also includes ready-to-use Cloud SIEM detection rules for enhan
 
 Configure the Datadog endpoint to forward BeyondTrust Identity Security Insights detections as logs to Datadog.
 
-1. Copy the generated URL inside the **Configuration** tab on the Datadog [BeyondTrust Identity Security Insights][2] tile.
+1. {{< integration-api-key-picker >}}
 2. Sign in to [BeyondTrust Identity Security Insights Portal][3].
 3. Go to **Insights > Integrations** from the top left side main menu.
 4. Click **Webhooks**.

--- a/beyondtrust_identity_security_insights/README.md
+++ b/beyondtrust_identity_security_insights/README.md
@@ -65,7 +65,6 @@ The BeyondTrust Identity Security Insights integration does not include any even
 For any further assistance, contact [Datadog support][4].
 
 [1]: https://www.beyondtrust.com/products/identity-security-insights
-[2]: /integrations/beyondtrust-identity-security-insights
 [3]: https://login.beyondtrust.io/signin/signIn
 [4]: https://docs.datadoghq.com/help/
 [5]: https://docs.datadoghq.com/actions/workflows/

--- a/beyondtrust_identity_security_insights/README.md
+++ b/beyondtrust_identity_security_insights/README.md
@@ -6,7 +6,7 @@
 
 Integrate BeyondTrust Identity Security Insights with Datadog's pre-built dashboard visualizations to gain insights into detection logs. With Datadog's built-in log pipelines, you can parse and enrich these logs to facilitate easy search and detailed insights.
 
-This integration also includes ready-to-use Cloud SIEM detection rules for enhanced monitoring and security. These Cloud SIEM rules can be used with [Datadog Workflow Automation][5] to orchestrate and automate your end-to-end processes with OOTB Workflow Blueprints.
+This integration also includes ready-to-use Cloud SIEM detection rules for enhanced monitoring and security. These Cloud SIEM rules can be used with [Datadog Workflow Automation][4] to orchestrate and automate your end-to-end processes with OOTB Workflow Blueprints.
 
 ## Setup
 
@@ -17,7 +17,7 @@ This integration also includes ready-to-use Cloud SIEM detection rules for enhan
 Configure the Datadog endpoint to forward BeyondTrust Identity Security Insights detections as logs to Datadog.
 
 1. {{< integration-api-key-picker >}}
-2. Sign in to [BeyondTrust Identity Security Insights Portal][3].
+2. Sign in to [BeyondTrust Identity Security Insights Portal][2].
 3. Go to **Insights > Integrations** from the top left side main menu.
 4. Click **Webhooks**.
 5. Click **Create Integration**.
@@ -62,9 +62,9 @@ The BeyondTrust Identity Security Insights integration does not include any even
 
 ## Support
 
-For any further assistance, contact [Datadog support][4].
+For any further assistance, contact [Datadog support][3].
 
 [1]: https://www.beyondtrust.com/products/identity-security-insights
-[3]: https://login.beyondtrust.io/signin/signIn
-[4]: https://docs.datadoghq.com/help/
-[5]: https://docs.datadoghq.com/actions/workflows/
+[2]: https://login.beyondtrust.io/signin/signIn
+[3]: https://docs.datadoghq.com/help/
+[4]: https://docs.datadoghq.com/actions/workflows/

--- a/beyondtrust_identity_security_insights/README.md
+++ b/beyondtrust_identity_security_insights/README.md
@@ -10,9 +10,7 @@ This integration also includes ready-to-use Cloud SIEM detection rules for enhan
 
 ## Setup
 
-### Configuration
-
-#### Webhook Configuration
+### Webhook Configuration
 
 Configure the Datadog endpoint to forward BeyondTrust Identity Security Insights detections as logs to Datadog.
 

--- a/beyondtrust_identity_security_insights/assets/webhook_config.json
+++ b/beyondtrust_identity_security_insights/assets/webhook_config.json
@@ -1,0 +1,1 @@
+{"type": "url", "source": "beyond-trust-identity-security-insights"}

--- a/checkpoint_harmony_email_and_collaboration/README.md
+++ b/checkpoint_harmony_email_and_collaboration/README.md
@@ -18,7 +18,7 @@ Follow the instructions below to configure this integration for your Check Point
 
 Configure the Datadog endpoint to forward Check Point Harmony Email & Collaboration events as logs to Datadog.
 
-1. Copy the generated URL inside the **Configuration** tab on the Datadog [Check Point Harmony Email & Collaboration integration tile][4].
+1. {{< integration-api-key-picker >}}
 2. Sign in to [Check Point Infinity Portal][5].
 3. If you are not already in the **Harmony Email & Collaboration** Administrator Portal:
    - Click the **Menu** icon in the top-left corner.

--- a/checkpoint_harmony_email_and_collaboration/README.md
+++ b/checkpoint_harmony_email_and_collaboration/README.md
@@ -12,9 +12,7 @@ Get detailed visibility into these events with out-of-the-box dashboards, and st
 
 Follow the instructions below to configure this integration for your Check Point Harmony Email & Collaboration account.
 
-### Configuration
-
-#### Webhook Configuration
+### Webhook Configuration
 
 Configure the Datadog endpoint to forward Check Point Harmony Email & Collaboration events as logs to Datadog.
 

--- a/checkpoint_harmony_email_and_collaboration/README.md
+++ b/checkpoint_harmony_email_and_collaboration/README.md
@@ -19,7 +19,7 @@ Follow the instructions below to configure this integration for your Check Point
 Configure the Datadog endpoint to forward Check Point Harmony Email & Collaboration events as logs to Datadog.
 
 1. {{< integration-api-key-picker >}}
-2. Sign in to [Check Point Infinity Portal][5].
+2. Sign in to [Check Point Infinity Portal][3].
 3. If you are not already in the **Harmony Email & Collaboration** Administrator Portal:
    - Click the **Menu** icon in the top-left corner.
    - In the **Harmony** section, click **Email & Collaboration**.
@@ -51,9 +51,8 @@ The Check Point Harmony Email & Collaboration integration does not include any e
 
 ## Troubleshooting
 
-Need help? Contact [Datadog support][3].
+Need help? Contact [Datadog support][2].
 
 [1]: https://www.checkpoint.com/harmony/email-security/
-[2]: https://app.datadoghq.com/account/settings/agent/latest
-[3]: https://docs.datadoghq.com/help/
-[5]: https://portal.checkpoint.com/
+[2]: https://docs.datadoghq.com/help/
+[3]: https://portal.checkpoint.com/

--- a/checkpoint_harmony_email_and_collaboration/README.md
+++ b/checkpoint_harmony_email_and_collaboration/README.md
@@ -56,5 +56,4 @@ Need help? Contact [Datadog support][3].
 [1]: https://www.checkpoint.com/harmony/email-security/
 [2]: https://app.datadoghq.com/account/settings/agent/latest
 [3]: https://docs.datadoghq.com/help/
-[4]: https://app.datadoghq.com/integrations/checkpoint_harmony_email_and_collaboration
 [5]: https://portal.checkpoint.com/

--- a/checkpoint_harmony_email_and_collaboration/assets/webhook_config.json
+++ b/checkpoint_harmony_email_and_collaboration/assets/webhook_config.json
@@ -1,0 +1,1 @@
+{"type": "url", "source": "checkpoint-harmony-email-and-collaboration"}

--- a/contentful/README.md
+++ b/contentful/README.md
@@ -63,4 +63,3 @@ Need help? Contact [Datadog support][4].
 [2]: https://www.contentful.com/developers/docs/webhooks/overview/
 [3]: https://be.contentful.com/login/
 [4]: https://docs.datadoghq.com/help/
-[5]: /integrations/contentful

--- a/contentful/README.md
+++ b/contentful/README.md
@@ -15,7 +15,7 @@ Follow the instructions below to configure this integration for your Contentful 
 #### Webhook Configuration
 Configure the Datadog endpoint to forward Contentful events as logs to Datadog. See [Contentful Webhook overview][2] for more details.
 
-1. Copy the generated URL inside the **Configuration** tab on the Datadog [Contentful integration tile][5].
+1. {{< integration-api-key-picker >}}
 2. Log in to your [Contentful account][3] as space admin.
 3. Go to **Settings > Webhooks**.
 4. Click on **Add Webhook**.

--- a/contentful/assets/webhook_config.json
+++ b/contentful/assets/webhook_config.json
@@ -1,0 +1,1 @@
+{"type": "url", "source": "contentful"}

--- a/intercom/README.md
+++ b/intercom/README.md
@@ -12,9 +12,7 @@ The Intercom integration seamlessly collects admin activities, data events, conv
 
 Follow the instructions below to configure this integration for your Intercom account.
 
-### Configuration
-
-#### Webhook Configuration
+### Webhook Configuration
 
 Configure the Datadog endpoint to forward Intercom events as logs to Datadog. See [Intercom webhook overview][3] for more details.
 

--- a/intercom/README.md
+++ b/intercom/README.md
@@ -4,7 +4,7 @@
 
 [Intercom][1] is a customer communication platform that enables businesses to engage with their users through in-app messaging, email, and chat. It offers features like live chat, automated messaging, and customer support tools, making it easier for companies to provide personalized customer experiences.
 
-The Intercom integration seamlessly collects admin activities, data events, conversations, news items, and ticket data, and ingests them into Datadog for comprehensive analysis using [webhooks][6].
+The Intercom integration seamlessly collects admin activities, data events, conversations, news items, and ticket data, and ingests them into Datadog for comprehensive analysis using [webhooks][5].
 
 **Minimum Agent version:** 7.57.1
 
@@ -78,10 +78,10 @@ The Intercom integration does not include any service checks.
 
 ## Support
 
-For further assistance, contact [Datadog Support][5].
+For further assistance, contact [Datadog Support][4].
 
 [1]: https://www.intercom.com/
 [2]: https://app.intercom.com/
 [3]: https://developers.intercom.com/docs/webhooks
-[5]: https://docs.datadoghq.com/help/
-[6]: https://developers.intercom.com/docs/references/2.10/webhooks/webhook-models
+[4]: https://docs.datadoghq.com/help/
+[5]: https://developers.intercom.com/docs/references/2.10/webhooks/webhook-models

--- a/intercom/README.md
+++ b/intercom/README.md
@@ -83,6 +83,5 @@ For further assistance, contact [Datadog Support][5].
 [1]: https://www.intercom.com/
 [2]: https://app.intercom.com/
 [3]: https://developers.intercom.com/docs/webhooks
-[4]: /integrations/intercom
 [5]: https://docs.datadoghq.com/help/
 [6]: https://developers.intercom.com/docs/references/2.10/webhooks/webhook-models

--- a/intercom/README.md
+++ b/intercom/README.md
@@ -18,7 +18,7 @@ Follow the instructions below to configure this integration for your Intercom ac
 
 Configure the Datadog endpoint to forward Intercom events as logs to Datadog. See [Intercom webhook overview][3] for more details.
 
-1. Copy the generated URL inside the **Configuration** tab on the Datadog [Intercom integration tile][4].
+1. {{< integration-api-key-picker >}}
 2. Sign in to your [Intercom][2] account using a user account with full access to Apps and Integrations.
 3. Go to **Settings**.
 4. In the Integrations section, select **Developer Hub**.

--- a/intercom/assets/webhook_config.json
+++ b/intercom/assets/webhook_config.json
@@ -1,0 +1,1 @@
+{"type": "url", "source": "intercom"}

--- a/jamf_pro/README.md
+++ b/jamf_pro/README.md
@@ -46,8 +46,8 @@ The Jamf Pro integration does not include any events.
 
 ## Support
 
-For any further assistance, contact [Datadog support][4].
+For any further assistance, contact [Datadog support][3].
 
 [1]: https://www.jamf.com/products/jamf-pro/
 [2]: https://developer.jamf.com/jamf-pro/docs/webhooks-1
-[4]: https://docs.datadoghq.com/help/
+[3]: https://docs.datadoghq.com/help/

--- a/jamf_pro/README.md
+++ b/jamf_pro/README.md
@@ -8,9 +8,7 @@ Integrate Jamf Pro with Datadog to gain insights into [Events][2] using pre-buil
 
 ## Setup
 
-### Configuration
-
-#### Webhook Configuration
+### Webhook Configuration
 
 Configure the Datadog endpoint to forward Jamf Pro detections as logs to Datadog.
 

--- a/jamf_pro/README.md
+++ b/jamf_pro/README.md
@@ -14,7 +14,7 @@ Integrate Jamf Pro with Datadog to gain insights into [Events][2] using pre-buil
 
 Configure the Datadog endpoint to forward Jamf Pro detections as logs to Datadog.
 
-1. Copy the generated URL inside the **Configuration** tab on the Datadog [Jamf Pro][3] tile.
+1. {{< integration-api-key-picker >}}
 2. In Jamf Pro, click **Settings** in the sidebar.
 3. In the **Global** section, click **Webhooks**.
 4. Click **New**.

--- a/jamf_pro/README.md
+++ b/jamf_pro/README.md
@@ -50,5 +50,4 @@ For any further assistance, contact [Datadog support][4].
 
 [1]: https://www.jamf.com/products/jamf-pro/
 [2]: https://developer.jamf.com/jamf-pro/docs/webhooks-1
-[3]: /integrations/jamf-pro
 [4]: https://docs.datadoghq.com/help/

--- a/jamf_pro/assets/webhook_config.json
+++ b/jamf_pro/assets/webhook_config.json
@@ -1,0 +1,1 @@
+{"type": "url", "source": "jamf-pro"}

--- a/postmark/README.md
+++ b/postmark/README.md
@@ -30,7 +30,7 @@ See [Postmark Webhook Overview][2] for more details.
 
 Perform the following steps to configure the webhook for both of the message streams mentioned above.
 
-1. Select an existing API key or create a new one by clicking one of the buttons below:<!-- UI Component to be added by DataDog team -->
+1. {{< integration-api-key-picker >}}
 2. Log in to your [Postmark account][3]. This redirects you to the [servers][4] page.
 3. Select the desired server. This redirects you to the **Message Streams** page.
 4. On the message streams page, select an existing broadcast or transactional message stream or create a new one. 

--- a/postmark/README.md
+++ b/postmark/README.md
@@ -11,9 +11,7 @@ To gain insights into Postmark's broadcast and transactional message streams, in
 Follow the instructions below to configure this integration for your Postmark account.
 
 
-### Configuration
-
-#### Enable open and link tracking in server settings for the message streams
+### Enable open and link tracking in server settings for the message streams
 Follow these steps to enable both features:
 
 1. Log into your [Postmark account][3]. This redirects you to the [servers][4] page.
@@ -21,7 +19,7 @@ Follow these steps to enable both features:
 3. In the navigation panel, click the **Settings** tab.
 4. In the **Tracking** section, enable both **Open tracking** and **Link tracking**.
 
-#### Webhook configuration steps
+### Webhook configuration steps
 Configure the Datadog endpoint to forward the following activity logs to Datadog:
 - **Broadcast** message streams
 - **Transactional** message streams

--- a/postmark/assets/webhook_config.json
+++ b/postmark/assets/webhook_config.json
@@ -1,0 +1,1 @@
+{"type": "url", "source": "postmark"}

--- a/push_security/README.md
+++ b/push_security/README.md
@@ -8,9 +8,7 @@ Integrate Push Security with Datadog's pre-built dashboard visualizations to gai
 
 ## Setup
 
-### Configuration
-
-#### Webhook Configuration
+### Webhook Configuration
 
 Configure the Datadog endpoint to forward Push Security events as logs to Datadog:
 

--- a/push_security/README.md
+++ b/push_security/README.md
@@ -14,7 +14,7 @@ Integrate Push Security with Datadog's pre-built dashboard visualizations to gai
 
 Configure the Datadog endpoint to forward Push Security events as logs to Datadog:
 
-1. Copy the generated URL inside the **Configuration** tab on the Datadog [Push Security][5] tile.
+1. {{< integration-api-key-picker >}}
 2. Sign in to [Push Security Portal][3].
 3. Go to **Settings** > **Webhooks**.
 4. Click **+ Webhook**.

--- a/push_security/README.md
+++ b/push_security/README.md
@@ -49,4 +49,3 @@ For further assistance, contact [Datadog support][4].
 [2]: https://pushsecurity.redoc.ly/webhooks-v1#operation/account-event
 [3]: http://login.pushsecurity.com/u/login
 [4]: https://docs.datadoghq.com/help/
-[5]: /integrations/push-security

--- a/push_security/assets/webhook_config.json
+++ b/push_security/assets/webhook_config.json
@@ -1,0 +1,1 @@
+{"type": "url", "source": "pushsecurity"}


### PR DESCRIPTION
## Summary

- Adds `webhook_config.json` assets for: adyen, beyondtrust-identity-security-insights, checkpoint-harmony-email-and-collaboration, contentful, intercom, jamf-pro, postmark, push-security
- Replaces "Copy the generated URL..." step 1 in each README with `{{< integration-api-key-picker >}}` shortcode
- Part of TXP-77: replacing custom `ConfigurationTab` React components in web-ui with auto-generated webhook config tabs

Note: `incident_io` already had these changes from a previous PR and is not included here.

## Test plan

- [ ] Verify `webhook_config.json` is valid JSON for each integration
- [ ] Verify `{{< integration-api-key-picker >}}` shortcode appears in the Setup section of each README
- [ ] Verify no unintended content changes were made to the READMEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)