### PR TITLE
[Port] Bumped kafka_consumer version to 7.2.1

### DIFF
--- a/kafka_consumer/CHANGELOG.md
+++ b/kafka_consumer/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 7.2.1 / 2026-05-12
+
+***Fixed***:
+
+* Switch cluster monitoring's earliest-offset fetch to AdminClient.list_offsets(earliest), and isolate its failures so an earliest-offset error no longer drops topic.message_rate, partition.isr, topic.config.*, and other unrelated topic-metadata metrics. ([#23580](https://github.com/DataDog/integrations-core/pull/23580))
+
 ## 7.2.0 / 2026-04-15
 
 ***Added***:

--- a/kafka_consumer/changelog.d/23580.fixed
+++ b/kafka_consumer/changelog.d/23580.fixed
@@ -1,1 +1,0 @@
-Switch cluster monitoring's earliest-offset fetch to AdminClient.list_offsets(earliest), and isolate its failures so an earliest-offset error no longer drops topic.message_rate, partition.isr, topic.config.*, and other unrelated topic-metadata metrics.

--- a/kafka_consumer/datadog_checks/kafka_consumer/__about__.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "7.2.0"
+__version__ = "7.2.1"

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -119,7 +119,7 @@ datadog-jboss-wildfly==3.4.0
 datadog-journald==3.2.0
 datadog-juniper-srx-firewall==1.3.0
 datadog-kafka-actions==2.6.0
-datadog-kafka-consumer==7.2.0
+datadog-kafka-consumer==7.2.1
 datadog-kafka==4.5.0
 datadog-karpenter==3.4.1
 datadog-keda==2.4.1


### PR DESCRIPTION
### What does this PR do?
Ports kafka consumer release from 7.79.x to master
### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
