### PR TITLE
Add ddev release changelog show command

### DIFF
--- a/ddev/changelog.d/23586.added
+++ b/ddev/changelog.d/23586.added
@@ -1,0 +1,1 @@
+Add `ddev release changelog show` command to print the section of a target's `CHANGELOG.md` for a given version.

--- a/ddev/src/ddev/cli/release/changelog/__init__.py
+++ b/ddev/src/ddev/cli/release/changelog/__init__.py
@@ -6,6 +6,7 @@ import click
 from ddev.cli.release.changelog.draft import draft
 from ddev.cli.release.changelog.fix import fix
 from ddev.cli.release.changelog.new import new
+from ddev.cli.release.changelog.show import show
 
 
 @click.group(short_help='Manage changelogs')
@@ -18,3 +19,4 @@ def changelog():
 changelog.add_command(draft)
 changelog.add_command(fix)
 changelog.add_command(new)
+changelog.add_command(show)

--- a/ddev/src/ddev/cli/release/changelog/show.py
+++ b/ddev/src/ddev/cli/release/changelog/show.py
@@ -1,0 +1,80 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+from ddev.utils.fs import Path
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ddev.cli.application import Application
+
+
+@click.command(short_help="Show the changelog section for a target's version")
+@click.argument('target')
+@click.argument('version')
+@click.option(
+    '--file',
+    '-f',
+    'output_file',
+    type=click.Path(dir_okay=False, writable=True, path_type=Path),
+    help='Write the extracted section to this file (overwrites if it exists) instead of stdout',
+)
+@click.pass_obj
+def show(app: Application, target: str, version: str, output_file: Path | None):
+    """
+    Print the section of TARGET's CHANGELOG.md that corresponds to VERSION.
+
+    The output is the markdown content between the ``## VERSION`` heading and the
+    next ``## `` heading, with surrounding blank lines stripped. Useful for
+    populating GitHub release notes from the just-built changelog.
+    """
+    try:
+        integration = app.repo.integrations.get(target)
+    except OSError:
+        app.abort(f'Unknown target: {target}')
+
+    changelog_path = integration.path / 'CHANGELOG.md'
+    if not changelog_path.is_file():
+        app.abort(f'Changelog not found: {changelog_path}')
+
+    section = _extract_version_section(changelog_path, version)
+    if section is None:
+        app.abort(f'No changelog section found for {target} version {version}')
+
+    if output_file:
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text(section, encoding='utf-8')
+        app.display_success(f'Wrote changelog section for {target} {version} to {output_file}')
+    else:
+        app.display_markdown(section)
+
+
+def _iter_version_section(path: Path, version: str) -> Iterator[str]:
+    """Yield the lines of the requested version's section, lazily.
+
+    Stops as soon as the next ``## `` heading after the section is encountered,
+    so we never read past the requested release in a long changelog.
+    """
+    with path.open(mode='r', encoding='utf-8') as f:
+        in_section = False
+        for line in f:
+            if line.startswith('## '):
+                tokens = line[3:].split()
+                if in_section:
+                    return
+                if tokens and tokens[0] == version:
+                    in_section = True
+                    continue
+            if in_section:
+                yield line
+
+
+def _extract_version_section(path: Path, version: str) -> str | None:
+    section = ''.join(_iter_version_section(path, version)).strip('\n')
+    return section or None

--- a/ddev/tests/cli/release/changelog/test_show.py
+++ b/ddev/tests/cli/release/changelog/test_show.py
@@ -1,0 +1,168 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+import pytest
+
+from ddev.cli.release.changelog.show import _extract_version_section
+from ddev.utils.fs import Path
+from tests.helpers.git import ClonedRepo
+from tests.helpers.runner import CliRunner
+
+CHANGELOG_BODY = """\
+# CHANGELOG - ddev
+
+<!-- towncrier release notes start -->
+
+## 16.1.1 / 2026-04-29
+
+***Fixed***:
+
+* Bumped datadog_checks_dev to version 38.0.0. Fixes dependency issues. ([#23516](https://github.com/DataDog/integrations-core/pull/23516))
+
+## 16.1.0 / 2026-04-29
+
+***Added***:
+
+* Add async GitHub API client. ([#22734](https://github.com/DataDog/integrations-core/pull/22734))
+* Use uv as the installer for hatch test environments. ([#23497](https://github.com/DataDog/integrations-core/pull/23497))
+
+## 1.0.10 / 2024-01-01
+
+***Fixed***:
+
+* Older release that should not match against 1.0.1. ([#1](https://github.com/DataDog/integrations-core/pull/1))
+
+## 1.0.1 / 2024-01-02
+
+***Fixed***:
+
+* Patch release. ([#2](https://github.com/DataDog/integrations-core/pull/2))
+"""
+
+
+@pytest.fixture
+def ddev_changelog(repo_with_towncrier: ClonedRepo) -> Path:
+    changelog = repo_with_towncrier.path / 'ddev' / 'CHANGELOG.md'
+    changelog.write_text(CHANGELOG_BODY)
+    return changelog
+
+
+@pytest.mark.parametrize(
+    'version, expected_substring, forbidden_substring',
+    [
+        pytest.param(
+            '16.1.1',
+            '* Bumped datadog_checks_dev to version 38.0.0',
+            '## 16.1.0',
+            id='middle_section',
+        ),
+        pytest.param(
+            '16.1.0',
+            '* Add async GitHub API client.',
+            '## 16.1.1',
+            id='multi_bullet_section',
+        ),
+        pytest.param(
+            '1.0.1',
+            '* Patch release.',
+            '* Older release',
+            id='strict_match_does_not_substring_into_1_0_10',
+        ),
+    ],
+)
+def test_extract_version_section_returns_expected_block(
+    ddev_changelog: Path, version: str, expected_substring: str, forbidden_substring: str
+):
+    section = _extract_version_section(ddev_changelog, version)
+
+    assert section is not None
+    assert expected_substring in section
+    assert forbidden_substring not in section
+    assert not section.startswith('\n')
+    assert not section.endswith('\n')
+
+
+def test_extract_version_section_returns_none_for_missing_version(ddev_changelog: Path):
+    assert _extract_version_section(ddev_changelog, '99.99.99') is None
+
+
+def test_show_prints_section_to_stdout(ddev: CliRunner, ddev_changelog: Path, helpers):
+    result = ddev('release', 'changelog', 'show', 'ddev', '16.1.1')
+
+    assert result.exit_code == 0, result.output
+    output = helpers.remove_trailing_spaces(result.output)
+    assert 'Fixed:' in output
+    assert 'Bumped datadog_checks_dev to version 38.0.0' in output
+    assert '16.1.0' not in output
+
+
+def test_show_writes_to_file(ddev: CliRunner, ddev_changelog: Path, tmp_path: Path):
+    output_file = tmp_path / 'release-notes.md'
+
+    result = ddev('release', 'changelog', 'show', 'ddev', '16.1.0', '--file', str(output_file))
+
+    assert result.exit_code == 0, result.output
+    assert f'Wrote changelog section for ddev 16.1.0 to {output_file}' in result.output
+    contents = output_file.read_text()
+    assert '* Add async GitHub API client.' in contents
+    assert '## 16.1.1' not in contents
+
+
+def test_show_creates_missing_parent_directories(ddev: CliRunner, ddev_changelog: Path, tmp_path: Path):
+    output_file = tmp_path / 'nested' / 'sub' / 'release-notes.md'
+
+    result = ddev('release', 'changelog', 'show', 'ddev', '16.1.1', '--file', str(output_file))
+
+    assert result.exit_code == 0, result.output
+    assert output_file.is_file()
+    assert '* Bumped datadog_checks_dev to version 38.0.0' in output_file.read_text()
+
+
+def test_show_strict_version_matching_against_substring(ddev: CliRunner, ddev_changelog: Path, helpers):
+    result = ddev('release', 'changelog', 'show', 'ddev', '1.0.1')
+
+    assert result.exit_code == 0, result.output
+    output = helpers.remove_trailing_spaces(result.output)
+    assert 'Patch release.' in output
+    assert 'Older release' not in output
+
+
+def test_show_aborts_when_version_missing(ddev: CliRunner, ddev_changelog: Path):
+    result = ddev('release', 'changelog', 'show', 'ddev', '99.99.99')
+
+    assert result.exit_code != 0
+    assert 'No changelog section found for ddev version 99.99.99' in result.output
+
+
+def test_show_aborts_when_changelog_missing(ddev: CliRunner, repo_with_towncrier: ClonedRepo):
+    changelog = repo_with_towncrier.path / 'ddev' / 'CHANGELOG.md'
+    if changelog.is_file():
+        changelog.unlink()
+
+    result = ddev('release', 'changelog', 'show', 'ddev', '1.0.0')
+
+    assert result.exit_code != 0
+    assert 'Changelog not found' in result.output
+
+
+def test_show_aborts_for_unknown_target(ddev: CliRunner, repo_with_towncrier: ClonedRepo):
+    result = ddev('release', 'changelog', 'show', 'definitely_not_an_integration', '1.0.0')
+
+    assert result.exit_code != 0
+    assert 'Unknown target: definitely_not_an_integration' in result.output
+
+
+@pytest.mark.parametrize(
+    'args, expected_message',
+    [
+        pytest.param([], "Missing argument 'TARGET'", id='no_args'),
+        pytest.param(['ddev'], "Missing argument 'VERSION'", id='target_only'),
+    ],
+)
+def test_show_argument_errors(ddev: CliRunner, repo_with_towncrier: ClonedRepo, args: list[str], expected_message: str):
+    result = ddev('release', 'changelog', 'show', *args)
+
+    assert result.exit_code != 0
+    assert expected_message in result.output


### PR DESCRIPTION
### What does this PR do?
Adds a new `ddev release changelog show <target> <version>` subcommand that prints the section of `<target>/CHANGELOG.md` matching the requested version. The extractor streams the file line-by-line and short-circuits at the next `## ` heading, so it doesn't read past the requested release.

The output can be written to a file via `--file/-f` or sent to stdout.

### Motivation
We don't have a programmatic way today to retrieve the changelog body of a single released version. Wrapping it in a tested ddev command is more maintainable than ad-hoc shell parsing and gives us a reusable building block for any tooling that needs a single version's notes.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged