### PR TITLE
Fix teamcity tests failure

### DIFF
--- a/teamcity/tests/docker/mockserver/docker-compose.yaml
+++ b/teamcity/tests/docker/mockserver/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   teamcity:
-    image: mockserver/mockserver:latest
+    image: mockserver/mockserver:5.15.0
     container_name: teamcity
     ports:
       - 8111:8111

--- a/teamcity/tests/docker/mockserver/docker-compose.yaml
+++ b/teamcity/tests/docker/mockserver/docker-compose.yaml
@@ -2,11 +2,11 @@ services:
   teamcity:
     image: mockserver/mockserver:latest
     container_name: teamcity
-    command: -serverPort 8111
     ports:
       - 8111:8111
     environment:
       MOCKSERVER_INITIALIZATION_JSON_PATH: /config/initializerJson.json
       MOCKSERVER_WATCH_INITIALIZATION_JSON: true
+      MOCKSERVER_SERVER_PORT: 8111
     volumes:
       - ./config:/config


### PR DESCRIPTION
### What does this PR do?
Fix the teamcity tests that started failing.

Root cause of the fialure: mockserver/mockserver:latest is a floating tag, and a newer mockserver image now ships with a built-in healthcheck that didn't exist before. 

The mockserver image's HEALTHCHECK runs `java -cp ... org.mockserver.cli.HealthCheck`, which probes the configured port. The container is started with -serverPort 8111 as a command-line flag, but the healthcheck CLI runs in a separate JVM and only reads the port from env var / system property (MOCKSERVER_SERVER_PORT). Since neither is set, the healthcheck probes the default port (1080), fails forever, and docker compose up --wait reports the container unhealthy and tears it down — even though mockserver itself is up on 8111 (you can see "8111 started on port: 8111" in the captured stdout).

To fix it:  make the existing healthcheck point at 8111:
```
  environment:
    MOCKSERVER_INITIALIZATION_JSON_PATH: /config/initializerJson.json
    MOCKSERVER_WATCH_INITIALIZATION_JSON: true
    MOCKSERVER_SERVER_PORT: 8111
```
  (Drop command: -serverPort 8111 since the env var now drives it.)
### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
