### PR TITLE
[DOCS-13885] Note that Cisco Duo Federal is not supported

### DIFF
--- a/cisco_duo/README.md
+++ b/cisco_duo/README.md
@@ -13,6 +13,8 @@ The Cisco Duo integration seamlessly collects multi-factor authentication (MFA) 
 
 ## Setup
 
+**Note**: This integration does not support Duo Federal accounts (`duofederal.com` domains). Only standard Duo accounts (`duosecurity.com` domains) are supported.
+
 ### Configuration
 
 #### Get API Credentials of Cisco Duo

--- a/cisco_duo/README.md
+++ b/cisco_duo/README.md
@@ -13,7 +13,11 @@ The Cisco Duo integration seamlessly collects multi-factor authentication (MFA) 
 
 ## Setup
 
-**Note**: This integration does not support Duo Federal accounts (`duofederal.com` domains). Only standard Duo accounts (`duosecurity.com` domains) are supported.
+<!-- partial
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">This integration does not support Duo Federal accounts (<code>duofederal.com</code> domains). Only standard Duo accounts (<code>duosecurity.com</code> domains) are supported.</div>
+{{< /site-region >}}
+partial -->
 
 ### Configuration
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-13885

The Cisco Duo integration supports standard Duo accounts (`duosecurity.com` domains) but does not support Duo Federal accounts (`duofederal.com` domains). This PR adds a note at the top of the Setup section to make that limitation clear to readers. 

The note only appears if you have site=US1-FED selected, and looks like this:

<img width="1031" height="212" alt="image" src="https://github.com/user-attachments/assets/575189e4-b117-45a1-96e8-83d8bdd67688" />