### PR TITLE
[agent_metrics] Fill in metadata.csv descriptions

### DIFF
--- a/agent_metrics/metadata.csv
+++ b/agent_metrics/metadata.csv
@@ -1,4 +1,4 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
-datadog.agent.python.version,gauge,,,,The Python version used by the Agent. The metric is tagged with the python_version.,0,agent_metrics,py version,
-datadog.agent.running,gauge,,,,Shows a value of 1 if the Agent is reporting to Datadog.,0,agent_metrics,running,
-datadog.agent.started,count,,,,A count sent with a value of 1 when the Agent starts (available in v6.12+).,0,agent_metrics,started,
+datadog.agent.python.version,gauge,,,,"A value of 1, tagged with python_version.",0,agent_metrics,py version,
+datadog.agent.running,gauge,,,,"A value of 1 if the Agent is running and reporting to Datadog, tagged with version (the Agent version).",0,agent_metrics,running,
+datadog.agent.started,count,,,,A count of 1 each time the Agent starts.,0,agent_metrics,started,

--- a/agent_metrics/metadata.csv
+++ b/agent_metrics/metadata.csv
@@ -1,4 +1,4 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
-datadog.agent.python.version,gauge,,,,,0,agent_metrics,py version,
-datadog.agent.running,gauge,,,,,0,agent_metrics,running,
-datadog.agent.started,count,,,,,0,agent_metrics,started,
+datadog.agent.python.version,gauge,,,,The Python version used by the Agent. The metric is tagged with the python_version.,0,agent_metrics,py version,
+datadog.agent.running,gauge,,,,Shows a value of 1 if the Agent is reporting to Datadog.,0,agent_metrics,running,
+datadog.agent.started,count,,,,A count sent with a value of 1 when the Agent starts (available in v6.12+).,0,agent_metrics,started,

--- a/agent_metrics/metadata.csv
+++ b/agent_metrics/metadata.csv
@@ -1,4 +1,4 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
-datadog.agent.python.version,gauge,,,,"A value of 1, tagged with python_version.",0,agent_metrics,py version,
-datadog.agent.running,gauge,,,,"A value of 1 if the Agent is running and reporting to Datadog, tagged with version (the Agent version).",0,agent_metrics,running,
-datadog.agent.started,count,,,,A count of 1 each time the Agent starts.,0,agent_metrics,started,
+datadog.agent.python.version,gauge,,,,"A value of 1, tagged with the Python version.",0,agent_metrics,py version,
+datadog.agent.running,gauge,,,,"A value of 1 if the Agent is running and reporting to Datadog, tagged with the Agent version.",0,agent_metrics,running,
+datadog.agent.started,count,,,,"A count of 1 each time the Agent starts.",0,agent_metrics,started,


### PR DESCRIPTION
### What does this PR do?

Populates the empty `description` column for the three metrics in`agent_metrics/metadata.csv`:
- `datadog.agent.python.version`
- `datadog.agent.running`
- `datadog.agent.started`

### Motivation
https://datadoghq.atlassian.net/browse/DOCS-13314 flagged that the metrics table on the Agent Metrics integration docs page was rendering with an empty right-side column.

### Additional Notes
These same metrics are also described on https://docs.datadoghq.com/getting_started/agent/#agent-metrics. The wording in this PR diverges slightly from that page (more explicit about the constant value and the relevant tags). Flagging so the two can be kept in sync. The getting started page may want a follow-up update