### PR TITLE
fix(release): drop arithmetic from dispatch job name

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -92,7 +92,7 @@ jobs:
         run: python .github/workflows/scripts/release_dispatch.py
 
   dispatch:
-    name: Dispatch wheel builds (batch ${{ strategy.job-index + 1 }})
+    name: Dispatch wheel builds (batch ${{ strategy.job-index }})
     needs: prepare
     if: needs.prepare.outputs.has_packages == 'true' && !inputs.dry-run
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What does this PR do?
Removes the unsupported `+ 1` arithmetic from the matrix job name in `.github/workflows/release-dispatch.yml`. The job name now uses the 0-indexed `strategy.job-index` directly.

### Motivation
The workflow file was failing validation with:

> (Line: 95, Col: 11): Unexpected symbol: '+'. Located at position 20 within expression: strategy.job-index + 1

GitHub Actions expressions don't support arithmetic operators, so the `+ 1` had to go. The trade-off is that batches now display as `batch 0`, `batch 1`, … instead of `batch 1`, `batch 2`, …. If 1-based numbering matters for display, an alternative is to inject a `batch_number` field into each matrix payload from `_release/dispatch.py` and reference `matrix.payload.batch_number` in the job name.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged