### PR TITLE
DDEV Validate DEP: Always set repo_choice if check_root is true

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -163,9 +163,18 @@ def check_root():
     return False
 
 
+def repo_choice_from_root(root: str) -> str:
+    """Derive ``repo_choice`` from a repo root path (same rule as ``--here``)."""
+    return os.path.basename(root).replace('integrations-', '')
+
+
 def initialize_root(config, agent=False, core=False, extras=False, marketplace=False, here=False, **kwargs):
     """Initialize root directory based on config and options"""
     if check_root():
+        root = get_root()
+        if root:
+            config['repo_choice'] = repo_choice_from_root(root)
+            config['repo_name'] = REPO_CHOICES.get(config['repo_choice'], config['repo_choice'])
         return
 
     repo_choice = (
@@ -197,8 +206,7 @@ def initialize_root(config, agent=False, core=False, extras=False, marketplace=F
 
         root = os.getcwd()
         if here:
-            # Repo choices use the integration repo name without the `integrations-` prefix
-            config['repo_choice'] = os.path.basename(root).replace('integrations-', '')
+            config['repo_choice'] = repo_choice_from_root(root)
 
     config['repo_name'] = REPO_CHOICES.get(config['repo_choice'], config['repo_choice'])
     set_root(root)

--- a/datadog_checks_dev/tests/tooling/test_utils.py
+++ b/datadog_checks_dev/tests/tooling/test_utils.py
@@ -5,6 +5,7 @@ import os
 from os.path import join
 
 import mock
+import pytest
 
 from datadog_checks.dev.tooling.config import copy_default_config
 from datadog_checks.dev.tooling.utils import (
@@ -85,6 +86,27 @@ def test_initialize_root_env_var(set_root, get_root):
         initialize_root(config)
         assert set_root.called
         set_root.assert_called_with(os.path.expanduser(ddev_env))
+
+
+@pytest.mark.parametrize(
+    'root_path, expected_choice, expected_name',
+    [
+        ('/fake/path/integrations-core', 'core', 'integrations-core'),
+        ('/fake/path/integrations-extras', 'extras', 'integrations-extras'),
+        ('/fake/path/marketplace', 'marketplace', 'marketplace'),
+    ],
+)
+@mock.patch('datadog_checks.dev.tooling.utils.get_root')
+@mock.patch('datadog_checks.dev.tooling.utils.set_root')
+def test_initialize_root_sets_repo_when_root_already_set(set_root, get_root, root_path, expected_choice, expected_name):
+    get_root.return_value = root_path
+
+    config = copy_default_config()
+    initialize_root(config)
+
+    assert not set_root.called
+    assert config['repo_choice'] == expected_choice
+    assert config['repo_name'] == expected_name
 
 
 @not_windows_ci


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

When check_root() was true, the repo_choice would never get set for the application config. initialize_root returns immediately when check_root() is true, so it never runs the [code](https://github.com/DataDog/integrations-core/blob/nasir.thomas/unpinned-dependencies-extras-and-market/datadog_checks_dev/datadog_checks/dev/tooling/utils.py#L166) that sets config['repo_choice']

This PR makes sure that repo_choice is set even if check_root() is true.

### Motivation
<!-- What inspired you to submit this pull request? -->

Issue found when working through this PR: https://github.com/DataDog/integrations-core/pull/23584

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
