### PR TITLE
[Backport 7.78.x] build: bump OpenSSL from 3.6.1 to 3.6.2 in all builder images

### DIFF
--- a/.builders/images/linux-aarch64/Dockerfile
+++ b/.builders/images/linux-aarch64/Dockerfile
@@ -19,8 +19,8 @@ ENV LDFLAGS="-Wl,-rpath,'\$\$ORIGIN' -Wl,--strip-debug"
 RUN yum install -y perl-IPC-Cmd perl-CPANPLUS perl-core && \
  cpanp -i List::Util 1.66 && \
  DOWNLOAD_URL="https://www.openssl.org/source/openssl-{{version}}.tar.gz" \
- VERSION="3.6.1" \
- SHA256="b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a82e" \
+ VERSION="3.6.2" \
+ SHA256="aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f" \
  RELATIVE_PATH="openssl-{{version}}" \
  # https://docs.python.org/3/using/unix.html#custom-openssl
  INSTALL_COMMAND="make install_sw" \

--- a/.builders/images/linux-x86_64/Dockerfile
+++ b/.builders/images/linux-x86_64/Dockerfile
@@ -19,8 +19,8 @@ ENV LDFLAGS="-Wl,-rpath,'\$\$ORIGIN' -Wl,--strip-debug"
 RUN yum install -y perl-IPC-Cmd perl-CPANPLUS perl-core && \
  cpanp -i List::Util 1.66 && \
  DOWNLOAD_URL="https://www.openssl.org/source/openssl-{{version}}.tar.gz" \
- VERSION="3.6.1" \
- SHA256="b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a82e" \
+ VERSION="3.6.2" \
+ SHA256="aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f" \
  RELATIVE_PATH="openssl-{{version}}" \
  # https://docs.python.org/3/using/unix.html#custom-openssl
  INSTALL_COMMAND="make install_sw" \

--- a/.builders/images/macos/builder_setup.sh
+++ b/.builders/images/macos/builder_setup.sh
@@ -23,8 +23,8 @@ cp -R /opt/mqm "${DD_PREFIX_PATH}"
 
 # openssl
 DOWNLOAD_URL="https://www.openssl.org/source/openssl-{{version}}.tar.gz" \
-VERSION="3.6.1" \
-SHA256="b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a82e" \
+VERSION="3.6.2" \
+SHA256="aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f" \
 RELATIVE_PATH="openssl-{{version}}" \
 CONFIGURE_SCRIPT="./config" \
   install-from-source \

--- a/.builders/images/windows-x86_64/Dockerfile
+++ b/.builders/images/windows-x86_64/Dockerfile
@@ -127,11 +127,11 @@ RUN Get-RemoteFile `
     Add-ToPath -Append "C:\nasm\nasm-$Env:NASM_VERSION" && `
     Remove-Item "nasm-$Env:NASM_VERSION-win64.zip"
 
-ENV OPENSSL_VERSION="3.6.1"
+ENV OPENSSL_VERSION="3.6.2"
 RUN Get-RemoteFile `
       -Uri https://www.openssl.org/source/openssl-$Env:OPENSSL_VERSION.tar.gz `
       -Path openssl-$Env:OPENSSL_VERSION.tar.gz `
-      -Hash 'b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a82e'; `
+      -Hash 'aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f'; `
     7z x openssl-$Env:OPENSSL_VERSION.tar.gz -r -y && `
     7z x openssl-$Env:OPENSSL_VERSION.tar -oC:\openssl_3 && `
     cd C:\openssl_3\openssl-$Env:OPENSSL_VERSION && `

--- a/.builders/images/windows-x86_64/build_script.ps1
+++ b/.builders/images/windows-x86_64/build_script.ps1
@@ -24,7 +24,7 @@ Remove-Item "librdkafka-${kafka_version}.tar.gz"
 $triplet = "x64-windows"
 $vcpkg_dir = "C:\vcpkg"
 $librdkafka_dir = "C:\librdkafka\librdkafka-${kafka_version}"
-$desired_commit = "48cfe1e0e928341709d97fc3d2eff10ad6262c96"
+$desired_commit = "36118ef68885436fd2a999188216337365856ad4"
 
 # Clone and configure vcpkg
 if (-Not (Test-Path -Path "$vcpkg_dir\.git")) {


### PR DESCRIPTION
## What does this PR do?

Backport of #23215 to `7.78.x`. Bumps OpenSSL from 3.6.1 to 3.6.2 in all builder images (linux-aarch64, linux-x86_64, macos, windows-x86_64).

## Motivation

VULN-59288 — backport the OpenSSL CVE fix to the active release branch.

## Notes for reviewer

The auto-backport failed (https://github.com/DataDog/integrations-core/pull/23215#issuecomment-4336516634), so this was cherry-picked manually with `git cherry-pick -x -m 1`. Conflict resolution:

- `.deps/builder_inputs.toml` — dropped (added on master after 7.78.x branched, doesn't exist on this branch).
- `.deps/image_digests.json` and `.deps/resolved/*.txt` — kept the 7.78.x version per AGENTS.md ("regenerate on the release branch — don't copy from master"). The `resolve-build-deps.yaml` workflow will open a follow-up `bot/update-dependency-resolution` PR after merge.

Cherry-pick source: 2c390e4e599dc6ba1cef1d5e820e8196770f4b66