### PR TITLE
Fix IBM Spectrum LSF monitor queries

### DIFF
--- a/ibm_spectrum_lsf/assets/dashboards/overview.json
+++ b/ibm_spectrum_lsf/assets/dashboards/overview.json
@@ -243,7 +243,7 @@
                             "display_format": "countsAndList",
                             "hide_zero_counts": true,
                             "last_triggered_format": "relative",
-                            "query": "tag:(source:ibm_spectrum_lsf)",
+                            "query": "tag:(integration:ibm-spectrum-lsf)",
                             "show_last_triggered": false,
                             "show_priority": false,
                             "show_status": true,

--- a/ibm_spectrum_lsf/assets/monitors/high_pending_jobs.json
+++ b/ibm_spectrum_lsf/assets/monitors/high_pending_jobs.json
@@ -10,7 +10,7 @@
 		"type": "query alert",
 		"query": "avg(last_1d):anomalies(sum:ibm_spectrum_lsf.queue.pending{*} by {queue_name,lsf_cluster_name}, 'basic', 2, direction='above', interval=300, alert_window='last_1h', count_default_zero='true') >= 1",
 		"message": "{{#is_alert}}\nNumber of Pending Jobs in IBM Spectrum LSF cluster {{lsf_cluster_name.name}} is higher than normal. \n{{/is_alert}}\n\n{{#is_warning}}\nNumber of Pending Jobs in IBM Spectrum LSF cluster {{lsf_cluster_name.name}} is higher than normal.\n{{/is_warning}}\n\n{{#is_recovery}}\nNumber of Pending Jobs in IBM Spectrum LSF cluster {{lsf_cluster_name.name}} is back to normal.\n{{/is_recovery}}",
-		"tags": [],
+		"tags": ["integration:ibm-spectrum-lsf"],
 		"options": {
 			"thresholds": {
 				"critical": 1,

--- a/ibm_spectrum_lsf/assets/monitors/no_gpu_slots_available.json
+++ b/ibm_spectrum_lsf/assets/monitors/no_gpu_slots_available.json
@@ -10,7 +10,7 @@
 		"type": "query alert",
 		"query": "avg(last_5m):sum:ibm_spectrum_lsf.server.gpu.num_gpus_shared_available{*} by {lsf_cluster_name} <= 0",
 		"message": "{{#is_alert}}There are no GPU Slots available to be shared with other jobs on cluster {{lsf_cluster_name.name}}. Jobs that require GPU resources cannot run until the current GPU-using jobs complete. {{/is_alert}}\n\n{{#is_recovery}}\nGPU slots are now available on cluster {{lsf_cluster_name.name}}. \n{{/is_recovery}}",
-		"tags": [],
+		"tags": ["integration:ibm-spectrum-lsf"],
 		"options": {
 			"thresholds": {
 				"critical": 0


### PR DESCRIPTION
### What does this PR do?
Adds a tag to ibm spectrum monitors and updates dashboard query
### Motivation
missing monitors in dashboard

tested in staging:
<img width="651" height="569" alt="Screenshot 2026-05-05 at 11 58 34 AM" src="https://github.com/user-attachments/assets/24a2d0b1-359c-430e-99c3-01fa3e2e21ba" />
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
