### PR TITLE
Handle PRs with more than 100 files in dependency promotion gate

### DIFF
--- a/.github/workflows/dependency-wheel-promotion-gate.yaml
+++ b/.github/workflows/dependency-wheel-promotion-gate.yaml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         script: |
-          const { data: files } = await github.rest.pulls.listFiles({
+          const files = await github.paginate(github.rest.pulls.listFiles, {
             owner: context.repo.owner,
             repo: context.repo.repo,
             pull_number: context.payload.pull_request.number,


### PR DESCRIPTION
### What does this PR do?
Handles PRs with more than 100 files in the dependency promotion gate; previously, a large PR that modified dependencies could pass the gate if the dependency changes weren't in the first 100 files returned

### Motivation
comment from @AAraKKe: https://github.com/DataDog/integrations-core/pull/23600#discussion_r3193956694
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
