### PR TITLE
chore: klaviyo -- normalize colon spacing in manifest monitors section

### DIFF
--- a/klaviyo/manifest.json
+++ b/klaviyo/manifest.json
@@ -53,10 +53,10 @@
         "source": "klaviyo"
     },
     "monitors": {
-      "High number of refunded orders" : "assets/monitors/high_number_of_refunds.json",
-      "High percentage of dropped or bounced email" : "assets/monitors/high_percentage_of_email_failures.json",
-      "High percentage of email marked as spam" : "assets/monitors/high_percentage_of_email_marked_as_spam.json",
-      "High percentage of SMS delivery failures" : "assets/monitors/high_percentage_of_sms_failures.json"
+      "High number of refunded orders": "assets/monitors/high_number_of_refunds.json",
+      "High percentage of dropped or bounced email": "assets/monitors/high_percentage_of_email_failures.json",
+      "High percentage of email marked as spam": "assets/monitors/high_percentage_of_email_marked_as_spam.json",
+      "High percentage of SMS delivery failures": "assets/monitors/high_percentage_of_sms_failures.json"
     }
   },
   "author": {


### PR DESCRIPTION
### What does this PR do?
Normalizes colon spacing in the `monitors` section of `klaviyo/manifest.json` so it matches the rest of the file (no space before `:`), aligning with the formatting used in `dashboards` and elsewhere in this manifest.

### Motivation
> [!NOTE] 
> **Re-trigger APW publish to the staging COBS keyspace.**
> After talking with IDP, by generating this PR we ensure we trigger APW flow redeploying the manifest content to COBS.

### Review checklist (to be filled by reviewers)
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged