### PR TITLE
[FRWEBINT-1677] Add Claude Code Costs widget group to Anthropic dashboard

### DIFF
--- a/anthropic_usage_and_costs/CHANGELOG.md
+++ b/anthropic_usage_and_costs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - Anthropic Usage and Costs
 
+## 1.1.0 / 2026-05-08
+
+***Added***:
+
+* Add "Claude Code Costs" group to the overview dashboard, surfacing Anthropic Claude Code metered/session billing (`cost_type:session_usage`) separately from API token spend.
+
 ## 1.0.0 / 2025-08-02
 
 ***Added***:

--- a/anthropic_usage_and_costs/assets/dashboards/anthropic_usage_and_costs_overview.json
+++ b/anthropic_usage_and_costs/assets/dashboards/anthropic_usage_and_costs_overview.json
@@ -2234,6 +2234,139 @@
         "width": 12,
         "height": 10
       }
+    },
+    {
+      "id": 8885191409050301,
+      "definition": {
+        "title": "Claude Code Costs",
+        "type": "group",
+        "show_title": true,
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 8885191409050302,
+            "definition": {
+              "title": "Claude Code Spend (past 30d)",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1"
+                    }
+                  ],
+                  "queries": [
+                    {
+                      "data_source": "cloud_cost",
+                      "name": "query1",
+                      "query": "sum:all.cost{providername:Anthropic,cost_type:session_usage,$workspace_name,$organization_name,$user_name,$email}.rollup(sum, 2592000)",
+                      "aggregator": "sum"
+                    }
+                  ],
+                  "response_format": "scalar"
+                }
+              ],
+              "autoscale": true,
+              "precision": 2,
+              "timeseries_background": {
+                "type": "bars"
+              },
+              "time": {
+                "type": "live",
+                "unit": "month",
+                "value": 1,
+                "hide_incomplete_cost_data": true
+              }
+            },
+            "layout": {
+              "x": 0,
+              "y": 0,
+              "width": 4,
+              "height": 3
+            }
+          },
+          {
+            "id": 8885191409050303,
+            "definition": {
+              "title": "Daily Claude Code Costs by Workspace (30 Days)",
+              "show_legend": true,
+              "legend_layout": "horizontal",
+              "legend_columns": [
+                "avg",
+                "min",
+                "max",
+                "value",
+                "sum"
+              ],
+              "time": {
+                "type": "live",
+                "unit": "month",
+                "value": 1,
+                "hide_incomplete_cost_data": true
+              },
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1"
+                    }
+                  ],
+                  "queries": [
+                    {
+                      "data_source": "cloud_cost",
+                      "name": "query1",
+                      "query": "sum:all.cost{providername:Anthropic,cost_type:session_usage,$workspace_name,$organization_name,$user_name,$email} by {workspace_name}.rollup(sum, daily)"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "bars"
+                }
+              ]
+            },
+            "layout": {
+              "x": 4,
+              "y": 0,
+              "width": 8,
+              "height": 3
+            }
+          },
+          {
+            "id": 8885191409050304,
+            "definition": {
+              "type": "note",
+              "content": "**Claude Code Costs** captures Anthropic Claude Code metered/session billing (`cost_type:session_usage`), separate from API token spend. Use the workspace breakdown to see per-team allocation. For per-user attribution, see the `claude_code.estimated_cost` metric (gauge, not CCM).",
+              "background_color": "blue",
+              "font_size": "14",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": false,
+              "tick_pos": "50%",
+              "tick_edge": "left",
+              "has_padding": true
+            },
+            "layout": {
+              "x": 0,
+              "y": 3,
+              "width": 12,
+              "height": 2
+            }
+          }
+        ]
+      },
+      "layout": {
+        "x": 0,
+        "y": 77,
+        "width": 12,
+        "height": 6
+      }
     }
   ],
   "template_variables": [


### PR DESCRIPTION
## Summary
Surfaces the new `cost_type:session_usage` CCM tag (added in [DataDog/dogweb#166424](https://github.com/DataDog/dogweb/pull/166424)) so customers can see Claude Code spend separately from API token spend.

The new "Claude Code Costs" group on the overview dashboard contains:
- **Claude Code Spend (past 30d)** — `query_value` summing `all.cost{providername:Anthropic,cost_type:session_usage,...}`.
- **Daily Claude Code Costs by Workspace (30 Days)** — timeseries broken down by `workspace_name`.
- A note explaining how this differs from the token-based widgets and pointing to `claude_code.estimated_cost` for per-user attribution.

## Customer context
Digital Asset filed [FRWEBINT-1677](https://datadoghq.atlassian.net/browse/FRWEBINT-1677).

## Companion PR
Pairs with [DataDog/dogweb#166424](https://github.com/DataDog/dogweb/pull/166424). The dashboard widget will only have data once that change ships.

## Test plan
- [ ] Verify widget renders correctly in the integration tile preview.
- [ ] Once dogweb#166424 ships, confirm `sum:all.cost{cost_type:session_usage}` returns data for tenants with Claude Code seats.

## Context
Generated as part of the [FR Viability Assessment — 2026-05-07](https://datadoghq.atlassian.net/wiki/spaces/WEBINT/pages/6686409636/FR+Viability+Assessment+2026-05-07).

[FRWEBINT-1677]: https://datadoghq.atlassian.net/browse/FRWEBINT-1677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ