### PR TITLE
[FA] Set display_priority in kyverno spec.yaml

### DIFF
--- a/kyverno/assets/configuration/spec.yaml
+++ b/kyverno/assets/configuration/spec.yaml
@@ -10,6 +10,7 @@ files:
     options:
     - template: instances/openmetrics
       overrides:
+        openmetrics_endpoint.display_priority: 3
         openmetrics_endpoint.value.example: http://localhost:8000/metrics
         openmetrics_endpoint.description: |
           Endpoint exposing the Kyverno Controller's Prometheus metrics. For more information refer to:

--- a/kyverno/changelog.d/23528.fixed
+++ b/kyverno/changelog.d/23528.fixed
@@ -1,1 +1,0 @@
-Set `display_priority` in `kyverno` spec.yaml based on field usage.

--- a/kyverno/changelog.d/23528.fixed
+++ b/kyverno/changelog.d/23528.fixed
@@ -1,0 +1,1 @@
+Set `display_priority` in `kyverno` spec.yaml based on field usage.


### PR DESCRIPTION
Set `display_priority` on fields in `kyverno/assets/configuration/spec.yaml` based on field importance and usage.