### PR TITLE
[DBMON-6589] Clean up dangling references on cancel to improve GC

### DIFF
--- a/postgres/changelog.d/23640.fixed
+++ b/postgres/changelog.d/23640.fixed
@@ -1,0 +1,1 @@
+Close dangling connections and break reference cycles on check cancel to reduce memory retention when checks are restarted or rescheduled

--- a/postgres/datadog_checks/postgres/data_observability.py
+++ b/postgres/datadog_checks/postgres/data_observability.py
@@ -36,7 +36,14 @@ class PostgresDataObservability(DBMAsyncJob):
             min_collection_interval=config.min_collection_interval,
             expected_db_exceptions=(psycopg.errors.DatabaseError,),
             job_name="data-observability",
+            shutdown_callback=self._shutdown,
         )
+
+    def _shutdown(self):
+        try:
+            self._check = None
+        except Exception:
+            pass
 
     @property
     def _do_config(self):

--- a/postgres/datadog_checks/postgres/data_observability.py
+++ b/postgres/datadog_checks/postgres/data_observability.py
@@ -40,6 +40,8 @@ class PostgresDataObservability(DBMAsyncJob):
         )
 
     def _shutdown(self):
+        if not self._cancel_event.is_set():
+            return
         try:
             self._check = None
         except Exception:

--- a/postgres/datadog_checks/postgres/data_observability.py
+++ b/postgres/datadog_checks/postgres/data_observability.py
@@ -36,16 +36,10 @@ class PostgresDataObservability(DBMAsyncJob):
             min_collection_interval=config.min_collection_interval,
             expected_db_exceptions=(psycopg.errors.DatabaseError,),
             job_name="data-observability",
-            shutdown_callback=self._shutdown,
         )
 
     def _shutdown(self):
-        if not self._cancel_event.is_set():
-            return
-        try:
-            self._check = None
-        except Exception:
-            pass
+        self._check = None
 
     @property
     def _do_config(self):

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -123,6 +123,8 @@ class PostgresMetadata(DBMAsyncJob):
         self.tags = None
 
     def _shutdown(self):
+        if not self._cancel_event.is_set():
+            return
         try:
             self._check = None
             self._schema_collector = None

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -125,6 +125,8 @@ class PostgresMetadata(DBMAsyncJob):
     def _shutdown(self):
         try:
             self._check = None
+            self._schema_collector = None
+            self._compiled_patterns_cache = None
         except Exception:
             pass
 

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -108,7 +108,6 @@ class PostgresMetadata(DBMAsyncJob):
         )
         self._check = check
         self._config = config
-        self.db_pool = self._check.db_pool
         self._collect_pg_settings_enabled = config.collect_settings.enabled
         self._collect_extensions_enabled = self._collect_pg_settings_enabled
         self._collect_schemas_enabled = config.collect_schemas.enabled

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -105,6 +105,7 @@ class PostgresMetadata(DBMAsyncJob):
             min_collection_interval=config.min_collection_interval,
             expected_db_exceptions=(psycopg.errors.DatabaseError,),
             job_name="database-metadata",
+            shutdown_callback=self._shutdown,
         )
         self._check = check
         self._config = config
@@ -120,6 +121,12 @@ class PostgresMetadata(DBMAsyncJob):
         self._conn_ttl_ms = self._config.idle_connection_timeout
         self._tags_no_db = None
         self.tags = None
+
+    def _shutdown(self):
+        try:
+            self._check = None
+        except Exception:
+            pass
 
     def _dbtags(self, db, *extra_tags):
         """

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -105,7 +105,6 @@ class PostgresMetadata(DBMAsyncJob):
             min_collection_interval=config.min_collection_interval,
             expected_db_exceptions=(psycopg.errors.DatabaseError,),
             job_name="database-metadata",
-            shutdown_callback=self._shutdown,
         )
         self._check = check
         self._config = config
@@ -123,14 +122,9 @@ class PostgresMetadata(DBMAsyncJob):
         self.tags = None
 
     def _shutdown(self):
-        if not self._cancel_event.is_set():
-            return
-        try:
-            self._check = None
-            self._schema_collector = None
-            self._compiled_patterns_cache = None
-        except Exception:
-            pass
+        self._check = None
+        self._schema_collector = None
+        self._compiled_patterns_cache = None
 
     def _dbtags(self, db, *extra_tags):
         """

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -17,6 +17,7 @@ from datadog_checks.base.utils.db import QueryExecutor
 from datadog_checks.base.utils.db.core import QueryManager
 from datadog_checks.base.utils.db.health import HealthEvent, HealthStatus
 from datadog_checks.base.utils.db.utils import (
+    DBMAsyncJob,
     default_json_event_encoding,
     tracked_query,
 )
@@ -472,42 +473,38 @@ class PostgreSql(DatabaseCheck):
 
         return self._dynamic_queries
 
+    @staticmethod
+    def _cancel_async_job(job: DBMAsyncJob):
+        job.cancel()
+        if job._job_loop_future:
+            job._job_loop_future.result()
+            job._job_loop_future = None
+        job._shutdown()
+
     def cancel(self):
         """
         Cancels and sends cancel signal to all threads.
         """
         if self._config.dbm:
-            self.statement_samples.cancel()
-            self.statement_metrics.cancel()
-            self.metadata_samples.cancel()
-            if self.statement_metrics._job_loop_future:
-                self.statement_metrics._job_loop_future.result()
-                self.statement_metrics._job_loop_future = None
-            if self.statement_samples._job_loop_future:
-                self.statement_samples._job_loop_future.result()
-                self.statement_samples._job_loop_future = None
-            if self.metadata_samples._job_loop_future:
-                self.metadata_samples._job_loop_future.result()
-                self.metadata_samples._job_loop_future = None
-            self.statement_metrics._shutdown()
-            self.statement_samples._shutdown()
-            self.metadata_samples._shutdown()
+            self._cancel_async_job(self.statement_metrics)
+            self._cancel_async_job(self.statement_samples)
+            self._cancel_async_job(self.metadata_samples)
         elif self._config.data_observability.enabled:
-            self.metadata_samples.cancel()
-            if self.metadata_samples._job_loop_future:
-                self.metadata_samples._job_loop_future.result()
-                self.metadata_samples._job_loop_future = None
-            self.metadata_samples._shutdown()
+            self._cancel_async_job(self.metadata_samples)
         if self._config.data_observability.enabled:
-            self.data_observability.cancel()
-            if self.data_observability._job_loop_future:
-                self.data_observability._job_loop_future.result()
-                self.data_observability._job_loop_future = None
-            self.data_observability._shutdown()
-        self._dynamic_queries = []
-        self._query_manager.executor = None
+            self._cancel_async_job(self.data_observability)
+        self._clean_state()
+        self._query_manager = None
+        self.health = None
+        self.check_initializations.clear()
+        # TODO: move diagnosis cleanup into AgentCheck.cancel() in the base class
+        self._diagnosis = None
         self._close_db()
         self._close_db_pool()
+        # CheckLoggingAdapter holds self.check until check_id is resolved via
+        # process(), which only happens after the agent scheduler calls run().
+        # If cancel() is called before that, the back-reference is never cleared.
+        self.log.check = None
 
     def _clean_state(self):
         self.log.debug("Cleaning state")

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -483,18 +483,23 @@ class PostgreSql(DatabaseCheck):
             self.metadata_samples.cancel()
             if self.statement_metrics._job_loop_future:
                 self.statement_metrics._job_loop_future.result()
+                self.statement_metrics._job_loop_future = None
             if self.statement_samples._job_loop_future:
                 self.statement_samples._job_loop_future.result()
+                self.statement_samples._job_loop_future = None
             if self.metadata_samples._job_loop_future:
                 self.metadata_samples._job_loop_future.result()
+                self.metadata_samples._job_loop_future = None
         elif self._config.data_observability.enabled:
             self.metadata_samples.cancel()
             if self.metadata_samples._job_loop_future:
                 self.metadata_samples._job_loop_future.result()
+                self.metadata_samples._job_loop_future = None
         if self._config.data_observability.enabled:
             self.data_observability.cancel()
             if self.data_observability._job_loop_future:
                 self.data_observability._job_loop_future.result()
+                self.data_observability._job_loop_future = None
         self._dynamic_queries = []
         self._query_manager.executor = None
         self._close_db()

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -490,16 +490,21 @@ class PostgreSql(DatabaseCheck):
             if self.metadata_samples._job_loop_future:
                 self.metadata_samples._job_loop_future.result()
                 self.metadata_samples._job_loop_future = None
+            self.statement_metrics._shutdown()
+            self.statement_samples._shutdown()
+            self.metadata_samples._shutdown()
         elif self._config.data_observability.enabled:
             self.metadata_samples.cancel()
             if self.metadata_samples._job_loop_future:
                 self.metadata_samples._job_loop_future.result()
                 self.metadata_samples._job_loop_future = None
+            self.metadata_samples._shutdown()
         if self._config.data_observability.enabled:
             self.data_observability.cancel()
             if self.data_observability._job_loop_future:
                 self.data_observability._job_loop_future.result()
                 self.data_observability._job_loop_future = None
+            self.data_observability._shutdown()
         self._dynamic_queries = []
         self._query_manager.executor = None
         self._close_db()

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -302,6 +302,15 @@ class PostgreSql(DatabaseCheck):
                 rows = cursor.fetchall()
                 return rows
 
+    def _close_db(self):
+        if self._db:
+            try:
+                self._db.close()
+            except Exception:
+                pass
+            finally:
+                self._db = None
+
     @contextlib.contextmanager
     def db(self):
         """
@@ -322,12 +331,7 @@ class PostgreSql(DatabaseCheck):
             self.log.warning(
                 "Connection to the database %s has been interrupted, closing connection", self._config.dbname
             )
-            try:
-                self._db.close()
-            except Exception:
-                pass
-            finally:
-                self._db = None
+            self._close_db()
             raise
         except Exception:
             self.log.exception("Unhandled exception while using database connection %s", self._config.dbname)
@@ -491,6 +495,7 @@ class PostgreSql(DatabaseCheck):
             self.data_observability.cancel()
             if self.data_observability._job_loop_future:
                 self.data_observability._job_loop_future.result()
+        self._close_db()
         self._close_db_pool()
 
     def _clean_state(self):

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -495,6 +495,8 @@ class PostgreSql(DatabaseCheck):
             self.data_observability.cancel()
             if self.data_observability._job_loop_future:
                 self.data_observability._job_loop_future.result()
+        self._dynamic_queries = []
+        self._query_manager.executor = None
         self._close_db()
         self._close_db_pool()
 

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -161,6 +161,7 @@ class PostgresStatementSamples(DBMAsyncJob):
             min_collection_interval=config.min_collection_interval,
             expected_db_exceptions=(psycopg.errors.DatabaseError,),
             job_name="query-samples",
+            shutdown_callback=self._shutdown,
         )
         self._check = check
         self._config = config
@@ -219,6 +220,12 @@ class PostgresStatementSamples(DBMAsyncJob):
         # Keep track of last time we sent an activity event
         self._time_since_last_activity_event = 0
         self._pg_stat_activity_cols = None
+
+    def _shutdown(self):
+        try:
+            self._check = None
+        except Exception:
+            pass
 
     def _dbtags(self, db, *extra_tags):
         """

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -161,7 +161,6 @@ class PostgresStatementSamples(DBMAsyncJob):
             min_collection_interval=config.min_collection_interval,
             expected_db_exceptions=(psycopg.errors.DatabaseError,),
             job_name="query-samples",
-            shutdown_callback=self._shutdown,
         )
         self._check = check
         self._config = config
@@ -222,17 +221,12 @@ class PostgresStatementSamples(DBMAsyncJob):
         self._pg_stat_activity_cols = None
 
     def _shutdown(self):
-        if not self._cancel_event.is_set():
-            return
-        try:
-            self._check = None
-            self._collection_strategy_cache = None
-            self._explain_errors_cache = None
-            self._explained_statements_ratelimiter = None
-            self._seen_samples_ratelimiter = None
-            self._raw_statement_text_cache = None
-        except Exception:
-            pass
+        self._check = None
+        self._collection_strategy_cache = None
+        self._explain_errors_cache = None
+        self._explained_statements_ratelimiter = None
+        self._seen_samples_ratelimiter = None
+        self._raw_statement_text_cache = None
 
     def _dbtags(self, db, *extra_tags):
         """

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -222,6 +222,7 @@ class PostgresStatementSamples(DBMAsyncJob):
 
     def _shutdown(self):
         self._check = None
+        self._explain_parameterized_queries = None
         self._collection_strategy_cache = None
         self._explain_errors_cache = None
         self._explained_statements_ratelimiter = None

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -222,6 +222,8 @@ class PostgresStatementSamples(DBMAsyncJob):
         self._pg_stat_activity_cols = None
 
     def _shutdown(self):
+        if not self._cancel_event.is_set():
+            return
         try:
             self._check = None
             self._collection_strategy_cache = None

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -224,6 +224,11 @@ class PostgresStatementSamples(DBMAsyncJob):
     def _shutdown(self):
         try:
             self._check = None
+            self._collection_strategy_cache = None
+            self._explain_errors_cache = None
+            self._explained_statements_ratelimiter = None
+            self._seen_samples_ratelimiter = None
+            self._raw_statement_text_cache = None
         except Exception:
             pass
 

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -152,8 +152,6 @@ class PostgresStatementSamples(DBMAsyncJob):
         if not config.query_samples.enabled:
             collection_interval = config.query_activity.collection_interval
 
-        self.db_pool = check.db_pool
-
         super(PostgresStatementSamples, self).__init__(
             check,
             rate_limit=1 / collection_interval,
@@ -646,7 +644,7 @@ class PostgresStatementSamples(DBMAsyncJob):
     def _get_db_explain_setup_state(self, dbname):
         # type: (str) -> Tuple[Optional[DBExplainError], Optional[Exception]]
         try:
-            self.db_pool.get_connection(dbname)
+            self._check.db_pool.get_connection(dbname)
         except psycopg.OperationalError as e:
             self._log.warning(
                 "cannot collect execution plans due to failed DB connection to dbname=%s: %s", dbname, repr(e)
@@ -712,7 +710,7 @@ class PostgresStatementSamples(DBMAsyncJob):
         start_time = time.time()
         if self._cancel_event.is_set():
             raise Exception("Job loop cancelled. Aborting query.")
-        with self.db_pool.get_connection(dbname) as conn:
+        with self._check.db_pool.get_connection(dbname) as conn:
             # When sending potentially non-ascii data, e.g. UTF8, we need to force
             # the client encoding to UTF-8 to match Python string encoding
             if conn.info.encoding.lower() in ["ascii", "sqlascii", "sql_ascii"]:

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -169,7 +169,6 @@ class PostgresStatementMetrics(DBMAsyncJob):
             dbms="postgres",
             rate_limit=1 / float(collection_interval),
             job_name="query-metrics",
-            shutdown_callback=self._shutdown,
         )
         self._check = check
         self._metrics_collection_interval = collection_interval
@@ -204,16 +203,11 @@ class PostgresStatementMetrics(DBMAsyncJob):
         )
 
     def _shutdown(self):
-        if not self._cancel_event.is_set():
-            return
-        try:
-            self._check = None
-            self._full_statement_text_cache = None
-            self._state = None
-            self._query_calls_cache = None
-            self._baseline_metrics = None
-        except Exception:
-            pass
+        self._check = None
+        self._full_statement_text_cache = None
+        self._state = None
+        self._query_calls_cache = None
+        self._baseline_metrics = None
 
     def _execute_query(self, query, params=(), binary=False, row_factory=None) -> Tuple[list, list]:
         if self._cancel_event.is_set():

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -169,6 +169,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
             dbms="postgres",
             rate_limit=1 / float(collection_interval),
             job_name="query-metrics",
+            shutdown_callback=self._shutdown,
         )
         self._check = check
         self._metrics_collection_interval = collection_interval
@@ -201,6 +202,12 @@ class PostgresStatementMetrics(DBMAsyncJob):
             maxsize=config.query_metrics.full_statement_text_cache_max_size,
             ttl=60 * 60 / config.query_metrics.full_statement_text_samples_per_hour_per_query,
         )
+
+    def _shutdown(self):
+        try:
+            self._check = None
+        except Exception:
+            pass
 
     def _execute_query(self, query, params=(), binary=False, row_factory=None) -> Tuple[list, list]:
         if self._cancel_event.is_set():

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -204,6 +204,8 @@ class PostgresStatementMetrics(DBMAsyncJob):
         )
 
     def _shutdown(self):
+        if not self._cancel_event.is_set():
+            return
         try:
             self._check = None
             self._full_statement_text_cache = None

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -206,6 +206,10 @@ class PostgresStatementMetrics(DBMAsyncJob):
     def _shutdown(self):
         try:
             self._check = None
+            self._full_statement_text_cache = None
+            self._state = None
+            self._query_calls_cache = None
+            self._baseline_metrics = None
         except Exception:
             pass
 

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -857,7 +857,7 @@ def test_database_instance_metadata(aggregator, pg_instance, dbm_enabled, report
         'database_instance:{}'.format(expected_database_instance),
     ]
     check = integration_check(pg_instance)
-    run_one_check(check)
+    run_one_check(check, cancel=False)
 
     # These tags are a bit dynamic in value, so we get them from the check and ensure they are present
     expected_tags.append('postgresql_version:{}'.format(check.raw_version))

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1215,7 +1215,7 @@ def test_activity_reported_hostname(
     check = integration_check(dbm_instance)
     check._connect()
 
-    run_one_check(check)
+    run_one_check(check, cancel=False)
     run_one_check(check)
 
     dbm_activity = aggregator.get_event_platform_events("dbm-activity")
@@ -1480,7 +1480,7 @@ def test_async_job_enabled(
     dbm_instance['query_metrics'] = {'enabled': statement_metrics_enabled, 'run_sync': False}
     check = integration_check(dbm_instance)
     check._connect()
-    run_one_check(check)
+    run_one_check(check, cancel=False)
     if statement_samples_enabled or statement_activity_enabled:
         assert check.statement_samples._job_loop_future is not None
     else:
@@ -1713,8 +1713,8 @@ def test_async_job_cancel_cancel(aggregator, integration_check, dbm_instance):
     check = integration_check(dbm_instance)
     check._connect()
     run_one_check(check)
-    assert not check.statement_samples._job_loop_future.running(), "samples thread should be stopped"
-    assert not check.statement_metrics._job_loop_future.running(), "metrics thread should be stopped"
+    assert check.statement_samples._job_loop_future is None, "samples future should be cleaned up after cancel"
+    assert check.statement_metrics._job_loop_future is None, "metrics future should be cleaned up after cancel"
     # if the thread doesn't start until after the cancel signal is set then the db connection will never
     # be created in the first place
     assert check.db_pool.pools.get(dbm_instance['dbname']) is None, "db connection should be gone"

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -336,3 +336,46 @@ def test_new_connection_closes_conn_when_configure_raises(integration_check, pg_
             with pytest.raises(psycopg.Error):
                 check._new_connection(check._config.dbname)
     conn.close.assert_called_once()
+
+
+def test_close_db_closes_open_connection(integration_check, pg_instance):
+    check = integration_check(pg_instance)
+    conn = mock.MagicMock()
+    conn.closed = False
+    check._db = conn
+
+    check._close_db()
+
+    conn.close.assert_called_once()
+    assert check._db is None
+
+
+def test_close_db_handles_already_closed_connection(integration_check, pg_instance):
+    check = integration_check(pg_instance)
+    conn = mock.MagicMock()
+    conn.close.side_effect = Exception("already closed")
+    check._db = conn
+
+    check._close_db()
+
+    assert check._db is None
+
+
+def test_close_db_noop_when_no_connection(integration_check, pg_instance):
+    check = integration_check(pg_instance)
+    check._db = None
+
+    check._close_db()
+
+    assert check._db is None
+
+
+def test_cancel_closes_main_db_connection(integration_check, pg_instance):
+    check = integration_check(pg_instance)
+    conn = mock.MagicMock()
+    check._db = conn
+
+    check.cancel()
+
+    conn.close.assert_called_once()
+    assert check._db is None

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -315,7 +315,7 @@ def test_run_explain_uses_parameterized_statement(pg_instance, integration_check
     conn_cm = mock.MagicMock()
     conn_cm.__enter__.return_value = mock_conn
 
-    with mock.patch.object(check.statement_samples.db_pool, 'get_connection', return_value=conn_cm):
+    with mock.patch.object(check.db_pool, 'get_connection', return_value=conn_cm):
         with mock.patch.object(check, 'histogram'):
             check.statement_samples._run_explain('testdb', statement, statement)
 

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -2,6 +2,8 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import copy
+import gc
+import weakref
 
 import mock
 import psycopg
@@ -9,7 +11,7 @@ import pytest
 from pytest import fail
 from semver import VersionInfo
 
-from datadog_checks.postgres import util
+from datadog_checks.postgres import PostgreSql, util
 from datadog_checks.postgres.schemas import PostgresSchemaCollector
 
 pytestmark = pytest.mark.unit
@@ -379,3 +381,46 @@ def test_cancel_closes_main_db_connection(integration_check, pg_instance):
 
     conn.close.assert_called_once()
     assert check._db is None
+
+
+def test_check_gc_after_cancel(pg_instance):
+    """Verify cancel() breaks all reference cycles so refcount alone reclaims the check.
+
+    If this test fails, the assertion message lists the types still holding a
+    reference to the check. To fix it:
+
+    1. Identify the referrer type in the failure message (e.g. ``QueryManager``).
+    2. Find which attribute on that object points back to the check (usually
+       ``self.check`` or ``self._check``).
+    3. Null that attribute in ``cancel()`` or add it to the relevant
+       ``_shutdown()`` method.
+    4. If the referrer is a closure or ``functools.partial``, find the
+       registration site and null or clear the container that holds it.
+    """
+    pg_instance['dbm'] = True
+    pg_instance['query_samples'] = {'enabled': True, 'run_sync': True, 'collection_interval': 1}
+    pg_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 10}
+    pg_instance['query_activity'] = {'enabled': True, 'collection_interval': 1}
+    pg_instance['data_observability'] = {'enabled': True, 'run_sync': True, 'collection_interval': 1}
+
+    check = PostgreSql('postgres', {}, [pg_instance])
+    ref = weakref.ref(check)
+
+    check.cancel()
+
+    gc.collect()
+    gc.disable()
+    try:
+        del check
+        obj = ref()
+        if obj is not None:
+            import inspect
+
+            referrers = [
+                f"bound method {r.__qualname__}" if inspect.ismethod(r) else type(r).__name__
+                for r in gc.get_referrers(obj)
+            ]
+            del obj
+            fail(f"Check still alive after cancel() + del -- pinned by: {referrers}")
+    finally:
+        gc.enable()

--- a/postgres/tests/utils.py
+++ b/postgres/tests/utils.py
@@ -137,17 +137,11 @@ def run_vacuum_thread(pg_instance, vacuum_query, application_name='test'):
 def run_one_check(check: AgentCheck, cancel=True):
     """
     Run check and immediately cancel.
-    Waits for all threads to close before continuing.
+    cancel() joins all threads and nulls futures, so no extra .result() calls needed.
     """
     check.run()
     if cancel:
         check.cancel()
-    if check.statement_samples._job_loop_future is not None:
-        check.statement_samples._job_loop_future.result()
-    if check.statement_metrics._job_loop_future is not None:
-        check.statement_metrics._job_loop_future.result()
-    if check.metadata_samples._job_loop_future is not None:
-        check.metadata_samples._job_loop_future.result()
 
 
 def normalize_object(obj):


### PR DESCRIPTION
### What does this PR do?

Ensures a Postgres check instance is fully reclaimable by CPython's reference-counting GC immediately after `cancel()` completes, without relying on the non-deterministic cyclic garbage collector.

#### Async job cleanup

- **Add `_shutdown()` methods to all async jobs** — Each `DBMAsyncJob` subclass (`PostgresStatementMetrics`, `PostgresStatementSamples`, `PostgresMetadata`, `PostgresDataObservability`) implements `_shutdown()` to null its `_check` back-reference and release caches (`TTLCache`, `RateLimitingTTLCache`, `ExplainParameterizedQueries`, `SchemaCollector`).
- **Call `_shutdown()` explicitly from `cancel()`** — A new `_cancel_async_job()` helper cancels the job, joins the future, nulls the future, and invokes `_shutdown()` — ensuring cleanup happens regardless of whether the job loop was ever started.
- **Remove redundant `db_pool` references** — `PostgresStatementSamples` and `PostgresMetadata` stored their own copy of `db_pool`. Removed in favor of accessing through `self._check.db_pool`.

#### Check-level cleanup

- **Close the standalone main DB connection on cancel** — `self._db` was never closed during `cancel()`, leaking an open socket. Extracts a `_close_db()` helper to deduplicate the close-and-null pattern shared with the `db()` context manager.
- **Null `_query_manager` and `health`** — Drops the `QueryManager` and `PostgresHealth` objects that hold back-references to the check.
- **Clear `check_initializations`** — The deque holds bound methods and a lambda that capture `self`, forming reference cycles.
- **Drop `_diagnosis`** — The `Diagnosis` object holds a `functools.partial` and `_sanitize` lambda that pin the check.
- **Null `CheckLoggingAdapter.check`** — The logging adapter holds a back-reference to the check that is only self-cleared after the first log call with a resolved `check_id`; `cancel()` before that point leaves the cycle intact.

#### Testing

- **Add `test_check_gc_after_cancel`** — A strict regression test that disables CPython's cyclic GC and verifies the check is reclaimed by refcount alone after `cancel()`. On failure, the assertion message lists the exact types still pinning the check for easy diagnosis.
- **Existing tests updated** for the new post-cancel state (`_job_loop_future is None`, `db_pool` accessed via `_check`).

### Motivation

When the agent rescheduled a Postgres check (config reload, autodiscovery churn), the check instance and all its async job objects were pinned in memory by bidirectional reference cycles until CPython's cyclic GC ran — which is non-deterministic and can be delayed significantly. In environments with frequent check rescheduling (e.g., dozens of autodiscovered databases), this caused unnecessary memory retention of connections, caches, and thread state. These changes ensure the entire object graph is reclaimable by reference counting immediately after `cancel()` completes.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged