### PR TITLE
[FA] Set display_priority in kubernetes_cluster_autoscaler spec.yaml

### DIFF
--- a/kubernetes_cluster_autoscaler/assets/configuration/spec.yaml
+++ b/kubernetes_cluster_autoscaler/assets/configuration/spec.yaml
@@ -10,6 +10,7 @@ files:
       options:
         - template: instances/openmetrics
           overrides:
+            openmetrics_endpoint.display_priority: 3
             openmetrics_endpoint.required: true
             openmetrics_endpoint.value.example: http://localhost:8085/metrics
             openmetrics_endpoint.description: |

--- a/kubernetes_cluster_autoscaler/changelog.d/23520.fixed
+++ b/kubernetes_cluster_autoscaler/changelog.d/23520.fixed
@@ -1,1 +1,0 @@
-Set `display_priority` in `kubernetes_cluster_autoscaler` spec.yaml based on field usage.

--- a/kubernetes_cluster_autoscaler/changelog.d/23520.fixed
+++ b/kubernetes_cluster_autoscaler/changelog.d/23520.fixed
@@ -1,0 +1,1 @@
+Set `display_priority` in `kubernetes_cluster_autoscaler` spec.yaml based on field usage.


### PR DESCRIPTION
Set `display_priority` on fields in `kubernetes_cluster_autoscaler/assets/configuration/spec.yaml` based on field importance and usage.