### PR TITLE
Restructure github_async into a lazy-loaded package

### DIFF
--- a/ddev/changelog.d/23685.added
+++ b/ddev/changelog.d/23685.added
@@ -1,0 +1,1 @@
+Restructure `ddev.utils.github_async` into a package with lazy model imports, add `create_pull_request` and `add_labels_to_issue` endpoints, and add a `FakeAsyncGitHubClient` test helper with a `mock_response` API.

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -78,6 +78,9 @@ include = ["src"]
 python-version = "3.13"
 scripts = ["ddev"]
 
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
 # Keep Black configuration to generate models through validate
 # Switch to Ruff after it provides a Python API
 [tool.black]

--- a/ddev/src/ddev/utils/github_async/__init__.py
+++ b/ddev/src/ddev/utils/github_async/__init__.py
@@ -1,0 +1,63 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Async GitHub REST API client.
+
+Typical usage::
+
+    from ddev.utils.github_async import async_github_client
+    from ddev.utils.github_async.models import PullRequest
+
+    async with async_github_client(token=my_token) as client:
+        response = await client.create_pull_request(...)
+
+Both this package's top-level symbols and the ``models`` subpackage use PEP 562
+``__getattr__`` to load submodules on demand. Importing a model from
+``ddev.utils.github_async.models`` does not load the HTTP client (so ``httpx``
+stays out of ``sys.modules`` for callers that only need the types).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    # Re-exports for type checkers / IDE autocomplete only; do not execute at runtime.
+    # The `X as X` aliases mark these as explicit re-exports for linters.
+    from .client import DEFAULT_BASE_URL as DEFAULT_BASE_URL
+    from .client import GITHUB_API_VERSION as GITHUB_API_VERSION
+    from .client import AsyncGitHubClient as AsyncGitHubClient
+    from .client import GitHubResponse as GitHubResponse
+    from .client import PaginationData as PaginationData
+    from .client import async_github_client as async_github_client
+
+# Map of exported name -> submodule (relative to this package) that defines it.
+MODULE_BY_NAME: dict[str, str] = {
+    'AsyncGitHubClient': 'client',
+    'async_github_client': 'client',
+    'GITHUB_API_VERSION': 'client',
+    'DEFAULT_BASE_URL': 'client',
+    'GitHubResponse': 'client',
+    'PaginationData': 'client',
+}
+
+
+def __getattr__(name: str) -> Any:
+    try:
+        module_name = MODULE_BY_NAME[name]
+    except KeyError:
+        raise AttributeError(f'module {__name__!r} has no attribute {name!r}') from None
+
+    import importlib
+
+    module = importlib.import_module(f'.{module_name}', __name__)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | MODULE_BY_NAME.keys())
+
+
+__all__ = sorted(MODULE_BY_NAME)

--- a/ddev/src/ddev/utils/github_async/client.py
+++ b/ddev/src/ddev/utils/github_async/client.py
@@ -1,4 +1,9 @@
-"""Async GitHub API client for triggering and monitoring GitHub Actions workflows"""
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Async HTTP client for the GitHub REST API."""
+
+from __future__ import annotations
 
 import re
 from collections.abc import AsyncIterator
@@ -9,6 +14,15 @@ from typing import Any, Literal, Self
 import httpx
 from pydantic import BaseModel, ConfigDict, Field
 
+from .models import (
+    ArtifactsList,
+    IssueComment,
+    Label,
+    PullRequest,
+    PullRequestReviewComment,
+    WorkflowRun,
+)
+
 GITHUB_API_VERSION = "2022-11-28"
 DEFAULT_BASE_URL = "https://api.github.com"
 
@@ -16,7 +30,7 @@ _LINK_RE = re.compile(r'<([^>]+)>;\s*rel="([^"]+)"')
 
 
 # ---------------------------------------------------------------------------
-# Pagination
+# Pagination + response wrappers
 # ---------------------------------------------------------------------------
 
 
@@ -45,11 +59,6 @@ class PaginationData:
         )
 
 
-# ---------------------------------------------------------------------------
-# Response and domain models
-# ---------------------------------------------------------------------------
-
-
 class GitHubResponse[T](BaseModel):
     """Generic wrapper for a GitHub API response."""
 
@@ -57,75 +66,6 @@ class GitHubResponse[T](BaseModel):
 
     data: T = Field(...)
     headers: dict[str, str] = Field(default_factory=dict)
-
-
-class WorkflowRun(BaseModel):
-    """A GitHub Actions workflow run."""
-
-    model_config = ConfigDict(extra="ignore")
-
-    id: int
-    name: str | None = None
-    status: str
-    conclusion: str | None = None
-    html_url: str | None = None
-    created_at: str | None = None
-    updated_at: str | None = None
-
-
-class Artifact(BaseModel):
-    """A GitHub Actions artifact."""
-
-    model_config = ConfigDict(extra="ignore")
-
-    id: int
-    name: str
-    size_in_bytes: int | None = None
-    url: str | None = None
-    archive_download_url: str | None = None
-    expired: bool
-
-
-class ArtifactsList(BaseModel):
-    """A list of artifacts with a total count."""
-
-    model_config = ConfigDict(extra="ignore")
-
-    total_count: int
-    artifacts: list[Artifact]
-
-
-class IssueComment(BaseModel):
-    """A GitHub issue (or PR) comment."""
-
-    model_config = ConfigDict(extra="ignore")
-
-    id: int
-    body: str
-    user: dict[str, Any] | None = None
-    created_at: str | None = None
-    updated_at: str | None = None
-    html_url: str | None = None
-
-
-class PullRequestReviewComment(BaseModel):
-    """An inline review comment on a pull request diff."""
-
-    model_config = ConfigDict(extra="ignore")
-
-    id: int
-    body: str
-    path: str
-    commit_id: str
-    html_url: str | None = None
-    created_at: str | None = None
-    updated_at: str | None = None
-    user: dict[str, Any] | None = None
-
-
-# ---------------------------------------------------------------------------
-# Client
-# ---------------------------------------------------------------------------
 
 
 class AsyncGitHubClient:
@@ -335,6 +275,78 @@ class AsyncGitHubClient:
         )
         return self._parse_response(response, IssueComment)
 
+    async def create_pull_request(
+        self,
+        owner: str,
+        repo: str,
+        title: str,
+        head: str,
+        base: str,
+        body: str = "",
+        draft: bool = False,
+        timeout: float | None = None,
+    ) -> GitHubResponse[PullRequest]:
+        """
+        Calls the GitHub API to create a pull request.
+
+        GitHub API Documentation:
+        https://docs.github.com/en/rest/pulls/pulls#create-a-pull-request
+
+        Args:
+            owner: Repository owner (user or organisation).
+            repo: Repository name.
+            title: Pull request title.
+            head: Name of the branch containing the changes.
+            base: Name of the branch to merge into.
+            body: Pull request body.
+            draft: Whether to open the pull request as a draft.
+            timeout: Optional timeout for this specific request. Defaults to the client's default_timeout.
+
+        Returns:
+            GitHubResponse[PullRequest]: The validated pull request data and headers.
+        """
+        response = await self._request(
+            "POST",
+            f"/repos/{owner}/{repo}/pulls",
+            timeout=timeout,
+            json={"title": title, "head": head, "base": base, "body": body, "draft": draft},
+        )
+        return self._parse_response(response, PullRequest)
+
+    async def add_labels_to_issue(
+        self,
+        owner: str,
+        repo: str,
+        issue_number: int,
+        labels: list[str],
+        timeout: float | None = None,
+    ) -> GitHubResponse[list[Label]]:
+        """
+        Calls the GitHub API to add one or more labels to an issue or pull request.
+
+        GitHub API Documentation:
+        https://docs.github.com/en/rest/issues/labels#add-labels-to-an-issue
+
+        Args:
+            owner: Repository owner (user or organisation).
+            repo: Repository name.
+            issue_number: Issue or pull request number.
+            labels: Labels to add. Existing labels on the issue are preserved.
+            timeout: Optional timeout for this specific request. Defaults to the client's default_timeout.
+
+        Returns:
+            GitHubResponse[list[Label]]: The full label list resulting from the operation (preserves
+            any pre-existing labels alongside the newly added ones).
+        """
+        response = await self._request(
+            "POST",
+            f"/repos/{owner}/{repo}/issues/{issue_number}/labels",
+            timeout=timeout,
+            json={"labels": labels},
+        )
+        labels_out = [Label.model_validate(item) for item in response.json()]
+        return GitHubResponse[list[Label]].model_validate({"data": labels_out, "headers": dict(response.headers)})
+
     async def create_pr_review_comment(
         self,
         owner: str,
@@ -358,18 +370,22 @@ class AsyncGitHubClient:
             owner: Repository owner (user or organisation).
             repo: Repository name.
             pull_number: Pull request number.
-            body: Markdown body text of the review comment.
+            body: Markdown body text of the comment.
             commit_id: SHA of the commit to comment on.
-            path: Relative path of the file to comment on.
-            position: Line index in the diff (deprecated but still supported by the API).
-            line: Line number in the file to comment on (used with `side`).
-            side: Side of the diff to comment on — ``"LEFT"`` or ``"RIGHT"``.
+            path: Path of the file to comment on.
+            position: Line index in the diff (mutually exclusive with line/side).
+            line: Line number in the file (newer style, paired with side).
+            side: 'LEFT' or 'RIGHT' (newer style, paired with line).
             timeout: Optional timeout for this specific request. Defaults to the client's default_timeout.
 
         Returns:
-            GitHubResponse[PullRequestReviewComment]: The validated review comment data and headers.
+            GitHubResponse[PullRequestReviewComment]: The validated comment data and headers.
         """
-        payload: dict[str, Any] = {"body": body, "commit_id": commit_id, "path": path}
+        payload: dict[str, Any] = {
+            "body": body,
+            "commit_id": commit_id,
+            "path": path,
+        }
         if position is not None:
             payload["position"] = position
         if line is not None:
@@ -386,7 +402,7 @@ class AsyncGitHubClient:
 
 
 # ---------------------------------------------------------------------------
-# Context manager helper
+# Async context manager
 # ---------------------------------------------------------------------------
 
 

--- a/ddev/src/ddev/utils/github_async/models/__init__.py
+++ b/ddev/src/ddev/utils/github_async/models/__init__.py
@@ -1,0 +1,72 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Lazy re-exports for the async GitHub client's domain models.
+
+Each model class lives in its own submodule (e.g. ``pull_request.py``). The
+re-exports below let callers write::
+
+    from ddev.utils.github_async.models import PullRequest
+
+without having to know which submodule the class lives in, and without
+eagerly importing every submodule when only one is used.
+
+Mechanism: PEP 562's module-level ``__getattr__`` hook. The first time a
+name is accessed, the matching submodule is imported on demand and the
+resolved attribute is cached on the package so subsequent accesses are free.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    # Re-exports for type checkers / IDE autocomplete. These imports do not
+    # execute at runtime (they live behind `TYPE_CHECKING`), so they do not
+    # break the lazy-loading guarantee. The `X as X` aliases mark these as
+    # explicit re-exports for linters.
+    from .comment import IssueComment as IssueComment
+    from .comment import PullRequestReviewComment as PullRequestReviewComment
+    from .label import Label as Label
+    from .pull_request import PullRequest as PullRequest
+    from .pull_request import PullRequestRef as PullRequestRef
+    from .user import GitHubUser as GitHubUser
+    from .workflow import Artifact as Artifact
+    from .workflow import ArtifactsList as ArtifactsList
+    from .workflow import WorkflowRun as WorkflowRun
+
+# Map of exported attribute name -> submodule (relative to this package) that
+# defines it. Submodules are imported on demand by `__getattr__`.
+MODULE_BY_NAME: dict[str, str] = {
+    'Artifact': 'workflow',
+    'ArtifactsList': 'workflow',
+    'GitHubUser': 'user',
+    'IssueComment': 'comment',
+    'Label': 'label',
+    'PullRequest': 'pull_request',
+    'PullRequestRef': 'pull_request',
+    'PullRequestReviewComment': 'comment',
+    'WorkflowRun': 'workflow',
+}
+
+
+def __getattr__(name: str) -> Any:
+    try:
+        module_name = MODULE_BY_NAME[name]
+    except KeyError:
+        raise AttributeError(f'module {__name__!r} has no attribute {name!r}') from None
+
+    import importlib
+
+    module = importlib.import_module(f'.{module_name}', __name__)
+    value = getattr(module, name)
+    # Cache so subsequent `from .models import Foo` is a plain dict lookup.
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | MODULE_BY_NAME.keys())
+
+
+__all__ = sorted(MODULE_BY_NAME)

--- a/ddev/src/ddev/utils/github_async/models/comment.py
+++ b/ddev/src/ddev/utils/github_async/models/comment.py
@@ -1,0 +1,38 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Issue and pull-request review comment models."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from .user import GitHubUser
+
+
+class IssueComment(BaseModel):
+    """A GitHub issue (or PR) comment."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: int
+    body: str
+    user: GitHubUser | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    html_url: str | None = None
+
+
+class PullRequestReviewComment(BaseModel):
+    """An inline review comment on a pull request diff."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: int
+    body: str
+    path: str
+    commit_id: str
+    html_url: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    user: GitHubUser | None = None

--- a/ddev/src/ddev/utils/github_async/models/label.py
+++ b/ddev/src/ddev/utils/github_async/models/label.py
@@ -1,0 +1,23 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""GitHub label model."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class Label(BaseModel):
+    """A label attached to an issue or pull request.
+
+    Field reference:
+    https://docs.github.com/en/rest/issues/labels#get-a-label
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: int
+    name: str
+    color: str | None = None
+    description: str | None = None

--- a/ddev/src/ddev/utils/github_async/models/pull_request.py
+++ b/ddev/src/ddev/utils/github_async/models/pull_request.py
@@ -1,0 +1,79 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Pull request models."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .label import Label
+from .user import GitHubUser
+
+
+class PullRequestRef(BaseModel):
+    """A head or base branch reference on a pull request.
+
+    Field reference (within the `pull-request` object):
+    https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    ref: str
+    sha: str
+    label: str | None = None  # e.g. 'octocat:new-topic'
+
+
+class PullRequest(BaseModel):
+    """A GitHub pull request.
+
+    Field reference:
+    https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    # `number` and `html_url` are required because consumers (notably `ddev release port-commit`)
+    # read them directly without nullability checks. Other fields stay optional to keep parsing
+    # resilient when an endpoint returns an abbreviated payload.
+
+    # Identifiers
+    id: int | None = None
+    number: int
+    node_id: str | None = None
+
+    # URLs
+    url: str | None = None
+    html_url: str
+    diff_url: str | None = None
+    patch_url: str | None = None
+
+    # State
+    state: str | None = None  # 'open' or 'closed'
+    draft: bool = False
+    merged: bool | None = None
+    locked: bool = False
+    merge_commit_sha: str | None = None
+
+    # Content
+    title: str | None = None
+    body: str | None = None
+
+    # People
+    user: GitHubUser | None = None
+    assignees: list[GitHubUser] = Field(default_factory=list)
+    requested_reviewers: list[GitHubUser] = Field(default_factory=list)
+
+    # Labels
+    labels: list[Label] = Field(default_factory=list)
+
+    # Timestamps (ISO 8601 strings; not parsed into datetime to keep the model lightweight)
+    created_at: str | None = None
+    updated_at: str | None = None
+    closed_at: str | None = None
+    merged_at: str | None = None
+
+    # Branch references
+    head: PullRequestRef | None = None
+    base: PullRequestRef | None = None

--- a/ddev/src/ddev/utils/github_async/models/user.py
+++ b/ddev/src/ddev/utils/github_async/models/user.py
@@ -1,0 +1,23 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""GitHub user model."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class GitHubUser(BaseModel):
+    """A GitHub user as returned by the REST API.
+
+    Field reference:
+    https://docs.github.com/en/rest/users/users#get-a-user
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: int | None = None
+    login: str | None = None
+    html_url: str | None = None
+    type: str | None = None  # 'User', 'Bot', 'Organization', etc.

--- a/ddev/src/ddev/utils/github_async/models/workflow.py
+++ b/ddev/src/ddev/utils/github_async/models/workflow.py
@@ -1,0 +1,44 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""GitHub Actions workflow models."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class WorkflowRun(BaseModel):
+    """A GitHub Actions workflow run."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: int
+    name: str | None = None
+    status: str
+    conclusion: str | None = None
+    html_url: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class Artifact(BaseModel):
+    """A GitHub Actions artifact."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: int
+    name: str
+    size_in_bytes: int | None = None
+    url: str | None = None
+    archive_download_url: str | None = None
+    expired: bool
+
+
+class ArtifactsList(BaseModel):
+    """A list of artifacts with a total count."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    total_count: int
+    artifacts: list[Artifact]

--- a/ddev/tests/conftest.py
+++ b/ddev/tests/conftest.py
@@ -4,12 +4,14 @@
 from __future__ import annotations
 
 import random
-from contextlib import ExitStack
-from typing import Generator
+from collections.abc import AsyncIterator
+from contextlib import ExitStack, asynccontextmanager
+from typing import Any, Generator
 
 import pytest
 import vcr
 from datadog_checks.dev.tooling.utils import set_root
+from pytest_mock import MockerFixture
 
 from ddev.cli.application import Application
 from ddev.cli.terminal import Terminal
@@ -24,6 +26,7 @@ from ddev.utils.platform import Platform
 
 from .helpers import APPLICATION, LOCAL_REPO_BRANCH, PLATFORM
 from .helpers.git import ClonedRepo
+from .helpers.github_async import FakeAsyncGitHubClient
 from .helpers.runner import CliRunner
 
 # Rewrite assertions on the assertions helper module
@@ -76,6 +79,28 @@ def github_manager(local_repo, config_file, terminal) -> GitHubManager:
         token=config_file.model.github.token,
         status=terminal.status,
     )
+
+
+@pytest.fixture
+def fake_async_github(mocker: MockerFixture) -> FakeAsyncGitHubClient:
+    """Patch `async_github_client` to yield a `FakeAsyncGitHubClient` and stub the token."""
+    fake = FakeAsyncGitHubClient()
+
+    @asynccontextmanager
+    async def fake_context(
+        token: str,
+        default_timeout: float = 30.0,
+        transport: Any = None,
+    ) -> AsyncIterator[FakeAsyncGitHubClient]:
+        yield fake
+
+    # Patch both import sites: the deep module name (for `from ...client import async_github_client`)
+    # and the package-level name (for `from ddev.utils.github_async import async_github_client`,
+    # which production code uses inside method bodies). Removing either leaves one import style unmocked.
+    mocker.patch('ddev.utils.github_async.client.async_github_client', fake_context)
+    mocker.patch('ddev.utils.github_async.async_github_client', fake_context)
+    mocker.patch.dict('os.environ', {'DD_GITHUB_TOKEN': 'ghp_test'})
+    return fake
 
 
 @pytest.fixture

--- a/ddev/tests/helpers/github_async.py
+++ b/ddev/tests/helpers/github_async.py
@@ -1,0 +1,281 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Test helpers for the async GitHub client.
+
+Provides a `FakeAsyncGitHubClient` that records every call and lets tests
+register canned responses with `mock_response`. The `fake_async_github`
+pytest fixture that wires this fake into `async_github_client` lives in
+the root `tests/conftest.py`.
+
+Quick reference:
+
+    def test_thing(fake_async_github):
+        # Sticky default for all matching calls
+        fake_async_github.mock_response(
+            'create_pull_request',
+            PullRequest(number=5, html_url='https://github.com/x/pr/5'),
+        )
+
+        # Partial match: only PR #5 gets the override
+        fake_async_github.mock_response(
+            'add_labels_to_issue',
+            httpx.HTTPStatusError(...),
+            issue_number=5,
+        )
+
+        # FIFO queue: first matching call raises, second succeeds
+        fake_async_github.mock_response('create_pull_request', err, once=True)
+        fake_async_github.mock_response('create_pull_request', pr_response, once=True)
+
+        do_thing_under_test()
+        fake_async_github.assert_called_with('create_pull_request', ...)
+        fake_async_github.assert_all_responses_consumed()
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from ddev.utils.github_async import GitHubResponse
+from ddev.utils.github_async.models import Label, PullRequest
+
+
+@dataclass
+class RecordedRequest:
+    """A single recorded call to the fake client."""
+
+    method: str
+    kwargs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class _MockEntry:
+    """A single registered response. The bucket it lives in (`_oneshot_mocks` vs `_sticky_mocks`)
+    determines whether it is consumed on use; that distinction is structural and not stored here.
+    """
+
+    response: Any
+    match_kwargs: dict[str, Any]
+
+
+def _default_response_factories() -> dict[str, Callable[[], Any]]:
+    """Built-in default responses used when no `mock_response` matches a call."""
+    return {
+        'create_pull_request': lambda: GitHubResponse(
+            data=PullRequest(number=1, html_url='https://github.com/test/repo/pull/1'),
+            headers={},
+        ),
+        'add_labels_to_issue': lambda: GitHubResponse.model_validate({'data': [], 'headers': {}}),
+    }
+
+
+class FakeAsyncGitHubClient:
+    """Test double for AsyncGitHubClient that records calls and serves canned responses.
+
+    Mock responses are registered via `mock_response`. Each call to a mirrored API method
+    consults, in order:
+
+    1. The one-shot queue for that method (FIFO, first match wins, consumed on use).
+    2. The sticky-mock list for that method (most-recent registration wins).
+    3. A built-in default response (see `_default_response_factories`).
+
+    Exceptions registered as responses are raised. Plain data values are auto-wrapped in
+    `GitHubResponse(data=value, headers={})`. Full `GitHubResponse` instances pass through.
+    """
+
+    def __init__(self) -> None:
+        self.requests: list[RecordedRequest] = []
+        self._oneshot_mocks: dict[str, list[_MockEntry]] = {}
+        self._sticky_mocks: dict[str, list[_MockEntry]] = {}
+        self._default_response_factories: dict[str, Callable[[], Any]] = _default_response_factories()
+
+    # ------------------------------------------------------------------
+    # Mock registration
+    # ------------------------------------------------------------------
+
+    def mock_response(
+        self,
+        method: str,
+        response: Any,
+        /,
+        *,
+        once: bool = False,
+        **match_kwargs: Any,
+    ) -> None:
+        """Register *response* to be returned by *method*.
+
+        Args:
+            method: Name of the client method to stub (e.g. ``'create_pull_request'``).
+            response: What to return. Behavior depends on its type:
+                - ``BaseException`` instance -> raised when the call is made.
+                - ``GitHubResponse`` instance -> returned as-is.
+                - Anything else (including ``None``) -> wrapped in
+                  ``GitHubResponse(data=response, headers={})``.
+            once: When True, this response is consumed by the first matching call
+                (FIFO across all one-shots registered for the method). Otherwise the
+                response is sticky and fires on every matching call until a more
+                recent sticky registration shadows it.
+            **match_kwargs: Optional key/value pairs that the call's recorded kwargs
+                must contain (partial match). With no kwargs, the response matches any
+                call to *method*.
+        """
+        entry = _MockEntry(response=response, match_kwargs=match_kwargs)
+        bucket = self._oneshot_mocks if once else self._sticky_mocks
+        bucket.setdefault(method, []).append(entry)
+
+    # ------------------------------------------------------------------
+    # Mirrored API surface
+    # ------------------------------------------------------------------
+
+    async def create_pull_request(
+        self,
+        owner: str,
+        repo: str,
+        title: str,
+        head: str,
+        base: str,
+        body: str = '',
+        draft: bool = False,
+        timeout: float | None = None,
+    ) -> GitHubResponse[PullRequest]:
+        return self._call(
+            'create_pull_request',
+            owner=owner,
+            repo=repo,
+            title=title,
+            head=head,
+            base=base,
+            body=body,
+            draft=draft,
+            timeout=timeout,
+        )
+
+    async def add_labels_to_issue(
+        self,
+        owner: str,
+        repo: str,
+        issue_number: int,
+        labels: list[str],
+        timeout: float | None = None,
+    ) -> GitHubResponse[list[Label]]:
+        return self._call(
+            'add_labels_to_issue',
+            owner=owner,
+            repo=repo,
+            issue_number=issue_number,
+            labels=labels,
+            timeout=timeout,
+        )
+
+    async def aclose(self) -> None:
+        return None
+
+    # ------------------------------------------------------------------
+    # Inspection / assertions
+    # ------------------------------------------------------------------
+
+    def calls_to(self, method: str) -> list[RecordedRequest]:
+        """Return every recorded call to *method*."""
+        return [r for r in self.requests if r.method == method]
+
+    def last_call(self, method: str) -> RecordedRequest:
+        """Return the most recent recorded call to *method*, raising if there are none.
+
+        Use when strict full-kwargs assertion is too tedious (e.g. a long PR body) and
+        you want to inspect individual fields with plain asserts.
+        """
+        calls = self.calls_to(method)
+        if not calls:
+            raise AssertionError(f'No calls to {method!r} were recorded.')
+        return calls[-1]
+
+    def assert_called_with(self, method: str, **expected_kwargs: Any) -> RecordedRequest:
+        """Assert *method* was called at least once with EXACTLY *expected_kwargs*.
+
+        Strict equality: every keyword the implementation passed must appear in
+        *expected_kwargs* and vice versa. Missing or extra keys both fail. Returns
+        the first matching call.
+        """
+        matches = [r for r in self.calls_to(method) if r.kwargs == expected_kwargs]
+        if not matches:
+            raise AssertionError(
+                f'No call to {method!r} matched {expected_kwargs!r}. Recorded calls: {self.calls_to(method)}'
+            )
+        return matches[0]
+
+    def assert_called_once_with(self, method: str, **expected_kwargs: Any) -> RecordedRequest:
+        """Assert *method* was called exactly once with EXACTLY *expected_kwargs*.
+
+        Strict equality, mirrors `Mock.assert_called_once_with`.
+        """
+        calls = self.calls_to(method)
+        if len(calls) != 1:
+            raise AssertionError(f'Expected exactly one call to {method!r}, got {len(calls)}. Recorded calls: {calls}')
+        only_call = calls[0]
+        if only_call.kwargs != expected_kwargs:
+            raise AssertionError(
+                f'Expected one call to {method!r} with {expected_kwargs!r}, got kwargs {only_call.kwargs!r}.'
+            )
+        return only_call
+
+    def assert_not_called(self, method: str) -> None:
+        """Assert that *method* was never called."""
+        calls = self.calls_to(method)
+        if calls:
+            raise AssertionError(f'Expected no calls to {method!r}, but got: {calls}')
+
+    def assert_all_responses_consumed(self) -> None:
+        """Assert every one-shot mock registered has been consumed by a call.
+
+        Use in tests that depend on a queued sequence firing (e.g. retry logic). Sticky
+        mocks are not affected; only one-shots are tracked.
+        """
+        pending = {method: queue for method, queue in self._oneshot_mocks.items() if queue}
+        if pending:
+            details = '; '.join(f'{method}: {len(queue)} remaining' for method, queue in pending.items())
+            raise AssertionError(f'One-shot responses were not consumed -> {details}')
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _record(self, method: str, **kwargs: Any) -> None:
+        self.requests.append(RecordedRequest(method=method, kwargs=kwargs))
+
+    def _call(self, method: str, **call_kwargs: Any) -> Any:
+        self._record(method, **call_kwargs)
+        response = self._resolve_response(method, call_kwargs)
+        if isinstance(response, BaseException):
+            raise response
+        if isinstance(response, GitHubResponse):
+            return response
+        return GitHubResponse.model_validate({'data': response, 'headers': {}})
+
+    def _resolve_response(self, method: str, call_kwargs: dict[str, Any]) -> Any:
+        # 1. One-shot queue: FIFO, first match wins, consumed.
+        queue = self._oneshot_mocks.get(method, [])
+        for i, entry in enumerate(queue):
+            if self._matches(call_kwargs, entry.match_kwargs):
+                queue.pop(i)
+                return entry.response
+
+        # 2. Sticky mocks: most-recent registration wins.
+        for entry in reversed(self._sticky_mocks.get(method, [])):
+            if self._matches(call_kwargs, entry.match_kwargs):
+                return entry.response
+
+        # 3. Built-in default for this method.
+        factory = self._default_response_factories.get(method)
+        if factory is None:
+            raise AssertionError(
+                f'No mock registered for {method!r} and no built-in default. '
+                f'Call fake_async_github.mock_response({method!r}, ...) in your test.'
+            )
+        return factory()
+
+    @staticmethod
+    def _matches(call_kwargs: dict[str, Any], match_kwargs: dict[str, Any]) -> bool:
+        return all(k in call_kwargs and call_kwargs[k] == v for k, v in match_kwargs.items())

--- a/ddev/tests/test_fake_github_async.py
+++ b/ddev/tests/test_fake_github_async.py
@@ -1,0 +1,268 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Tests for the FakeAsyncGitHubClient helper itself."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from ddev.utils.github_async import GitHubResponse
+from ddev.utils.github_async.models import PullRequest
+from tests.helpers.github_async import FakeAsyncGitHubClient
+
+
+@pytest.fixture
+def fake() -> FakeAsyncGitHubClient:
+    return FakeAsyncGitHubClient()
+
+
+async def test_default_response_used_when_no_mock_registered(fake: FakeAsyncGitHubClient) -> None:
+    response = await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
+    assert isinstance(response.data, PullRequest)
+    assert response.data.number == 1
+
+
+def test_unknown_method_without_default_raises(fake: FakeAsyncGitHubClient) -> None:
+    with pytest.raises(AssertionError, match='No mock registered'):
+        fake._call('not_a_real_method')
+
+
+async def test_sticky_mock_with_inner_data_is_auto_wrapped(fake: FakeAsyncGitHubClient) -> None:
+    fake.mock_response('create_pull_request', PullRequest(number=42, html_url='https://x/42'))
+
+    response = await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
+
+    assert isinstance(response, GitHubResponse)
+    assert response.data.number == 42
+
+
+async def test_sticky_mock_with_full_response_passes_through(fake: FakeAsyncGitHubClient) -> None:
+    full = GitHubResponse.model_validate(
+        {'data': PullRequest(number=99, html_url='https://x/99'), 'headers': {'x-rate-limit': '5'}}
+    )
+    fake.mock_response('create_pull_request', full)
+
+    response = await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
+
+    assert response is full
+    assert response.headers['x-rate-limit'] == '5'
+
+
+async def test_sticky_mock_partial_match_only_fires_for_matching_call(fake: FakeAsyncGitHubClient) -> None:
+    fake.mock_response('create_pull_request', PullRequest(number=7, html_url='https://x/7'), draft=True)
+
+    # Default fires for non-matching calls.
+    default = await fake.create_pull_request('o', 'r', 'T', 'h', 'b', draft=False)
+    assert default.data.number == 1
+
+    # Mock fires for matching calls.
+    matched = await fake.create_pull_request('o', 'r', 'T', 'h', 'b', draft=True)
+    assert matched.data.number == 7
+
+
+async def test_most_recent_sticky_mock_wins(fake: FakeAsyncGitHubClient) -> None:
+    fake.mock_response('create_pull_request', PullRequest(number=1, html_url='https://x/1'))
+    fake.mock_response('create_pull_request', PullRequest(number=2, html_url='https://x/2'))
+
+    response = await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
+
+    assert response.data.number == 2
+
+
+async def test_exception_response_raises(fake: FakeAsyncGitHubClient) -> None:
+    err = httpx.HTTPStatusError('boom', request=httpx.Request('POST', 'https://x'), response=httpx.Response(422))
+    fake.mock_response('create_pull_request', err)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
+
+
+async def test_one_shot_consumed_then_falls_through_to_sticky(fake: FakeAsyncGitHubClient) -> None:
+    fake.mock_response('create_pull_request', PullRequest(number=10, html_url='https://x/10'), once=True)
+    fake.mock_response('create_pull_request', PullRequest(number=99, html_url='https://x/99'))  # sticky
+
+    first = await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
+    second = await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
+    third = await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
+
+    assert first.data.number == 10  # one-shot
+    assert second.data.number == 99  # sticky
+    assert third.data.number == 99  # sticky
+
+
+async def test_multiple_one_shots_fire_in_registration_order(fake: FakeAsyncGitHubClient) -> None:
+    """The retry pattern: first call errors, second succeeds."""
+    err = httpx.HTTPStatusError('try again', request=httpx.Request('POST', 'https://x'), response=httpx.Response(500))
+    fake.mock_response('create_pull_request', err, once=True)
+    fake.mock_response('create_pull_request', PullRequest(number=5, html_url='https://x/5'), once=True)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
+
+    response = await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
+    assert response.data.number == 5
+
+
+async def test_one_shot_with_match_kwargs_only_consumed_when_match(fake: FakeAsyncGitHubClient) -> None:
+    fake.mock_response(
+        'create_pull_request',
+        PullRequest(number=7, html_url='https://x/7'),
+        once=True,
+        draft=True,
+    )
+
+    # Non-matching call ignores the one-shot, hits built-in default.
+    non_match = await fake.create_pull_request('o', 'r', 'T', 'h', 'b', draft=False)
+    assert non_match.data.number == 1
+
+    # Matching call consumes the one-shot.
+    match = await fake.create_pull_request('o', 'r', 'T', 'h', 'b', draft=True)
+    assert match.data.number == 7
+
+    # Second matching call: one-shot is gone, falls through to default.
+    next_match = await fake.create_pull_request('o', 'r', 'T', 'h', 'b', draft=True)
+    assert next_match.data.number == 1
+
+
+async def test_assert_all_responses_consumed_passes_when_empty(fake: FakeAsyncGitHubClient) -> None:
+    fake.mock_response('create_pull_request', PullRequest(number=5, html_url='https://x/5'), once=True)
+    await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
+
+    fake.assert_all_responses_consumed()  # must not raise
+
+
+async def test_assert_all_responses_consumed_fails_with_pending(fake: FakeAsyncGitHubClient) -> None:
+    fake.mock_response('create_pull_request', PullRequest(number=1, html_url='https://x/1'), once=True)
+    fake.mock_response('create_pull_request', PullRequest(number=2, html_url='https://x/2'), once=True)
+
+    await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
+
+    with pytest.raises(AssertionError, match='not consumed'):
+        fake.assert_all_responses_consumed()
+
+
+async def test_assert_called_once_with_passes_on_single_exact_match(fake: FakeAsyncGitHubClient) -> None:
+    await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
+
+    fake.assert_called_once_with(
+        'create_pull_request',
+        owner='o',
+        repo='r',
+        title='T',
+        head='h',
+        base='b',
+        body='',
+        draft=False,
+        timeout=None,
+    )
+
+
+async def test_assert_called_once_with_fails_when_called_twice(fake: FakeAsyncGitHubClient) -> None:
+    await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
+    await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
+
+    with pytest.raises(AssertionError, match=r'Expected exactly one call to .* got 2'):
+        fake.assert_called_once_with(
+            'create_pull_request',
+            owner='o',
+            repo='r',
+            title='T',
+            head='h',
+            base='b',
+            body='',
+            draft=False,
+            timeout=None,
+        )
+
+
+async def test_assert_called_once_with_fails_on_wrong_kwargs(fake: FakeAsyncGitHubClient) -> None:
+    await fake.create_pull_request('o', 'r', 'T', 'h', 'b', draft=False)
+
+    with pytest.raises(AssertionError, match=r'Expected one call to .* with .* got kwargs'):
+        fake.assert_called_once_with(
+            'create_pull_request',
+            owner='o',
+            repo='r',
+            title='T',
+            head='h',
+            base='b',
+            body='',
+            draft=True,
+            timeout=None,
+        )
+
+
+async def test_last_call_returns_most_recent(fake: FakeAsyncGitHubClient) -> None:
+    await fake.create_pull_request('o', 'r', 'T1', 'h', 'b')
+    await fake.create_pull_request('o', 'r', 'T2', 'h', 'b')
+
+    last = fake.last_call('create_pull_request')
+
+    assert last.method == 'create_pull_request'
+    assert last.kwargs['title'] == 'T2'
+
+
+def test_last_call_raises_when_no_calls_recorded(fake: FakeAsyncGitHubClient) -> None:
+    with pytest.raises(AssertionError, match='No calls to'):
+        fake.last_call('create_pull_request')
+
+
+async def test_assert_called_with_passes_on_exact_match(fake: FakeAsyncGitHubClient) -> None:
+    await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
+    await fake.create_pull_request('o', 'r', 'OTHER', 'h', 'b')
+
+    fake.assert_called_with(
+        'create_pull_request',
+        owner='o',
+        repo='r',
+        title='T',
+        head='h',
+        base='b',
+        body='',
+        draft=False,
+        timeout=None,
+    )
+
+
+async def test_assert_called_with_fails_when_no_match(fake: FakeAsyncGitHubClient) -> None:
+    await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
+
+    with pytest.raises(AssertionError, match='No call to'):
+        fake.assert_called_with(
+            'create_pull_request',
+            owner='o',
+            repo='r',
+            title='WRONG',
+            head='h',
+            base='b',
+            body='',
+            draft=False,
+            timeout=None,
+        )
+
+
+async def test_assert_not_called_passes_when_method_unused(fake: FakeAsyncGitHubClient) -> None:
+    await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
+
+    fake.assert_not_called('add_labels_to_issue')
+
+
+async def test_assert_not_called_fails_when_method_was_called(fake: FakeAsyncGitHubClient) -> None:
+    await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
+
+    with pytest.raises(AssertionError, match='Expected no calls'):
+        fake.assert_not_called('create_pull_request')
+
+
+async def test_calls_are_recorded_regardless_of_response(fake: FakeAsyncGitHubClient) -> None:
+    err = httpx.HTTPStatusError('boom', request=httpx.Request('POST', 'https://x'), response=httpx.Response(500))
+    fake.mock_response('create_pull_request', err, once=True)
+    fake.mock_response('create_pull_request', PullRequest(number=5, html_url='https://x/5'))
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await fake.create_pull_request('o', 'r', 'T', 'h', 'b', draft=True)
+    await fake.create_pull_request('o', 'r', 'T', 'h', 'b', draft=False)
+
+    assert len(fake.calls_to('create_pull_request')) == 2

--- a/ddev/tests/utils/test_github_async.py
+++ b/ddev/tests/utils/test_github_async.py
@@ -11,14 +11,20 @@ import pytest
 
 from ddev.utils.github_async import (
     GITHUB_API_VERSION,
-    ArtifactsList,
     AsyncGitHubClient,
     GitHubResponse,
-    IssueComment,
     PaginationData,
+    async_github_client,
+)
+from ddev.utils.github_async.models import (
+    ArtifactsList,
+    GitHubUser,
+    IssueComment,
+    Label,
+    PullRequest,
+    PullRequestRef,
     PullRequestReviewComment,
     WorkflowRun,
-    async_github_client,
 )
 
 # ---------------------------------------------------------------------------
@@ -140,7 +146,6 @@ def test_client_valid_token_builds_client() -> None:
     assert "Bearer ghp_test_token" in client._client.headers.get("authorization", "")  # must not raise
 
 
-@pytest.mark.asyncio
 async def test_client_request_headers() -> None:
     captured: httpx.Headers | None = None
 
@@ -163,13 +168,11 @@ async def test_client_request_headers() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_context_manager_yields_client() -> None:
     async with async_github_client(token=TOKEN) as client:
         assert not client._client.is_closed
 
 
-@pytest.mark.asyncio
 async def test_context_manager_closes_on_exit() -> None:
     async with async_github_client(token=TOKEN) as client:
         inner = client._client
@@ -182,7 +185,6 @@ async def test_context_manager_closes_on_exit() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_create_workflow_dispatch_success() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "POST"
@@ -199,7 +201,6 @@ async def test_create_workflow_dispatch_success() -> None:
     assert result.headers.get("x-ratelimit-remaining") == "59"
 
 
-@pytest.mark.asyncio
 async def test_create_workflow_dispatch_with_inputs() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         body = json.loads(request.content)
@@ -210,7 +211,6 @@ async def test_create_workflow_dispatch_with_inputs() -> None:
     await client.create_workflow_dispatch("o", "r", 123, "main", inputs={"env": "prod"})
 
 
-@pytest.mark.asyncio
 async def test_create_workflow_dispatch_http_error_raises() -> None:
     client = _make_client(httpx.MockTransport(lambda r: httpx.Response(422)))
     with pytest.raises(httpx.HTTPStatusError) as exc_info:
@@ -223,7 +223,6 @@ async def test_create_workflow_dispatch_http_error_raises() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_workflow_run_success() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "GET"
@@ -237,7 +236,6 @@ async def test_get_workflow_run_success() -> None:
     assert result.data.status == "completed"
 
 
-@pytest.mark.asyncio
 async def test_get_workflow_run_headers_forwarded() -> None:
     def handler(_: httpx.Request) -> httpx.Response:
         return _json_response(_workflow_run_payload(), headers={"x-ratelimit-remaining": "50"})
@@ -247,7 +245,6 @@ async def test_get_workflow_run_headers_forwarded() -> None:
     assert result.headers.get("x-ratelimit-remaining") == "50"
 
 
-@pytest.mark.asyncio
 async def test_get_workflow_run_http_error_raises() -> None:
     client = _make_client(httpx.MockTransport(lambda r: httpx.Response(404)))
     with pytest.raises(httpx.HTTPStatusError) as exc_info:
@@ -260,7 +257,6 @@ async def test_get_workflow_run_http_error_raises() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_list_workflow_run_artifacts_single_page() -> None:
     artifacts = [_artifact(1), _artifact(2)]
 
@@ -278,7 +274,6 @@ async def test_list_workflow_run_artifacts_single_page() -> None:
     assert len(pages[0].data.artifacts) == 2
 
 
-@pytest.mark.asyncio
 async def test_list_workflow_run_artifacts_two_pages() -> None:
     page1_artifacts = [_artifact(1)]
     page2_artifacts = [_artifact(2)]
@@ -305,7 +300,6 @@ async def test_list_workflow_run_artifacts_two_pages() -> None:
     assert pages[1].data.artifacts[0].id == 2
 
 
-@pytest.mark.asyncio
 async def test_list_workflow_run_artifacts_pagination_stops_when_no_next() -> None:
     def handler(_: httpx.Request) -> httpx.Response:
         return _json_response({"total_count": 1, "artifacts": [_artifact(1)]})
@@ -317,7 +311,6 @@ async def test_list_workflow_run_artifacts_pagination_stops_when_no_next() -> No
     assert count == 1
 
 
-@pytest.mark.asyncio
 async def test_list_workflow_run_artifacts_http_error_raises() -> None:
     client = _make_client(httpx.MockTransport(lambda r: httpx.Response(403)))
     with pytest.raises(httpx.HTTPStatusError) as exc_info:
@@ -326,7 +319,6 @@ async def test_list_workflow_run_artifacts_http_error_raises() -> None:
     assert exc_info.value.response.status_code == 403
 
 
-@pytest.mark.asyncio
 async def test_list_workflow_run_artifacts_per_page_forwarded() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.url.params["per_page"] == "100"
@@ -342,7 +334,6 @@ async def test_list_workflow_run_artifacts_per_page_forwarded() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_create_issue_comment_success() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "POST"
@@ -355,9 +346,10 @@ async def test_create_issue_comment_success() -> None:
     result = await client.create_issue_comment("owner", "repo", 7, "LGTM")
     assert isinstance(result.data, IssueComment)
     assert result.data.body == "LGTM"
+    assert isinstance(result.data.user, GitHubUser)
+    assert result.data.user.login == "octocat"
 
 
-@pytest.mark.asyncio
 async def test_create_issue_comment_http_error_raises() -> None:
     client = _make_client(httpx.MockTransport(lambda r: httpx.Response(404)))
     with pytest.raises(httpx.HTTPStatusError) as exc_info:
@@ -370,7 +362,6 @@ async def test_create_issue_comment_http_error_raises() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_create_pr_review_comment_success_with_position() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         assert "/pulls/3/comments" in request.url.path
@@ -387,9 +378,10 @@ async def test_create_pr_review_comment_success_with_position() -> None:
     )
     assert isinstance(result.data, PullRequestReviewComment)
     assert result.data.commit_id == "abc123"
+    assert isinstance(result.data.user, GitHubUser)
+    assert result.data.user.login == "reviewer"
 
 
-@pytest.mark.asyncio
 async def test_create_pr_review_comment_success_with_line_and_side() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         body = json.loads(request.content)
@@ -403,7 +395,6 @@ async def test_create_pr_review_comment_success_with_line_and_side() -> None:
     assert isinstance(result.data, PullRequestReviewComment)
 
 
-@pytest.mark.asyncio
 async def test_create_pr_review_comment_http_error_raises() -> None:
     client = _make_client(httpx.MockTransport(lambda r: httpx.Response(422)))
     with pytest.raises(httpx.HTTPStatusError) as exc_info:
@@ -412,11 +403,227 @@ async def test_create_pr_review_comment_http_error_raises() -> None:
 
 
 # ---------------------------------------------------------------------------
+# create_pull_request
+# ---------------------------------------------------------------------------
+
+
+def _pull_request_payload(number: int = 1) -> dict[str, Any]:
+    return {
+        "number": number,
+        "html_url": f"https://github.com/owner/repo/pull/{number}",
+    }
+
+
+def _full_pull_request_payload(number: int = 42) -> dict[str, Any]:
+    """A richer PR payload exercising sub-models (user, labels, head/base)."""
+    return {
+        "id": 9000 + number,
+        "number": number,
+        "node_id": "PR_kwDOABCD123",
+        "url": f"https://api.github.com/repos/owner/repo/pulls/{number}",
+        "html_url": f"https://github.com/owner/repo/pull/{number}",
+        "diff_url": f"https://github.com/owner/repo/pull/{number}.diff",
+        "patch_url": f"https://github.com/owner/repo/pull/{number}.patch",
+        "state": "open",
+        "draft": True,
+        "merged": False,
+        "locked": False,
+        "merge_commit_sha": None,
+        "title": "Fix bug",
+        "body": "Backport",
+        "user": {
+            "id": 1,
+            "login": "octocat",
+            "html_url": "https://github.com/octocat",
+            "type": "User",
+        },
+        "assignees": [],
+        "requested_reviewers": [
+            {"id": 2, "login": "reviewer", "type": "User"},
+        ],
+        "labels": [
+            {"id": 100, "name": "qa/skip-qa", "color": "5319e7"},
+            {"id": 101, "name": "backport/7.62.x", "color": "5319e7"},
+        ],
+        "created_at": "2026-05-01T00:00:00Z",
+        "updated_at": "2026-05-02T00:00:00Z",
+        "closed_at": None,
+        "merged_at": None,
+        "head": {
+            "ref": "alice/fix",
+            "sha": "1234567890abcdef00",
+            "label": "alice:alice/fix",
+        },
+        "base": {
+            "ref": "master",
+            "sha": "cafebabe00",
+            "label": "owner:master",
+        },
+    }
+
+
+async def test_create_pull_request_success() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert "/repos/owner/repo/pulls" in request.url.path
+        body = json.loads(request.content)
+        assert body == {
+            "title": "Fix bug",
+            "head": "alice/fix",
+            "base": "master",
+            "body": "Fix description",
+            "draft": False,
+        }
+        return _json_response(_pull_request_payload(number=42), status_code=201)
+
+    client = _make_client(httpx.MockTransport(handler))
+    result = await client.create_pull_request("owner", "repo", "Fix bug", "alice/fix", "master", "Fix description")
+    assert isinstance(result.data, PullRequest)
+    assert result.data.number == 42
+    assert result.data.html_url == "https://github.com/owner/repo/pull/42"
+
+
+async def test_create_pull_request_draft_true_forwarded() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        assert body["draft"] is True
+        return _json_response(_pull_request_payload(number=7), status_code=201)
+
+    client = _make_client(httpx.MockTransport(handler))
+    result = await client.create_pull_request("o", "r", "T", "h", "b", draft=True)
+    assert result.data.number == 7
+
+
+async def test_create_pull_request_http_error_raises() -> None:
+    client = _make_client(httpx.MockTransport(lambda r: httpx.Response(422)))
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        await client.create_pull_request("o", "r", "T", "h", "b")
+    assert exc_info.value.response.status_code == 422
+
+
+async def test_create_pull_request_parses_full_response() -> None:
+    """Exercises sub-models (GitHubUser, Label, PullRequestRef) end-to-end."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return _json_response(_full_pull_request_payload(number=42), status_code=201)
+
+    client = _make_client(httpx.MockTransport(handler))
+    result = await client.create_pull_request("owner", "repo", "Fix bug", "alice/fix", "master")
+
+    pr = result.data
+    assert pr.id == 9042
+    assert pr.number == 42
+    assert pr.state == "open"
+    assert pr.draft is True
+    assert pr.title == "Fix bug"
+
+    assert isinstance(pr.user, GitHubUser)
+    assert pr.user.login == "octocat"
+
+    assert [label.name for label in pr.labels] == ["qa/skip-qa", "backport/7.62.x"]
+    assert all(isinstance(label, Label) for label in pr.labels)
+
+    assert isinstance(pr.head, PullRequestRef)
+    assert pr.head.ref == "alice/fix"
+    assert pr.head.sha == "1234567890abcdef00"
+    assert isinstance(pr.base, PullRequestRef)
+    assert pr.base.ref == "master"
+
+    assert [r.login for r in pr.requested_reviewers] == ["reviewer"]
+    assert pr.created_at == "2026-05-01T00:00:00Z"
+
+
+async def test_create_pull_request_ignores_extra_fields() -> None:
+    """Unknown top-level fields in the response must not break parsing."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = _full_pull_request_payload()
+        payload["mergeable_state"] = "clean"
+        payload["additions"] = 42
+        payload["unknown_future_field"] = {"nested": True}
+        return _json_response(payload, status_code=201)
+
+    client = _make_client(httpx.MockTransport(handler))
+    result = await client.create_pull_request("o", "r", "T", "h", "b")
+    assert result.data.number == 42
+
+
+# ---------------------------------------------------------------------------
+# add_labels_to_issue
+# ---------------------------------------------------------------------------
+
+
+async def test_add_labels_to_issue_success() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert "/repos/owner/repo/issues/3/labels" in request.url.path
+        body = json.loads(request.content)
+        assert body == {"labels": ["qa/skip-qa", "backport/7.62.x"]}
+        return _json_response([{"id": 1, "name": "qa/skip-qa"}, {"id": 2, "name": "backport/7.62.x"}], status_code=200)
+
+    client = _make_client(httpx.MockTransport(handler))
+    result = await client.add_labels_to_issue("owner", "repo", 3, ["qa/skip-qa", "backport/7.62.x"])
+    assert [label.name for label in result.data] == ["qa/skip-qa", "backport/7.62.x"]
+    assert all(isinstance(label, Label) for label in result.data)
+
+
+async def test_add_labels_to_issue_http_error_raises() -> None:
+    client = _make_client(httpx.MockTransport(lambda r: httpx.Response(404)))
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        await client.add_labels_to_issue("o", "r", 1, ["bug"])
+    assert exc_info.value.response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Lazy-loading guarantees for the `models` subpackage
+# ---------------------------------------------------------------------------
+
+
+def test_models_subpackage_loads_only_requested_submodule() -> None:
+    """Importing one model must not eagerly load every other model submodule.
+
+    Runs each scenario in a clean subprocess so the import effect is observable
+    (the parent test process has already loaded everything for other tests).
+    """
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import sys
+        from ddev.utils.github_async.models import PullRequest  # noqa: F401
+
+        assert 'ddev.utils.github_async.client' not in sys.modules, 'client module should not be loaded'
+        assert 'httpx' not in sys.modules, 'httpx should not be loaded when only models are imported'
+
+        prefix = 'ddev.utils.github_async.models.'
+        loaded = sorted(name[len(prefix):] for name in sys.modules if name.startswith(prefix))
+        print(','.join(loaded))
+        """
+    )
+    result = subprocess.run([sys.executable, '-c', script], capture_output=True, text=True, check=True)
+    loaded = set(result.stdout.strip().split(','))
+
+    # `pull_request` and its two type dependencies (`user`, `label`) must load.
+    assert {'pull_request', 'user', 'label'} <= loaded
+    # Unrelated model submodules must stay unloaded.
+    assert 'workflow' not in loaded
+    assert 'comment' not in loaded
+
+
+def test_models_subpackage_unknown_attribute_raises_attribute_error() -> None:
+    import ddev.utils.github_async.models as models
+
+    with pytest.raises(AttributeError, match='no attribute'):
+        models.NotARealModel  # noqa: B018
+
+
+# ---------------------------------------------------------------------------
 # Custom timeout per request
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_per_request_timeout_forwarded() -> None:
     """Ensure per-request timeout reaches the transport without raising."""
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Restructures `ddev.utils.github_async` from a single file into a package with the client in `client.py` and one model per submodule under `models/`. Both `__init__.py` files use PEP 562 `__getattr__`, so e.g. `from ddev.utils.github_async.models import PullRequest` only loads `pull_request.py` (plus its `user`/`label` dependencies), not every model.

Adds two new endpoints needed by upcoming work, expands the ``PullRequest`` model with the fields you typically need when inspecting a PR (state, draft, title/body, user/assignees, labels, branches, timestamps), and introduces a ``FakeAsyncGitHubClient`` test helper with a ``mock_response`` API supporting sticky replies, one-shot FIFO queues, partial-kwarg matching, and exception responses.

### Motivation
<!-- What inspired you to submit this pull request? -->

Sets up the async-client surface and test infrastructure that a stacked PR on top will use to add a new ``ddev release port-commit`` command. Lands the refactor on its own so review can focus on the client/test-fixture shape independent of feature code.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the ``qa/skip-qa`` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the ``backport/<branch-name>`` label to the PR and it will automatically open a backport PR once this one is merged