### PR TITLE
Port in-product tile instructions for some OAuth integrations to the README that gets parsed inside the "Configuration instructions" section

### DIFF
--- a/docusign/README.md
+++ b/docusign/README.md
@@ -8,13 +8,13 @@ Docusign integration provides real-time insights into Docusign activities, such 
 
 ## Setup
 
-To collect Docusign logs, click the **Authorize** button to authenticate using OAuth.
+To collect Docusign logs, click **Authorize** to authenticate using OAuth.
 
-In order to add a new Docusign account, you first have to make sure:
+To add a Docusign account, make sure that:
 
-- The account has **admin access permission** within your Docusign organization. Otherwise, we won't be able to collect log events for you.
-- The account **may not be an admin** of more than one organization on Docusign as explained [here][2].
-- **Docusign Monitor** feature is enabled. This integration is only available for accounts with the paid version of [Monitor][3].
+- The account has **admin access permission** within your Docusign organization. Otherwise, Datadog can't collect log events for you.
+- The account is **not an admin** of more than one Docusign organization, as explained in [How to get monitoring data][2].
+- The **Docusign Monitor** feature is enabled. This integration is only available for accounts with the paid version of [Monitor][3].
 
 ## Data Collected
 

--- a/docusign/README.md
+++ b/docusign/README.md
@@ -8,49 +8,13 @@ Docusign integration provides real-time insights into Docusign activities, such 
 
 ## Setup
 
+To collect Docusign logs, click the **Authorize** button to authenticate using OAuth.
 
-### Prerequisites
+In order to add a new Docusign account, you first have to make sure:
 
-- Docusign Developer Account
-- Docusign account with a plan that includes Docusign Monitor
-
-
-### Generate API credentials in Docusign
-
-1. Log in to [Developer Admin Console][2].
-2. Get your **Account Name** from the **Account Profile** page.
-3. Access the **Apps and Keys** page under the **Integrations** section.
-4. Obtain the **User ID** from the **My Account Information** section.
-5. Click on **Add App and Integration Key** button.
-6. Provide an App Name and click **Create App**.
-7. Get your **Integration Key** from the General Info section.
-8. Click on **Generate RSA**, to get **RSA Private Key**.
-9. Click on **ADD URI**, set Redirect URI to `http://localhost/`.
-10. Click on **Save** button.
-11. Perform application consent by opening the accompanying Sample URL after replacing the placeholders 
-    - URL: `<BASE_URI>/oauth/auth?response_type=code&scope=signature impersonation organization_read&client_id=<YOUR_INTEGRATION_KEY>&redirect_uri=<YOUR_REDIRECT_URI>`
-        - `<BASE_URI>`: Use `https://account-d.docusign.com` for Developer or `https://account.docusign.com` for Production.
-        - `<YOUR_INTEGRATION_KEY>`: Replace with your Integration Key (Client ID) obtained previously.
-        - `<YOUR_REDIRECT_URI>`: Replace with your redirect URI, e.g., `http://localhost/`.
-    - Sign in to your account if prompted to
-    - Click on **Allow Access** 
-    - Note: _After selecting Accept, the browser will display a message saying that it can't load the page. You can safely ignore this page and close the tab._
-12. To test the integration with Developer account, select `Developer` option for the **Account Type** configuration parameter of the integration.
-13. Perform the [Go-Live][3] process for the App to access the [Production Account][4].
-14. Navigate to the Admin console and perform steps 2 to 10 and update the respective configuration parameters for the integration.
-
-
-### Connect your Docusign Account to Datadog
-
-1. Add your Account Type, Docusign Account Name, User Id, Integration Key, and RSA Private Key
-    |Parameters|Description|
-    |--------------------|--------------------|
-    |Account Type|Dropdown to select the type of Docusign account (e.g., Developer or Production).|
-    |Docusign Account Name|The name associated with the Docusign account (case sensitive).|
-    |User ID |A GUID value that uniquely identifies a Docusign user.|
-    |Integration Key|A unique GUID that identifies a Docusign integration.|
-    |RSA Private Key|A cryptographic key for signing JWT tokens for secure API authentication.|
-2. Click the Save button to save your settings.
+- The account has **admin access permission** within your Docusign organization. Otherwise, we won't be able to collect log events for you.
+- The account **may not be an admin** of more than one organization on Docusign as explained [here][2].
+- **Docusign Monitor** feature is enabled. This integration is only available for accounts with the paid version of [Monitor][3].
 
 ## Data Collected
 
@@ -68,10 +32,9 @@ The Docusign integration does not include any events.
 
 ## Support
 
-For further assistance, contact [Datadog Support][5].
+For further assistance, contact [Datadog Support][4].
 
 [1]: https://www.docusign.com/
-[2]: https://apps-d.docusign.com/admin/admin-dashboard
-[3]: https://developers.docusign.com/platform/go-live/
-[4]: https://apps.docusign.com/admin/admin-dashboard
-[5]: https://docs.datadoghq.com/help/
+[2]: https://developers.docusign.com/docs/monitor-api/how-to/get-monitoring-data/
+[3]: https://www.docusign.com/products/monitor
+[4]: https://docs.datadoghq.com/help/

--- a/hubspot_content_hub/README.md
+++ b/hubspot_content_hub/README.md
@@ -6,25 +6,36 @@
 
 The HubSpot Content Hub integration collects Activity Logs (audit, login, security) and Analytics Metrics (breakdown categories, content types), sending them to Datadog for detailed analysis. The logs are parsed and enriched for efficient searching, while the metrics provide insights into content performance.
 
-Use Datadog [Reference Tables][5] to enrich your telemetry with metadata from HubSpot. You can map value fields to a primary key to automatically append these fields to logs or events containing that key.
+Use Datadog [Reference Tables][2] to enrich your telemetry with metadata from HubSpot. You can map value fields to a primary key to automatically append these fields to logs or events containing that key.
 
 The integration includes dashboards that show and analyze both Activity Logs and Analytics Metrics, making it easier to monitor and understand trends and issues.
 
 ## Setup
 
-To integrate HubSpot with Datadog, Datadog connects to HubSpot using OAuth. The authenticated user must have owner permissions in the organizations that want to be integrated.
+To integrate HubSpot with Datadog, the authenticated user must be an owner of the organization you want to fetch data from.
 
-### Installation
+### Metrics and Logs
 
-1. Navigate to the [Integrations Page][2] and search for the "HubSpot Content Hub" integration.
-2. Click the tile.
-3. To add an account to install the integration, click the **Add Account** button.
-4. Read the instructions in the modal and choose your telemetry and reference tables settings. Then, click the **Authorize** button, which redirects you to the HubSpot login page.
-5. After logging in, you are prompted to select which HubSpot account you want to grant access to.
-6. Click **Authorize**.
-7. You're redirected back to Datadog's HubSpot tile with a new account. Datadog recommends changing the account name to something that is easier to remember. You can add multiple accounts with access to different organizations.
+To collect HubSpot metrics and logs, click the  **Authorize** button to authenticate using OAuth.
 
-**Note**: HubSpot saves this authorization selection. To be prompted again or add new organizations, revoke app access in HubSpot (`User Preferences > Integrations > Connected Applications > Datadog - HubSpot OAuth App`), then restart the setup process.
+### Companies Reference Tables
+
+Import company data from HubSpot as a Reference Table to enrich your Datadog logs and metrics with CRM details. You can also join Reference Tables with Product Analytics to correlate activity data across accounts.
+
+#### Get Started
+
+- Enable **Companies Reference Table** and click the **Authorize** button.
+
+#### After Setup
+
+- Datadog automatically creates a single Companies Reference Table for an account with the format `hubspot_companies_hubspotaccountid`
+- Your [HubSpot Reference Tables][3] will be available after a few minutes. Datadog automatically starts syncing data once the table is created.
+- Use [Event Management][4] to monitor your Reference Table's creation. You'll see progress events, success confirmations, and any errors that occur.
+- When ingestion succeeds, you'll see a [success event][5] for your Reference Table.
+
+#### For Existing Accounts
+
+- To create a Company Reference Table for an existing HubSpot account, edit the account and select the Companies Reference Table toggle.
 
 ## Data Collected
 
@@ -48,14 +59,15 @@ The HubSpot Content Hub integration does not include any events.
 
 ### Reference Tables
 
-[Reference Tables][5] allow you to automatically enrich and join your telemetry with additional fields from Companies defined in your HubSpot account.
+[Reference Tables][2] allow you to automatically enrich and join your telemetry with additional fields from Companies defined in your HubSpot account.
 
 ## Troubleshooting
 
-Need help? Contact [Datadog support][3].
+Need help? Contact [Datadog support][6].
 
 [1]: https://www.hubspot.com/products/content
-[2]: /integrations
-[3]: https://app.hubspot.com/login
-[4]: https://docs.datadoghq.com/help/
-[5]: /reference-tables
+[2]: /reference-tables
+[3]: /reference-tables?order=desc&p=1&sort=updated_at&source=HUBSPOT_CONTENT_HUB
+[4]: /event/explorer?query=source%3Ahubspot_content_hub&from_ts=1767286800000&to_ts=1767294000000&live=true
+[5]: /event/explorer?query=source%3Ahubspot_content_hub%20status%3Aok&from_ts=1767286800000&to_ts=1767294000000&live=true
+[6]: https://app.hubspot.com/login

--- a/hubspot_content_hub/README.md
+++ b/hubspot_content_hub/README.md
@@ -12,7 +12,7 @@ The integration includes dashboards that show and analyze both Activity Logs and
 
 ## Setup
 
-To integrate HubSpot with Datadog, the authenticated user must be an owner of the organization you want to fetch data from.
+To integrate HubSpot with Datadog, you must authenticate as an owner of the HubSpot organization that Datadog fetches data from.
 
 ### Metrics and Logs
 
@@ -28,10 +28,10 @@ Import company data from HubSpot as a Reference Table to enrich your Datadog log
 
 #### After Setup
 
-- Datadog automatically creates a single Companies Reference Table for an account with the format `hubspot_companies_hubspotaccountid`
-- Your [HubSpot Reference Tables][3] will be available after a few minutes. Datadog automatically starts syncing data once the table is created.
+- Datadog automatically creates one Companies Reference Table for each account, using the format `hubspot_companies_hubspotaccountid`.
+- Your [HubSpot Reference Tables][3] are available after a few minutes. Datadog automatically starts syncing data after the table is created.
 - Use [Event Management][4] to monitor your Reference Table's creation. You'll see progress events, success confirmations, and any errors that occur.
-- When ingestion succeeds, you'll see a [success event][5] for your Reference Table.
+- When ingestion succeeds, a [success event][5] appears for your Reference Table.
 
 #### For Existing Accounts
 

--- a/hubspot_content_hub/README.md
+++ b/hubspot_content_hub/README.md
@@ -70,4 +70,4 @@ Need help? Contact [Datadog support][6].
 [3]: /reference-tables?order=desc&p=1&sort=updated_at&source=HUBSPOT_CONTENT_HUB
 [4]: /event/explorer?query=source%3Ahubspot_content_hub&from_ts=1767286800000&to_ts=1767294000000&live=true
 [5]: /event/explorer?query=source%3Ahubspot_content_hub%20status%3Aok&from_ts=1767286800000&to_ts=1767294000000&live=true
-[6]: https://app.hubspot.com/login
+[6]: https://docs.datadoghq.com/help/

--- a/klaviyo/README.md
+++ b/klaviyo/README.md
@@ -38,10 +38,10 @@ Klaviyo does not include any events.
 
 ## Troubleshooting
 
-Need help? Contact [Datadog support][3].
+Need help? Contact [Datadog support][4].
 
 [1]: https://www.klaviyo.com/
 [2]: /logs?query=source%3Aklaviyo%2A
 [3]: /logs/pipelines/indexes
-[3]: https://docs.datadoghq.com/help/
+[4]: https://docs.datadoghq.com/help/
 

--- a/klaviyo/README.md
+++ b/klaviyo/README.md
@@ -8,14 +8,14 @@ Integrate Klaviyo with Datadog to gain insights into marketing campaign communic
 
 ## Setup
 
-The user who authenticates this integration must have access to the following Klaviyo Scopes:
+To authenticate this integration, you must have access to the following Klaviyo Scopes:
 
 - `accounts:read`
 - `events:read`
 - `flows:read`
 - `metrics:read`
 
-To add a new Klaviyo account, click the **Authorize** button and follow the instructions. Once you are redirected back to this page and the authentication is successful, your logs should be available within 5 minutes.
+To add a Klaviyo account, click **Authorize** and follow the instructions. After you are redirected back to this page and authentication succeeds, your logs should be available within 5 minutes.
 
 You can view your logs in the [Log Explorer][2]. Ensure you have a [Logs Index][3] set up for `source:klaviyo`.
 

--- a/klaviyo/README.md
+++ b/klaviyo/README.md
@@ -8,28 +8,16 @@ Integrate Klaviyo with Datadog to gain insights into marketing campaign communic
 
 ## Setup
 
-Follow the instructions below to configure this integration for Klaviyo Marketing and eCommerce events.
+The user who authenticates this integration must have access to the following Klaviyo Scopes:
 
-### Configuration
+- `accounts:read`
+- `events:read`
+- `flows:read`
+- `metrics:read`
 
-#### Install Datadog Integration in Klaviyo
-Within your Klaviyo account, first add the Datadog integration. The integration allows Datadog
-to see Klaviyo events and metrics via the Klaviyo API.
+To add a new Klaviyo account, click the **Authorize** button and follow the instructions. Once you are redirected back to this page and the authentication is successful, your logs should be available within 5 minutes.
 
-1. Log in to your [Klaviyo account][2].
-2. In the left-side panel, navigate to **Integrations**.
-3. Click **Add integrations**.
-4. Search for Datadog and click on the tile.
-5. Click **Install**. 
-6. Navigate to Datadog, then log in.
-
-#### Install Klaviyo Integration in Datadog
-After the above installation within Klaviyo is performed, complete the Datadog integration by clicking 
-**Install Integration** which guides you through an authorization process with Klaviyo.
-
-The authorization process will include an approval dialog which asks to give Datadog permission to
-read Klaviyo events and metrics. The scopes involved for this
-access are "accounts:read metrics:read events:read" and nothing more.
+You can view your logs in the [Log Explorer][2]. Ensure you have a [Logs Index][3] set up for `source:klaviyo`.
 
 ## Data Collected
 
@@ -53,6 +41,7 @@ Klaviyo does not include any events.
 Need help? Contact [Datadog support][3].
 
 [1]: https://www.klaviyo.com/
-[2]: https://www.klaviyo.com/login
+[2]: /logs?query=source%3Aklaviyo%2A
+[3]: /logs/pipelines/indexes
 [3]: https://docs.datadoghq.com/help/
 

--- a/ringcentral/README.md
+++ b/ringcentral/README.md
@@ -2,69 +2,20 @@
 
 ## Overview
 
-[RingCentral][5] is a leading cloud-based communication and collaboration platform for businesses. It offers services such as voice, messaging, and video conferencing, seamlessly integrating with various business applications.
+[RingCentral][1] is a leading cloud-based communication and collaboration platform for businesses. It offers services such as voice, messaging, and video conferencing, seamlessly integrating with various business applications.
 
 The RingCentral integration collects voice and audit logs, as well as Voice (Analytics) and A2P SMS metrics, and sends them to Datadog for comprehensive analysis.
 
 ## Setup
 
-### Generate API Credentials in RingCentral
+To collect RingCentral logs and metrics, click the **Authorize** button to authenticate using OAuth.
 
-1. Log into your [RingCentral Developer][2] account using a user with a Super Admin role or [Custom role](#create-and-assign-a-custom-role).  
-2. Click **Console**.
-3. Under the *Apps* section, click **Register App**.
-4. Select **Rest API app** for the App type .
-5. Fill in the required details for your application, such as the name and description.
+To integrate RingCentral with Datadog, you need a RingCentral account with appropriate permissions to access the RingCentral APIs. The required permissions are:
 
-   | Field     | Selection | 
-   | ---  | ----------- | 
-   | Do you intend to promote this app in the RingCentral App Gallery? | **No** |
-   | Auth type | **JWT auth flow** |
-   | Issue refresh tokens | **Yes** |
-   | Application scopes | Select the following: Analytics, Read Audit Trail, Read Call Log, A2P SMS|
-6. Click on Create App.
-7. After creating the application, find the `clientId` and `clientSecret` in the application settings.
-8. To get the JWT Token, locate the **Credentials** by clicking your username in the top-right corner.
-9. Click **Create JWT**.
-10. Add an appropriate label and select the **Production** environment.
-11. Allow this JWT token for only a specific app and add the `clientId` of the application created above.
-12. If you select an expiration date, make sure you create a new JWT and update it in the integration configuration before the expiry date.
-13. Click **Create JWT**.
-
-
-#### Create and assign a custom role
-1. Create a custom role, following the [RingCentral documentation][3].
-2. Select **Standard** role as a starting point.
-3. Provide additional **Audit Trail** and **Company Call Log - View Only** permissions to the role.
-4. Assign a custom role to a user, following the [RingCentral documentation][4].
-
-
-### Get RingCentral account ID
-1. Visit [RingCentral][1] and log in as a Super Admin.
-2. Under the **Users** section, click **Users with Extensions**.
-3. From the list of users, click on the user who has a "Super Admin" suffix in their name to open the user's details panel.
-4. Look at the URL in your web browser's address bar.
-5. Find the 9-digit number within the URL. This is your RingCentral account ID.
-   - **Example URL:** https://service.ringcentral.com/application/users/users/default/123456789/settings/default
-   - The `123456789` is your Account ID.
-
-
-### Connect your RingCentral account to Datadog
-
-1. Add your RingCentral credentials.
-
-   | Parameters       |   Description                                                 |
-   | ---------------  | --------------------------------------------------------------|
-   |Account ID        | The account ID of RingCentral.                                |
-   |Client ID         | The client ID of the RingCentral application.                 |
-   |Client Secret     | The client secret of the RingCentral application.             |
-   |JWT Token         | The JWT token from RingCentral.                               |
-   |Get Voice Calls Logs  | Enable to collect voice call logs from RingCentral. The default value is "true". |
-   |Get Voice(Analytics) Metrics | Enable to collect Voice(Analytics) metrics from RingCentral. The default value is "true". |
-   |Get SMS Metrics    | Enable to collect SMS metrics from RingCentral. The default value is "true".  | 
-   |Get Audit Logs     | Enable to collect audit logs from RingCentral. The default value is "true".   |
-
-2. Click the **Save** button to save your settings.
+- Read Call Log
+- Read Audit Trail
+- Analytics
+- A2P SMS
 
 ## Data Collected
 
@@ -84,11 +35,7 @@ The RingCentral integration does not include any events.
 
 ## Support
 
-For further assistance, contact [Datadog Support][6].
+For further assistance, contact [Datadog Support][2].
 
-[1]: https://service.ringcentral.com/
-[2]: https://developers.ringcentral.com/
-[3]: https://support.ringcentral.com/article-v2/10641-user-roles-permissions-edit-permission-custom-role.html?brand=RC_US&product=RingEX&language=en_US
-[4]: https://support.ringcentral.com/article-v2/10647-user-roles-permissions-assign-role-user-details.html?brand=RC_US&product=RingEX&language=en_US
-[5]: https://www.ringcentral.com/
-[6]: https://docs.datadoghq.com/help/
+[1]: https://www.ringcentral.com/
+[2]: https://docs.datadoghq.com/help/


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This merges the content of the tiles back into the README which are the source of truth.

### Motivation
<!-- What inspired you to submit this pull request? -->

There is ongoing effort to auto-generate OAuth integrations and part of this requires pulling the "configuration instructions" from these README files.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
