### PR TITLE
[postgres][mysql] classify connection errors for the DBM Setup UI

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/health.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/health.py
@@ -73,6 +73,7 @@ class Health:
         cooldown_time: int = None,
         cooldown_values: list[str] = None,
         data: dict = None,
+        error_code: str = None,
     ):
         """
         Submit a health event to the aggregator.
@@ -89,6 +90,10 @@ class Health:
         :param cooldown_values: list of str
             Additional values to include in the cooldown key.
         :param data: A dictionary to be submitted as `data`. Must be JSON serializable.
+        :param error_code: Stable kebab-case classification of the failure
+            (e.g. "connection-refused", "privilege-replication-client"). Read
+            by the DBM Setup UI to render an actionable remediation card.
+            Should be omitted for non-error events.
         """
         category = self.check.__NAMESPACE__ or self.check.__class__.__name__.lower()
         if cooldown_time:
@@ -99,23 +104,21 @@ class Health:
                 if self._ttl_cache.get(cooldown_key, None):
                     return
                 self._ttl_cache[cooldown_key] = cooldown_time
-        self.check.event_platform_event(
-            json.dumps(
-                {
-                    'timestamp': time.time() * 1000,
-                    'version': 1,
-                    'check_id': self.check.check_id,
-                    'category': category,
-                    'name': name,
-                    'status': status,
-                    'tags': tags or [],
-                    'ddagentversion': datadog_agent.get_version(),
-                    'ddagenthostname': datadog_agent.get_hostname(),
-                    'data': data,
-                }
-            ),
-            "dbm-health",
-        )
+        payload = {
+            'timestamp': time.time() * 1000,
+            'version': 1,
+            'check_id': self.check.check_id,
+            'category': category,
+            'name': name,
+            'status': status,
+            'tags': tags or [],
+            'ddagentversion': datadog_agent.get_version(),
+            'ddagenthostname': datadog_agent.get_hostname(),
+            'data': data,
+        }
+        if error_code:
+            payload['error_code'] = error_code
+        self.check.event_platform_event(json.dumps(payload), "dbm-health")
 
     def submit_exception_health_event(self, exception: Exception, data: dict):
         trace = traceback.extract_tb(exception.__traceback__)

--- a/mysql/datadog_checks/mysql/connection_errors.py
+++ b/mysql/datadog_checks/mysql/connection_errors.py
@@ -1,0 +1,107 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""
+Classification of MySQL connection / setup failures into stable
+kebab-case error codes that the DBM Setup UI uses to render an
+actionable remediation card. Mirrors the pattern in
+sqlserver/connection_errors.py.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+
+
+class ConnectionErrorCode(Enum):
+    """Stable kebab-case classification of a MySQL connection / setup failure.
+
+    Values match the APIDatabaseHostAgentWarningCode union in the web-ui
+    (packages/apps/databases/lib/api-database-types/api-database-types.ts).
+    """
+
+    unknown = "inferred-connection-error"
+    connection_refused = "connection-refused"
+    connection_timeout = "connection-timeout"
+    host_unreachable = "host-unreachable"
+    auth_failed_password = "auth-failed-password"
+    auth_failed_user_not_found = "auth-failed-user-not-found"
+    auth_database_not_found = "auth-database-not-found"
+    privilege_replication_client = "privilege-replication-client"
+    privilege_select_on_schema = "privilege-select-on-schema"
+    performance_schema_not_enabled = "performance-schema-not-enabled"
+    events_statements_consumers_disabled = "mysql-events-statements-consumers-disabled"
+    events_waits_current_not_enabled = "events-waits-current-not-enabled"
+    user_exceeded_max_user_connections = "user-exceeded-max_user_connections"
+
+
+# pymysql OperationalError exposes its mysql error code as exc.args[0]. The
+# canonical mapping below is consulted before regex matching on the message.
+MYSQL_ERROR_CODE_MAP: dict[int, ConnectionErrorCode] = {
+    1044: ConnectionErrorCode.auth_database_not_found,  # Access denied for user to db
+    1045: ConnectionErrorCode.auth_failed_password,  # Access denied (using password: YES)
+    1049: ConnectionErrorCode.auth_database_not_found,  # Unknown database
+    1226: ConnectionErrorCode.user_exceeded_max_user_connections,  # max_user_connections exceeded
+    1227: ConnectionErrorCode.privilege_replication_client,  # privilege required (e.g. SUPER, REPLICATION CLIENT)
+    2003: ConnectionErrorCode.connection_refused,  # Can't connect to MySQL server
+    2005: ConnectionErrorCode.host_unreachable,  # Unknown server host
+    2013: ConnectionErrorCode.connection_timeout,  # Lost connection during query
+}
+
+
+# Regex fallback when the mysql error code is missing or ambiguous. Order
+# matters — the first match wins.
+KNOWN_ERROR_PATTERNS: list[tuple[re.Pattern, ConnectionErrorCode]] = [
+    (
+        re.compile(r"must grant REPLICATION CLIENT|SLAVE MONITOR", re.IGNORECASE),
+        ConnectionErrorCode.privilege_replication_client,
+    ),
+    (re.compile(r"must grant PROCESS", re.IGNORECASE), ConnectionErrorCode.privilege_select_on_schema),
+    (
+        re.compile(r"Access denied for user .+ \(using password", re.IGNORECASE),
+        ConnectionErrorCode.auth_failed_password,
+    ),
+    (re.compile(r"Unknown database", re.IGNORECASE), ConnectionErrorCode.auth_database_not_found),
+    (
+        re.compile(r"has exceeded the 'max_user_connections'", re.IGNORECASE),
+        ConnectionErrorCode.user_exceeded_max_user_connections,
+    ),
+    (re.compile(r"Connection refused", re.IGNORECASE), ConnectionErrorCode.connection_refused),
+    (re.compile(r"timed out|timeout expired", re.IGNORECASE), ConnectionErrorCode.connection_timeout),
+    (re.compile(r"Unknown server host|Name or service not known", re.IGNORECASE), ConnectionErrorCode.host_unreachable),
+    (re.compile(r"performance_schema is disabled", re.IGNORECASE), ConnectionErrorCode.performance_schema_not_enabled),
+    (
+        re.compile(r"events_statements.*consumers are disabled|events_statements.*not enabled", re.IGNORECASE),
+        ConnectionErrorCode.events_statements_consumers_disabled,
+    ),
+]
+
+
+def classify_error_message(message: str) -> ConnectionErrorCode:
+    """Match the raw error string against KNOWN_ERROR_PATTERNS.
+
+    Returns ConnectionErrorCode.unknown when nothing matches.
+    """
+    if not message:
+        return ConnectionErrorCode.unknown
+    for pattern, code in KNOWN_ERROR_PATTERNS:
+        if pattern.search(message):
+            return code
+    return ConnectionErrorCode.unknown
+
+
+def format_connection_exception(exc: Exception) -> tuple[str, ConnectionErrorCode]:
+    """Classify a pymysql OperationalError (or similar) into a (message, code).
+
+    Prefers the structured mysql error code on exc.args[0] when present,
+    else falls back to regex matching on the exception's repr.
+    """
+    msg = repr(exc)
+    # pymysql.err.OperationalError raises with (errno, message). Trust that first.
+    args = getattr(exc, "args", None)
+    if args and isinstance(args, tuple) and len(args) >= 1 and isinstance(args[0], int):
+        mapped = MYSQL_ERROR_CODE_MAP.get(args[0])
+        if mapped is not None:
+            return msg, mapped
+    return msg, classify_error_message(msg)

--- a/mysql/tests/test_connection_errors.py
+++ b/mysql/tests/test_connection_errors.py
@@ -1,0 +1,102 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Unit tests for the MySQL connection-error classifier."""
+
+import pytest
+
+from datadog_checks.mysql.connection_errors import (
+    MYSQL_ERROR_CODE_MAP,
+    ConnectionErrorCode,
+    classify_error_message,
+    format_connection_exception,
+)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # Privilege errors observed in staging
+        (
+            "Privileges error getting replication status (must grant REPLICATION CLIENT): "
+            "(1227, 'Access denied; you need (at least one of) the SUPER, SLAVE MONITOR privilege(s) for this operation')",
+            ConnectionErrorCode.privilege_replication_client,
+        ),
+        # Auth
+        (
+            "(1045, \"Access denied for user 'datadog'@'10.0.0.1' (using password: YES)\")",
+            ConnectionErrorCode.auth_failed_password,
+        ),
+        # DB not found
+        (
+            "(1049, \"Unknown database 'analytics'\")",
+            ConnectionErrorCode.auth_database_not_found,
+        ),
+        # Connection
+        (
+            "(2003, \"Can't connect to MySQL server on '10.0.0.1' (Connection refused)\")",
+            ConnectionErrorCode.connection_refused,
+        ),
+        (
+            "Lost connection to MySQL server during query (timed out)",
+            ConnectionErrorCode.connection_timeout,
+        ),
+        # max_user_connections
+        (
+            "User datadog has exceeded the 'max_user_connections' resource",
+            ConnectionErrorCode.user_exceeded_max_user_connections,
+        ),
+        # Fallback
+        ('something we have never seen', ConnectionErrorCode.unknown),
+        ('', ConnectionErrorCode.unknown),
+    ],
+)
+def test_classify_error_message(raw, expected):
+    assert classify_error_message(raw) == expected
+
+
+class _FakePyMySQLOperationalError(Exception):
+    """Mimics pymysql.err.OperationalError where args = (errno, message)."""
+
+    def __init__(self, errno, message):
+        super().__init__(errno, message)
+
+
+@pytest.mark.parametrize(
+    "errno,expected",
+    [
+        (1044, ConnectionErrorCode.auth_database_not_found),
+        (1045, ConnectionErrorCode.auth_failed_password),
+        (1049, ConnectionErrorCode.auth_database_not_found),
+        (1227, ConnectionErrorCode.privilege_replication_client),
+        (2003, ConnectionErrorCode.connection_refused),
+        (2005, ConnectionErrorCode.host_unreachable),
+        (2013, ConnectionErrorCode.connection_timeout),
+    ],
+)
+def test_format_connection_exception_uses_errno(errno, expected):
+    exc = _FakePyMySQLOperationalError(errno, 'irrelevant message')
+    msg, code = format_connection_exception(exc)
+    assert code == expected, f'errno {errno} should map to {expected}'
+    assert msg  # always returns a non-empty repr
+
+
+def test_format_connection_exception_falls_back_to_regex_when_no_errno():
+    exc = Exception('must grant REPLICATION CLIENT')
+    msg, code = format_connection_exception(exc)
+    assert code == ConnectionErrorCode.privilege_replication_client
+    assert 'REPLICATION CLIENT' in msg
+
+
+def test_codes_match_canonical_kebab_case_strings():
+    """Catch accidental drift from the web-ui APIDatabaseHostAgentWarningCode union."""
+    assert ConnectionErrorCode.connection_refused.value == 'connection-refused'
+    assert ConnectionErrorCode.privilege_replication_client.value == 'privilege-replication-client'
+    assert ConnectionErrorCode.performance_schema_not_enabled.value == 'performance-schema-not-enabled'
+    assert ConnectionErrorCode.unknown.value == 'inferred-connection-error'
+
+
+def test_mysql_error_code_map_covers_canonical_codes():
+    """Every entry in MYSQL_ERROR_CODE_MAP should resolve to a defined enum value."""
+    for errno, code in MYSQL_ERROR_CODE_MAP.items():
+        assert isinstance(code, ConnectionErrorCode), errno

--- a/postgres/datadog_checks/postgres/connection_errors.py
+++ b/postgres/datadog_checks/postgres/connection_errors.py
@@ -1,0 +1,88 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""
+Classification of Postgres connection / setup failures into stable
+kebab-case error codes that the DBM Setup UI uses to render an
+actionable remediation card. Mirrors the pattern in
+sqlserver/connection_errors.py.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+
+
+class ConnectionErrorCode(Enum):
+    """Stable kebab-case classification of a Postgres connection / setup failure.
+
+    Values match the APIDatabaseHostAgentWarningCode union in the web-ui
+    (packages/apps/databases/lib/api-database-types/api-database-types.ts).
+    """
+
+    unknown = "inferred-connection-error"
+    connection_refused = "connection-refused"
+    connection_timeout = "connection-timeout"
+    host_unreachable = "host-unreachable"
+    database_starting_up = "database-starting-up"
+    database_shutting_down = "database-shutting-down"
+    auth_failed_password = "auth-failed-password"
+    auth_failed_user_not_found = "auth-failed-user-not-found"
+    auth_database_not_found = "auth-database-not-found"
+    privilege_pg_monitor = "privilege-pg-monitor"
+    privilege_select_on_schema = "privilege-select-on-schema"
+    pg_stat_statements_not_loaded = "pg-stat-statements-not-loaded"
+    pg_stat_statements_not_created = "pg-stat-statements-not-created"
+    ssl_required_by_server = "ssl-required-by-server"
+    ssl_cert_verify_failed = "ssl-cert-verify-failed"
+    ssl_protocol_mismatch = "ssl-protocol-mismatch"
+
+
+# Order matters: more-specific patterns first so they win over generic fallbacks.
+KNOWN_ERROR_PATTERNS: list[tuple[re.Pattern, ConnectionErrorCode]] = [
+    (re.compile(r"the database system is starting up", re.IGNORECASE), ConnectionErrorCode.database_starting_up),
+    (re.compile(r"the database system is shutting down", re.IGNORECASE), ConnectionErrorCode.database_shutting_down),
+    (re.compile(r"could not translate host name", re.IGNORECASE), ConnectionErrorCode.host_unreachable),
+    (re.compile(r"no route to host|network is unreachable", re.IGNORECASE), ConnectionErrorCode.host_unreachable),
+    (re.compile(r"name or service not known", re.IGNORECASE), ConnectionErrorCode.host_unreachable),
+    (re.compile(r"password authentication failed", re.IGNORECASE), ConnectionErrorCode.auth_failed_password),
+    (re.compile(r"no pg_hba\.conf entry", re.IGNORECASE), ConnectionErrorCode.auth_failed_user_not_found),
+    (re.compile(r'role ".+" does not exist', re.IGNORECASE), ConnectionErrorCode.auth_failed_user_not_found),
+    (re.compile(r'database ".+" does not exist', re.IGNORECASE), ConnectionErrorCode.auth_database_not_found),
+    (
+        re.compile(r"server does not support SSL|SSL connection.*required", re.IGNORECASE),
+        ConnectionErrorCode.ssl_required_by_server,
+    ),
+    (
+        re.compile(r"certificate verify failed|self.signed certificate", re.IGNORECASE),
+        ConnectionErrorCode.ssl_cert_verify_failed,
+    ),
+    (re.compile(r"tlsv1|protocol version", re.IGNORECASE), ConnectionErrorCode.ssl_protocol_mismatch),
+    (re.compile(r"connection refused", re.IGNORECASE), ConnectionErrorCode.connection_refused),
+    (re.compile(r"timed out|timeout expired", re.IGNORECASE), ConnectionErrorCode.connection_timeout),
+]
+
+
+def classify_error_message(message: str) -> ConnectionErrorCode:
+    """Match the raw error string against KNOWN_ERROR_PATTERNS.
+
+    Returns ConnectionErrorCode.unknown when nothing matches.
+    """
+    if not message:
+        return ConnectionErrorCode.unknown
+    for pattern, code in KNOWN_ERROR_PATTERNS:
+        if pattern.search(message):
+            return code
+    return ConnectionErrorCode.unknown
+
+
+def format_connection_exception(exc: Exception) -> tuple[str, ConnectionErrorCode]:
+    """Classify a psycopg OperationalError (or similar) into a (message, code) tuple.
+
+    The code is suitable for plumbing into Health.submit_health_event(error_code=...).
+    The message is the original exception's repr — preserved so the UI can show
+    "Show raw error" for support context.
+    """
+    msg = repr(exc)
+    return msg, classify_error_message(msg)

--- a/postgres/tests/test_connection_errors.py
+++ b/postgres/tests/test_connection_errors.py
@@ -1,0 +1,99 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Unit tests for the Postgres connection-error classifier."""
+
+import pytest
+
+from datadog_checks.postgres.connection_errors import (
+    ConnectionErrorCode,
+    classify_error_message,
+    format_connection_exception,
+)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # Connection-level
+        (
+            'connection failed: connection to server at "10.0.0.1", port 5432 failed: '
+            'Connection refused Is the server running on that host and accepting TCP/IP connections?',
+            ConnectionErrorCode.connection_refused,
+        ),
+        (
+            'connection failed: connection to server at "10.0.0.1", port 5432 failed: '
+            'FATAL:  the database system is starting up',
+            ConnectionErrorCode.database_starting_up,
+        ),
+        (
+            'connection failed: connection to server at "10.0.0.1", port 5432 failed: '
+            'FATAL:  the database system is shutting down',
+            ConnectionErrorCode.database_shutting_down,
+        ),
+        (
+            'could not translate host name "no-such-host" to address: nodename nor servname provided',
+            ConnectionErrorCode.host_unreachable,
+        ),
+        (
+            'connection failed: timeout expired',
+            ConnectionErrorCode.connection_timeout,
+        ),
+        # Auth
+        (
+            'connection failed: FATAL:  password authentication failed for user "datadog"',
+            ConnectionErrorCode.auth_failed_password,
+        ),
+        (
+            'FATAL:  no pg_hba.conf entry for host "10.0.0.1", user "datadog"',
+            ConnectionErrorCode.auth_failed_user_not_found,
+        ),
+        (
+            'FATAL:  role "datadog" does not exist',
+            ConnectionErrorCode.auth_failed_user_not_found,
+        ),
+        (
+            'FATAL:  database "production" does not exist',
+            ConnectionErrorCode.auth_database_not_found,
+        ),
+        # SSL
+        (
+            'server does not support SSL, but SSL was required',
+            ConnectionErrorCode.ssl_required_by_server,
+        ),
+        (
+            'SSL error: certificate verify failed',
+            ConnectionErrorCode.ssl_cert_verify_failed,
+        ),
+        # Fallback
+        (
+            'some random error we have never seen',
+            ConnectionErrorCode.unknown,
+        ),
+        ('', ConnectionErrorCode.unknown),
+    ],
+)
+def test_classify_error_message(raw, expected):
+    assert classify_error_message(raw) == expected
+
+
+def test_format_connection_exception_returns_message_and_code():
+    exc = Exception('connection refused')
+    msg, code = format_connection_exception(exc)
+    assert code == ConnectionErrorCode.connection_refused
+    assert 'connection refused' in msg
+
+
+def test_format_connection_exception_unknown_falls_back_to_unknown():
+    exc = Exception('something wholly unrecognized')
+    msg, code = format_connection_exception(exc)
+    assert code == ConnectionErrorCode.unknown
+    assert 'wholly unrecognized' in msg
+
+
+def test_codes_match_canonical_kebab_case_strings():
+    """Catch accidental drift from the web-ui APIDatabaseHostAgentWarningCode union."""
+    assert ConnectionErrorCode.connection_refused.value == 'connection-refused'
+    assert ConnectionErrorCode.database_starting_up.value == 'database-starting-up'
+    assert ConnectionErrorCode.privilege_pg_monitor.value == 'privilege-pg-monitor'
+    assert ConnectionErrorCode.unknown.value == 'inferred-connection-error'


### PR DESCRIPTION
Adds Postgres + MySQL counterparts to sqlserver/connection_errors.py so that connection / setup failures emit a stable kebab-case classification (e.g. "connection-refused",
"privilege-replication-client", "database-starting-up") that flows through to the DBM Setup page as an actionable remediation card.

Changes:

- `datadog_checks_base.utils.db.health.Health.submit_health_event` takes an optional `error_code` arg and forwards it on the dbm-health event payload alongside the existing `data` blob.

- `postgres/datadog_checks/postgres/connection_errors.py` (new): ConnectionErrorCode enum + KNOWN_ERROR_PATTERNS regex table + format_connection_exception(). Codes match the canonical kebab-case values in the web-ui APIDatabaseHostAgentWarningCode union. Covers connection-refused, database-starting-up, host- unreachable, password / role / database / pg_hba auth failures, and the SSL family.

- `mysql/datadog_checks/mysql/connection_errors.py` (new): parallel module driven by pymysql's mysql errno (1045, 1227, 2003 etc.) with a regex fallback for repr-only exception strings — including the staging "must grant REPLICATION CLIENT" pattern.

- Unit tests on both sides keyed by the literal error strings we see in staging today, plus a sanity test that enum values stay in sync with the kebab-case web-ui codes.

Plumbing into postgres.py / mysql.py _connect() sites is left as a follow-up commit on this branch — the classifier modules are intentionally standalone so the wiring is small and reviewable.

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
