### PR TITLE
[FA] Set display_priority in traefik_mesh spec.yaml

### DIFF
--- a/traefik_mesh/assets/configuration/spec.yaml
+++ b/traefik_mesh/assets/configuration/spec.yaml
@@ -10,12 +10,14 @@ files:
       options:
       - template: instances/openmetrics
         overrides:
+          openmetrics_endpoint.display_priority: 3
           openmetrics_endpoint.required: true
           openmetrics_endpoint.value.example: http://<PROXY_ENDPOINT>:<METRICS_PORT>
           openmetrics_endpoint.description: |
             Endpoint exposing the Traefic Proxy Prometheus metrics. For more information refer to:
             https://doc.traefik.io/traefik/observability/metrics/prometheus/
       - name: traefik_proxy_api_endpoint
+        display_priority: 2
         fleet_configurable: true
         formats: ["url"]
         required: false
@@ -25,6 +27,7 @@ files:
           pattern: \w+
           type: string
       - name: traefik_controller_api_endpoint
+        display_priority: 1
         fleet_configurable: true
         formats: ["url"]
         required: false

--- a/traefik_mesh/changelog.d/23521.fixed
+++ b/traefik_mesh/changelog.d/23521.fixed
@@ -1,0 +1,1 @@
+Set `display_priority` in `traefik_mesh` spec.yaml based on field usage.

--- a/traefik_mesh/datadog_checks/traefik_mesh/data/conf.yaml.example
+++ b/traefik_mesh/datadog_checks/traefik_mesh/data/conf.yaml.example
@@ -51,6 +51,16 @@ instances:
     #
   - openmetrics_endpoint: http://<PROXY_ENDPOINT>:<METRICS_PORT>
 
+    ## @param traefik_proxy_api_endpoint - string - optional - default: http://<PROXY_ENDPOINT>:<API_PORT>
+    ## URL of the Traefik Mesh proxy to query.
+    #
+    # traefik_proxy_api_endpoint: http://<PROXY_ENDPOINT>:<API_PORT>
+
+    ## @param traefik_controller_api_endpoint - string - optional - default: http://<CONTROLLER_ENDPOINT>:<API_PORT>
+    ## URL of the Traefik Mesh controller to query.
+    #
+    # traefik_controller_api_endpoint: http://<CONTROLLER_ENDPOINT>:<API_PORT>
+
     ## @param raw_metric_prefix - string - optional
     ## A prefix that is removed from all exposed metric names, if present.
     ## All configuration options will use the prefix-less name.
@@ -641,13 +651,3 @@ instances:
     #   - <INCLUDE_REGEX>
     #   exclude:
     #   - <EXCLUDE_REGEX>
-
-    ## @param traefik_proxy_api_endpoint - string - optional - default: http://<PROXY_ENDPOINT>:<API_PORT>
-    ## URL of the Traefik Mesh proxy to query.
-    #
-    # traefik_proxy_api_endpoint: http://<PROXY_ENDPOINT>:<API_PORT>
-
-    ## @param traefik_controller_api_endpoint - string - optional - default: http://<CONTROLLER_ENDPOINT>:<API_PORT>
-    ## URL of the Traefik Mesh controller to query.
-    #
-    # traefik_controller_api_endpoint: http://<CONTROLLER_ENDPOINT>:<API_PORT>


### PR DESCRIPTION
Set `display_priority` on fields in `traefik_mesh/assets/configuration/spec.yaml` based on field importance and usage.