### PR TITLE
[DBMON-6547] Add support for surfacing Mysql blocking queries from metadata locks

### DIFF
--- a/mysql/changelog.d/23505.added
+++ b/mysql/changelog.d/23505.added
@@ -1,0 +1,1 @@
+Add metadata lock blocking detection to activity query for MySQL 8.0+.

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -89,21 +89,52 @@ WHERE
 """
 
 BLOCKING_COLUMNS_MYSQL8 = """\
-    ,blocking_thread.thread_id AS blocking_thread_id,
-    blocking_thread.processlist_id AS blocking_processlist_id
+    ,COALESCE(blocking_thread.thread_id, mdl_blocking_thread.thread_id) AS blocking_thread_id,
+    COALESCE(blocking_thread.processlist_id, mdl_blocking_thread.processlist_id) AS blocking_processlist_id,
+    mdl_waiting.OBJECT_TYPE AS mdl_object_type,
+    mdl_waiting.OBJECT_SCHEMA AS mdl_object_schema,
+    mdl_waiting.OBJECT_NAME AS mdl_object_name,
+    mdl_waiting.LOCK_TYPE AS mdl_waiting_lock_type,
+    mdl_blocking.LOCK_TYPE AS mdl_blocking_lock_type
 """
 
 BLOCKING_JOINS_MYSQL8 = """\
-    LEFT JOIN performance_schema.data_lock_waits AS lock_waits ON thread_a.thread_id = lock_waits.requesting_thread_id
-    LEFT JOIN performance_schema.threads AS blocking_thread ON lock_waits.blocking_thread_id = blocking_thread.thread_id
+    LEFT JOIN performance_schema.data_lock_waits AS lock_waits
+        ON thread_a.thread_id = lock_waits.requesting_thread_id
+    LEFT JOIN performance_schema.threads AS blocking_thread
+        ON lock_waits.blocking_thread_id = blocking_thread.thread_id
+    LEFT JOIN performance_schema.metadata_locks AS mdl_waiting
+        ON thread_a.thread_id = mdl_waiting.OWNER_THREAD_ID
+        AND mdl_waiting.LOCK_STATUS = 'PENDING'
+    LEFT JOIN performance_schema.metadata_locks AS mdl_blocking
+        ON mdl_waiting.OBJECT_TYPE = mdl_blocking.OBJECT_TYPE
+        AND mdl_waiting.OBJECT_SCHEMA = mdl_blocking.OBJECT_SCHEMA
+        AND mdl_waiting.OBJECT_NAME = mdl_blocking.OBJECT_NAME
+        AND mdl_blocking.LOCK_STATUS = 'GRANTED'
+        AND mdl_waiting.OWNER_THREAD_ID != mdl_blocking.OWNER_THREAD_ID
+    LEFT JOIN performance_schema.threads AS mdl_blocking_thread
+        ON mdl_blocking.OWNER_THREAD_ID = mdl_blocking_thread.thread_id
 """
 
 IDLE_BLOCKERS_SUBQUERY_MYSQL8 = """\
         OR
-        -- Include idle sessions that are blocking others
+        -- Include idle sessions that are blocking others via InnoDB data locks
         thread_a.thread_id IN (
             SELECT blocking_thread_id
             FROM performance_schema.data_lock_waits
+        )
+        OR
+        -- Include idle sessions that are blocking others via metadata locks
+        thread_a.thread_id IN (
+            SELECT mdl_granted.OWNER_THREAD_ID
+            FROM performance_schema.metadata_locks AS mdl_pending
+            JOIN performance_schema.metadata_locks AS mdl_granted
+                ON mdl_pending.OBJECT_TYPE = mdl_granted.OBJECT_TYPE
+                AND mdl_pending.OBJECT_SCHEMA = mdl_granted.OBJECT_SCHEMA
+                AND mdl_pending.OBJECT_NAME = mdl_granted.OBJECT_NAME
+                AND mdl_granted.LOCK_STATUS = 'GRANTED'
+                AND mdl_pending.LOCK_STATUS = 'PENDING'
+                AND mdl_pending.OWNER_THREAD_ID != mdl_granted.OWNER_THREAD_ID
         )
 """
 

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -108,8 +108,8 @@ BLOCKING_JOINS_MYSQL8 = """\
         AND mdl_waiting.LOCK_STATUS = 'PENDING'
     LEFT JOIN performance_schema.metadata_locks AS mdl_blocking
         ON mdl_waiting.OBJECT_TYPE = mdl_blocking.OBJECT_TYPE
-        AND mdl_waiting.OBJECT_SCHEMA = mdl_blocking.OBJECT_SCHEMA
-        AND mdl_waiting.OBJECT_NAME = mdl_blocking.OBJECT_NAME
+        AND mdl_waiting.OBJECT_SCHEMA <=> mdl_blocking.OBJECT_SCHEMA
+        AND mdl_waiting.OBJECT_NAME <=> mdl_blocking.OBJECT_NAME
         AND mdl_blocking.LOCK_STATUS = 'GRANTED'
         AND mdl_waiting.OWNER_THREAD_ID != mdl_blocking.OWNER_THREAD_ID
     LEFT JOIN performance_schema.threads AS mdl_blocking_thread
@@ -130,8 +130,8 @@ IDLE_BLOCKERS_SUBQUERY_MYSQL8 = """\
             FROM performance_schema.metadata_locks AS mdl_pending
             JOIN performance_schema.metadata_locks AS mdl_granted
                 ON mdl_pending.OBJECT_TYPE = mdl_granted.OBJECT_TYPE
-                AND mdl_pending.OBJECT_SCHEMA = mdl_granted.OBJECT_SCHEMA
-                AND mdl_pending.OBJECT_NAME = mdl_granted.OBJECT_NAME
+                AND mdl_pending.OBJECT_SCHEMA <=> mdl_granted.OBJECT_SCHEMA
+                AND mdl_pending.OBJECT_NAME <=> mdl_granted.OBJECT_NAME
                 AND mdl_granted.LOCK_STATUS = 'GRANTED'
                 AND mdl_pending.LOCK_STATUS = 'PENDING'
                 AND mdl_pending.OWNER_THREAD_ID != mdl_granted.OWNER_THREAD_ID

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -667,6 +667,95 @@ def test_deadlocks(aggregator, dd_run_check, dbm_instance):
     )
 
 
+@pytest.mark.skipif(
+    MYSQL_FLAVOR == 'mariadb' or MYSQL_VERSION_PARSED < parse_version('8.0'),
+    reason='MDL blocking detection requires MySQL 8.0+ with metadata_locks instrument enabled by default',
+)
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_mdl_blocking_activity(aggregator, dbm_instance, dd_run_check, root_conn):
+    """Verify that metadata lock contention appears in the activity payload with blocking relationships."""
+    config = deepcopy(dbm_instance)
+    config['query_activity']['collect_blocking_queries'] = True
+    # Disable all metrics that could query information_schema or touch user table
+    # metadata — those queries acquire SHARED_READ metadata locks which would get
+    # queued behind the ALTER TABLE's pending EXCLUSIVE lock, deadlocking the check.
+    config['options'] = {
+        'extra_performance_metrics': False,
+        'replication': False,
+        'extra_status_metrics': False,
+        'extra_innodb_metrics': False,
+        'schema_size_metrics': False,
+        'table_size_metrics': False,
+        'system_table_size_metrics': False,
+        'table_rows_stats_metrics': False,
+    }
+    config['index_metrics'] = {'enabled': False}
+    config['only_custom_queries'] = True
+    check = MySql(CHECK_NAME, {}, instances=[config])
+
+    MDL_TABLE = 'testdb.mdl_test_table'
+
+    with closing(root_conn.cursor()) as cur:
+        cur.execute('DROP TABLE IF EXISTS {}'.format(MDL_TABLE))
+        cur.execute('CREATE TABLE {} (id INT PRIMARY KEY, val VARCHAR(50))'.format(MDL_TABLE))
+        cur.execute('INSERT INTO {} VALUES (1, %s)'.format(MDL_TABLE), ('hello',))
+    # PyMySQL defaults to autocommit=False, so the DDL/DML above opened an
+    # implicit transaction that holds a SHARED_WRITE metadata lock on the table.
+    # Commit to release it before we set up the intentional MDL contention.
+    root_conn.commit()
+
+    root_password = 'mypass' if MYSQL_FLAVOR == 'percona' or MYSQL_REPLICATION in ('group', 'hybrid') else None
+    holder_conn = pymysql.connect(host=HOST, port=PORT, user='root', password=root_password)
+    ddl_conn = pymysql.connect(host=HOST, port=PORT, user='root', password=root_password)
+    ddl_ready = Event()
+
+    def _hold_shared_mdl(conn):
+        conn.begin()
+        conn.cursor().execute('SELECT * FROM {}'.format(MDL_TABLE))
+
+    def _run_ddl(conn, ready_event):
+        ready_event.set()
+        try:
+            conn.cursor().execute('ALTER TABLE {} ADD COLUMN new_col INT'.format(MDL_TABLE))
+        except Exception:
+            pass
+
+    executor = ThreadPoolExecutor(2)
+    try:
+        executor.submit(_hold_shared_mdl, holder_conn)
+        time.sleep(0.2)
+        executor.submit(_run_ddl, ddl_conn, ddl_ready)
+        ddl_ready.wait(timeout=5)
+        time.sleep(0.5)
+
+        dd_run_check(check)
+
+        dbm_activity = aggregator.get_event_platform_events("dbm-activity")
+        assert dbm_activity, "should have collected at least one activity payload"
+
+        all_rows = [row for event in dbm_activity for row in event['mysql_activity']]
+        mdl_blocked_rows = [r for r in all_rows if r.get('mdl_object_name') == 'mdl_test_table']
+        assert mdl_blocked_rows, "should have at least one activity row with MDL blocking context; all rows: {}".format(
+            [(r.get('sql_text', '?')[:60], r.get('mdl_object_name')) for r in all_rows]
+        )
+
+        mdl_row = mdl_blocked_rows[0]
+        assert mdl_row['mdl_object_type'] == 'TABLE'
+        assert mdl_row['mdl_object_schema'] == 'testdb'
+        assert mdl_row.get('blocking_thread_id'), "MDL blocked row should have a blocking_thread_id"
+    finally:
+        holder_conn.commit()
+        holder_conn.close()
+        # Wait for the ALTER TABLE to complete now that the MDL holder released.
+        # Must shutdown before closing ddl_conn — closing a socket that another
+        # thread is recv()ing on deadlocks on macOS.
+        executor.shutdown(wait=True)
+        ddl_conn.close()
+        with closing(root_conn.cursor()) as cur:
+            cur.execute('DROP TABLE IF EXISTS {}'.format(MDL_TABLE))
+
+
 def _get_conn_for_user(user, _autocommit=False):
     return pymysql.connect(host=HOST, port=PORT, user=user, password=user, autocommit=_autocommit)
 

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -697,6 +697,8 @@ def test_mdl_blocking_activity(aggregator, dbm_instance, dd_run_check, root_conn
     MDL_TABLE = 'testdb.mdl_test_table'
 
     with closing(root_conn.cursor()) as cur:
+        # Ensure the consumer is enabled — other tests in this session may disable it.
+        cur.execute("UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name = 'events_waits_current'")
         cur.execute('DROP TABLE IF EXISTS {}'.format(MDL_TABLE))
         cur.execute('CREATE TABLE {} (id INT PRIMARY KEY, val VARCHAR(50))'.format(MDL_TABLE))
         cur.execute('INSERT INTO {} VALUES (1, %s)'.format(MDL_TABLE), ('hello',))


### PR DESCRIPTION
### What does this PR do?

Extends the MySQL 8.0 activity query to detect metadata lock (MDL) blocking by joining `performance_schema.metadata_locks`. This surfaces blocking relationships during DDL operations, `FLUSH TABLES`, `LOCK TABLE ... WRITE`, and other scenarios where exclusive metadata locks conflict with shared locks held by active sessions.

Changes:
- Add MDL blocking `LEFT JOIN`s to the MySQL 8.0 activity query alongside the existing `data_lock_waits` join
- `COALESCE` the blocking thread from either InnoDB data locks or metadata locks
- Include MDL context columns (`mdl_object_type`, `mdl_object_schema`, `mdl_object_name`, `mdl_waiting_lock_type`, `mdl_blocking_lock_type`) in the activity payload
- Add idle MDL blocker detection so sleeping sessions holding granted metadata locks are included in results
- Gated to MySQL 8.0+ (non-MariaDB) behind the existing `collect_blocking_queries` flag

### Motivation

The current blocking graph only detects InnoDB data lock contention. When a DDL operation acquires an exclusive metadata lock, all DML on that table blocks — but this blocking relationship is invisible. Users see sessions waiting on metadata locks as well as query samples with `wait/lock/metadata/sql/mdl` wait_events but no way to identify the cause without leaving Datadog. 

Attached you can see the same test scenario script demonstrating a query holding an exclusive lock on a table causing MDL blocking queries before and after the query change. With this PR we'll now get blocking query chains

<img width="1755" height="888" alt="Screenshot 2026-04-28 at 4 30 05 PM" src="https://github.com/user-attachments/assets/54587927-d2f6-4ff5-bd48-0efa2d230747" />

This also handles and surfaces global/shared MDL blocking queries such as `FLUSH TABLES WITH READ LOCK` queries which will result in NULL object schemas

Terminal 1
```sql
FLUSH TABLES WITH READ LOCK; SELECT SLEEP(60); UNLOCK TABLES;
```

Terminal 2
```sql
INSERT INTO dbm_order...
```

Which produces rows that look like this
```
OBJECT_TYPE  OBJECT_SCHEMA  OBJECT_NAME  LOCK_TYPE            LOCK_STATUS
GLOBAL       NULL           NULL         SHARED               GRANTED    ← FTWRL holder
GLOBAL       NULL           NULL         INTENTION_EXCLUSIVE  PENDING    ← blocked DML
```

<img width="1757" height="848" alt="Screenshot 2026-04-28 at 5 12 26 PM" src="https://github.com/user-attachments/assets/aed5db89-63fe-4b2d-b0c8-b5a46ddd3fce" />



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged