### PR TITLE
fix Postgres diagnose conn handling

### DIFF
--- a/postgres/changelog.d/23602.fixed
+++ b/postgres/changelog.d/23602.fixed
@@ -1,0 +1,1 @@
+Fix connection leak and improve error handling during Postgres database connectivity diagnostics

--- a/postgres/datadog_checks/postgres/diagnose.py
+++ b/postgres/datadog_checks/postgres/diagnose.py
@@ -198,12 +198,9 @@ class PostgresDiagnose:
         """
         host_desc = self._host_desc()
         username = self._check._config.username
-        conn = None
         try:
             conn = self._check._new_connection(dbname)
-        except psycopg.Error as e:
-            if conn is not None:
-                _safe_close(conn)
+        except Exception as e:
             code = DatabaseConfigurationError.connection_failure
             self._fail(
                 code,

--- a/postgres/datadog_checks/postgres/diagnose.py
+++ b/postgres/datadog_checks/postgres/diagnose.py
@@ -223,12 +223,31 @@ class PostgresDiagnose:
     def _diagnose_version(self, conn):
         code = DatabaseConfigurationError.postgres_version_unsupported
         try:
-            raw_version = _fetchone(conn, "SHOW SERVER_VERSION")[0]
+            with conn.cursor() as cursor:
+                cursor.execute("SHOW SERVER_VERSION")
+                row = cursor.fetchone()
+        except psycopg.Error as e:
+            self._fail(
+                code,
+                diagnosis="Unable to determine Postgres version: {}".format(e),
+                category=CATEGORY_POSTGRES,
+                rawerror=str(e),
+            )
+            return
+        if not row or row[0] is None:
+            self._fail(
+                code,
+                diagnosis="Unable to determine Postgres version: SHOW SERVER_VERSION returned no rows.",
+                category=CATEGORY_POSTGRES,
+            )
+            return
+        raw_version = row[0]
+        try:
             version = VersionUtils.parse_version(raw_version)
         except Exception as e:
             self._fail(
                 code,
-                diagnosis="Unable to determine Postgres version: {}".format(e),
+                diagnosis="Unable to parse Postgres version {!r}: {}".format(raw_version, e),
                 category=CATEGORY_POSTGRES,
                 rawerror=str(e),
             )
@@ -364,17 +383,37 @@ class PostgresDiagnose:
     def _diagnose_pg_monitor_role(self, conn):
         # pg_monitor only exists on PG >= 10.
         code = DatabaseConfigurationError.missing_pg_monitor_role
-        row = _fetchone(
-            conn,
-            "SELECT 1 FROM pg_roles WHERE rolname = 'pg_monitor'",
-        )
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute("SELECT 1 FROM pg_roles WHERE rolname = 'pg_monitor'")
+                row = cursor.fetchone()
+        except psycopg.Error as e:
+            self._fail(
+                code,
+                diagnosis="Unable to check pg_monitor role membership: {}".format(e),
+                category=CATEGORY_POSTGRES,
+                description=DIAGNOSTIC_METADATA[code]["description"],
+                remediation=build_remediation(code),
+                rawerror=str(e),
+            )
+            return
         if row is None:
             # PG < 10 has no pg_monitor role — the version diagnostic handles unsupported versions.
             return
-        has_role = _fetchone(
-            conn,
-            "SELECT pg_has_role(current_user, 'pg_monitor', 'MEMBER')",
-        )
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute("SELECT pg_has_role(current_user, 'pg_monitor', 'MEMBER')")
+                has_role = cursor.fetchone()
+        except psycopg.Error as e:
+            self._fail(
+                code,
+                diagnosis="Unable to check pg_monitor role membership: {}".format(e),
+                category=CATEGORY_POSTGRES,
+                description=DIAGNOSTIC_METADATA[code]["description"],
+                remediation=build_remediation(code),
+                rawerror=str(e),
+            )
+            return
         if has_role and has_role[0]:
             self._check.diagnosis.success(
                 name=code.value,

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -1018,7 +1018,11 @@ class PostgreSql(DatabaseCheck):
             kwargs["token_provider"] = self.db_pool.token_provider
 
         conn = TokenAwareConnection.connect(**kwargs)
-        self.db_pool._configure_connection(conn)
+        try:
+            self.db_pool._configure_connection(conn)
+        except Exception:
+            conn.close()
+            raise
         return conn
 
     def _connect(self):

--- a/postgres/tests/test_diagnose.py
+++ b/postgres/tests/test_diagnose.py
@@ -283,6 +283,32 @@ def test_probe_connection_uses_pool_configuration(integration_check, pg_instance
     configure.assert_called_once_with(conn)
 
 
+@pytest.mark.parametrize(
+    'err',
+    [
+        pytest.param(
+            __import__('botocore.exceptions', fromlist=['NoCredentialsError']).NoCredentialsError(),
+            id='aws-no-credentials',
+        ),
+        pytest.param(
+            __import__('azure.core.exceptions', fromlist=['ClientAuthenticationError']).ClientAuthenticationError(
+                message='managed identity unavailable'
+            ),
+            id='azure-auth-error',
+        ),
+    ],
+)
+def test_non_psycopg_connection_error_surfaces_fail_diagnostic(integration_check, pg_instance, err):
+    """Non-psycopg exceptions from AWS/Azure token providers must produce a
+    connection-failure FAIL row, not an unhandled traceback."""
+    check = integration_check(pg_instance)
+    with mock.patch('datadog_checks.postgres.postgres.TokenAwareConnection.connect', side_effect=err):
+        diagnoses = _get_diagnoses(check)
+    rows = _by_name(diagnoses, DatabaseConfigurationError.connection_failure.value)
+    assert len(rows) == 1
+    assert rows[0]['result'] == Diagnosis.DIAGNOSIS_FAIL
+
+
 def test_configure_connection_failure_emits_connection_fail_diagnostic(integration_check, pg_instance):
     """When _configure_connection raises on the probe connection, diagnose must close the
     leaked connection and emit a connection-failure FAIL row rather than crashing."""

--- a/postgres/tests/test_diagnose.py
+++ b/postgres/tests/test_diagnose.py
@@ -283,6 +283,20 @@ def test_probe_connection_uses_pool_configuration(integration_check, pg_instance
     configure.assert_called_once_with(conn)
 
 
+def test_configure_connection_failure_emits_connection_fail_diagnostic(integration_check, pg_instance):
+    """When _configure_connection raises on the probe connection, diagnose must close the
+    leaked connection and emit a connection-failure FAIL row rather than crashing."""
+    check = integration_check(pg_instance)
+    conn = mock.MagicMock()
+    with mock.patch('datadog_checks.postgres.postgres.TokenAwareConnection.connect', return_value=conn):
+        with mock.patch.object(check.db_pool, '_configure_connection', side_effect=psycopg.Error('SET failed')):
+            diagnoses = _get_diagnoses(check)
+    conn.close.assert_called()
+    rows = _by_name(diagnoses, DatabaseConfigurationError.connection_failure.value)
+    assert len(rows) == 1
+    assert rows[0]['result'] == Diagnosis.DIAGNOSIS_FAIL
+
+
 # -- Server config diagnostics ------------------------------------------------
 
 

--- a/postgres/tests/test_diagnose.py
+++ b/postgres/tests/test_diagnose.py
@@ -407,6 +407,34 @@ def test_unsupported_postgres_version_fails(integration_check, pg_instance):
     assert '9.5' in entry['diagnosis']
 
 
+def test_version_probe_psycopg_error_surfaces_underlying_message(integration_check, pg_instance):
+    """A transient connection error during the version probe should surface the underlying
+    psycopg error, not 'NoneType' object is not subscriptable from indexing a swallowed None."""
+    check = integration_check(pg_instance)
+    responses = _override(
+        _happy_server_responses(),
+        'SHOW SERVER_VERSION',
+        psycopg.OperationalError('server closed the connection unexpectedly'),
+    )
+    diagnoses = _run(check, responses)
+    entry = _by_name(diagnoses, DatabaseConfigurationError.postgres_version_unsupported.value)[0]
+    assert entry['result'] == Diagnosis.DIAGNOSIS_FAIL
+    assert 'server closed the connection unexpectedly' in entry['diagnosis']
+    assert 'NoneType' not in entry['diagnosis']
+
+
+def test_version_probe_no_rows_fails_clearly(integration_check, pg_instance):
+    """An empty result from SHOW SERVER_VERSION should fail with a clear message rather than
+    crash on None subscripting."""
+    check = integration_check(pg_instance)
+    responses = _override(_happy_server_responses(), 'SHOW SERVER_VERSION', [])
+    diagnoses = _run(check, responses)
+    entry = _by_name(diagnoses, DatabaseConfigurationError.postgres_version_unsupported.value)[0]
+    assert entry['result'] == Diagnosis.DIAGNOSIS_FAIL
+    assert 'NoneType' not in entry['diagnosis']
+    assert 'SHOW SERVER_VERSION' in entry['diagnosis']
+
+
 # -- Privilege diagnostics ----------------------------------------------------
 
 
@@ -417,6 +445,35 @@ def test_missing_pg_monitor_role_fails(integration_check, pg_instance):
     entry = _by_name(diagnoses, DatabaseConfigurationError.missing_pg_monitor_role.value)[0]
     assert entry['result'] == Diagnosis.DIAGNOSIS_FAIL
     assert 'pg_monitor' in entry['remediation']
+
+
+def test_pg_monitor_role_existence_probe_psycopg_error_surfaces_underlying_message(integration_check, pg_instance):
+    """A transient error on the pg_roles probe must not be mistaken for PG < 10 (silent skip)."""
+    check = integration_check(pg_instance)
+    responses = _override(
+        _happy_server_responses(),
+        "rolname = 'pg_monitor'",
+        psycopg.OperationalError('server closed the connection unexpectedly'),
+    )
+    diagnoses = _run(check, responses)
+    entry = _by_name(diagnoses, DatabaseConfigurationError.missing_pg_monitor_role.value)[0]
+    assert entry['result'] == Diagnosis.DIAGNOSIS_FAIL
+    assert 'server closed the connection unexpectedly' in entry['diagnosis']
+
+
+def test_pg_monitor_has_role_probe_psycopg_error_surfaces_underlying_message(integration_check, pg_instance):
+    """A transient error on the pg_has_role probe must not be misclassified as 'not a member'."""
+    check = integration_check(pg_instance)
+    responses = _override(
+        _happy_server_responses(),
+        'pg_has_role',
+        psycopg.OperationalError('server closed the connection unexpectedly'),
+    )
+    diagnoses = _run(check, responses)
+    entry = _by_name(diagnoses, DatabaseConfigurationError.missing_pg_monitor_role.value)[0]
+    assert entry['result'] == Diagnosis.DIAGNOSIS_FAIL
+    assert 'server closed the connection unexpectedly' in entry['diagnosis']
+    assert 'not a member' not in entry['diagnosis']
 
 
 def test_pg_stat_database_access_fails_on_permission_error(integration_check, pg_instance):

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -325,3 +325,14 @@ def test_run_explain_uses_parameterized_statement(pg_instance, integration_check
     assert '$stmt$' not in query, "Dollar-quote tag must not appear in the SQL template"
     assert statement not in query, "Statement must not be interpolated into the SQL template"
     assert params == (statement,), "Statement must be passed as a bound parameter"
+
+
+def test_new_connection_closes_conn_when_configure_raises(integration_check, pg_instance):
+    """If _configure_connection raises after connect() succeeds, the connection must be closed."""
+    check = integration_check(pg_instance)
+    conn = mock.MagicMock()
+    with mock.patch('datadog_checks.postgres.postgres.TokenAwareConnection.connect', return_value=conn):
+        with mock.patch.object(check.db_pool, '_configure_connection', side_effect=psycopg.Error('SET failed')):
+            with pytest.raises(psycopg.Error):
+                check._new_connection(check._config.dbname)
+    conn.close.assert_called_once()


### PR DESCRIPTION
### What does this PR do?
- Fixes a potential connection leak when PostgreSql._new_connection() successfully opens a connection but then fails to configure the connection with our expected initialization SET commands.
- Fixes surfacing connection errors in diagnose.py when opening a connection and receives an authentication error from AWS or Azure managed providers.

### Motivation
Follow up from #23433 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
