### PR TITLE
Pin python version in the release-dispatch workflow

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -44,6 +44,7 @@ env:
   # Default ddev version when callers don't pass `ddev-version`. Tracked by Renovate.
   # renovate: datasource=pypi depName=ddev
   DEFAULT_DDEV_VERSION: "16.0.0"
+  PYTHON_VERSION: "3.13"
 
 jobs:
   prepare:
@@ -58,6 +59,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # ddev needs full tag history
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install ddev
         run: pip install "ddev==${{ inputs.ddev-version || env.DEFAULT_DDEV_VERSION }}"


### PR DESCRIPTION
### What does this PR do?
Pins the Python version for the release-dispatch workflow

### Motivation
The intent is to fix the [workflow](https://github.com/DataDog/integrations-extras/actions/runs/25558085407/job/75022144840) in the extras repository, which is failing because the GitHub runner is shipped with Python 3.12. This prevents the installation of the latest ddev version, as it requires Python 3.13+.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
