### PR TITLE
Revert "Fix nutanix conftest: pytest.fail on unregistered URLs instead of silent 404"

### DIFF
--- a/nutanix/tests/conftest.py
+++ b/nutanix/tests/conftest.py
@@ -348,6 +348,9 @@ def mock_http_get(mocker):
             mock_resp.json = mocker.Mock(return_value=response_data)
             return mock_resp
 
-        pytest.fail(f"url `{url}` not registered")
+        print(f"[MOCK ERROR] No matching endpoint for URL: {url}")
+        mock_resp.status_code = 404
+        mock_resp.raise_for_status = mocker.Mock(side_effect=Exception("404 Not Found"))
+        return mock_resp
 
     return mocker.patch('requests.Session.get', side_effect=mock_response)


### PR DESCRIPTION
Reverts DataDog/integrations-core#23462