### PR TITLE
[FA] Set display_priority in strimzi spec.yaml

### DIFF
--- a/strimzi/assets/configuration/spec.yaml
+++ b/strimzi/assets/configuration/spec.yaml
@@ -9,6 +9,7 @@ files:
   - template: instances
     options:
     - name: cluster_operator_endpoint
+      display_priority: 5
       description: |
         Endpoint exposing the Cluster Operator's Prometheus metrics.
       fleet_configurable: true
@@ -17,6 +18,7 @@ files:
         example: http://cluster-operator-address:8080/metrics
         type: string
     - name: topic_operator_endpoint
+      display_priority: 4
       description: |
         Endpoint exposing the Topic Operator's Prometheus metrics.
       fleet_configurable: true
@@ -25,6 +27,7 @@ files:
         example: http://topic-operator-address:8080/metrics
         type: string
     - name: user_operator_endpoint
+      display_priority: 3
       description: |
         Endpoint exposing the User Operator's Prometheus metrics.
       fleet_configurable: true

--- a/strimzi/changelog.d/23525.fixed
+++ b/strimzi/changelog.d/23525.fixed
@@ -1,0 +1,1 @@
+Set `display_priority` in `strimzi` spec.yaml based on field usage.

--- a/strimzi/changelog.d/23525.fixed
+++ b/strimzi/changelog.d/23525.fixed
@@ -1,1 +1,0 @@
-Set `display_priority` in `strimzi` spec.yaml based on field usage.


### PR DESCRIPTION
Set `display_priority` on fields in `strimzi/assets/configuration/spec.yaml` based on field importance and usage.