### PR TITLE
Isolate ddev release-notes extraction in an unprivileged job

### DIFF
--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -707,6 +707,65 @@ jobs:
         path: ddev/signed/${{ steps.pkg.outputs.path }}
         if-no-files-found: error
 
+  # Extraction runs in its own unprivileged job so the dependency-resolving install of
+  # ddev never executes inside the privileged publish job (which holds contents: write
+  # and id-token: write). A compromised transitive dep can still execute here, but it
+  # has no access to release credentials and cannot tamper with archives/installers.
+  extract-release-notes:
+    name: Extract release notes
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    needs:
+    - define-tags
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Set up Python ${{ env.PYTHON_VERSION }}
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: "${{ env.PYTHON_VERSION }}"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      with:
+        enable-cache: false
+
+    - name: Install ddev from local folder
+      working-directory: .
+      run: uv pip install --system -e ./datadog_checks_dev[cli] -e ./ddev
+
+    - name: Configure ddev
+      working-directory: .
+      run: |-
+        ddev config override
+        ddev config set upgrade_check false
+
+    # Extraction is best-effort: failing here must not block the release. We always
+    # emit release-notes.md (possibly empty) so the publish job's artifact download
+    # succeeds and the release proceeds with an empty body if extraction failed.
+    - name: Extract release notes from CHANGELOG
+      working-directory: .
+      run: |
+        version="${GITHUB_REF_NAME#ddev-v}"
+        notes_file="release-notes.md"
+        : > "$notes_file"
+        if ! ddev release changelog show ddev "$version" --file "$notes_file"; then
+          echo "::warning::Failed to extract changelog section for ddev $version; release body will be empty."
+          : > "$notes_file"
+        fi
+
+    - name: Upload release notes
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: release-notes
+        path: release-notes.md
+        if-no-files-found: error
+
   publish:
     name: Publish release
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
@@ -716,6 +775,7 @@ jobs:
     - binaries
     - windows-packaging
     - macos-packaging
+    - extract-release-notes
     runs-on: ubuntu-latest
 
     permissions:
@@ -761,6 +821,14 @@ jobs:
         path: installers
         merge-multiple: true
 
+    # Downloaded by exact name (not pattern) so this step cannot pull in artifacts
+    # uploaded by other jobs.
+    - name: Download release notes
+      uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+      with:
+        name: release-notes
+        path: release-notes
+
     # Publish wheels to PyPI using Trusted Publishers.
     # https://docs.pypi.org/trusted-publishers/using-a-publisher/
     # This job needs to run from within the pypi-ddev environment. PyPi validates the
@@ -771,46 +839,10 @@ jobs:
       with:
         skip-existing: true
 
-    - name: Set up Python ${{ env.PYTHON_VERSION }}
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      with:
-        python-version: "${{ env.PYTHON_VERSION }}"
-
-    - name: Install uv
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-      with:
-        enable-cache: false
-
-    - name: Install ddev from local folder
-      working-directory: .
-      run: uv pip install --system -e ./datadog_checks_dev[cli] -e ./ddev
-
-    - name: Configure ddev
-      working-directory: .
-      run: |-
-        ddev config override
-        ddev config set upgrade_check false
-
-    # Extraction is best-effort: PyPI publish has already happened by this point, so any failure
-    # here must not abort the workflow before the GitHub release is created. On failure we log a
-    # warning, leave the body file empty, and let the release proceed with an empty body.
-    - name: Extract release notes from CHANGELOG
-      id: release-notes
-      working-directory: .
-      run: |
-        version="${GITHUB_REF_NAME#ddev-v}"
-        notes_file="${RUNNER_TEMP}/release-notes.md"
-        : > "$notes_file"
-        if ! ddev release changelog show ddev "$version" --file "$notes_file"; then
-          echo "::warning::Failed to extract changelog section for ddev $version; release body will be empty."
-          : > "$notes_file"
-        fi
-        echo "path=$notes_file" >> "$GITHUB_OUTPUT"
-
     - name: Add assets to current release
       uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
       with:
-        body_path: ${{ steps.release-notes.outputs.path }}
+        body_path: release-notes/release-notes.md
         files: |-
           archives/*
           installers/*

--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -714,8 +714,6 @@ jobs:
   extract-release-notes:
     name: Extract release notes
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    needs:
-    - define-tags
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -719,45 +719,55 @@ jobs:
     permissions:
       contents: read
 
+    # Extraction is best-effort end-to-end: any failure in setup, install, configure,
+    # or the extraction itself must not block the release. We pre-create an empty
+    # release-notes.md, run the install/extract steps with continue-on-error so they
+    # never fail the job, and always upload the artifact. The publish job can rely on
+    # extract-release-notes succeeding; the body it consumes may be empty.
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+    - name: Initialize empty release notes
+      working-directory: .
+      run: ': > release-notes.md'
+
     - name: Set up Python ${{ env.PYTHON_VERSION }}
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      continue-on-error: true
       with:
         python-version: "${{ env.PYTHON_VERSION }}"
 
     - name: Install uv
       uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      continue-on-error: true
       with:
         enable-cache: false
 
     - name: Install ddev from local folder
+      continue-on-error: true
       working-directory: .
       run: uv pip install --system -e ./datadog_checks_dev[cli] -e ./ddev
 
     - name: Configure ddev
+      continue-on-error: true
       working-directory: .
       run: |-
         ddev config override
         ddev config set upgrade_check false
 
-    # Extraction is best-effort: failing here must not block the release. We always
-    # emit release-notes.md (possibly empty) so the publish job's artifact download
-    # succeeds and the release proceeds with an empty body if extraction failed.
     - name: Extract release notes from CHANGELOG
+      continue-on-error: true
       working-directory: .
       run: |
         version="${GITHUB_REF_NAME#ddev-v}"
-        notes_file="release-notes.md"
-        : > "$notes_file"
-        if ! ddev release changelog show ddev "$version" --file "$notes_file"; then
+        if ! ddev release changelog show ddev "$version" --file release-notes.md; then
           echo "::warning::Failed to extract changelog section for ddev $version; release body will be empty."
-          : > "$notes_file"
+          : > release-notes.md
         fi
 
     - name: Upload release notes
+      if: always()
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: release-notes


### PR DESCRIPTION
### What does this PR do?

Splits the changelog extraction added in #23587 out of the privileged `publish` job into a new `extract-release-notes` job that runs with `permissions: contents: read` only.

- New `extract-release-notes` job: checks out the repo, sets up Python + uv, installs `./datadog_checks_dev[cli]` and `./ddev`, runs `ddev release changelog show`, and uploads the result as the `release-notes` artifact. Best-effort: on failure it warns and uploads an empty file so the release still proceeds.
- `publish` job: removes the Python setup, `uv pip install`, `ddev config`, and changelog extraction steps. Adds a download of the `release-notes` artifact by exact name (not pattern) and feeds `release-notes/release-notes.md` to `softprops/action-gh-release`.
- `publish` now has `extract-release-notes` in its `needs:` list and runs in parallel with the build jobs.

### Motivation

[AI-6799](https://datadoghq.atlassian.net/browse/AI-6799). The previous version installed ddev's full transitive dependency graph (unpinned, unconstrained, no `--no-deps`) inside the privileged publish job, which holds `contents: write` and `id-token: write` and where `archives/*` and `installers/*` are already on disk before the GitHub release upload. A compromised transitive dependency could execute during install and tamper with release assets or abuse the OIDC/release token before `softprops/action-gh-release` ran.

GitHub Actions permissions are scoped per job, so reordering steps inside the publish job doesn't deny those tokens to dependency build code. Moving the install into a separate job with read-only permissions does: dependency code can still execute there, but it has no path to mint an OIDC token, no `contents: write`, and no access to the `archives/`/`installers/` workspaces.

The existing build jobs (`python-artifacts`, `binaries`, `windows-packaging`, `macos-packaging`) already install Python deps, so this new job sits at the same baseline rather than escalating into the publish job.

### Notes

- The publish job downloads `release-notes` by exact name; build artifacts are still pulled by pattern, so this step cannot accidentally pick up artifacts uploaded by other jobs.
- Extraction stays best-effort because PyPI publish has already happened by the time the release upload runs; better to have a release with an empty body than no release.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

[AI-6799]: https://datadoghq.atlassian.net/browse/AI-6799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ