### PR TITLE
[sqlserver] Report AO secondary lag on Azure SQL Managed Instance

### DIFF
--- a/sqlserver/changelog.d/23558.fixed
+++ b/sqlserver/changelog.d/23558.fixed
@@ -1,0 +1,1 @@
+Report Always On secondary lag metrics on Azure SQL Managed Instance when ProductMajorVersion reports 12.

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/ao_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/ao_metrics.py
@@ -4,6 +4,7 @@
 
 from typing import List
 
+from datadog_checks.sqlserver.const import ENGINE_EDITION_AZURE_MANAGED_INSTANCE
 from datadog_checks.sqlserver.utils import is_azure_database
 
 from .base import SqlserverDatabaseMetricsBase
@@ -89,6 +90,10 @@ class SqlserverAoMetrics(SqlserverDatabaseMetricsBase):
             f"include_ao_metrics={self.include_ao_metrics})"
         )
 
+    def _supports_secondary_lag_seconds(self) -> bool:
+        # Managed Instance supports this DMV column while reporting a non-boxed ProductMajorVersion.
+        return self.major_version >= 13 or self.engine_edition == ENGINE_EDITION_AZURE_MANAGED_INSTANCE
+
     def __get_query_ao_availability_groups(self) -> dict:
         """
         Construct the sys.availability_groups QueryExecutor configuration based on the SQL Server major version
@@ -168,7 +173,7 @@ class SqlserverAoMetrics(SqlserverDatabaseMetricsBase):
         }
 
         # Include metrics based on version
-        if self.major_version >= 13:
+        if self._supports_secondary_lag_seconds():
             column_definitions_metrics["DRS.secondary_lag_seconds"] = {
                 "name": "ao.secondary_lag_seconds",
                 "type": "gauge",

--- a/sqlserver/tests/test_database_metrics.py
+++ b/sqlserver/tests/test_database_metrics.py
@@ -11,6 +11,8 @@ import pytest
 
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.const import (
+    ENGINE_EDITION_AZURE_MANAGED_INSTANCE,
+    ENGINE_EDITION_SQL_DATABASE,
     STATIC_INFO_ENGINE_EDITION,
     STATIC_INFO_MAJOR_VERSION,
     STATIC_INFO_SERVERNAME,
@@ -306,6 +308,36 @@ def test_sqlserver_availability_replicas_query_uses_parameterized_queries(init_c
     assert "resource_group_id = ?" in q['query']
     assert "database_name = ?" in q['query']
     assert q['params'] == (ag_with_quotes, db_with_quotes)
+
+
+@pytest.mark.parametrize(
+    'engine_edition, major_version, expected',
+    [
+        (ENGINE_EDITION_AZURE_MANAGED_INSTANCE, 12, True),
+        (ENGINE_EDITION_SQL_DATABASE, 12, False),
+        (SQLSERVER_ENGINE_EDITION, 12, False),
+        (SQLSERVER_ENGINE_EDITION, 13, True),
+    ],
+)
+def test_sqlserver_ao_metrics_secondary_lag_support(
+    init_config, instance_docker_metrics, engine_edition, major_version, expected
+):
+    instance_docker_metrics['database_metrics'] = {
+        'ao_metrics': {'enabled': True},
+    }
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
+    ao_metrics = SqlserverAoMetrics(
+        config=sqlserver_check._config,
+        new_query_executor=sqlserver_check._new_query_executor,
+        server_static_info={
+            STATIC_INFO_ENGINE_EDITION: engine_edition,
+            STATIC_INFO_MAJOR_VERSION: major_version,
+        },
+        execute_query_handler=mock.MagicMock(),
+    )
+
+    assert ("DRS.secondary_lag_seconds" in ao_metrics.queries[0]['query']) is expected
+    assert ("sqlserver.ao.secondary_lag_seconds" in ao_metrics.metric_names()[0]) is expected
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## What changed

This updates SQL Server Always On database metrics so `sqlserver.ao.secondary_lag_seconds` is included for Azure SQL Managed Instance even when `ProductMajorVersion` reports 12.

## Why

The query reads `DRS.secondary_lag_seconds` from `sys.dm_hadr_database_replica_states`. Microsoft documents that DMV as applying to Azure SQL Managed Instance, and documents `secondary_lag_seconds` as available on SQL Server 2016+.

Azure SQL Managed Instance can report a non-boxed `ProductMajorVersion` such as 12, so the boxed SQL Server `major_version >= 13` gate suppresses a supported Managed Instance metric. The fix keeps boxed SQL Server behavior unchanged and adds an `EngineEdition = 8` path for Managed Instance only.

Split out from #23533 for separation of concerns.

https://datadoghq.atlassian.net/browse/SDBM-2571