### PR TITLE
Migrate 10 more integrations to mock_http

### DIFF
--- a/arangodb/tests/test_arangodb.py
+++ b/arangodb/tests/test_arangodb.py
@@ -49,15 +49,15 @@ def test_invalid_endpoint(aggregator, instance_invalid_endpoint, dd_run_check):
         ),
     ],
 )
-def test_check(instance, dd_run_check, aggregator, tag_condition, base_tags):
+def test_check(instance, dd_run_check, aggregator, tag_condition, base_tags, mock_http):
     check = ArangodbCheck('arangodb', {}, [instance])
 
-    def mock_requests_get(session, url, *args, **kwargs):
+    def mock_requests_get(url, *args, **kwargs):
         fixture = url.rsplit('/', 1)[-1]
         return MockHTTPResponse(file_path=os.path.join(os.path.dirname(__file__), 'fixtures', tag_condition, fixture))
 
-    with mock.patch('requests.Session.get', side_effect=mock_requests_get, autospec=True):
-        dd_run_check(check)
+    mock_http.get.side_effect = mock_requests_get
+    dd_run_check(check)
 
     aggregator.assert_service_check(
         'arangodb.openmetrics.health',

--- a/cert_manager/tests/test_cert_manager.py
+++ b/cert_manager/tests/test_cert_manager.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 
-import mock
 import pytest
 
 from datadog_checks.base.utils.http_testing import MockHTTPResponse
@@ -13,12 +12,9 @@ from .common import ACME_METRICS, CERT_METRICS, CONTROLLER_METRICS, MOCK_INSTANC
 
 
 @pytest.fixture()
-def error_metrics():
-    with mock.patch(
-        'requests.Session.get',
-        return_value=mock.MagicMock(status_code=502, headers={'Content-Type': "text/plain"}),
-    ):
-        yield
+def error_metrics(mock_http):
+    mock_http.get.return_value = MockHTTPResponse(status_code=502, headers={'Content-Type': "text/plain"})
+    yield
 
 
 @pytest.mark.unit
@@ -28,14 +24,14 @@ def test_config():
 
 
 @pytest.mark.unit
-def test_check(aggregator, dd_run_check):
+def test_check(aggregator, dd_run_check, mock_http):
     check = CertManagerCheck('cert_manager', {}, [MOCK_INSTANCE])
 
     def mock_requests_get(url, *args, **kwargs):
         return MockHTTPResponse(file_path=os.path.join(os.path.dirname(__file__), 'fixtures', 'cert_manager.txt'))
 
-    with mock.patch('requests.Session.get', side_effect=mock_requests_get, autospec=True):
-        dd_run_check(check)
+    mock_http.get.side_effect = mock_requests_get
+    dd_run_check(check)
 
     expected_metrics = dict(CERT_METRICS)
     expected_metrics.update(CONTROLLER_METRICS)

--- a/cert_manager/tests/test_cert_manager.py
+++ b/cert_manager/tests/test_cert_manager.py
@@ -12,7 +12,7 @@ from .common import ACME_METRICS, CERT_METRICS, CONTROLLER_METRICS, MOCK_INSTANC
 
 
 @pytest.fixture()
-def error_metrics(mock_http):
+def mock_http_error_response(mock_http):
     mock_http.get.return_value = MockHTTPResponse(status_code=502, headers={'Content-Type': "text/plain"})
     yield
 
@@ -51,7 +51,7 @@ def test_check(aggregator, dd_run_check, mock_http):
 
 
 @pytest.mark.unit
-def test_openmetrics_error(aggregator, instance, error_metrics):
+def test_openmetrics_error(aggregator, instance, mock_http_error_response):
     check = CertManagerCheck('cert_manager', {}, [MOCK_INSTANCE])
     with pytest.raises(Exception):
         check.check(MOCK_INSTANCE)

--- a/envoy/tests/legacy/test_unit.py
+++ b/envoy/tests/legacy/test_unit.py
@@ -167,9 +167,7 @@ def test_config(extra_config, expected_http_kwargs, check):
         ),
     ],
 )
-def test_metadata_with_exception(
-    datadog_agent, fixture_path, mock_http_response, check, exception, log_call_parameters, mock_http
-):
+def test_metadata_with_exception(datadog_agent, check, exception, log_call_parameters, mock_http):
     instance = INSTANCES['main']
     check = check(instance)
     check.check_id = 'test:123'

--- a/envoy/tests/legacy/test_unit.py
+++ b/envoy/tests/legacy/test_unit.py
@@ -5,8 +5,8 @@ from copy import deepcopy
 
 import mock
 import pytest
-import requests
 
+from datadog_checks.base.utils.http_exceptions import HTTPRequestError, HTTPTimeoutError
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.envoy import Envoy
 from datadog_checks.envoy.metrics import METRIC_PREFIX, METRICS
@@ -147,7 +147,7 @@ def test_config(extra_config, expected_http_kwargs, check):
     'exception, log_call_parameters',
     [
         pytest.param(
-            requests.exceptions.Timeout(),
+            HTTPTimeoutError('timed out'),
             ('Envoy endpoint `%s` timed out after %s seconds', 'http://localhost:8001/server_info', (10.0, 10.0)),
             id="timeout",
         ),
@@ -157,7 +157,7 @@ def test_config(extra_config, expected_http_kwargs, check):
             id="index error",
         ),
         pytest.param(
-            requests.exceptions.RequestException('Req Exception'),
+            HTTPRequestError('Req Exception'),
             (
                 'Error collecting Envoy version with url=`%s`. Error: %s',
                 'http://localhost:8001/server_info',
@@ -168,17 +168,17 @@ def test_config(extra_config, expected_http_kwargs, check):
     ],
 )
 def test_metadata_with_exception(
-    datadog_agent, fixture_path, mock_http_response, check, exception, log_call_parameters
+    datadog_agent, fixture_path, mock_http_response, check, exception, log_call_parameters, mock_http
 ):
     instance = INSTANCES['main']
     check = check(instance)
     check.check_id = 'test:123'
     check.log = mock.MagicMock()
 
-    with mock.patch('requests.Session.get', side_effect=exception):
-        check._collect_metadata()
-        datadog_agent.assert_metadata_count(0)
-        check.log.warning.assert_called_with(*log_call_parameters)
+    mock_http.get.side_effect = exception
+    check._collect_metadata()
+    datadog_agent.assert_metadata_count(0)
+    check.log.warning.assert_called_with(*log_call_parameters)
 
 
 @pytest.mark.parametrize(

--- a/haproxy/tests/legacy/test_unit.py
+++ b/haproxy/tests/legacy/test_unit.py
@@ -9,6 +9,8 @@ from collections import defaultdict
 import mock
 import pytest
 
+from datadog_checks.base.utils.http_testing import MockHTTPResponse
+
 from . import common
 
 pytestmark = [common.requires_legacy_environment]
@@ -427,15 +429,14 @@ def test_regex_tags(aggregator, check, haproxy_mock):
     aggregator.assert_service_check('haproxy.backend_up', tags=tags)
 
 
-def test_version_failure(aggregator, check, datadog_agent):
+def test_version_failure(aggregator, check, datadog_agent, mock_http):
     config = copy.deepcopy(BASE_CONFIG)
     haproxy_check = check(config)
     filepath = os.path.join(os.path.dirname(common.HERE), 'fixtures', 'mock_data')
     with open(filepath, 'rb') as f:
         data = f.read()
-    with mock.patch('requests.Session.get') as m:
-        m.side_effect = [RuntimeError("Ooops"), mock.Mock(content=data)]
-        haproxy_check.check(config)
+    mock_http.get.side_effect = [RuntimeError("Ooops"), MockHTTPResponse(content=data)]
+    haproxy_check.check(config)
 
     # Version failed, but we should have some metrics
     aggregator.assert_metric(

--- a/openstack_controller/tests/legacy/test_openstack.py
+++ b/openstack_controller/tests/legacy/test_openstack.py
@@ -38,16 +38,13 @@ def test_parse_uptime_string(aggregator):
     assert uptime_parsed == [0.04, 0.14, 0.19]
 
 
-def test_api_error_log_no_password(check, instance, caplog):
+def test_api_error_log_no_password(check, instance, caplog, mock_http):
+    mock_http.post.side_effect = HTTPError(mock.Mock(status=404), 'not found')
     with caplog.at_level(logging.DEBUG):
         with pytest.raises(KeystoneUnreachable):
-            with mock.patch('datadog_checks.base.utils.http.requests.Session.post') as req:
-                req.side_effect = HTTPError(mock.Mock(status=404), 'not found')
-                check._api = SimpleApi(check.log, instance.get("keystone_server_url"), check.http)
-                identity = Authenticator._get_user_identity(instance.get("user"))
-                Authenticator._post_auth_token(
-                    check._api.logger, instance.get("keystone_server_url"), identity, check.http
-                )
+            check._api = SimpleApi(check.log, instance.get("keystone_server_url"), check.http)
+            identity = Authenticator._get_user_identity(instance.get("user"))
+            Authenticator._post_auth_token(check._api.logger, instance.get("keystone_server_url"), identity, check.http)
 
     expected_pass = "'password': '********'"
 

--- a/powerdns_recursor/tests/test_metadata.py
+++ b/powerdns_recursor/tests/test_metadata.py
@@ -12,7 +12,7 @@ from datadog_checks.powerdns_recursor import PowerDNSRecursorCheck
 from . import common
 
 
-def test_metadata_unit(datadog_agent, mock_http):
+def _make_check():
     version = common._get_pdns_version()
     if version == 3:
         instance = common.CONFIG
@@ -21,22 +21,28 @@ def test_metadata_unit(datadog_agent, mock_http):
     check = PowerDNSRecursorCheck("powerdns_recursor", {}, [instance])
     check.check_id = 'test:123'
     check.log = mock.MagicMock()
+    config_obj, _ = check._get_config(instance)
+    return check, config_obj
 
-    config_obj, tags = check._get_config(instance)
 
+def test_metadata_unit_timeout(datadog_agent, mock_http):
+    check, config_obj = _make_check()
     mock_http.get.side_effect = HTTPTimeoutError('')
     check._collect_metadata(config_obj)
     datadog_agent.assert_metadata_count(0)
     check.log.debug.assert_called_with('Error collecting PowerDNS Recursor version: %s', '')
 
-    datadog_agent.reset()
-    mock_http.get.reset_mock(side_effect=True)
+
+def test_metadata_unit_missing_header(datadog_agent, mock_http):
+    check, config_obj = _make_check()
     mock_http.get.return_value = MockHTTPResponse()
     check._collect_metadata(config_obj)
     datadog_agent.assert_metadata_count(0)
     check.log.debug.assert_called_with("Couldn't find the PowerDNS Recursor Server version header")
 
-    datadog_agent.reset()
+
+def test_metadata_unit_bad_version_header(datadog_agent, mock_http):
+    check, config_obj = _make_check()
     mock_http.get.return_value = MockHTTPResponse(headers={'Server': 'wrong_stuff'})
     check._collect_metadata(config_obj)
     datadog_agent.assert_metadata_count(0)

--- a/powerdns_recursor/tests/test_metadata.py
+++ b/powerdns_recursor/tests/test_metadata.py
@@ -4,15 +4,15 @@
 
 import mock
 import pytest
-import requests
 
+from datadog_checks.base.utils.http_exceptions import HTTPTimeoutError
 from datadog_checks.base.utils.http_testing import MockHTTPResponse
 from datadog_checks.powerdns_recursor import PowerDNSRecursorCheck
 
 from . import common
 
 
-def test_metadata_unit(datadog_agent):
+def test_metadata_unit(datadog_agent, mock_http):
     version = common._get_pdns_version()
     if version == 3:
         instance = common.CONFIG
@@ -24,24 +24,23 @@ def test_metadata_unit(datadog_agent):
 
     config_obj, tags = check._get_config(instance)
 
-    with mock.patch('requests.Session.get', side_effect=requests.exceptions.Timeout()):
-        check._collect_metadata(config_obj)
-        datadog_agent.assert_metadata_count(0)
-        check.log.debug.assert_called_with('Error collecting PowerDNS Recursor version: %s', '')
+    mock_http.get.side_effect = HTTPTimeoutError('')
+    check._collect_metadata(config_obj)
+    datadog_agent.assert_metadata_count(0)
+    check.log.debug.assert_called_with('Error collecting PowerDNS Recursor version: %s', '')
 
     datadog_agent.reset()
-    with mock.patch('requests.Session.get', return_value=MockHTTPResponse()):
-        check._collect_metadata(config_obj)
-        datadog_agent.assert_metadata_count(0)
-        check.log.debug.assert_called_with("Couldn't find the PowerDNS Recursor Server version header")
+    mock_http.get.reset_mock(side_effect=True)
+    mock_http.get.return_value = MockHTTPResponse()
+    check._collect_metadata(config_obj)
+    datadog_agent.assert_metadata_count(0)
+    check.log.debug.assert_called_with("Couldn't find the PowerDNS Recursor Server version header")
 
     datadog_agent.reset()
-    with mock.patch('requests.Session.get', return_value=MockHTTPResponse(headers={'Server': 'wrong_stuff'})):
-        check._collect_metadata(config_obj)
-        datadog_agent.assert_metadata_count(0)
-        check.log.debug.assert_called_with(
-            'Error while decoding PowerDNS Recursor version: %s', 'list index out of range'
-        )
+    mock_http.get.return_value = MockHTTPResponse(headers={'Server': 'wrong_stuff'})
+    check._collect_metadata(config_obj)
+    datadog_agent.assert_metadata_count(0)
+    check.log.debug.assert_called_with('Error while decoding PowerDNS Recursor version: %s', 'list index out of range')
 
 
 @pytest.mark.usefixtures('dd_environment')

--- a/traefik_mesh/tests/test_unit.py
+++ b/traefik_mesh/tests/test_unit.py
@@ -161,19 +161,19 @@ def test_submit_version(datadog_agent, dd_run_check, mock_http_response):
     datadog_agent.assert_metadata('test:123', version_metadata)
 
 
-def test_get_json_handles_http_status_error():
+def test_get_json_handles_http_status_error(mock_http):
     check = TraefikMeshCheck('traefik_mesh', {}, [OM_MOCKED_INSTANCE])
-    with mock.patch('requests.Session.get', side_effect=HTTPStatusError('404 Client Error')):
-        assert check._get_json('http://example.com/api') is None
+    mock_http.get.side_effect = HTTPStatusError('404 Client Error')
+    assert check._get_json('http://example.com/api') is None
 
 
-def test_get_json_handles_http_connection_error():
+def test_get_json_handles_http_connection_error(mock_http):
     check = TraefikMeshCheck('traefik_mesh', {}, [OM_MOCKED_INSTANCE])
-    with mock.patch('requests.Session.get', side_effect=_HTTPConnectionError('Connection refused')):
-        assert check._get_json('http://example.com/api') is None
+    mock_http.get.side_effect = _HTTPConnectionError('Connection refused')
+    assert check._get_json('http://example.com/api') is None
 
 
-def test_get_json_handles_http_timeout_error():
+def test_get_json_handles_http_timeout_error(mock_http):
     check = TraefikMeshCheck('traefik_mesh', {}, [OM_MOCKED_INSTANCE])
-    with mock.patch('requests.Session.get', side_effect=_HTTPTimeoutError('Read timed out')):
-        assert check._get_json('http://example.com/api') is None
+    mock_http.get.side_effect = _HTTPTimeoutError('Read timed out')
+    assert check._get_json('http://example.com/api') is None

--- a/twistlock/tests/test_twistlock.py
+++ b/twistlock/tests/test_twistlock.py
@@ -35,7 +35,7 @@ HERE = get_here()
 
 
 def mock_get_factory(fixture_group):
-    def mock_get(session, url, *args, **kwargs):
+    def mock_get(url, *args, **kwargs):
         split_url = url.split('/')
         path = split_url[-1]
         return MockHTTPResponse(file_path=os.path.join(HERE, 'fixtures', fixture_group, '{}.json'.format(path)))
@@ -44,12 +44,12 @@ def mock_get_factory(fixture_group):
 
 
 @pytest.mark.parametrize('fixture_group', ['twistlock', 'prisma_cloud'])
-def test_check(aggregator, instance, fixture_group):
+def test_check(aggregator, instance, fixture_group, mock_http):
     check = TwistlockCheck('twistlock', {}, [instance])
 
-    with mock.patch('requests.Session.get', side_effect=mock_get_factory(fixture_group), autospec=True):
-        check.check(instance)
-        check.check(instance)
+    mock_http.get.side_effect = mock_get_factory(fixture_group)
+    check.check(instance)
+    check.check(instance)
 
     for metric in METRICS:
         aggregator.assert_metric(metric)
@@ -60,7 +60,7 @@ def test_check(aggregator, instance, fixture_group):
 
 
 @pytest.mark.parametrize('fixture_group', ['twistlock', 'prisma_cloud'])
-def test_config_project(aggregator, instance, fixture_group):
+def test_config_project(aggregator, instance, fixture_group, mock_http):
     project = 'foo'
     project_tag = 'project:{}'.format(project)
     qparams = {'project': project}
@@ -68,28 +68,19 @@ def test_config_project(aggregator, instance, fixture_group):
     instance['project'] = project
     check = TwistlockCheck('twistlock', {}, [instance])
 
-    with mock.patch('requests.Session.get', side_effect=mock_get_factory(fixture_group), autospec=True) as r:
-        check.check(instance)
+    mock_http.get.side_effect = mock_get_factory(fixture_group)
+    check.check(instance)
 
-        r.assert_called_with(
-            mock.ANY,  # The session object is passed as the first argument
-            mock.ANY,  # The URL is passed as the second argument
-            params=qparams,
-            auth=mock.ANY,
-            cert=mock.ANY,
-            headers=mock.ANY,
-            proxies=mock.ANY,
-            timeout=mock.ANY,
-            verify=mock.ANY,
-            allow_redirects=mock.ANY,
-        )
+    # project config option propagates to the params query string
+    mock_http.get.assert_called_with(mock.ANY, params=qparams)
+
     # Check if metrics are tagged with the project.
     for metric in METRICS:
         aggregator.assert_metric_has_tag(metric, project_tag)
 
 
 @pytest.mark.parametrize('fixture_group', ['twistlock', 'prisma_cloud'])
-def test_report_image_scan_empty_instances(aggregator, instance, fixture_group):
+def test_report_image_scan_empty_instances(aggregator, instance, fixture_group, mock_http):
     check = TwistlockCheck('twistlock', {}, [instance])
 
     def mock_get(url, *args, **kwargs):
@@ -100,19 +91,17 @@ def test_report_image_scan_empty_instances(aggregator, instance, fixture_group):
             return MockHTTPResponse(file_path=os.path.join(HERE, 'fixtures', fixture_group, '{}.json'.format(path)))
         return MockHTTPResponse(file_path=os.path.join(HERE, 'fixtures', 'empty_images.json'))
 
-    with mock.patch('requests.Session.get', side_effect=mock_get):
-        check.check(instance)
-        check.check(instance)
+    mock_http.get.side_effect = mock_get
+    check.check(instance)
+    check.check(instance)
 
 
-def test_err_response(aggregator, instance):
+def test_err_response(aggregator, instance, mock_http):
     check = TwistlockCheck('twistlock', {}, [instance])
 
+    mock_http.get.return_value = MockHTTPResponse('{"err": "invalid credentials"}')
     with pytest.raises(Exception, match='^Error in response'):
-        with mock.patch(
-            'requests.Session.get', return_value=MockHTTPResponse('{"err": "invalid credentials"}'), autospec=True
-        ):
-            check.check(instance)
+        check.check(instance)
 
 
 @pytest.mark.e2e

--- a/vllm/tests/test_unit.py
+++ b/vllm/tests/test_unit.py
@@ -2,8 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from unittest import mock
-
 import pytest
 
 from datadog_checks.base.constants import ServiceCheck
@@ -14,7 +12,7 @@ from datadog_checks.vllm import vLLMCheck
 from .common import METRICS_MOCK, get_fixture_path
 
 
-def test_check_vllm(dd_run_check, aggregator, datadog_agent, instance):
+def test_check_vllm(dd_run_check, aggregator, datadog_agent, instance, mock_http):
     check = vLLMCheck("vLLM", {}, [instance])
     check.check_id = "test:123"
 
@@ -23,8 +21,8 @@ def test_check_vllm(dd_run_check, aggregator, datadog_agent, instance):
         MockHTTPResponse(file_path=get_fixture_path("vllm_version.json")),
     ]
 
-    with mock.patch('requests.Session.get', side_effect=mock_responses):
-        dd_run_check(check)
+    mock_http.get.side_effect = mock_responses
+    dd_run_check(check)
 
     for metric in METRICS_MOCK:
         aggregator.assert_metric(metric)
@@ -38,7 +36,7 @@ def test_check_vllm(dd_run_check, aggregator, datadog_agent, instance):
     datadog_agent.assert_metadata("test:123", version_metadata)
 
 
-def test_check_vllm_w_ray_prefix(dd_run_check, aggregator, datadog_agent, ray_instance):
+def test_check_vllm_w_ray_prefix(dd_run_check, aggregator, datadog_agent, ray_instance, mock_http):
     check = vLLMCheck("vLLM", {}, [ray_instance])
     check.check_id = "test:123"
 
@@ -47,8 +45,8 @@ def test_check_vllm_w_ray_prefix(dd_run_check, aggregator, datadog_agent, ray_in
         MockHTTPResponse(file_path=get_fixture_path("vllm_version.json")),
     ]
 
-    with mock.patch('requests.Session.get', side_effect=mock_responses):
-        dd_run_check(check)
+    mock_http.get.side_effect = mock_responses
+    dd_run_check(check)
 
     for metric in METRICS_MOCK:
         aggregator.assert_metric(metric)

--- a/voltdb/tests/test_integration.py
+++ b/voltdb/tests/test_integration.py
@@ -6,10 +6,11 @@ from typing import Callable  # noqa: F401
 
 import mock
 import pytest
-import requests
 
 from datadog_checks.base.stubs.aggregator import AggregatorStub  # noqa: F401
 from datadog_checks.base.stubs.datadog_agent import DatadogAgentStub  # noqa: F401
+from datadog_checks.base.utils.http_exceptions import HTTPRequestError
+from datadog_checks.base.utils.http_testing import MockHTTPResponse
 from datadog_checks.voltdb import VoltDBCheck
 from datadog_checks.voltdb.client import Client
 from datadog_checks.voltdb.types import Instance  # noqa: F401
@@ -70,26 +71,24 @@ class TestCheck:
 
         assertions.assert_service_checks(aggregator, instance, connect_status=VoltDBCheck.CRITICAL)
 
-    def test_http_error(self, aggregator, instance):
-        # type: (AggregatorStub, Instance) -> None
+    def test_http_error(self, aggregator, instance, mock_http):
+        # type: (AggregatorStub, Instance, object) -> None
         check = VoltDBCheck('voltdb', {}, [instance])
 
-        with mock.patch('requests.Session.get', side_effect=requests.RequestException('Something failed')):
-            error = check.run()
+        mock_http.get.side_effect = HTTPRequestError('Something failed')
+        error = check.run()
 
         assert 'Something failed' in error
 
         assertions.assert_service_checks(aggregator, instance, connect_status=VoltDBCheck.CRITICAL)
         aggregator.assert_all_metrics_covered()  # No metrics collected.
 
-    def test_http_response_error(self, aggregator, instance):
-        # type: (AggregatorStub, Instance) -> None
+    def test_http_response_error(self, aggregator, instance, mock_http):
+        # type: (AggregatorStub, Instance, object) -> None
         check = VoltDBCheck('voltdb', {}, [instance])
 
-        resp = requests.Response()
-        resp.status_code = 503
-        with mock.patch('requests.Session.get', return_value=resp):
-            error = check.run()
+        mock_http.get.return_value = MockHTTPResponse(status_code=503)
+        error = check.run()
 
         assert '503 Server Error' in error
 


### PR DESCRIPTION
## Motivation

Step 5 of the [Test Decoupling Plan](https://datadoghq.atlassian.net/wiki/spaces/AI/pages/6276618810). Eliminate direct `requests.Session.*` patches in test files so tests are decoupled from the HTTP backend. Part of the [httpx migration](https://datadoghq.atlassian.net/wiki/spaces/AI/pages/6214681547).

## Approach

Per-integration migration to the `mock_http` fixture (introduced in #22676), one commit per integration. Drop boilerplate kwargs and assert only the contract being tested.

`powerdns_recursor`'s `test_metadata_unit` was split into three focused tests with a `_make_check()` helper. The original sequenced three sub-cases sharing one `mock_http.get` with asymmetric `reset_mock` calls. That structure makes it hard to add new sub-cases without breaking existing ones. Migrating the file was a fitting cleanup window since every assertion line was already being touched.

For full details, see the [PR 5.1 plan page](https://datadoghq.atlassian.net/wiki/spaces/AI/pages/6640271656).

## Verification

- [ ] CI passes against `mwdd146980/httpx-migration-base` (this PR stacks on #22676)
- [ ] Local: `ddev test -fs <intg>` + `ddev --no-interactive test --recreate <intg>` per integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)