### PR TITLE
[consul] Make health check status cache size and TTL configurable

### DIFF
--- a/consul/assets/configuration/spec.yaml
+++ b/consul/assets/configuration/spec.yaml
@@ -167,6 +167,7 @@ files:
       value:
         type: integer
         example: 5000
+        minimum: 1
 
     - name: health_checks_cache_ttl
       fleet_configurable: true
@@ -175,6 +176,7 @@ files:
       value:
         type: integer
         example: 3600
+        minimum: 1
 
     - template: instances/http
     - template: instances/default

--- a/consul/assets/configuration/spec.yaml
+++ b/consul/assets/configuration/spec.yaml
@@ -158,6 +158,7 @@ files:
         example: true
 
     - name: health_checks_cache_size
+      fleet_configurable: true
       description: |
         Maximum number of health check entries kept in the cache used to detect status
         transitions. Increase this if your Consul cluster reports more than 5000 distinct
@@ -168,6 +169,7 @@ files:
         example: 5000
 
     - name: health_checks_cache_ttl
+      fleet_configurable: true
       description: |
         Time-to-live in seconds for entries in the health check status cache.
       value:

--- a/consul/assets/configuration/spec.yaml
+++ b/consul/assets/configuration/spec.yaml
@@ -159,17 +159,17 @@ files:
 
     - name: health_checks_cache_size
       description: |
-        Maximum number of health check entries kept in the in-memory cache used to detect
-        status transitions. Increase if your Consul cluster reports more than 5000 distinct
-        health checks across nodes, otherwise transitions may be missed and failure events
-        may be re-emitted spuriously.
+        Maximum number of health check entries kept in the cache used to detect status
+        transitions. Increase this if your Consul cluster reports more than 5000 distinct
+        health checks across nodes. Evicted entries cause status transitions to be missed
+        and failure events to be re-emitted on subsequent check runs.
       value:
         type: integer
         example: 5000
 
     - name: health_checks_cache_ttl
       description: |
-        Time-to-live (in seconds) for entries in the health check status cache.
+        Time-to-live in seconds for entries in the health check status cache.
       value:
         type: integer
         example: 3600

--- a/consul/assets/configuration/spec.yaml
+++ b/consul/assets/configuration/spec.yaml
@@ -157,6 +157,23 @@ files:
         display_default: false
         example: true
 
+    - name: health_checks_cache_size
+      description: |
+        Maximum number of health check entries kept in the in-memory cache used to detect
+        status transitions. Increase if your Consul cluster reports more than 5000 distinct
+        health checks across nodes, otherwise transitions may be missed and failure events
+        may be re-emitted spuriously.
+      value:
+        type: integer
+        example: 5000
+
+    - name: health_checks_cache_ttl
+      description: |
+        Time-to-live (in seconds) for entries in the health check status cache.
+      value:
+        type: integer
+        example: 3600
+
     - template: instances/http
     - template: instances/default
   - template: logs

--- a/consul/changelog.d/23603.added
+++ b/consul/changelog.d/23603.added
@@ -1,0 +1,1 @@
+Make the health check status cache size and TTL configurable via ``health_checks_cache_size`` and ``health_checks_cache_ttl``.

--- a/consul/datadog_checks/consul/common.py
+++ b/consul/datadog_checks/consul/common.py
@@ -24,6 +24,10 @@ MAX_SERVICES = 50
 # Increase the number of threads to collect consul services checks
 THREADS_COUNT = 1
 
+# Defaults for the in-memory cache used to detect health check status transitions
+HEALTH_CHECKS_CACHE_SIZE = 5000
+HEALTH_CHECKS_CACHE_TTL = 3600
+
 STATUS_SC = {
     'up': AgentCheck.OK,
     'passing': AgentCheck.OK,

--- a/consul/datadog_checks/consul/config_models/defaults.py
+++ b/consul/datadog_checks/consul/config_models/defaults.py
@@ -48,6 +48,14 @@ def instance_enable_legacy_tags_normalization():
     return True
 
 
+def instance_health_checks_cache_size():
+    return 5000
+
+
+def instance_health_checks_cache_ttl():
+    return 3600
+
+
 def instance_kerberos_auth():
     return 'disabled'
 

--- a/consul/datadog_checks/consul/config_models/instance.py
+++ b/consul/datadog_checks/consul/config_models/instance.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from types import MappingProxyType
 from typing import Any, Optional
 
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from typing_extensions import Literal
 
 from datadog_checks.base.utils.functions import identity
@@ -76,8 +76,8 @@ class InstanceConfig(BaseModel):
     enable_legacy_tags_normalization: Optional[bool] = None
     extra_headers: Optional[MappingProxyType[str, Any]] = None
     headers: Optional[MappingProxyType[str, Any]] = None
-    health_checks_cache_size: Optional[int] = None
-    health_checks_cache_ttl: Optional[int] = None
+    health_checks_cache_size: Optional[int] = Field(None, ge=1)
+    health_checks_cache_ttl: Optional[int] = Field(None, ge=1)
     kerberos_auth: Optional[Literal['required', 'optional', 'disabled']] = None
     kerberos_cache: Optional[str] = None
     kerberos_delegate: Optional[bool] = None

--- a/consul/datadog_checks/consul/config_models/instance.py
+++ b/consul/datadog_checks/consul/config_models/instance.py
@@ -76,6 +76,8 @@ class InstanceConfig(BaseModel):
     enable_legacy_tags_normalization: Optional[bool] = None
     extra_headers: Optional[MappingProxyType[str, Any]] = None
     headers: Optional[MappingProxyType[str, Any]] = None
+    health_checks_cache_size: Optional[int] = None
+    health_checks_cache_ttl: Optional[int] = None
     kerberos_auth: Optional[Literal['required', 'optional', 'disabled']] = None
     kerberos_cache: Optional[str] = None
     kerberos_delegate: Optional[bool] = None

--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -24,6 +24,8 @@ from .common import (
     CONSUL_CHECK,
     HEALTH_CHECK,
     HEALTH_CHECK_METRIC,
+    HEALTH_CHECKS_CACHE_SIZE,
+    HEALTH_CHECKS_CACHE_TTL,
     MAX_CONFIG_TTL,
     MAX_SERVICES,
     SOURCE_TYPE_NAME,
@@ -133,7 +135,15 @@ class ConsulCheck(OpenMetricsBaseCheck):
         if 'acl_token' in self.instance:
             self.http.options['headers']['X-Consul-Token'] = self.instance['acl_token']
 
-        self.health_checks = TTLCache(ttl=3600, maxsize=5000)
+        cache_size = self.instance.get(
+            'health_checks_cache_size',
+            self.init_config.get('health_checks_cache_size', HEALTH_CHECKS_CACHE_SIZE),
+        )
+        cache_ttl = self.instance.get(
+            'health_checks_cache_ttl',
+            self.init_config.get('health_checks_cache_ttl', HEALTH_CHECKS_CACHE_TTL),
+        )
+        self.health_checks = TTLCache(ttl=cache_ttl, maxsize=cache_size)
 
     def _is_dogstatsd_configured(self):
         """Check if the agent has a consul dogstatsd profile configured"""

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -147,6 +147,19 @@ instances:
     #
     # collect_health_checks: true
 
+    ## @param health_checks_cache_size - integer - optional - default: 5000
+    ## Maximum number of health check entries kept in the in-memory cache used to detect
+    ## status transitions. Increase if your Consul cluster reports more than 5000 distinct
+    ## health checks across nodes, otherwise transitions may be missed and failure events
+    ## may be re-emitted spuriously.
+    #
+    # health_checks_cache_size: 5000
+
+    ## @param health_checks_cache_ttl - integer - optional - default: 3600
+    ## Time-to-live (in seconds) for entries in the health check status cache.
+    #
+    # health_checks_cache_ttl: 3600
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -148,15 +148,15 @@ instances:
     # collect_health_checks: true
 
     ## @param health_checks_cache_size - integer - optional - default: 5000
-    ## Maximum number of health check entries kept in the in-memory cache used to detect
-    ## status transitions. Increase if your Consul cluster reports more than 5000 distinct
-    ## health checks across nodes, otherwise transitions may be missed and failure events
-    ## may be re-emitted spuriously.
+    ## Maximum number of health check entries kept in the cache used to detect status
+    ## transitions. Increase this if your Consul cluster reports more than 5000 distinct
+    ## health checks across nodes. Evicted entries cause status transitions to be missed
+    ## and failure events to be re-emitted on subsequent check runs.
     #
     # health_checks_cache_size: 5000
 
     ## @param health_checks_cache_ttl - integer - optional - default: 3600
-    ## Time-to-live (in seconds) for entries in the health check status cache.
+    ## Time-to-live in seconds for entries in the health check status cache.
     #
     # health_checks_cache_ttl: 3600
 

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -688,6 +688,13 @@ def test_health_checks_cache_configurable():
     assert consul_check.health_checks.ttl == 60
 
 
+def test_health_checks_cache_configurable_via_init_config():
+    init_config = {'health_checks_cache_size': 42, 'health_checks_cache_ttl': 7}
+    consul_check = ConsulCheck(common.CHECK_NAME, init_config, [consul_mocks.MOCK_CONFIG])
+    assert consul_check.health_checks.maxsize == 42
+    assert consul_check.health_checks.ttl == 7
+
+
 def test_health_checks_cache_eviction_re_emits_failure_event(aggregator):
     config = dict(consul_mocks.MOCK_CONFIG_DISABLE_SERVICE_TAG)
     config['collect_health_checks'] = True

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -671,3 +671,34 @@ def test_config(test_case, extra_config, expected_http_kwargs, mocker):
         }
         http_wargs.update(expected_http_kwargs)
         mock_session.get.assert_called_with('/v1/status/leader', **http_wargs)
+
+
+def test_health_checks_cache_defaults():
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG])
+    assert consul_check.health_checks.maxsize == 5000
+    assert consul_check.health_checks.ttl == 3600
+
+
+def test_health_checks_cache_configurable():
+    config = dict(consul_mocks.MOCK_CONFIG)
+    config['health_checks_cache_size'] = 10
+    config['health_checks_cache_ttl'] = 60
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, [config])
+    assert consul_check.health_checks.maxsize == 10
+    assert consul_check.health_checks.ttl == 60
+
+
+def test_health_checks_cache_eviction_re_emits_failure_event(aggregator):
+    config = dict(consul_mocks.MOCK_CONFIG_DISABLE_SERVICE_TAG)
+    config['collect_health_checks'] = True
+    config['health_checks_cache_size'] = 1
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, [config])
+    my_mocks = consul_mocks._get_consul_mocks()
+    my_mocks['consul_request'] = consul_mocks.mock_get_health_check
+    consul_mocks.mock_check(consul_check, my_mocks)
+
+    consul_check.check(None)
+    consul_check.check(None)
+
+    failure_events = [e for e in aggregator.events if e['event_type'] == 'consul.check_failed']
+    assert len(failure_events) == 2


### PR DESCRIPTION
## Motivation

`ConsulCheck` keeps an in-memory `TTLCache` keyed by `(check_id, service_id, service_name, node_name)` to detect health check status transitions and emit `consul.check_failed` events. Both the size (5000) and TTL (3600s) have been hardcoded since the cache was introduced.

Customers with large Consul clusters that report more than 5000 distinct health checks hit eviction. Evicted entries look new on the next run, which causes missed transitions and re-emitted failure events.

Closes [AGENT-16145](https://datadoghq.atlassian.net/browse/AGENT-16145).

## Approach

Two new instance/init_config options, falling back to the existing defaults:

- `health_checks_cache_size` (default 5000)
- `health_checks_cache_ttl` (default 3600)

Both are `fleet_configurable` and constrained to `minimum: 1` in the spec. Pydantic codegen produces `Field(None, ge=1)`, so non-positive values are rejected at first `check()` via `check_initializations` with a clear error naming the bad field.

The instance/init_config/default precedence matches the existing `max_services` / `threads_count` pattern.

## Verification

- `ddev --no-interactive test consul`: 28 passed, 3 skipped.
- `ddev test -fs consul`: clean.
- TDD: four new unit tests cover defaults, instance override, init_config override, and the eviction-causes-event-re-emit regression with a small cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AGENT-16145]: https://datadoghq.atlassian.net/browse/AGENT-16145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ