### PR TITLE
Fix missing image on Versa SD-WAN dashboard

### DIFF
--- a/versa/assets/dashboards/versa.json
+++ b/versa/assets/dashboards/versa.json
@@ -16,7 +16,7 @@
             "id": 6107883287952970,
             "definition": {
               "type": "image",
-              "url": "/api/v2/images/32d08fa3-bbc7-4285-ad3f-72cc275a4eb9",
+              "url": "/static/images/logos/versa_large.svg",
               "sizing": "contain",
               "has_background": true,
               "has_border": true,


### PR DESCRIPTION
The image widget was pointing to /api/v2/images/<UUID>, which is the per-org image upload API. The UUID only resolved in the demo org where the dashboard was originally built, so the image was missing for all customers (reported on prod and staging).

Switch to the static asset path used by sibling integrations (e.g. Cisco SD-WAN), which is org-agnostic and ships with web-ui.

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
