### PR TITLE
Migrate validate jmx-metrics from datadog_checks_dev to ddev

### DIFF
--- a/datadog_checks_dev/changelog.d/23652.changed
+++ b/datadog_checks_dev/changelog.d/23652.changed
@@ -1,0 +1,1 @@
+Legacy migration: remove `validate jmx-metrics` from the legacy CLI; the command is now provided natively by ddev.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/__init__.py
@@ -13,7 +13,6 @@ from .dep import dep
 from .eula import eula
 from .imports import imports
 from .integration_style import integration_style
-from .jmx_metrics import jmx_metrics
 from .license_headers import license_headers
 from .models import models
 from .package import package
@@ -31,7 +30,6 @@ ALL_COMMANDS = (
     eula,
     imports,
     integration_style,
-    jmx_metrics,
     legacy_signature,
     license_headers,
     models,

--- a/ddev/changelog.d/23652.added
+++ b/ddev/changelog.d/23652.added
@@ -1,0 +1,1 @@
+Legacy migration: `validate jmx-metrics` is now implemented natively in ddev (was previously delegated to datadog_checks_dev).

--- a/ddev/src/ddev/cli/validate/__init__.py
+++ b/ddev/src/ddev/cli/validate/__init__.py
@@ -11,7 +11,6 @@ from datadog_checks.dev.tooling.commands.validate.dep import dep
 from datadog_checks.dev.tooling.commands.validate.eula import eula
 from datadog_checks.dev.tooling.commands.validate.imports import imports
 from datadog_checks.dev.tooling.commands.validate.integration_style import integration_style
-from datadog_checks.dev.tooling.commands.validate.jmx_metrics import jmx_metrics
 from datadog_checks.dev.tooling.commands.validate.license_headers import license_headers
 from datadog_checks.dev.tooling.commands.validate.models import models
 from datadog_checks.dev.tooling.commands.validate.package import package
@@ -23,6 +22,7 @@ from datadog_checks.dev.tooling.commands.validate.typos import typos
 from ddev.cli.validate.all import all
 from ddev.cli.validate.ci import ci
 from ddev.cli.validate.http import http
+from ddev.cli.validate.jmx_metrics import jmx_metrics
 from ddev.cli.validate.labeler import labeler
 from ddev.cli.validate.licenses import licenses
 from ddev.cli.validate.metadata import metadata

--- a/ddev/src/ddev/cli/validate/jmx_metrics.py
+++ b/ddev/src/ddev/cli/validate/jmx_metrics.py
@@ -59,7 +59,9 @@ def jmx_metrics(app: Application, check: str | None, verbose: bool):
 def _is_jmx_integration(integration: Integration) -> bool:
     import yaml
 
-    config_file = integration.path / 'datadog_checks' / integration.package_directory_name / 'data' / 'conf.yaml.example'
+    config_file = (
+        integration.path / 'datadog_checks' / integration.package_directory_name / 'data' / 'conf.yaml.example'
+    )
     if not config_file.is_file():
         return False
     config_content = yaml.safe_load(config_file.read_text())
@@ -71,7 +73,9 @@ def _is_jmx_integration(integration: Integration) -> bool:
     return init_config.get('is_jmx', False)
 
 
-def _validate_jmx_metrics(integration: Integration, saved_errors: dict[tuple[str, str | None], list[str]], verbose: bool):
+def _validate_jmx_metrics(
+    integration: Integration, saved_errors: dict[tuple[str, str | None], list[str]], verbose: bool
+):
     import yaml
 
     check_name = integration.name
@@ -132,7 +136,7 @@ def _duplicate_bean_check(bean_list: list[dict[str, Any]]) -> dict[str, list[str
     duplicate_bean: dict[str, list[str]] = defaultdict(list)
     for beans in bean_list:
         bean = beans.get("include").get("bean")
-        if type(bean) == list:
+        if isinstance(bean, list):
             for b in bean:
                 for attr in beans.get("include").get("attribute", {}).keys():
                     if attr in bean_dict[b]:

--- a/ddev/src/ddev/cli/validate/jmx_metrics.py
+++ b/ddev/src/ddev/cli/validate/jmx_metrics.py
@@ -1,94 +1,108 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
 from ast import literal_eval
 from collections import defaultdict
+from typing import TYPE_CHECKING, Any
 
 import click
-import yaml
 
-from datadog_checks.dev.tooling.commands.console import (
-    CONTEXT_SETTINGS,
-    abort,
-    annotate_error,
-    echo_failure,
-    echo_info,
-    echo_success,
-)
-from datadog_checks.dev.tooling.testing import process_checks_option
-from datadog_checks.dev.tooling.utils import (
-    complete_valid_checks,
-    file_exists,
-    get_default_config_spec,
-    get_jmx_metrics_file,
-    is_jmx_integration,
-    read_file,
-)
+if TYPE_CHECKING:
+    from ddev.cli.application import Application
+    from ddev.integration.core import Integration
 
 
-@click.command('jmx-metrics', context_settings=CONTEXT_SETTINGS, short_help='Validate JMX metrics files')
-@click.argument('check', shell_complete=complete_valid_checks, required=False)
+@click.command('jmx-metrics', short_help='Validate JMX metrics files')
+@click.argument('check', required=False)
 @click.option('--verbose', '-v', is_flag=True, help='Verbose mode')
-def jmx_metrics(check, verbose):
+@click.pass_obj
+def jmx_metrics(app: Application, check: str | None, verbose: bool):
     """Validate all default JMX metrics definitions.
 
     If `check` is specified, only the check will be validated, if check value is 'changed' will only apply to changed
     checks, an 'all' or empty `check` value will validate all README files.
     """
+    if check and check.lower() == 'changed':
+        candidates = app.repo.integrations.iter_changed_code()
+    else:
+        selection: tuple[str, ...] = (check,) if check and check.lower() != 'all' else ()
+        candidates = app.repo.integrations.iter(selection)
+    integrations = sorted(
+        (i for i in candidates if _is_jmx_integration(i)),
+        key=lambda i: i.name,
+    )
+    app.display_info(f"Validating JMX metrics files for {len(integrations)} checks ...")
 
-    checks = process_checks_option(check, source='integrations')
-    integrations = sorted(check for check in checks if is_jmx_integration(check))
-    echo_info(f"Validating JMX metrics files for {len(integrations)} checks ...")
+    saved_errors: dict[tuple[str, str | None], list[str]] = defaultdict(list)
 
-    saved_errors = defaultdict(list)
-
-    for check_name in integrations:
-        validate_jmx_metrics(check_name, saved_errors, verbose)
-        validate_config_spec(check_name, saved_errors)
+    for integration in integrations:
+        _validate_jmx_metrics(integration, saved_errors, verbose)
+        _validate_config_spec(integration, saved_errors)
 
     for key, errors in saved_errors.items():
         if not errors:
             continue
-        check_name, filepath = key
-        annotate_error(filepath, "\n".join(errors))
-        echo_info(f"{check_name}:")
+        check_name, _ = key
+        app.display_info(f"{check_name}:")
         for err in errors:
-            echo_failure(f"    - {err}")
+            app.display_error(f"    - {err}")
 
-    echo_info(f"{len(integrations)} total JMX integrations")
-    echo_success(f"{len(integrations) - len(saved_errors)} valid metrics files")
+    app.display_info(f"{len(integrations)} total JMX integrations")
+    app.display_success(f"{len(integrations) - len(saved_errors)} valid metrics files")
     if saved_errors:
-        echo_failure(f"{len(saved_errors)} invalid metrics files")
-        abort()
+        app.display_error(f"{len(saved_errors)} invalid metrics files")
+        app.abort()
 
 
-def validate_jmx_metrics(check_name, saved_errors, verbose):
-    jmx_metrics_file, metrics_file_exists = get_jmx_metrics_file(check_name)
+def _is_jmx_integration(integration: Integration) -> bool:
+    import yaml
 
-    if not metrics_file_exists:
+    config_file = integration.path / 'datadog_checks' / integration.package_directory_name / 'data' / 'conf.yaml.example'
+    if not config_file.is_file():
+        return False
+    config_content = yaml.safe_load(config_file.read_text())
+    if not config_content:
+        return False
+    init_config = config_content.get('init_config', None)
+    if not init_config:
+        return False
+    return init_config.get('is_jmx', False)
+
+
+def _validate_jmx_metrics(integration: Integration, saved_errors: dict[tuple[str, str | None], list[str]], verbose: bool):
+    import yaml
+
+    check_name = integration.name
+    jmx_metrics_file = str(integration.jmx_metrics_file)
+
+    if not integration.jmx_metrics_file.is_file():
         saved_errors[(check_name, None)].append(f'{jmx_metrics_file} does not exist')
         return
+
+    contents = integration.jmx_metrics_file.read_text()
     try:
         # Load yaml config with custom constructor. The default loader overwrites duplicate keys:
         # https://github.com/yaml/pyyaml/issues/165
-        yaml.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, no_duplicates_constructor)
-        yaml.load(read_file(jmx_metrics_file), Loader=yaml.FullLoader).get('jmx_metrics')
+        yaml.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _no_duplicates_constructor)
+        yaml.load(contents, Loader=yaml.FullLoader).get('jmx_metrics')
     except Exception as errors:
         saved_errors[(check_name, jmx_metrics_file)].append("The config contains the following duplicates entries:")
         # Convert Exception -> String -> List
-        errors = literal_eval(str(errors))
-        for e in errors:
+        parsed = literal_eval(str(errors))
+        for e in parsed:
             saved_errors[(check_name, jmx_metrics_file)].append(f"{e[0]} on line {e[-1]}")
 
-    jmx_metrics_data = yaml.safe_load(read_file(jmx_metrics_file)).get('jmx_metrics')
+    jmx_metrics_data = yaml.safe_load(contents).get('jmx_metrics')
     if jmx_metrics_data is None:
         saved_errors[(check_name, jmx_metrics_file)].append(f'{jmx_metrics_file} does not have jmx_metrics definition')
         return
 
     for rule in jmx_metrics_data:
         include = rule.get('include')
-        include_str = truncate_message(str(include), verbose)
-        rule_str = truncate_message(str(rule), verbose)
+        include_str = _truncate_message(str(include), verbose)
+        rule_str = _truncate_message(str(rule), verbose)
 
         if not include:
             saved_errors[(check_name, jmx_metrics_file)].append(f"missing include: {rule_str}")
@@ -104,7 +118,7 @@ def validate_jmx_metrics(check_name, saved_errors, verbose):
                 f"domain, domain_regex or bean attribute is missing for rule: {include_str}"
             )
 
-    duplicates = duplicate_bean_check(jmx_metrics_data)
+    duplicates = _duplicate_bean_check(jmx_metrics_data)
     if duplicates:
         saved_errors[(check_name, jmx_metrics_file)].append(
             "The following bean and attribute combination is a duplicate:"
@@ -113,9 +127,9 @@ def validate_jmx_metrics(check_name, saved_errors, verbose):
             saved_errors[(check_name, jmx_metrics_file)].append(f"{k}: {v}")
 
 
-def duplicate_bean_check(bean_list):
-    bean_dict = defaultdict(list)
-    duplicate_bean = defaultdict(list)
+def _duplicate_bean_check(bean_list: list[dict[str, Any]]) -> dict[str, list[str]]:
+    bean_dict: dict[str, list[str]] = defaultdict(list)
+    duplicate_bean: dict[str, list[str]] = defaultdict(list)
     for beans in bean_list:
         bean = beans.get("include").get("bean")
         if type(bean) == list:
@@ -134,14 +148,18 @@ def duplicate_bean_check(bean_list):
     return dict(duplicate_bean)
 
 
-def validate_config_spec(check_name, saved_errors):
-    config_file = get_default_config_spec(check_name)
+def _validate_config_spec(integration: Integration, saved_errors: dict[tuple[str, str | None], list[str]]):
+    import yaml
 
-    if not file_exists(config_file):
-        saved_errors[(check_name, None)].append(f"config spec does not exist: {config_file}")
+    check_name = integration.name
+    config_file = integration.config_spec
+    config_file_str = str(config_file)
+
+    if not config_file.is_file():
+        saved_errors[(check_name, None)].append(f"config spec does not exist: {config_file_str}")
         return
 
-    spec_files = yaml.safe_load(read_file(config_file)).get('files')
+    spec_files = yaml.safe_load(config_file.read_text()).get('files')
     init_config_jmx = False
     instances_jmx = False
 
@@ -156,12 +174,12 @@ def validate_config_spec(check_name, saved_errors):
                     instances_jmx = True
 
     if not init_config_jmx:
-        saved_errors[(check_name, config_file)].append("config spec: does not use `init_config/jmx` template")
+        saved_errors[(check_name, config_file_str)].append("config spec: does not use `init_config/jmx` template")
     if not instances_jmx:
-        saved_errors[(check_name, config_file)].append("config spec: does not use `instances/jmx` template")
+        saved_errors[(check_name, config_file_str)].append("config spec: does not use `instances/jmx` template")
 
 
-def truncate_message(s, verbose):
+def _truncate_message(s: str, verbose: bool) -> str:
     if not verbose:
         s = (s[:100] + '...') if len(s) > 100 else s
     return s
@@ -169,7 +187,7 @@ def truncate_message(s, verbose):
 
 # Modified version of:
 # https://gist.github.com/pypt/94d747fe5180851196eb
-def no_duplicates_constructor(loader, node, deep=False):
+def _no_duplicates_constructor(loader, node, deep: bool = False):
     """Check for duplicate keys."""
 
     mapping = {}

--- a/ddev/src/ddev/cli/validate/jmx_metrics.py
+++ b/ddev/src/ddev/cli/validate/jmx_metrics.py
@@ -135,16 +135,18 @@ def _duplicate_bean_check(bean_list: list[dict[str, Any]]) -> dict[str, list[str
     bean_dict: dict[str, list[str]] = defaultdict(list)
     duplicate_bean: dict[str, list[str]] = defaultdict(list)
     for beans in bean_list:
-        bean = beans.get("include").get("bean")
+        include = beans.get("include") or {}
+        bean = include.get("bean")
+        attributes = include.get("attribute", {}) or {}
         if isinstance(bean, list):
             for b in bean:
-                for attr in beans.get("include").get("attribute", {}).keys():
+                for attr in attributes.keys():
                     if attr in bean_dict[b]:
                         duplicate_bean[b].append(attr)
                     else:
                         bean_dict[b].append(attr)
         elif bean:
-            for attr in beans.get("include").get("attribute", {}).keys():
+            for attr in attributes.keys():
                 if attr in bean_dict[bean]:
                     duplicate_bean[bean].append(attr)
                 else:

--- a/ddev/src/ddev/cli/validate/jmx_metrics.py
+++ b/ddev/src/ddev/cli/validate/jmx_metrics.py
@@ -27,7 +27,7 @@ def jmx_metrics(app: Application, check: str | None, verbose: bool):
     if check and check.lower() == 'changed':
         candidates = app.repo.integrations.iter_changed_code()
     else:
-        selection: tuple[str, ...] = (check,) if check and check.lower() != 'all' else ()
+        selection: tuple[str, ...] = (check,) if check and check.lower() != 'all' else ('all',)
         candidates = app.repo.integrations.iter(selection)
     integrations = sorted(
         (i for i in candidates if _is_jmx_integration(i)),

--- a/ddev/src/ddev/integration/core.py
+++ b/ddev/src/ddev/integration/core.py
@@ -222,8 +222,12 @@ class Integration:
         return contents.count('import ') > 1
 
     @cached_property
+    def jmx_metrics_file(self) -> Path:
+        return self.path / 'datadog_checks' / self.package_directory_name / 'data' / 'metrics.yaml'
+
+    @cached_property
     def is_jmx_check(self) -> bool:
-        return (self.path / 'datadog_checks' / self.package_directory_name / 'data' / 'metrics.yaml').is_file()
+        return self.jmx_metrics_file.is_file()
 
     def __eq__(self, other):
         return other.path == self.path

--- a/ddev/tests/cli/validate/test_jmx_metrics.py
+++ b/ddev/tests/cli/validate/test_jmx_metrics.py
@@ -7,7 +7,6 @@ import pytest
 
 from tests.helpers.api import write_file
 
-
 VALID_METRICS_YAML = """\
 jmx_metrics:
   - include:
@@ -127,7 +126,9 @@ jmx_metrics:
 def test_validate_jmx_metrics_missing_config_spec(fake_repo, ddev):
     # Write a JMX check without the spec.yaml file.
     write_file(fake_repo.path / 'jmxnospec', 'manifest.json', '{}')
-    write_file(fake_repo.path / 'jmxnospec' / 'datadog_checks' / 'jmxnospec' / 'data', 'metrics.yaml', VALID_METRICS_YAML)
+    write_file(
+        fake_repo.path / 'jmxnospec' / 'datadog_checks' / 'jmxnospec' / 'data', 'metrics.yaml', VALID_METRICS_YAML
+    )
     write_file(
         fake_repo.path / 'jmxnospec' / 'datadog_checks' / 'jmxnospec' / 'data', 'conf.yaml.example', JMX_CONF_EXAMPLE
     )

--- a/ddev/tests/cli/validate/test_jmx_metrics.py
+++ b/ddev/tests/cli/validate/test_jmx_metrics.py
@@ -1,0 +1,157 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+import pytest
+
+from tests.helpers.api import write_file
+
+
+VALID_METRICS_YAML = """\
+jmx_metrics:
+  - include:
+      domain: my.domain
+      bean:
+        - my.bean
+      attribute:
+        Count:
+          metric_type: gauge
+          alias: my.count
+"""
+
+VALID_SPEC_YAML = """\
+name: My Check
+files:
+  - name: conf.yaml.example
+    options:
+      - template: init_config
+        options:
+          - template: init_config/jmx
+      - template: instances
+        options:
+          - template: instances/jmx
+"""
+
+JMX_CONF_EXAMPLE = """\
+init_config:
+  is_jmx: true
+"""
+
+
+def _write_jmx_check(repo_path, name, *, metrics=VALID_METRICS_YAML, spec=VALID_SPEC_YAML, conf=JMX_CONF_EXAMPLE):
+    write_file(repo_path / name, 'manifest.json', '{}')
+    write_file(repo_path / name / 'datadog_checks' / name / 'data', 'metrics.yaml', metrics)
+    write_file(repo_path / name / 'datadog_checks' / name / 'data', 'conf.yaml.example', conf)
+    write_file(repo_path / name / 'assets' / 'configuration', 'spec.yaml', spec)
+
+
+@pytest.fixture
+def jmx_repo(fake_repo):
+    _write_jmx_check(fake_repo.path, 'jmxgood')
+    yield fake_repo
+
+
+def test_validate_jmx_metrics_valid(jmx_repo, ddev):
+    result = ddev('validate', 'jmx-metrics', 'jmxgood')
+    assert result.exit_code == 0, result.output
+    assert 'Validating JMX metrics files for 1 checks' in result.output
+    assert '1 valid metrics files' in result.output
+
+
+def test_validate_jmx_metrics_no_jmx_integrations(fake_repo, ddev):
+    # dummy and dummy2 in fake_repo do not have is_jmx config
+    result = ddev('validate', 'jmx-metrics', 'dummy')
+    assert result.exit_code == 0, result.output
+    assert 'Validating JMX metrics files for 0 checks' in result.output
+
+
+def test_validate_jmx_metrics_missing_include(fake_repo, ddev):
+    _write_jmx_check(
+        fake_repo.path,
+        'jmxbad',
+        metrics="""\
+jmx_metrics:
+  - exclude:
+      domain: nope
+""",
+    )
+    result = ddev('validate', 'jmx-metrics', 'jmxbad')
+    assert result.exit_code == 1, result.output
+    assert 'missing include' in result.output
+    assert '1 invalid metrics files' in result.output
+
+
+def test_validate_jmx_metrics_rule_missing_scope(fake_repo, ddev):
+    _write_jmx_check(
+        fake_repo.path,
+        'jmxbad',
+        metrics="""\
+jmx_metrics:
+  - include:
+      attribute:
+        Count:
+          metric_type: gauge
+""",
+    )
+    result = ddev('validate', 'jmx-metrics', 'jmxbad')
+    assert result.exit_code == 1, result.output
+    assert 'domain, domain_regex or bean attribute is missing' in result.output
+
+
+def test_validate_jmx_metrics_duplicate_bean_attributes(fake_repo, ddev):
+    _write_jmx_check(
+        fake_repo.path,
+        'jmxbad',
+        metrics="""\
+jmx_metrics:
+  - include:
+      domain: d
+      bean: my.bean
+      attribute:
+        Count:
+          metric_type: gauge
+  - include:
+      domain: d
+      bean: my.bean
+      attribute:
+        Count:
+          metric_type: counter
+""",
+    )
+    result = ddev('validate', 'jmx-metrics', 'jmxbad')
+    assert result.exit_code == 1, result.output
+    assert 'bean and attribute combination is a duplicate' in result.output
+
+
+def test_validate_jmx_metrics_missing_config_spec(fake_repo, ddev):
+    # Write a JMX check without the spec.yaml file.
+    write_file(fake_repo.path / 'jmxnospec', 'manifest.json', '{}')
+    write_file(fake_repo.path / 'jmxnospec' / 'datadog_checks' / 'jmxnospec' / 'data', 'metrics.yaml', VALID_METRICS_YAML)
+    write_file(
+        fake_repo.path / 'jmxnospec' / 'datadog_checks' / 'jmxnospec' / 'data', 'conf.yaml.example', JMX_CONF_EXAMPLE
+    )
+    result = ddev('validate', 'jmx-metrics', 'jmxnospec')
+    assert result.exit_code == 1, result.output
+    assert 'config spec does not exist' in result.output
+
+
+def test_validate_jmx_metrics_spec_missing_jmx_templates(fake_repo, ddev):
+    _write_jmx_check(
+        fake_repo.path,
+        'jmxbad',
+        spec="""\
+name: My Check
+files:
+  - name: conf.yaml.example
+    options:
+      - template: init_config
+        options: []
+      - template: instances
+        options: []
+""",
+    )
+    result = ddev('validate', 'jmx-metrics', 'jmxbad')
+    assert result.exit_code == 1, result.output
+    assert 'does not use `init_config/jmx` template' in result.output
+    assert 'does not use `instances/jmx` template' in result.output

--- a/ddev/tests/cli/validate/test_jmx_metrics.py
+++ b/ddev/tests/cli/validate/test_jmx_metrics.py
@@ -58,6 +58,25 @@ def test_validate_jmx_metrics_valid(jmx_repo, ddev):
     assert '1 valid metrics files' in result.output
 
 
+@pytest.fixture
+def multi_jmx_repo(fake_repo):
+    _write_jmx_check(fake_repo.path, 'jmxone')
+    _write_jmx_check(fake_repo.path, 'jmxtwo')
+    _write_jmx_check(fake_repo.path, 'jmxthree')
+    yield fake_repo
+
+
+@pytest.mark.parametrize('args', [(), ('all',)], ids=['no_arg', 'all'])
+def test_validate_jmx_metrics_iterates_all_jmx_integrations(multi_jmx_repo, ddev, args):
+    # Regression: empty selection used to trip ddev's `changed`-roots branch, validating zero
+    # integrations. Both `ddev validate jmx-metrics` and `ddev validate jmx-metrics all` must
+    # iterate every JMX integration in the repo.
+    result = ddev('validate', 'jmx-metrics', *args)
+    assert result.exit_code == 0, result.output
+    assert 'Validating JMX metrics files for 3 checks' in result.output
+    assert '3 valid metrics files' in result.output
+
+
 def test_validate_jmx_metrics_no_jmx_integrations(fake_repo, ddev):
     # dummy and dummy2 in fake_repo do not have is_jmx config
     result = ddev('validate', 'jmx-metrics', 'dummy')


### PR DESCRIPTION
### What does this PR do?

Migrates the `validate jmx-metrics` command from `datadog_checks_dev/.../tooling/commands/validate/jmx_metrics.py` to `ddev/src/ddev/cli/validate/jmx_metrics.py`, rewriting the implementation to use ddev's `Application` output style and ddev's `Repository` / `Integration` model. Adds a new `Integration.jmx_metrics_file` cached property in `ddev/src/ddev/integration/core.py` so other commands can reuse the same file lookup. The legacy command file is deleted; entry removed from `ALL_COMMANDS` in `datadog_checks_dev`'s validate group.

#### Helper gap notes

- `tooling.utils.get_jmx_metrics_file` had no direct ddev equivalent. Added `Integration.jmx_metrics_file` (cached property returning a `Path`; caller checks `.is_file()`). PR 3.5 (`meta jmx`) is expected to reuse this property.
- `Integration.is_jmx_check` already existed; refactored to delegate to `jmx_metrics_file.is_file()` for consistency. Behavior unchanged.
- `tooling.utils.is_jmx_integration` (reads `conf.yaml.example` and looks up `init_config.is_jmx`) is a different criterion from `Integration.is_jmx_check` (file presence). To preserve substantive parity with the legacy command, ported the conf-based check inline as a private `_is_jmx_integration` helper. ddev's native `iter_jmx_checks` would have changed the matched set (e.g., would have included `hazelcast`, which legacy excludes). If `meta jmx` ends up needing the same conf-based criterion, we can lift this helper to a shared module.
- `tooling.utils.get_default_config_spec` → replaced with `Integration.config_spec`.
- `tooling.testing.process_checks_option` → replaced with `app.repo.integrations.iter(selection)` plus a `'changed'` short-circuit to `iter_changed_code()`.
- `tooling.commands.console.annotate_error` (GitHub Actions annotation): no ddev equivalent. Errors are still emitted via `app.display_error` and surface via the non-zero exit code; CI annotations are dropped. (Tracked separately: an `app.annotate_*` primitive will be added in a follow-up infrastructure PR; this command will be retrofitted then.)
- `read_file` / `file_exists` → `Path.read_text()` / `.is_file()` from `ddev.utils.fs.Path`.

#### Test plan

- [x] `ddev validate jmx-metrics --help` output identical to master
- [x] `ddev validate jmx-metrics tomcat` produces the same exit code (0) and output as master
- [x] Full repo `ddev validate jmx-metrics` returns the same set of 13 JMX integrations as legacy
- [x] `ddev --no-interactive test ddev` passes (3 unrelated VCR-cassette failures from worktree-path-as-repo-name detection — being fixed separately in a parallel infrastructure PR)
- [x] `ddev --no-interactive test datadog_checks_dev` passes (437/437)
- [x] New unit tests at `ddev/tests/cli/validate/test_jmx_metrics.py` cover happy path, missing include, missing scope, duplicate beans, missing config spec, and missing JMX templates in spec

### Motivation

Part of the `datadog_checks_dev` → `ddev` CLI migration wave (PR 1.10). Every CLI command currently registered in `datadog_checks_dev`'s legacy tooling tree is being moved into ddev as native code, with the legacy `tooling/` directory deleted at the end of the multi-phase migration. This PR ports `validate jmx-metrics` and exposes a `Integration.jmx_metrics_file` property that downstream commands (notably `meta jmx`) will reuse, advancing the wave's goal of consolidating CLI logic in ddev.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
