### PR TITLE
[nutanix] Fix vm.disk_capacity_bytes to source from VM config

### DIFF
--- a/nutanix/changelog.d/23583.fixed
+++ b/nutanix/changelog.d/23583.fixed
@@ -1,1 +1,1 @@
-Fix `nutanix.vm.disk_capacity_bytes` to report allocated disk capacity per VM. The metric was previously declared but no value was ever submitted.
+Fix `nutanix.vm.disk_capacity_bytes` to report allocated disk capacity per VM.

--- a/nutanix/changelog.d/23583.fixed
+++ b/nutanix/changelog.d/23583.fixed
@@ -1,0 +1,1 @@
+Fix `nutanix.vm.disk_capacity_bytes` to report allocated disk capacity per VM. The metric was previously declared but no value was ever submitted.

--- a/nutanix/datadog_checks/nutanix/infrastructure_monitor.py
+++ b/nutanix/datadog_checks/nutanix/infrastructure_monitor.py
@@ -230,8 +230,14 @@ class InfrastructureMonitor:
         memory_bytes = int(vm.get("memorySizeBytes") or 0)
         return num_sockets, num_cores_per_socket, num_threads_per_core, num_sockets * num_cores_per_socket, memory_bytes
 
+    def _extract_vm_disk_capacity_bytes(self, vm: dict) -> int:
+        """Sum allocated disk capacity across the VM's attached disks (config-sourced)."""
+        return sum(
+            int(get_nested(d, "backingInfo/diskSizeBytes") or 0) for d in vm.get("disks") or [] if isinstance(d, dict)
+        )
+
     def _report_vm_capacity_metrics(self, vm: dict, hostname: str, vm_tags: list[str]) -> None:
-        """Report VM capacity metrics (CPU and memory allocation)."""
+        """Report VM capacity metrics (CPU, memory, and disk allocation)."""
         num_sockets, num_cores_per_socket, num_threads_per_core, vcpus_allocated, memory_bytes = (
             self._extract_vm_capacity(vm)
         )
@@ -241,6 +247,9 @@ class InfrastructureMonitor:
         self.check.gauge("vm.cpu.threads_per_core", num_threads_per_core, hostname=hostname, tags=vm_tags)
         self.check.gauge("vm.cpu.vcpus_allocated", vcpus_allocated, hostname=hostname, tags=vm_tags)
         self.check.gauge("vm.memory.allocated_bytes", memory_bytes, hostname=hostname, tags=vm_tags)
+        self.check.gauge(
+            "vm.disk_capacity_bytes", self._extract_vm_disk_capacity_bytes(vm), hostname=hostname, tags=vm_tags
+        )
 
     def _report_cluster_basic_metrics(self, cluster: dict, cluster_tags: list[str]) -> None:
         """Report basic cluster metrics (counts)."""

--- a/nutanix/datadog_checks/nutanix/metrics.py
+++ b/nutanix/datadog_checks/nutanix/metrics.py
@@ -103,7 +103,6 @@ VM_STATS_METRICS = {
     "controllerWss3600SecondReadMb": "vm.controller.wss3600second_read_mb",
     "controllerWss3600SecondUnionMb": "vm.controller.wss3600second_union_mb",
     "controllerWss3600SecondWriteMb": "vm.controller.wss3600second_write_mb",
-    "diskCapacityBytes": "vm.disk_capacity_bytes",
     "diskUsagePpm": "vm.disk_usage_ppm",
     "frameBufferUsagePpm": "vm.frame_buffer_usage_ppm",
     "gpuUsagePpm": "vm.gpu_usage_ppm",

--- a/nutanix/tests/metrics.py
+++ b/nutanix/tests/metrics.py
@@ -144,7 +144,6 @@ VM_STATS_METRICS_OPTIONAL = [
     "nutanix.vm.hypervisor.swap_in_rate_kbps",
     "nutanix.vm.hypervisor.swap_out_rate_kbps",
     "nutanix.vm.memory_usage_bytes",
-    "nutanix.vm.disk_capacity_bytes",
     "nutanix.vm.disk_usage_ppm",
     "nutanix.vm.hypervisor.vm_running_time_usecs",
 ]
@@ -190,6 +189,7 @@ VM_CAPACITY_METRICS = [
     "nutanix.vm.cpu.threads_per_core",
     "nutanix.vm.cpu.vcpus_allocated",
     "nutanix.vm.memory.allocated_bytes",
+    "nutanix.vm.disk_capacity_bytes",
 ]
 
 ALL_METRICS = (

--- a/nutanix/tests/test_capacity_metrics.py
+++ b/nutanix/tests/test_capacity_metrics.py
@@ -49,6 +49,10 @@ def test_vm_capacity_metrics(dd_run_check, aggregator, mock_instance, mock_http_
     aggregator.assert_metric("nutanix.vm.memory.allocated_bytes", value=8589934592, tags=UBUNTU_VM_TAGS)
     aggregator.assert_metric("nutanix.vm.memory.allocated_bytes", value=8589934592, tags=RANDOM_VM_TAGS)
 
+    aggregator.assert_metric("nutanix.vm.disk_capacity_bytes", value=1118240243712, tags=PCVM_TAGS)
+    aggregator.assert_metric("nutanix.vm.disk_capacity_bytes", value=21474836480, tags=UBUNTU_VM_TAGS)
+    aggregator.assert_metric("nutanix.vm.disk_capacity_bytes", value=21474836480, tags=RANDOM_VM_TAGS)
+
 
 def test_host_capacity_metrics(dd_run_check, aggregator, mock_instance, mock_http_get):
     check = NutanixCheck('nutanix', {}, [mock_instance])


### PR DESCRIPTION
## Summary

`nutanix.vm.disk_capacity_bytes` was mapped from `diskCapacityBytes` on the AHV v4 stats endpoint. The field is defined in the spec but optional, and AHV doesn't actually populate it — so the metric was silently never collected.

Source it from the VM **config** instead: sum `disks[].backingInfo.diskSizeBytes` per VM, mirroring how `vm.memory.allocated_bytes` reads `memorySizeBytes`. Allocated capacity is a configuration attribute anyway, not a runtime metric — the config path is both more reliable and a better conceptual fit.

## Validation

- `ddev --no-interactive test nutanix` — 108 unit tests pass
- `ddev test -fs nutanix` — formatter and ruff clean
- Deployed against a live Prism Central — `nutanix.vm.disk_capacity_bytes` now reports allocated disk per VM where it previously emitted nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)