### PR TITLE
fix: add MarkCacheBytes to SystemMetrics query mapping

### DIFF
--- a/clickhouse/changelog.d/23677.fixed
+++ b/clickhouse/changelog.d/23677.fixed
@@ -1,0 +1,1 @@
+Add MarkCacheBytes to SystemMetrics query mapping for ClickHouse 25.x+ compatibility, where the metric was moved from system.asynchronous_metrics to system.metrics.

--- a/clickhouse/datadog_checks/clickhouse/queries.py
+++ b/clickhouse/datadog_checks/clickhouse/queries.py
@@ -181,6 +181,7 @@ SystemMetrics = {
                 'LocalThreadScheduled': {'name': 'thread.local.scheduled', 'type': 'gauge'},
                 'MMappedFileBytes': {'name': 'mmapped.file.size', 'type': 'gauge'},
                 'MMappedFiles': {'name': 'mmapped.file.current', 'type': 'gauge'},
+                'MarkCacheBytes': {'name': 'table.mergetree.storage.mark.cache', 'type': 'gauge'},
                 'MarksLoaderThreads': {'name': 'threads.marks_loader.total', 'type': 'gauge'},
                 'MarksLoaderThreadsActive': {'name': 'threads.marks_loader.active', 'type': 'gauge'},
                 'MarksLoaderThreadsScheduled': {'name': 'threads.marks_loader.scheduled', 'type': 'gauge'},


### PR DESCRIPTION
### What does this PR do?
Adds `MarkCacheBytes` to the `SystemMetrics` query mapping so that the `clickhouse.table.mergetree.storage.mark.cache` metric is collected for users running ClickHouse 25.x+.

The existing entry in `SystemAsynchronousMetrics` is kept for backwards compatibility with older ClickHouse versions. Only one table will ever contain the metric, so there's no risk of double-reporting.

### Motivation
ClickHouse [PR #81023](https://github.com/ClickHouse/ClickHouse/pull/81023) (merged June 2025) moved `MarkCacheBytes` from `system.asynchronous_metrics` to `system.metrics`. As a result, the `clickhouse.table.mergetree.storage.mark.cache` metric is no longer collected for users running ClickHouse 25.x+.

Verified against ClickHouse `25.12.3.21`:
 - `SELECT metric FROM system.asynchronous_metrics WHERE metric = 'MarkCacheBytes'` → 0 rows
 - `SELECT metric FROM system.metrics WHERE metric = 'MarkCacheBytes'` → 1 row

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
