### PR TITLE
ci(release): use setup-ddev action in release-dispatch.yml

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -43,7 +43,8 @@ permissions:
 env:
   # Default ddev version when callers don't pass `ddev-version`. Tracked by Renovate.
   # renovate: datasource=pypi depName=ddev
-  DEFAULT_DDEV_VERSION: "14.3.2"
+  DEFAULT_DDEV_VERSION: "16.0.0"
+  PYTHON_VERSION: "3.13"
 
 jobs:
   prepare:
@@ -59,8 +60,34 @@ jobs:
         with:
           fetch-depth: 0 # ddev needs full tag history
 
+      - name: Checkout integrations-core actions
+        if: github.repository != 'DataDog/integrations-core'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: "DataDog/integrations-core"
+          ref: master
+          fetch-depth: 1
+          sparse-checkout: .github/actions
+          path: core-temp
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
+
       - name: Install ddev
-        run: pip install "ddev==${{ inputs.ddev-version || env.DEFAULT_DDEV_VERSION }}"
+        if: github.repository == 'DataDog/integrations-core'
+        uses: ./.github/actions/setup-ddev
+        with:
+          install-mode: pypi
+          ddev-version: "==${{ inputs.ddev-version || env.DEFAULT_DDEV_VERSION }}"
+
+      - name: Install ddev
+        if: github.repository != 'DataDog/integrations-core'
+        uses: ./core-temp/.github/actions/setup-ddev
+        with:
+          install-mode: pypi
+          ddev-version: "==${{ inputs.ddev-version || env.DEFAULT_DDEV_VERSION }}"
 
       - name: Configure ddev
         env:
@@ -92,7 +119,7 @@ jobs:
         run: python .github/workflows/scripts/release_dispatch.py
 
   dispatch:
-    name: Dispatch wheel builds (batch ${{ strategy.job-index + 1 }})
+    name: Dispatch wheel builds (batch ${{ strategy.job-index }})
     needs: prepare
     if: needs.prepare.outputs.has_packages == 'true' && !inputs.dry-run
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Replaces the bare `pip install "ddev==..."` with the composite `setup-ddev` action introduced in #23623
- When running from `integrations-core` the action is at `.github/actions/setup-ddev`
- When invoked as a reusable workflow from `integrations-extras` or `marketplace` (`github.repository != DataDog/integrations-core`), the `prepare` job does a sparse checkout of `integrations-core` into `core-temp` first, then calls `./core-temp/.github/actions/setup-ddev`
- Both paths use `install-mode: pypi` and forward the caller-supplied or default ddev version
- Explicit `setup-python` ensures the action's cache keys are stable regardless of runner default

**Depends on #23623** for the action definition — this PR should be merged after that one lands.

## Test plan
- [ ] Trigger a manual `workflow_dispatch` on `release-trigger.yml` with `dry-run: true` and confirm the `prepare` job installs ddev via the action (check the step names in the run log)
- [ ] Confirm the same run log shows the correct Python version set up before install