### PR TITLE
Wait for spark executors to register in dd_environment

### DIFF
--- a/spark/tests/conftest.py
+++ b/spark/tests/conftest.py
@@ -45,15 +45,18 @@ def check_executors_registered():
     # to register with the driver after the application starts. Until at least one
     # non-driver executor appears, the /executors endpoint returns only the driver and
     # `spark.executor.*` metrics are never emitted, causing flaky integration tests.
+    # The cluster runs a single worker with one core (SPARK_WORKER_CORES=1), so only one
+    # of the two apps can own a non-driver executor at a time; either app having one is
+    # enough for `test_integration_standalone` to observe executor metrics.
     for port in (4040, 4050):
         apps = requests.get('http://{}:{}/api/v1/applications'.format(HOST, port)).json()
         if not apps:
-            return False
+            continue
         app_id = apps[0]['id']
         executors = requests.get('http://{}:{}/api/v1/applications/{}/executors'.format(HOST, port, app_id)).json()
-        if not any(executor.get('id') != 'driver' for executor in executors):
-            return False
-    return True
+        if any(executor.get('id') != 'driver' for executor in executors):
+            return True
+    return False
 
 
 def get_custom_hosts():

--- a/spark/tests/conftest.py
+++ b/spark/tests/conftest.py
@@ -27,6 +27,7 @@ def dd_environment():
                 ]
             ),
             WaitFor(check_metrics_available, wait=5),
+            WaitFor(check_executors_registered, wait=5, attempts=60),
         ],
         attempts=2,
     ):
@@ -37,6 +38,22 @@ def check_metrics_available():
     endpoint = 'http://{}:4050/metrics/json'.format(HOST)
     r = requests.get(endpoint)
     return r.text.count("driver.spark.streaming") >= 6
+
+
+def check_executors_registered():
+    # Spark standalone executors are separate JVMs spawned by workers; they take time
+    # to register with the driver after the application starts. Until at least one
+    # non-driver executor appears, the /executors endpoint returns only the driver and
+    # `spark.executor.*` metrics are never emitted, causing flaky integration tests.
+    for port in (4040, 4050):
+        apps = requests.get('http://{}:{}/api/v1/applications'.format(HOST, port)).json()
+        if not apps:
+            return False
+        app_id = apps[0]['id']
+        executors = requests.get('http://{}:{}/api/v1/applications/{}/executors'.format(HOST, port, app_id)).json()
+        if not any(executor.get('id') != 'driver' for executor in executors):
+            return False
+    return True
 
 
 def get_custom_hosts():


### PR DESCRIPTION
### What does this PR do?

Adds a `check_executors_registered` wait condition to the spark integration's `dd_environment` fixture. The fixture now polls `/api/v1/applications/<id>/executors` on both driver apps (4040, 4050) and only proceeds once each app has at least one non-driver executor registered.

### Motivation

`test_integration_standalone` was flaky, failing intermittently with:

```
AssertionError: Needed at least 1 candidates for 'spark.executor.total_duration', got 0
```

In Spark standalone mode, executors are separate JVMs that workers spawn and register with the driver *after* the application is up. The `/executors` endpoint returns the driver immediately, but real executors appear later. The previous fixture only waited for streaming metrics to flow, so when the test ran before any non-driver executor had registered, `_spark_executor_metrics` only emitted `spark.driver.*` and not `spark.executor.*`. The failing log confirms this: `spark.executor.count = 1.0` (driver-only entry), driver metrics present, executor metrics absent.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged