### PR TITLE
[FA] Set display_priority in ray spec.yaml

### DIFF
--- a/ray/assets/configuration/spec.yaml
+++ b/ray/assets/configuration/spec.yaml
@@ -9,6 +9,8 @@ files:
   - template: instances
     options:
     - template: instances/openmetrics
+      overrides:
+        openmetrics_endpoint.display_priority: 3
   - template: logs
     example:
     - type: file

--- a/ray/changelog.d/23523.fixed
+++ b/ray/changelog.d/23523.fixed
@@ -1,0 +1,1 @@
+Set `display_priority` in `ray` spec.yaml based on field usage.

--- a/ray/changelog.d/23523.fixed
+++ b/ray/changelog.d/23523.fixed
@@ -1,1 +1,0 @@
-Set `display_priority` in `ray` spec.yaml based on field usage.


### PR DESCRIPTION
Set `display_priority` on fields in `ray/assets/configuration/spec.yaml` based on field importance and usage.