### PR TITLE
Quiet validation PR comments

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,6 +5,7 @@ on:
     branches:
     - master
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
 

--- a/ddev/src/ddev/cli/validate/all/__init__.py
+++ b/ddev/src/ddev/cli/validate/all/__init__.py
@@ -55,7 +55,7 @@ def all(
     If TARGET is provided (e.g. 'changed'), per-integration validations are
     scoped to that target. Repo-wide validations always run without a target.
     """
-    from ddev.cli.validate.all.github import get_pr_number, write_step_summary
+    from ddev.cli.validate.all.github import get_pr_number, should_suppress_validation_comments, write_step_summary
     from ddev.cli.validate.all.orchestrator import ValidationOrchestrator
 
     selected = _load_validations(app)
@@ -69,12 +69,14 @@ def all(
         app.abort()
 
     pr_number = get_pr_number(app)
+    suppress_pr_comments = should_suppress_validation_comments()
     orchestrator = ValidationOrchestrator(
         app=app,
         target=target,
         validations=list(selected),
         fix=fix,
         pr_number=pr_number,
+        suppress_pr_comments=suppress_pr_comments,
         grace_period=grace_period,
         max_timeout=max_timeout,
         subprocess_timeout=subprocess_timeout,

--- a/ddev/src/ddev/cli/validate/all/github.py
+++ b/ddev/src/ddev/cli/validate/all/github.py
@@ -82,6 +82,8 @@ def pr_has_label_from_event(event_path: str, label: str) -> bool:
 
 
 def should_suppress_validation_comments() -> bool:
+    if os.environ.get("GITHUB_EVENT_NAME") != "pull_request":
+        return False
     if event_path := os.environ.get("GITHUB_EVENT_PATH"):
         return pr_has_label_from_event(event_path, VALIDATION_COMMENT_SUPPRESSION_LABEL)
     return False

--- a/ddev/src/ddev/cli/validate/all/github.py
+++ b/ddev/src/ddev/cli/validate/all/github.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 COMMENT_HEADING = "## Validation Report"
 COMMENT_STATUS_SUCCESS = "<!-- ddev-validation-report:success -->"
 COMMENT_STATUS_ACTION_REQUIRED = "<!-- ddev-validation-report:action-required -->"
+# Suppresses all validation PR comments, including failures, on the next validation run.
 VALIDATION_COMMENT_SUPPRESSION_LABEL = "ci/skip-validation-comments"
 
 

--- a/ddev/src/ddev/cli/validate/all/github.py
+++ b/ddev/src/ddev/cli/validate/all/github.py
@@ -15,6 +15,9 @@ if TYPE_CHECKING:
     from ddev.cli.validate.all.orchestrator import ValidationConfig, ValidationResult
 
 COMMENT_HEADING = "## Validation Report"
+COMMENT_STATUS_SUCCESS = "<!-- ddev-validation-report:success -->"
+COMMENT_STATUS_ACTION_REQUIRED = "<!-- ddev-validation-report:action-required -->"
+VALIDATION_COMMENT_SUPPRESSION_LABEL = "ci/skip-validation-comments"
 
 
 def parse_pr_number_from_event(event_path: str) -> int | None:
@@ -59,6 +62,30 @@ def get_pr_number(app: Application) -> int | None:
     return None
 
 
+def pr_has_label_from_event(event_path: str, label: str) -> bool:
+    """Return whether the GitHub Actions PR event payload contains a label."""
+    try:
+        event = json.loads(Path(event_path).read_text())
+    except (json.JSONDecodeError, OSError):
+        return False
+
+    pr = event.get("pull_request")
+    if not isinstance(pr, dict):
+        return False
+
+    labels = pr.get("labels", [])
+    if not isinstance(labels, list):
+        return False
+
+    return any(isinstance(item, dict) and item.get("name") == label for item in labels)
+
+
+def should_suppress_validation_comments() -> bool:
+    if event_path := os.environ.get("GITHUB_EVENT_PATH"):
+        return pr_has_label_from_event(event_path, VALIDATION_COMMENT_SUPPRESSION_LABEL)
+    return False
+
+
 def get_workflow_run_url() -> str | None:
     server = os.environ.get("GITHUB_SERVER_URL")
     repo = os.environ.get("GITHUB_REPOSITORY")
@@ -75,8 +102,14 @@ def write_step_summary(content: str) -> None:
                 f.write(content + "\n")
 
 
-def _build_preamble(error: str | None, warning: str | None) -> list[str]:
+def is_successful_validation_comment(body: str) -> bool:
+    return COMMENT_STATUS_SUCCESS in body
+
+
+def _build_preamble(error: str | None, warning: str | None, status_marker: str | None = None) -> list[str]:
     parts: list[str] = [f"{COMMENT_HEADING}\n"]
+    if status_marker:
+        parts.append(f"{status_marker}\n")
     if error:
         parts.append(f"> **Error:** {error}\n")
     if warning:
@@ -136,6 +169,7 @@ def format_pr_comment(
     *,
     error: str | None = None,
     warning: str | None = None,
+    successful: bool = False,
 ) -> str:
     """Format a PR comment with collapsible sections to reduce clutter."""
     failures: dict[str, ValidationResult] = {}
@@ -144,7 +178,8 @@ def format_pr_comment(
         (passed if result.success else failures)[name] = result
 
     incomplete = _build_incomplete_warning(expected_validations, results)
-    parts = _build_preamble(error, warning)
+    status_marker = COMMENT_STATUS_SUCCESS if successful else COMMENT_STATUS_ACTION_REQUIRED
+    parts = _build_preamble(error, warning, status_marker)
     parts.extend(incomplete)
 
     if failures:

--- a/ddev/src/ddev/cli/validate/all/orchestrator.py
+++ b/ddev/src/ddev/cli/validate/all/orchestrator.py
@@ -18,6 +18,7 @@ from ddev.cli.validate.all.github import (
     format_pr_comment,
     format_step_summary,
     get_workflow_run_url,
+    is_successful_validation_comment,
     write_step_summary,
 )
 from ddev.event_bus.orchestrator import BaseMessage, EventBusOrchestrator, SyncProcessor
@@ -183,6 +184,7 @@ class ValidationOrchestrator(EventBusOrchestrator):
         validations: list[str] | None = None,
         fix: bool = False,
         pr_number: int | None = None,
+        suppress_pr_comments: bool = False,
         grace_period: float = 5,
         max_timeout: float = 600,
         subprocess_timeout: float = SUBPROCESS_TIMEOUT,
@@ -199,6 +201,7 @@ class ValidationOrchestrator(EventBusOrchestrator):
         self._target = target
         self._fix = fix
         self._pr_number = pr_number
+        self._suppress_pr_comments = suppress_pr_comments
         self._results: dict[str, ValidationResult] = {}
 
         self.register_processor(
@@ -236,14 +239,20 @@ class ValidationOrchestrator(EventBusOrchestrator):
 
         return error_msg, extra_warning
 
-    def _delete_previous_comments(self, pr_number: int) -> None:
-        try:
-            comments = self._app.github.get_pull_request_comments(pr_number)
-            for comment in comments:
-                if comment.get("body", "").startswith(COMMENT_HEADING):
-                    self._app.github.delete_comment(comment["id"])
-        except Exception as exc:
-            self._app.display_warning(f"Failed to clean up previous validation comments: {exc}")
+    def _current_run_succeeded(self, exception: Exception | None) -> bool:
+        return (
+            exception is None
+            and len(self._results) == len(self._validations)
+            and all(result.success for result in self._results.values())
+        )
+
+    def _get_previous_validation_comments(self, pr_number: int) -> list[dict]:
+        comments = self._app.github.get_pull_request_comments(pr_number)
+        return [comment for comment in comments if comment.get("body", "").startswith(COMMENT_HEADING)]
+
+    def _delete_comments(self, comments: list[dict]) -> None:
+        for comment in comments:
+            self._app.github.delete_comment(comment["id"])
 
     def _publish_report(self, exception: Exception | None) -> None:
         error_msg, extra_warning = self._build_error_and_warning(exception)
@@ -258,6 +267,7 @@ class ValidationOrchestrator(EventBusOrchestrator):
         )
         write_step_summary(summary_body)
 
+        current_succeeded = self._current_run_succeeded(exception)
         comment_body = format_pr_comment(
             self._results,
             VALIDATIONS,
@@ -265,6 +275,7 @@ class ValidationOrchestrator(EventBusOrchestrator):
             self._validations,
             error=error_msg,
             warning=extra_warning,
+            successful=current_succeeded,
         )
         if run_url := get_workflow_run_url():
             comment_body += f"\n\n[View full run]({run_url})"
@@ -283,8 +294,21 @@ class ValidationOrchestrator(EventBusOrchestrator):
         previous_level = httpx_logger.level
         httpx_logger.setLevel(logging.WARNING)
         try:
+            self._app.logger.debug("Fetching previous validation comments on PR #%s...", self._pr_number)
+            previous_comments = self._get_previous_validation_comments(self._pr_number)
+            if self._suppress_pr_comments:
+                self._app.logger.debug("Validation PR comments are suppressed for PR #%s.", self._pr_number)
+                self._delete_comments(previous_comments)
+                return
+            if (
+                current_succeeded
+                and previous_comments
+                and all(is_successful_validation_comment(comment.get("body", "")) for comment in previous_comments)
+            ):
+                self._app.logger.debug("Previous validation comments already reported success; skipping PR comment.")
+                return
             self._app.logger.debug("Deleting previous validation comments on PR #%s...", self._pr_number)
-            self._delete_previous_comments(self._pr_number)
+            self._delete_comments(previous_comments)
             self._app.logger.debug("Posting validation comment on PR #%s...", self._pr_number)
             self._app.github.post_pull_request_comment(self._pr_number, comment_body)
             self._app.logger.debug("Comment posted successfully.")

--- a/ddev/src/ddev/cli/validate/all/orchestrator.py
+++ b/ddev/src/ddev/cli/validate/all/orchestrator.py
@@ -270,20 +270,9 @@ class ValidationOrchestrator(EventBusOrchestrator):
             return False
         return all(is_successful_validation_comment(comment["body"]) for comment in previous_comments)
 
-    def _publish_report(self, exception: Exception | None) -> None:
-        error_msg, extra_warning = self._build_error_and_warning(exception)
-
-        summary_body = format_step_summary(
-            self._results,
-            VALIDATIONS,
-            self._target,
-            self._validations,
-            error=error_msg,
-            warning=extra_warning,
-        )
-        write_step_summary(summary_body)
-
-        current_succeeded = self._current_run_succeeded(exception)
+    def _build_pr_comment_body(
+        self, error_msg: str | None, extra_warning: str | None, current_succeeded: bool
+    ) -> str:
         comment_body = format_pr_comment(
             self._results,
             VALIDATIONS,
@@ -295,6 +284,50 @@ class ValidationOrchestrator(EventBusOrchestrator):
         )
         if run_url := get_workflow_run_url():
             comment_body += f"\n\n[View full run]({run_url})"
+        return comment_body
+
+    def _fetch_previous_validation_comments_or_empty(self, pr_number: int) -> list[GithubComment]:
+        self._app.logger.debug("Fetching previous validation comments on PR #%s...", pr_number)
+        try:
+            return self._get_previous_validation_comments(pr_number)
+        except Exception as exc:
+            self._app.display_warning(f"Failed to read previous validation comments: {type(exc).__name__}: {exc}")
+            return []
+
+    def _sync_pr_comment(self, comment_body: str, current_succeeded: bool) -> None:
+        if self._pr_number is None:
+            return
+
+        previous_comments = self._fetch_previous_validation_comments_or_empty(self._pr_number)
+        if self._suppress_pr_comments:
+            self._app.logger.debug("Validation PR comments are suppressed for PR #%s.", self._pr_number)
+            self._delete_comments(previous_comments)
+            return
+        if self._previous_success_already_reported(current_succeeded, previous_comments):
+            self._app.logger.debug("Previous validation comments already reported success; skipping PR comment.")
+            return
+
+        self._app.logger.debug("Deleting previous validation comments on PR #%s...", self._pr_number)
+        self._delete_comments(previous_comments)
+        self._app.logger.debug("Posting validation comment on PR #%s...", self._pr_number)
+        self._app.github.post_pull_request_comment(self._pr_number, comment_body)
+        self._app.logger.debug("Comment posted successfully.")
+
+    def _publish_report(self, exception: Exception | None) -> None:
+        error_msg, extra_warning = self._build_error_and_warning(exception)
+        write_step_summary(
+            format_step_summary(
+                self._results,
+                VALIDATIONS,
+                self._target,
+                self._validations,
+                error=error_msg,
+                warning=extra_warning,
+            )
+        )
+
+        current_succeeded = self._current_run_succeeded(exception)
+        comment_body = self._build_pr_comment_body(error_msg, extra_warning, current_succeeded)
 
         self._app.logger.debug("PR number: %s", self._pr_number)
         self._app.logger.debug("GitHub token configured: %s", bool(self._app.config.github.token))
@@ -310,24 +343,7 @@ class ValidationOrchestrator(EventBusOrchestrator):
         previous_level = httpx_logger.level
         httpx_logger.setLevel(logging.WARNING)
         try:
-            self._app.logger.debug("Fetching previous validation comments on PR #%s...", self._pr_number)
-            try:
-                previous_comments = self._get_previous_validation_comments(self._pr_number)
-            except Exception as exc:
-                self._app.display_warning(f"Failed to read previous validation comments: {type(exc).__name__}: {exc}")
-                previous_comments = []
-            if self._suppress_pr_comments:
-                self._app.logger.debug("Validation PR comments are suppressed for PR #%s.", self._pr_number)
-                self._delete_comments(previous_comments)
-                return
-            if self._previous_success_already_reported(current_succeeded, previous_comments):
-                self._app.logger.debug("Previous validation comments already reported success; skipping PR comment.")
-                return
-            self._app.logger.debug("Deleting previous validation comments on PR #%s...", self._pr_number)
-            self._delete_comments(previous_comments)
-            self._app.logger.debug("Posting validation comment on PR #%s...", self._pr_number)
-            self._app.github.post_pull_request_comment(self._pr_number, comment_body)
-            self._app.logger.debug("Comment posted successfully.")
+            self._sync_pr_comment(comment_body, current_succeeded)
         except Exception as exc:
             self._app.display_warning(f"Failed to post PR comment: {type(exc).__name__}: {exc}")
             write_step_summary(f"\n> Failed to post PR comment: {type(exc).__name__}: {exc}")

--- a/ddev/src/ddev/cli/validate/all/orchestrator.py
+++ b/ddev/src/ddev/cli/validate/all/orchestrator.py
@@ -261,7 +261,12 @@ class ValidationOrchestrator(EventBusOrchestrator):
 
     def _delete_comments(self, comments: list[GithubComment]) -> None:
         for comment in comments:
-            self._app.github.delete_comment(comment["id"])
+            try:
+                self._app.github.delete_comment(comment["id"])
+            except Exception as exc:
+                self._app.display_warning(
+                    f"Failed to delete previous validation comment {comment['id']}: {type(exc).__name__}: {exc}"
+                )
 
     def _previous_success_already_reported(
         self, current_succeeded: bool, previous_comments: list[GithubComment]

--- a/ddev/src/ddev/cli/validate/all/orchestrator.py
+++ b/ddev/src/ddev/cli/validate/all/orchestrator.py
@@ -275,9 +275,7 @@ class ValidationOrchestrator(EventBusOrchestrator):
             return False
         return all(is_successful_validation_comment(comment["body"]) for comment in previous_comments)
 
-    def _build_pr_comment_body(
-        self, error_msg: str | None, extra_warning: str | None, current_succeeded: bool
-    ) -> str:
+    def _build_pr_comment_body(self, error_msg: str | None, extra_warning: str | None, current_succeeded: bool) -> str:
         comment_body = format_pr_comment(
             self._results,
             VALIDATIONS,

--- a/ddev/src/ddev/cli/validate/all/orchestrator.py
+++ b/ddev/src/ddev/cli/validate/all/orchestrator.py
@@ -311,7 +311,11 @@ class ValidationOrchestrator(EventBusOrchestrator):
         httpx_logger.setLevel(logging.WARNING)
         try:
             self._app.logger.debug("Fetching previous validation comments on PR #%s...", self._pr_number)
-            previous_comments = self._get_previous_validation_comments(self._pr_number)
+            try:
+                previous_comments = self._get_previous_validation_comments(self._pr_number)
+            except Exception as exc:
+                self._app.display_warning(f"Failed to read previous validation comments: {type(exc).__name__}: {exc}")
+                previous_comments = []
             if self._suppress_pr_comments:
                 self._app.logger.debug("Validation PR comments are suppressed for PR #%s.", self._pr_number)
                 self._delete_comments(previous_comments)

--- a/ddev/src/ddev/cli/validate/all/orchestrator.py
+++ b/ddev/src/ddev/cli/validate/all/orchestrator.py
@@ -11,7 +11,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from ddev.cli.validate.all.github import (
     COMMENT_HEADING,
@@ -25,6 +25,11 @@ from ddev.event_bus.orchestrator import BaseMessage, EventBusOrchestrator, SyncP
 
 if TYPE_CHECKING:
     from ddev.cli.application import Application
+
+
+class GithubComment(TypedDict):
+    id: int
+    body: str
 
 
 @dataclass(frozen=True)
@@ -246,11 +251,15 @@ class ValidationOrchestrator(EventBusOrchestrator):
             and all(result.success for result in self._results.values())
         )
 
-    def _get_previous_validation_comments(self, pr_number: int) -> list[dict]:
-        comments = self._app.github.get_pull_request_comments(pr_number)
-        return [comment for comment in comments if comment.get("body", "").startswith(COMMENT_HEADING)]
+    def _get_previous_validation_comments(self, pr_number: int) -> list[GithubComment]:
+        comments: list[dict[str, Any]] = self._app.github.get_pull_request_comments(pr_number)
+        return [
+            {"id": comment["id"], "body": comment.get("body", "")}
+            for comment in comments
+            if comment.get("body", "").startswith(COMMENT_HEADING)
+        ]
 
-    def _delete_comments(self, comments: list[dict]) -> None:
+    def _delete_comments(self, comments: list[GithubComment]) -> None:
         for comment in comments:
             self._app.github.delete_comment(comment["id"])
 

--- a/ddev/src/ddev/cli/validate/all/orchestrator.py
+++ b/ddev/src/ddev/cli/validate/all/orchestrator.py
@@ -263,6 +263,13 @@ class ValidationOrchestrator(EventBusOrchestrator):
         for comment in comments:
             self._app.github.delete_comment(comment["id"])
 
+    def _previous_success_already_reported(
+        self, current_succeeded: bool, previous_comments: list[GithubComment]
+    ) -> bool:
+        if not current_succeeded or not previous_comments:
+            return False
+        return all(is_successful_validation_comment(comment["body"]) for comment in previous_comments)
+
     def _publish_report(self, exception: Exception | None) -> None:
         error_msg, extra_warning = self._build_error_and_warning(exception)
 
@@ -309,11 +316,7 @@ class ValidationOrchestrator(EventBusOrchestrator):
                 self._app.logger.debug("Validation PR comments are suppressed for PR #%s.", self._pr_number)
                 self._delete_comments(previous_comments)
                 return
-            if (
-                current_succeeded
-                and previous_comments
-                and all(is_successful_validation_comment(comment.get("body", "")) for comment in previous_comments)
-            ):
+            if self._previous_success_already_reported(current_succeeded, previous_comments):
                 self._app.logger.debug("Previous validation comments already reported success; skipping PR comment.")
                 return
             self._app.logger.debug("Deleting previous validation comments on PR #%s...", self._pr_number)

--- a/ddev/tests/cli/validate/all/test_command.py
+++ b/ddev/tests/cli/validate/all/test_command.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+from ddev.cli.validate.all.github import VALIDATION_COMMENT_SUPPRESSION_LABEL
 from ddev.cli.validate.all.orchestrator import VALIDATIONS
 
 from .conftest import completed_process
@@ -117,3 +118,27 @@ def test_all_command_aborts_when_no_validations_configured(ddev):
 
     assert result.exit_code != 0
     assert NO_VALIDATIONS_ERROR in result.output
+
+
+def test_all_command_passes_comment_suppression_label_state(ddev, tmp_path, monkeypatch):
+    event_file = tmp_path / "event.json"
+    event_file.write_text(f'{{"pull_request": {{"labels": [{{"name": "{VALIDATION_COMMENT_SUPPRESSION_LABEL}"}}]}}}}')
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_file))
+    captured: dict[str, object] = {}
+
+    class FakeOrchestrator:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def run(self):
+            pass
+
+    with (
+        patch("ddev.cli.validate.all._load_validations", return_value={"config": VALIDATIONS["config"]}),
+        patch("ddev.cli.validate.all.orchestrator.ValidationOrchestrator", FakeOrchestrator),
+    ):
+        result = ddev("validate", "all", *FAST_ORCHESTRATOR_OPTS)
+
+    assert result.exit_code == 0, result.output
+    assert captured["suppress_pr_comments"] is True

--- a/ddev/tests/cli/validate/all/test_command.py
+++ b/ddev/tests/cli/validate/all/test_command.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
+
 from ddev.cli.validate.all.github import VALIDATION_COMMENT_SUPPRESSION_LABEL
 from ddev.cli.validate.all.orchestrator import VALIDATIONS
 
@@ -120,9 +122,16 @@ def test_all_command_aborts_when_no_validations_configured(ddev):
     assert NO_VALIDATIONS_ERROR in result.output
 
 
-def test_all_command_passes_comment_suppression_label_state(ddev, tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    "label, expected",
+    [
+        pytest.param(VALIDATION_COMMENT_SUPPRESSION_LABEL, True, id="label-present"),
+        pytest.param("other-label", False, id="label-absent"),
+    ],
+)
+def test_all_command_passes_comment_suppression_label_state(ddev, tmp_path, monkeypatch, label, expected):
     event_file = tmp_path / "event.json"
-    event_file.write_text(f'{{"pull_request": {{"labels": [{{"name": "{VALIDATION_COMMENT_SUPPRESSION_LABEL}"}}]}}}}')
+    event_file.write_text(f'{{"pull_request": {{"labels": [{{"name": "{label}"}}]}}}}')
     monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
     monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_file))
     captured: dict[str, object] = {}
@@ -141,4 +150,4 @@ def test_all_command_passes_comment_suppression_label_state(ddev, tmp_path, monk
         result = ddev("validate", "all", *FAST_ORCHESTRATOR_OPTS)
 
     assert result.exit_code == 0, result.output
-    assert captured["suppress_pr_comments"] is True
+    assert captured["suppress_pr_comments"] is expected

--- a/ddev/tests/cli/validate/all/test_github.py
+++ b/ddev/tests/cli/validate/all/test_github.py
@@ -6,12 +6,17 @@ from __future__ import annotations
 import pytest
 
 from ddev.cli.validate.all.github import (
+    COMMENT_STATUS_ACTION_REQUIRED,
+    COMMENT_STATUS_SUCCESS,
+    VALIDATION_COMMENT_SUPPRESSION_LABEL,
     format_pr_comment,
     format_step_summary,
     get_pr_number,
     get_workflow_run_url,
+    is_successful_validation_comment,
     parse_pr_number_from_event,
     parse_pr_number_from_ref,
+    pr_has_label_from_event,
     write_step_summary,
 )
 from ddev.cli.validate.all.orchestrator import ValidationConfig, ValidationResult
@@ -127,6 +132,8 @@ def test_format_pr_comment_all_passed(helpers):
     expected = helpers.dedent("""
         ## Validation Report
 
+        <!-- ddev-validation-report:success -->
+
         All 2 validations passed.
 
         <details>
@@ -138,7 +145,7 @@ def test_format_pr_comment_all_passed(helpers):
         | `config` | Validate default configuration files against spec.yaml | ✅ |
 
         </details>""")
-    assert format_pr_comment(results, CONFIGS, "changed", list(results)) == expected
+    assert format_pr_comment(results, CONFIGS, "changed", list(results), successful=True) == expected
 
 
 def test_format_pr_comment_one_failure_with_target(helpers):
@@ -148,6 +155,8 @@ def test_format_pr_comment_one_failure_with_target(helpers):
     }
     expected = helpers.dedent("""
         ## Validation Report
+
+        <!-- ddev-validation-report:action-required -->
 
         | Validation | Description | Status |
         |---|---|---|
@@ -173,6 +182,8 @@ def test_format_pr_comment_all_failures_no_details_section(helpers):
     expected = helpers.dedent("""
         ## Validation Report
 
+        <!-- ddev-validation-report:action-required -->
+
         | Validation | Description | Status |
         |---|---|---|
         | `config` | Validate default configuration files against spec.yaml | ❌ |
@@ -185,7 +196,7 @@ def test_format_pr_comment_no_fix_command_when_all_pass():
     results = {
         "config": ValidationResult(name="config", success=True, stdout="ok", stderr="", duration=1.0),
     }
-    comment = format_pr_comment(results, CONFIGS, None, list(results))
+    comment = format_pr_comment(results, CONFIGS, None, list(results), successful=True)
     assert "All 1 validations passed." in comment
     assert "ddev validate all" not in comment
 
@@ -196,6 +207,8 @@ def test_format_pr_comment_with_error_and_warning(helpers):
     }
     expected = helpers.dedent("""
         ## Validation Report
+
+        <!-- ddev-validation-report:action-required -->
 
         > **Error:** Error running validations: boom
 
@@ -231,7 +244,7 @@ def test_format_pr_comment_missing_config_uses_empty_description():
     results = {
         "unknown": ValidationResult(name="unknown", success=True, stdout="ok", stderr="", duration=1.0),
     }
-    comment = format_pr_comment(results, CONFIGS, None, list(results))
+    comment = format_pr_comment(results, CONFIGS, None, list(results), successful=True)
     assert "| `unknown` |  | ✅ |" in comment
 
 
@@ -251,6 +264,51 @@ def test_format_step_summary_incomplete_validations_warns():
     }
     summary = format_step_summary(results, CONFIGS, None, ["ci", "config", "metadata"])
     assert "2 validation(s) did not complete: `config`, `metadata`" in summary
+
+
+def test_format_step_summary_does_not_include_comment_status():
+    results = {
+        "config": ValidationResult(name="config", success=True, stdout="ok", stderr="", duration=1.0),
+    }
+    summary = format_step_summary(results, CONFIGS, None, ["config"])
+    assert COMMENT_STATUS_SUCCESS not in summary
+    assert COMMENT_STATUS_ACTION_REQUIRED not in summary
+
+
+@pytest.mark.parametrize(
+    "body, expected",
+    [
+        pytest.param(f"## Validation Report\n\n{COMMENT_STATUS_SUCCESS}\n\nAll good", True, id="success-marker"),
+        pytest.param(
+            f"## Validation Report\n\n{COMMENT_STATUS_ACTION_REQUIRED}\n\nBad", False, id="action-required-marker"
+        ),
+        pytest.param("## Validation Report\n\nAll 2 validations passed.", False, id="legacy-success"),
+        pytest.param("unrelated comment", False, id="unrelated-comment"),
+    ],
+)
+def test_is_successful_validation_comment(body, expected):
+    assert is_successful_validation_comment(body) is expected
+
+
+@pytest.mark.parametrize(
+    "content, expected",
+    [
+        pytest.param(
+            f'{{"pull_request": {{"labels": [{{"name": "{VALIDATION_COMMENT_SUPPRESSION_LABEL}"}}]}}}}',
+            True,
+            id="label-present",
+        ),
+        pytest.param('{"pull_request": {"labels": [{"name": "other"}]}}', False, id="other-label"),
+        pytest.param('{"pull_request": {"labels": []}}', False, id="no-labels"),
+        pytest.param('{"pull_request": {}}', False, id="missing-labels"),
+        pytest.param('{"pull_request": "bad"}', False, id="pr-not-dict"),
+        pytest.param("{bad json}", False, id="malformed-json"),
+    ],
+)
+def test_pr_has_label_from_event(tmp_path, content, expected):
+    event_file = tmp_path / "event.json"
+    event_file.write_text(content)
+    assert pr_has_label_from_event(str(event_file), VALIDATION_COMMENT_SUPPRESSION_LABEL) is expected
 
 
 # --- format_step_summary ---

--- a/ddev/tests/cli/validate/all/test_github.py
+++ b/ddev/tests/cli/validate/all/test_github.py
@@ -320,9 +320,7 @@ def test_pr_has_label_from_event(tmp_path, content, expected):
         pytest.param("pull_request_review", False, id="pull-request-review"),
     ],
 )
-def test_should_suppress_validation_comments_only_for_pull_request_events(
-    tmp_path, monkeypatch, event_name, expected
-):
+def test_should_suppress_validation_comments_only_for_pull_request_events(tmp_path, monkeypatch, event_name, expected):
     event_file = tmp_path / "event.json"
     event_file.write_text(f'{{"pull_request": {{"labels": [{{"name": "{VALIDATION_COMMENT_SUPPRESSION_LABEL}"}}]}}}}')
     monkeypatch.setenv("GITHUB_EVENT_NAME", event_name)

--- a/ddev/tests/cli/validate/all/test_github.py
+++ b/ddev/tests/cli/validate/all/test_github.py
@@ -17,6 +17,7 @@ from ddev.cli.validate.all.github import (
     parse_pr_number_from_event,
     parse_pr_number_from_ref,
     pr_has_label_from_event,
+    should_suppress_validation_comments,
     write_step_summary,
 )
 from ddev.cli.validate.all.orchestrator import ValidationConfig, ValidationResult
@@ -309,6 +310,25 @@ def test_pr_has_label_from_event(tmp_path, content, expected):
     event_file = tmp_path / "event.json"
     event_file.write_text(content)
     assert pr_has_label_from_event(str(event_file), VALIDATION_COMMENT_SUPPRESSION_LABEL) is expected
+
+
+@pytest.mark.parametrize(
+    "event_name, expected",
+    [
+        pytest.param("pull_request", True, id="pull-request"),
+        pytest.param("pull_request_target", False, id="pull-request-target"),
+        pytest.param("pull_request_review", False, id="pull-request-review"),
+    ],
+)
+def test_should_suppress_validation_comments_only_for_pull_request_events(
+    tmp_path, monkeypatch, event_name, expected
+):
+    event_file = tmp_path / "event.json"
+    event_file.write_text(f'{{"pull_request": {{"labels": [{{"name": "{VALIDATION_COMMENT_SUPPRESSION_LABEL}"}}]}}}}')
+    monkeypatch.setenv("GITHUB_EVENT_NAME", event_name)
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_file))
+
+    assert should_suppress_validation_comments() is expected
 
 
 # --- format_step_summary ---

--- a/ddev/tests/cli/validate/all/test_orchestrator.py
+++ b/ddev/tests/cli/validate/all/test_orchestrator.py
@@ -311,6 +311,25 @@ def test_on_finalize_deletes_previous_validation_comments(mock_app):
     mock_app.github.post_pull_request_comment.assert_called_once()
 
 
+def test_on_finalize_posts_pr_comment_when_deleting_previous_comment_fails(mock_app):
+    mock_app.config.github.token = "fake-token"
+    mock_app.github.get_pull_request_comments.return_value = [
+        {"id": 100, "body": "## Validation Report\nold report"},
+    ]
+    mock_app.github.delete_comment.side_effect = RuntimeError("not found")
+
+    orch = ValidationOrchestrator(app=mock_app, validations=["config"], target=None, pr_number=42)
+    orch._results = {
+        "config": ValidationResult(name="config", success=True, stdout="ok", stderr="", duration=1.0),
+    }
+    asyncio.run(orch.on_finalize(exception=None))
+
+    mock_app.github.delete_comment.assert_called_once_with(100)
+    mock_app.github.post_pull_request_comment.assert_called_once()
+    warning_args = [str(c) for c in mock_app.display_warning.call_args_list]
+    assert any("Failed to delete previous validation comment 100" in w for w in warning_args)
+
+
 def test_on_finalize_skips_pr_comment_on_repeated_success(mock_app):
     mock_app.config.github.token = "fake-token"
     mock_app.github.get_pull_request_comments.return_value = [

--- a/ddev/tests/cli/validate/all/test_orchestrator.py
+++ b/ddev/tests/cli/validate/all/test_orchestrator.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from ddev.cli.validate.all import _load_validations
+from ddev.cli.validate.all.github import COMMENT_STATUS_ACTION_REQUIRED, COMMENT_STATUS_SUCCESS
 from ddev.cli.validate.all.orchestrator import (
     VALIDATIONS,
     ValidationMessage,
@@ -204,6 +205,7 @@ def test_on_finalize_writes_step_summary(mock_app, tmp_path, monkeypatch):
 
 def test_on_finalize_posts_pr_comment_on_failure(mock_app):
     mock_app.config.github.token = "fake-token"
+    mock_app.github.get_pull_request_comments.return_value = []
 
     orch = ValidationOrchestrator(app=mock_app, validations=["config"], target=None, pr_number=42)
     orch._results = {
@@ -219,12 +221,14 @@ def test_on_finalize_posts_pr_comment_on_failure(mock_app):
     assert "Validate default configuration files against spec.yaml" in body
     assert "| `config` |" in body
     assert "❌" in body
+    assert COMMENT_STATUS_ACTION_REQUIRED in body
     assert "[View full run](https://github.com/DataDog/integrations-core/actions/runs/12345)" in body
 
 
 def test_on_finalize_pr_comment_omits_run_link_when_env_missing(mock_app, monkeypatch):
     monkeypatch.delenv("GITHUB_RUN_ID")
     mock_app.config.github.token = "fake-token"
+    mock_app.github.get_pull_request_comments.return_value = []
 
     orch = ValidationOrchestrator(app=mock_app, validations=["config"], target=None, pr_number=42)
     orch._results = {
@@ -242,6 +246,7 @@ def test_on_finalize_step_summary_does_not_include_run_link(mock_app, tmp_path, 
     monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
 
     mock_app.config.github.token = "fake-token"
+    mock_app.github.get_pull_request_comments.return_value = []
     orch = ValidationOrchestrator(app=mock_app, validations=["config"], target=None, pr_number=42)
     orch._results = {
         "config": ValidationResult(name="config", success=False, stdout="err", stderr="", duration=1.0),
@@ -255,6 +260,7 @@ def test_on_finalize_step_summary_does_not_include_run_link(mock_app, tmp_path, 
 
 def test_on_finalize_posts_pr_comment_on_success(mock_app):
     mock_app.config.github.token = "fake-token"
+    mock_app.github.get_pull_request_comments.return_value = []
 
     orch = ValidationOrchestrator(app=mock_app, validations=["config", "ci"], target=None, pr_number=42)
     orch._results = {
@@ -269,6 +275,7 @@ def test_on_finalize_posts_pr_comment_on_success(mock_app):
     assert "<details>" in body
     assert "| `ci` |" in body
     assert "| `config` |" in body
+    assert COMMENT_STATUS_SUCCESS in body
 
 
 def test_on_finalize_deletes_previous_validation_comments(mock_app):
@@ -286,6 +293,113 @@ def test_on_finalize_deletes_previous_validation_comments(mock_app):
 
     mock_app.github.delete_comment.assert_called_once_with(100)
     mock_app.github.post_pull_request_comment.assert_called_once()
+
+
+def test_on_finalize_skips_pr_comment_on_repeated_success(mock_app):
+    mock_app.config.github.token = "fake-token"
+    mock_app.github.get_pull_request_comments.return_value = [
+        {"id": 100, "body": f"## Validation Report\n\n{COMMENT_STATUS_SUCCESS}\n\nAll 1 validations passed."},
+    ]
+
+    orch = ValidationOrchestrator(app=mock_app, validations=["config"], target=None, pr_number=42)
+    orch._results = {
+        "config": ValidationResult(name="config", success=True, stdout="ok", stderr="", duration=1.0),
+    }
+    asyncio.run(orch.on_finalize(exception=None))
+
+    mock_app.github.get_pull_request_comments.assert_called_once_with(42)
+    mock_app.github.delete_comment.assert_not_called()
+    mock_app.github.post_pull_request_comment.assert_not_called()
+
+
+def test_on_finalize_posts_recovery_comment_after_failure(mock_app):
+    mock_app.config.github.token = "fake-token"
+    mock_app.github.get_pull_request_comments.return_value = [
+        {"id": 100, "body": f"## Validation Report\n\n{COMMENT_STATUS_ACTION_REQUIRED}\n\nold failure"},
+    ]
+
+    orch = ValidationOrchestrator(app=mock_app, validations=["config"], target=None, pr_number=42)
+    orch._results = {
+        "config": ValidationResult(name="config", success=True, stdout="ok", stderr="", duration=1.0),
+    }
+    asyncio.run(orch.on_finalize(exception=None))
+
+    mock_app.github.delete_comment.assert_called_once_with(100)
+    mock_app.github.post_pull_request_comment.assert_called_once()
+    body = mock_app.github.post_pull_request_comment.call_args[0][1]
+    assert COMMENT_STATUS_SUCCESS in body
+
+
+def test_on_finalize_posts_failure_comment_after_success(mock_app):
+    mock_app.config.github.token = "fake-token"
+    mock_app.github.get_pull_request_comments.return_value = [
+        {"id": 100, "body": f"## Validation Report\n\n{COMMENT_STATUS_SUCCESS}\n\nold success"},
+    ]
+
+    orch = ValidationOrchestrator(app=mock_app, validations=["config"], target=None, pr_number=42)
+    orch._results = {
+        "config": ValidationResult(name="config", success=False, stdout="err", stderr="", duration=1.0),
+    }
+    with pytest.raises(SystemExit):
+        asyncio.run(orch.on_finalize(exception=None))
+
+    mock_app.github.delete_comment.assert_called_once_with(100)
+    mock_app.github.post_pull_request_comment.assert_called_once()
+    body = mock_app.github.post_pull_request_comment.call_args[0][1]
+    assert COMMENT_STATUS_ACTION_REQUIRED in body
+
+
+def test_on_finalize_posts_success_when_previous_comment_has_no_status(mock_app):
+    mock_app.config.github.token = "fake-token"
+    mock_app.github.get_pull_request_comments.return_value = [
+        {"id": 100, "body": "## Validation Report\n\nAll 1 validations passed."},
+    ]
+
+    orch = ValidationOrchestrator(app=mock_app, validations=["config"], target=None, pr_number=42)
+    orch._results = {
+        "config": ValidationResult(name="config", success=True, stdout="ok", stderr="", duration=1.0),
+    }
+    asyncio.run(orch.on_finalize(exception=None))
+
+    mock_app.github.delete_comment.assert_called_once_with(100)
+    mock_app.github.post_pull_request_comment.assert_called_once()
+    body = mock_app.github.post_pull_request_comment.call_args[0][1]
+    assert COMMENT_STATUS_SUCCESS in body
+
+
+def test_on_finalize_suppresses_pr_comments_and_deletes_previous_comments(mock_app):
+    mock_app.config.github.token = "fake-token"
+    mock_app.github.get_pull_request_comments.return_value = [
+        {"id": 100, "body": f"## Validation Report\n\n{COMMENT_STATUS_ACTION_REQUIRED}\n\nold failure"},
+        {"id": 200, "body": "unrelated comment"},
+    ]
+
+    orch = ValidationOrchestrator(
+        app=mock_app, validations=["config"], target=None, pr_number=42, suppress_pr_comments=True
+    )
+    orch._results = {
+        "config": ValidationResult(name="config", success=True, stdout="ok", stderr="", duration=1.0),
+    }
+    asyncio.run(orch.on_finalize(exception=None))
+
+    mock_app.github.delete_comment.assert_called_once_with(100)
+    mock_app.github.post_pull_request_comment.assert_not_called()
+
+
+def test_on_finalize_suppresses_pr_comments_with_no_previous_comments(mock_app):
+    mock_app.config.github.token = "fake-token"
+    mock_app.github.get_pull_request_comments.return_value = []
+
+    orch = ValidationOrchestrator(
+        app=mock_app, validations=["config"], target=None, pr_number=42, suppress_pr_comments=True
+    )
+    orch._results = {
+        "config": ValidationResult(name="config", success=True, stdout="ok", stderr="", duration=1.0),
+    }
+    asyncio.run(orch.on_finalize(exception=None))
+
+    mock_app.github.delete_comment.assert_not_called()
+    mock_app.github.post_pull_request_comment.assert_not_called()
 
 
 def test_on_finalize_includes_pr_warning_in_summary(mock_app, tmp_path, monkeypatch):
@@ -306,6 +420,7 @@ def test_on_finalize_includes_pr_warning_in_summary(mock_app, tmp_path, monkeypa
 
 def test_on_finalize_handles_post_failure(mock_app):
     mock_app.config.github.token = "fake-token"
+    mock_app.github.get_pull_request_comments.return_value = []
     mock_app.github.post_pull_request_comment.side_effect = RuntimeError("network error")
 
     orch = ValidationOrchestrator(app=mock_app, validations=["config"], target=None, pr_number=42)

--- a/ddev/tests/cli/validate/all/test_orchestrator.py
+++ b/ddev/tests/cli/validate/all/test_orchestrator.py
@@ -278,6 +278,22 @@ def test_on_finalize_posts_pr_comment_on_success(mock_app):
     assert COMMENT_STATUS_SUCCESS in body
 
 
+def test_on_finalize_posts_pr_comment_when_fetching_previous_comments_fails(mock_app):
+    mock_app.config.github.token = "fake-token"
+    mock_app.github.get_pull_request_comments.side_effect = RuntimeError("network error")
+
+    orch = ValidationOrchestrator(app=mock_app, validations=["config"], target=None, pr_number=42)
+    orch._results = {
+        "config": ValidationResult(name="config", success=True, stdout="ok", stderr="", duration=1.0),
+    }
+    asyncio.run(orch.on_finalize(exception=None))
+
+    mock_app.display_warning.assert_called()
+    warning_args = [str(c) for c in mock_app.display_warning.call_args_list]
+    assert any("Failed to read previous validation comments" in w for w in warning_args)
+    mock_app.github.post_pull_request_comment.assert_called_once()
+
+
 def test_on_finalize_deletes_previous_validation_comments(mock_app):
     mock_app.config.github.token = "fake-token"
     mock_app.github.get_pull_request_comments.return_value = [


### PR DESCRIPTION
<!-- dd-meta {"pullId":"16793c85-6b6c-4265-a302-9c7a70a438cc","source":"chat","resourceId":"39859f7e-82c7-4873-b11c-31a21d9aa9a4","workflowId":"1a885601-e93e-442e-a9d9-ad48a1042c91","codeChangeId":"1a885601-e93e-442e-a9d9-ad48a1042c91","sourceType":"chat"} -->
### What does this PR do?
Adds quieter validation PR reporting for `ddev validate all` by marking validation report comments with hidden status metadata, skipping duplicate success comments, and allowing PRs labeled `ci/skip-validation-comments` to suppress validation report comments entirely.

### Motivation
Validation reports should remain useful when they require attention or show recovery, but repeated successful validation comments add noise to active PRs. A label-based suppression option also gives maintainers an explicit way to keep PR conversations quiet while validations continue to run.

### Changes
- Add hidden success/action-required markers to validation PR comments.
- Detect previous successful validation comments by metadata and skip posting when the current run also succeeds.
- Add `ci/skip-validation-comments` label detection from the pull request event payload.
- Delete existing validation report comments and post nothing when comment suppression is enabled.
- Keep workflow step summaries unchanged so each run still has local validation context.
- Add tests for success/failure/success transitions, metadata formatting, and label-based suppression.

### Testing/Validation
- `ruff check --fix ddev/src/ddev/cli/validate/all/__init__.py ddev/src/ddev/cli/validate/all/github.py ddev/src/ddev/cli/validate/all/orchestrator.py ddev/tests/cli/validate/all/test_command.py ddev/tests/cli/validate/all/test_github.py ddev/tests/cli/validate/all/test_orchestrator.py`
- `ddev --no-interactive test ddev -- tests/cli/validate/all/test_github.py tests/cli/validate/all/test_orchestrator.py tests/cli/validate/all/test_command.py`
- Attempted `ddev release changelog new fixed ddev -m "Allow PRs to suppress validation report comments with a label."`, but it could not run in this detached worktree because `origin/master` is unavailable.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/39859f7e-82c7-4873-b11c-31a21d9aa9a4)

Comment @datadog to request changes