### PR TITLE
[FA] Set display_priority in kubelet spec.yaml

### DIFF
--- a/kubelet/assets/configuration/spec.yaml
+++ b/kubelet/assets/configuration/spec.yaml
@@ -8,6 +8,7 @@ files:
   - template: instances
     options:
     - name: cadvisor_metrics_endpoint
+      display_priority: 5
       description: |
         1.7.6+ clusters expose container metrics in the prometheus format.
         This is the default setting. See next section for legacy clusters.
@@ -18,6 +19,7 @@ files:
         type: string
         example: http://10.8.0.1:10255/metrics/cadvisor
     - name: kubelet_metrics_endpoint
+      display_priority: 4
       description: |
         URL of the kubelet metrics prometheus endpoint
         Pass an empty string to disable kubelet metrics collection.
@@ -25,6 +27,7 @@ files:
         type: string
         example: http://10.8.0.1:10255/metrics
     - name: probes_metrics_endpoint
+      display_priority: 3
       description: |
         URL of the probe metrics prometheus endpoint
         Pass an empty string to disable probe metrics collection.
@@ -32,6 +35,7 @@ files:
         type: string
         example: http://10.8.0.1:10255/metrics/probes
     - name: cadvisor_port
+      display_priority: 1
       description: |
         Metric collection for legacy (< 1.7.6) clusters via the kubelet's cadvisor port.
         This port is closed by default on k8s 1.7+ and OpenShift, enable it
@@ -42,6 +46,7 @@ files:
         type: integer
         example: 4194
     - name: enabled_rates
+      display_priority: 2
       description: |
         Allow list of rate type metrics to collect from cadvisor.
       value:
@@ -52,6 +57,7 @@ files:
         - cpu.*
         - network.*
     - name: enabled_gauges
+      display_priority: 2
       description: |
         Allow list of gauge type metrics to collect from cadvisor.
       value:
@@ -84,6 +90,7 @@ files:
     - template: instances
       options:
       - name: cadvisor_metrics_endpoint
+        display_priority: 5
         description: |
           1.7.6+ clusters expose container metrics in the prometheus format.
           This is the default setting. See next section for legacy clusters.
@@ -94,6 +101,7 @@ files:
           type: string
           example: http://10.8.0.1:10255/metrics/cadvisor
       - name: kubelet_metrics_endpoint
+        display_priority: 4
         description: |
           URL of the kubelet metrics prometheus endpoint
           Pass an empty string to disable kubelet metrics collection.
@@ -101,6 +109,7 @@ files:
           type: string
           example: http://10.8.0.1:10255/metrics
       - name: probes_metrics_endpoint
+        display_priority: 3
         description: |
           URL of the probe metrics prometheus endpoint
           Pass an empty string to disable probe metrics collection.
@@ -108,6 +117,7 @@ files:
           type: string
           example: http://10.8.0.1:10255/metrics/probes
       - name: cadvisor_port
+        display_priority: 1
         description: |
           Metric collection for legacy (< 1.7.6) clusters via the kubelet's cadvisor port.
           This port is closed by default on k8s 1.7+ and OpenShift, enable it
@@ -118,6 +128,7 @@ files:
           type: integer
           example: 4194
       - name: enabled_rates
+        display_priority: 2
         description: |
           Allow list of rate type metrics to collect from cadvisor.
         value:
@@ -128,6 +139,7 @@ files:
           - cpu.*
           - network.*
       - name: enabled_gauges
+        display_priority: 2
         description: |
           Allow list of gauge type metrics to collect from cadvisor.
         value:

--- a/kubelet/changelog.d/23526.fixed
+++ b/kubelet/changelog.d/23526.fixed
@@ -1,0 +1,1 @@
+Set `display_priority` in `kubelet` spec.yaml based on field usage.

--- a/kubelet/datadog_checks/kubelet/data/conf.yaml.default
+++ b/kubelet/datadog_checks/kubelet/data/conf.yaml.default
@@ -75,15 +75,6 @@ instances:
     #
     # probes_metrics_endpoint: http://10.8.0.1:10255/metrics/probes
 
-    ## @param cadvisor_port - integer - optional - default: 4194
-    ## Metric collection for legacy (< 1.7.6) clusters via the kubelet's cadvisor port.
-    ## This port is closed by default on k8s 1.7+ and OpenShift, enable it
-    ## via the `--cadvisor-port=4194` kubelet option.
-    ##
-    ## Port to connect to, uncomment and set accordingly to enable collection.
-    #
-    # cadvisor_port: 4194
-
     ## @param enabled_rates - list of strings - optional
     ## Allow list of rate type metrics to collect from cadvisor.
     #
@@ -96,6 +87,15 @@ instances:
     #
     # enabled_gauges:
     #   - filesystem.*
+
+    ## @param cadvisor_port - integer - optional - default: 4194
+    ## Metric collection for legacy (< 1.7.6) clusters via the kubelet's cadvisor port.
+    ## This port is closed by default on k8s 1.7+ and OpenShift, enable it
+    ## via the `--cadvisor-port=4194` kubelet option.
+    ##
+    ## Port to connect to, uncomment and set accordingly to enable collection.
+    #
+    # cadvisor_port: 4194
 
     ## @param health_service_check - boolean - optional - default: true
     ## Send a service check reporting about the health of the Prometheus endpoint.

--- a/kubelet/datadog_checks/kubelet/data/conf.yaml.example
+++ b/kubelet/datadog_checks/kubelet/data/conf.yaml.example
@@ -67,15 +67,6 @@ instances:
     #
     # probes_metrics_endpoint: http://10.8.0.1:10255/metrics/probes
 
-    ## @param cadvisor_port - integer - optional - default: 4194
-    ## Metric collection for legacy (< 1.7.6) clusters via the kubelet's cadvisor port.
-    ## This port is closed by default on k8s 1.7+ and OpenShift, enable it
-    ## via the `--cadvisor-port=4194` kubelet option.
-    ##
-    ## Port to connect to, uncomment and set accordingly to enable collection.
-    #
-    # cadvisor_port: 4194
-
     ## @param enabled_rates - list of strings - optional
     ## Allow list of rate type metrics to collect from cadvisor.
     #
@@ -88,6 +79,15 @@ instances:
     #
     # enabled_gauges:
     #   - filesystem.*
+
+    ## @param cadvisor_port - integer - optional - default: 4194
+    ## Metric collection for legacy (< 1.7.6) clusters via the kubelet's cadvisor port.
+    ## This port is closed by default on k8s 1.7+ and OpenShift, enable it
+    ## via the `--cadvisor-port=4194` kubelet option.
+    ##
+    ## Port to connect to, uncomment and set accordingly to enable collection.
+    #
+    # cadvisor_port: 4194
 
     ## @param health_service_check - boolean - optional - default: true
     ## Send a service check reporting about the health of the Prometheus endpoint.


### PR DESCRIPTION
Set `display_priority` on fields in `kubelet/assets/configuration/spec.yaml` based on field importance and usage.