### PR TITLE
[snmp] Remove pause_auto_refresh from dashboards

### DIFF
--- a/snmp/assets/dashboards/bgp_ospf_overview.json
+++ b/snmp/assets/dashboards/bgp_ospf_overview.json
@@ -1331,6 +1331,5 @@
   ],
   "layout_type": "ordered",
   "notify_list": [],
-  "pause_auto_refresh": false,
   "reflow_type": "fixed"
 }

--- a/snmp/assets/dashboards/datacenter_overview.json
+++ b/snmp/assets/dashboards/datacenter_overview.json
@@ -4610,6 +4610,5 @@
   ],
   "layout_type": "ordered",
   "notify_list": [],
-  "pause_auto_refresh": false,
   "reflow_type": "fixed"
 }

--- a/snmp/assets/dashboards/interface_performance.json
+++ b/snmp/assets/dashboards/interface_performance.json
@@ -2931,6 +2931,5 @@
   ],
   "layout_type": "ordered",
   "notify_list": [],
-  "pause_auto_refresh": false,
   "reflow_type": "fixed"
 }

--- a/snmp/assets/dashboards/ndm_troubleshooting.json
+++ b/snmp/assets/dashboards/ndm_troubleshooting.json
@@ -2845,6 +2845,5 @@
   ],
   "layout_type": "ordered",
   "notify_list": [],
-  "pause_auto_refresh": false,
   "reflow_type": "fixed"
 }

--- a/snmp/assets/dashboards/netflow_monitoring.json
+++ b/snmp/assets/dashboards/netflow_monitoring.json
@@ -3035,6 +3035,5 @@
   ],
   "layout_type": "ordered",
   "notify_list": [],
-  "pause_auto_refresh": false,
   "reflow_type": "fixed"
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
fixing failing validations on the dashboard assets for snmp

if this is acceptable, this pr can be merged instead of https://github.com/DataDog/integrations-core/pull/23552 to accomplish the same goal: not break APW staging deployments

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
