### PR TITLE
[DBMON-6589] Eliminate reference cycle in Postgres diagnose

### DIFF
--- a/postgres/changelog.d/23647.fixed
+++ b/postgres/changelog.d/23647.fixed
@@ -1,0 +1,1 @@
+Eliminate reference cycle in diagnostic instrumentation

--- a/postgres/datadog_checks/postgres/diagnose.py
+++ b/postgres/datadog_checks/postgres/diagnose.py
@@ -32,6 +32,11 @@ from .version_utils import V9_6, VersionUtils
 RECOMMENDED_TRACK_ACTIVITY_QUERY_SIZE = 4096
 
 
+def run_diagnostics(check):
+    """Entry point for ``Diagnosis.register()``; creates a short-lived worker per invocation."""
+    PostgresDiagnose(check)._run()
+
+
 class PostgresDiagnose:
     """Explicit pre-flight diagnostics for `datadog-agent diagnose`."""
 
@@ -41,21 +46,6 @@ class PostgresDiagnose:
         # don't emit downstream-effect FAILs with nonsensical remediations (e.g. "CREATE EXTENSION"
         # when shared_preload_libraries is empty). Reset at the top of the first orchestrator.
         self._failed = set()
-
-    # -- registration ---------------------------------------------------------
-
-    def register(self):
-        """Register the diagnostic entry point with the check's Diagnosis object.
-
-        Idempotent: re-invoking `register` on the same Diagnosis object is a no-op.
-        ``Diagnosis.register`` extends an internal list, so without this guard a
-        repeated call would stack the entry point and produce N× the diagnostics.
-        """
-        d = self._check.diagnosis
-        if getattr(d, '_postgres_diagnostics_registered', False):
-            return
-        d._postgres_diagnostics_registered = True
-        d.register(self._run)
 
     # -- orchestrator ---------------------------------------------------------
 

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -47,7 +47,7 @@ from datadog_checks.postgres.statements import PostgresStatementMetrics
 
 from .__about__ import __version__
 from .config import build_config, sanitize
-from .diagnose import PostgresDiagnose
+from .diagnose import run_diagnostics
 from .util import (
     ANALYZE_PROGRESS_METRICS,
     AWS_RDS_HOSTNAME_SUFFIX,
@@ -191,8 +191,7 @@ class PostgreSql(DatabaseCheck):
             ttl=self._config.database_instance_collection_interval,
         )  # type: TTLCache
 
-        # Register explicit pre-flight diagnostics for `datadog-agent diagnose`.
-        PostgresDiagnose(self).register()
+        self.diagnosis.register(functools.partial(run_diagnostics, self))
 
     def _submit_initialization_health_event(self):
         try:


### PR DESCRIPTION
## Summary

Restructure `PostgresDiagnose` from a persistent companion object into a short-lived
run-scoped worker, eliminating a reference cycle that could prevent or delay GC of the check
instance after `cancel()`. Also remove the monkey-patched idempotency guard
(`_postgres_diagnostics_registered`); traced the agent's Go code and confirmed `__init__`
is called exactly once per check instance.

### Before

`PostgresDiagnose` was created in `__init__` and kept alive for the lifetime of the check
via a bound method registered in `Diagnosis._diagnostics`. This formed a cycle that
CPython's refcount mechanism could not free:

    check
      -> diagnosis
           -> _diagnostics[]
                -> bound method _run
                     -> PostgresDiagnose
                          -> _check
                               -> check  (CYCLE)

After `check.cancel()` + `del check`, `PostgresDiagnose` still appeared in `gc.get_referrers(check)`.

### After

A `functools.partial` wrapping a module-level `run_diagnostics(check)` function is
registered instead. No persistent `PostgresDiagnose` instance exists between diagnostic
runs:

    check
      -> diagnosis
           -> _diagnostics[]
                -> partial(run_diagnostics)
                     -> args tuple
                          -> check  (direct reference, no cycle)

When the agent invokes `get_diagnoses()`, a transient `PostgresDiagnose(check)` is created,
runs all probes, and goes out of scope immediately -- freed by refcount, no cyclic GC needed.

After `check.cancel()` + `del check`, `PostgresDiagnose` no longer appears in the referrer list.

## Test plan

- [x] All existing `test_diagnose` tests pass (107 tests)
- [x] `test_check_gc_after_cancel` confirms `PostgresDiagnose` no longer appears in the referrer list after `cancel()` + `del`
- [x] Formatter and linter pass clean

The `test_check_gc_after_cancel` can be seen below. It will be added into the repo to run on CI after the existing issues being caught have all been mitigated.

```python
import gc
import weakref
from datadog_checks.postgres import PostgreSql

def test_check_gc_after_cancel(pg_instance):
    pg_instance['dbm'] = True
    pg_instance['query_samples'] = {'enabled': True, 'run_sync': True, 'collection_interval': 1}
    pg_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 10}
    pg_instance['query_activity'] = {'enabled': True, 'collection_interval': 1}
    pg_instance['data_observability'] = {'enabled': True, 'run_sync': True, 'collection_interval': 1}

    check = PostgreSql('postgres', {}, [pg_instance])
    ref = weakref.ref(check)

    check.cancel()

    gc.collect()
    gc.disable()
    try:
        del check
        obj = ref()
        if obj is not None:
            import inspect

            referrers = [
                f"bound method {r.__qualname__}" if inspect.ismethod(r) else type(r).__name__
                for r in gc.get_referrers(obj)
            ]
            del obj
            assert False, f"Check still alive after cancel() + del -- pinned by: {referrers}"
    finally:
        gc.enable()
```