### PR TITLE
Fix Phase.on_error signature

### DIFF
--- a/ddev/src/ddev/ai/phases/base.py
+++ b/ddev/src/ddev/ai/phases/base.py
@@ -19,6 +19,7 @@ from ddev.ai.react.callbacks import CallbackSet
 from ddev.ai.react.process import ReActProcess
 from ddev.ai.tools.fs.file_registry import FileRegistry
 from ddev.ai.tools.registry import ToolRegistry
+from ddev.event_bus.exceptions import MessageProcessingError, ProcessorHookError
 from ddev.event_bus.orchestrator import AsyncProcessor, BaseMessage
 
 
@@ -260,9 +261,8 @@ class Phase(AsyncProcessor[PhaseTrigger]):
             )
         )
 
-    async def on_error(self, error: Exception) -> None:
+    async def on_error(self, error: MessageProcessingError | ProcessorHookError) -> None:
         """Write failed checkpoint and emit PhaseFailedMessage."""
-        original_error = getattr(error, 'original_exception', error)
         try:
             self._checkpoint_manager.write_phase_checkpoint(
                 self._phase_id,
@@ -270,7 +270,7 @@ class Phase(AsyncProcessor[PhaseTrigger]):
                     "status": "failed",
                     "started_at": self._started_at.isoformat() if self._started_at else None,
                     "finished_at": datetime.now(UTC).isoformat(),
-                    "error": str(original_error),
+                    "error": str(error.original_exception),
                 },
             )
         except Exception:
@@ -280,6 +280,6 @@ class Phase(AsyncProcessor[PhaseTrigger]):
                 PhaseFailedMessage(
                     id=f"{self._phase_id}_failed",
                     phase_id=self._phase_id,
-                    error=str(original_error),
+                    error=str(error.original_exception),
                 )
             )

--- a/ddev/src/ddev/ai/phases/base.py
+++ b/ddev/src/ddev/ai/phases/base.py
@@ -255,13 +255,14 @@ class Phase(AsyncProcessor[PhaseTrigger]):
         """Emit PhaseTrigger to unblock dependent phases."""
         self.submit_message(
             PhaseTrigger(
-                id=f"{self._phase_id}_finished_{message.id}",
+                id=f"{self._phase_id}_finished",
                 phase_id=self._phase_id,
             )
         )
 
-    async def on_error(self, message: PhaseTrigger, error: Exception) -> None:
+    async def on_error(self, error: Exception) -> None:
         """Write failed checkpoint and emit PhaseFailedMessage."""
+        original_error = getattr(error, 'original_exception', error)
         try:
             self._checkpoint_manager.write_phase_checkpoint(
                 self._phase_id,
@@ -269,7 +270,7 @@ class Phase(AsyncProcessor[PhaseTrigger]):
                     "status": "failed",
                     "started_at": self._started_at.isoformat() if self._started_at else None,
                     "finished_at": datetime.now(UTC).isoformat(),
-                    "error": str(error),
+                    "error": str(original_error),
                 },
             )
         except Exception:
@@ -277,8 +278,8 @@ class Phase(AsyncProcessor[PhaseTrigger]):
         finally:
             self.submit_message(
                 PhaseFailedMessage(
-                    id=f"{self._phase_id}_failed_{message.id}",
+                    id=f"{self._phase_id}_failed",
                     phase_id=self._phase_id,
-                    error=str(error),
+                    error=str(original_error),
                 )
             )

--- a/ddev/src/ddev/ai/phases/orchestrator.py
+++ b/ddev/src/ddev/ai/phases/orchestrator.py
@@ -124,7 +124,9 @@ class PhaseOrchestrator(EventBusOrchestrator):
             raise FatalProcessingError(f"Phase '{message.phase_id}' failed: {message.error}")
 
     async def on_finalize(self, exception: Exception | None) -> None:
-        if self._failed_phase is not None:
-            raise FatalProcessingError(
-                f"Pipeline aborted: phase '{self._failed_phase}' failed: {self._failed_error or '<unknown>'}"
+        if exception is not None and self._failed_phase is not None:
+            self._logger.error(
+                "Pipeline aborted: phase '%s' failed: %s",
+                self._failed_phase,
+                self._failed_error or "<unknown>",
             )

--- a/ddev/src/ddev/ai/phases/orchestrator.py
+++ b/ddev/src/ddev/ai/phases/orchestrator.py
@@ -125,6 +125,6 @@ class PhaseOrchestrator(EventBusOrchestrator):
 
     async def on_finalize(self, exception: Exception | None) -> None:
         if self._failed_phase is not None:
-            raise RuntimeError(
+            raise FatalProcessingError(
                 f"Pipeline aborted: phase '{self._failed_phase}' failed: {self._failed_error or '<unknown>'}"
             )

--- a/ddev/tests/ai/phases/test_base.py
+++ b/ddev/tests/ai/phases/test_base.py
@@ -15,7 +15,7 @@ from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.ai.tools.fs.file_registry import FileRegistry
 from ddev.ai.tools.registry import ToolRegistry
-from ddev.event_bus.exceptions import MessageProcessingError
+from ddev.event_bus.exceptions import HookName, MessageProcessingError, ProcessorHookError
 
 from .conftest import MockAgent, make_agent_factory, make_response, resolve_key
 
@@ -471,7 +471,9 @@ async def test_on_error_emits_failed_message(flow_dir, monkeypatch, message_queu
     mock_agent = MockAgent([])
     phase, _ = _make_phase(flow_dir, mock_agent, monkeypatch, message_queue)
 
-    wrapped = MessageProcessingError("p1", PhaseTrigger(id="start", phase_id=None), RuntimeError("boom"))
+    wrapped = ProcessorHookError(
+        HookName.ON_SUCCESS, "p1", PhaseTrigger(id="start", phase_id=None), RuntimeError("boom")
+    )
     await phase.on_error(wrapped)
 
     msg = message_queue.get_nowait()

--- a/ddev/tests/ai/phases/test_base.py
+++ b/ddev/tests/ai/phases/test_base.py
@@ -15,6 +15,7 @@ from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.ai.tools.fs.file_registry import FileRegistry
 from ddev.ai.tools.registry import ToolRegistry
+from ddev.event_bus.exceptions import MessageProcessingError
 
 from .conftest import MockAgent, make_agent_factory, make_response, resolve_key
 
@@ -445,7 +446,7 @@ async def test_on_success_emits_finished_message(flow_dir, monkeypatch, message_
     msg = message_queue.get_nowait()
     assert isinstance(msg, PhaseTrigger)
     assert msg.phase_id == "p1"
-    assert msg.id == "p1_finished_start"
+    assert msg.id == "p1_finished"
 
 
 # ---------------------------------------------------------------------------
@@ -457,7 +458,8 @@ async def test_on_error_writes_failed_checkpoint(flow_dir, monkeypatch, message_
     mock_agent = MockAgent([])
     phase, mgr = _make_phase(flow_dir, mock_agent, monkeypatch, message_queue)
 
-    await phase.on_error(PhaseTrigger(id="start", phase_id=None), RuntimeError("boom"))
+    wrapped = MessageProcessingError("p1", PhaseTrigger(id="start", phase_id=None), RuntimeError("boom"))
+    await phase.on_error(wrapped)
 
     checkpoint = mgr.read()["p1"]
     assert checkpoint["status"] == "failed"
@@ -469,7 +471,8 @@ async def test_on_error_emits_failed_message(flow_dir, monkeypatch, message_queu
     mock_agent = MockAgent([])
     phase, _ = _make_phase(flow_dir, mock_agent, monkeypatch, message_queue)
 
-    await phase.on_error(PhaseTrigger(id="start", phase_id=None), RuntimeError("boom"))
+    wrapped = MessageProcessingError("p1", PhaseTrigger(id="start", phase_id=None), RuntimeError("boom"))
+    await phase.on_error(wrapped)
 
     msg = message_queue.get_nowait()
     assert isinstance(msg, PhaseFailedMessage)
@@ -482,7 +485,8 @@ async def test_on_error_writes_failed_checkpoint_after_start(flow_dir, monkeypat
     phase, mgr = _make_phase(flow_dir, mock_agent, monkeypatch, message_queue)
     phase._started_at = datetime.now(UTC)
 
-    await phase.on_error(PhaseTrigger(id="start", phase_id=None), RuntimeError("boom"))
+    wrapped = MessageProcessingError("p1", PhaseTrigger(id="start", phase_id=None), RuntimeError("boom"))
+    await phase.on_error(wrapped)
 
     checkpoint = mgr.read()["p1"]
     assert checkpoint["status"] == "failed"
@@ -663,7 +667,8 @@ async def test_failed_phase_omits_memory_path(flow_dir, monkeypatch, message_que
     mock_agent = MockAgent([])
     phase, mgr = _make_phase(flow_dir, mock_agent, monkeypatch, message_queue)
 
-    await phase.on_error(PhaseTrigger(id="start", phase_id=None), RuntimeError("boom"))
+    wrapped = MessageProcessingError("p1", PhaseTrigger(id="start", phase_id=None), RuntimeError("boom"))
+    await phase.on_error(wrapped)
 
     checkpoint = mgr.read()["p1"]
     assert "memory_path" not in checkpoint

--- a/ddev/tests/ai/phases/test_orchestrator.py
+++ b/ddev/tests/ai/phases/test_orchestrator.py
@@ -466,7 +466,7 @@ async def test_on_finalize_after_phase_failed_raises(tmp_path, file_access_polic
     with pytest.raises(FatalProcessingError):
         await orchestrator.on_message_received(msg)
 
-    with pytest.raises(RuntimeError, match="Pipeline aborted.*p1.*boom"):
+    with pytest.raises(FatalProcessingError, match="Pipeline aborted.*p1.*boom"):
         await orchestrator.on_finalize(None)
 
 
@@ -505,5 +505,5 @@ def test_run_raises_runtime_error_when_phase_fails(tmp_path, file_access_policy)
     )
     orchestrator._phase_registry.register("FailingPhase", FailingPhase)
 
-    with pytest.raises(RuntimeError, match="Pipeline aborted"):
+    with pytest.raises(FatalProcessingError, match="Pipeline aborted"):
         orchestrator.run()

--- a/ddev/tests/ai/phases/test_orchestrator.py
+++ b/ddev/tests/ai/phases/test_orchestrator.py
@@ -454,7 +454,30 @@ async def test_on_finalize_no_failure_is_noop(tmp_path, file_access_policy):
     await orchestrator.on_finalize(None)  # must not raise
 
 
-async def test_on_finalize_after_phase_failed_raises(tmp_path, file_access_policy):
+async def test_on_finalize_after_phase_failed_logs(tmp_path, file_access_policy, caplog):
+    import logging
+
+    orchestrator = PhaseOrchestrator(
+        flow_yaml_path=Path("/fake/flow.yaml"),
+        checkpoint_path=Path("/fake/checkpoints.yaml"),
+        runtime_variables={},
+        anthropic_client=MagicMock(),
+        file_access_policy=file_access_policy,
+    )
+    msg = PhaseFailedMessage(id="f1", phase_id="p1", error="boom")
+    exc = FatalProcessingError("Phase 'p1' failed: boom")
+    with pytest.raises(FatalProcessingError):
+        await orchestrator.on_message_received(msg)
+
+    with caplog.at_level(logging.ERROR):
+        await orchestrator.on_finalize(exc)  # must not raise
+
+    assert any("Pipeline aborted" in r.message and "p1" in r.message and "boom" in r.message for r in caplog.records)
+
+
+async def test_on_finalize_no_exception_no_log(tmp_path, file_access_policy, caplog):
+    import logging
+
     orchestrator = PhaseOrchestrator(
         flow_yaml_path=Path("/fake/flow.yaml"),
         checkpoint_path=Path("/fake/checkpoints.yaml"),
@@ -466,8 +489,10 @@ async def test_on_finalize_after_phase_failed_raises(tmp_path, file_access_polic
     with pytest.raises(FatalProcessingError):
         await orchestrator.on_message_received(msg)
 
-    with pytest.raises(FatalProcessingError, match="Pipeline aborted.*p1.*boom"):
-        await orchestrator.on_finalize(None)
+    with caplog.at_level(logging.ERROR):
+        await orchestrator.on_finalize(None)  # exception=None means clean exit — no log
+
+    assert not any("Pipeline aborted" in r.message for r in caplog.records)
 
 
 def test_run_raises_runtime_error_when_phase_fails(tmp_path, file_access_policy):
@@ -505,5 +530,5 @@ def test_run_raises_runtime_error_when_phase_fails(tmp_path, file_access_policy)
     )
     orchestrator._phase_registry.register("FailingPhase", FailingPhase)
 
-    with pytest.raises(FatalProcessingError, match="Pipeline aborted"):
+    with pytest.raises(FatalProcessingError, match="Phase 'failing' failed"):
         orchestrator.run()


### PR DESCRIPTION
### What does this PR do?

Fixes three issues in the AI phase framework:

1. **`Phase.on_error` signature** — the override had `(self, message: PhaseTrigger, error: Exception)` but the base class `BaseProcessor.on_error` now only takes `(self, error: MessageProcessingError | ProcessorHookError)` (see #23489 and #23575). The orchestrator's `_task_wrapper` always calls `processor.on_error(wrapped_error)` with a single argument, so the old signature meant `Phase.on_error` was never actually invoked — it silently failed with a `TypeError` that was swallowed by the `fail_fast=False` policy.

2. **Pipeline abort propagation** — `PhaseOrchestrator.on_finalize` was raising `RuntimeError`, but the base `EventBusOrchestrator.finalize` only lets `FatalProcessingError` and `CancelledError` pass through. Any other exception gets wrapped in `OrchestratorHookError` and swallowed by the `fail_fast=False` policy, so the abort error was silently dropped and `run()` appeared to succeed after a phase failure. Changed to raise `FatalProcessingError` so it propagates correctly. Updated the two affected tests accordingly.

3. **`PhaseTrigger.id` simplification** — the id was constructed as `f"{phase_id}_finished_{message.id}"`, causing the string to accumulate the full causal chain of every preceding trigger (e.g. `phase_B_finished_phase_A_finished_start`). The id only needs to be unique within the queue, and since each phase emits at most one success trigger (guarded by `_executed`), `f"{phase_id}_finished"` is sufficient.

### Motivation

The `on_error` mismatch was a latent bug introduced when the orchestrator was refactored to wrap errors before calling `on_error`. As a result, a failing phase would never write its failure checkpoint or emit `PhaseFailedMessage`, so the pipeline would silently stall instead of aborting. The other two changes were discovered while fixing this.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged