### PR TITLE
Add New External DNS Metrics: controller.consecutive.soft.errors & controller.last_reconcile

### DIFF
--- a/external_dns/changelog.d/23671.added
+++ b/external_dns/changelog.d/23671.added
@@ -1,0 +1,1 @@
+Added metrics external_dns.controller.last_reconcile & external_dns.controller.consecutive.soft.errors

--- a/external_dns/datadog_checks/external_dns/metrics.py
+++ b/external_dns/datadog_checks/external_dns/metrics.py
@@ -9,4 +9,6 @@ DEFAULT_METRICS = {
     'source_errors_total': 'source.errors.total',
     'registry_errors_total': 'registry.errors.total',
     'external_dns_controller_last_sync_timestamp_seconds': 'controller.last_sync',
+    'external_dns_controller_consecutive_soft_errors': 'controller.consecutive.soft.errors',
+    'external_dns_controller_last_reconcile_timestamp_seconds': 'controller.last.reconcile.timestamp.seconds',
 }

--- a/external_dns/datadog_checks/external_dns/metrics.py
+++ b/external_dns/datadog_checks/external_dns/metrics.py
@@ -10,5 +10,5 @@ DEFAULT_METRICS = {
     'registry_errors_total': 'registry.errors.total',
     'external_dns_controller_last_sync_timestamp_seconds': 'controller.last_sync',
     'external_dns_controller_consecutive_soft_errors': 'controller.consecutive.soft.errors',
-    'external_dns_controller_last_reconcile_timestamp_seconds': 'controller.last.reconcile.timestamp.seconds',
+    'external_dns_controller_last_reconcile_timestamp_seconds': 'controller.last_reconcile',
 }

--- a/external_dns/metadata.csv
+++ b/external_dns/metadata.csv
@@ -1,5 +1,7 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
 external_dns.controller.last_sync,gauge,,second,,Timestamp of last successful sync with the DNS provider,0,external_dns,controller last sync timestamp,
+external_dns.controller.consecutive.soft.errors,gauge,,error,,Number of consecutive soft errors in reconciliation loop,-1,external_dns,controller consecutive soft errors,
+external_dns.controller.last.reconcile.timestamp.seconds,gauge,,second,,Timestamp of last reconcile attempt,0,external_dns,controller last reconcile timestamp,
 external_dns.registry.endpoints.total,gauge,,resource,,Number of registry endpoints,0,external_dns,registry endpoints,
 external_dns.registry.errors.total,gauge,,error,,Number of registry errors,-1,external_dns,registry errors,
 external_dns.source.endpoints.total,gauge,,resource,,Number of source endpoints,0,external_dns,source endpoints,

--- a/external_dns/metadata.csv
+++ b/external_dns/metadata.csv
@@ -1,7 +1,7 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
 external_dns.controller.last_sync,gauge,,second,,Timestamp of last successful sync with the DNS provider,0,external_dns,controller last sync timestamp,
 external_dns.controller.consecutive.soft.errors,gauge,,error,,Number of consecutive soft errors in reconciliation loop,-1,external_dns,controller consecutive soft errors,
-external_dns.controller.last.reconcile.timestamp.seconds,gauge,,second,,Timestamp of last reconcile attempt,0,external_dns,controller last reconcile timestamp,
+external_dns.controller.last_reconcile,gauge,,second,,Timestamp of last reconcile attempt,0,external_dns,controller last reconcile timestamp,
 external_dns.registry.endpoints.total,gauge,,resource,,Number of registry endpoints,0,external_dns,registry endpoints,
 external_dns.registry.errors.total,gauge,,error,,Number of registry errors,-1,external_dns,registry errors,
 external_dns.source.endpoints.total,gauge,,resource,,Number of source endpoints,0,external_dns,source endpoints,

--- a/external_dns/metadata.csv
+++ b/external_dns/metadata.csv
@@ -1,8 +1,8 @@
-metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
-external_dns.controller.last_sync,gauge,,second,,Timestamp of last successful sync with the DNS provider,0,external_dns,controller last sync timestamp,
-external_dns.controller.consecutive.soft.errors,gauge,,error,,Number of consecutive soft errors in reconciliation loop,-1,external_dns,controller consecutive soft errors,
-external_dns.controller.last_reconcile,gauge,,second,,Timestamp of last reconcile attempt,0,external_dns,controller last reconcile timestamp,
-external_dns.registry.endpoints.total,gauge,,resource,,Number of registry endpoints,0,external_dns,registry endpoints,
-external_dns.registry.errors.total,gauge,,error,,Number of registry errors,-1,external_dns,registry errors,
-external_dns.source.endpoints.total,gauge,,resource,,Number of source endpoints,0,external_dns,source endpoints,
-external_dns.source.errors.total,gauge,,error,,Number of source errors,-1,external_dns,source errors,
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric,sample_tags
+external_dns.controller.consecutive.soft.errors,gauge,,error,,Number of consecutive soft errors in reconciliation loop,-1,external_dns,controller consecutive soft errors,,
+external_dns.controller.last_reconcile,gauge,,second,,Timestamp of last reconcile attempt,0,external_dns,controller last reconcile timestamp,,
+external_dns.controller.last_sync,gauge,,second,,Timestamp of last successful sync with the DNS provider,0,external_dns,controller last sync timestamp,,
+external_dns.registry.endpoints.total,gauge,,resource,,Number of registry endpoints,0,external_dns,registry endpoints,,
+external_dns.registry.errors.total,gauge,,error,,Number of registry errors,-1,external_dns,registry errors,,
+external_dns.source.endpoints.total,gauge,,resource,,Number of source endpoints,0,external_dns,source endpoints,,
+external_dns.source.errors.total,gauge,,error,,Number of source errors,-1,external_dns,source errors,,

--- a/external_dns/tests/fixtures/metrics.txt
+++ b/external_dns/tests/fixtures/metrics.txt
@@ -13,3 +13,9 @@ source_errors_total 0
 # HELP external_dns_controller_last_sync_timestamp_seconds Timestamp of last successful sync with the DNS provider
 # TYPE external_dns_controller_last_sync_timestamp_seconds gauge
 external_dns_controller_last_sync_timestamp_seconds 1.6343090342347014e+09
+# HELP external_dns_controller_consecutive_soft_errors Number of consecutive soft errors in reconciliation loop
+# TYPE external_dns_controller_consecutive_soft_errors gauge
+external_dns_controller_consecutive_soft_errors 0
+# HELP external_dns_controller_last_reconcile_timestamp_seconds Timestamp of last reconcile attempt
+# TYPE external_dns_controller_last_reconcile_timestamp_seconds gauge
+external_dns_controller_last_reconcile_timestamp_seconds 1.715520123e+09


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds two new metrics controller.consecutive.soft.errors & controller.last_reconcile

Verified the metrics with this documentation: https://kubernetes-sigs.github.io/external-dns/latest/docs/monitoring/metrics/#supported-metrics

### Motivation
<!-- What inspired you to submit this pull request? -->

Customer FR 
https://datadoghq.atlassian.net/browse/FRAGENT-3558
https://datadoghq.atlassian.net/browse/FRAGENT-3559

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
