### PR TITLE
[DOCS-14261] Remove GA/pricing banners from NDM integrations

### DIFF
--- a/cisco_aci/README.md
+++ b/cisco_aci/README.md
@@ -21,8 +21,6 @@ By integrating ACI metrics with Datadog's infrastructure and application monitor
 
 ## Setup
 
-**The Cisco ACI integration is Generally Available. To learn more about billing implications, visit our [pricing page][19].**
-
 ### Installation
 
 The Cisco ACI check is packaged with the Agent, so simply [install the Agent][1] on a server within your network.
@@ -202,4 +200,3 @@ Contact [Datadog support][9].
 [16]: /logs
 [17]: https://docs.datadoghq.com/logs/log_collection/?tab=host#setup
 [18]: https://github.com/DataDog/integrations-core/blob/master/cisco_aci/tests/cisco_aci_query.py
-[19]: https://www.datadoghq.com/pricing/?product=network-monitoring&tab=network-device-monitoring#products

--- a/cisco_sdwan/README.md
+++ b/cisco_sdwan/README.md
@@ -20,8 +20,6 @@ By surfacing traffic and throughput metrics at the device and interface level, t
 
 ## Setup
 
-**The Cisco SD-WAN NDM integration is Generally Available. To learn more about billing implications, visit our [pricing page][8].**
-
 Follow the instructions below to install and configure this check for an Agent running on a host. For containerized environments, see the [Autodiscovery Integration Templates][3] for guidance on applying these instructions.
 
 ### Installation
@@ -63,4 +61,3 @@ Need help? Contact [Datadog support][7].
 [5]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [6]: https://github.com/DataDog/integrations-core/blob/master/cisco_sdwan/metadata.csv
 [7]: https://docs.datadoghq.com/help/
-[8]: https://www.datadoghq.com/pricing/?product=network-monitoring&tab=network-device-monitoring#products

--- a/versa/README.md
+++ b/versa/README.md
@@ -22,8 +22,6 @@ This integration provides insight into how applications and users consume bandwi
 
 ## Setup
 
-**The Versa NDM integration is Generally Available. To learn more about billing implications, visit our [pricing page][10].**
-
 Follow the instructions below to install and configure this check for an Agent running on a host. For containerized environments, see the [Autodiscovery Integration Templates][3] for guidance on applying these instructions.
 
 ### Installation
@@ -71,4 +69,3 @@ Need help? Contact [Datadog support][9].
 [7]: https://github.com/DataDog/integrations-core/blob/master/versa/metadata.csv
 [8]: https://github.com/DataDog/integrations-core/blob/master/versa/assets/service_checks.json
 [9]: https://docs.datadoghq.com/help/
-[10]: https://www.datadoghq.com/pricing/?product=network-monitoring&tab=network-device-monitoring#products


### PR DESCRIPTION
### What does this PR do?

Removes the GA/pricing banners from the Versa, Cisco ACI, and Cisco SD-WAN READMEs.

### Motivation

Fixes DOCS-14261. These integrations have been released for a little while now, and we don't generally state that something in the docs is GA (it's just assumed, in the absence of Preview status). Pricing changes are communicated in release notes.

See also https://github.com/DataDog/integrations-internal-core/pull/3254 for removing similar banners from FortiNet FortiManager, Meraki, and VeloCloud SD-WAN.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [x] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged