### PR TITLE
Update .yaml workflows in update-python-config

### DIFF
--- a/ddev/changelog.d/23573.fixed
+++ b/ddev/changelog.d/23573.fixed
@@ -1,0 +1,1 @@
+Include .yaml workflow files in update-python-config so all workflow Python pins are updated.

--- a/ddev/src/ddev/cli/meta/scripts/update_py_config.py
+++ b/ddev/src/ddev/cli/meta/scripts/update_py_config.py
@@ -60,9 +60,11 @@ def integrations(app):
 
 
 def update_ci_files(app: Application, new_version: str, old_version: str, tracker: ValidationTracker):
+    workflows_dir = app.repo.path / ".github" / "workflows"
     files_to_update = [
-        *(app.repo.path / ".github" / "workflows").glob("*.yml"),
-        *(app.repo.path / ".github" / "workflows" / "scripts").glob("*.sh"),
+        *workflows_dir.glob("*.yml"),
+        *workflows_dir.glob("*.yaml"),
+        *(workflows_dir / "scripts").glob("*.sh"),
     ]
 
     # Patterns to match:

--- a/ddev/tests/cli/meta/scripts/conftest.py
+++ b/ddev/tests/cli/meta/scripts/conftest.py
@@ -108,6 +108,19 @@ env:
     )
 
     write_file(
+        repo_path / '.github' / 'workflows',
+        'claim-pypi-name.yaml',
+        f"""name: claim pypi name
+jobs:
+  claim:
+    steps:
+    - uses: actions/setup-python@v6
+      with:
+        python-version: "{OLD_PYTHON_VERSION}"
+""",
+    )
+
+    write_file(
         repo_path / 'ddev',
         'pyproject.toml',
         f"""[tool.black]

--- a/ddev/tests/cli/meta/scripts/test_update_py_config.py
+++ b/ddev/tests/cli/meta/scripts/test_update_py_config.py
@@ -14,7 +14,7 @@ def test_update_py_config(fake_repo, ddev):
     result = ddev('meta', 'scripts', 'update-python-config', NEW_PYTHON_VERSION)
 
     assert result.exit_code == 0, result.output
-    assert result.output.endswith('Python upgrades\n\nPassed: 9\n')
+    assert result.output.endswith('Python upgrades\n\nPassed: 10\n')
 
     contents = constant_file.read_text()
     assert f'PYTHON_VERSION = {OLD_PYTHON_VERSION!r}' not in contents
@@ -24,6 +24,11 @@ def test_update_py_config(fake_repo, ddev):
     contents = ci_file.read_text()
     assert f'PYTHON_VERSION: "{OLD_PYTHON_VERSION}"' not in contents
     assert f'PYTHON_VERSION: "{NEW_PYTHON_VERSION}"' in contents
+
+    yaml_workflow = fake_repo.path / '.github' / 'workflows' / 'claim-pypi-name.yaml'
+    contents = yaml_workflow.read_text()
+    assert f'python-version: "{OLD_PYTHON_VERSION}"' not in contents
+    assert f'python-version: "{NEW_PYTHON_VERSION}"' in contents
 
     hatch_file = fake_repo.path / 'dummy' / 'hatch.toml'
     contents = hatch_file.read_text()


### PR DESCRIPTION
### What does this PR do?
Extend the CI-files glob in \`ddev meta scripts update-python-config\` to also pick up \`.yaml\` workflow files (in addition to \`.yml\`).

### Motivation
While reviewing Renovate PR #23481 we noticed several workflows still pinned older Python versions (e.g. \`claim-pypi-name.yaml\` was on 3.11, \`dependency-wheel-promotion.yaml\` on 3.13) even after past minor bumps. The reason: \`update_ci_files\` only globbed \`*.yml\`, so any workflow that uses the \`.yaml\` extension was silently skipped.

This PR makes the file selection cover both extensions and adds a regression test fixture (\`claim-pypi-name.yaml\`) to lock the behavior in.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the \`qa/skip-qa\` label if the PR doesn't need to be tested during QA.