### PR TITLE
Mongo Query Metrics

### DIFF
--- a/mongo/README.md
+++ b/mongo/README.md
@@ -535,6 +535,8 @@ Then, [instrument your application container][8] and set `DD_AGENT_HOST` to the 
 
 ## Data Collected
 
+Some of the metrics listed below require additional configuration, see the [sample mongo.d/conf.yaml][5] for all configurable options. Query metrics for MongoDB require Datadog Agent v7.78 or later.
+
 ### Metrics
 
 See [metadata.csv][22] for a list of metrics provided by this check.


### PR DESCRIPTION
### What does this PR do?
Adds call out and link of the new query metrics available with agent v7.78 or later. Follows same style as Postgres.

### Motivation
The release of agent v7.78 has enabled Mongo query metrics to be supported in Database Monitoring/Query Metrics for a customers Mongo instance. This PR just adds the call out that for some metrics, additional set up is required and links to the sample `mongo.d/conf.yaml` file. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
