### PR TITLE
Add ddev validate to ddev tools

### DIFF
--- a/ddev/src/ddev/ai/tools/registry.py
+++ b/ddev/src/ddev/ai/tools/registry.py
@@ -70,6 +70,7 @@ TOOL_MANIFEST: dict[str, ToolSpec] = {
     "ddev_env_stop": ToolSpec("shell.ddev.env_stop", "DdevEnvStopTool"),
     "ddev_env_test": ToolSpec("shell.ddev.env_test", "DdevEnvTestTool"),
     "ddev_release_changelog": ToolSpec("shell.ddev.release_changelog", "DdevReleaseChangelogTool"),
+    "ddev_validate": ToolSpec("shell.ddev.validate", "DdevValidateTool"),
 }
 
 

--- a/ddev/src/ddev/ai/tools/shell/ddev/validate.py
+++ b/ddev/src/ddev/ai/tools/shell/ddev/validate.py
@@ -8,17 +8,18 @@ from pydantic import Field
 from ddev.ai.tools.core.base import BaseToolInput
 from ddev.ai.tools.shell.base import CmdTool
 
+ValidateSubcommand = Literal["config", "models", "metadata"]
+
 
 class DdevValidateInput(BaseToolInput):
     subcommand: Annotated[
-        Literal["config", "models", "metadata", "all"],
+        ValidateSubcommand,
         Field(
             description=(
                 "Which validator to run. "
                 "'config' validates assets/configuration/spec.yaml against data/conf.yaml.example. "
                 "'models' validates spec.yaml against datadog_checks/<integration>/config_models/. "
                 "'metadata' validates metadata.csv. "
-                "'all' runs the full orchestrator across every validator."
             )
         ),
     ]
@@ -28,30 +29,24 @@ class DdevValidateInput(BaseToolInput):
         Field(
             description=(
                 "Regenerate / auto-fix derived files instead of only checking. "
-                "For 'config' and 'models', regenerates conf.yaml.example and config_models/ from spec.yaml. "
+                "For 'config', regenerates conf.yaml.example. "
+                "For 'models', regenerates config_models/. "
                 "For 'metadata', rewrites metadata.csv into canonical form. "
-                "For 'all', forwards an auto-fix flag to every sub-validator that supports it."
             )
         ),
     ] = False
 
 
-# Maps the user-facing `sync` boolean to the actual CLI flag the underlying
-# `ddev validate <subcommand>` accepts.
-_SYNC_FLAG: dict[str, str] = {
+_SYNC_FLAG: dict[ValidateSubcommand, str] = {
     "config": "-s",
     "models": "-s",
     "metadata": "--sync",
-    "all": "--fix",
 }
 
 
 class DdevValidateTool(CmdTool[DdevValidateInput]):
-    """Validates an integration's spec, generated config example, generated
-    Pydantic config models, or metadata.csv. Set `sync=true` to regenerate the
-    derived files (conf.yaml.example, config_models/, metadata.csv) from the
-    spec, instead of only checking them. Always run with `sync=true` after
-    editing assets/configuration/spec.yaml so the generated files stay in sync."""
+    """Validates an integration's spec, config example, config models, or metadata.csv.
+    Set `sync=true` to regenerate the derived files from spec.yaml."""
 
     timeout = 120
 

--- a/ddev/src/ddev/ai/tools/shell/ddev/validate.py
+++ b/ddev/src/ddev/ai/tools/shell/ddev/validate.py
@@ -1,0 +1,67 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from typing import Annotated, Literal
+
+from pydantic import Field
+
+from ddev.ai.tools.core.base import BaseToolInput
+from ddev.ai.tools.shell.base import CmdTool
+
+
+class DdevValidateInput(BaseToolInput):
+    subcommand: Annotated[
+        Literal["config", "models", "metadata", "all"],
+        Field(
+            description=(
+                "Which validator to run. "
+                "'config' validates assets/configuration/spec.yaml against data/conf.yaml.example. "
+                "'models' validates spec.yaml against datadog_checks/<integration>/config_models/. "
+                "'metadata' validates metadata.csv. "
+                "'all' runs the full orchestrator across every validator."
+            )
+        ),
+    ]
+    integration: Annotated[str, Field(description="Integration name to validate")]
+    sync: Annotated[
+        bool,
+        Field(
+            description=(
+                "Regenerate / auto-fix derived files instead of only checking. "
+                "For 'config' and 'models', regenerates conf.yaml.example and config_models/ from spec.yaml. "
+                "For 'metadata', rewrites metadata.csv into canonical form. "
+                "For 'all', forwards an auto-fix flag to every sub-validator that supports it."
+            )
+        ),
+    ] = False
+
+
+# Maps the user-facing `sync` boolean to the actual CLI flag the underlying
+# `ddev validate <subcommand>` accepts.
+_SYNC_FLAG: dict[str, str] = {
+    "config": "-s",
+    "models": "-s",
+    "metadata": "--sync",
+    "all": "--fix",
+}
+
+
+class DdevValidateTool(CmdTool[DdevValidateInput]):
+    """Validates an integration's spec, generated config example, generated
+    Pydantic config models, or metadata.csv. Set `sync=true` to regenerate the
+    derived files (conf.yaml.example, config_models/, metadata.csv) from the
+    spec, instead of only checking them. Always run with `sync=true` after
+    editing assets/configuration/spec.yaml so the generated files stay in sync."""
+
+    timeout = 120
+
+    @property
+    def name(self) -> str:
+        return "ddev_validate"
+
+    def cmd(self, tool_input: DdevValidateInput) -> list[str]:
+        cmd = ["ddev", "--no-interactive", "validate", tool_input.subcommand]
+        if tool_input.sync:
+            cmd.append(_SYNC_FLAG[tool_input.subcommand])
+        cmd.append(tool_input.integration)
+        return cmd

--- a/ddev/src/ddev/ai/tools/shell/ddev/validate.py
+++ b/ddev/src/ddev/ai/tools/shell/ddev/validate.py
@@ -8,7 +8,7 @@ from pydantic import Field
 from ddev.ai.tools.core.base import BaseToolInput
 from ddev.ai.tools.shell.base import CmdTool
 
-ValidateSubcommand = Literal["config", "models", "metadata"]
+ValidateSubcommand = Literal["config", "models", "metadata", "all"]
 
 
 class DdevValidateInput(BaseToolInput):
@@ -16,10 +16,15 @@ class DdevValidateInput(BaseToolInput):
         ValidateSubcommand,
         Field(
             description=(
-                "Which validator to run. "
-                "'config' validates assets/configuration/spec.yaml against data/conf.yaml.example. "
-                "'models' validates spec.yaml against datadog_checks/<integration>/config_models/. "
-                "'metadata' validates metadata.csv. "
+                "Which validator to run. Options:"
+                "- 'config': validates assets/configuration/spec.yaml against data/conf.yaml.example. "
+                "- 'models': validates spec.yaml against datadog_checks/<integration>/config_models/. "
+                "- 'metadata': validates metadata.csv. "
+                "- 'all': runs all ~20 validators in parallel. Some of these always scan the entire "
+                "repository, so the output may include failures for files outside of <integration>. "
+                "IGNORE those unrelated failures — only act on failures that reference files inside "
+                "your integration's directory.  It might take a long time to run. Use 'all' only as "
+                "a final sweep to catch issues the targeted validators do not cover."
             )
         ),
     ]
@@ -32,6 +37,7 @@ class DdevValidateInput(BaseToolInput):
                 "For 'config', regenerates conf.yaml.example. "
                 "For 'models', regenerates config_models/. "
                 "For 'metadata', rewrites metadata.csv into canonical form. "
+                "For 'all', auto-fixes every validator that supports it."
             )
         ),
     ] = False
@@ -41,7 +47,7 @@ class DdevValidateTool(CmdTool[DdevValidateInput]):
     """Validates an integration's spec, config example, config models, or metadata.csv.
     Set `sync=true` to regenerate the derived files from spec.yaml."""
 
-    timeout = 120
+    timeout = 660
 
     @property
     def name(self) -> str:
@@ -50,6 +56,6 @@ class DdevValidateTool(CmdTool[DdevValidateInput]):
     def cmd(self, tool_input: DdevValidateInput) -> list[str]:
         cmd = ["ddev", "--no-interactive", "validate", tool_input.subcommand]
         if tool_input.sync:
-            cmd.append("--sync")
+            cmd.append("--fix" if tool_input.subcommand == "all" else "--sync")
         cmd.append(tool_input.integration)
         return cmd

--- a/ddev/src/ddev/ai/tools/shell/ddev/validate.py
+++ b/ddev/src/ddev/ai/tools/shell/ddev/validate.py
@@ -37,13 +37,6 @@ class DdevValidateInput(BaseToolInput):
     ] = False
 
 
-_SYNC_FLAG: dict[ValidateSubcommand, str] = {
-    "config": "-s",
-    "models": "-s",
-    "metadata": "--sync",
-}
-
-
 class DdevValidateTool(CmdTool[DdevValidateInput]):
     """Validates an integration's spec, config example, config models, or metadata.csv.
     Set `sync=true` to regenerate the derived files from spec.yaml."""
@@ -57,6 +50,6 @@ class DdevValidateTool(CmdTool[DdevValidateInput]):
     def cmd(self, tool_input: DdevValidateInput) -> list[str]:
         cmd = ["ddev", "--no-interactive", "validate", tool_input.subcommand]
         if tool_input.sync:
-            cmd.append(_SYNC_FLAG[tool_input.subcommand])
+            cmd.append("--sync")
         cmd.append(tool_input.integration)
         return cmd

--- a/ddev/tests/ai/tools/shell/ddev/test_ddev_tools.py
+++ b/ddev/tests/ai/tools/shell/ddev/test_ddev_tools.py
@@ -169,7 +169,7 @@ def test_release_changelog_invalid_change_type_raises():
 # --- ddev validate ---
 
 
-@pytest.mark.parametrize("subcommand", ["config", "models", "metadata", "all"])
+@pytest.mark.parametrize("subcommand", ["config", "models", "metadata"])
 def test_validate_cmd_all_subcommands(subcommand: str):
     cmd = DdevValidateTool().cmd(DdevValidateInput(subcommand=subcommand, integration="mycheck"))
     assert cmd == ["ddev", "--no-interactive", "validate", subcommand, "mycheck"]
@@ -181,9 +181,13 @@ def test_validate_cmd_all_subcommands(subcommand: str):
         ("config", "-s"),
         ("models", "-s"),
         ("metadata", "--sync"),
-        ("all", "--fix"),
     ],
 )
 def test_validate_cmd_sync_flag_per_subcommand(subcommand: str, expected_flag: str):
     cmd = DdevValidateTool().cmd(DdevValidateInput(subcommand=subcommand, integration="mycheck", sync=True))
-    assert cmd[4] == expected_flag
+    assert cmd == ["ddev", "--no-interactive", "validate", subcommand, expected_flag, "mycheck"]
+
+
+def test_validate_invalid_subcommand_raises():
+    with pytest.raises(ValidationError):
+        DdevValidateInput(subcommand="lint", integration="mycheck")

--- a/ddev/tests/ai/tools/shell/ddev/test_ddev_tools.py
+++ b/ddev/tests/ai/tools/shell/ddev/test_ddev_tools.py
@@ -175,17 +175,10 @@ def test_validate_cmd_all_subcommands(subcommand: str):
     assert cmd == ["ddev", "--no-interactive", "validate", subcommand, "mycheck"]
 
 
-@pytest.mark.parametrize(
-    "subcommand,expected_flag",
-    [
-        ("config", "-s"),
-        ("models", "-s"),
-        ("metadata", "--sync"),
-    ],
-)
-def test_validate_cmd_sync_flag_per_subcommand(subcommand: str, expected_flag: str):
+@pytest.mark.parametrize("subcommand", ["config", "models", "metadata"])
+def test_validate_cmd_sync_flag_per_subcommand(subcommand: str):
     cmd = DdevValidateTool().cmd(DdevValidateInput(subcommand=subcommand, integration="mycheck", sync=True))
-    assert cmd == ["ddev", "--no-interactive", "validate", subcommand, expected_flag, "mycheck"]
+    assert cmd == ["ddev", "--no-interactive", "validate", subcommand, "--sync", "mycheck"]
 
 
 def test_validate_invalid_subcommand_raises():

--- a/ddev/tests/ai/tools/shell/ddev/test_ddev_tools.py
+++ b/ddev/tests/ai/tools/shell/ddev/test_ddev_tools.py
@@ -11,6 +11,7 @@ from ddev.ai.tools.shell.ddev.env_start import DdevEnvStartTool, EnvStartInput
 from ddev.ai.tools.shell.ddev.env_stop import DdevEnvStopTool, EnvStopInput
 from ddev.ai.tools.shell.ddev.env_test import DdevEnvTestTool, EnvTestInput
 from ddev.ai.tools.shell.ddev.release_changelog import DdevReleaseChangelogTool, ReleaseChangelogInput
+from ddev.ai.tools.shell.ddev.validate import DdevValidateInput, DdevValidateTool
 
 # --- ddev create ---
 
@@ -163,3 +164,26 @@ def test_release_changelog_cmd_message_placement():
 def test_release_changelog_invalid_change_type_raises():
     with pytest.raises(ValidationError):
         ReleaseChangelogInput(change_type="patch", integration="mycheck", message="Some message")
+
+
+# --- ddev validate ---
+
+
+@pytest.mark.parametrize("subcommand", ["config", "models", "metadata", "all"])
+def test_validate_cmd_all_subcommands(subcommand: str):
+    cmd = DdevValidateTool().cmd(DdevValidateInput(subcommand=subcommand, integration="mycheck"))
+    assert cmd == ["ddev", "--no-interactive", "validate", subcommand, "mycheck"]
+
+
+@pytest.mark.parametrize(
+    "subcommand,expected_flag",
+    [
+        ("config", "-s"),
+        ("models", "-s"),
+        ("metadata", "--sync"),
+        ("all", "--fix"),
+    ],
+)
+def test_validate_cmd_sync_flag_per_subcommand(subcommand: str, expected_flag: str):
+    cmd = DdevValidateTool().cmd(DdevValidateInput(subcommand=subcommand, integration="mycheck", sync=True))
+    assert cmd[4] == expected_flag

--- a/ddev/tests/ai/tools/shell/ddev/test_ddev_tools.py
+++ b/ddev/tests/ai/tools/shell/ddev/test_ddev_tools.py
@@ -169,7 +169,7 @@ def test_release_changelog_invalid_change_type_raises():
 # --- ddev validate ---
 
 
-@pytest.mark.parametrize("subcommand", ["config", "models", "metadata"])
+@pytest.mark.parametrize("subcommand", ["config", "models", "metadata", "all"])
 def test_validate_cmd_all_subcommands(subcommand: str):
     cmd = DdevValidateTool().cmd(DdevValidateInput(subcommand=subcommand, integration="mycheck"))
     assert cmd == ["ddev", "--no-interactive", "validate", subcommand, "mycheck"]
@@ -179,6 +179,11 @@ def test_validate_cmd_all_subcommands(subcommand: str):
 def test_validate_cmd_sync_flag_per_subcommand(subcommand: str):
     cmd = DdevValidateTool().cmd(DdevValidateInput(subcommand=subcommand, integration="mycheck", sync=True))
     assert cmd == ["ddev", "--no-interactive", "validate", subcommand, "--sync", "mycheck"]
+
+
+def test_validate_cmd_all_uses_fix_flag():
+    cmd = DdevValidateTool().cmd(DdevValidateInput(subcommand="all", integration="mycheck", sync=True))
+    assert cmd == ["ddev", "--no-interactive", "validate", "all", "--fix", "mycheck"]
 
 
 def test_validate_invalid_subcommand_raises():


### PR DESCRIPTION
### What does this PR do?

Adds a new `DdevValidateTool` shell tool to the AI agent harness at `ddev/src/ddev/ai/tools/shell/ddev/validate.py`. The tool wraps `ddev validate` with four subcommands:

- `config` — validates `assets/configuration/spec.yaml` against `data/conf.yaml.example`.
- `models` — validates `spec.yaml` against `datadog_checks/<integration>/config_models/`.
- `metadata` — validates `metadata.csv`.
- `all` — runs all ~20 validators in parallel. Intended as a final sweep, since it takes considerably longer than the targeted three.

A `sync` boolean maps to `--sync` for the targeted subcommands and to `--fix` for `all`.

Tests covering all subcommand shapes are in `ddev/tests/ai/tools/shell/ddev/test_ddev_tools.py`.

### Motivation

The AI agent harness could edit `assets/configuration/spec.yaml` but had no way to subsequently run `ddev validate config --sync` or `ddev validate models --sync` to regenerate the derived files (`conf.yaml.example`, `config_models/`) from the updated spec. Without this tool, an agent that edits the spec produces an integration with stale generated files, causing CI to reject the PR.

The `all` subcommand additionally lets the agent run a final pre-commit sweep covering validators the targeted three do not (license headers, imports, readmes, codeowners, etc.).

`DdevValidateTool` closes this gap and completes the integration authoring lifecycle that the shell tools layer exposes to the agent.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged