### PR TITLE
Update docker_run health wait default

### DIFF
--- a/cassandra_nodetool/tests/conftest.py
+++ b/cassandra_nodetool/tests/conftest.py
@@ -50,14 +50,14 @@ def dd_environment():
         compose_file,
         build=True,
         service_name=common.CASSANDRA_CONTAINER_NAME,
-        waith_for_health=True,
+        wait_for_health=True,
     ):
         cassandra_seed = get_container_ip("{}".format(common.CASSANDRA_CONTAINER_NAME))
         env['CASSANDRA_SEEDS'] = cassandra_seed
         with docker_run(
             compose_file,
             service_name=common.CASSANDRA_CONTAINER_NAME_2,
-            waith_for_health=True,
+            wait_for_health=True,
             conditions=[WaitFor(create_keyspace, attempts=10, wait=10)],
         ):
             yield common.CONFIG_INSTANCE, E2E_METADATA

--- a/datadog_checks_dev/changelog.d/23436.changed
+++ b/datadog_checks_dev/changelog.d/23436.changed
@@ -1,1 +1,0 @@
-Make docker_run wait for Docker Compose service health by default.

--- a/datadog_checks_dev/changelog.d/23436.changed
+++ b/datadog_checks_dev/changelog.d/23436.changed
@@ -1,0 +1,1 @@
+Make docker_run wait for Docker Compose service health by default.

--- a/datadog_checks_dev/changelog.d/23628.changed
+++ b/datadog_checks_dev/changelog.d/23628.changed
@@ -1,0 +1,1 @@
+Make docker_run wait for Docker Compose service health by default.

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -107,7 +107,7 @@ def shared_logs(example_log_configs, mount_whitelist=None):
 @contextmanager
 def docker_run(
     compose_file=None,
-    waith_for_health=False,
+    wait_for_health=True,
     build=False,
     service_name=None,
     up=None,
@@ -132,7 +132,7 @@ def docker_run(
         compose_file (str):
             A path to a Docker compose file. A custom tear
             down is not required when using this.
-        waith_for_health (bool):
+        wait_for_health (bool):
             Whether or not to wait for the health of the service to be healthy before yielding.
         build (bool):
             Whether or not to build images for when `compose_file` is provided
@@ -176,8 +176,7 @@ def docker_run(
         composeFileArgs = {'compose_file': compose_file, 'build': build, 'service_name': service_name}
         if capture is not None:
             composeFileArgs['capture'] = capture
-        if waith_for_health:
-            composeFileArgs['waith_for_health'] = waith_for_health
+        composeFileArgs['wait_for_health'] = wait_for_health
         set_up = ComposeFileUp(**composeFileArgs)
         if down is not None:
             tear_down = down
@@ -244,16 +243,16 @@ class ComposeFileUp(LazyFunction):
         build: bool = False,
         service_name: str | None = None,
         capture: str | None = None,
-        waith_for_health: bool = False,
+        wait_for_health: bool = True,
     ):
         self.compose_file = compose_file
         self.build = build
         self.service_name = service_name
         self.capture = capture
-        self.waith_for_health = waith_for_health
+        self.wait_for_health = wait_for_health
         self.command = ['docker', 'compose', '-f', self.compose_file, 'up', '-d', '--force-recreate']
 
-        if waith_for_health:
+        if wait_for_health:
             self.command.append('--wait')
 
         if self.build:

--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -8,7 +8,7 @@ import pytest
 import tenacity
 
 from datadog_checks.dev.ci import running_on_ci
-from datadog_checks.dev.docker import compose_file_active, docker_run
+from datadog_checks.dev.docker import ComposeFileUp, compose_file_active, docker_run
 from datadog_checks.dev.subprocess import run_command
 
 from .common import not_windows_ci
@@ -36,6 +36,33 @@ class TestComposeFileActive:
 
 
 class TestDockerRun:
+    def test_wait_for_health_default(self):
+        set_up = self.get_set_up()
+
+        assert '--wait' in set_up.command
+
+    def test_wait_for_health_explicit_disable(self):
+        set_up = self.get_set_up(wait_for_health=False)
+
+        assert '--wait' not in set_up.command
+
+    def test_wait_for_health_typo_rejected(self):
+        compose_file = os.path.join(DOCKER_DIR, 'test_default.yaml')
+
+        with pytest.raises(TypeError, match='unexpected keyword argument'):
+            with docker_run(compose_file, waith_for_health=False):
+                pass
+
+    def get_set_up(self, **kwargs):
+        compose_file = os.path.join(DOCKER_DIR, 'test_default.yaml')
+
+        with mock.patch('datadog_checks.dev.docker.environment_run') as environment_run:
+            environment_run.return_value.__enter__.return_value = None
+            with docker_run(compose_file, **kwargs):
+                pass
+
+        return environment_run.call_args[1]['up']
+
     @pytest.mark.parametrize(
         "capture",
         [
@@ -93,3 +120,25 @@ class TestDockerRun:
 
         with docker_run(up=up, down=mock.MagicMock(), attempts=3, conditions=[condition], attempts_wait=0):
             assert condition.call_count == 2
+
+
+class TestComposeFileUp:
+    def test_wait_for_health_default(self):
+        compose_file = os.path.join(DOCKER_DIR, 'test_default.yaml')
+
+        compose_file_up = ComposeFileUp(compose_file)
+
+        assert '--wait' in compose_file_up.command
+
+    def test_wait_for_health_explicit_disable(self):
+        compose_file = os.path.join(DOCKER_DIR, 'test_default.yaml')
+
+        compose_file_up = ComposeFileUp(compose_file, wait_for_health=False)
+
+        assert '--wait' not in compose_file_up.command
+
+    def test_wait_for_health_typo_rejected(self):
+        compose_file = os.path.join(DOCKER_DIR, 'test_default.yaml')
+
+        with pytest.raises(TypeError, match='unexpected keyword argument'):
+            ComposeFileUp(compose_file, waith_for_health=False)

--- a/envoy/tests/docker/api_v3/Dockerfile-service
+++ b/envoy/tests/docker/api_v3/Dockerfile-service
@@ -1,7 +1,7 @@
 FROM envoyproxy/envoy:v1.31.0
 RUN apt-get update && apt-get install -y python3 bash python3-pip
 RUN python3 --version && pip3 --version
-RUN pip3 install -q Flask==2.1.2 requests==2.28.1
+RUN pip3 install -q Flask==2.1.2 requests==2.28.1 'Werkzeug<3'
 RUN mkdir /code
 ADD ./service.py /code
 ADD ./start_service.sh /usr/local/bin/start_service.sh

--- a/envoy/tests/docker/api_v3/service-envoy.yaml
+++ b/envoy/tests/docker/api_v3/service-envoy.yaml
@@ -23,7 +23,9 @@ static_resources:
               - match: {prefix: "/service"}
                 route: {cluster: local_service}
           http_filters:
-          - name: envoy.router
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
   clusters:
   - name: local_service
     connect_timeout: 0.25s

--- a/harbor/tests/conftest.py
+++ b/harbor/tests/conftest.py
@@ -54,7 +54,7 @@ def dd_environment(e2e_instance):
     if os.environ.get('HARBOR_USE_SSL'):
         cert_dir = os.path.join(HERE, 'compose', 'common', 'cert')
         e2e_metadata['docker_volumes'] = ['{}:/home/harbor/tests/compose/common/cert'.format(cert_dir)]
-    with docker_run(compose_file, conditions=conditions, attempts=5, waith_for_health=True):
+    with docker_run(compose_file, conditions=conditions, attempts=5, wait_for_health=True):
         yield e2e_instance, e2e_metadata
 
 

--- a/http_check/tests/conftest.py
+++ b/http_check/tests/conftest.py
@@ -29,6 +29,7 @@ def dd_environment(mock_local_http_dns):
     with docker_run(
         os.path.join(HERE, 'compose', 'docker-compose.yml'),
         build=True,
+        wait_for_health=False,
         log_patterns=["start worker process"],
         conditions=[WaitFor(call_endpoint, args=("https://127.0.0.1",))],
     ):

--- a/kafka/tests/conftest.py
+++ b/kafka/tests/conftest.py
@@ -31,6 +31,6 @@ def dd_environment():
                 service="kafka",
             ),
         ],
-        waith_for_health=True,
+        wait_for_health=True,
     ):
         yield load_jmx_config(), {'use_jmx': True}

--- a/kong/tests/conftest.py
+++ b/kong/tests/conftest.py
@@ -17,7 +17,9 @@ def dd_environment():
     Start a kong cluster
     """
     with docker_run(
-        compose_file=os.path.join(common.HERE, 'compose', 'docker-compose.yml'), endpoints=common.STATUS_URL
+        compose_file=os.path.join(common.HERE, 'compose', 'docker-compose.yml'),
+        wait_for_health=False,
+        endpoints=common.STATUS_URL,
     ):
         yield common.openmetrics_instance
 

--- a/krakend/tests/docker/Dockerfile
+++ b/krakend/tests/docker/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY requirements.txt /app/requirements.txt
 COPY api.py /app/api.py
 
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 RUN pip install -r requirements.txt
 
 # Run the application

--- a/krakend/tests/docker/docker-compose.yml
+++ b/krakend/tests/docker/docker-compose.yml
@@ -25,9 +25,10 @@ services:
       - ./krakend.json:/etc/krakend/krakend.json:ro
     command: ["run", "-d", "-c", "/etc/krakend/krakend.json"]
     depends_on:
-      - api
+      api:
+        condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/__health"]
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/__health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/krakend/tests/lab/docker-compose.yml
+++ b/krakend/tests/lab/docker-compose.yml
@@ -25,11 +25,12 @@ services:
       - ../docker/krakend.json:/etc/krakend/krakend.json:ro
     command: ["run", "-d", "-c", "/etc/krakend/krakend.json"]
     depends_on:
-      - api
+      api:
+        condition: service_healthy
     labels:
       com.datadoghq.ad.checks: '{"krakend": {"instances": [{"openmetrics_endpoint": "http://localhost:9090/metrics"}], "logs": [{"source": "krakend", "service": "test-api", "type": "docker"}]}}'
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/__health"]
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/__health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/marathon/tests/compose/docker-compose.yml
+++ b/marathon/tests/compose/docker-compose.yml
@@ -35,7 +35,9 @@ services:
       - MESOS_WORK_DIR=/var/tmp/mesos
       - MESOS_MASTER=zk://zookeeper:2181/mesos
       - MESOS_SWITCH_USER=0
-      - MESOS_CONTAINERIZERS=docker,mesos
+      - MESOS_CONTAINERIZERS=mesos
+      - MESOS_LAUNCHER=posix
+      - MESOS_SYSTEMD_ENABLE_SUPPORT=false
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup
       - /var/run/docker.sock:/run/docker.sock

--- a/nifi/tests/docker/docker-compose.yaml
+++ b/nifi/tests/docker/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       SINGLE_USER_CREDENTIALS_USERNAME: admin
       SINGLE_USER_CREDENTIALS_PASSWORD: ctsBtRBKHRAx69EqUghvvgEvjnaLjFEB
     healthcheck:
-      test: ["CMD-SHELL", "curl -sk -o /dev/null -w '%{http_code}' https://localhost:8443/nifi-api/flow/about | grep -qv 000"]
+      test: ["CMD-SHELL", "curl -sk -o /dev/null -w '%{http_code}' https://$$(hostname):8443/nifi-api/flow/about | grep -qv 000"]
       interval: 10s
       timeout: 5s
       retries: 30

--- a/postgres/tests/compose/docker-compose-replication.yaml
+++ b/postgres/tests/compose/docker-compose-replication.yaml
@@ -9,6 +9,7 @@ services:
       test: ["CMD-SHELL", "pg_isready -U datadog -d datadog_test && if [[ ! -e /tmp/container_ready.txt ]]; then exit 1; fi"]
       interval: 1s
       timeout: 5s
+      start_period: 60s
       retries: 5
     networks:
       - pg-net
@@ -28,6 +29,7 @@ services:
       test: ["CMD-SHELL", "pg_isready -p 5433 -U datadog -d datadog_test && if [[ ! -e /tmp/container_ready.txt ]]; then exit 1; fi"]
       interval: 1s
       timeout: 5s
+      start_period: 60s
       retries: 5
     networks:
       - pg-net
@@ -47,6 +49,7 @@ services:
       test: ["CMD-SHELL", "pg_isready -p 5434 -U datadog -d datadog_test && if [[ ! -e /tmp/container_ready.txt ]]; then exit 1; fi"]
       interval: 1s
       timeout: 5s
+      start_period: 60s
       retries: 5
     networks:
       - pg-net
@@ -66,6 +69,7 @@ services:
       test: ["CMD-SHELL", "pg_isready -p 5435 -U datadog -d datadog_test && if [[ ! -e /tmp/container_ready.txt ]]; then exit 1; fi"]
       interval: 1s
       timeout: 5s
+      start_period: 60s
       retries: 5
     networks:
       - pg-net

--- a/postgres/tests/compose/docker-compose.yaml
+++ b/postgres/tests/compose/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
       test: ["CMD-SHELL", "pg_isready -U datadog -d datadog_test && if [[ ! -e /tmp/container_ready.txt ]]; then exit 1; fi"]
       interval: 1s
       timeout: 5s
+      start_period: 60s
       retries: 5
     volumes:
       - ./resources:/docker-entrypoint-initdb.d/

--- a/prefect/tests/conftest.py
+++ b/prefect/tests/conftest.py
@@ -60,7 +60,7 @@ def dd_environment(instance: Callable[[str], dict[str, str | dict[str, list[str]
         compose_file=str(COMPOSE_FILE_E2E),
         conditions=conditions,
         env_vars={"PREFECT_PORT": str(port)},
-        waith_for_health=True,
+        wait_for_health=True,
         mount_logs=True,
     ):
         yield (

--- a/tls/tests/conftest.py
+++ b/tls/tests/conftest.py
@@ -39,7 +39,9 @@ def clean_fips_environment():
 
 @pytest.fixture(scope='session')
 def dd_environment(instance_e2e, mock_local_tls_dns):
-    with docker_run(os.path.join(HERE, 'compose', 'docker-compose.yml'), build=True, sleep=20):
+    with docker_run(
+        os.path.join(HERE, 'compose', 'docker-compose.yml'), build=True, wait_for_health=False, sleep=20
+    ):
         e2e_metadata = {'docker_volumes': ['{}:{}'.format(CA_CERT, CA_CERT_MOUNT_PATH)]}
         yield instance_e2e, e2e_metadata
 

--- a/tls/tests/conftest.py
+++ b/tls/tests/conftest.py
@@ -39,9 +39,7 @@ def clean_fips_environment():
 
 @pytest.fixture(scope='session')
 def dd_environment(instance_e2e, mock_local_tls_dns):
-    with docker_run(
-        os.path.join(HERE, 'compose', 'docker-compose.yml'), build=True, wait_for_health=False, sleep=20
-    ):
+    with docker_run(os.path.join(HERE, 'compose', 'docker-compose.yml'), build=True, wait_for_health=False, sleep=20):
         e2e_metadata = {'docker_volumes': ['{}:{}'.format(CA_CERT, CA_CERT_MOUNT_PATH)]}
         yield instance_e2e, e2e_metadata
 

--- a/tls/tests/fips/docker-compose.yml
+++ b/tls/tests/fips/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - ./ca.key:/etc/ssl/private/server.key
     command: ["/usr/local/bin/start-server.sh", "ECDHE-RSA-AES128-SHA256"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "https://localhost:443"]
+      test: ["CMD-SHELL", "printf '' | timeout 5 openssl s_client -connect localhost:443 -brief"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -22,7 +22,7 @@ services:
       - ./ca.key:/etc/ssl/private/server.key
     command: ["/usr/local/bin/start-server.sh", "ECDHE-RSA-CHACHA20-POLY1305"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "https://localhost:443"]
+      test: ["CMD-SHELL", "printf '' | timeout 5 openssl s_client -connect localhost:443 -brief"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
### What does this PR do?
Updates `docker_run` and `ComposeFileUp` to use the correctly spelled `wait_for_health` argument and to wait for Docker Compose service health by default.

The misspelled `waith_for_health` keyword is removed, and in-repo callers that explicitly opted into health waiting were updated to use `wait_for_health`. Unit tests cover the new default, explicit opt-out, and rejection of the old typo.

This also fixes or documents the compose environments that CI showed were incompatible with Docker Compose `--wait`:

- `http_check` and non-FIPS `tls`: opt out with `wait_for_health=False` because their compose stacks include a successful one-shot `cert-builder` container.
- FIPS `tls`: replace `curl`-based container healthchecks with an `openssl s_client` probe so the checks use binaries already present in the Alpine-based test image and validate the TLS listener directly.
- `kong`: opt out with `wait_for_health=False` because its migration containers are expected to exit successfully before the long-running service is ready.
- `krakend`: install `curl` in the FastAPI test image, make the KrakenD service wait for the API service to become healthy, and use `wget` for the KrakenD container healthcheck because the upstream KrakenD image does not include `curl`.
- `envoy`: fix the API v3 service sidecar to use the v3 router filter config and pin Werkzeug to a Flask 2.1-compatible version so the backend service starts reliably.
- `nifi`: update the container-side healthcheck to target NiFi through the container hostname instead of `localhost`, matching how NiFi binds its HTTPS listener.
- `postgres`: add a startup grace period to the base and replication compose healthchecks so Docker does not mark containers unhealthy during expected init, restart, and replica bootstrap windows before `/tmp/container_ready.txt` is written.
- `marathon`: adjust the Mesos slave test container to avoid obsolete systemd/cgroup-v1 Docker containerizer assumptions while preserving the Marathon API test environment.

### Motivation
The previous `waith_for_health` keyword was misspelled and defaulted to `False`, so most compose-backed test environments skipped Docker Compose `--wait` unless they opted in manually.

Enabling health waiting by default makes compose-level failures visible before tests run. The follow-up integration changes either fix stale healthchecks/service setup or explicitly preserve the previous behavior where a compose stack intentionally contains one-shot containers.

### Validation

- `ddev --no-interactive test datadog_checks_dev -- -k docker`
- Targeted compose checks with `docker compose up -d --force-recreate --wait` for the affected KrakenD, Marathon, Postgres, and TLS FIPS stacks.
- Targeted integration checks for Marathon and Postgres after their compose changes.
- Draft PR CI has been used to identify and iterate on affected integrations.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)
