### PR TITLE
Handle wheel promotion gate on forks

### DIFF
--- a/.github/workflows/dependency-wheel-promotion-gate.yaml
+++ b/.github/workflows/dependency-wheel-promotion-gate.yaml
@@ -1,7 +1,7 @@
 name: Dependency Wheel Promotion Gate
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
     - master
     - 7.*.*
@@ -36,41 +36,25 @@ jobs:
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         script: |
-          try {
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.payload.pull_request.head.sha,
-              state: 'pending',
-              context: 'dependency-wheel-promotion',
-              description: 'Wheels must be promoted to stable before merge. Run: ddev dep promote <PR_URL>',
-            });
-          } catch (err) {
-            if (err.status === 403) {
-              core.warning(`Unable to set commit status (expected for fork PRs): ${err.message}`);
-            } else {
-              throw err;
-            }
-          }
+          await github.rest.repos.createCommitStatus({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            sha: context.payload.pull_request.head.sha,
+            state: 'pending',
+            context: 'dependency-wheel-promotion',
+            description: 'Wheels must be promoted to stable before merge. Run: ddev dep promote <PR_URL>',
+          });
 
     - name: Set dependency-wheel-promotion status to success
       if: steps.deps-changed.outputs.changed == 'false'
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         script: |
-          try {
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.payload.pull_request.head.sha,
-              state: 'success',
-              context: 'dependency-wheel-promotion',
-              description: 'No dependency changes — promotion not required.',
-            });
-          } catch (err) {
-            if (err.status === 403) {
-              core.warning(`Unable to set commit status (expected for fork PRs): ${err.message}`);
-            } else {
-              throw err;
-            }
-          }
+          await github.rest.repos.createCommitStatus({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            sha: context.payload.pull_request.head.sha,
+            state: 'success',
+            context: 'dependency-wheel-promotion',
+            description: 'No dependency changes — promotion not required.',
+          });

--- a/.github/workflows/dependency-wheel-promotion-gate.yaml
+++ b/.github/workflows/dependency-wheel-promotion-gate.yaml
@@ -36,25 +36,41 @@ jobs:
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         script: |
-          await github.rest.repos.createCommitStatus({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            sha: context.payload.pull_request.head.sha,
-            state: 'pending',
-            context: 'dependency-wheel-promotion',
-            description: 'Wheels must be promoted to stable before merge. Run: ddev dep promote <PR_URL>',
-          });
+          try {
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: 'pending',
+              context: 'dependency-wheel-promotion',
+              description: 'Wheels must be promoted to stable before merge. Run: ddev dep promote <PR_URL>',
+            });
+          } catch (err) {
+            if (err.status === 403) {
+              core.warning(`Unable to set commit status (expected for fork PRs): ${err.message}`);
+            } else {
+              throw err;
+            }
+          }
 
     - name: Set dependency-wheel-promotion status to success
       if: steps.deps-changed.outputs.changed == 'false'
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         script: |
-          await github.rest.repos.createCommitStatus({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            sha: context.payload.pull_request.head.sha,
-            state: 'success',
-            context: 'dependency-wheel-promotion',
-            description: 'No dependency changes — promotion not required.',
-          });
+          try {
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: 'success',
+              context: 'dependency-wheel-promotion',
+              description: 'No dependency changes — promotion not required.',
+            });
+          } catch (err) {
+            if (err.status === 403) {
+              core.warning(`Unable to set commit status (expected for fork PRs): ${err.message}`);
+            } else {
+              throw err;
+            }
+          }


### PR DESCRIPTION
### What does this PR do?
Handle wheel promotion github failure on forks by triggering on pull_request_target
### Motivation
this workflow used to fail on forks: https://github.com/DataDog/integrations-core/actions/runs/25372136808/job/74439354917?pr=23593
since it doesn't checkout code it's safe to run on the target
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
