### PR TITLE
Test: Workato account_config with missing required field

### DIFF
--- a/workato/assets/account_config.json
+++ b/workato/assets/account_config.json
@@ -1,0 +1,14 @@
+{
+  "supported_auth_methods": [],
+  "additional_config_fields": [
+    {
+      "type": "password",
+      "key": "api_token",
+      "label": "API client token",
+      "help": "Workato API client token for authentication.",
+      "editable": true,
+      "required": true
+    }
+  ],
+  "dataflow_config": []
+}


### PR DESCRIPTION
## Summary
This PR creates a test `account_config.json` for Workato that intentionally **omits** required fields to verify the account-config-runtime APW validator catches these errors.

## What's Missing
This account_config is missing elements that the Workato crawler requires:

### Missing Field
- `region` - Required by the crawler but NOT declared in this account_config

### Missing Dataflows
- Any dataflows required by the crawler (if applicable)

## Expected Validation Errors
When APW runs the account-config-runtime validator (from dogweb #165310), it should fail with:
- "Stable field 'region' from crawler 'workato' is not declared in account_config.json"
- Any errors for missing required dataflows (if the crawler defines them)

## Related PRs
- dogweb #165310 - APW validator implementation
- integrations-core #23591 - Workato test with EXTRA field/dataflow (opposite test case)
- integrations-internal-core #3210 - Twilio test with EXTRA fields/dataflows
- integrations-internal-core #3211 - Twilio test with MISSING fields/dataflows

**DO NOT MERGE** - This is a test PR to verify validator behavior.