### PR TITLE
Fix calico E2E flake by waiting for default FelixConfiguration before patching

### DIFF
--- a/calico/tests/conftest.py
+++ b/calico/tests/conftest.py
@@ -5,7 +5,7 @@ from os import path
 
 import pytest
 
-from datadog_checks.dev.conditions import CheckEndpoints
+from datadog_checks.dev.conditions import CheckEndpoints, WaitFor
 from datadog_checks.dev.kind import kind_run
 from datadog_checks.dev.kube_port_forward import port_forward
 from datadog_checks.dev.subprocess import run_command
@@ -14,6 +14,11 @@ from .common import EXTRA_METRICS
 
 NAMESPACE = "calico"
 HERE = path.dirname(path.abspath(__file__))
+
+
+def _felix_config_default_exists():
+    result = run_command(["kubectl", "get", "felixconfiguration", "default"], capture='both')
+    return result.code == 0
 
 
 def setup_calico():
@@ -32,10 +37,27 @@ def setup_calico():
     # Wait for pods
     run_command(["kubectl", "wait", "--for=condition=Ready", "pods", "--all", "--all-namespaces", "--timeout=300s"])
 
-    # Activate Felix
+    # calico-node creates the default FelixConfiguration asynchronously after pods report Ready.
+    WaitFor(_felix_config_default_exists, attempts=60, wait=2)()
+
+    # check=True so a missed patch fails loudly here instead of as a connection-refused timeout later.
     run_command(
-        """kubectl exec -i -n kube-system calicoctl -- /calicoctl patch felixConfiguration
-        default --patch '{"spec":{"prometheusMetricsEnabled": true}}'"""
+        [
+            "kubectl",
+            "exec",
+            "-i",
+            "-n",
+            "kube-system",
+            "calicoctl",
+            "--",
+            "/calicoctl",
+            "patch",
+            "felixConfiguration",
+            "default",
+            "--patch",
+            '{"spec":{"prometheusMetricsEnabled": true}}',
+        ],
+        check=True,
     )
 
 


### PR DESCRIPTION
### What does this PR do?

In `calico/tests/conftest.py::setup_calico`, wait for the default `FelixConfiguration` resource to exist before patching it to enable Prometheus metrics, and use `check=True` on the patch so any future regression fails loudly at the patch step rather than as an opaque downstream timeout.

### Motivation

The Calico E2E job has been flaking intermittently on PR and `master` runs (e.g. master run [25589885652](https://github.com/DataDog/integrations-core/actions/runs/25589885652/job/75125491276), this PR's parent commit, and others). Each time, the failure looks like:

```
Hit error: resource does not exist: FelixConfiguration(default) with error:
  felixconfigurations.crd.projectcalico.org "default" not found
command terminated with exit code 1
...
ERROR at setup of test_check - datadog_checks.dev.errors.RetryError:
  Endpoint: http://10.1.0.x:port/metrics
  Error: <urlopen error [Errno 111] Connection refused>
```

The root cause:

1. `kubectl wait --for=condition=Ready pods ...` returns as soon as Calico pods pass their readiness probe, but the `default` FelixConfiguration CR is created asynchronously by `calico-node` *after* it starts. There is a small window where pods are Ready but `default` does not yet exist.
2. The immediate `calicoctl patch felixConfiguration default ...` then fails with `not found`. Because `datadog_checks.dev.subprocess.run_command` defaults to `check=False`, the failure is silently swallowed.
3. Setup proceeds, port-forward succeeds (the Service exists), but Felix never starts serving Prometheus on port 9091 because the patch never landed.
4. `CheckEndpoints` retries for ~200s and then raises `RetryError`, failing the entire session-scoped fixture and every test in the run.

The fix waits for the resource to exist before patching, and makes the patch loud on failure so this class of regression cannot recur silently.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the \`qa/skip-qa\` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the \`backport/<branch-name>\` label to the PR and it will automatically open a backport PR once this one is merged