### PR TITLE
Migrate squid tests to mock_http fixture

### DIFF
--- a/squid/tests/test_squid.py
+++ b/squid/tests/test_squid.py
@@ -2,8 +2,9 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-import mock
 import pytest
+
+from datadog_checks.base.utils.http_testing import MockHTTPResponse
 
 from . import common
 
@@ -78,12 +79,11 @@ def test_check_ok(aggregator, check, instance):
     ],
 )
 @pytest.mark.usefixtures("dd_environment")
-def test_version_metadata(check, instance, datadog_agent, raw_version, version_metadata, count):
-    with mock.patch('datadog_checks.base.utils.http.requests.Session.get') as g:
-        g.return_value.headers = {'Server': raw_version}
+def test_version_metadata(check, instance, datadog_agent, mock_http, raw_version, version_metadata, count):
+    mock_http.get.return_value = MockHTTPResponse(headers={'Server': raw_version})
 
-        check.check_id = 'test:123'
-        check.check(instance)
+    check.check_id = 'test:123'
+    check.check(instance)
 
-        datadog_agent.assert_metadata('test:123', version_metadata)
-        datadog_agent.assert_metadata_count(count)
+    datadog_agent.assert_metadata('test:123', version_metadata)
+    datadog_agent.assert_metadata_count(count)

--- a/squid/tests/test_unit.py
+++ b/squid/tests/test_unit.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 import mock
 import pytest
 
+from datadog_checks.base.utils.http_testing import MockHTTPResponse
 from datadog_checks.squid import SquidCheck
 
 from . import common
@@ -55,40 +56,37 @@ def test_parse_instance(aggregator, check):
         check.parse_instance(instance)
 
 
-def test_get_counters(check):
+def test_get_counters(check, mock_http):
     """
     Squid can return a trailing newline at the end of its metrics and it would be
     treated as a metric line: an error would be raised attempting to parse the line
     due to a missing = character.
     See https://github.com/DataDog/integrations-core/pull/1643
     """
-    with mock.patch('datadog_checks.squid.squid.requests.Session.get') as g:
-        with mock.patch('datadog_checks.squid.SquidCheck.submit_version'):
-            g.return_value = mock.MagicMock(text="client_http.requests=42\n\n")
-            check.parse_counter = mock.MagicMock(return_value=('foo', 'bar'))
-            check.get_counters('host', 'port', [])
-            # we assert `parse_counter` was called only once despite the raw text
-            # containing multiple `\n` chars
-            check.parse_counter.assert_called_once()
+    with mock.patch('datadog_checks.squid.SquidCheck.submit_version'):
+        mock_http.get.return_value = MockHTTPResponse(content="client_http.requests=42\n\n")
+        check.parse_counter = mock.MagicMock(return_value=('foo', 'bar'))
+        check.get_counters('host', 'port', [])
+        # we assert `parse_counter` was called only once despite the raw text
+        # containing multiple `\n` chars
+        check.parse_counter.assert_called_once()
 
 
-def test_host_without_protocol(check, instance):
-    with mock.patch('datadog_checks.squid.squid.requests.Session.get') as g:
-        with mock.patch('datadog_checks.squid.SquidCheck.submit_version'):
-            g.return_value = mock.MagicMock(text="client_http.requests=42\n\n")
-            check.parse_counter = mock.MagicMock(return_value=('foo', 'bar'))
-            check.check(instance)
-            assert g.call_args.args[0] == 'http://localhost:3128/squid-internal-mgr/counters'
+def test_host_without_protocol(check, instance, mock_http):
+    with mock.patch('datadog_checks.squid.SquidCheck.submit_version'):
+        mock_http.get.return_value = MockHTTPResponse(content="client_http.requests=42\n\n")
+        check.parse_counter = mock.MagicMock(return_value=('foo', 'bar'))
+        check.check(instance)
+        assert mock_http.get.call_args.args[0] == 'http://localhost:3128/squid-internal-mgr/counters'
 
 
-def test_host_https(check, instance):
+def test_host_https(check, instance, mock_http):
     instance['host'] = 'https://localhost'
-    with mock.patch('datadog_checks.squid.squid.requests.Session.get') as g:
-        with mock.patch('datadog_checks.squid.SquidCheck.submit_version'):
-            g.return_value = mock.MagicMock(text="client_http.requests=42\n\n")
-            check.parse_counter = mock.MagicMock(return_value=('foo', 'bar'))
-            check.check(instance)
-            assert g.call_args.args[0] == 'https://localhost:3128/squid-internal-mgr/counters'
+    with mock.patch('datadog_checks.squid.SquidCheck.submit_version'):
+        mock_http.get.return_value = MockHTTPResponse(content="client_http.requests=42\n\n")
+        check.parse_counter = mock.MagicMock(return_value=('foo', 'bar'))
+        check.check(instance)
+        assert mock_http.get.call_args.args[0] == 'https://localhost:3128/squid-internal-mgr/counters'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation

Test fixtures patching `requests.Session.get` will silently break when squid switches from `requests` to `httpx`. Migrate to `mock_http` fixture + `MockHTTPResponse` so tests are transport-agnostic.

### Approach

- Replace `mock.patch('datadog_checks.squid.squid.requests.Session.get')` with `mock_http` fixture in `test_unit.py` (3 tests).
- Replace `mock.patch('datadog_checks.base.utils.http.requests.Session.get')` with `mock_http` fixture in `test_squid.py::test_version_metadata`.

### Verification

```
ddev test -fs squid
ddev --no-interactive test squid
```

All unit tests pass. `dd_environment`-gated tests fail at fixture setup due to local Docker image pull (pre-existing, unrelated to this change).