### PR TITLE
Bump datadog_checks_dev to 38.0.0 in ddev

### DIFF
--- a/ddev/changelog.d/23516.fixed
+++ b/ddev/changelog.d/23516.fixed
@@ -1,0 +1,1 @@
+Bumped datadog_checks_dev to version 38.0.0. Fixes dependency issues with new virtualenv.

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "click~=8.1.6",
     "coverage",
     "datadog-api-client==2.20.0",
-    "datadog-checks-dev[cli]~=37.0",
+    "datadog-checks-dev[cli]~=38.0",
     "hatch>=1.13.0",
     "httpx",
     "jsonpointer",


### PR DESCRIPTION
### What does this PR do?

Bump the `datadog-checks-dev[cli]` dependency in `ddev/pyproject.toml` from `~=37.0` to `~=38.0`.

### Motivation
<!-- What inspired you to submit this pull request? -->
The latests updates for `datadog_checks_dev` virtualenv requirement need to go hand in hand with ddev which is causing errors when ddev tries to be installed since it requires exactly version 37.x

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged