### PR TITLE
Surface promote workflow run URL from CLI and PR

### DIFF
--- a/.github/workflows/dependency-wheel-promotion.yaml
+++ b/.github/workflows/dependency-wheel-promotion.yaml
@@ -1,4 +1,5 @@
 name: Dependency Wheel Promotion
+run-name: "Promote wheels for PR #${{ inputs.pr_number }} (${{ github.actor }})"
 
 on:
   workflow_dispatch:
@@ -70,17 +71,19 @@ jobs:
             state: 'success',
             context: 'dependency-wheel-promotion',
             description: 'Wheels promoted to stable storage.',
+            target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
           });
 
     - name: Post success comment
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         script: |
+          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
           await github.rest.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: ${{ inputs.pr_number }},
-            body: `Wheels promoted to stable storage for commit ${{ inputs.head_sha }} by @${context.actor}.`,
+            body: `Wheels promoted to stable storage for commit ${{ inputs.head_sha }} by @${context.actor}. [Workflow run](${runUrl}).`,
           });
 
     - name: Set dependency-wheel-promotion status to error
@@ -95,4 +98,5 @@ jobs:
             state: 'error',
             context: 'dependency-wheel-promotion',
             description: 'Wheel promotion failed. Check the Actions tab for details.',
+            target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
           });

--- a/ddev/changelog.d/23563.added
+++ b/ddev/changelog.d/23563.added
@@ -1,0 +1,1 @@
+`ddev dep promote` now prints a link to the dependency-wheel-promotion workflow's recent runs page after dispatching, so users can jump straight to their queued run.

--- a/ddev/src/ddev/cli/dep/promote.py
+++ b/ddev/src/ddev/cli/dep/promote.py
@@ -52,8 +52,7 @@ def promote(app: Application, pr_url: str):
         )
 
     runs_url = (
-        f'https://github.com/{app.github.repo_id}/actions/workflows/{PROMOTE_WORKFLOW}'
-        f'?query=event%3Aworkflow_dispatch'
+        f'https://github.com/{app.github.repo_id}/actions/workflows/{PROMOTE_WORKFLOW}?query=event%3Aworkflow_dispatch'
     )
     app.display_success(f'Promote workflow dispatched for PR #{pr_number}.')
     app.display_info(f'Recent runs: {runs_url}')

--- a/ddev/src/ddev/cli/dep/promote.py
+++ b/ddev/src/ddev/cli/dep/promote.py
@@ -51,4 +51,9 @@ def promote(app: Application, pr_url: str):
             inputs={'pr_number': str(pr_number), 'head_sha': head_sha},
         )
 
-    app.display_success(f'Promote workflow dispatched for PR #{pr_number}. Check the Actions tab for progress.')
+    runs_url = (
+        f'https://github.com/{app.github.repo_id}/actions/workflows/{PROMOTE_WORKFLOW}'
+        f'?query=event%3Aworkflow_dispatch'
+    )
+    app.display_success(f'Promote workflow dispatched for PR #{pr_number}.')
+    app.display_info(f'Recent runs: {runs_url}')


### PR DESCRIPTION
## Summary
- `ddev dep promote` prints a recent-runs URL (filtered to `workflow_dispatch` events) so users can jump straight from the CLI to their freshly-queued run.
- `dependency-wheel-promotion.yaml` sets a per-run `run-name` that includes the PR number and actor, so the run row in the Actions UI is identifiable at a glance.
- The success commit status, the error commit status, and the PR comment posted by the workflow all now carry the run URL, so reviewers can click through from the PR to the exact run that promoted the wheels.

## Test plan
- [ ] Run `ddev dep promote <pr-url>` against a real PR and confirm the printed runs URL lands on the workflow's filtered runs list.
- [ ] Trigger the workflow and confirm the Actions UI shows `Promote wheels for PR #<n> (<actor>)` instead of the generic workflow name.
- [ ] Confirm the success comment on the PR contains a working `[Workflow run]` link.
- [ ] Confirm the `dependency-wheel-promotion` commit status's "Details" link points at the run (both success and error paths).