### PR TITLE
Fix kafka actions license header

### DIFF
--- a/kafka_actions/datadog_checks/kafka_actions/message_filter.py
+++ b/kafka_actions/datadog_checks/kafka_actions/message_filter.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2025-present
+# (C) Datadog, Inc. 2026-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 """Message filtering with jq-style capabilities."""


### PR DESCRIPTION
### What does this PR do?
Fixes kafka actions license header
### Motivation
License header validation was failing on the release branch; this only needs to be on 7.79.x because the file that failed was removed on master: https://github.com/DataDog/integrations-core/pull/23430
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
