### PR TITLE
Migrate apache mock_hide_server_version fixture to mock_http

### DIFF
--- a/apache/tests/conftest.py
+++ b/apache/tests/conftest.py
@@ -52,7 +52,12 @@ def mock_hide_server_version(mock_http):
     def filter_server_version(url, *args, **kwargs):
         r = requests.get(url, **kwargs)
         content = '\n'.join(line for line in r.text.splitlines() if 'ServerVersion' not in line)
-        return MockHTTPResponse(content=content, headers=dict(r.headers))
+        return MockHTTPResponse(
+            content=content,
+            status_code=r.status_code,
+            headers=dict(r.headers),
+            url=r.url,
+        )
 
     mock_http.get.side_effect = filter_server_version
     yield

--- a/apache/tests/conftest.py
+++ b/apache/tests/conftest.py
@@ -4,11 +4,11 @@
 
 import os
 
-import mock
 import pytest
 import requests
 
 from datadog_checks.apache import Apache
+from datadog_checks.base.utils.http_testing import MockHTTPResponse
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckEndpoints, WaitFor
 
@@ -48,19 +48,14 @@ def check_status_page_ready():
 
 
 @pytest.fixture
-def mock_hide_server_version():
-    req = mock.MagicMock()
-    with mock.patch('datadog_checks.base.utils.http.requests.Session', return_value=req):
+def mock_hide_server_version(mock_http):
+    def filter_server_version(url, *args, **kwargs):
+        r = requests.get(url, **kwargs)
+        content = '\n'.join(line for line in r.text.splitlines() if 'ServerVersion' not in line)
+        return MockHTTPResponse(content=content, headers=dict(r.headers))
 
-        def mock_requests_get_headers(*args, **kwargs):
-            r = requests.get(*args, **kwargs)
-            old_iter = r.iter_lines
-            r.iter_lines = mock.MagicMock()
-            r.iter_lines.return_value = (l for l in old_iter(decode_unicode=True) if 'ServerVersion' not in l)
-            return r
-
-        req.get = mock_requests_get_headers
-        yield
+    mock_http.get.side_effect = filter_server_version
+    yield
 
 
 @pytest.fixture


### PR DESCRIPTION
## Motivation

Last `requests.Session` patch in apache test surface. Closes Step 5 conftest cleanup.

## Approach

Route version-stripping fixture through `mock_http`. Side-effect performs real GET against HTTPD container brought up by `dd_environment`, then returns `MockHTTPResponse` with `ServerVersion` filtered out and headers preserved.

Sole consumer is `test_metadata_in_header` (`@pytest.mark.usefixtures("dd_environment")`, integration-style). Runs under `ddev test apache`, not `ddev env test`.

## Verification

- [x] `ddev test -fs apache` clean
- [x] `ddev --no-interactive test apache` 18 passed, 1 skipped
- [x] `ddev --no-interactive test apache -- -k test_metadata_in_header` 1 passed

Plan: https://datadoghq.atlassian.net/wiki/spaces/AI/pages/6677695868

🤖 Generated with [Claude Code](https://claude.com/claude-code)