### PR TITLE
Revert "Fix nutanix conftest: pytest.fail on unregistered URLs instead of silent 404 (#23462)"

### DIFF
--- a/nutanix/tests/conftest.py
+++ b/nutanix/tests/conftest.py
@@ -348,6 +348,9 @@ def mock_http_get(mocker):
             mock_resp.json = mocker.Mock(return_value=response_data)
             return mock_resp
 
-        pytest.fail(f"url `{url}` not registered")
+        print(f"[MOCK ERROR] No matching endpoint for URL: {url}")
+        mock_resp.status_code = 404
+        mock_resp.raise_for_status = mocker.Mock(side_effect=Exception("404 Not Found"))
+        return mock_resp
 
     return mocker.patch('requests.Session.get', side_effect=mock_response)


### PR DESCRIPTION
### What does this PR do?
Reverts #23462.

### Motivation
Discussed with @NouemanKHAL. The fallthrough returning 404 simulates realistic Nutanix "resource not found" responses for trimmed fixtures (production has 100000s of audits/events that fixtures cannot store). `pytest.fail` was overly strict and removed the ability to test graceful 404 handling paths.

### Verification
  - `ddev test -fs nutanix` clean
  - `ddev --no-interactive test nutanix` passes (114/114)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
