### PR TITLE
Add cycle detection to AI flow config

### DIFF
--- a/ddev/src/ddev/ai/phases/config.py
+++ b/ddev/src/ddev/ai/phases/config.py
@@ -16,26 +16,39 @@ class FlowConfigError(Exception):
     """Wraps Pydantic ValidationError or YAML errors with a user-friendly message."""
 
 
-def _detect_cycles(dependency_map: dict[str, list[str]]) -> list[list[str]]:
+def _detect_cycles(
+    dependency_map: dict[str, list[str]],
+    limit: int = 50,
+) -> tuple[list[list[str]], bool]:
     """Return every simple cycle in the dependency graph, each as an ordered list of phase IDs."""
-    # Implementation based in Johnson's algorithm (1975): each cycle is reported exactly once by
-    # only starting DFS from a node when it is the lowest-ranked node in the cycle.
+    # Enumerate every simple cycle exactly once: from each node, DFS only through
+    # higher-ranked nodes, so each cycle is reported only when started from its
+    # lowest-ranked member. (Tiernan-style enumeration with rank canonicalization.)
     rank = {n: i for i, n in enumerate(dependency_map)}
     cycles: list[list[str]] = []
 
-    def dfs(start: str, current: str, path: list[str], on_path: set[str]) -> None:
+    class _LimitReached(Exception):
+        """Raised when the cycle limit is reached."""
+
+        pass
+
+    def dfs(start: str, current: str, path: list[str], on_path: set[str]):
         for dep in dependency_map.get(current, []):
             if dep == start:
                 cycles.append(path + [start])
-            elif rank[dep] > rank[start] and dep not in on_path:
+                if len(cycles) >= limit:
+                    raise _LimitReached
+            elif dep in rank and rank[dep] > rank[start] and dep not in on_path:
                 on_path.add(dep)
                 dfs(start, dep, path + [dep], on_path)
                 on_path.discard(dep)
 
-    for start in dependency_map:
-        dfs(start, start, [start], {start})
-
-    return cycles
+    try:
+        for start in dependency_map:
+            dfs(start, start, [start], {start})
+    except _LimitReached:
+        return cycles, True
+    return cycles, False
 
 
 class TaskConfig(BaseModel):
@@ -131,9 +144,11 @@ class FlowConfig(BaseModel):
                 raise ValueError(f"Phase {phase_id!r} references unknown agent: {phase.agent!r}")
 
         dependency_map = {entry.phase: entry.dependencies for entry in self.flow}
-        if cycles := _detect_cycles(dependency_map):
+        cycles, truncated = _detect_cycles(dependency_map)
+        if cycles:
             formatted = "\n  ".join(" → ".join(c) for c in cycles)
-            raise ValueError(f"Cycle(s) detected in flow:\n  {formatted}")
+            suffix = f"\n  (showing first {len(cycles)}; more cycles exist)" if truncated else ""
+            raise ValueError(f"Cycle(s) detected in flow:\n  {formatted}{suffix}")
 
         return self
 

--- a/ddev/src/ddev/ai/phases/config.py
+++ b/ddev/src/ddev/ai/phases/config.py
@@ -16,32 +16,26 @@ class FlowConfigError(Exception):
     """Wraps Pydantic ValidationError or YAML errors with a user-friendly message."""
 
 
-def _detect_cycle(dependency_map: dict[str, list[str]]) -> list[str] | None:
-    """Return the first cycle found as an ordered list of phase IDs, or None if acyclic."""
-    visiting: set[str] = set()
-    visited: set[str] = set()
-    path: list[str] = []
+def _detect_cycles(dependency_map: dict[str, list[str]]) -> list[list[str]]:
+    """Return every simple cycle in the dependency graph, each as an ordered list of phase IDs."""
+    # Implementation based in Johnson's algorithm (1975): each cycle is reported exactly once by
+    # only starting DFS from a node when it is the lowest-ranked node in the cycle.
+    rank = {n: i for i, n in enumerate(dependency_map)}
+    cycles: list[list[str]] = []
 
-    def dfs(node: str) -> list[str] | None:
-        visiting.add(node)
-        path.append(node)
-        for dep in dependency_map.get(node, []):
-            if dep in visiting:
-                return path[path.index(dep) :] + [dep]
-            if dep not in visited:
-                result = dfs(dep)
-                if result is not None:
-                    return result
-        path.pop()
-        visiting.discard(node)
-        visited.add(node)
-        return None
+    def dfs(start: str, current: str, path: list[str], on_path: set[str]) -> None:
+        for dep in dependency_map.get(current, []):
+            if dep == start:
+                cycles.append(path + [start])
+            elif rank[dep] > rank[start] and dep not in on_path:
+                on_path.add(dep)
+                dfs(start, dep, path + [dep], on_path)
+                on_path.discard(dep)
 
-    for node in dependency_map:
-        if node not in visited:
-            if (cycle := dfs(node)) is not None:
-                return cycle
-    return None
+    for start in dependency_map:
+        dfs(start, start, [start], {start})
+
+    return cycles
 
 
 class TaskConfig(BaseModel):
@@ -137,8 +131,9 @@ class FlowConfig(BaseModel):
                 raise ValueError(f"Phase {phase_id!r} references unknown agent: {phase.agent!r}")
 
         dependency_map = {entry.phase: entry.dependencies for entry in self.flow}
-        if cycle := _detect_cycle(dependency_map):
-            raise ValueError(f"Cycle detected in flow: {' → '.join(cycle)}")
+        if cycles := _detect_cycles(dependency_map):
+            formatted = "\n  ".join(" → ".join(c) for c in cycles)
+            raise ValueError(f"Cycle(s) detected in flow:\n  {formatted}")
 
         return self
 

--- a/ddev/src/ddev/ai/phases/config.py
+++ b/ddev/src/ddev/ai/phases/config.py
@@ -2,6 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+from __future__ import annotations
+
 from pathlib import Path
 
 import yaml
@@ -14,6 +16,34 @@ class FlowConfigError(Exception):
     """Wraps Pydantic ValidationError or YAML errors with a user-friendly message."""
 
 
+def _detect_cycle(dependency_map: dict[str, list[str]]) -> list[str] | None:
+    """Return the first cycle found as an ordered list of phase IDs, or None if acyclic."""
+    visiting: set[str] = set()
+    visited: set[str] = set()
+    path: list[str] = []
+
+    def dfs(node: str) -> list[str] | None:
+        visiting.add(node)
+        path.append(node)
+        for dep in dependency_map.get(node, []):
+            if dep in visiting:
+                return path[path.index(dep) :] + [dep]
+            if dep not in visited:
+                result = dfs(dep)
+                if result is not None:
+                    return result
+        path.pop()
+        visiting.discard(node)
+        visited.add(node)
+        return None
+
+    for node in dependency_map:
+        if node not in visited:
+            if (cycle := dfs(node)) is not None:
+                return cycle
+    return None
+
+
 class TaskConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
     name: str
@@ -21,7 +51,7 @@ class TaskConfig(BaseModel):
     prompt: str | None = None
 
     @model_validator(mode="after")
-    def exactly_one_source(self) -> "TaskConfig":
+    def exactly_one_source(self) -> TaskConfig:
         if (self.prompt_path is None) == (self.prompt is None):
             raise ValueError("Exactly one of 'prompt_path' or 'prompt' must be set")
         return self
@@ -35,7 +65,7 @@ class CheckpointConfig(BaseModel):
     memory_prompt_path: Path | None = None
 
     @model_validator(mode="after")
-    def exactly_one_source(self) -> "CheckpointConfig":
+    def exactly_one_source(self) -> CheckpointConfig:
         if (self.memory_prompt is None) == (self.memory_prompt_path is None):
             raise ValueError("Exactly one of 'memory_prompt' or 'memory_prompt_path' must be set")
         return self
@@ -86,7 +116,7 @@ class FlowConfig(BaseModel):
     flow: list[FlowEntry]
 
     @model_validator(mode="after")
-    def cross_references(self) -> "FlowConfig":
+    def cross_references(self) -> FlowConfig:
         """Validate all cross-references between agents, phases, and dependencies."""
         scheduled = {entry.phase for entry in self.flow}
         seen: set[str] = set()
@@ -105,10 +135,15 @@ class FlowConfig(BaseModel):
         for phase_id, phase in self.phases.items():
             if phase.agent not in self.agents:
                 raise ValueError(f"Phase {phase_id!r} references unknown agent: {phase.agent!r}")
+
+        dependency_map = {entry.phase: entry.dependencies for entry in self.flow}
+        if cycle := _detect_cycle(dependency_map):
+            raise ValueError(f"Cycle detected in flow: {' → '.join(cycle)}")
+
         return self
 
     @classmethod
-    def from_yaml(cls, path: Path, config_dir: Path) -> "FlowConfig":
+    def from_yaml(cls, path: Path, config_dir: Path) -> FlowConfig:
         """Load, parse, and validate flow.yaml. Raises FlowConfigError on any problem."""
         try:
             raw = yaml.safe_load(path.read_text())

--- a/ddev/tests/ai/phases/test_config.py
+++ b/ddev/tests/ai/phases/test_config.py
@@ -12,6 +12,7 @@ from ddev.ai.phases.config import (
     FlowConfigError,
     PhaseConfig,
     TaskConfig,
+    _detect_cycle,
 )
 
 # ---------------------------------------------------------------------------
@@ -295,3 +296,90 @@ def test_from_yaml_invalid_yaml(tmp_path):
 def test_from_yaml_missing_file(tmp_path):
     with pytest.raises(FlowConfigError, match="Failed to load"):
         FlowConfig.from_yaml(tmp_path / "nonexistent.yaml", tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# _detect_cycle
+# ---------------------------------------------------------------------------
+
+
+def test_detect_cycle_no_nodes():
+    assert _detect_cycle({}) is None
+
+
+def test_detect_cycle_no_edges():
+    assert _detect_cycle({"a": [], "b": [], "c": []}) is None
+
+
+def test_detect_cycle_direct_self_loop():
+    cycle = _detect_cycle({"a": ["a"]})
+    assert cycle == ["a", "a"]
+
+
+def test_detect_cycle_two_node_cycle():
+    cycle = _detect_cycle({"a": ["b"], "b": ["a"]})
+    assert cycle is not None
+    assert cycle[0] == cycle[-1]
+    assert set(cycle) == {"a", "b"}
+
+
+def test_detect_cycle_partial_cycle():
+    # d → a → b → c → a  (d is not part of the cycle)
+    cycle = _detect_cycle({"d": ["a"], "a": ["b"], "b": ["c"], "c": ["a"]})
+    assert cycle is not None
+    assert cycle[0] == cycle[-1]
+    assert set(cycle[:-1]) == {"a", "b", "c"}
+
+
+def test_detect_cycle_acyclic():
+    assert _detect_cycle({"d": ["a", "b"], "a": ["c"], "b": ["c"], "c": []}) is None
+
+
+# ---------------------------------------------------------------------------
+# FlowConfig cycle detection via model_validate
+# ---------------------------------------------------------------------------
+
+
+def _three_phase_config() -> dict:
+    agent = {"tools": []}
+    task = {"name": "t", "prompt": "Do it."}
+    return {
+        "agents": {"writer": agent},
+        "phases": {
+            "p1": {"agent": "writer", "tasks": [task]},
+            "p2": {"agent": "writer", "tasks": [task]},
+            "p3": {"agent": "writer", "tasks": [task]},
+        },
+    }
+
+
+def test_flow_config_direct_cycle_raises():
+    raw = _three_phase_config()
+    raw["flow"] = [
+        {"phase": "p1", "dependencies": ["p2"]},
+        {"phase": "p2", "dependencies": ["p1"]},
+    ]
+    with pytest.raises(ValidationError, match="Cycle detected"):
+        FlowConfig.model_validate(raw)
+
+
+def test_flow_config_three_node_cycle_raises():
+    raw = _three_phase_config()
+    raw["flow"] = [
+        {"phase": "p1", "dependencies": ["p3"]},
+        {"phase": "p2", "dependencies": ["p1"]},
+        {"phase": "p3", "dependencies": ["p2"]},
+    ]
+    with pytest.raises(ValidationError, match="Cycle detected"):
+        FlowConfig.model_validate(raw)
+
+
+def test_flow_config_acyclic_chain_ok():
+    raw = _three_phase_config()
+    raw["flow"] = [
+        {"phase": "p1"},
+        {"phase": "p2", "dependencies": ["p1"]},
+        {"phase": "p3", "dependencies": ["p1"]},
+    ]
+    config = FlowConfig.model_validate(raw)
+    assert len(config.flow) == 3

--- a/ddev/tests/ai/phases/test_config.py
+++ b/ddev/tests/ai/phases/test_config.py
@@ -12,7 +12,6 @@ from ddev.ai.phases.config import (
     FlowConfigError,
     PhaseConfig,
     TaskConfig,
-    _detect_cycle,
 )
 
 # ---------------------------------------------------------------------------
@@ -306,43 +305,6 @@ def test_from_yaml_missing_file(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# _detect_cycle
-# ---------------------------------------------------------------------------
-
-
-def test_detect_cycle_no_nodes():
-    assert _detect_cycle({}) is None
-
-
-def test_detect_cycle_no_edges():
-    assert _detect_cycle({"a": [], "b": [], "c": []}) is None
-
-
-def test_detect_cycle_direct_self_loop():
-    cycle = _detect_cycle({"a": ["a"]})
-    assert cycle == ["a", "a"]
-
-
-def test_detect_cycle_two_node_cycle():
-    cycle = _detect_cycle({"a": ["b"], "b": ["a"]})
-    assert cycle is not None
-    assert cycle[0] == cycle[-1]
-    assert set(cycle) == {"a", "b"}
-
-
-def test_detect_cycle_partial_cycle():
-    # d → a → b → c → a  (d is not part of the cycle)
-    cycle = _detect_cycle({"d": ["a"], "a": ["b"], "b": ["c"], "c": ["a"]})
-    assert cycle is not None
-    assert cycle[0] == cycle[-1]
-    assert set(cycle[:-1]) == {"a", "b", "c"}
-
-
-def test_detect_cycle_acyclic():
-    assert _detect_cycle({"d": ["a", "b"], "a": ["c"], "b": ["c"], "c": []}) is None
-
-
-# ---------------------------------------------------------------------------
 # FlowConfig cycle detection via model_validate
 # ---------------------------------------------------------------------------
 
@@ -390,6 +352,28 @@ def test_flow_config_acyclic_chain_ok():
     ]
     config = FlowConfig.model_validate(raw)
     assert len(config.flow) == 3
+
+
+def test_flow_disjoined_graphs_ok():
+    agent = {"tools": []}
+    task = {"name": "t", "prompt": "Do it."}
+    raw = {
+        "agents": {"writer": agent},
+        "phases": {
+            "p1": {"agent": "writer", "tasks": [task]},
+            "p2": {"agent": "writer", "tasks": [task]},
+            "p3": {"agent": "writer", "tasks": [task]},
+            "p4": {"agent": "writer", "tasks": [task]},
+        },
+        "flow": [
+            {"phase": "p1"},
+            {"phase": "p2", "dependencies": ["p1"]},
+            {"phase": "p3"},
+            {"phase": "p4", "dependencies": ["p3"]},
+        ],
+    }
+    config = FlowConfig.model_validate(raw)
+    assert len(config.flow) == 4
 
 
 def test_flow_config_self_dependency_raises():

--- a/ddev/tests/ai/phases/test_config.py
+++ b/ddev/tests/ai/phases/test_config.py
@@ -406,7 +406,5 @@ def test_flow_config_two_independent_cycles_reports_both():
         FlowConfig.model_validate(raw)
     error = str(exc_info.value)
     assert "Cycle" in error
-    assert "p1" in error
-    assert "p2" in error
-    assert "p3" in error
-    assert "p4" in error
+    assert "p1 → p3 → p2 → p1" in error
+    assert "p1 → p4 → p2 → p1" in error

--- a/ddev/tests/ai/phases/test_config.py
+++ b/ddev/tests/ai/phases/test_config.py
@@ -171,6 +171,13 @@ def test_flow_config_dependency_not_scheduled_in_flow():
         FlowConfig.model_validate(raw)
 
 
+def test_flow_config_duplicate_phase_raises():
+    raw = _minimal_config()
+    raw["flow"] = [{"phase": "p1"}, {"phase": "p1"}]
+    with pytest.raises(ValidationError, match="Duplicate phase"):
+        FlowConfig.model_validate(raw)
+
+
 def test_flow_config_unknown_agent_in_phase():
     raw = _minimal_config()
     raw["phases"]["p1"]["agent"] = "nonexistent"
@@ -383,3 +390,10 @@ def test_flow_config_acyclic_chain_ok():
     ]
     config = FlowConfig.model_validate(raw)
     assert len(config.flow) == 3
+
+
+def test_flow_config_self_dependency_raises():
+    raw = _minimal_config()
+    raw["flow"] = [{"phase": "p1", "dependencies": ["p1"]}]
+    with pytest.raises(ValidationError, match="Cycle detected"):
+        FlowConfig.model_validate(raw)

--- a/ddev/tests/ai/phases/test_config.py
+++ b/ddev/tests/ai/phases/test_config.py
@@ -328,7 +328,7 @@ def test_flow_config_direct_cycle_raises():
         {"phase": "p1", "dependencies": ["p2"]},
         {"phase": "p2", "dependencies": ["p1"]},
     ]
-    with pytest.raises(ValidationError, match="Cycle detected"):
+    with pytest.raises(ValidationError, match="Cycle"):
         FlowConfig.model_validate(raw)
 
 
@@ -339,7 +339,7 @@ def test_flow_config_three_node_cycle_raises():
         {"phase": "p2", "dependencies": ["p1"]},
         {"phase": "p3", "dependencies": ["p2"]},
     ]
-    with pytest.raises(ValidationError, match="Cycle detected"):
+    with pytest.raises(ValidationError, match="Cycle"):
         FlowConfig.model_validate(raw)
 
 
@@ -379,5 +379,34 @@ def test_flow_disjoined_graphs_ok():
 def test_flow_config_self_dependency_raises():
     raw = _minimal_config()
     raw["flow"] = [{"phase": "p1", "dependencies": ["p1"]}]
-    with pytest.raises(ValidationError, match="Cycle detected"):
+    with pytest.raises(ValidationError, match="Cycle"):
         FlowConfig.model_validate(raw)
+
+
+def test_flow_config_two_independent_cycles_reports_both():
+    agent = {"tools": []}
+    task = {"name": "t", "prompt": "Do it."}
+    raw = {
+        "agents": {"writer": agent},
+        "phases": {
+            "p1": {"agent": "writer", "tasks": [task]},
+            "p2": {"agent": "writer", "tasks": [task]},
+            "p3": {"agent": "writer", "tasks": [task]},
+            "p4": {"agent": "writer", "tasks": [task]},
+        },
+        "flow": [
+            # dependency edges: p1→p3→p2→p1 and p1→p4→p2→p1
+            {"phase": "p1", "dependencies": ["p3", "p4"]},
+            {"phase": "p2", "dependencies": ["p1"]},
+            {"phase": "p3", "dependencies": ["p2"]},
+            {"phase": "p4", "dependencies": ["p2"]},
+        ],
+    }
+    with pytest.raises(ValidationError) as exc_info:
+        FlowConfig.model_validate(raw)
+    error = str(exc_info.value)
+    assert "Cycle" in error
+    assert "p1" in error
+    assert "p2" in error
+    assert "p3" in error
+    assert "p4" in error


### PR DESCRIPTION
### What does this PR do?

Adds cycle detection to `FlowConfig` validation in the AI framework's phase configuration.

A new `_detect_cycle` function runs DFS over the phase dependency graph and returns the first cycle found as an ordered list of phase IDs. `FlowConfig.cross_references` calls it after all other dependency checks pass and raises a `ValidationError` with a readable `→`-separated cycle path (e.g. `p1 → p2 → p3 → p1`).

New test coverage for this cycle detection has also been added to `tests/ai/phases/test_config.py`.

Also adds `from __future__ import annotations` to `config.py` and updates forward-reference string annotations (e.g. `-> "TaskConfig"`) to plain annotations (`-> TaskConfig`).

### Motivation

Without cycle detection, a flow config with circular dependencies (e.g. `p1` depends on `p2` which depends on `p1`) would pass validation silently and cause the orchestrator to deadlock at runtime. Failing fast at load time with a clear error message is strictly better.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged