### PR TITLE
ddev lab: environment setup automation design

### DIFF
--- a/ddev/changelog.d/23682.added
+++ b/ddev/changelog.d/23682.added
@@ -1,0 +1,1 @@
+Add a proof-of-concept `ddev lab` command that delegates Milvus lab lifecycle operations to the Agent E2E framework.

--- a/ddev/changelog.d/23682.added
+++ b/ddev/changelog.d/23682.added
@@ -1,1 +1,1 @@
-Add a proof-of-concept `ddev lab` command that delegates Milvus lab lifecycle operations to the Agent E2E framework.
+Add proof-of-concept `ddev lab` commands that delegate Milvus lab lifecycle, listing, status, and connection operations to the Agent E2E framework.

--- a/ddev/src/ddev/cli/__init__.py
+++ b/ddev/src/ddev/cli/__init__.py
@@ -17,6 +17,7 @@ from ddev.cli.config import config
 from ddev.cli.dep import dep
 from ddev.cli.docs import docs
 from ddev.cli.env import env
+from ddev.cli.lab import lab
 from ddev.cli.meta import meta
 from ddev.cli.release import release
 from ddev.cli.size import size
@@ -157,6 +158,7 @@ ddev.add_command(create)
 ddev.add_command(dep)
 ddev.add_command(docs)
 ddev.add_command(env)
+ddev.add_command(lab)
 ddev.add_command(meta)
 ddev.add_command(release)
 ddev.add_command(run)

--- a/ddev/src/ddev/cli/lab/__init__.py
+++ b/ddev/src/ddev/cli/lab/__init__.py
@@ -22,6 +22,33 @@ def lab() -> None:
     """Manage remote integration labs."""
 
 
+@lab.command(name='list', short_help='List remote integration labs')
+@click.option(
+    '--agent-repo',
+    type=click.Path(file_okay=False, path_type=Path),
+    help='Path to a datadog-agent checkout. Defaults to the configured `repos.agent` path.',
+)
+@click.option(
+    '--agent-branch',
+    default=POC_AGENT_BRANCH,
+    show_default=True,
+    help='datadog-agent branch that contains the lab scenario POC.',
+)
+@click.option('--skip-branch-check', is_flag=True, help='Do not verify the datadog-agent checkout branch.')
+@click.pass_obj
+def list_command(
+    app: Application,
+    *,
+    agent_repo: Path | None,
+    agent_branch: str,
+    skip_branch_check: bool,
+) -> None:
+    """List remote integration labs by delegating to the Agent E2E framework."""
+    _run_agent_e2e_command(
+        app, _base_agent_e2e_command('list', 'milvus'), agent_repo, agent_branch, skip_branch_check
+    )
+
+
 @lab.command(short_help='Create a remote integration lab')
 @click.argument('integration')
 @click.option('--stack-name', help='Pulumi stack name to pass to the Agent E2E scenario.')
@@ -102,6 +129,112 @@ def destroy(
 ) -> None:
     """Destroy a remote integration lab by delegating to the Agent E2E framework."""
     command = _base_agent_e2e_command('destroy', integration)
+    if stack_name:
+        command.append(f'--stack-name={stack_name}')
+
+    _run_agent_e2e_command(app, command, agent_repo, agent_branch, skip_branch_check)
+
+
+@lab.command(short_help='Show remote integration lab status')
+@click.argument('integration')
+@click.option('--stack-name', help='Pulumi stack name to pass to the Agent E2E scenario.')
+@click.option(
+    '--agent-repo',
+    type=click.Path(file_okay=False, path_type=Path),
+    help='Path to a datadog-agent checkout. Defaults to the configured `repos.agent` path.',
+)
+@click.option(
+    '--agent-branch',
+    default=POC_AGENT_BRANCH,
+    show_default=True,
+    help='datadog-agent branch that contains the lab scenario POC.',
+)
+@click.option('--skip-branch-check', is_flag=True, help='Do not verify the datadog-agent checkout branch.')
+@click.pass_obj
+def show(
+    app: Application,
+    *,
+    integration: str,
+    stack_name: str | None,
+    agent_repo: Path | None,
+    agent_branch: str,
+    skip_branch_check: bool,
+) -> None:
+    """Show remote integration lab status by delegating to the Agent E2E framework."""
+    _status(app, integration, stack_name, agent_repo, agent_branch, skip_branch_check)
+
+
+@lab.command(short_help='Show remote integration lab status')
+@click.argument('integration')
+@click.option('--stack-name', help='Pulumi stack name to pass to the Agent E2E scenario.')
+@click.option(
+    '--agent-repo',
+    type=click.Path(file_okay=False, path_type=Path),
+    help='Path to a datadog-agent checkout. Defaults to the configured `repos.agent` path.',
+)
+@click.option(
+    '--agent-branch',
+    default=POC_AGENT_BRANCH,
+    show_default=True,
+    help='datadog-agent branch that contains the lab scenario POC.',
+)
+@click.option('--skip-branch-check', is_flag=True, help='Do not verify the datadog-agent checkout branch.')
+@click.pass_obj
+def status(
+    app: Application,
+    *,
+    integration: str,
+    stack_name: str | None,
+    agent_repo: Path | None,
+    agent_branch: str,
+    skip_branch_check: bool,
+) -> None:
+    """Show remote integration lab status by delegating to the Agent E2E framework."""
+    _status(app, integration, stack_name, agent_repo, agent_branch, skip_branch_check)
+
+
+@lab.command(short_help='Connect to a remote integration lab')
+@click.argument('integration')
+@click.option('--stack-name', help='Pulumi stack name to pass to the Agent E2E scenario.')
+@click.option(
+    '--agent-repo',
+    type=click.Path(file_okay=False, path_type=Path),
+    help='Path to a datadog-agent checkout. Defaults to the configured `repos.agent` path.',
+)
+@click.option(
+    '--agent-branch',
+    default=POC_AGENT_BRANCH,
+    show_default=True,
+    help='datadog-agent branch that contains the lab scenario POC.',
+)
+@click.option('--skip-branch-check', is_flag=True, help='Do not verify the datadog-agent checkout branch.')
+@click.pass_obj
+def connect(
+    app: Application,
+    *,
+    integration: str,
+    stack_name: str | None,
+    agent_repo: Path | None,
+    agent_branch: str,
+    skip_branch_check: bool,
+) -> None:
+    """Connect to a remote integration lab by delegating to the Agent E2E framework."""
+    command = _base_agent_e2e_command('connect', integration)
+    if stack_name:
+        command.append(f'--stack-name={stack_name}')
+
+    _run_agent_e2e_command(app, command, agent_repo, agent_branch, skip_branch_check)
+
+
+def _status(
+    app: Application,
+    integration: str,
+    stack_name: str | None,
+    agent_repo: Path | None,
+    agent_branch: str,
+    skip_branch_check: bool,
+) -> None:
+    command = _base_agent_e2e_command('status', integration)
     if stack_name:
         command.append(f'--stack-name={stack_name}')
 

--- a/ddev/src/ddev/cli/lab/__init__.py
+++ b/ddev/src/ddev/cli/lab/__init__.py
@@ -1,0 +1,163 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+from ddev.utils.fs import Path
+
+if TYPE_CHECKING:
+    from ddev.cli.application import Application
+
+
+POC_AGENT_BRANCH = 'add-milvus-e2e-scenario'
+SUPPORTED_LABS = {'milvus'}
+
+
+@click.group(short_help='Manage remote integration labs')
+def lab() -> None:
+    """Manage remote integration labs."""
+
+
+@lab.command(short_help='Create a remote integration lab')
+@click.argument('integration')
+@click.option('--stack-name', help='Pulumi stack name to pass to the Agent E2E scenario.')
+@click.option('--use-fakeintake', is_flag=True, help='Deploy fakeintake and point the Agent at it.')
+@click.option('--agent-version', help='Agent image tag to pass to the Agent E2E scenario.')
+@click.option('--full-image-path', help='Full Agent image path to pass to the Agent E2E scenario.')
+@click.option(
+    '--agent-env',
+    multiple=True,
+    help='Extra Agent environment variable to pass through, for example DD_LOG_LEVEL=debug.',
+)
+@click.option(
+    '--agent-repo',
+    type=click.Path(file_okay=False, path_type=Path),
+    help='Path to a datadog-agent checkout. Defaults to the configured `repos.agent` path.',
+)
+@click.option(
+    '--agent-branch',
+    default=POC_AGENT_BRANCH,
+    show_default=True,
+    help='datadog-agent branch that contains the lab scenario POC.',
+)
+@click.option('--skip-branch-check', is_flag=True, help='Do not verify the datadog-agent checkout branch.')
+@click.pass_obj
+def create(
+    app: Application,
+    *,
+    integration: str,
+    stack_name: str | None,
+    use_fakeintake: bool,
+    agent_version: str | None,
+    full_image_path: str | None,
+    agent_env: tuple[str, ...],
+    agent_repo: Path | None,
+    agent_branch: str,
+    skip_branch_check: bool,
+) -> None:
+    """Create a remote integration lab by delegating to the Agent E2E framework."""
+    command = _base_agent_e2e_command('create', integration)
+    if stack_name:
+        command.append(f'--stack-name={stack_name}')
+    if use_fakeintake:
+        command.append('--use-fakeintake')
+    if agent_version:
+        command.append(f'--agent-version={agent_version}')
+    if full_image_path:
+        command.append(f'--full-image-path={full_image_path}')
+    for env_var in agent_env:
+        command.append(f'--agent-env={env_var}')
+
+    _run_agent_e2e_command(app, command, agent_repo, agent_branch, skip_branch_check)
+
+
+@lab.command(short_help='Destroy a remote integration lab')
+@click.argument('integration')
+@click.option('--stack-name', help='Pulumi stack name to pass to the Agent E2E scenario.')
+@click.option(
+    '--agent-repo',
+    type=click.Path(file_okay=False, path_type=Path),
+    help='Path to a datadog-agent checkout. Defaults to the configured `repos.agent` path.',
+)
+@click.option(
+    '--agent-branch',
+    default=POC_AGENT_BRANCH,
+    show_default=True,
+    help='datadog-agent branch that contains the lab scenario POC.',
+)
+@click.option('--skip-branch-check', is_flag=True, help='Do not verify the datadog-agent checkout branch.')
+@click.pass_obj
+def destroy(
+    app: Application,
+    *,
+    integration: str,
+    stack_name: str | None,
+    agent_repo: Path | None,
+    agent_branch: str,
+    skip_branch_check: bool,
+) -> None:
+    """Destroy a remote integration lab by delegating to the Agent E2E framework."""
+    command = _base_agent_e2e_command('destroy', integration)
+    if stack_name:
+        command.append(f'--stack-name={stack_name}')
+
+    _run_agent_e2e_command(app, command, agent_repo, agent_branch, skip_branch_check)
+
+
+def _base_agent_e2e_command(action: str, integration: str) -> list[str]:
+    normalized_integration = integration.lower().replace('_', '-')
+    if normalized_integration not in SUPPORTED_LABS:
+        supported = ', '.join(sorted(SUPPORTED_LABS))
+        raise click.ClickException(f'Unsupported lab {integration!r}. This POC supports: {supported}')
+
+    return ['dda', 'inv', f'aws.{action}-{normalized_integration}']
+
+
+def _run_agent_e2e_command(
+    app: Application,
+    command: list[str],
+    agent_repo: Path | None,
+    agent_branch: str,
+    skip_branch_check: bool,
+) -> None:
+    resolved_agent_repo = _resolve_agent_repo(app, agent_repo)
+    if not skip_branch_check:
+        _check_agent_branch(app, resolved_agent_repo, agent_branch)
+
+    app.display_info(f'Running in {resolved_agent_repo}: {" ".join(command)}')
+    process = app.platform.run_command(command, cwd=str(resolved_agent_repo))
+    if process.returncode:
+        app.abort(code=process.returncode)
+
+
+def _resolve_agent_repo(app: Application, agent_repo: Path | None) -> Path:
+    resolved_agent_repo = agent_repo or Path(app.config.repos['agent']).expand()
+    if not resolved_agent_repo.is_dir():
+        app.abort(
+            f'datadog-agent checkout not found at `{resolved_agent_repo}`. '
+            'Pass --agent-repo or configure [repos].agent.'
+        )
+    return resolved_agent_repo
+
+
+def _check_agent_branch(app: Application, agent_repo: Path, expected_branch: str) -> None:
+    process = app.platform.run_command(
+        ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+        cwd=str(agent_repo),
+        capture_output=True,
+        text=True,
+    )
+    if process.returncode:
+        app.abort(f'Unable to determine datadog-agent branch at `{agent_repo}`.')
+
+    current_branch = process.stdout.strip()
+    if current_branch != expected_branch:
+        app.abort(
+            f'This POC expects datadog-agent branch `{expected_branch}`, but `{agent_repo}` is on '
+            f'`{current_branch}`. Run `git -C {agent_repo} fetch origin {expected_branch}` then '
+            f'`git -C {agent_repo} checkout {expected_branch}`, or pass --skip-branch-check.'
+        )

--- a/docs/superpowers/specs/2026-05-05-environment-setup-automation-design.md
+++ b/docs/superpowers/specs/2026-05-05-environment-setup-automation-design.md
@@ -1,0 +1,559 @@
+# Environment Setup Automation Design
+
+**Date:** 2026-05-05  
+**Last revised:** 2026-05-07  
+**Status:** Draft  
+**Scope:** `ddev lab` — agentic framework for provisioning, seeding, and load-testing Datadog integration environments on remote EC2 infrastructure
+
+---
+
+## 1. Problem and Goals
+
+Setting up environments for Datadog integrations is one of the highest-friction steps in integration development. The pain concentrates in three areas:
+
+1. **Infrastructure complexity** — Some integrations (Oracle DB, IBM MQ, Kafka + ZooKeeper, Lustre clusters) require real VMs, licenses, or multi-node topologies that cannot run locally and require significant manual effort.
+2. **Data quality** — Test datasets are minimal or absent; developers run checks against empty systems that don't reflect production behavior, masking metric collection gaps.
+3. **Portability** — Environment setup knowledge is tribal. When a developer leaves or switches integrations, the environment has to be reconstructed from scratch.
+
+### Goals
+
+| Priority | Goal |
+|----------|------|
+| Primary | Provision a fully running integration environment on EC2 with a single command |
+| Primary | Seed the environment with realistic-looking data |
+| Primary | Generate continuous background load that exercises the integration's metric surface |
+| Primary | Include a configured Datadog Agent in every lab, ready to run the integration check |
+| Optional | Produce a human-readable record of what was set up and why |
+
+### Non-goals
+
+- Replacing `ddev env` for local unit/integration testing — `ddev lab` is for E2E and exploratory work against live infrastructure
+- Supporting every integration on day one — start with the hardest ones (Oracle, IBM MQ, Kafka, Cassandra, Lustre)
+- Running any part of the environment on a developer's local machine — all labs are remote
+
+---
+
+## 2. Architecture Overview
+
+The system has two distinct layers:
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  AI Research Phase  (runs once per integration version)          │
+│                                                                  │
+│  Sources: vendor docs, Docker Hub, metadata.csv, manifest.json   │
+│  (Does NOT require existing tests or compose files)              │
+│                                                                  │
+│  Produces complete tests/lab/ subtree:                           │
+│    lab.yaml                  ← manifest + narrative              │
+│    tests/lab/compose/        ← service topology (Docker)         │
+│    tests/lab/seed/           ← numbered, idempotent scripts      │
+│    tests/lab/load/           ← Locust or k6 script               │
+│    tests/lab/agent/          ← Datadog Agent integration config  │
+│    tests/lab/provision/      ← Ansible playbook (bare-metal only)│
+│    [starter main.tf]         ← handed to cloud-inventory repo    │
+└────────────────────────┬─────────────────────────────────────────┘
+                         │  artifacts reviewed + committed
+                         ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  Deterministic Execution Layer  (ddev lab CLI)                   │
+│                                                                  │
+│  create:   terraform apply → wait SSH → healthchecks →           │
+│            seed → load → start Agent → register                  │
+│                                                                  │
+│  stop:     stop load → docker compose down → update registry     │
+│                                                                  │
+│  destroy:  stop load → stop services → terraform destroy →       │
+│            deregister                                            │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+No AI runs at execution time. The AI phase is a one-time investment per integration version, repeatable when the technology version changes. The execution layer is a simple deterministic pipeline any team member can run.
+
+---
+
+## 3. The Research Phase
+
+### Trigger
+
+```bash
+ddev lab research <integration>                          # generate all artifacts fresh
+ddev lab research --update <integration> --version 3.8  # update for a new tech version
+```
+
+### Information sources
+
+The research agent has access to the following — **and nothing else**. The integration may be brand new with no existing tests or compose files, so the agent cannot rely on them.
+
+| Source | What it provides |
+|--------|-----------------|
+| `<integration>/metadata.csv` | The full set of metrics the integration collects — tells the agent what data must exist to make metric values non-zero |
+| `<integration>/manifest.json` | Integration display name, tags, categories — context for documentation searches |
+| Vendor documentation (WebFetch/WebSearch) | Service topology requirements, configuration, resource minimums |
+| Docker Hub (WebFetch) | Canonical image names, available tags, recommended versions |
+
+### What the agent produces
+
+The agent writes a complete `tests/lab/` subtree under the integration directory:
+
+```
+<integration>/
+  lab.yaml                            ← manifest (see Section 4)
+  tests/
+    lab/
+      compose/
+        docker-compose.yml            ← service(s) + Datadog Agent as Docker services
+      seed/
+        01_<description>.sh           ← numbered, idempotent, ordered
+        02_<description>.py
+        ...
+      load/
+        locustfile.py                 ← or k6_script.js
+      agent/
+        conf.yaml                     ← Datadog Agent integration config (instances, logs)
+      provision/                      ← bare-metal runtimes only
+        install_<service>.yml         ← Ansible playbook
+```
+
+Additionally, the agent produces a **starter `main.tf`** for the cloud-inventory repo (printed to stdout or saved to a staging path) that a cloud-infrastructure team member reviews and commits to `cloud-inventory/aws/agent-integrations-dev/labs/<integration>/`.
+
+### YAML comments as narrative
+
+Every non-obvious decision in `lab.yaml` and the generated scripts carries a YAML or shell comment explaining what the agent found in the documentation and why it made each choice (e.g., why a specific instance type, why a particular partition count, what metrics a given seed script targets). The human reviewer reads the comments to audit the agent's reasoning without needing to repeat the research.
+
+### Re-generation
+
+`ddev lab research --update kafka --version 3.8` diffs against the existing artifacts. The agent fetches the new version's changelog and release notes, identifies changed APIs or configuration keys, and updates the affected files. Unchanged files are left untouched.
+
+---
+
+## 4. The `lab.yaml` Schema
+
+`lab.yaml` is the manifest. It declares infrastructure, healthchecks, execution order, and Agent configuration. The generated scripts it references are the actual implementation.
+
+```yaml
+# lab.yaml — generated by `ddev lab research`, reviewed by a human before merging.
+# Comments in this file and in tests/lab/ explain every non-obvious decision.
+
+metadata:
+  integration: kafka
+  tech_version: "3.7"
+  generated_at: "2026-05-05"
+
+infrastructure:
+  # All labs run on EC2 — keeps environments shareable and off developer machines.
+  # Terraform source lives in cloud-inventory; see Section 5.
+  terraform:
+    source: cloud-inventory/aws/agent-integrations-dev/labs/kafka
+    region: us-east-1
+    # t3.large: Kafka broker + ZooKeeper combined require ~4 GB RAM under load.
+    # Upgrade to r5.xlarge if broker heap exceeds 2 GB.
+    instance_type: t3.large
+
+  runtime:
+    # Docker Compose runs inside the EC2 instance.
+    # For licensed software that can't be containerized, use type: bare-metal.
+    type: compose
+    file: tests/lab/compose/docker-compose.yml
+
+# Each service in the topology gets its own healthcheck entry.
+# Healthchecks run FROM the EC2 instance (via SSH), so "localhost" is the instance.
+# Seeds and load only start after all healthchecks pass.
+healthchecks:
+  - name: kafka-broker
+    type: tcp
+    host: localhost
+    port: 9092
+    timeout: 120s
+    interval: 5s
+  - name: zookeeper
+    type: tcp
+    host: localhost
+    port: 2181
+    timeout: 60s
+    interval: 5s
+
+seed:
+  # Seed scripts run in numbered order over SSH after all healthchecks pass.
+  # Scripts must be idempotent — re-running ddev lab create must not fail.
+  - type: script
+    path: tests/lab/seed/01_create_topics.sh
+    # Creates 10 topics with 3 partitions each to exercise kafka.partition.* metrics.
+  - type: script
+    path: tests/lab/seed/02_produce_sample_events.py
+    # Produces 50k events across all topics to populate consumer group lag metrics.
+
+load:
+  # Continuous background load keeps metric values non-zero during Agent check runs.
+  driver: locust                           # locust | k6
+  script: tests/lab/load/locustfile.py
+  # 20 RPS generates stable consumer lag without saturating a t3.large broker.
+  target_rps: 20
+
+agent:
+  # Datadog Agent runs as a service in docker-compose.yml (compose runtime) or as
+  # a standalone Docker container on the EC2 instance (bare-metal runtime).
+  # The image tag is intentionally mutable — use `ddev lab upgrade` to update.
+  image: datadog/agent:latest
+  config: tests/lab/agent/conf.yaml
+  # API key fetched from Secrets Manager at runtime; never stored in this file.
+  api_key_secret: agent-integrations-dev/datadog-api-key
+```
+
+### Bare-metal runtime example (Oracle)
+
+```yaml
+infrastructure:
+  terraform:
+    source: cloud-inventory/aws/agent-integrations-dev/labs/oracle
+    region: us-east-1
+    instance_type: r5.xlarge             # Oracle minimum: 16 GB RAM
+  runtime:
+    type: bare-metal
+    # Ansible installs Oracle from the license-gated S3 bucket.
+    provisioner: tests/lab/provision/install_oracle.yml
+    # Teardown runs the teardown playbook to deregister Oracle before terraform destroy.
+    teardown: tests/lab/provision/teardown_oracle.yml
+
+agent:
+  image: datadog/agent:latest
+  config: tests/lab/agent/conf.yaml
+  api_key_secret: agent-integrations-dev/datadog-api-key
+```
+
+### Cluster runtime example (Lustre)
+
+```yaml
+metadata:
+  integration: lustre
+  tech_version: "2.15"
+
+infrastructure:
+  terraform:
+    source: cloud-inventory/aws/agent-integrations-dev/labs/lustre
+    region: us-east-1
+    # Lustre requires a minimum 3-node cluster: MGS, MDS, and OSS.
+    # Instance sizing from Lustre hardware guide: r6i.xlarge for MDS/OSS under test load.
+    instance_type: r6i.xlarge
+
+  runtime:
+    type: bare-metal
+    provisioner: tests/lab/provision/install_lustre_cluster.yml
+    teardown: tests/lab/provision/teardown_lustre_cluster.yml
+
+healthchecks:
+  - name: mgs
+    type: script
+    script: tests/lab/healthcheck/check_mgs.sh
+    timeout: 180s
+    interval: 10s
+  - name: mds
+    type: script
+    script: tests/lab/healthcheck/check_mds.sh
+    timeout: 180s
+    interval: 10s
+  - name: oss
+    type: script
+    script: tests/lab/healthcheck/check_oss.sh
+    timeout: 180s
+    interval: 10s
+```
+
+---
+
+## 5. Healthcheck Mechanism
+
+### Stage 1 — EC2 SSH readiness
+
+Before any healthcheck from `lab.yaml` runs, the CLI polls for SSH availability on port 22. This catches instance boot failures, user-data script crashes, and AMI provisioning delays. Timeout is fixed at 5 minutes; if SSH isn't available by then, `ddev lab create` aborts and prints the EC2 console log for diagnosis.
+
+### Stage 2 — Service readiness
+
+Each entry in `healthchecks` is polled independently until it passes or times out. All entries must pass before seed scripts begin.
+
+Supported healthcheck types:
+
+| Type | Mechanism | When to use |
+|------|-----------|-------------|
+| `tcp` | TCP connection to `host:port` | Databases, message brokers, simple servers |
+| `http` | HTTP GET, expect `200` (or configurable status) | REST APIs, management UIs |
+| `script` | SSH + run script, expect exit code 0 | Complex readiness checks (cluster quorum, replication lag, Lustre mount state) |
+
+Healthcheck scripts live in `tests/lab/healthcheck/` and are part of the research phase output.
+
+### Failure behavior
+
+If any healthcheck times out, `ddev lab create` prints which check failed, shows the last N lines of the relevant service log (via SSH), and exits non-zero. The EC2 instance is left running for manual inspection. Running `ddev lab destroy <integration>` still works to clean up.
+
+---
+
+## 6. The Datadog Agent in the Lab
+
+Every lab provisions a Datadog Agent configured to run the integration check continuously. This is the primary artifact of the lab — the goal is to see real metrics flowing into Datadog from a live service.
+
+### Compose runtime
+
+The Agent runs as a service in `tests/lab/compose/docker-compose.yml`, generated by the research phase:
+
+```yaml
+services:
+  kafka:
+    image: confluentinc/cp-kafka:3.7.0
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    # ... generated from vendor docs
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:3.7.0
+    # ...
+
+  datadog-agent:
+    image: ${DD_AGENT_IMAGE:-datadog/agent:latest}
+    environment:
+      DD_API_KEY: ${DD_API_KEY}
+      DD_SITE: datadoghq.com
+    volumes:
+      - ./agent/conf.yaml:/etc/datadog-agent/conf.d/kafka.d/conf.yaml:ro
+    depends_on:
+      kafka:
+        condition: service_healthy
+```
+
+The `DD_AGENT_IMAGE` environment variable defaults to `datadog/agent:latest`, allowing version overrides without editing the compose file.
+
+### Bare-metal runtime
+
+The Agent runs as a Docker container on the EC2 instance alongside the bare-metal service. The Ansible provisioner installs Docker (if not present), pulls the Agent image, and starts it with the same volume mount pattern.
+
+### Updating the Agent
+
+```bash
+ddev lab upgrade <integration> --agent 7.57.0
+# Pulls datadog/agent:7.57.0 on the EC2 instance, restarts the container, verifies the check runs.
+
+ddev lab upgrade <integration> --integration 16.2.0
+# Updates the integration package inside the Agent container to the specified version.
+```
+
+`ddev lab upgrade` does not reprovision the EC2 instance or re-seed data. It only restarts the Agent container with the new image or package.
+
+---
+
+## 7. Infrastructure — Terraform in cloud-inventory
+
+### Prerequisites
+
+The CLI requires both repos to be configured in ddev:
+
+```bash
+ddev config set repos.core /path/to/integrations-core
+ddev config set repos.cloud-inventory /path/to/cloud-inventory
+```
+
+`ddev lab` resolves Terraform source paths from `lab.yaml` relative to the `cloud-inventory` repo root.
+
+### Directory layout
+
+```
+cloud-inventory/
+  terraform-modules/
+    integration-lab-ec2/           # recipe: single-instance lab
+      main.tf
+      variables.tf
+      outputs.tf
+    integration-lab-ec2-cluster/   # recipe: multi-node lab (Kafka, Lustre, Cassandra)
+      main.tf
+      variables.tf
+      outputs.tf
+  aws/
+    agent-integrations-dev/
+      labs/
+        kafka/
+          main.tf                  # calls integration-lab-ec2-cluster
+          terraform.tfvars
+        oracle/
+          main.tf
+          terraform.tfvars
+        lustre/
+          main.tf
+          terraform.tfvars
+```
+
+### What the recipe modules handle
+
+- EC2 instance(s) + security group (SSH + service ports, ingress from team VPN CIDR only)
+- IAM instance profile for SSM access (fallback if SSH key is lost)
+- S3 bucket for seed artifacts, load scripts, and license files
+- CloudWatch log group for EC2 system logs
+- `team = agent-integrations` and `env = lab` tags for cost attribution
+
+### Integration-specific configs
+
+Each `labs/<integration>/main.tf` calls the appropriate recipe module and sets:
+
+- Instance type and count from `lab.yaml`
+- AMI ID (Ubuntu 22.04 base, maintained by the platform team)
+- Service-specific ports for the security group
+- License file S3 paths (bare-metal runtimes only)
+
+The research phase generates a starter `main.tf`. A cloud-infrastructure team member reviews and merges it into cloud-inventory separately from the integrations-core artifacts.
+
+---
+
+## 8. CLI — `ddev lab`
+
+### Full command surface
+
+```bash
+# Lab lifecycle
+ddev lab create <integration>              # provision → healthcheck → seed → load → Agent
+ddev lab stop <integration>                # stop load + services, leave EC2 running
+ddev lab start <integration>              # restart services + load on a stopped lab
+ddev lab destroy <integration>            # full teardown: services → terraform destroy → deregister
+ddev lab reload <integration>             # re-run seed scripts without reprovisioning
+
+# Visibility
+ddev lab list                              # all labs (all owners), with status
+ddev lab status <integration>             # EC2 state, service health, Agent check status
+ddev lab logs <integration> [service]     # tail logs from a service or the Agent
+ddev lab ssh <integration>                # open SSH session
+
+# Updates
+ddev lab upgrade <integration> --agent <version>        # update Agent image
+ddev lab upgrade <integration> --integration <version>  # update integration package
+
+# Research phase
+ddev lab research <integration>                          # generate all artifacts
+ddev lab research --update <integration> --version <v>  # update for a new tech version
+```
+
+### `ddev lab create` flow
+
+```
+1.  Read <integration>/lab.yaml
+2.  terraform apply in cloud-inventory/aws/agent-integrations-dev/labs/<integration>/
+3.  Poll port 22 until SSH is available (5 min max)
+4.  For bare-metal runtime: ansible-playbook tests/lab/provision/install_<service>.yml
+5.  For each healthcheck in parallel: poll until pass or timeout
+6.  For each seed script in order: ssh <ec2_ip> "bash -s" < tests/lab/seed/<script>
+7.  Fetch DD_API_KEY from Secrets Manager
+8.  For bare-metal: docker run -d datadog/agent on EC2 with conf volume
+9.  For compose: DD_API_KEY=<key> docker compose up -d (Agent service included)
+10. ssh <ec2_ip> "nohup <load driver> ..." to start background load
+11. Write lab entry to shared registry (S3)
+12. Print: EC2 IP, SSH command, Agent container name, Datadog integration dashboard URL
+```
+
+### `ddev lab destroy` flow
+
+```
+1.  ssh <ec2_ip>: pkill -f locust (or k6)              ← stop load generator
+2.  For compose runtime: docker compose down --volumes  ← stop services + remove data
+3.  For bare-metal: ansible-playbook teardown_<service>.yml  ← deregister + clean up
+4.  terraform destroy in cloud-inventory/aws/.../labs/<integration>/
+5.  Remove integration entry from S3 registry
+```
+
+### `ddev lab stop` / `ddev lab start`
+
+`stop` halts services without destroying EC2. Useful for saving costs overnight:
+
+```
+stop: ssh → stop load → docker compose stop (or systemd stop)
+      → update registry status to "stopped"
+
+start: ssh → docker compose start (or systemd start)
+       → re-run all healthchecks → restart load generator
+       → update registry status to "running"
+```
+
+### Shared lab registry
+
+Lives in S3 (`s3://agent-integrations-dev-lab-state/registry.json`), visible to the whole team:
+
+```json
+{
+  "kafka": {
+    "owner": "david.kirov@datadoghq.com",
+    "ec2_instance_id": "i-0abc123",
+    "ec2_ip": "10.0.1.42",
+    "terraform_workspace": "kafka",
+    "started_at": "2026-05-05T10:30:00Z",
+    "last_active_at": "2026-05-07T09:15:00Z",
+    "tech_version": "3.7",
+    "agent_version": "7.56.2",
+    "status": "running"
+  }
+}
+```
+
+Any team member can destroy a lab they don't own but is prompted to confirm. `ddev lab list` renders this as a table with status indicators.
+
+---
+
+## 9. Research Artifact Conventions
+
+### Directory layout
+
+```
+<integration>/
+  lab.yaml
+  tests/
+    lab/
+      compose/
+        docker-compose.yml        # service topology + Agent service
+      seed/
+        01_<description>.sh       # numbered, idempotent, ordered
+        02_<description>.py
+        ...
+      load/
+        locustfile.py             # or k6_script.js
+      agent/
+        conf.yaml                 # Datadog Agent integration config
+      healthcheck/
+        check_<service>.sh        # custom healthcheck scripts (script type only)
+      provision/                  # bare-metal runtimes only
+        install_<service>.yml
+        teardown_<service>.yml
+```
+
+### Seed script conventions
+
+- Numbered prefix controls execution order
+- Must be idempotent (`CREATE TABLE IF NOT EXISTS`, `CREATE TOPIC IF NOT EXISTS`)
+- Target specific metrics from `metadata.csv` — comments name which metrics each script enables
+- Secrets (passwords, license keys) come from environment variables injected by the Terraform IAM instance profile, never hardcoded
+
+### Load generator conventions
+
+- Locust is the default; k6 for protocols Locust doesn't support natively (e.g., raw Kafka protocol)
+- `target_rps` from `lab.yaml` sets the load level
+- Load daemon logs to `/var/log/ddev-lab-load.log` on the EC2 instance
+
+### Agent config conventions
+
+`tests/lab/agent/conf.yaml` follows standard Datadog integration config format, pre-filled with connection details that match the compose file or bare-metal installation (localhost, standard ports, credentials from environment variables).
+
+---
+
+## 10. Phased Rollout
+
+| Phase | Scope | Success criteria |
+|-------|-------|-----------------|
+| 1 | CLI skeleton: `create`, `stop`, `destroy`, `list`, `status` + shared registry + Kafka as reference (research artifacts hand-written) | Team member runs `ddev lab create kafka` and sees Agent metrics in Datadog |
+| 2 | `ddev lab research` command + research agent | Agent produces complete `tests/lab/` for Kafka from docs alone; diff against hand-written is minimal |
+| 3 | Research + runtime for Oracle and IBM MQ (bare-metal, Ansible provisioner) | `ddev lab create oracle` works end-to-end including teardown |
+| 4 | Lustre cluster support (multi-instance Terraform + cluster healthchecks) | `ddev lab create lustre` provisions 3-node cluster, Agent reports filesystem metrics |
+| 5 | `ddev lab upgrade`, cost controls (auto-stop after 7 days of inactivity) | Team can update Agent version without reprovisioning |
+
+---
+
+## 11. Open Questions
+
+1. **Terraform state backend** — cloud-inventory uses its own remote state. Lab workspaces should use the same backend. Confirm with cloud-infrastructure team before Phase 1.
+2. **AMI maintenance** — who owns Ubuntu 22.04 base AMI rotation? Platform team or agent-integrations?
+3. **Datadog API key in the lab** — the API key for the Agent should emit to a dedicated org/environment (e.g., `agent-integrations-labs` in the sandbox org) to avoid polluting production metric streams. Confirm with the Datadog-internal infra team.
+4. **Lustre licensing** — Lustre is open source but the cluster topology for production-like testing requires specific kernel modules on the AMI. Confirm AMI requirements with whoever last set up a Lustre test environment.
+5. **Cost controls** — auto-stop after 7 days of inactivity via a Lambda in cloud-inventory or `ddev lab gc`?
+6. **CI integration** — `ddev lab create` callable from CI for long-running E2E suites? If yes, registry needs a `ci_run_id` field and auto-destroy on pipeline completion.

--- a/docs/superpowers/specs/2026-05-05-environment-setup-automation-design.md
+++ b/docs/superpowers/specs/2026-05-05-environment-setup-automation-design.md
@@ -1,9 +1,9 @@
 # Environment Setup Automation Design
 
 **Date:** 2026-05-05  
-**Last revised:** 2026-05-07  
+**Last revised:** 2026-05-12  
 **Status:** Draft  
-**Scope:** `ddev lab` — agentic framework for provisioning, seeding, and load-testing Datadog integration environments on remote EC2 infrastructure
+**Scope:** `ddev lab` — agentic framework for provisioning, seeding, and load-testing Datadog integration environments on remote cloud infrastructure (AWS and GCP)
 
 ---
 
@@ -19,7 +19,7 @@ Setting up environments for Datadog integrations is one of the highest-friction 
 
 | Priority | Goal |
 |----------|------|
-| Primary | Provision a fully running integration environment on EC2 with a single command |
+| Primary | Provision a fully running integration environment on remote cloud infrastructure with a single command |
 | Primary | Seed the environment with realistic-looking data |
 | Primary | Generate continuous background load that exercises the integration's metric surface |
 | Primary | Include a configured Datadog Agent in every lab, ready to run the integration check |
@@ -45,25 +45,26 @@ The system has two distinct layers:
 │  (Does NOT require existing tests or compose files)              │
 │                                                                  │
 │  Produces complete tests/lab/ subtree:                           │
-│    lab.yaml                  ← manifest + narrative              │
+│    lab.yaml                  ← machine-readable manifest         │
+│    tests/lab/RESEARCH.md     ← human-readable narrative          │
 │    tests/lab/compose/        ← service topology (Docker)         │
 │    tests/lab/seed/           ← numbered, idempotent scripts      │
 │    tests/lab/load/           ← Locust or k6 script               │
 │    tests/lab/agent/          ← Datadog Agent integration config  │
 │    tests/lab/provision/      ← Ansible playbook (bare-metal only)│
-│    [starter main.tf]         ← handed to cloud-inventory repo    │
+│    [starter Pulumi program]  ← reviewed + merged to infra/       │
 └────────────────────────┬─────────────────────────────────────────┘
                          │  artifacts reviewed + committed
                          ▼
 ┌──────────────────────────────────────────────────────────────────┐
 │  Deterministic Execution Layer  (ddev lab CLI)                   │
 │                                                                  │
-│  create:   terraform apply → wait SSH → healthchecks →           │
+│  create:   pulumi up → wait SSH → healthchecks →                 │
 │            seed → load → start Agent → register                  │
 │                                                                  │
 │  stop:     stop load → docker compose down → update registry     │
 │                                                                  │
-│  destroy:  stop load → stop services → terraform destroy →       │
+│  destroy:  stop load → stop services → pulumi destroy →          │
 │            deregister                                            │
 └──────────────────────────────────────────────────────────────────┘
 ```
@@ -98,9 +99,10 @@ The agent writes a complete `tests/lab/` subtree under the integration directory
 
 ```
 <integration>/
-  lab.yaml                            ← manifest (see Section 4)
+  lab.yaml                            ← machine-readable manifest (see Section 4)
   tests/
     lab/
+      RESEARCH.md                     ← human-readable narrative (see below)
       compose/
         docker-compose.yml            ← service(s) + Datadog Agent as Docker services
       seed/
@@ -111,15 +113,26 @@ The agent writes a complete `tests/lab/` subtree under the integration directory
         locustfile.py                 ← or k6_script.js
       agent/
         conf.yaml                     ← Datadog Agent integration config (instances, logs)
-      provision/                      ← bare-metal runtimes only
+      healthcheck/
+        check_<service>.sh            ← custom healthcheck scripts (script type only)
+      provision/                      ← bare-metal and cluster runtimes only
         install_<service>.yml         ← Ansible playbook
+        teardown_<service>.yml
 ```
 
-Additionally, the agent produces a **starter `main.tf`** for the cloud-inventory repo (printed to stdout or saved to a staging path) that a cloud-infrastructure team member reviews and commits to `cloud-inventory/aws/agent-integrations-dev/labs/<integration>/`.
+Additionally, the agent produces a **starter Pulumi program** (`infra/labs/<integration>/`) that a team member reviews and merges alongside the integrations-core artifacts (see Section 7).
 
-### YAML comments as narrative
+### RESEARCH.md — human-readable narrative
 
-Every non-obvious decision in `lab.yaml` and the generated scripts carries a YAML or shell comment explaining what the agent found in the documentation and why it made each choice (e.g., why a specific instance type, why a particular partition count, what metrics a given seed script targets). The human reviewer reads the comments to audit the agent's reasoning without needing to repeat the research.
+`lab.yaml` is clean YAML with no inline comments. The agent's reasoning lives in `tests/lab/RESEARCH.md` instead. This file explains:
+
+- What this technology is and how it is typically deployed in production
+- Why specific choices were made — instance type, service topology, partition counts, network configuration
+- Which metrics each seed script targets (referenced from `metadata.csv`)
+- Operational gotchas identified in the vendor documentation
+- Links to the specific documentation pages and Docker Hub tags consulted
+
+The human reviewer reads `RESEARCH.md` to audit the agent's reasoning without needing to repeat the research. When the lab is updated for a new tech version, the agent rewrites the affected sections of `RESEARCH.md` alongside the affected artifacts.
 
 ### Re-generation
 
@@ -129,36 +142,20 @@ Every non-obvious decision in `lab.yaml` and the generated scripts carries a YAM
 
 ## 4. The `lab.yaml` Schema
 
-`lab.yaml` is the manifest. It declares infrastructure, healthchecks, execution order, and Agent configuration. The generated scripts it references are the actual implementation.
+`lab.yaml` is the machine-readable manifest. It declares infrastructure, healthchecks, execution order, and Agent configuration. All narrative explaining the choices lives in `RESEARCH.md`.
 
 ```yaml
-# lab.yaml — generated by `ddev lab research`, reviewed by a human before merging.
-# Comments in this file and in tests/lab/ explain every non-obvious decision.
-
 metadata:
   integration: kafka
   tech_version: "3.7"
   generated_at: "2026-05-05"
 
 infrastructure:
-  # All labs run on EC2 — keeps environments shareable and off developer machines.
-  # Terraform source lives in cloud-inventory; see Section 5.
-  terraform:
-    source: cloud-inventory/aws/agent-integrations-dev/labs/kafka
-    region: us-east-1
-    # t3.large: Kafka broker + ZooKeeper combined require ~4 GB RAM under load.
-    # Upgrade to r5.xlarge if broker heap exceeds 2 GB.
-    instance_type: t3.large
-
+  cloud: aws
   runtime:
-    # Docker Compose runs inside the EC2 instance.
-    # For licensed software that can't be containerized, use type: bare-metal.
     type: compose
     file: tests/lab/compose/docker-compose.yml
 
-# Each service in the topology gets its own healthcheck entry.
-# Healthchecks run FROM the EC2 instance (via SSH), so "localhost" is the instance.
-# Seeds and load only start after all healthchecks pass.
 healthchecks:
   - name: kafka-broker
     type: tcp
@@ -174,29 +171,19 @@ healthchecks:
     interval: 5s
 
 seed:
-  # Seed scripts run in numbered order over SSH after all healthchecks pass.
-  # Scripts must be idempotent — re-running ddev lab create must not fail.
   - type: script
     path: tests/lab/seed/01_create_topics.sh
-    # Creates 10 topics with 3 partitions each to exercise kafka.partition.* metrics.
   - type: script
     path: tests/lab/seed/02_produce_sample_events.py
-    # Produces 50k events across all topics to populate consumer group lag metrics.
 
 load:
-  # Continuous background load keeps metric values non-zero during Agent check runs.
-  driver: locust                           # locust | k6
+  driver: locust
   script: tests/lab/load/locustfile.py
-  # 20 RPS generates stable consumer lag without saturating a t3.large broker.
   target_rps: 20
 
 agent:
-  # Datadog Agent runs as a service in docker-compose.yml (compose runtime) or as
-  # a standalone Docker container on the EC2 instance (bare-metal runtime).
-  # The image tag is intentionally mutable — use `ddev lab upgrade` to update.
   image: datadog/agent:latest
   config: tests/lab/agent/conf.yaml
-  # API key fetched from Secrets Manager at runtime; never stored in this file.
   api_key_secret: agent-integrations-dev/datadog-api-key
 ```
 
@@ -204,15 +191,10 @@ agent:
 
 ```yaml
 infrastructure:
-  terraform:
-    source: cloud-inventory/aws/agent-integrations-dev/labs/oracle
-    region: us-east-1
-    instance_type: r5.xlarge             # Oracle minimum: 16 GB RAM
+  cloud: aws
   runtime:
     type: bare-metal
-    # Ansible installs Oracle from the license-gated S3 bucket.
     provisioner: tests/lab/provision/install_oracle.yml
-    # Teardown runs the teardown playbook to deregister Oracle before terraform destroy.
     teardown: tests/lab/provision/teardown_oracle.yml
 
 agent:
@@ -229,15 +211,21 @@ metadata:
   tech_version: "2.15"
 
 infrastructure:
-  terraform:
-    source: cloud-inventory/aws/agent-integrations-dev/labs/lustre
-    region: us-east-1
-    # Lustre requires a minimum 3-node cluster: MGS, MDS, and OSS.
-    # Instance sizing from Lustre hardware guide: r6i.xlarge for MDS/OSS under test load.
-    instance_type: r6i.xlarge
-
+  cloud: aws
   runtime:
-    type: bare-metal
+    type: cluster
+    nodes:
+      - role: mgs_mds
+        count: 1
+        instance_type: r6i.xlarge
+      - role: oss
+        count: 2
+        instance_type: r6i.xlarge
+      - role: client
+        count: 1
+        instance_type: t3.large
+    network:
+      lnet_port: 988
     provisioner: tests/lab/provision/install_lustre_cluster.yml
     teardown: tests/lab/provision/teardown_lustre_cluster.yml
 
@@ -263,13 +251,13 @@ healthchecks:
 
 ## 5. Healthcheck Mechanism
 
-### Stage 1 — EC2 SSH readiness
+### Stage 1 — SSH readiness
 
-Before any healthcheck from `lab.yaml` runs, the CLI polls for SSH availability on port 22. This catches instance boot failures, user-data script crashes, and AMI provisioning delays. Timeout is fixed at 5 minutes; if SSH isn't available by then, `ddev lab create` aborts and prints the EC2 console log for diagnosis.
+Before any healthcheck from `lab.yaml` runs, the CLI polls for SSH availability on port 22 of each provisioned instance. This catches instance boot failures, user-data script crashes, and provisioning delays. Timeout is fixed at 5 minutes per instance; if SSH isn't available by then, `ddev lab create` aborts and prints the cloud console log for diagnosis.
 
 ### Stage 2 — Service readiness
 
-Each entry in `healthchecks` is polled independently until it passes or times out. All entries must pass before seed scripts begin.
+Each entry in `healthchecks` is polled independently until it passes or times out. All entries must pass before seed scripts begin. For cluster runtimes, healthchecks run against their respective nodes using the IP map produced by Pulumi (see Section 7).
 
 Supported healthcheck types:
 
@@ -283,7 +271,7 @@ Healthcheck scripts live in `tests/lab/healthcheck/` and are part of the researc
 
 ### Failure behavior
 
-If any healthcheck times out, `ddev lab create` prints which check failed, shows the last N lines of the relevant service log (via SSH), and exits non-zero. The EC2 instance is left running for manual inspection. Running `ddev lab destroy <integration>` still works to clean up.
+If any healthcheck times out, `ddev lab create` prints which check failed, shows the last N lines of the relevant service log (via SSH), and exits non-zero. Instances are left running for manual inspection. `ddev lab destroy <integration>` still works to clean up.
 
 ---
 
@@ -302,11 +290,9 @@ services:
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    # ... generated from vendor docs
 
   zookeeper:
     image: confluentinc/cp-zookeeper:3.7.0
-    # ...
 
   datadog-agent:
     image: ${DD_AGENT_IMAGE:-datadog/agent:latest}
@@ -322,82 +308,99 @@ services:
 
 The `DD_AGENT_IMAGE` environment variable defaults to `datadog/agent:latest`, allowing version overrides without editing the compose file.
 
-### Bare-metal runtime
+### Bare-metal and cluster runtimes
 
-The Agent runs as a Docker container on the EC2 instance alongside the bare-metal service. The Ansible provisioner installs Docker (if not present), pulls the Agent image, and starts it with the same volume mount pattern.
+The Agent runs as a Docker container on one of the EC2 instances (the client node for cluster runtimes). The Ansible provisioner installs Docker if not present, pulls the Agent image, and starts it with the same volume mount pattern.
 
 ### Updating the Agent
 
 ```bash
 ddev lab upgrade <integration> --agent 7.57.0
-# Pulls datadog/agent:7.57.0 on the EC2 instance, restarts the container, verifies the check runs.
+# Pulls datadog/agent:7.57.0 on the instance, restarts the container, verifies the check runs.
 
 ddev lab upgrade <integration> --integration 16.2.0
 # Updates the integration package inside the Agent container to the specified version.
 ```
 
-`ddev lab upgrade` does not reprovision the EC2 instance or re-seed data. It only restarts the Agent container with the new image or package.
+`ddev lab upgrade` does not reprovision instances or re-seed data. It only restarts the Agent container with the new image or package.
 
 ---
 
-## 7. Infrastructure — Terraform in cloud-inventory
+## 7. Infrastructure — Pulumi Automation API
 
-### Prerequisites
+### Why Pulumi
 
-The CLI requires both repos to be configured in ddev:
+The infrastructure provisioning layer must be multi-cloud (AWS today, GCP in future sprints) and must execute on demand — not auto-applied on merge. The [Pulumi Automation API](https://www.pulumi.com/docs/using-pulumi/automation-api/) satisfies both:
 
-```bash
-ddev config set repos.core /path/to/integrations-core
-ddev config set repos.cloud-inventory /path/to/cloud-inventory
-```
+- **Multi-cloud**: the same Python program targets AWS or GCP by selecting a provider; switching is a `cloud:` field in `lab.yaml`
+- **On-demand**: `ddev lab create` calls `pulumi.up()` directly via the Python SDK — no external CI/CD trigger, no separate repo with auto-apply
+- **In-repo**: Pulumi programs live in `ddev/src/ddev/cli/lab/infra/` (Python), eliminating the cloud-inventory dependency
+- **State in object storage**: stack state stored in S3 (`aws`) or GCS (`gcp`) under `agent-integrations-dev-lab-state/pulumi/<integration>/`
 
-`ddev lab` resolves Terraform source paths from `lab.yaml` relative to the `cloud-inventory` repo root.
-
-### Directory layout
+### Pulumi program structure
 
 ```
-cloud-inventory/
-  terraform-modules/
-    integration-lab-ec2/           # recipe: single-instance lab
-      main.tf
-      variables.tf
-      outputs.tf
-    integration-lab-ec2-cluster/   # recipe: multi-node lab (Kafka, Lustre, Cassandra)
-      main.tf
-      variables.tf
-      outputs.tf
-  aws/
-    agent-integrations-dev/
-      labs/
-        kafka/
-          main.tf                  # calls integration-lab-ec2-cluster
-          terraform.tfvars
-        oracle/
-          main.tf
-          terraform.tfvars
-        lustre/
-          main.tf
-          terraform.tfvars
+ddev/src/ddev/cli/lab/
+  infra/
+    __init__.py
+    base.py              ← abstract LabInfra class (provision, destroy, outputs)
+    aws.py               ← AWS provider implementation
+    gcp.py               ← GCP provider implementation (Phase 2+)
+    cluster.py           ← multi-node cluster logic (node roles, security groups, IP map)
 ```
 
-### What the recipe modules handle
+The research phase generates a starter Pulumi program and places it in `infra/labs/<integration>/` inside the same PR as the `tests/lab/` artifacts. A team member reviews it before merging — same review gate as any other generated artifact.
 
-- EC2 instance(s) + security group (SSH + service ports, ingress from team VPN CIDR only)
-- IAM instance profile for SSM access (fallback if SSH key is lost)
-- S3 bucket for seed artifacts, load scripts, and license files
-- CloudWatch log group for EC2 system logs
-- `team = agent-integrations` and `env = lab` tags for cost attribution
+### What the Pulumi program provisions
 
-### Integration-specific configs
+**Single-instance (compose and bare-metal runtimes):**
+- VM instance (EC2 or GCE) + security group (SSH + service ports, ingress from team VPN CIDR only)
+- IAM instance profile / service account for Secrets Manager access
+- Object storage bucket for seed artifacts and license files
+- Cost-attribution tags: `team = agent-integrations`, `env = lab`
 
-Each `labs/<integration>/main.tf` calls the appropriate recipe module and sets:
+**Cluster runtime (Lustre, Kafka, Cassandra):**
+- VPC + subnet shared by all nodes
+- Security group with `lnet_port` (or equivalent) open between all instances in the group
+- Instances launched per role (from `lab.yaml` nodes list)
+- Outputs a `{role → [ip, ...]}` map used by subsequent steps
 
-- Instance type and count from `lab.yaml`
-- AMI ID (Ubuntu 22.04 base, maintained by the platform team)
-- Service-specific ports for the security group
-- License file S3 paths (bare-metal runtimes only)
+### Cluster provisioning flow (Lustre example)
 
-The research phase generates a starter `main.tf`. A cloud-infrastructure team member reviews and merges it into cloud-inventory separately from the integrations-core artifacts.
+Because LNET configuration requires each node to know the actual IP addresses of other nodes, provisioning follows a two-phase approach:
+
+```
+1. pulumi up  →  launch all nodes, emit {role → [ip, ...]} map
+2. Render Ansible inventory + vars from IP map
+3. ansible-playbook install_lustre_cluster.yml  (all nodes in parallel where possible)
+     Stage A: install kernel modules + lnet tools on all nodes
+     Stage B: configure lnet.conf with actual NIDs on all nodes
+     Stage C: start MGS → start MDS → start OSS → mount client
+4. Healthchecks run against per-role nodes
+5. Seed scripts run on client node
+6. Agent container starts on client node
+```
+
+The Ansible playbook receives the IP map via `--extra-vars`. Startup order (MGS before OSS before client mount) is encoded in the playbook's play sequence.
+
+### Registry entry
+
+```json
+{
+  "kafka": {
+    "owner": "david.kirov@datadoghq.com",
+    "cloud": "aws",
+    "instance_ids": ["i-0abc123"],
+    "instance_ips": {"primary": "10.0.1.42"},
+    "pulumi_stack": "agent-integrations/kafka",
+    "started_at": "2026-05-05T10:30:00Z",
+    "last_active_at": "2026-05-07T09:15:00Z",
+    "tech_version": "3.7",
+    "agent_version": "7.56.2",
+    "status": "running"
+  }
+}
+```
 
 ---
 
@@ -408,14 +411,14 @@ The research phase generates a starter `main.tf`. A cloud-infrastructure team me
 ```bash
 # Lab lifecycle
 ddev lab create <integration>              # provision → healthcheck → seed → load → Agent
-ddev lab stop <integration>                # stop load + services, leave EC2 running
+ddev lab stop <integration>                # stop load + services, leave instances running
 ddev lab start <integration>              # restart services + load on a stopped lab
-ddev lab destroy <integration>            # full teardown: services → terraform destroy → deregister
+ddev lab destroy <integration>            # full teardown: services → pulumi destroy → deregister
 ddev lab reload <integration>             # re-run seed scripts without reprovisioning
 
 # Visibility
 ddev lab list                              # all labs (all owners), with status
-ddev lab status <integration>             # EC2 state, service health, Agent check status
+ddev lab status <integration>             # instance state, service health, Agent check status
 ddev lab logs <integration> [service]     # tail logs from a service or the Agent
 ddev lab ssh <integration>                # open SSH session
 
@@ -432,32 +435,33 @@ ddev lab research --update <integration> --version <v>  # update for a new tech 
 
 ```
 1.  Read <integration>/lab.yaml
-2.  terraform apply in cloud-inventory/aws/agent-integrations-dev/labs/<integration>/
-3.  Poll port 22 until SSH is available (5 min max)
-4.  For bare-metal runtime: ansible-playbook tests/lab/provision/install_<service>.yml
+2.  pulumi up  (Pulumi Automation API, state in S3/GCS)
+3.  Poll port 22 on each instance until SSH is available (5 min max)
+4.  For bare-metal / cluster runtime: ansible-playbook install_<service>.yml
+    (cluster: with rendered IP map as extra-vars, plays run in role order)
 5.  For each healthcheck in parallel: poll until pass or timeout
-6.  For each seed script in order: ssh <ec2_ip> "bash -s" < tests/lab/seed/<script>
+6.  For each seed script in order: ssh <ip> "bash -s" < tests/lab/seed/<script>
 7.  Fetch DD_API_KEY from Secrets Manager
-8.  For bare-metal: docker run -d datadog/agent on EC2 with conf volume
+8.  For bare-metal / cluster: docker run -d datadog/agent on client node with conf volume
 9.  For compose: DD_API_KEY=<key> docker compose up -d (Agent service included)
-10. ssh <ec2_ip> "nohup <load driver> ..." to start background load
+10. ssh <ip> "nohup <load driver> ..." to start background load
 11. Write lab entry to shared registry (S3)
-12. Print: EC2 IP, SSH command, Agent container name, Datadog integration dashboard URL
+12. Print: instance IP(s), SSH command, Agent container name, Datadog dashboard URL
 ```
 
 ### `ddev lab destroy` flow
 
 ```
-1.  ssh <ec2_ip>: pkill -f locust (or k6)              ← stop load generator
-2.  For compose runtime: docker compose down --volumes  ← stop services + remove data
-3.  For bare-metal: ansible-playbook teardown_<service>.yml  ← deregister + clean up
-4.  terraform destroy in cloud-inventory/aws/.../labs/<integration>/
+1.  ssh <ip>: pkill -f locust (or k6)
+2.  For compose runtime: docker compose down --volumes
+3.  For bare-metal / cluster: ansible-playbook teardown_<service>.yml
+4.  pulumi destroy  (removes all cloud resources for the stack)
 5.  Remove integration entry from S3 registry
 ```
 
 ### `ddev lab stop` / `ddev lab start`
 
-`stop` halts services without destroying EC2. Useful for saving costs overnight:
+`stop` halts services without destroying instances. Useful for saving costs overnight:
 
 ```
 stop: ssh → stop load → docker compose stop (or systemd stop)
@@ -470,25 +474,7 @@ start: ssh → docker compose start (or systemd start)
 
 ### Shared lab registry
 
-Lives in S3 (`s3://agent-integrations-dev-lab-state/registry.json`), visible to the whole team:
-
-```json
-{
-  "kafka": {
-    "owner": "david.kirov@datadoghq.com",
-    "ec2_instance_id": "i-0abc123",
-    "ec2_ip": "10.0.1.42",
-    "terraform_workspace": "kafka",
-    "started_at": "2026-05-05T10:30:00Z",
-    "last_active_at": "2026-05-07T09:15:00Z",
-    "tech_version": "3.7",
-    "agent_version": "7.56.2",
-    "status": "running"
-  }
-}
-```
-
-Any team member can destroy a lab they don't own but is prompted to confirm. `ddev lab list` renders this as a table with status indicators.
+Lives in S3 (`s3://agent-integrations-dev-lab-state/registry.json`), visible to the whole team. `ddev lab list` renders it as a table with status indicators. Any team member can destroy a lab they don't own but is prompted to confirm.
 
 ---
 
@@ -501,19 +487,21 @@ Any team member can destroy a lab they don't own but is prompted to confirm. `dd
   lab.yaml
   tests/
     lab/
+      RESEARCH.md               ← human-readable: topology rationale, metric coverage,
+                                   operational gotchas, documentation sources
       compose/
-        docker-compose.yml        # service topology + Agent service
+        docker-compose.yml      ← service topology + Agent service
       seed/
-        01_<description>.sh       # numbered, idempotent, ordered
+        01_<description>.sh     ← numbered, idempotent, ordered
         02_<description>.py
         ...
       load/
-        locustfile.py             # or k6_script.js
+        locustfile.py           ← or k6_script.js
       agent/
-        conf.yaml                 # Datadog Agent integration config
+        conf.yaml               ← Datadog Agent integration config
       healthcheck/
-        check_<service>.sh        # custom healthcheck scripts (script type only)
-      provision/                  # bare-metal runtimes only
+        check_<service>.sh      ← custom healthcheck scripts (script type only)
+      provision/                ← bare-metal and cluster runtimes only
         install_<service>.yml
         teardown_<service>.yml
 ```
@@ -522,18 +510,18 @@ Any team member can destroy a lab they don't own but is prompted to confirm. `dd
 
 - Numbered prefix controls execution order
 - Must be idempotent (`CREATE TABLE IF NOT EXISTS`, `CREATE TOPIC IF NOT EXISTS`)
-- Target specific metrics from `metadata.csv` — comments name which metrics each script enables
-- Secrets (passwords, license keys) come from environment variables injected by the Terraform IAM instance profile, never hardcoded
+- `RESEARCH.md` documents which metrics from `metadata.csv` each script targets
+- Secrets (passwords, license keys) come from environment variables injected via IAM instance profile / service account, never hardcoded
 
 ### Load generator conventions
 
 - Locust is the default; k6 for protocols Locust doesn't support natively (e.g., raw Kafka protocol)
 - `target_rps` from `lab.yaml` sets the load level
-- Load daemon logs to `/var/log/ddev-lab-load.log` on the EC2 instance
+- Load daemon logs to `/var/log/ddev-lab-load.log` on the instance
 
 ### Agent config conventions
 
-`tests/lab/agent/conf.yaml` follows standard Datadog integration config format, pre-filled with connection details that match the compose file or bare-metal installation (localhost, standard ports, credentials from environment variables).
+`tests/lab/agent/conf.yaml` follows standard Datadog integration config format, pre-filled with connection details matching the compose file or bare-metal installation (localhost, standard ports, credentials from environment variables).
 
 ---
 
@@ -541,19 +529,19 @@ Any team member can destroy a lab they don't own but is prompted to confirm. `dd
 
 | Phase | Scope | Success criteria |
 |-------|-------|-----------------|
-| 1 | CLI skeleton: `create`, `stop`, `destroy`, `list`, `status` + shared registry + Kafka as reference (research artifacts hand-written) | Team member runs `ddev lab create kafka` and sees Agent metrics in Datadog |
-| 2 | `ddev lab research` command + research agent | Agent produces complete `tests/lab/` for Kafka from docs alone; diff against hand-written is minimal |
+| 1 | CLI skeleton: `create`, `stop`, `destroy`, `list`, `status` + shared registry + Kafka as reference (research artifacts hand-written, Pulumi program hand-written) | Team member runs `ddev lab create kafka` and sees Agent metrics in Datadog |
+| 2 | `ddev lab research` command + research agent | Agent produces complete `tests/lab/` + `RESEARCH.md` for Kafka from docs alone; diff against hand-written is minimal |
 | 3 | Research + runtime for Oracle and IBM MQ (bare-metal, Ansible provisioner) | `ddev lab create oracle` works end-to-end including teardown |
-| 4 | Lustre cluster support (multi-instance Terraform + cluster healthchecks) | `ddev lab create lustre` provisions 3-node cluster, Agent reports filesystem metrics |
-| 5 | `ddev lab upgrade`, cost controls (auto-stop after 7 days of inactivity) | Team can update Agent version without reprovisioning |
+| 4 | Lustre cluster support (cluster runtime, multi-node Pulumi + LNET Ansible provisioner) | `ddev lab create lustre` provisions 3+1 node cluster, Agent reports filesystem metrics |
+| 5 | GCP provider + `ddev lab upgrade` + cost controls (auto-stop after 7 days of inactivity) | `cloud: gcp` in `lab.yaml` works; team can update Agent version without reprovisioning |
 
 ---
 
 ## 11. Open Questions
 
-1. **Terraform state backend** — cloud-inventory uses its own remote state. Lab workspaces should use the same backend. Confirm with cloud-infrastructure team before Phase 1.
-2. **AMI maintenance** — who owns Ubuntu 22.04 base AMI rotation? Platform team or agent-integrations?
-3. **Datadog API key in the lab** — the API key for the Agent should emit to a dedicated org/environment (e.g., `agent-integrations-labs` in the sandbox org) to avoid polluting production metric streams. Confirm with the Datadog-internal infra team.
-4. **Lustre licensing** — Lustre is open source but the cluster topology for production-like testing requires specific kernel modules on the AMI. Confirm AMI requirements with whoever last set up a Lustre test environment.
-5. **Cost controls** — auto-stop after 7 days of inactivity via a Lambda in cloud-inventory or `ddev lab gc`?
+1. **Pulumi state backend** — S3 bucket `agent-integrations-dev-lab-state` needs to be created and access policy set. Who owns this in AWS? Confirm with cloud-infrastructure team before Phase 1.
+2. **AMI / base image maintenance** — who owns Ubuntu 22.04 base image rotation for EC2 (and equivalent for GCP)? Platform team or agent-integrations?
+3. **Datadog API key in the lab** — the Agent should emit to a dedicated org/environment (e.g., `agent-integrations-labs` in the sandbox org) to avoid polluting production metric streams. Confirm with Datadog-internal infra team.
+4. **Lustre kernel modules** — the `install_lustre_cluster.yml` playbook needs to install `lustre-server` and `lustre-client` kernel modules. These may require a specific kernel version pinned in the AMI. Confirm requirements with whoever last set up a Lustre test environment (see internal Confluence page for prior art).
+5. **Cost controls** — auto-stop after 7 days of inactivity via a scheduled Lambda or `ddev lab gc`? Where does the Lambda live if not in cloud-inventory?
 6. **CI integration** — `ddev lab create` callable from CI for long-running E2E suites? If yes, registry needs a `ci_run_id` field and auto-destroy on pipeline completion.

--- a/docs/superpowers/specs/2026-05-19-agent-e2e-framework-lab-backend.md
+++ b/docs/superpowers/specs/2026-05-19-agent-e2e-framework-lab-backend.md
@@ -134,14 +134,21 @@ The same pattern can be reused for other single-node Docker-compatible integrati
 This PR includes a deliberately small `ddev lab` POC that delegates to the Milvus scenario from the `datadog-agent` branch `add-milvus-e2e-scenario`.
 
 ```bash
+ddev lab list
 ddev lab create milvus --stack-name my-milvus-lab --use-fakeintake
+ddev lab status milvus --stack-name my-milvus-lab
+ddev lab show milvus --stack-name my-milvus-lab
+ddev lab connect milvus --stack-name my-milvus-lab
 ddev lab destroy milvus --stack-name my-milvus-lab
 ```
 
 The wrapper does not implement its own infrastructure logic. It resolves the configured `repos.agent` checkout, verifies that checkout is on `add-milvus-e2e-scenario`, then shells out to:
 
 ```bash
+dda inv aws.list-milvus ...
 dda inv aws.create-milvus ...
+dda inv aws.status-milvus ...
+dda inv aws.connect-milvus ...
 dda inv aws.destroy-milvus ...
 ```
 

--- a/docs/superpowers/specs/2026-05-19-agent-e2e-framework-lab-backend.md
+++ b/docs/superpowers/specs/2026-05-19-agent-e2e-framework-lab-backend.md
@@ -1,0 +1,141 @@
+# Agent E2E Framework as a `ddev lab` Backend
+
+**Date:** 2026-05-19  
+**Status:** Exploration note  
+**Related design:** `2026-05-05-environment-setup-automation-design.md`
+
+This note records an alternative implementation path for `ddev lab`: use the Agent DevX team's existing E2E framework in `DataDog/datadog-agent` as the deterministic lab execution backend.
+
+The main design document describes two layers:
+
+1. an AI-assisted research phase that generates reviewed lab artifacts; and
+2. a deterministic execution layer that provisions remote infrastructure, starts the workload, seeds data, starts load, and runs the Datadog Agent.
+
+The Agent E2E framework can provide the second layer today. A lab would still be launched from `ddev`, but the cloud provisioning and Agent deployment would be delegated to `datadog-agent/test/e2e-framework` scenarios.
+
+## Why consider this approach
+
+The Agent E2E framework already solves several problems that `ddev lab` would otherwise need to rebuild:
+
+- Pulumi-based AWS, GCP, Azure, Docker host, ECS, EKS, and Kind provisioning patterns.
+- Agent deployment with configurable image version, full image path, flavor, extra environment variables, and fakeintake support.
+- SSH key, stack naming, Pulumi config, and destroy-task conventions.
+- Reusable Docker Compose components for workload containers.
+- Standard stack outputs that expose hosts, Docker managers, Agents, and fakeintake endpoints.
+- Existing Agent-team ownership of the infrastructure primitives used by Agent E2E tests.
+
+The Milvus lab prototype in `datadog-agent` demonstrates the shape of this approach: a command such as `dda inv aws.create-milvus` provisions an AWS Docker host, starts Milvus, starts a load generator, and deploys a Datadog Agent configured with the Milvus integration.
+
+## Proposed split of responsibilities
+
+### integrations-core
+
+`integrations-core` remains the source of truth for integration-specific intent:
+
+```text
+<integration>/
+  lab.yaml
+  tests/lab/
+    RESEARCH.md
+    agent/conf.yaml
+    seed/
+    load/
+    healthcheck/
+```
+
+The research phase still reads `metadata.csv`, `manifest.json`, vendor documentation, and image documentation to decide what topology, seed data, and load are required to exercise the integration's metric surface.
+
+### datadog-agent
+
+`datadog-agent` owns the executable lab backend:
+
+```text
+test/e2e-framework/components/datadog/apps/<integration>/
+  docker.go
+  docker-compose.yaml
+
+test/e2e-framework/scenarios/aws/<integration>/
+  run.go
+  BUILD.bazel
+
+tasks/e2e_framework/aws/<integration>.py
+```
+
+The scenario provisions the infrastructure, starts the workload, injects the Agent configuration, wires fakeintake when requested, and exports standard outputs.
+
+### ddev
+
+`ddev` provides the user-facing command and hides the backend detail:
+
+```bash
+ddev lab create milvus
+```
+
+Internally, that command could map to the appropriate Agent E2E scenario:
+
+```bash
+dda inv aws.create-milvus --stack-name <derived-stack-name> --use-fakeintake
+```
+
+Over time, `ddev lab` could become a thin orchestration layer that reads `lab.yaml`, selects the backend scenario, passes Agent image and fakeintake options, and prints normalized lab status.
+
+## Lifecycle mapping
+
+| `ddev lab` command | Agent E2E framework equivalent |
+|--------------------|---------------------------------|
+| `ddev lab create <integration>` | `dda inv aws.create-<integration>` |
+| `ddev lab destroy <integration>` | `dda inv aws.destroy-<integration>` |
+| `ddev lab ssh <integration>` | SSH command from Pulumi stack outputs |
+| `ddev lab logs <integration> [service]` | Docker context command against the provisioned host |
+| `ddev lab status <integration>` | Agent status, Docker status, fakeintake status from exported outputs |
+
+A first version does not need to implement every command. The minimum useful wrapper is `create`, `destroy`, and a way to print connection commands.
+
+## Example: Milvus lab
+
+A Milvus lab can be represented as:
+
+- a Docker Compose workload with Milvus standalone, etcd, MinIO, and a Python load generator;
+- Datadog Autodiscovery labels or mounted check config for the Milvus integration;
+- an AWS Docker-host scenario in the Agent E2E framework;
+- an invoke task exposed as `dda inv aws.create-milvus`.
+
+The resulting flow is:
+
+```text
+1. ddev lab create milvus
+2. ddev invokes the Agent E2E framework task
+3. Pulumi creates an AWS EC2 Docker host
+4. Docker Compose starts Milvus and the load generator
+5. The Agent container starts with Milvus integration configuration
+6. The task prints SSH, Docker logs, and Agent status commands
+```
+
+The same pattern can be reused for other single-node Docker-compatible integrations such as Kafka, Cassandra, Redis variants, or any integration whose interesting metric surface can be exercised from containers.
+
+## Benefits
+
+- **Lower implementation cost:** avoid building a parallel Pulumi execution backend in `ddev` before the lab concept is proven.
+- **Agent-native behavior:** labs run the same Agent deployment components used by Agent E2E tests.
+- **Fakeintake support:** developers can validate payloads without needing a real Datadog API key.
+- **Clear cleanup path:** destroy tasks already call Pulumi destroy and remove the stack.
+- **Incremental adoption:** labs can start as explicit Agent E2E scenarios, then be wrapped by `ddev lab` once conventions stabilize.
+
+## Trade-offs
+
+- **Cross-repository workflow:** integration authors may need changes in both `integrations-core` and `datadog-agent`.
+- **Backend dependency:** `ddev lab` would depend on a local checkout of `datadog-agent`, a packaged backend, or a documented way to invoke `dda`.
+- **Artifact location:** generated research artifacts live naturally in `integrations-core`, while executable Pulumi scenarios live naturally in `datadog-agent`.
+- **Garbage collection:** the existing Agent E2E flow relies primarily on explicit destroy tasks. A shared TTL-based lab registry would still need design work.
+- **Advanced topologies:** multi-node clusters such as Lustre may still require bespoke scenario code and close coordination with Agent DevX.
+
+## Recommended next step
+
+Use the Agent E2E framework as the Phase 1 execution backend for one or two reference labs. Keep the initial `ddev lab` wrapper intentionally small:
+
+```bash
+ddev lab create <integration> --backend agent-e2e
+ddev lab destroy <integration> --backend agent-e2e
+```
+
+If the developer experience is good, the wrapper can absorb more behavior from the design document: registry entries, normalized status, logs, SSH helpers, Agent upgrades, and eventually research-generated scenario scaffolding.

--- a/docs/superpowers/specs/2026-05-19-agent-e2e-framework-lab-backend.md
+++ b/docs/superpowers/specs/2026-05-19-agent-e2e-framework-lab-backend.md
@@ -129,13 +129,31 @@ The same pattern can be reused for other single-node Docker-compatible integrati
 - **Garbage collection:** the existing Agent E2E flow relies primarily on explicit destroy tasks. A shared TTL-based lab registry would still need design work.
 - **Advanced topologies:** multi-node clusters such as Lustre may still require bespoke scenario code and close coordination with Agent DevX.
 
+## POC wrapper in this PR
+
+This PR includes a deliberately small `ddev lab` POC that delegates to the Milvus scenario from the `datadog-agent` branch `add-milvus-e2e-scenario`.
+
+```bash
+ddev lab create milvus --stack-name my-milvus-lab --use-fakeintake
+ddev lab destroy milvus --stack-name my-milvus-lab
+```
+
+The wrapper does not implement its own infrastructure logic. It resolves the configured `repos.agent` checkout, verifies that checkout is on `add-milvus-e2e-scenario`, then shells out to:
+
+```bash
+dda inv aws.create-milvus ...
+dda inv aws.destroy-milvus ...
+```
+
+This is intentionally a proof of concept, not a final CLI contract. It is meant to validate whether a thin `ddev` UX on top of Agent DevX E2E scenarios is useful before investing in a new lab backend.
+
 ## Recommended next step
 
 Use the Agent E2E framework as the Phase 1 execution backend for one or two reference labs. Keep the initial `ddev lab` wrapper intentionally small:
 
 ```bash
-ddev lab create <integration> --backend agent-e2e
-ddev lab destroy <integration> --backend agent-e2e
+ddev lab create <integration>
+ddev lab destroy <integration>
 ```
 
 If the developer experience is good, the wrapper can absorb more behavior from the design document: registry entries, normalized status, logs, SSH helpers, Agent upgrades, and eventually research-generated scenario scaffolding.


### PR DESCRIPTION
## What does this PR do?

Adds a WIP design spec for `ddev lab` — an agentic framework for provisioning Datadog integration environments on remote infrastructure with a single command.

## Motivation

Setting up environments for complex integrations (Oracle, IBM MQ, Kafka, Lustre) is one of the highest-friction steps in integration development. This design explores automating that entirely: an AI research phase reads vendor documentation and generates all provisioning artifacts, which a deterministic CLI then executes to spin up a fully seeded, load-generating environment with a configured Datadog Agent.

Design doc: `docs/superpowers/specs/2026-05-05-environment-setup-automation-design.md`

**Status:** Design in progress — open questions remain on Pulumi vs. Terraform, cloud-inventory placement, and Lustre cluster networking.

## Review checklist

- [ ] Design doc reviewed
- [ ] Open questions flagged in Section 11 discussed with relevant teams

qa/skip-qa