### PR TITLE
Skip Python version bumps in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -63,6 +63,19 @@
       "minimumReleaseAge": "7 days"
     },
     {
+      "description": "Don't auto-bump Python via setup-python's python-version input. Patches are bumped by the Upgrade Python version workflow (ddev meta scripts upgrade-python-version); minor bumps are coordinated manually.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchDepTypes": [
+        "uses-with"
+      ],
+      "matchDepNames": [
+        "python"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Runner versions (runs-on) and container/service/docker images are bumped manually when needed.",
       "matchManagers": [
         "github-actions"


### PR DESCRIPTION
### What does this PR do?
Re-add the rule that disables Renovate updates for the `python-version` input of `actions/setup-python`. The exclusion is scoped to the `uses-with` depType to fit the rule structure introduced in #23570.

### Motivation
The `python` exclusion that landed in #23293 / #23294 was effectively dropped in #23570 when the github-actions rules were refactored: the previous python-disable rule was replaced with the runner/docker/container/service disable rule, while a new `uses-with` allow rule re-enabled python-version bumps. Renovate then opened #23481, attempting to bump every workflow's `python-version` to 3.14.

Python patch versions are managed by the `Upgrade Python version` workflow (`ddev meta scripts upgrade-python-version`); minor bumps are coordinated manually via `ddev meta scripts update-python-config`. Renovate should stay out of those.

### Review checklist (to be filled by reviewers)

- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.