### PR TITLE
[postgres] Qualify diagnose category with instance host

### DIFF
--- a/postgres/changelog.d/23620.fixed
+++ b/postgres/changelog.d/23620.fixed
@@ -1,0 +1,1 @@
+Qualify the diagnose category with the instance host so multiple instances are distinguishable in `datadog-agent diagnose` output.

--- a/postgres/datadog_checks/postgres/diagnose.py
+++ b/postgres/datadog_checks/postgres/diagnose.py
@@ -763,7 +763,12 @@ class PostgresDiagnose:
 
     @property
     def _category(self) -> str:
-        identifier = self._check.database_identifier
+        # Fall back to host:port — diagnose must keep working on broken config,
+        # which is exactly when database_identifier (templated over config+tags) can blow up.
+        try:
+            identifier = self._check.database_identifier
+        except Exception:
+            identifier = self._host_desc()
         if len(identifier) > 27:
             identifier = f"{identifier[:12]}...{identifier[-12:]}"
         return f"instance={identifier}"

--- a/postgres/datadog_checks/postgres/diagnose.py
+++ b/postgres/datadog_checks/postgres/diagnose.py
@@ -27,8 +27,6 @@ from .util import (
 )
 from .version_utils import V9_6, VersionUtils
 
-CATEGORY_POSTGRES = "postgres"
-
 # Recommended minimum track_activity_query_size. Default Postgres value is 1024, which
 # silently truncates queries and breaks explain plan collection.
 RECOMMENDED_TRACK_ACTIVITY_QUERY_SIZE = 4096
@@ -207,7 +205,7 @@ class PostgresDiagnose:
                 diagnosis="Failed to connect to {host} (dbname={db}) as {user}: {err}".format(
                     host=host_desc, db=dbname, user=username, err=e
                 ),
-                category=CATEGORY_POSTGRES,
+                category=self._category,
                 description=DIAGNOSTIC_METADATA[code]["description"],
                 remediation=build_remediation(code),
                 rawerror=str(e),
@@ -216,7 +214,7 @@ class PostgresDiagnose:
         self._check.diagnosis.success(
             name=DatabaseConfigurationError.connection_failure.value,
             diagnosis="Connected to {host} (dbname={db}) as {user}".format(host=host_desc, db=dbname, user=username),
-            category=CATEGORY_POSTGRES,
+            category=self._category,
         )
         return conn
 
@@ -230,7 +228,7 @@ class PostgresDiagnose:
             self._fail(
                 code,
                 diagnosis="Unable to determine Postgres version: {}".format(e),
-                category=CATEGORY_POSTGRES,
+                category=self._category,
                 rawerror=str(e),
             )
             return
@@ -238,7 +236,7 @@ class PostgresDiagnose:
             self._fail(
                 code,
                 diagnosis="Unable to determine Postgres version: SHOW SERVER_VERSION returned no rows.",
-                category=CATEGORY_POSTGRES,
+                category=self._category,
             )
             return
         raw_version = row[0]
@@ -248,7 +246,7 @@ class PostgresDiagnose:
             self._fail(
                 code,
                 diagnosis="Unable to parse Postgres version {!r}: {}".format(raw_version, e),
-                category=CATEGORY_POSTGRES,
+                category=self._category,
                 rawerror=str(e),
             )
             return
@@ -256,7 +254,7 @@ class PostgresDiagnose:
             self._fail(
                 code,
                 diagnosis="Postgres version {} is below the minimum supported version (9.6).".format(raw_version),
-                category=CATEGORY_POSTGRES,
+                category=self._category,
                 description=DIAGNOSTIC_METADATA[code]["description"],
                 remediation=build_remediation(code),
             )
@@ -264,7 +262,7 @@ class PostgresDiagnose:
         self._check.diagnosis.success(
             name=code.value,
             diagnosis="Postgres version {} is supported.".format(raw_version),
-            category=CATEGORY_POSTGRES,
+            category=self._category,
         )
 
     def _diagnose_shared_preload_libraries(self, conn):
@@ -281,7 +279,7 @@ class PostgresDiagnose:
                     "pg_monitor members. Grant pg_monitor to the datadog user so this "
                     "diagnostic can run."
                 ),
-                category=CATEGORY_POSTGRES,
+                category=self._category,
                 description=DIAGNOSTIC_METADATA[code]["description"],
                 remediation=build_remediation(DatabaseConfigurationError.missing_pg_monitor_role),
             )
@@ -290,7 +288,7 @@ class PostgresDiagnose:
             self._check.diagnosis.success(
                 name=code.value,
                 diagnosis="shared_preload_libraries contains pg_stat_statements.",
-                category=CATEGORY_POSTGRES,
+                category=self._category,
             )
             return
         self._fail(
@@ -299,7 +297,7 @@ class PostgresDiagnose:
                 "shared_preload_libraries = '{}' does not contain pg_stat_statements; DBM query metrics "
                 "will not be collected until the server is restarted with it loaded."
             ).format(libs),
-            category=CATEGORY_POSTGRES,
+            category=self._category,
             description=DIAGNOSTIC_METADATA[code]["description"],
             remediation=build_remediation(code),
         )
@@ -317,7 +315,7 @@ class PostgresDiagnose:
             self._check.diagnosis.success(
                 name=code.value,
                 diagnosis="track_activity_query_size = {} (>= {}).".format(size, RECOMMENDED_TRACK_ACTIVITY_QUERY_SIZE),
-                category=CATEGORY_POSTGRES,
+                category=self._category,
             )
             return
         self._check.diagnosis.warning(
@@ -326,7 +324,7 @@ class PostgresDiagnose:
                 "track_activity_query_size = {} is below the recommended {}; long queries will be "
                 "truncated and may not be explainable."
             ).format(size, RECOMMENDED_TRACK_ACTIVITY_QUERY_SIZE),
-            category=CATEGORY_POSTGRES,
+            category=self._category,
             description=DIAGNOSTIC_METADATA[code]["description"],
             remediation=build_remediation(code),
         )
@@ -340,13 +338,13 @@ class PostgresDiagnose:
             self._check.diagnosis.success(
                 name=code.value,
                 diagnosis="track_io_timing is on.",
-                category=CATEGORY_POSTGRES,
+                category=self._category,
             )
             return
         self._check.diagnosis.warning(
             name=code.value,
             diagnosis="track_io_timing = {}; I/O timing columns will not be collected.".format(raw),
-            category=CATEGORY_POSTGRES,
+            category=self._category,
             description=DIAGNOSTIC_METADATA[code]["description"],
             remediation=build_remediation(code),
         )
@@ -367,7 +365,7 @@ class PostgresDiagnose:
             self._check.diagnosis.success(
                 name=code.value,
                 diagnosis="pg_stat_statements.max = {} (<= threshold {}).".format(value, threshold),
-                category=CATEGORY_POSTGRES,
+                category=self._category,
             )
             return
         self._check.diagnosis.warning(
@@ -375,7 +373,7 @@ class PostgresDiagnose:
             diagnosis=(
                 "pg_stat_statements.max = {} exceeds the threshold of {}; the collection query may run slowly."
             ).format(value, threshold),
-            category=CATEGORY_POSTGRES,
+            category=self._category,
             description=DIAGNOSTIC_METADATA[code]["description"],
             remediation=build_remediation(code),
         )
@@ -391,7 +389,7 @@ class PostgresDiagnose:
             self._fail(
                 code,
                 diagnosis="Unable to check pg_monitor role membership: {}".format(e),
-                category=CATEGORY_POSTGRES,
+                category=self._category,
                 description=DIAGNOSTIC_METADATA[code]["description"],
                 remediation=build_remediation(code),
                 rawerror=str(e),
@@ -408,7 +406,7 @@ class PostgresDiagnose:
             self._fail(
                 code,
                 diagnosis="Unable to check pg_monitor role membership: {}".format(e),
-                category=CATEGORY_POSTGRES,
+                category=self._category,
                 description=DIAGNOSTIC_METADATA[code]["description"],
                 remediation=build_remediation(code),
                 rawerror=str(e),
@@ -418,13 +416,13 @@ class PostgresDiagnose:
             self._check.diagnosis.success(
                 name=code.value,
                 diagnosis="Current user is a member of pg_monitor.",
-                category=CATEGORY_POSTGRES,
+                category=self._category,
             )
             return
         self._fail(
             code,
             diagnosis=("The datadog user is not a member of pg_monitor; other users' activity rows will be masked."),
-            category=CATEGORY_POSTGRES,
+            category=self._category,
             description=DIAGNOSTIC_METADATA[code]["description"],
             remediation=build_remediation(code),
         )
@@ -446,7 +444,7 @@ class PostgresDiagnose:
             self._fail(
                 DatabaseConfigurationError.undefined_activity_view,
                 diagnosis="Unable to query {}: {}".format(view, e),
-                category=CATEGORY_POSTGRES,
+                category=self._category,
                 description=DIAGNOSTIC_METADATA[DatabaseConfigurationError.undefined_activity_view]["description"],
                 remediation=build_remediation(DatabaseConfigurationError.undefined_activity_view),
                 rawerror=str(e),
@@ -459,7 +457,7 @@ class PostgresDiagnose:
                     "{} rows in {} are masked as '<insufficient privilege>'; activity samples will miss "
                     "other users' queries."
                 ).format(masked, view),
-                category=CATEGORY_POSTGRES,
+                category=self._category,
                 description=DIAGNOSTIC_METADATA[code]["description"],
                 remediation=build_remediation(code),
             )
@@ -467,7 +465,7 @@ class PostgresDiagnose:
         self._check.diagnosis.success(
             name=code.value,
             diagnosis="{} is readable with full query visibility.".format(view),
-            category=CATEGORY_POSTGRES,
+            category=self._category,
         )
 
     def _diagnose_pg_stat_database_access(self, conn):
@@ -487,7 +485,7 @@ class PostgresDiagnose:
             self._fail(
                 code,
                 diagnosis="Unable to SELECT from pg_stat_database: {}".format(e),
-                category=CATEGORY_POSTGRES,
+                category=self._category,
                 description=DIAGNOSTIC_METADATA[code]["description"],
                 remediation=build_remediation(code),
                 rawerror=str(e),
@@ -496,7 +494,7 @@ class PostgresDiagnose:
         self._check.diagnosis.success(
             name=code.value,
             diagnosis="pg_stat_database is readable.",
-            category=CATEGORY_POSTGRES,
+            category=self._category,
         )
 
     def _diagnose_datadog_schema(self, conn, dbname=None, failed=None):
@@ -514,13 +512,13 @@ class PostgresDiagnose:
             self._check.diagnosis.success(
                 name=code.value,
                 diagnosis="`datadog` schema exists in {}.".format(dbname),
-                category=CATEGORY_POSTGRES,
+                category=self._category,
             )
             return
         self._fail(
             code,
             diagnosis="`datadog` schema is missing in {}; DBM setup is incomplete.".format(dbname),
-            category=CATEGORY_POSTGRES,
+            category=self._category,
             description=DIAGNOSTIC_METADATA[code]["description"],
             remediation=build_remediation(code),
             failed_codes=failed,
@@ -557,13 +555,13 @@ class PostgresDiagnose:
             self._check.diagnosis.success(
                 name=code.value,
                 diagnosis="datadog has USAGE on schema `{}` in {}.".format(schema, dbname),
-                category=CATEGORY_POSTGRES,
+                category=self._category,
             )
             return
         self._fail(
             code,
             diagnosis="datadog is missing USAGE on schema `{}` in {}.".format(schema, dbname),
-            category=CATEGORY_POSTGRES,
+            category=self._category,
             description=build_description(code, schema=schema),
             remediation=build_remediation(code, schema=schema),
             failed_codes=failed,
@@ -585,13 +583,13 @@ class PostgresDiagnose:
             self._check.diagnosis.success(
                 name=created.value,
                 diagnosis="pg_stat_statements extension is installed in schema `{}` in {}.".format(row, dbname),
-                category=CATEGORY_POSTGRES,
+                category=self._category,
             )
             return
         self._fail(
             created,
             diagnosis="pg_stat_statements extension is not installed in {}.".format(dbname),
-            category=CATEGORY_POSTGRES,
+            category=self._category,
             description=build_description(created, dbname=dbname),
             remediation=build_remediation(created, dbname=dbname),
             failed_codes=failed,
@@ -632,7 +630,7 @@ class PostgresDiagnose:
             self._fail(
                 code,
                 diagnosis=diagnosis,
-                category=CATEGORY_POSTGRES,
+                category=self._category,
                 description=DIAGNOSTIC_METADATA[code]["description"],
                 remediation=remediation,
                 rawerror=str(e),
@@ -642,7 +640,7 @@ class PostgresDiagnose:
         self._check.diagnosis.success(
             name=code.value,
             diagnosis="{} is readable in {}.".format(view, dbname),
-            category=CATEGORY_POSTGRES,
+            category=self._category,
         )
 
     def _diagnose_explain_function(self, conn, dbname=None, failed=None):
@@ -675,7 +673,7 @@ class PostgresDiagnose:
                 diagnosis="{} cannot be executed in {}; execution plans cannot be collected: {}".format(
                     explain_function, dbname, e
                 ),
-                category=CATEGORY_POSTGRES,
+                category=self._category,
                 description=build_description(code, explain_function=explain_function),
                 remediation=build_remediation(code, explain_function=explain_function),
                 rawerror=str(e),
@@ -687,7 +685,7 @@ class PostgresDiagnose:
             self._check.diagnosis.success(
                 name=code.value,
                 diagnosis="{} executed successfully in {}.".format(explain_function, dbname),
-                category=CATEGORY_POSTGRES,
+                category=self._category,
             )
             return
         self._fail(
@@ -695,7 +693,7 @@ class PostgresDiagnose:
             diagnosis="{} did not return an execution plan in {}; execution plans cannot be collected.".format(
                 explain_function, dbname
             ),
-            category=CATEGORY_POSTGRES,
+            category=self._category,
             description=build_description(code, explain_function=explain_function),
             remediation=build_remediation(code, explain_function=explain_function),
             failed_codes=failed,
@@ -716,7 +714,7 @@ class PostgresDiagnose:
             self._check.diagnosis.warning(
                 name=code.value,
                 diagnosis="Postgres config validation did not complete (check initialization failed).",
-                category=CATEGORY_POSTGRES,
+                category=self._category,
             )
             return
 
@@ -729,7 +727,7 @@ class PostgresDiagnose:
             self._check.diagnosis.success(
                 name=code.value,
                 diagnosis=diagnosis_line,
-                category=CATEGORY_POSTGRES,
+                category=self._category,
             )
             return
 
@@ -756,12 +754,19 @@ class PostgresDiagnose:
         method(
             name=code.value,
             diagnosis=diagnosis_line,
-            category=CATEGORY_POSTGRES,
+            category=self._category,
             description=description,
             remediation=remediation,
         )
 
     # -- helpers --------------------------------------------------------------
+
+    @property
+    def _category(self) -> str:
+        host = self._host_desc()
+        if len(host) > 27:
+            host = f"{host[:12]}...{host[-12:]}"
+        return f"postgres:{host}"
 
     def _host_desc(self):
         host = self._check._config.host or "localhost"

--- a/postgres/datadog_checks/postgres/diagnose.py
+++ b/postgres/datadog_checks/postgres/diagnose.py
@@ -766,7 +766,7 @@ class PostgresDiagnose:
         host = self._host_desc()
         if len(host) > 27:
             host = f"{host[:12]}...{host[-12:]}"
-        return f"postgres:{host}"
+        return f"instance={host}"
 
     def _host_desc(self):
         host = self._check._config.host or "localhost"

--- a/postgres/datadog_checks/postgres/diagnose.py
+++ b/postgres/datadog_checks/postgres/diagnose.py
@@ -763,10 +763,10 @@ class PostgresDiagnose:
 
     @property
     def _category(self) -> str:
-        host = self._host_desc()
-        if len(host) > 27:
-            host = f"{host[:12]}...{host[-12:]}"
-        return f"instance={host}"
+        identifier = self._check.database_identifier
+        if len(identifier) > 27:
+            identifier = f"{identifier[:12]}...{identifier[-12:]}"
+        return f"instance={identifier}"
 
     def _host_desc(self):
         host = self._check._config.host or "localhost"


### PR DESCRIPTION
## Summary

- `diagnose.py` used a module-level constant `CATEGORY_POSTGRES = "postgres"` for all diagnostic results. With multiple postgres instances configured, every instance's diagnostics appeared under the same category, making it impossible to tell which instance a diagnostic belongs to.
- Replaced the constant with a `_category` property that returns `instance={database_identifier}` — the canonical, templated identifier already used in metadata, health events, and statement payloads — so the diagnose category matches what's surfaced in the UI and other logs/debug channels.
- `database_identifier` resolves a Template over `_config` and `tags`, which can blow up on a broken config — precisely the state diagnose is meant to surface. Wrapped in `try/except` with a `host:port` fallback so the category is always populated.
- Long identifiers are truncated to 27 chars max: `first12...last12`.

## Test plan

- [ ] `ddev --no-interactive test postgres -- -k test_diagnose` — all 63 diagnose tests pass
- [ ] Manual: configure two postgres instances with different hosts, run `datadog-agent diagnose` and verify each instance's results appear under their own `instance=<database_identifier>` category

🤖 Generated with [Claude Code](https://claude.com/claude-code)