### PR TITLE
apply security format refs to template configuration YAMLs

### DIFF
--- a/datadog_checks_dev/changelog.d/23540.added
+++ b/datadog_checks_dev/changelog.d/23540.added
@@ -1,0 +1,1 @@
+add secret and tag to allowed metadata integration format annotation  

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/constants.py
@@ -46,5 +46,6 @@ ALLOWED_FORMATS = {
     'java_jvm_options',
     'path',
     'port',
+    'secret',
     'url',
 }

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/constants.py
@@ -47,5 +47,6 @@ ALLOWED_FORMATS = {
     'path',
     'port',
     'secret',
+    'tag',
     'url',
 }

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
@@ -95,7 +95,7 @@
   fleet_configurable: true
 - name: password
   display_priority: 0
-  secret: true
+  formats: ["secret"]
   value:
     type: string
   description: The password to use if services are behind basic or NTLM auth.
@@ -300,6 +300,7 @@
 - name: tls_cert
   display_priority: 0
   fleet_configurable: true
+  formats: ["path"]
   value:
     example: <CERT_PATH>
     type: string
@@ -311,6 +312,7 @@
 - name: tls_private_key
   display_priority: 0
   fleet_configurable: true
+  formats: ["secret"]
   value:
     example: <PRIVATE_KEY_PATH>
     type: string
@@ -321,6 +323,7 @@
 - name: tls_ca_cert
   display_priority: 0
   fleet_configurable: true
+  formats: ["path"]
   value:
     example: <CA_CERT_PATH>
     type: string

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
@@ -95,6 +95,7 @@
   fleet_configurable: true
 - name: password
   display_priority: 0
+  secret: true
   formats: ["secret"]
   value:
     type: string

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
@@ -45,7 +45,7 @@
 - name: password
   display_priority: 0
   description: Password to use when connecting to JMX.
-  secret: true
+  formats: ["secret"]
   value:
     type: string
   fleet_configurable: true
@@ -97,7 +97,7 @@
   display_priority: 0
   description: 'A list of Java JVM options, for example: "-Xmx200m -Xms50m".'
   fleet_configurable: true
-  formats: ["java_jvm_options"]
+  formats: ["jvm"]
   value:
     type: string
   
@@ -117,7 +117,7 @@
   description: |
     The password for your TrustStore.jks file.
     `trust_store_password` should be set if SSL is enabled.
-  secret: true
+  formats: ["secret"]
   value:
     type: string
   fleet_configurable: true
@@ -138,7 +138,7 @@
   description: |
     The password to your key store.
     `key_store_password` should be set if client authentication is enabled on the target JVM.
-  secret: true
+  formats: ["secret"]
   value:
     type: string
   fleet_configurable: true

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
@@ -45,6 +45,7 @@
 - name: password
   display_priority: 0
   description: Password to use when connecting to JMX.
+  secret: true
   formats: ["secret"]
   value:
     type: string
@@ -117,6 +118,7 @@
   description: |
     The password for your TrustStore.jks file.
     `trust_store_password` should be set if SSL is enabled.
+  secret: true
   formats: ["secret"]
   value:
     type: string
@@ -138,6 +140,7 @@
   description: |
     The password to your key store.
     `key_store_password` should be set if client authentication is enabled on the target JVM.
+  secret: true
   formats: ["secret"]
   value:
     type: string

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
@@ -97,7 +97,7 @@
   display_priority: 0
   description: 'A list of Java JVM options, for example: "-Xmx200m -Xms50m".'
   fleet_configurable: true
-  formats: ["jvm"]
+  formats: ["java_jvm_options"]
   value:
     type: string
   

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics_legacy_base.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics_legacy_base.yaml
@@ -3,6 +3,7 @@
   required: true
   description: The URL where your application metrics are exposed by Prometheus.
   fleet_configurable: true
+  formats: ["url"]
   value:
     type: string
 - name: namespace

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/pdh_legacy.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/pdh_legacy.yaml
@@ -21,7 +21,7 @@
   display_priority: 0
   legacy: true
   required: false
-  secret: true
+  formats: ["secret"]
   description: The password from the credentials needed to connect to the host.
   fleet_configurable: true
   value:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/pdh_legacy.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/pdh_legacy.yaml
@@ -21,6 +21,7 @@
   display_priority: 0
   legacy: true
   required: false
+  secret: true
   formats: ["secret"]
   description: The password from the credentials needed to connect to the host.
   fleet_configurable: true

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/perf_counters.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/perf_counters.yaml
@@ -16,7 +16,7 @@
   display_priority: 0
   description: |
     The password of `username`.
-  secret: true
+  formats: ["secret"]
   fleet_configurable: true
   value:
     type: string

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/perf_counters.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/perf_counters.yaml
@@ -16,6 +16,7 @@
   display_priority: 0
   description: |
     The password of `username`.
+  secret: true
   formats: ["secret"]
   fleet_configurable: true
   value:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/tags.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/tags.yaml
@@ -7,6 +7,7 @@ value:
   type: array
   items:
     type: string
+    formats: ["tag"]
 description: |
   A list of tags to attach to every metric and service check emitted by this instance.
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/tls.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/tls.yaml
@@ -9,6 +9,7 @@
 - name: tls_ca_cert
   display_priority: 0
   fleet_configurable: true
+  formats: ["path"]
   value:
     example: <CA_CERT_PATH>
     type: string
@@ -23,6 +24,7 @@
 - name: tls_cert
   display_priority: 0
   fleet_configurable: true
+  formats: ["path"]
   value:
     example: <CERT_PATH>
     type: string
@@ -36,7 +38,7 @@
 - name: tls_private_key
   display_priority: 0
   fleet_configurable: true
-  secret: true
+  formats: ["secret"]
   value:
     example: <PRIVATE_KEY_PATH>
     type: string
@@ -48,7 +50,7 @@
     Setting this implicitly sets `tls_verify` to true.
 - name: tls_private_key_password
   display_priority: 0
-  secret: true
+  formats: ["secret"]
   fleet_configurable: true
   value:
     example: <PRIVATE_KEY_PASSWORD>

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/tls.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/tls.yaml
@@ -38,6 +38,7 @@
 - name: tls_private_key
   display_priority: 0
   fleet_configurable: true
+  secret: true
   formats: ["secret"]
   value:
     example: <PRIVATE_KEY_PATH>
@@ -50,6 +51,7 @@
     Setting this implicitly sets `tls_verify` to true.
 - name: tls_private_key_password
   display_priority: 0
+  secret: true
   formats: ["secret"]
   fleet_configurable: true
   value:

--- a/datadog_checks_dev/tests/tooling/configuration/test_load.py
+++ b/datadog_checks_dev/tests/tooling/configuration/test_load.py
@@ -905,7 +905,7 @@ def test_option_formats_unknown_value():
 
     assert (
         'test, test.yaml, instances, foo: Attribute `formats` contains unknown value(s): '
-        'made_up_format, valid values are java_jvm_options | path | port | url'
+        'made_up_format, valid values are java_jvm_options | path | port | secret | url'
     ) in spec.errors
 
 
@@ -984,7 +984,7 @@ def test_value_type_object_property_formats_invalid():
 
     assert (
         'test, test.yaml, instances, foo: Attribute `formats` for property `bar` contains unknown value(s): '
-        'unknown, valid values are java_jvm_options | path | port | url'
+        'unknown, valid values are java_jvm_options | path | port | secret | url'
     ) in spec.errors
 
 

--- a/datadog_checks_dev/tests/tooling/configuration/test_load.py
+++ b/datadog_checks_dev/tests/tooling/configuration/test_load.py
@@ -905,7 +905,7 @@ def test_option_formats_unknown_value():
 
     assert (
         'test, test.yaml, instances, foo: Attribute `formats` contains unknown value(s): '
-        'made_up_format, valid values are java_jvm_options | path | port | secret | url'
+        'made_up_format, valid values are java_jvm_options | path | port | secret | tag | url'
     ) in spec.errors
 
 
@@ -984,7 +984,7 @@ def test_value_type_object_property_formats_invalid():
 
     assert (
         'test, test.yaml, instances, foo: Attribute `formats` for property `bar` contains unknown value(s): '
-        'unknown, valid values are java_jvm_options | path | port | secret | url'
+        'unknown, valid values are java_jvm_options | path | port | secret | tag | url'
     ) in spec.errors
 
 
@@ -2893,7 +2893,7 @@ def test_template_mapping():
     assert options[0]['name'] == 'foo'
     assert options[1] == {
         'name': 'tags',
-        'value': {'example': ['<KEY_1>:<VALUE_1>', '<KEY_2>:<VALUE_2>'], 'type': 'array', 'items': {'type': 'string'}},
+        'value': {'example': ['<KEY_1>:<VALUE_1>', '<KEY_2>:<VALUE_2>'], 'type': 'array', 'items': {'type': 'string', 'formats': ['tag']}},
         'description': (
             'A list of tags to attach to every metric and service check emitted by this instance.\n'
             '\n'

--- a/datadog_checks_dev/tests/tooling/configuration/test_load.py
+++ b/datadog_checks_dev/tests/tooling/configuration/test_load.py
@@ -2893,7 +2893,11 @@ def test_template_mapping():
     assert options[0]['name'] == 'foo'
     assert options[1] == {
         'name': 'tags',
-        'value': {'example': ['<KEY_1>:<VALUE_1>', '<KEY_2>:<VALUE_2>'], 'type': 'array', 'items': {'type': 'string', 'formats': ['tag']}},
+        'value': {
+            'example': ['<KEY_1>:<VALUE_1>', '<KEY_2>:<VALUE_2>'],
+            'type': 'array',
+            'items': {'type': 'string', 'formats': ['tag']},
+        },
         'description': (
             'A list of tags to attach to every metric and service check emitted by this instance.\n'
             '\n'

--- a/kubernetes_state_core/assets/configuration/spec.yaml
+++ b/kubernetes_state_core/assets/configuration/spec.yaml
@@ -85,6 +85,7 @@ files:
               type: array
               items:
                 type: string
+                formats: ["tag"]
               example:
                 - <KEY_1>:<VALUE_1>
                 - <KEY_2>:<VALUE_2>


### PR DESCRIPTION
## Summary

- Replaces `secret: true` with `formats: ["secret"]` in template YAMLs (`http`, `jmx`, `tls`, `pdh_legacy`, `perf_counters`) 
- Adds `formats: ["path"]` to TLS cert/CA cert fields in `http` and `tls` templates
- Adds `formats: ["tag"]` to `tags` items in the `tags` template and `kubernetes_state_core` spec
- Adds `formats: ["url"]` to `prometheus_url` in `openmetrics_legacy_base`

- Add secret and tag to allowed format
