### PR TITLE
[Backport 7.79.x] Bump lxml from 6.0.1 to 6.1.0

### DIFF
--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -21,7 +21,7 @@ jellyfish==1.2.1
 kubernetes==35.0.0
 lazy-loader==0.5
 ldap3==2.9.1
-lxml==6.0.1
+lxml==6.1.0
 lz4==4.4.5
 mmh3==5.2.1
 oauthlib==3.3.1

--- a/ibm_was/changelog.d/23418.fixed
+++ b/ibm_was/changelog.d/23418.fixed
@@ -1,0 +1,1 @@
+Bump lxml to 6.1.0 to address CVE-2026-41066.

--- a/ibm_was/pyproject.toml
+++ b/ibm_was/pyproject.toml
@@ -36,7 +36,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "lxml==6.0.1",
+    "lxml==6.1.0",
 ]
 
 [project.urls]

--- a/mac_audit_logs/changelog.d/23418.fixed
+++ b/mac_audit_logs/changelog.d/23418.fixed
@@ -1,0 +1,1 @@
+Bump lxml to 6.1.0 to address CVE-2026-41066.

--- a/mac_audit_logs/pyproject.toml
+++ b/mac_audit_logs/pyproject.toml
@@ -37,7 +37,7 @@ dynamic = [
 
 [project.optional-dependencies]
 deps = [
-    "lxml==6.0.1",
+    "lxml==6.1.0",
 ]
 
 [project.urls]

--- a/sqlserver/changelog.d/23418.fixed
+++ b/sqlserver/changelog.d/23418.fixed
@@ -1,0 +1,1 @@
+Bump lxml to 6.1.0 to address CVE-2026-41066.

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -38,7 +38,7 @@ license = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "azure-identity==1.25.3",
-    "lxml==6.0.1",
+    "lxml==6.1.0",
     "pyodbc==5.3.0",
     "pywin32==311; sys_platform == 'win32'",
 ]


### PR DESCRIPTION
## What does this PR do?

Backport of #23418 to `7.79.x`. Bumps lxml from 6.0.1 to 6.1.0 in `ibm_was`, `mac_audit_logs`, `sqlserver`, and `agent_requirements.in`.

## Motivation

VULN-64320 / CVE-2026-41066 — backport the lxml CVE fix to the active release branch.

## Notes for reviewer

The auto-backport failed (https://github.com/DataDog/integrations-core/pull/23418#issuecomment-4336932676), so this was cherry-picked manually with `git cherry-pick -x -m 1`. Conflict resolution:

- `.deps/metadata.json` and `.deps/resolved/*.txt` — kept the 7.79.x version per AGENTS.md ("regenerate on the release branch — don't copy from master"). The `resolve-build-deps.yaml` workflow will open a follow-up `bot/update-dependency-resolution` PR after merge.

Cherry-pick source: 4f02a687dd2323beda528c2d11cc1e27865923e4