### PR TITLE
Migrate linkerd + istio v1 tests off requests_mock

### DIFF
--- a/istio/tests/test_unit_istio_v1.py
+++ b/istio/tests/test_unit_istio_v1.py
@@ -1,22 +1,22 @@
 # (C) Datadog, Inc. 2024-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import requests_mock
-
+from datadog_checks.base.utils.http_testing import MockHTTPResponse
 from datadog_checks.istio import Istio
 
 from . import common
 from .utils import _assert_tags_excluded, get_response
 
 
-def test_legacy_istiod(aggregator, dd_run_check):
+def test_legacy_istiod(aggregator, dd_run_check, mock_openmetrics_http):
     """
     Test the istiod deployment endpoint for v1.5+ check for OpenMetricsV1 implementation
     """
+    mock_openmetrics_http.get.return_value = MockHTTPResponse(
+        content=get_response('1.5', 'istiod.txt'), headers={'Content-Type': 'text/plain'}
+    )
     check = Istio('istio', {}, [common.MOCK_LEGACY_ISTIOD_INSTANCE])
-    with requests_mock.Mocker() as metric_request:
-        metric_request.get('http://localhost:8080/metrics', text=get_response('1.5', 'istiod.txt'))
-        dd_run_check(check)
+    dd_run_check(check)
 
     for metric in common.ISTIOD_METRICS:
         aggregator.assert_metric(metric)
@@ -24,15 +24,16 @@ def test_legacy_istiod(aggregator, dd_run_check):
     aggregator.assert_all_metrics_covered()
 
 
-def test_legacy_proxy_mesh(aggregator, dd_run_check):
+def test_legacy_proxy_mesh(aggregator, dd_run_check, mock_openmetrics_http):
     """
     Test proxy mesh check for OpenMetricsV1 implementation
     """
+    mock_openmetrics_http.get.return_value = MockHTTPResponse(
+        content=get_response('1.5', 'istio-proxy.txt'), headers={'Content-Type': 'text/plain'}
+    )
     check = Istio(common.CHECK_NAME, {}, [common.MOCK_LEGACY_MESH_INSTANCE])
+    dd_run_check(check)
 
-    with requests_mock.Mocker() as metric_request:
-        metric_request.get('http://localhost:15090/metrics', text=get_response('1.5', 'istio-proxy.txt'))
-        dd_run_check(check)
     for metric in common.LEGACY_MESH_METRICS + common.MESH_MERICS_1_5:
         aggregator.assert_metric(metric)
 
@@ -41,19 +42,19 @@ def test_legacy_proxy_mesh(aggregator, dd_run_check):
     aggregator.assert_all_metrics_covered()
 
 
-def test_legacy_proxy_mesh_exclude(aggregator, dd_run_check):
+def test_legacy_proxy_mesh_exclude(aggregator, dd_run_check, mock_openmetrics_http):
     """
     Test proxy mesh check for OpenMetricsV1 implementation
     """
+    mock_openmetrics_http.get.return_value = MockHTTPResponse(
+        content=get_response('1.5', 'istio-proxy.txt'), headers={'Content-Type': 'text/plain'}
+    )
     exclude_tags = ['destination_app', 'destination_principal']
     instance = common.MOCK_LEGACY_MESH_INSTANCE
     instance['exclude_labels'] = exclude_tags
 
     check = Istio(common.CHECK_NAME, {}, [instance])
-
-    with requests_mock.Mocker() as metric_request:
-        metric_request.get('http://localhost:15090/metrics', text=get_response('1.5', 'istio-proxy.txt'))
-        dd_run_check(check)
+    dd_run_check(check)
 
     for metric in common.LEGACY_MESH_METRICS + common.MESH_MERICS_1_5:
         aggregator.assert_metric(metric)
@@ -63,13 +64,13 @@ def test_legacy_proxy_mesh_exclude(aggregator, dd_run_check):
     aggregator.assert_all_metrics_covered()
 
 
-def test_legacy_version_metadata(datadog_agent, dd_run_check):
+def test_legacy_version_metadata(datadog_agent, dd_run_check, mock_openmetrics_http):
+    mock_openmetrics_http.get.return_value = MockHTTPResponse(
+        content=get_response('1.5', 'istiod.txt'), headers={'Content-Type': 'text/plain'}
+    )
     check = Istio(common.CHECK_NAME, {}, [common.MOCK_LEGACY_ISTIOD_INSTANCE])
     check.check_id = 'test:123'
-
-    with requests_mock.Mocker() as metric_request:
-        metric_request.get('http://localhost:8080/metrics', text=get_response('1.5', 'istiod.txt'))
-        dd_run_check(check)
+    dd_run_check(check)
 
     # Use version mocked from istiod 1.5 fixture
     MOCK_VERSION = '1.5.0'

--- a/linkerd/tests/test_linkerd.py
+++ b/linkerd/tests/test_linkerd.py
@@ -4,8 +4,8 @@
 import os
 
 import pytest
-import requests_mock
 
+from datadog_checks.base.utils.http_testing import MockHTTPResponse
 from datadog_checks.linkerd import LinkerdCheck
 
 from .common import (
@@ -31,14 +31,15 @@ def get_response(filename):
     return response
 
 
-def test_linkerd(aggregator, dd_run_check):
+def test_linkerd(aggregator, dd_run_check, mock_openmetrics_http):
     """
     Test the full check
     """
+    mock_openmetrics_http.get.return_value = MockHTTPResponse(
+        content=get_response('linkerd.txt'), headers={'Content-Type': 'text/plain'}
+    )
     check = LinkerdCheck('linkerd', {}, [MOCK_INSTANCE])
-    with requests_mock.Mocker() as metric_request:
-        metric_request.get('http://fake.tld/prometheus', text=get_response('linkerd.txt'))
-        dd_run_check(check)
+    dd_run_check(check)
 
     for metric in LINKERD_FIXTURE_VALUES:
         aggregator.assert_metric(metric, LINKERD_FIXTURE_VALUES[metric])
@@ -52,11 +53,12 @@ def test_linkerd(aggregator, dd_run_check):
     )
 
 
-def test_linkerd_v2(aggregator, dd_run_check):
+def test_linkerd_v2(aggregator, dd_run_check, mock_openmetrics_http):
+    mock_openmetrics_http.get.return_value = MockHTTPResponse(
+        content=get_response('linkerd_v2.txt'), headers={'Content-Type': 'text/plain'}
+    )
     check = LinkerdCheck('linkerd', {}, [MOCK_INSTANCE])
-    with requests_mock.Mocker() as metric_request:
-        metric_request.get('http://fake.tld/prometheus', text=get_response('linkerd_v2.txt'))
-        dd_run_check(check)
+    dd_run_check(check)
 
     for metric_name, metric_type in EXPECTED_METRICS_V2.items():
         aggregator.assert_metric(metric_name, metric_type=metric_type)
@@ -83,12 +85,11 @@ def test_linkerd_v2_new(aggregator, dd_run_check, mock_http_response):
     )
 
 
-def test_openmetrics_error(monkeypatch, dd_run_check):
+def test_openmetrics_error(dd_run_check, mock_openmetrics_http):
+    mock_openmetrics_http.get.side_effect = Exception("test error")
     check = LinkerdCheck('linkerd', {}, [MOCK_INSTANCE])
-    with requests_mock.Mocker() as metric_request:
-        metric_request.get('http://fake.tld/prometheus', exc="Exception")
-        with pytest.raises(Exception):
-            dd_run_check(check)
+    with pytest.raises(Exception):
+        dd_run_check(check)
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
## Motivation

Step 6 PR 6.1 of the httpx test-decoupling migration. Two integrations still mock at the `requests` layer via `requests_mock.Mocker()`, which couples test mocks to the underlying HTTP library and blocks the eventual `requests` → `httpx` swap.

Plan: https://datadoghq.atlassian.net/wiki/spaces/AI/pages/6692406054

## Approach

Replace `requests_mock.Mocker()` with `mock_openmetrics_http` (the OpenMetrics v1 mixin fixture that patches `OpenMetricsScraperMixin.get_http_handler`) and `MockHTTPResponse`. v2 tests already use `mock_http_response` and are unchanged.

Pattern A (text response):
```python
def test_X(aggregator, dd_run_check, mock_openmetrics_http):
    mock_openmetrics_http.get.return_value = MockHTTPResponse(
        content=get_response(...), headers={'Content-Type': 'text/plain'},
    )
    ...
```

Pattern B (exception): set `mock_openmetrics_http.get.side_effect`.

7 tests across 2 files: linkerd/tests/test_linkerd.py (3 v1 tests), istio/tests/test_unit_istio_v1.py (4 tests).

## Verification

- `ddev test -fs linkerd istio` — clean.
- `ddev --no-interactive test linkerd` — 4 passed, 1 e2e skipped.
- `ddev --no-interactive test istio` — 24 passed, 2 e2e skipped.

Stacked on `mwdd146980/httpx-migration-base`.