### PR TITLE
Enable schema collection for Postgres by default

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -953,7 +953,7 @@ files:
             Enable collection of database schemas. Requires `dbm: true`.
           value:
             type: boolean
-            example: false
+            example: true
         - name: max_tables
           fleet_configurable: true
           description: |

--- a/postgres/changelog.d/23626.added
+++ b/postgres/changelog.d/23626.added
@@ -1,1 +1,1 @@
-Enable schema collection for Postgres by default. This functionality still requires `dbm:true`. To disable, set `collect_schemas.enabled: false`.
+Enable schema collection for Postgres by default. This functionality still requires `dbm:true` or `data_observability.enabled:true`. To disable, set `collect_schemas.enabled: false`.

--- a/postgres/changelog.d/23626.added
+++ b/postgres/changelog.d/23626.added
@@ -1,0 +1,1 @@
+Enable schema collection for Postgres by default. This functionality still requires `dbm:true`. To disable, set `collect_schemas.enabled: false`.

--- a/postgres/datadog_checks/postgres/config_models/dict_defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/dict_defaults.py
@@ -86,7 +86,7 @@ def instance_collect_settings():
 
 def instance_collect_schemas():
     return instance.CollectSchemas(
-        enabled=False,
+        enabled=True,
         max_tables=300,
         max_columns=50,
         collection_interval=600,

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -593,10 +593,10 @@ instances:
     #
     # collect_schemas:
 
-        ## @param enabled - boolean - optional - default: false
+        ## @param enabled - boolean - optional - default: true
         ## Enable collection of database schemas. Requires `dbm: true`.
         #
-        # enabled: false
+        # enabled: true
 
         ## @param max_tables - number - optional - default: 300
         ## Maximum amount of tables the Agent collects from the instance.

--- a/postgres/tests/test_config_defaults.py
+++ b/postgres/tests/test_config_defaults.py
@@ -115,7 +115,7 @@ EXPECTED_DEFAULTS = {
     },
     # === DBM: Schema collection ===
     'collect_schemas': {
-        'enabled': False,
+        'enabled': True,
         'max_tables': 300,
         'max_columns': 50,
         'collection_interval': 600,

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -2127,6 +2127,7 @@ def test_samples_encoding(
     dbm_instance,
 ):
     dbm_instance['query_metrics']['enabled'] = False
+    dbm_instance['collect_schemas'] = {'enabled': False}
     if POSTGRES_LOCALE == 'C':
         dbm_instance['query_encodings'] = ['latin1', 'utf-8']
     check = integration_check(dbm_instance)

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -486,7 +486,7 @@ def test_successful_explain(
     dbm_instance['query_metrics']['enabled'] = False
     dbm_instance['query_samples']['explain_parameterized_queries'] = False
     dbm_instance['collect_schemas'] = {'enabled': False}
-    
+
     check = integration_check(dbm_instance)
     check._connect()
 

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1363,6 +1363,7 @@ def test_statement_run_explain_errors(
     dbm_instance['query_activity']['enabled'] = False
     dbm_instance['query_metrics']['enabled'] = False
     dbm_instance['query_samples']['explain_parameterized_queries'] = False
+    dbm_instance['collect_schemas'] = {'enabled': False}
     check = integration_check(dbm_instance)
     check._connect()
 

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -920,6 +920,7 @@ def test_statement_reported_hostname(
     expected_hostname,
 ):
     dbm_instance['reported_hostname'] = reported_hostname
+    dbm_instance['collect_schemas'] = {'enabled': False}
 
     check = integration_check(dbm_instance)
 

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1416,6 +1416,7 @@ def test_statement_run_explain_parameterized_queries(
     dbm_instance['query_activity']['enabled'] = False
     dbm_instance['query_metrics']['enabled'] = False
     dbm_instance['query_samples']['explain_parameterized_queries'] = True
+    dbm_instance['collect_schemas'] = {'enabled': False}
     check = integration_check(dbm_instance)
     check._connect()
 

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -89,6 +89,7 @@ def test_statement_metrics_multiple_pgss_rows_single_query_signature(
     # don't need samples for this test
     dbm_instance['query_samples'] = {'enabled': False}
     dbm_instance['query_activity'] = {'enabled': False}
+    dbm_instance['collect_schemas'] = {'enabled': False}
     dbm_instance['query_metrics']['incremental_query_metrics'] = True
     connections = {}
 
@@ -232,6 +233,7 @@ def test_statement_metrics(
     # don't need samples for this test
     dbm_instance['query_samples'] = {'enabled': False}
     dbm_instance['query_activity'] = {'enabled': False}
+    dbm_instance['collect_schemas'] = {'enabled': False}
     connections = {}
 
     def _run_queries():
@@ -339,6 +341,7 @@ def test_wal_metrics(aggregator, integration_check, dbm_instance):
     # don't need samples for this test
     dbm_instance['query_samples'] = {'enabled': False}
     dbm_instance['query_activity'] = {'enabled': False}
+    dbm_instance['collect_schemas'] = {'enabled': False}
 
     connections = {}
 
@@ -372,6 +375,7 @@ def test_statement_metrics_with_duplicates(aggregator, integration_check, dbm_in
     # don't need samples for this test
     dbm_instance['query_samples'] = {'enabled': False}
     dbm_instance['query_activity'] = {'enabled': False}
+    dbm_instance['collect_schemas'] = {'enabled': False}
 
     # The query signature matches the normalized query returned by the mock agent and would need to be
     # updated if the normalized query is updated
@@ -1988,6 +1992,7 @@ def test_plan_time_metrics(aggregator, integration_check, dbm_instance):
     # don't need samples for this test
     dbm_instance['query_samples'] = {'enabled': False}
     dbm_instance['query_activity'] = {'enabled': False}
+    dbm_instance['collect_schemas'] = {'enabled': False}
 
     connections = {}
 
@@ -2079,6 +2084,7 @@ def test_metrics_encoding(
         dbm_instance['query_encodings'] = ['latin1', 'utf-8']
     dbm_instance['query_samples'] = {'enabled': False}
     dbm_instance['query_activity'] = {'enabled': False}
+    dbm_instance['collect_schemas'] = {'enabled': False}
     # dbm_instance['query_activity']['enabled'] = False
     check = integration_check(dbm_instance)
     check._connect()

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -485,6 +485,8 @@ def test_successful_explain(
     # Don't need metrics for this one
     dbm_instance['query_metrics']['enabled'] = False
     dbm_instance['query_samples']['explain_parameterized_queries'] = False
+    dbm_instance['collect_schemas'] = {'enabled': False}
+    
     check = integration_check(dbm_instance)
     check._connect()
 
@@ -719,6 +721,7 @@ def test_statement_samples_collect(
 ):
     dbm_instance['pg_stat_activity_view'] = pg_stat_activity_view
     dbm_instance['query_metrics']['enabled'] = False
+    dbm_instance['collect_schemas'] = {'enabled': False}
     dbm_instance['dbstrict'] = dbstrict
     dbm_instance['dbname'] = dbname
     dbm_instance['ignore_databases'] = ignore_databases
@@ -834,6 +837,7 @@ def test_statement_metadata(
     """Tests for metadata in both samples and metrics"""
     dbm_instance['pg_stat_statements_view'] = pg_stat_statements_view
     dbm_instance['query_metrics']['run_sync'] = True
+    dbm_instance['collect_schemas'] = {'enabled': False}
 
     # If query or normalized_query changes, the query_signatures for both will need to be updated as well.
     query = '''

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -569,6 +569,7 @@ def test_failed_explain_handling(
     # Don't need metrics for this one
     dbm_instance['query_metrics']['enabled'] = False
     dbm_instance['query_samples']['explain_parameterized_queries'] = False
+    dbm_instance['collect_schemas'] = {'enabled': False}
     if explain_function_override:
         dbm_instance['query_samples']['explain_function'] = explain_function_override
     check = integration_check(dbm_instance)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Sets schema collection to default to true for Postgres. Schema collection still requires `dbm:true` or `data_observability.enabled:true` and can be disabled with `collect_schemas.enabled: false`.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
