### PR TITLE
[fluentd] mark fluentd command as require_trusted_provider

### DIFF
--- a/fluentd/assets/configuration/spec.yaml
+++ b/fluentd/assets/configuration/spec.yaml
@@ -12,6 +12,7 @@ files:
       fleet_configurable: true
       value:
         type: string
+        require_trusted_provider: true
         example: fluentd
     - template: init_config/http
     - template: init_config/default
@@ -31,6 +32,7 @@ files:
       fleet_configurable: true
       value:
         type: string
+        require_trusted_provider: true
         example: fluentd
     - name: plugin_ids
       description: Enter your Plugin IDs to monitor a specific scope of plugins.

--- a/fluentd/changelog.d/23629.added
+++ b/fluentd/changelog.d/23629.added
@@ -1,0 +1,1 @@
+Add support for security validation in models

--- a/fluentd/changelog.d/23629.added
+++ b/fluentd/changelog.d/23629.added
@@ -1,1 +1,1 @@
-Add support for security validation in models
+Add support for security validation in models for the `fluentd` configuration option.

--- a/fluentd/datadog_checks/fluentd/config_models/instance.py
+++ b/fluentd/datadog_checks/fluentd/config_models/instance.py
@@ -22,7 +22,7 @@ from . import defaults, validators
 
 
 SECURE_FIELD_NAMES = frozenset(
-    ['auth_token', 'kerberos_cache', 'kerberos_keytab', 'tls_ca_cert', 'tls_cert', 'tls_private_key']
+    ['auth_token', 'fluentd', 'kerberos_cache', 'kerberos_keytab', 'tls_ca_cert', 'tls_cert', 'tls_private_key']
 )
 
 

--- a/fluentd/datadog_checks/fluentd/config_models/shared.py
+++ b/fluentd/datadog_checks/fluentd/config_models/shared.py
@@ -19,6 +19,9 @@ from datadog_checks.base.utils.models import validation
 from . import defaults, validators
 
 
+SECURE_FIELD_NAMES = frozenset(['fluentd'])
+
+
 class Proxy(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -51,6 +54,11 @@ class SharedConfig(BaseModel):
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
             value = getattr(validators, f'shared_{info.field_name}', identity)(value, field=field)
+
+            if info.field_name in SECURE_FIELD_NAMES:
+                validation.security.check_field_trusted_provider(
+                    info.field_name, value, info.context.get('security_config')
+                )
         else:
             value = getattr(defaults, f'shared_{info.field_name}', lambda: value)()
 


### PR DESCRIPTION
## Summary

Mark the `fluentd` config option (in both `init_config` and `instances`) as `require_trusted_provider: true`. Its value is executed as a shell command, so it must come from a trusted configuration provider. This integration was missed in the original rollout (#23109).