### PR TITLE
Test: Workato account_config with extra field and dataflow

### DIFF
--- a/workato/assets/account_config.json
+++ b/workato/assets/account_config.json
@@ -1,0 +1,67 @@
+{
+  "supported_auth_methods": [],
+  "additional_config_fields": [
+    {
+      "type": "password",
+      "key": "api_token",
+      "label": "API client token",
+      "help": "Workato API client token for authentication.",
+      "editable": true,
+      "required": true
+    },
+    {
+      "type": "dropdown",
+      "key": "region",
+      "label": "Region",
+      "help": "Workato region.",
+      "editable": true,
+      "required": true,
+      "options": [
+        {
+          "value": "US",
+          "label": "US"
+        },
+        {
+          "value": "EU",
+          "label": "EU"
+        },
+        {
+          "value": "JP",
+          "label": "JP"
+        },
+        {
+          "value": "SG",
+          "label": "SG"
+        },
+        {
+          "value": "AU",
+          "label": "AU"
+        },
+        {
+          "value": "IL",
+          "label": "IL"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "key": "extra_test_field",
+      "label": "Extra Test Field",
+      "help": "This field does NOT exist in the crawler - should cause validation to fail",
+      "editable": true,
+      "required": false
+    }
+  ],
+  "dataflow_config": [
+    {
+      "dataflow_id": "workato-extra-test-dataflow",
+      "toggle": {
+        "default": false,
+        "label": "Extra Test Dataflow",
+        "help": "This dataflow does NOT exist in any crawler - should cause validation to fail",
+        "editable": true
+      },
+      "additional_config_fields": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
This PR creates a test `account_config.json` for Workato that intentionally includes extra fields and dataflows to verify the account-config-runtime APW validator catches these errors.

## What's Extra
This account_config includes elements that do NOT exist in the Workato crawler:

### Extra Field
- `extra_test_field` - NOT declared in the crawler

### Extra Dataflow
- `workato-extra-test-dataflow` - NOT declared in any crawler

## Expected Validation Errors
When APW runs the account-config-runtime validator (from dogweb #165310), it should fail with:
- "Field 'extra_test_field' from account_config.json is not declared in crawler 'workato'"
- "Dataflow 'workato-extra-test-dataflow' from account_config.json is not declared in any crawler"

## Related PRs
- dogweb #165310 - APW validator implementation
- integrations-internal-core #3210 - Twilio test with EXTRA fields/dataflows
- integrations-internal-core #3211 - Twilio test with MISSING fields/dataflows

**DO NOT MERGE** - This is a test PR to verify validator behavior.