### PR TITLE
[FA] Set display_priority in boundary spec.yaml

### DIFF
--- a/boundary/assets/configuration/spec.yaml
+++ b/boundary/assets/configuration/spec.yaml
@@ -10,6 +10,7 @@ files:
     options:
     - name: health_endpoint
       fleet_configurable: true
+      display_priority: 5
       required: true
       description: |
         The Boundary controller's health endpoint.
@@ -18,6 +19,7 @@ files:
         example: http://localhost:9203/health
     - template: instances/openmetrics
       overrides:
+        openmetrics_endpoint.display_priority: 3
         openmetrics_endpoint.value.example: http://localhost:9203/metrics
         openmetrics_endpoint.description: |
           The URL where Boundary exposes Prometheus metrics.

--- a/boundary/changelog.d/23524.fixed
+++ b/boundary/changelog.d/23524.fixed
@@ -1,0 +1,1 @@
+Set `display_priority` in `boundary` spec.yaml based on field usage.

--- a/boundary/changelog.d/23524.fixed
+++ b/boundary/changelog.d/23524.fixed
@@ -1,1 +1,0 @@
-Set `display_priority` in `boundary` spec.yaml based on field usage.


### PR DESCRIPTION
Set `display_priority` on fields in `boundary/assets/configuration/spec.yaml` based on field importance and usage.