### PR TITLE
Fix Cilium e2e metric readiness

### DIFF
--- a/cilium/tests/conftest.py
+++ b/cilium/tests/conftest.py
@@ -9,6 +9,7 @@ import pytest
 from datadog_checks.base.utils.common import get_docker_hostname
 from datadog_checks.cilium import CiliumCheck
 from datadog_checks.dev import run_command
+from datadog_checks.dev.conditions import WaitFor
 from datadog_checks.dev.kind import kind_run
 from datadog_checks.dev.kube_port_forward import port_forward
 from datadog_checks.dev.utils import get_active_env
@@ -131,6 +132,51 @@ def setup_cilium():
         )
         if result.stderr:
             raise Exception(result.stderr)
+
+    WaitFor(
+        wait_for_cilium_metric_families,
+        attempts=60,
+        wait=2,
+        args=(
+            pods[0].strip(),
+            [
+                "cilium_forward_bytes_total",
+                "cilium_forward_count_total",
+                "cilium_endpoint_regeneration_time_stats_seconds",
+                "cilium_policy_regeneration_time_stats_seconds",
+            ],
+        ),
+    )()
+
+
+def wait_for_cilium_metric_families(pod, families):
+    missing = []
+    for family in families:
+        result = run_command(
+            [
+                "kubectl",
+                "exec",
+                "-n",
+                "cilium",
+                "-c",
+                "cilium-agent",
+                pod,
+                "--",
+                "cilium",
+                "metrics",
+                "list",
+                "--match-pattern",
+                family,
+            ],
+            capture=True,
+        )
+        if result.stderr:
+            raise Exception(result.stderr)
+        if family not in result.stdout:
+            missing.append(family)
+
+    if missing:
+        raise AssertionError("Cilium metric families are not available yet: {}".format(", ".join(missing)))
 
 
 def get_instances(agent_host, agent_port, operator_host, operator_port, use_openmetrics):


### PR DESCRIPTION
### What does this PR do?

Adds an adaptive readiness gate to the Cilium e2e fixture. After the existing Cilium API limiter warmup (`cilium endpoint list`), the fixture now polls Cilium's own metric registry until the raw metric families backing the historically missing Datadog metrics are available.

This targets intermittent `Test Agent release` failures like:

```text
Needed at least 1 candidates for 'cilium.forward_bytes.count', got 0
```

### Motivation

Kubernetes pod/deployment readiness is not enough for this fixture: Cilium can be `Ready` while event-driven metric families such as `cilium_forward_bytes_total` have not yet appeared. The recent CI path removed incidental warmup delay, making this race easier to hit.

Rather than adding a fixed sleep (sensitive to noisy CI runners) or introducing a larger workload/traffic fixture, this waits directly on Cilium's metrics surface using:

```bash
cilium metrics list --match-pattern <family>
```

### Testing

Ran formatting/lint:

```bash
cd ddev
hatch run -- ddev --no-interactive test -fs cilium
```

Reproduced the failure locally before the fix with warm `--new-env` and rc.3 agent. Verified after the fix:

```bash
hatch run -- ddev --no-interactive env test \
  --new-env \
  --agent registry.datadoghq.com/agent:7.79.0-rc.3 \
  cilium py3.13-1.11 \
  -- -k 'test_check_ok and not fips'
```

Additional local verification:

- `py3.13-1.11`: 3/3 warm attempts passed
- `py3.13-1.10`: 1/1 warm attempt passed
- `py3.13-1.9`: 1/1 warm attempt passed
