### PR TITLE
test: Add account_config.json for Plaid (incomplete for validator tes…

### DIFF
--- a/plaid/assets/account_config.json
+++ b/plaid/assets/account_config.json
@@ -1,0 +1,36 @@
+{
+  "supported_auth_methods": [],
+  "additional_config_fields": [
+    {
+      "field_type": "text",
+      "field": {
+        "key": "api_base_url",
+        "label": "API base URL",
+        "help": "For example: production.plaid.com",
+        "editable": true,
+        "required": true,
+        "pattern": null
+      }
+    },
+    {
+      "field_type": "text",
+      "field": {
+        "key": "client_id",
+        "label": "Client ID",
+        "editable": true,
+        "required": true,
+        "pattern": null
+      }
+    },
+    {
+      "field_type": "password",
+      "field": {
+        "key": "secret",
+        "label": "Secret",
+        "editable": true,
+        "required": true
+      }
+    }
+  ],
+  "dataflow_config": []
+}


### PR DESCRIPTION
…ting)

Add account_config.json for Plaid integration with intentionally incomplete field definitions to test the account-config-validator in staging.

This file includes only 3 out of 4 required fields (missing access_token) to verify that the APW validator correctly detects and reports missing fields when compared against the crawler-sdk crawler definitions.

Fields included:
- api_base_url
- client_id
- secret

Fields intentionally omitted:
- access_token (should be flagged by validator)

Related to account-config-validator implementation.

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
