### PR TITLE
Trigger release-scripts test workflow when itself changes

### DIFF
--- a/.github/workflows/test-release-scripts.yml
+++ b/.github/workflows/test-release-scripts.yml
@@ -8,11 +8,13 @@ on:
       - ".github/workflows/scripts/**"
       - ".github/workflows/release-dispatch.yml"
       - ".github/workflows/release-trigger.yml"
+      - ".github/workflows/test-release-scripts.yml"
   pull_request:
     paths:
       - ".github/workflows/scripts/**"
       - ".github/workflows/release-dispatch.yml"
       - ".github/workflows/release-trigger.yml"
+      - ".github/workflows/test-release-scripts.yml"
 
 jobs:
   test:


### PR DESCRIPTION
### What does this PR do?
Adds `.github/workflows/test-release-scripts.yml` to its own `paths` filter (under both `push` and `pull_request`) so that any change to the workflow file itself triggers the unit-test job.

### Motivation
Today the workflow only runs when `release-dispatch.yml`, `release-trigger.yml`, or `.github/workflows/scripts/**` change. A PR that only edits `test-release-scripts.yml` (e.g., a Renovate-driven `pytest` version bump like #23568) does not re-run the tests, so the bump goes unverified by this workflow unless an unrelated release file happens to change in the same PR.

This PR closes that gap. The workflow only runs `pip install pytest && pytest tests/ -v` on a temp runner; tests mock all external boundaries (no network, no real `subprocess`, no GitHub API calls), so this has zero release side effects.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the \`qa/skip-qa\` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the \`backport/<branch-name>\` label to the PR and it will automatically open a backport PR once this one is merged