### PR TITLE
[FA] Set display_priority in bentoml spec.yaml

### DIFF
--- a/bentoml/assets/configuration/spec.yaml
+++ b/bentoml/assets/configuration/spec.yaml
@@ -10,6 +10,7 @@ files:
     options:
     - template: instances/openmetrics
       overrides:
+        openmetrics_endpoint.display_priority: 3
         openmetrics_endpoint.value.example: http://localhost:3000/metrics
         openmetrics_endpoint.description: |
           Endpoint exposing the BentoML Prometheus metrics. For more information refer to:

--- a/bentoml/changelog.d/23519.fixed
+++ b/bentoml/changelog.d/23519.fixed
@@ -1,1 +1,0 @@
-Set `display_priority` in `bentoml` spec.yaml based on field usage.

--- a/bentoml/changelog.d/23519.fixed
+++ b/bentoml/changelog.d/23519.fixed
@@ -1,0 +1,1 @@
+Set `display_priority` in `bentoml` spec.yaml based on field usage.


### PR DESCRIPTION
Set `display_priority` on fields in `bentoml/assets/configuration/spec.yaml` based on field importance and usage.