### PR TITLE
Track pinned Python deps in workflows via Renovate

### DIFF
--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -29,6 +29,7 @@ defaults:
 env:
   APP_NAME: ddev
   PYTHON_VERSION: "3.13"
+  # renovate: datasource=pypi depName=pyoxidizer
   PYOXIDIZER_VERSION: "0.24.0"
 
 jobs:

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -40,6 +40,11 @@ permissions:
   id-token: write
   contents: write # ddev needs to push tags
 
+env:
+  # Default ddev version when callers don't pass `ddev-version`. Tracked by Renovate.
+  # renovate: datasource=pypi depName=ddev
+  DEFAULT_DDEV_VERSION: "14.3.2"
+
 jobs:
   prepare:
     name: Tag releases and build dispatch batches
@@ -55,7 +60,7 @@ jobs:
           fetch-depth: 0 # ddev needs full tag history
 
       - name: Install ddev
-        run: pip install "ddev${{ inputs.ddev-version && format('=={0}', inputs.ddev-version) || '==14.3.2' }}"
+        run: pip install "ddev==${{ inputs.ddev-version || env.DEFAULT_DDEV_VERSION }}"
 
       - name: Configure ddev
         env:

--- a/.github/workflows/validate-renovate-config.yml
+++ b/.github/workflows/validate-renovate-config.yml
@@ -1,0 +1,20 @@
+name: Validate Renovate config
+
+on:
+  pull_request:
+    paths:
+      - 'renovate.json'
+  push:
+    branches:
+      - master
+    paths:
+      - 'renovate.json'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate Renovate config
+        run: npx --yes --package renovate renovate-config-validator --strict renovate.json

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,8 @@
         "^\\.github/workflows/[^/]+\\.ya?ml$"
       ],
       "matchStrings": [
-        "(?<depName>[a-zA-Z][a-zA-Z0-9._-]*)==(?<currentValue>[0-9]+(?:\\.[0-9]+){1,2})"
+        "(?<depName>[a-zA-Z][a-zA-Z0-9._-]*)==(?<currentValue>[0-9]+(?:\\.[0-9]+){1,2})",
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[a-zA-Z][a-zA-Z0-9._-]*)\\s+[A-Z][A-Z0-9_]*: \"(?<currentValue>[0-9]+(?:\\.[0-9]+){1,2})\""
       ],
       "datasourceTemplate": "pypi"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,20 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "enabledManagers": [
-    "github-actions"
+    "github-actions",
+    "custom.regex"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^\\.github/workflows/[^/]+\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "(?<depName>[a-zA-Z][a-zA-Z0-9._-]*)==(?<currentValue>[0-9]+(?:\\.[0-9]+){1,2})"
+      ],
+      "datasourceTemplate": "pypi"
+    }
   ],
   "packageRules": [
     {
@@ -49,6 +62,20 @@
         "renovate/actions",
         "qa/skip-qa"
       ]
+    },
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "groupName": "workflow python deps",
+      "schedule": [
+        "before 6am on Monday"
+      ],
+      "labels": [
+        "renovate/workflow-deps",
+        "qa/skip-qa"
+      ],
+      "minimumReleaseAge": "7 days"
     }
   ]
 }


### PR DESCRIPTION
### What does this PR do?

Adds a custom regex manager to `renovate.json` so Renovate proposes bumps for `name==X.Y[.Z]` pins inside `.github/workflows/*.yml`. The existing `github-actions` manager doesn't see pip dependencies installed in workflow `run:` steps, so those pins drift silently today.

All proposed PRs require human review (no auto-merge). Grouped under a single weekly batch with the `renovate/workflow-deps` label.

### Motivation

We pinned `hatch` and `virtualenv` in `build-ddev.yml` for deterministic builds and stable cache reuse, and we want a mechanism that keeps those pins (and any future ones) up to date without manual tracking.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the \`qa/skip-qa\` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the \`backport/<branch-name>\` label to the PR and it will automatically open a backport PR once this one is merged