### PR TITLE
[clickhouse] Skip emitting empty storage_health payloads

### DIFF
--- a/clickhouse/changelog.d/23553.fixed
+++ b/clickhouse/changelog.d/23553.fixed
@@ -1,0 +1,1 @@
+Skip emitting empty storage_health payloads when every parts-and-merges collection is empty.

--- a/clickhouse/datadog_checks/clickhouse/parts_and_merges.py
+++ b/clickhouse/datadog_checks/clickhouse/parts_and_merges.py
@@ -818,6 +818,8 @@ class ClickhousePartsAndMerges(DBMAsyncJob):
         thresholds: list[dict] | None = None,
     ) -> None:
         """Emit a per-cycle row-level payload consumed by dbm-events-processor."""
+        if not (parts or merges or mutations or replication_queue or detached_parts or thresholds):
+            return
         now_ms = int(time.time() * 1000)
         payload = {
             "host": self._check.reported_hostname,

--- a/clickhouse/tests/test_parts_and_merges.py
+++ b/clickhouse/tests/test_parts_and_merges.py
@@ -856,10 +856,25 @@ def test_emit_events_uses_query_activity_channel_not_metadata(check):
         mock.patch('datadog_checks.clickhouse.parts_and_merges.datadog_agent') as agent_mock,
     ):
         agent_mock.get_version.return_value = '7.64.0'
-        job._emit_events([], [], [], [], [])
+        job._emit_events(_collected_parts(), [], [], [], [])
 
     activity_mock.assert_called_once()
     metadata_mock.assert_not_called()
+
+
+def test_emit_events_skips_when_all_collections_empty(check):
+    job = check.parts_and_merges
+    job.tags = ['test:clickhouse']
+    job._tags_no_db = ['test:clickhouse']
+
+    with (
+        mock.patch.object(check, 'database_monitoring_query_activity') as activity_mock,
+        mock.patch('datadog_checks.clickhouse.parts_and_merges.datadog_agent') as agent_mock,
+    ):
+        agent_mock.get_version.return_value = '7.64.0'
+        job._emit_events([], [], [], [], [], [])
+
+    activity_mock.assert_not_called()
 
 
 # -----------------------------------------------------------------------------

--- a/clickhouse/tests/test_parts_and_merges.py
+++ b/clickhouse/tests/test_parts_and_merges.py
@@ -922,6 +922,29 @@ def test_collect_and_emit_runs_with_partial_failures(check):
     assert payload['clickhouse']['active_merges'] == _collected_merges()
 
 
+def test_collect_and_emit_skips_when_all_collectors_empty(check):
+    job = check.parts_and_merges
+    job.tags = ['test:clickhouse']
+    job._tags_no_db = ['test:clickhouse']
+
+    with (
+        mock.patch.object(job, '_collect_parts', return_value=[]),
+        mock.patch.object(job, '_collect_merges', return_value=[]),
+        mock.patch.object(job, '_collect_mutations', return_value=[]),
+        mock.patch.object(job, '_collect_mutations_aggregated', return_value=[]),
+        mock.patch.object(job, '_collect_replication_queue', return_value=[]),
+        mock.patch.object(job, '_collect_replication_queue_aggregated', return_value=[]),
+        mock.patch.object(job, '_collect_detached_parts', return_value=[]),
+        mock.patch.object(job, '_collect_thresholds', return_value=[]),
+        mock.patch.object(check, 'database_monitoring_query_activity') as activity_mock,
+        mock.patch('datadog_checks.clickhouse.parts_and_merges.datadog_agent') as agent_mock,
+    ):
+        agent_mock.get_version.return_value = '7.64.0'
+        job._collect_and_emit()
+
+    activity_mock.assert_not_called()
+
+
 # -----------------------------------------------------------------------------
 # Cluster routing
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Skip the `storage_health` event emission in `ClickhousePartsAndMerges._emit_events` when every collection (parts, merges, mutations, replication queue, detached parts, thresholds) is empty. Previously the integration emitted a payload every collection cycle regardless of whether the queries returned anything, including when every collector caught an exception and returned `[]`.

## Why this matters

The integration was sending one `storage_health` event per collection cycle (default 60s) for every   
  monitored ClickHouse instance, even when there was nothing to report. Two scenarios where this is
  undesirable:                                                                                          
                                                            
  - **Idle / empty instances**: a fresh ClickHouse with no user tables produces no useful storage_health
   data, but the integration was still emitting an empty payload every minute.
  - **Total collection failure**: when every collector hits an exception (auth issue, network blip,     
  ClickHouse restart, restricted system tables on managed services), all eight collectors return `[]`.  
  The integration was emitting a payload claiming "everything is empty," which is misleading — we don't 
  actually know the state of the database in that case.                                                 
                                                            
The new guard makes the agent emit only when at least one collection has rows. For any production 
  instance with actual data, this is a no-op.      

## Behavior in real environments

The guard short-circuits only when **every** collection is empty:

| Scenario | Result |
|---|---|
| Healthy production with data | `parts` and `thresholds` populated → emits as before |
| Healthy ClickHouse Cloud with data | `parts` populated → emits as before |
| Idle moment, busy database | `parts`/`thresholds` populated → emits as before |
| Fresh self-hosted, no user tables yet | `thresholds` populated → emits thresholds-only payload |
| Fresh ClickHouse Cloud, no user data, restricted system tables | all empty → skips |
| All collection queries fail (auth/network/restart) | all empty → skips |

For any production customer with actual data, this is a no-op.

## Test plan

 - [x] `test_emit_events_shape` — all collections populated, payload contains every section
  - [x] `test_emit_events_uses_query_activity_channel_not_metadata` — emits via the query-activity      
  channel rather than the metadata channel (updated to use non-empty input)                             
  - [x] `test_emit_events_skips_when_all_collections_empty` — *(new)* every collection empty, no
  emission                                                                                              
  - [x] `test_collect_and_emit_skips_when_all_collectors_empty` — *(new)* end-to-end: every `_collect_*`
   returns empty, `_collect_and_emit` produces no emission                                              
  - [x] `test_collect_and_emit_runs_with_partial_failures` — pre-existing, still passes: when only one
  collector returns rows, emission still happens   
```
$ ddev --no-interactive test clickhouse -- -k "emit_events"
3 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)