### PR TITLE
Add Account Name field release notes (hubspot-content-hub, docusign, ringcentral, klaviyo, microsoft-copilot)

### DIFF
--- a/docusign/CHANGELOG.md
+++ b/docusign/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ***Added***:
 
-* Added an Account Name field that serves as a customizable alias for the account. Existing accounts have been backfilled with the account creation date as the default value.
+* Added an **Account name** field that serves as a customizable alias for the account. Existing accounts have been backfilled with the account creation date as the default value.
 
 ## 1.0.0 / 2024-08-13
 

--- a/docusign/CHANGELOG.md
+++ b/docusign/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - docusign
 
+## 1.1.0 / 2026-04-30
+
+***Added***:
+
+* Added an Account Name field that serves as a customizable alias for the account. Existing accounts have been backfilled with the account creation date as the default value.
+
 ## 1.0.0 / 2024-08-13
 
 ***Added***:

--- a/hubspot_content_hub/CHANGELOG.md
+++ b/hubspot_content_hub/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ***Added***:
 
-* Added an Account Name field that serves as a customizable alias for the account. Existing accounts have been backfilled with the account creation date as the default value.
+* Added an **Account name** field that serves as a customizable alias for the account. Existing accounts have been backfilled with the account creation date as the default value.
 
 ## 1.1.0 / 2026-02-02
 

--- a/hubspot_content_hub/CHANGELOG.md
+++ b/hubspot_content_hub/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - hubspot_content_hub
 
+## 1.2.0 / 2026-04-30
+
+***Added***:
+
+* Added an Account Name field that serves as a customizable alias for the account. Existing accounts have been backfilled with the account creation date as the default value.
+
 ## 1.1.0 / 2026-02-02
 
 ***Added***:

--- a/klaviyo/CHANGELOG.md
+++ b/klaviyo/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ***Added***:
 
-* Added an Account Name field that serves as a customizable alias for the account. Existing accounts have been backfilled with the account creation date as the default value.
+* Added an **Account name** field that serves as a customizable alias for the account. Existing accounts have been backfilled with the account creation date as the default value.
 
 ## 1.0.0 / 2025-07-11
 

--- a/klaviyo/CHANGELOG.md
+++ b/klaviyo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - Klaviyo
 
+## 1.1.0 / 2026-04-30
+
+***Added***:
+
+* Added an Account Name field that serves as a customizable alias for the account. Existing accounts have been backfilled with the account creation date as the default value.
+
 ## 1.0.0 / 2025-07-11
 
 ***Added***:

--- a/microsoft_copilot/CHANGELOG.md
+++ b/microsoft_copilot/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ***Added***:
 
-* Added an Account Name field that serves as a customizable alias for the account. Existing accounts have been backfilled with the account creation date as the default value.
+* Added an **Account name** field that serves as a customizable alias for the account. Existing accounts have been backfilled with the account creation date as the default value.
 
 ## 1.0.0 / 2025-09-24
 

--- a/microsoft_copilot/CHANGELOG.md
+++ b/microsoft_copilot/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - Microsoft Copilot
 
+## 1.1.0 / 2026-04-30
+
+***Added***:
+
+* Added an Account Name field that serves as a customizable alias for the account. Existing accounts have been backfilled with the account creation date as the default value.
+
 ## 1.0.0 / 2025-09-24
 
 ***Added***:

--- a/ringcentral/CHANGELOG.md
+++ b/ringcentral/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ***Added***:
 
-* Added an Account Name field that serves as a customizable alias for the account. Existing accounts have been backfilled with the account creation date as the default value.
+* Added an **Account name** field that serves as a customizable alias for the account. Existing accounts have been backfilled with the account creation date as the default value.
 
 ## 1.0.0 / 2024-08-08
 

--- a/ringcentral/CHANGELOG.md
+++ b/ringcentral/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - RingCentral
 
+## 1.1.0 / 2026-04-30
+
+***Added***:
+
+* Added an Account Name field that serves as a customizable alias for the account. Existing accounts have been backfilled with the account creation date as the default value.
+
 ## 1.0.0 / 2024-08-08
 
 ***Added***:


### PR DESCRIPTION
## Summary

- Adds `CHANGELOG.md` entries for the new **Account Name** field across 5 integrations in this repo: `hubspot_content_hub`, `docusign`, `ringcentral`, `klaviyo`, `microsoft_copilot`
- The Account Name field is an editable alias for the account; existing accounts were backfilled with the account creation date as the default value
- Companion PR in `integrations-internal-core` covers the remaining 5 integrations (atlassian_audit_records, zoom_activity_logs, gitlab_audit_events, github_copilot, microsoft_graph)

## Test plan

- [ ] CHANGELOG entries follow existing format conventions per integration
- [ ] Version numbers correctly incremented (minor bump for new feature)
- [ ] No functional code changes — changelog only

🤖 Generated with [Claude Code](https://claude.com/claude-code)