### PR TITLE
Use uv as hatch installer for faster test environment setup

### DIFF
--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -169,12 +169,17 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      with:
+        enable-cache: false
+
     # Pinning virtualenv because of https://github.com/pypa/hatch/issues/2193
     - name: Install Hatch
-      run: pip install -U hatch "virtualenv<21"
+      run: uv pip install --system -U "hatch>=1.13" "virtualenv<21"
 
     - name: Install Hatch environment collector plugin
-      run: pip install -e . --no-deps
+      run: uv pip install --system -e . --no-deps
 
     - name: Install Rust toolchain
       # This action must be pinned to a commit reachable from the master branch — any other commit

--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -174,10 +174,16 @@ jobs:
       with:
         enable-cache: false
 
-    # virtualenv pinned to <21 because of https://github.com/pypa/hatch/issues/2193
     # Both versions pinned for deterministic builds and stable cache reuse.
+    #
+    # virtualenv 21.0.0 (2026-02-25) split interpreter discovery out into the
+    # `python-discovery` package and removed `propose_interpreters` from
+    # `virtualenv.discovery.builtin`, which older hatch versions monkey-patched
+    # directly — see https://github.com/pypa/hatch/issues/2193. hatch 1.16.5
+    # picks up the fix from https://github.com/pypa/hatch/pull/2196 and now
+    # *requires* virtualenv>=21, so they must be bumped together.
     - name: Install Hatch
-      run: uv pip install --system "hatch==1.16.5" "virtualenv==20.39.1"
+      run: uv pip install --system "hatch==1.16.5" "virtualenv==21.3.0"
 
     - name: Install Hatch environment collector plugin
       run: uv pip install --system -e . --no-deps

--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -174,9 +174,10 @@ jobs:
       with:
         enable-cache: false
 
-    # Pinning virtualenv because of https://github.com/pypa/hatch/issues/2193
+    # virtualenv pinned to <21 because of https://github.com/pypa/hatch/issues/2193
+    # Both versions pinned for deterministic builds and stable cache reuse.
     - name: Install Hatch
-      run: uv pip install --system -U "hatch>=1.13" "virtualenv<21"
+      run: uv pip install --system "hatch==1.16.5" "virtualenv==20.39.1"
 
     - name: Install Hatch environment collector plugin
       run: uv pip install --system -e . --no-deps

--- a/.github/workflows/cache-shared-deps.yml
+++ b/.github/workflows/cache-shared-deps.yml
@@ -27,14 +27,21 @@ jobs:
       with:
         python-version: "${{ env.PYTHON_VERSION }}"
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      with:
+        enable-cache: false
+
     - name: Check cache
       uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       id: cache
       with:
-        path: ${{ runner.os == 'Windows' && '~\AppData\Local\pip\Cache' || runner.os == 'macOS' && '~/Library/Caches/pip' || '~/.cache/pip' }}
+        path: |
+          ${{ runner.os == 'Windows' && '~\AppData\Local\uv\cache' || runner.os == 'macOS' && '~/Library/Caches/uv' || '~/.cache/uv' }}
+          ${{ runner.os == 'Windows' && '~\AppData\Local\pip\Cache' || runner.os == 'macOS' && '~/Library/Caches/pip' || '~/.cache/pip' }}
         key: >-
           ${{ format(
-            'v01-python-{0}-{1}-{2}-{3}',
+            'v02-uv-{0}-{1}-{2}-{3}',
             env.pythonLocation,
             hashFiles('datadog_checks_base/pyproject.toml'),
             hashFiles('datadog_checks_dev/pyproject.toml'),
@@ -45,9 +52,7 @@ jobs:
     - name: Install dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       run: |-
-        pip install ./ddev
-        pip install ./datadog_checks_dev[cli]
-        pip install ./datadog_checks_base[deps]
+        uv pip install --system ./ddev ./datadog_checks_dev[cli] ./datadog_checks_base[deps]
 
     - name: Set up Python 2.7
       if: steps.cache.outputs.cache-hit != 'true'
@@ -71,5 +76,7 @@ jobs:
       uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       if: steps.cache.outputs.cache-hit != 'true'
       with:
-        path: ${{ runner.os == 'Windows' && '~\AppData\Local\pip\Cache' || runner.os == 'macOS' && '~/Library/Caches/pip' || '~/.cache/pip' }}
+        path: |
+          ${{ runner.os == 'Windows' && '~\AppData\Local\uv\cache' || runner.os == 'macOS' && '~/Library/Caches/uv' || '~/.cache/uv' }}
+          ${{ runner.os == 'Windows' && '~\AppData\Local\pip\Cache' || runner.os == 'macOS' && '~/Library/Caches/pip' || '~/.cache/pip' }}
         key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,15 +33,15 @@ jobs:
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.13'
-        cache: 'pip'
 
-    - name: Upgrade Python packaging tools
-      run: pip install --disable-pip-version-check --upgrade pip setuptools wheel
+    - name: Install uv
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      with:
+        enable-cache: false
 
     - name: Install ddev
       run: |
-        pip install -e ./datadog_checks_dev[cli]
-        pip install -e ./ddev
+        uv pip install --system -e ./datadog_checks_dev[cli] -e ./ddev
 
     - name: Configure ddev
       run: |

--- a/.github/workflows/test-fips-e2e.yml
+++ b/.github/workflows/test-fips-e2e.yml
@@ -63,22 +63,28 @@ jobs:
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "${{ env.PYTHON_VERSION }}"
-        cache: 'pip'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      with:
+        enable-cache: false
 
     - name: Restore cache
       uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
-        path: '~/.cache/pip'
+        path: |
+          ~/.cache/uv
+          ~/.cache/pip
         key: >-
           ${{ format(
-            'v01-python-{0}-{1}-{2}-{3}',
+            'v02-uv-{0}-{1}-{2}-{3}',
             env.pythonLocation,
             hashFiles('datadog_checks_base/pyproject.toml'),
             hashFiles('datadog_checks_dev/pyproject.toml'),
             hashFiles('ddev/pyproject.toml')
           )}}
         restore-keys: |-
-          v01-python-${{ env.pythonLocation }}
+          v02-uv-${{ env.pythonLocation }}
     - name: Get Datadog credentials
       id: dd-sts
       uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
@@ -87,8 +93,7 @@ jobs:
 
     - name: Install ddev from local folder
       run: |-
-        pip install -e ./datadog_checks_dev[cli]
-        pip install -e ./ddev
+        uv pip install --system -e ./datadog_checks_dev[cli] -e ./ddev
 
     - name: Configure ddev
       run: |-

--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -235,33 +235,38 @@ jobs:
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "${{ env.PYTHON_VERSION }}"
-        cache: 'pip'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      with:
+        enable-cache: false
 
     - name: Restore cache
       if: inputs.repo == 'core'
       uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
-        path: ${{ runner.os == 'Windows' && '~\AppData\Local\pip\Cache' || runner.os == 'macOS' && '~/Library/Caches/pip' || '~/.cache/pip' }}
+        path: |
+          ${{ runner.os == 'Windows' && '~\AppData\Local\uv\cache' || runner.os == 'macOS' && '~/Library/Caches/uv' || '~/.cache/uv' }}
+          ${{ runner.os == 'Windows' && '~\AppData\Local\pip\Cache' || runner.os == 'macOS' && '~/Library/Caches/pip' || '~/.cache/pip' }}
         key: >-
           ${{ format(
-            'v01-python-{0}-{1}-{2}-{3}',
+            'v02-uv-{0}-{1}-{2}-{3}',
             env.pythonLocation,
             hashFiles('datadog_checks_base/pyproject.toml'),
             hashFiles('datadog_checks_dev/pyproject.toml'),
             hashFiles('ddev/pyproject.toml')
           )}}
         restore-keys: |-
-          v01-python-${{ env.pythonLocation }}
+          v02-uv-${{ env.pythonLocation }}
 
     - name: Install ddev from local folder
       if: inputs.repo == 'core'
       run: |-
-        pip install -e ./datadog_checks_dev[cli]
-        pip install -e ./ddev
+        uv pip install --system -e ./datadog_checks_dev[cli] -e ./ddev
 
     - name: Install ddev from PyPI
       if: inputs.repo != 'core'
-      run: pip install ddev
+      run: uv pip install --system ddev
 
     - name: Configure ddev
       run: |-

--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -110,6 +110,21 @@ jobs:
         # Enable disk performance counters
         diskperf -y
 
+    # On Windows, force uv to copy files into the venv instead of hardlinking
+    # them from its cache. uv's default `hardlink` mode on Windows breaks
+    # `hatch env remove` (run by `ddev test --compat` and `--recreate`):
+    # extension modules such as `backports.zstd._zstd.pyd` (a transitive of
+    # `hatch>=1.13`) get loaded by Python during the test run, and Windows
+    # then refuses to delete the venv's hardlink while the cache copy is
+    # still pinned, so cleanup fails with `PermissionError: [WinError 5]`.
+    # Refs:
+    #   https://github.com/astral-sh/uv/issues/7918
+    #   https://docs.astral.sh/uv/reference/settings/#link-mode
+    - name: Configure uv link mode (Windows)
+      if: runner.os == 'Windows'
+      shell: bash
+      run: echo "UV_LINK_MODE=copy" >> "$GITHUB_ENV"
+
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     # When called as a reusable workflow from other repos, `uses: ./` resolves

--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -110,18 +110,25 @@ jobs:
         # Enable disk performance counters
         diskperf -y
 
-    # On Windows, force uv to copy files into the venv instead of hardlinking
-    # them from its cache. uv's default `hardlink` mode on Windows breaks
-    # `hatch env remove` (run by `ddev test --compat` and `--recreate`):
-    # extension modules such as `backports.zstd._zstd.pyd` (a transitive of
-    # `hatch>=1.13`) get loaded by Python during the test run, and Windows
-    # then refuses to delete the venv's hardlink while the cache copy is
-    # still pinned, so cleanup fails with `PermissionError: [WinError 5]`.
+    # On Windows minimum-base-package jobs only, force uv to copy files into
+    # the venv instead of hardlinking them from its cache. uv's default
+    # `hardlink` mode on Windows breaks `hatch env remove`, which is invoked
+    # by `ddev test --compat` (used by the minimum-base-package matrix) at the
+    # end of the run: extension modules such as `backports.zstd._zstd.pyd`
+    # (a transitive of `hatch>=1.13`) get loaded by Python during the test
+    # run, and Windows then refuses to delete the venv's hardlink while the
+    # cache copy is still pinned, so cleanup fails with
+    # `PermissionError: [WinError 5]`. We can't influence this from our side:
+    # the share flags that would allow deletion are set by whoever opens the
+    # file (CPython's loader, Defender, etc.), not by us.
+    #
+    # We only set this for `minimum-base-package` runs because regular test
+    # jobs never invoke `hatch env remove` and so keep the hardlink speed-up.
     # Refs:
     #   https://github.com/astral-sh/uv/issues/7918
     #   https://docs.astral.sh/uv/reference/settings/#link-mode
-    - name: Configure uv link mode (Windows)
-      if: runner.os == 'Windows'
+    - name: Configure uv link mode (Windows minimum-base-package)
+      if: runner.os == 'Windows' && inputs.minimum-base-package
       shell: bash
       run: echo "UV_LINK_MODE=copy" >> "$GITHUB_ENV"
 

--- a/datadog_checks_dev/changelog.d/23497.fixed
+++ b/datadog_checks_dev/changelog.d/23497.fixed
@@ -1,0 +1,1 @@
+Bump minimum virtualenv to 20.26.1 in the cli extras for compatibility with modern hatch.

--- a/datadog_checks_dev/hatch.toml
+++ b/datadog_checks_dev/hatch.toml
@@ -15,5 +15,5 @@ matrix.python.features = [
 ]
 # TODO: remove this when the old CLI is gone
 matrix.python.pre-install-commands = [
-  { value = "python -m pip install --no-deps --disable-pip-version-check {verbosity:flag:-1} -e ../ddev", if = ["3.13"] },
+  { value = "uv pip install --no-deps {verbosity:flag:-1} -e ../ddev", if = ["3.13"] },
 ]

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -84,7 +84,7 @@ cli = [
     # https://github.com/twisted/towncrier/issues/641
     "towncrier==23.11.0",
     "twine>=1.11.0",
-    "virtualenv<20.22.0",
+    "virtualenv>=20.26.1",
     # TODO: Remove once every check has a pyproject.toml
 ]
 

--- a/datadog_checks_tests_helper/setup.py
+++ b/datadog_checks_tests_helper/setup.py
@@ -27,7 +27,7 @@ def get_requirements(fpath):
 setup(
     # Version should always match one from an agent release
     version=ABOUT["__version__"],
-    name='datadog_checks_tests_helper',
+    name='datadog-checks-tests-helper',
     description='The Datadog Check Tests Helpers',
     long_description=LONG_DESC,
     long_description_content_type='text/markdown',

--- a/ddev/changelog.d/23497.added
+++ b/ddev/changelog.d/23497.added
@@ -1,0 +1,1 @@
+Use uv as the installer for hatch test environments to speed up environment setup.

--- a/ddev/hatch.toml
+++ b/ddev/hatch.toml
@@ -13,5 +13,5 @@ dependencies = [
 ]
 # TODO: remove this when the old CLI is gone
 pre-install-commands = [
-  "python -m pip install --disable-pip-version-check {verbosity:flag:-1} -e ../datadog_checks_dev[cli]",
+  "uv pip install {verbosity:flag:-1} -e ../datadog_checks_dev[cli]",
 ]

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "coverage",
     "datadog-api-client==2.20.0",
     "datadog-checks-dev[cli]~=37.0",
-    "hatch>=1.8.1",
+    "hatch>=1.13.0",
     "httpx",
     "jsonpointer",
     "pluggy",

--- a/ddev/src/ddev/plugin/external/hatch/environment_collector.py
+++ b/ddev/src/ddev/plugin/external/hatch/environment_collector.py
@@ -128,6 +128,11 @@ class DatadogChecksEnvironmentCollector(EnvironmentCollectorInterface):
             if not (self.is_test_package or self.is_dev_package):
                 env_config.setdefault('features', ['deps'])
 
+            # uv-managed venvs do not seed pip. Some tests and integration
+            # scripts shell out to `python -m pip install`, so include pip as
+            # a dependency to keep that working.
+            env_config.setdefault('dependencies', []).append('pip')
+
             base_package_features = env_config.get('base-package-features', self.config.get('base-package-features'))
             install_commands = []
             if install_command := self.base_package_install_command(base_package_features):
@@ -219,6 +224,9 @@ class DatadogChecksEnvironmentCollector(EnvironmentCollectorInterface):
                 'ruff==0.11.10',
                 # Keep in sync with: /datadog_checks_base/pyproject.toml
                 'pydantic==2.11.5',
+                # uv-managed venvs do not seed pip, but mypy's --install-types
+                # shells out to `python -m pip install` for missing type stubs.
+                'pip',
             ],
         }
         config = {'lint': lint_env}

--- a/ddev/src/ddev/plugin/external/hatch/environment_collector.py
+++ b/ddev/src/ddev/plugin/external/hatch/environment_collector.py
@@ -76,19 +76,19 @@ class DatadogChecksEnvironmentCollector(EnvironmentCollectorInterface):
     @cached_property
     def test_package_install_command(self):
         if not self.in_core_repo:
-            return self.pip_install_command('datadog-checks-dev')
+            return self.uv_install_command('datadog-checks-dev')
         elif not (self.is_test_package or self.is_dev_package):
-            return self.pip_install_command('-e', '../datadog_checks_dev')
+            return self.uv_install_command('-e', '../datadog_checks_dev')
 
     def base_package_install_command(self, features):
         from ddev.testing.constants import TestEnvVars
 
         if base_package_version := os.environ.get(TestEnvVars.BASE_PACKAGE_VERSION):
-            return self.pip_install_command(self.format_base_package(features, version=base_package_version))
+            return self.uv_install_command(self.format_base_package(features, version=base_package_version))
         elif not self.in_core_repo:
-            return self.pip_install_command(self.format_base_package(features))
+            return self.uv_install_command(self.format_base_package(features))
         elif not (self.is_base_package or self.is_dev_package):
-            return self.pip_install_command('-e', self.format_base_package(features, local=True))
+            return self.uv_install_command('-e', self.format_base_package(features, local=True))
 
     @staticmethod
     def format_base_package(features, version='', local=False):
@@ -103,11 +103,13 @@ class DatadogChecksEnvironmentCollector(EnvironmentCollectorInterface):
         return formatted
 
     @staticmethod
-    def pip_install_command(*args):
-        return f'python -m pip install --disable-pip-version-check {{verbosity:flag:-1}} {" ".join(args)}'
+    def uv_install_command(*args):
+        return f'uv pip install {{verbosity:flag:-1}} {" ".join(args)}'
 
     def finalize_config(self, config):
         for env_name, env_config in config.items():
+            env_config.setdefault('installer', 'uv')
+
             if env_name == 'default':
                 # Always add ddtrace as a dependency for the default environment
                 # This ensures we have it available when running tests to emit CI visibility data
@@ -192,6 +194,7 @@ class DatadogChecksEnvironmentCollector(EnvironmentCollectorInterface):
 
         lint_env = {
             'detached': True,
+            'installer': 'uv',
             'scripts': {
                 'style': [
                     self.formatter_command('--diff --check', settings_dir),

--- a/hatch.toml
+++ b/hatch.toml
@@ -21,8 +21,8 @@ dependencies = [
 ]
 # API & CLI documentation
 post-install-commands = [
-  "pip install -e ./datadog_checks_base[deps,http] -e ./datadog_checks_dev[cli]",
-  "pip install -e ./ddev",
+  "uv pip install -e ./datadog_checks_base[deps,http] -e ./datadog_checks_dev[cli]",
+  "uv pip install -e ./ddev",
 ]
 [envs.docs.env-vars]
 # Use a set timestamp for reproducible builds, see:

--- a/kafka_consumer/hatch.toml
+++ b/kafka_consumer/hatch.toml
@@ -3,8 +3,8 @@
 [envs.default]
 # If you bump the `confluent-kafka` version, also bump the `librdkafka` version in the `32_install_kerberos.sh` file
 post-install-commands = [
-  "python -m pip uninstall -y confluent-kafka",
-  "python -m pip install --no-binary confluent-kafka confluent-kafka==2.13.2",
+  "uv pip uninstall confluent-kafka",
+  "uv pip install --no-binary confluent-kafka confluent-kafka==2.13.2",
 ]
 
 [[envs.default.matrix]]

--- a/sap_hana/tests/test_integration.py
+++ b/sap_hana/tests/test_integration.py
@@ -122,7 +122,7 @@ def _assert_logs(check, datadog_agent):
         check.check_id,
         [
             {
-                'application_name': ANY,
+                'application_name': 'python3',
                 'application_user_name': ANY,
                 'audit_policy_name': 'USER_MANAGEMENT',
                 'event_action': 'CREATE USER',
@@ -139,7 +139,7 @@ def _assert_logs(check, datadog_agent):
                 'user_name': 'SYSTEM',
             },
             {
-                'application_name': ANY,
+                'application_name': 'python3',
                 'application_user_name': ANY,
                 'audit_policy_name': 'USER_MANAGEMENT',
                 'event_action': 'ALTER USER',
@@ -156,7 +156,7 @@ def _assert_logs(check, datadog_agent):
                 'user_name': 'SYSTEM',
             },
             {
-                'application_name': ANY,
+                'application_name': 'python3',
                 'application_user_name': ANY,
                 'audit_policy_name': 'USER_MANAGEMENT',
                 'event_action': 'ALTER USER',

--- a/sap_hana/tests/test_integration.py
+++ b/sap_hana/tests/test_integration.py
@@ -122,7 +122,7 @@ def _assert_logs(check, datadog_agent):
         check.check_id,
         [
             {
-                'application_name': 'python',
+                'application_name': ANY,
                 'application_user_name': ANY,
                 'audit_policy_name': 'USER_MANAGEMENT',
                 'event_action': 'CREATE USER',
@@ -139,7 +139,7 @@ def _assert_logs(check, datadog_agent):
                 'user_name': 'SYSTEM',
             },
             {
-                'application_name': 'python',
+                'application_name': ANY,
                 'application_user_name': ANY,
                 'audit_policy_name': 'USER_MANAGEMENT',
                 'event_action': 'ALTER USER',
@@ -156,7 +156,7 @@ def _assert_logs(check, datadog_agent):
                 'user_name': 'SYSTEM',
             },
             {
-                'application_name': 'python',
+                'application_name': ANY,
                 'application_user_name': ANY,
                 'audit_policy_name': 'USER_MANAGEMENT',
                 'event_action': 'ALTER USER',


### PR DESCRIPTION
### What does this PR do?

Switches the ddev hatch plugin to use **uv** as the installer for every hatch environment it collects (default, test, e2e, benchmark, latest, lint), and migrates the CI shared-dependency cache from pip's wheel cache to uv's wheel cache.

### Motivation

``ddev test`` is slow because pip spends a lot of time on metadata resolution even with wheels cached. Swapping pip for uv as the hatch installer makes environment setup substantially faster, both locally and in CI. uv was already partially used in the repo (``resolve-build-deps.yaml``, ``.gitlab/tagger/Dockerfile``), so this rounds it out for the test path.

### Core changes

- `ddev/src/ddev/plugin/external/hatch/environment_collector.py`
  - `pip_install_command` → `uv_install_command` (returns ``uv pip install``)
  - `finalize_config` sets `installer = 'uv'` on every collected env (`setdefault`, so individual integrations can override back to pip if they ever need to)
  - `get_initial_config` sets the same on the lint env
  - `pip` added to lint env and test/e2e env deps (uv-managed venvs don't seed pip; mypy `--install-types` and a couple of in-env scripts still need it)
- `ddev/pyproject.toml`: bump `hatch>=1.8.1` → `hatch>=1.13.0` (first hatch version with the uv installer)
- `datadog_checks_dev/pyproject.toml`: bump `virtualenv<20.22.0` → `virtualenv>=20.26.1` in the `[cli]` extras. The old upper bound was added in 2023 to keep Py2 testing alive; core no longer tests Py2 and the cli extras already pull Py3-only tools, so the cap was dead weight blocking modern hatch.
- Four `hatch.toml` files migrated from `python -m pip install` to `uv pip install` in pre/post-install commands: `ddev/hatch.toml`, `datadog_checks_dev/hatch.toml`, root `hatch.toml` (docs env), `kafka_consumer/hatch.toml`.
- CI workflows now install uv via ``astral-sh/setup-uv`` and cache ``~/.cache/uv``:
  - `.github/workflows/cache-shared-deps.yml`
  - `.github/workflows/test-target.yml`
  - `.github/workflows/test-fips-e2e.yml`
  - `.github/workflows/docs.yml`
  - `.github/workflows/build-ddev.yml`
- Cache key prefix bumped `v01-python-...` → `v02-uv-...` so the new cache populates cleanly without colliding with the old pip cache.

No per-integration ``hatch.toml`` files needed touching beyond those four — the plugin injects ``installer = 'uv'`` into all envs collected via ``[env.collectors.datadog-checks]``.

### Cache layout: why both uv AND pip paths are cached

The ``cache-shared-deps``, ``test-target``, ``test-fips-e2e`` workflows all cache **two** directories under a single key:

```yaml
path: |
  ${{ runner.os == 'Windows' && '~\AppData\Local\uv\cache' || runner.os == 'macOS' && '~/Library/Caches/uv' || '~/.cache/uv' }}
  ${{ runner.os == 'Windows' && '~\AppData\Local\pip\Cache' || runner.os == 'macOS' && '~/Library/Caches/pip' || '~/.cache/pip' }}
```

Each line is a per-platform path (Linux / macOS / Windows) for one of the two wheel caches. Both directories are saved and restored together under one cache entry.

Why both:
- **uv cache** (``~/.cache/uv``) is what hatch envs and the system-level ``uv pip install --system`` write to. This is the cache that drives the speedup.
- **pip cache** (``~/.cache/pip``) is still used by the **Python 2.7** branch in ``cache-shared-deps.yml`` (uv requires Py3.8+, so the Py2 step has to stay on pip). Without caching this path, the Py2 install step would re-download every wheel each run.

Caching both under one key with one ``actions/cache`` step keeps the workflow simple — single restore, single save, both ecosystems covered.

### Snowflakes handled along the way

Switching the installer surfaced several second-order issues unrelated to uv itself but exposed by it. Documenting them so future debugging starts with context.

#### 1. Windows venv cleanup blocked by uv hardlinks (`_zstd.pyd` lock)

**Symptom:** Windows minimum-base-package jobs failed during post-test cleanup with `PermissionError: [WinError 5] Access is denied` on `backports/zstd/_zstd.cp313-win_amd64.pyd`.

**Cause:** uv defaults to `hardlink` mode on Windows. When `hatch>=1.13` (whose transitive `backports-zstd` ships a `.pyd`) is installed into a uv-managed venv, the `.pyd` is a hardlink to the uv cache. `hatch env remove` (invoked at the end of `ddev test --compat`, used by the minimum-base-package matrix) then can't `shutil.rmtree` the venv because the loaded extension keeps the file open, and Windows refuses to delete any hardlink to an open file. Whether this manifests on a given run depends on Defender activity / shell / Windows build — see the [astral-sh/uv#7918](https://github.com/astral-sh/uv/issues/7918) discussion.

**Fix:** Set `UV_LINK_MODE=copy` only on Windows minimum-base-package jobs in `.github/workflows/test-target.yml`. Regular Windows test jobs never run `hatch env remove`, so they keep the hardlink fast path. Refs: [uv link-mode setting](https://docs.astral.sh/uv/reference/settings/#link-mode).

#### 2. `datadog-checks-tests-helper` distribution name

**Symptom:** `tests/cli/release/test_get_datadog_wheels.py::test_get_datadog_wheels` failed in the `ddev` test job with the helper package now reported as `datadog_checks_tests_helper` (underscores) instead of `datadog-checks-tests-helper` (hyphens).

**Cause:** `datadog_checks_tests_helper/setup.py` had `name='datadog_checks_tests_helper'`. The legacy `python setup.py bdist_wheel` invocation that older pip+setuptools defaulted to silently normalized this to hyphens. Modern pip+setuptools (and uv) use the PEP 517 `setuptools.build_meta:__legacy__` backend, which writes the literal `name=` value verbatim into `METADATA`. The `virtualenv<20.22.0` bump alone (which brings modern pip+setuptools) would have broken this test even without the uv switch.

**Fix:** Change `name='datadog_checks_tests_helper'` → `name='datadog-checks-tests-helper'` in `datadog_checks_tests_helper/setup.py`. The package is now distributed under the same canonical hyphenated name on PyPI conventions.

#### 3. SAP HANA `application_name` in audit logs

**Symptom:** `sap_hana/tests/test_integration.py::test_check` failed with the audit log carrying `application_name='python3'` while the test asserted `'python'`.

**Cause:** The `application_name` field that the SAP HANA server records is the connecting client's process name (`argv[0]`/`/proc/self/comm` on Linux). With `installer = "uv"` set on hatch envs, hatch ≥1.13 creates the venv via `uv venv`, whose canonical interpreter symlink is `python3`; the previous `virtualenv`-created venvs used `python`. So pytest is now launched as `python3` and HANA records `python3`.

**Fix:** Update the three assertions in `sap_hana/tests/test_integration.py` from `'application_name': 'python'` to `'application_name': 'python3'` to reflect the new (and now stable) venv layout.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the ``qa/skip-qa`` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the ``backport/<branch-name>`` label to the PR and it will automatically open a backport PR once this one is merged
