### PR TITLE
fix harbor tests when running on release workflow

### DIFF
--- a/harbor/tests/conftest.py
+++ b/harbor/tests/conftest.py
@@ -50,8 +50,12 @@ def dd_environment(e2e_instance):
         CheckDockerLogs(compose_file, expected_log, wait=3, service='core'),
         WaitFor(create_simple_user, wait=5),
     ]
+    e2e_metadata = {}
+    if os.environ.get('HARBOR_USE_SSL'):
+        cert_dir = os.path.join(HERE, 'compose', 'common', 'cert')
+        e2e_metadata['docker_volumes'] = ['{}:/home/harbor/tests/compose/common/cert'.format(cert_dir)]
     with docker_run(compose_file, conditions=conditions, attempts=5, waith_for_health=True):
-        yield e2e_instance
+        yield e2e_instance, e2e_metadata
 
 
 def create_simple_user():


### PR DESCRIPTION
### What does this PR do?
Fixes harbor tests when running on the Test Agent Release workflow

### Motivation
These tests were broken on the 7.79.x branch. Since we stopped using the --dev flag to run agent release tests, we no longer mount the integration directory into the agent container at /home/harbor/. This stopped the cert fixture from being mounted, which caused the test to fail.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
