### PR TITLE
Add ddev release port-commit command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,9 @@ treemap*.png
 # Claude Code PR review artifacts
 .agint-review/
 
+# `ddev release port-commit` worktrees
+.worktrees/
+
 # Ignore any metadata file except root json in the downloader
 datadog_checks_downloader/datadog_checks/downloader/data/repo/targets/*
 !datadog_checks_downloader/datadog_checks/downloader/data/repo/targets/.gitignore

--- a/ddev/changelog.d/23686.added
+++ b/ddev/changelog.d/23686.added
@@ -1,0 +1,1 @@
+Add `ddev release port-commit` command to backport a commit to a target branch.

--- a/ddev/src/ddev/cli/release/__init__.py
+++ b/ddev/src/ddev/cli/release/__init__.py
@@ -11,6 +11,7 @@ from ddev.cli.release.agent import agent
 from ddev.cli.release.branch import branch
 from ddev.cli.release.changelog import changelog
 from ddev.cli.release.list_versions import list_versions
+from ddev.cli.release.port_commit import port_commit
 from ddev.cli.release.show import show
 from ddev.cli.release.stats import stats
 
@@ -28,6 +29,7 @@ release.add_command(build)
 release.add_command(changelog)
 release.add_command(list_versions)
 release.add_command(make)
+release.add_command(port_commit)
 release.add_command(show)
 release.add_command(stats)
 release.add_command(tag)

--- a/ddev/src/ddev/cli/release/port_commit.py
+++ b/ddev/src/ddev/cli/release/port_commit.py
@@ -1,0 +1,99 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from ddev.cli.application import Application
+
+
+@click.command(name='port-commit', short_help='Backport a commit onto a target branch')
+@click.pass_obj
+@click.argument('commit_hash', required=False)
+@click.option('-t', '--target-branch', default='master', show_default=True, help='Target branch to port to.')
+@click.option('-p', '--branch-prefix', default='port', show_default=True, help='Branch name prefix.')
+@click.option('-s', '--branch-suffix', default=None, help='Branch name suffix. Defaults to `to-<target-branch>`.')
+@click.option(
+    '-l',
+    '--pr-labels',
+    default='qa/skip-qa',
+    show_default=True,
+    help='Comma-separated PR labels.',
+)
+@click.option('--no-pr', is_flag=True, default=False, help="Don't create a pull request.")
+@click.option('--draft', is_flag=True, default=False, help='Open the PR as a draft.')
+@click.option('--verify', is_flag=True, default=False, help='Run commit hooks (skipped by default).')
+@click.option('--dry-run', is_flag=True, default=False, help='Print every step instead of executing it.')
+def port_commit(
+    app: Application,
+    commit_hash: str | None,
+    target_branch: str,
+    branch_prefix: str,
+    branch_suffix: str | None,
+    pr_labels: str,
+    no_pr: bool,
+    draft: bool,
+    verify: bool,
+    dry_run: bool,
+) -> None:
+    """
+    Backport a commit onto a target branch.
+
+    Cherry-picks COMMIT_HASH onto `--target-branch` (default `master`) on a new branch named
+    `<github-user>/<prefix>-<sha[:10]>-<suffix>`, preserving `.in-toto` files from the target
+    branch so package signatures stay intact. Pushes the branch and, unless `--no-pr` is set,
+    opens a pull request titled `[Backport] <subject>` and labeled with `--pr-labels`.
+
+    If COMMIT_HASH is omitted, the current HEAD commit is used after confirmation.
+
+    The GitHub user for the branch prefix is taken from `ddev config` (`github.user`) or the
+    `DD_GITHUB_USER` / `GITHUB_USER` / `GITHUB_ACTOR` environment variables.
+    """
+    from ddev.cli.release.port_commit_workflow import PortStepError, build_port_steps, resolve_port_plan
+
+    plan = resolve_port_plan(
+        app,
+        commit_hash=commit_hash,
+        target_branch=target_branch,
+        branch_prefix=branch_prefix,
+        branch_suffix=branch_suffix,
+        pr_labels=pr_labels,
+        no_pr=no_pr,
+        draft=draft,
+        verify=verify,
+        dry_run=dry_run,
+    )
+    bundle = build_port_steps(app, plan)
+
+    success = False
+    error_msg: str | None = None
+    try:
+        for step in bundle.steps:
+            step.run()
+        success = True
+    except PortStepError as e:
+        error_msg = str(e)
+    finally:
+        # If the PR was created before the failure (e.g. labeling failed afterwards), the worktree
+        # holds no recoverable state — the work is pushed and the PR exists on GitHub. Suppress the
+        # warning in that case to avoid a misleading "inspect the worktree" message.
+        pr_already_created = bundle.pr_step is not None and bundle.pr_step.pr_url is not None
+        if not success and not plan.dry_run and not pr_already_created:
+            app.display_warning(f'Worktree left at `{plan.worktree_path}` for inspection.')
+
+    if error_msg is not None:
+        app.abort(error_msg)
+
+    try:
+        bundle.teardown.run()
+    except PortStepError as e:
+        app.display_warning(f'Could not remove worktree at `{plan.worktree_path}`: {e}')
+        app.display_warning(f'Run `git worktree remove --force {plan.worktree_path}` to clean it up manually.')
+
+    if bundle.pr_step is not None and not plan.dry_run:
+        app.display_success(f'Pull request created: {bundle.pr_step.pr_url}')
+    app.display_success('All done.')

--- a/ddev/src/ddev/cli/release/port_commit.py
+++ b/ddev/src/ddev/cli/release/port_commit.py
@@ -53,7 +53,12 @@ def port_commit(
     The GitHub user for the branch prefix is taken from `ddev config` (`github.user`) or the
     `DD_GITHUB_USER` / `GITHUB_USER` / `GITHUB_ACTOR` environment variables.
     """
-    from ddev.cli.release.port_commit_workflow import PortStepError, build_port_steps, resolve_port_plan
+    from ddev.cli.release.port_commit_workflow import (
+        PortStepError,
+        build_port_steps,
+        display_completion_summary,
+        resolve_port_plan,
+    )
 
     plan = resolve_port_plan(
         app,
@@ -94,6 +99,9 @@ def port_commit(
         app.display_warning(f'Could not remove worktree at `{plan.worktree_path}`: {e}')
         app.display_warning(f'Run `git worktree remove --force {plan.worktree_path}` to clean it up manually.')
 
-    if bundle.pr_step is not None and not plan.dry_run:
-        app.display_success(f'Pull request created: {bundle.pr_step.pr_url}')
-    app.display_success('All done.')
+    if plan.dry_run:
+        app.display_success('Dry run complete.')
+        return
+
+    pr_url = bundle.pr_step.pr_url if bundle.pr_step is not None else None
+    display_completion_summary(app, plan, pr_url=pr_url)

--- a/ddev/src/ddev/cli/release/port_commit_workflow.py
+++ b/ddev/src/ddev/cli/release/port_commit_workflow.py
@@ -19,6 +19,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import click
+from rich.panel import Panel
+from rich.text import Text
 
 from ddev.utils.fs import Path
 from ddev.utils.git import GitRepository
@@ -61,7 +63,7 @@ class PortStep:
                 self.app.display_info(f'  (dry-run) {cmd}')
             return
 
-        self.app.display_info(f'{self.describe()}...')
+        self.app.output(Text(f'{self.describe()}...'), stderr=True)
         try:
             self.execute()
         except PortStepError:
@@ -69,7 +71,8 @@ class PortStep:
         except OSError as e:
             raise PortStepError(str(e)) from e
 
-        self.app.display_success(f'{self.describe()}: done.')
+        self.app.output(Text(f'{self.describe()}: done.', style='cyan'), stderr=True)
+        self.app.output('', stderr=True)
 
 
 class FetchOriginStep(PortStep):
@@ -370,8 +373,11 @@ def split_commit_subject(subject: str) -> tuple[str, str | None]:
     return PR_NUMBER_SUFFIX_PATTERN.sub('', subject), match.group(1)
 
 
-def build_pr_body(app: Application, *, sha: str, subject: str, target: str, original_pr: str | None) -> str:
-    info_lines = [f'**Backported commit**: `{sha[:10]}` - {subject}']
+def build_pr_body(
+    app: Application, *, sha: str, subject: str, target: str, original_pr: str | None, owner: str, repo: str
+) -> str:
+    commit_link = f'[`{sha[:10]}`](https://github.com/{owner}/{repo}/commit/{sha})'
+    info_lines = [f'**Backported commit**: {commit_link} - {subject}']
     if original_pr:
         info_lines.append(f'**Original PR**: #{original_pr}')
     info_lines.append(f'**Target branch**: `{target}`')
@@ -488,6 +494,7 @@ def resolve_port_plan(
 
     suffix = branch_suffix or f'to-{target_branch}'
     new_branch = f'{user}/{branch_prefix}-{full_sha[:10]}-{suffix}'.lower()
+    owner, repo = resolve_owner_repo(app)
     plan = PortPlan(
         full_sha=full_sha,
         clean_subject=clean_subject,
@@ -496,7 +503,15 @@ def resolve_port_plan(
         new_branch=new_branch,
         worktree_path=_worktree_path_for(app, new_branch),
         pr_title=f'[Backport] {clean_subject}',
-        pr_body=build_pr_body(app, sha=full_sha, subject=clean_subject, target=target_branch, original_pr=original_pr),
+        pr_body=build_pr_body(
+            app,
+            sha=full_sha,
+            subject=clean_subject,
+            target=target_branch,
+            original_pr=original_pr,
+            owner=owner,
+            repo=repo,
+        ),
         labels=parse_labels(pr_labels),
         draft=draft,
         create_pr=not no_pr,
@@ -504,7 +519,7 @@ def resolve_port_plan(
         dry_run=dry_run,
     )
 
-    app.display_info(_format_plan_summary(plan))
+    app.output(_format_plan_summary(plan), stderr=True)
 
     if not dry_run and not click.confirm('Continue?'):
         app.abort('Did not get confirmation, aborting.')
@@ -512,22 +527,47 @@ def resolve_port_plan(
     return plan
 
 
-def _format_plan_summary(plan: PortPlan) -> str:
-    original_pr_line = f'  Original PR: #{plan.original_pr}' if plan.original_pr else '  Original PR: (none)'
-    return '\n'.join(
-        [
-            'Configuration:',
-            f'  Target branch: {plan.target_branch}',
-            f'  Commit: {plan.full_sha[:10]} - {plan.clean_subject}',
-            original_pr_line,
-            f'  New branch: {plan.new_branch}',
-            f'  Worktree path: {plan.worktree_path}',
-            f'  Create PR: {plan.create_pr} (draft={plan.draft})',
-            f'  PR labels: {", ".join(plan.labels) if plan.labels else "(none)"}',
-            f'  Verify commit: {plan.verify}',
-            f'  Dry run: {plan.dry_run}',
-        ]
-    )
+def display_completion_summary(app: Application, plan: PortPlan, *, pr_url: str | None) -> None:
+    """Print a panel summarising the port outcome."""
+    text = Text()
+    rows: list[tuple[str, str]] = [
+        ('Commit', f'{plan.full_sha[:10]} - {plan.clean_subject}'),
+        ('Target', plan.target_branch),
+        ('Branch', plan.new_branch),
+    ]
+    if pr_url is not None:
+        rows.append(('Pull request', pr_url))
+
+    label_width = max(len(label) for label, _ in rows)
+    for i, (label, value) in enumerate(rows):
+        if i:
+            text.append('\n')
+        text.append(f'{label}:'.ljust(label_width + 2), style='bold')
+        text.append(value)
+
+    app.output(Panel(text, title='Backport completed', title_align='left', border_style='cyan'), stderr=True)
+
+
+def _format_plan_summary(plan: PortPlan) -> Text:
+    text = Text()
+    text.append('Configuration:', style='bold')
+
+    rows: list[tuple[str, str]] = [
+        ('Target branch', plan.target_branch),
+        ('Commit', f'{plan.full_sha[:10]} - {plan.clean_subject}'),
+        ('Original PR', f'#{plan.original_pr}' if plan.original_pr else '(none)'),
+        ('New branch', plan.new_branch),
+        ('Worktree path', str(plan.worktree_path)),
+        ('Create PR', f'{plan.create_pr} (draft={plan.draft})'),
+        ('PR labels', ', '.join(plan.labels) if plan.labels else '(none)'),
+        ('Verify commit', str(plan.verify)),
+        ('Dry run', str(plan.dry_run)),
+    ]
+    for label, value in rows:
+        text.append('\n  ')
+        text.append(f'{label}:', style='bold')
+        text.append(f' {value}')
+    return text
 
 
 @dataclass(frozen=True)

--- a/ddev/src/ddev/cli/release/port_commit_workflow.py
+++ b/ddev/src/ddev/cli/release/port_commit_workflow.py
@@ -1,0 +1,585 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Workflow internals for the `ddev release port-commit` command.
+
+Kept in a separate module so the command file stays small and the workflow
+classes are not imported on `--help` or other command-listing operations.
+Import this module from inside the command body, not at module top level.
+
+The workflow runs in an isolated git worktree at `.worktrees/port-commit/<branch>/`
+so the user's primary working tree is never mutated. On success the worktree is
+removed; on failure it is left in place for the user to inspect or finish manually.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import click
+
+from ddev.utils.fs import Path
+from ddev.utils.git import GitRepository
+
+if TYPE_CHECKING:
+    from ddev.cli.application import Application
+
+
+PR_NUMBER_SUFFIX_PATTERN = re.compile(r'\s*\(#(\d+)\)\s*$')
+PR_TEMPLATE_RELATIVE_PATH = '.github/PULL_REQUEST_TEMPLATE.md'
+PR_TEMPLATE_HEADING = '### What does this PR do?'
+IN_TOTO_SUFFIX = '.in-toto'
+WORKTREE_BASE = '.worktrees/port-commit'
+
+
+class PortStepError(Exception):
+    """Raised by a PortStep to signal a clean abort with a user-facing message."""
+
+
+class PortStep:
+    """Single step of the port-commit workflow."""
+
+    def __init__(self, app: Application, *, dry_run: bool = False) -> None:
+        self.app = app
+        self.dry_run = dry_run
+
+    def describe(self) -> str:
+        raise NotImplementedError
+
+    def planned_commands(self) -> list[str]:
+        return []
+
+    def execute(self) -> None:
+        raise NotImplementedError
+
+    def run(self) -> None:
+        if self.dry_run:
+            self.app.display_info(self.describe())
+            for cmd in self.planned_commands():
+                self.app.display_info(f'  (dry-run) {cmd}')
+            return
+
+        with self.app.status(self.describe()):
+            try:
+                self.execute()
+            except PortStepError:
+                raise
+            except OSError as e:
+                raise PortStepError(str(e)) from e
+
+        self.app.display_success(f'{self.describe()}: done.')
+
+
+class FetchOriginStep(PortStep):
+    def __init__(self, app: Application, *, git: GitRepository, dry_run: bool = False) -> None:
+        super().__init__(app, dry_run=dry_run)
+        self.git = git
+
+    def describe(self) -> str:
+        return 'Fetching latest changes from origin'
+
+    def planned_commands(self) -> list[str]:
+        return ['git fetch origin']
+
+    def execute(self) -> None:
+        self.git.run('fetch', 'origin')
+
+
+class SetupWorktreeStep(PortStep):
+    """Create the isolated worktree on a fresh port branch."""
+
+    def __init__(
+        self,
+        app: Application,
+        *,
+        main_git: GitRepository,
+        worktree_path: Path,
+        branch: str,
+        target: str,
+        dry_run: bool = False,
+    ) -> None:
+        super().__init__(app, dry_run=dry_run)
+        self.main_git = main_git
+        self.worktree_path = worktree_path
+        self.branch = branch
+        self.target = target
+
+    def describe(self) -> str:
+        return (
+            f'Creating worktree at `{self.worktree_path}` on new branch `{self.branch}` '
+            '(resetting if branch already exists)'
+        )
+
+    def planned_commands(self) -> list[str]:
+        return [
+            f'git worktree add -B {self.branch} {self.worktree_path} origin/{self.target} '
+            '# -B resets the branch if it already exists locally',
+        ]
+
+    def execute(self) -> None:
+        self.worktree_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self.main_git.run('worktree', 'add', '-B', self.branch, str(self.worktree_path), f'origin/{self.target}')
+        except OSError as e:
+            raise PortStepError(f'Failed to create worktree at `{self.worktree_path}`: {e}') from e
+
+
+class TeardownWorktreeStep(PortStep):
+    """Remove the worktree on a successful run."""
+
+    def __init__(
+        self,
+        app: Application,
+        *,
+        main_git: GitRepository,
+        worktree_path: Path,
+        dry_run: bool = False,
+    ) -> None:
+        super().__init__(app, dry_run=dry_run)
+        self.main_git = main_git
+        self.worktree_path = worktree_path
+
+    def describe(self) -> str:
+        return f'Removing worktree at `{self.worktree_path}`'
+
+    def planned_commands(self) -> list[str]:
+        return [f'git worktree remove --force {self.worktree_path}']
+
+    def execute(self) -> None:
+        self.main_git.run('worktree', 'remove', '--force', str(self.worktree_path))
+
+
+class CherryPickStep(PortStep):
+    """Cherry-pick a commit, auto-resolving `.in-toto`-only conflicts."""
+
+    def __init__(self, app: Application, *, git: GitRepository, sha: str, dry_run: bool = False) -> None:
+        super().__init__(app, dry_run=dry_run)
+        self.git = git
+        self.sha = sha
+
+    def describe(self) -> str:
+        return f'Cherry-picking {self.sha[:10]}'
+
+    def planned_commands(self) -> list[str]:
+        return [f'git cherry-pick --no-commit {self.sha}']
+
+    def execute(self) -> None:
+        try:
+            self.git.run('cherry-pick', '--no-commit', self.sha)
+            return
+        except OSError:
+            pass
+
+        conflicts = [line for line in self.git.capture('diff', '--name-only', '--diff-filter=U').splitlines() if line]
+        non_in_toto = [f for f in conflicts if IN_TOTO_SUFFIX not in f]
+        in_toto = [f for f in conflicts if IN_TOTO_SUFFIX in f]
+
+        if non_in_toto:
+            try:
+                self.git.run('cherry-pick', '--abort')
+            except OSError:
+                pass
+            listing = '\n  '.join(non_in_toto)
+            raise PortStepError(f'Cherry-pick has conflicts in non-`.in-toto` files:\n  {listing}')
+
+        if not in_toto:
+            raise PortStepError('Cherry-pick failed without conflicts. Resolve manually and try again.')
+
+        for path in in_toto:
+            _resolve_in_toto_conflict(self.git, path)
+
+
+class PreserveInTotoStep(PortStep):
+    """Reset any staged `.in-toto` changes to keep the target branch's signature metadata."""
+
+    def __init__(self, app: Application, *, git: GitRepository, dry_run: bool = False) -> None:
+        super().__init__(app, dry_run=dry_run)
+        self.git = git
+
+    def describe(self) -> str:
+        return 'Preserving `.in-toto` files from target branch'
+
+    def planned_commands(self) -> list[str]:
+        return ['# Reset any staged .in-toto changes to HEAD']
+
+    def execute(self) -> None:
+        staged = [line for line in self.git.capture('diff', '--cached', '--name-only').splitlines() if line]
+        affected = [f for f in staged if IN_TOTO_SUFFIX in f]
+        if not affected:
+            return
+
+        for path in affected:
+            _restore_path_from_head(self.git, path)
+
+
+class CommitStep(PortStep):
+    def __init__(
+        self,
+        app: Application,
+        *,
+        git: GitRepository,
+        subject: str,
+        verify: bool = False,
+        dry_run: bool = False,
+    ) -> None:
+        super().__init__(app, dry_run=dry_run)
+        self.git = git
+        self.subject = subject
+        self.verify = verify
+
+    @property
+    def message(self) -> str:
+        return f'[Backport] {self.subject}'
+
+    def describe(self) -> str:
+        return f'Committing changes as "{self.message}"'
+
+    def planned_commands(self) -> list[str]:
+        flags = '' if self.verify else '--no-verify '
+        return [f'git commit {flags}-m "{self.message}"']
+
+    def execute(self) -> None:
+        args = ['commit', '-m', self.message]
+        if not self.verify:
+            args.insert(1, '--no-verify')
+        self.git.run(*args)
+
+
+class PushStep(PortStep):
+    def __init__(self, app: Application, *, git: GitRepository, branch: str, dry_run: bool = False) -> None:
+        super().__init__(app, dry_run=dry_run)
+        self.git = git
+        self.branch = branch
+
+    def describe(self) -> str:
+        return f'Pushing `{self.branch}` to origin'
+
+    def planned_commands(self) -> list[str]:
+        return [f'git push origin {self.branch}']
+
+    def execute(self) -> None:
+        self.git.run('push', 'origin', self.branch)
+
+
+class CreatePullRequestStep(PortStep):
+    def __init__(
+        self,
+        app: Application,
+        *,
+        owner: str,
+        repo: str,
+        title: str,
+        head: str,
+        base: str,
+        body: str,
+        labels: list[str],
+        draft: bool,
+        dry_run: bool = False,
+    ) -> None:
+        super().__init__(app, dry_run=dry_run)
+        self.owner = owner
+        self.repo = repo
+        self.title = title
+        self.head = head
+        self.base = base
+        self.body = body
+        self.labels = labels
+        self.draft = draft
+        self.pr_url: str | None = None
+
+    def describe(self) -> str:
+        flavor = 'draft pull request' if self.draft else 'pull request'
+        return f'Creating {flavor} `{self.title}`'
+
+    def planned_commands(self) -> list[str]:
+        label_part = f' --label {",".join(self.labels)}' if self.labels else ''
+        draft_part = ' --draft' if self.draft else ''
+        endpoint = f'/repos/{self.owner}/{self.repo}/pulls'
+        return [f'POST {endpoint} (head={self.head}, base={self.base}{draft_part}){label_part}']
+
+    def execute(self) -> None:
+        import asyncio
+
+        import httpx
+        from pydantic import ValidationError
+
+        try:
+            asyncio.run(self._create_pr())
+        except (httpx.HTTPError, ValidationError) as e:
+            if self.pr_url:
+                raise PortStepError(
+                    f'Pull request created at {self.pr_url} but labeling failed: {e}. '
+                    'Add the labels manually on the PR.'
+                ) from e
+            raise PortStepError(f'Failed to create pull request: {e}') from e
+
+    async def _create_pr(self) -> None:
+        from ddev.utils.github_async import async_github_client
+
+        async with async_github_client(token=self.app.config.github.token) as client:
+            response = await client.create_pull_request(
+                owner=self.owner,
+                repo=self.repo,
+                title=self.title,
+                head=self.head,
+                base=self.base,
+                body=self.body,
+                draft=self.draft,
+            )
+            pr = response.data
+            self.pr_url = pr.html_url
+            if self.labels:
+                await client.add_labels_to_issue(
+                    owner=self.owner,
+                    repo=self.repo,
+                    issue_number=pr.number,
+                    labels=self.labels,
+                )
+
+
+def _path_exists_in_head(git: GitRepository, path: str) -> bool:
+    try:
+        git.capture('cat-file', '-e', f'HEAD:{path}')
+        return True
+    except OSError:
+        return False
+
+
+def _resolve_in_toto_conflict(git: GitRepository, path: str) -> None:
+    if not _path_exists_in_head(git, path):
+        git.run('rm', '--force', path)
+        return
+    git.run('checkout', '--ours', path)
+    git.run('add', path)
+
+
+def _restore_path_from_head(git: GitRepository, path: str) -> None:
+    if not _path_exists_in_head(git, path):
+        git.run('rm', '--force', path)
+        return
+    git.run('checkout', 'HEAD', '--', path)
+
+
+def split_commit_subject(subject: str) -> tuple[str, str | None]:
+    """Return (subject_without_pr_suffix, original_pr_number_or_None)."""
+    match = PR_NUMBER_SUFFIX_PATTERN.search(subject)
+    if not match:
+        return subject, None
+    return PR_NUMBER_SUFFIX_PATTERN.sub('', subject), match.group(1)
+
+
+def build_pr_body(app: Application, *, sha: str, subject: str, target: str, original_pr: str | None) -> str:
+    info_lines = [f'**Backported commit**: `{sha[:10]}` - {subject}']
+    if original_pr:
+        info_lines.append(f'**Original PR**: #{original_pr}')
+    info_lines.append(f'**Target branch**: `{target}`')
+    info_block = '\n'.join(info_lines) + '\n'
+
+    template_path = app.repo.path / PR_TEMPLATE_RELATIVE_PATH
+    if not template_path.is_file():
+        return f'{PR_TEMPLATE_HEADING}\n\n{info_block}'
+
+    template = template_path.read_text()
+    if PR_TEMPLATE_HEADING in template:
+        return template.replace(PR_TEMPLATE_HEADING, f'{PR_TEMPLATE_HEADING}\n\n{info_block}', 1)
+    return f'{info_block}\n{template}'
+
+
+def parse_labels(raw: str) -> list[str]:
+    return [label.strip() for label in raw.split(',') if label.strip()]
+
+
+def resolve_owner_repo(app: Application) -> tuple[str, str]:
+    """Resolve (owner, repo) for the active repository.
+
+    Falls back to `DataDog/<full_name>` when `full_name` is unqualified.
+    """
+    full = app.repo.full_name
+    if '/' in full:
+        owner, repo = full.split('/', 1)
+        return owner, repo
+    return 'DataDog', full
+
+
+def _sanitize_branch_for_path(branch: str) -> str:
+    return branch.replace('/', '-')
+
+
+def _worktree_path_for(app: Application, branch: str) -> Path:
+    return app.repo.path / WORKTREE_BASE / _sanitize_branch_for_path(branch)
+
+
+@dataclass(frozen=True)
+class PortPlan:
+    """All values needed to execute the port workflow, resolved up front."""
+
+    full_sha: str
+    clean_subject: str
+    original_pr: str | None
+    target_branch: str
+    new_branch: str
+    worktree_path: Path
+    pr_title: str
+    pr_body: str
+    labels: list[str]
+    draft: bool
+    create_pr: bool
+    verify: bool
+    dry_run: bool
+
+
+def resolve_port_plan(
+    app: Application,
+    *,
+    commit_hash: str | None,
+    target_branch: str,
+    branch_prefix: str,
+    branch_suffix: str | None,
+    pr_labels: str,
+    no_pr: bool,
+    draft: bool,
+    verify: bool,
+    dry_run: bool,
+) -> PortPlan:
+    """Validate inputs, resolve derived values, and confirm with the user. Aborts on failure."""
+    user = app.config.github.user
+    if not user:
+        app.abort(
+            'No GitHub user configured. Set `github.user` via `ddev config set github.user <name>` '
+            'or export DD_GITHUB_USER.'
+        )
+
+    if not no_pr and not dry_run and not app.config.github.token:
+        app.abort(
+            'No GitHub token configured. Set `github.token` via `ddev config set github.token <token>` '
+            'or export DD_GITHUB_TOKEN. Re-run with `--no-pr` to skip pull request creation.'
+        )
+
+    if commit_hash is None:
+        head_commit = app.repo.git.latest_commit()
+        app.display_info(f'No commit specified. Current HEAD: `{head_commit.sha[:10]}` - {head_commit.subject}')
+        if not dry_run and not click.confirm('Use this commit?'):
+            app.abort('Did not get confirmation, aborting.')
+        commit_hash = head_commit.sha
+
+    try:
+        full_sha = app.repo.git.capture('rev-parse', '--verify', f'{commit_hash}^{{commit}}').strip()
+    except OSError:
+        app.abort(f'Commit `{commit_hash}` does not exist.')
+
+    log_entries = app.repo.git.log(['hash:%H', 'subject:%s'], n=1, source=full_sha)
+    if not log_entries:
+        app.abort(f'Could not read commit `{full_sha}`.')
+    clean_subject, original_pr = split_commit_subject(log_entries[0]['subject'])
+
+    in_toto_files = [
+        line
+        for line in app.repo.git.capture('diff-tree', '--no-commit-id', '--name-only', '-r', full_sha).splitlines()
+        if IN_TOTO_SUFFIX in line
+    ]
+    if in_toto_files:
+        listing = '\n  '.join(in_toto_files)
+        app.display_warning(
+            f'Commit touches {len(in_toto_files)} `.in-toto` file(s); they will be preserved '
+            f'from `{target_branch}`:\n  {listing}'
+        )
+
+    suffix = branch_suffix or f'to-{target_branch}'
+    new_branch = f'{user}/{branch_prefix}-{full_sha[:10]}-{suffix}'
+    plan = PortPlan(
+        full_sha=full_sha,
+        clean_subject=clean_subject,
+        original_pr=original_pr,
+        target_branch=target_branch,
+        new_branch=new_branch,
+        worktree_path=_worktree_path_for(app, new_branch),
+        pr_title=f'[Backport] {clean_subject}',
+        pr_body=build_pr_body(app, sha=full_sha, subject=clean_subject, target=target_branch, original_pr=original_pr),
+        labels=parse_labels(pr_labels),
+        draft=draft,
+        create_pr=not no_pr,
+        verify=verify,
+        dry_run=dry_run,
+    )
+
+    app.display_info(_format_plan_summary(plan))
+
+    if not dry_run and not click.confirm('Continue?'):
+        app.abort('Did not get confirmation, aborting.')
+
+    return plan
+
+
+def _format_plan_summary(plan: PortPlan) -> str:
+    original_pr_line = f'  Original PR: #{plan.original_pr}' if plan.original_pr else '  Original PR: (none)'
+    return '\n'.join(
+        [
+            'Configuration:',
+            f'  Target branch: {plan.target_branch}',
+            f'  Commit: {plan.full_sha[:10]} - {plan.clean_subject}',
+            original_pr_line,
+            f'  New branch: {plan.new_branch}',
+            f'  Worktree path: {plan.worktree_path}',
+            f'  Create PR: {plan.create_pr} (draft={plan.draft})',
+            f'  PR labels: {", ".join(plan.labels) if plan.labels else "(none)"}',
+            f'  Verify commit: {plan.verify}',
+            f'  Dry run: {plan.dry_run}',
+        ]
+    )
+
+
+@dataclass(frozen=True)
+class PortStepBundle:
+    """All steps produced by `build_port_steps`, separated by lifecycle role.
+
+    `steps` is the ordered sequence the caller iterates and runs. `pr_step` is a
+    post-run handle for the PR URL (or `None` when `--no-pr`). `teardown` is the
+    worktree-removal step held separately so the caller can skip it on failure,
+    leaving the worktree on disk for inspection.
+    """
+
+    steps: list[PortStep]
+    pr_step: CreatePullRequestStep | None
+    teardown: TeardownWorktreeStep
+
+
+def build_port_steps(app: Application, plan: PortPlan) -> PortStepBundle:
+    """Build the workflow steps grouped by lifecycle role."""
+    main_git = app.repo.git
+    worktree_git = GitRepository(plan.worktree_path)
+
+    steps: list[PortStep] = [
+        FetchOriginStep(app, git=main_git, dry_run=plan.dry_run),
+        SetupWorktreeStep(
+            app,
+            main_git=main_git,
+            worktree_path=plan.worktree_path,
+            branch=plan.new_branch,
+            target=plan.target_branch,
+            dry_run=plan.dry_run,
+        ),
+        CherryPickStep(app, git=worktree_git, sha=plan.full_sha, dry_run=plan.dry_run),
+        PreserveInTotoStep(app, git=worktree_git, dry_run=plan.dry_run),
+        CommitStep(app, git=worktree_git, subject=plan.clean_subject, verify=plan.verify, dry_run=plan.dry_run),
+        PushStep(app, git=worktree_git, branch=plan.new_branch, dry_run=plan.dry_run),
+    ]
+    pr_step: CreatePullRequestStep | None = None
+    if plan.create_pr:
+        owner, repo = resolve_owner_repo(app)
+        pr_step = CreatePullRequestStep(
+            app,
+            owner=owner,
+            repo=repo,
+            title=plan.pr_title,
+            head=plan.new_branch,
+            base=plan.target_branch,
+            body=plan.pr_body,
+            labels=plan.labels,
+            draft=plan.draft,
+            dry_run=plan.dry_run,
+        )
+        steps.append(pr_step)
+    teardown = TeardownWorktreeStep(app, main_git=main_git, worktree_path=plan.worktree_path, dry_run=plan.dry_run)
+    return PortStepBundle(steps=steps, pr_step=pr_step, teardown=teardown)

--- a/ddev/src/ddev/cli/release/port_commit_workflow.py
+++ b/ddev/src/ddev/cli/release/port_commit_workflow.py
@@ -61,13 +61,13 @@ class PortStep:
                 self.app.display_info(f'  (dry-run) {cmd}')
             return
 
-        with self.app.status(self.describe()):
-            try:
-                self.execute()
-            except PortStepError:
-                raise
-            except OSError as e:
-                raise PortStepError(str(e)) from e
+        self.app.display_info(f'{self.describe()}...')
+        try:
+            self.execute()
+        except PortStepError:
+            raise
+        except OSError as e:
+            raise PortStepError(str(e)) from e
 
         self.app.display_success(f'{self.describe()}: done.')
 
@@ -487,7 +487,7 @@ def resolve_port_plan(
         )
 
     suffix = branch_suffix or f'to-{target_branch}'
-    new_branch = f'{user}/{branch_prefix}-{full_sha[:10]}-{suffix}'
+    new_branch = f'{user}/{branch_prefix}-{full_sha[:10]}-{suffix}'.lower()
     plan = PortPlan(
         full_sha=full_sha,
         clean_subject=clean_subject,

--- a/ddev/tests/cli/release/test_port_commit.py
+++ b/ddev/tests/cli/release/test_port_commit.py
@@ -1,0 +1,622 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+from pathlib import Path as StdPath
+from unittest.mock import MagicMock, call
+
+import pytest
+from pytest_mock import MockerFixture
+
+from ddev.cli.release.port_commit_workflow import (
+    CherryPickStep,
+    CommitStep,
+    CreatePullRequestStep,
+    PortStep,
+    PortStepError,
+    PreserveInTotoStep,
+    SetupWorktreeStep,
+    TeardownWorktreeStep,
+    build_pr_body,
+    parse_labels,
+    split_commit_subject,
+)
+from ddev.utils.git import GitCommit
+from ddev.utils.github_async.models import PullRequest
+from tests.helpers.github_async import FakeAsyncGitHubClient
+from tests.helpers.runner import CliRunner
+
+
+@pytest.fixture
+def app_mock(mocker: MockerFixture) -> MagicMock:
+    app = mocker.MagicMock()
+    app.status.return_value.__enter__ = MagicMock(return_value=None)
+    app.status.return_value.__exit__ = MagicMock(return_value=None)
+    return app
+
+
+@pytest.fixture
+def git_mock(mocker: MockerFixture) -> MagicMock:
+    return mocker.MagicMock()
+
+
+@pytest.mark.parametrize(
+    'subject,expected_clean,expected_pr',
+    [
+        ('Fix flake (#12345)', 'Fix flake', '12345'),
+        ('Fix flake', 'Fix flake', None),
+        ('Multi part subject (#1)', 'Multi part subject', '1'),
+        ('Trailing spaces (#999)   ', 'Trailing spaces', '999'),
+    ],
+)
+def test_split_commit_subject(subject, expected_clean, expected_pr):
+    assert split_commit_subject(subject) == (expected_clean, expected_pr)
+
+
+@pytest.mark.parametrize(
+    'raw,expected',
+    [
+        ('qa/skip-qa', ['qa/skip-qa']),
+        ('qa/skip-qa, backport/7.62.x', ['qa/skip-qa', 'backport/7.62.x']),
+        ('', []),
+        ('  ,  , ', []),
+    ],
+)
+def test_parse_labels(raw, expected):
+    assert parse_labels(raw) == expected
+
+
+def test_build_pr_body_uses_template(app_mock, tmp_path):
+    template_dir = tmp_path / '.github'
+    template_dir.mkdir()
+    template_file = template_dir / 'PULL_REQUEST_TEMPLATE.md'
+    template_file.write_text('### What does this PR do?\n\n<!-- describe -->\n\n### Motivation\n')
+    app_mock.repo.path = tmp_path
+
+    body = build_pr_body(app_mock, sha='abcdef1234567890', subject='Fix bug', target='7.62.x', original_pr='12345')
+
+    assert '**Backported commit**: `abcdef1234`' in body
+    assert '**Original PR**: #12345' in body
+    assert '**Target branch**: `7.62.x`' in body
+    assert '### Motivation' in body
+
+
+def test_build_pr_body_without_template(app_mock, tmp_path):
+    app_mock.repo.path = tmp_path
+
+    body = build_pr_body(app_mock, sha='abcdef1234567890', subject='Fix bug', target='master', original_pr=None)
+
+    assert '### What does this PR do?' in body
+    assert '**Backported commit**: `abcdef1234`' in body
+    assert 'Original PR' not in body
+
+
+class _RunnableStep(PortStep):
+    def __init__(self, app, *, fail=False, dry_run=False):
+        super().__init__(app, dry_run=dry_run)
+        self.fail = fail
+        self.executed = False
+
+    def describe(self):
+        return 'Doing the thing'
+
+    def planned_commands(self):
+        return ['echo hi']
+
+    def execute(self):
+        self.executed = True
+        if self.fail:
+            raise OSError('boom')
+
+
+def test_port_step_dry_run_skips_execute(app_mock):
+    step = _RunnableStep(app_mock, dry_run=True)
+    step.run()
+    assert step.executed is False
+    app_mock.status.assert_not_called()
+    info_calls = [c.args[0] for c in app_mock.display_info.call_args_list]
+    assert 'Doing the thing' in info_calls
+    assert any('echo hi' in line for line in info_calls)
+
+
+def test_port_step_executes_and_emits_success(app_mock):
+    step = _RunnableStep(app_mock)
+    step.run()
+    assert step.executed is True
+    app_mock.status.assert_called_once_with('Doing the thing')
+    app_mock.display_success.assert_called_once()
+
+
+def test_port_step_wraps_oserror_as_port_step_error(app_mock):
+    step = _RunnableStep(app_mock, fail=True)
+    with pytest.raises(PortStepError, match='boom'):
+        step.run()
+
+
+def test_setup_worktree_step_creates_branch_in_worktree(app_mock, git_mock, tmp_path):
+    worktree_path = tmp_path / '.worktrees' / 'port-commit' / 'alice-port-1234567890-to-master'
+
+    step = SetupWorktreeStep(
+        app_mock,
+        main_git=git_mock,
+        worktree_path=worktree_path,
+        branch='alice/port-1234567890-to-master',
+        target='master',
+    )
+    step.execute()
+
+    git_mock.run.assert_called_once_with(
+        'worktree', 'add', '-B', 'alice/port-1234567890-to-master', str(worktree_path), 'origin/master'
+    )
+    assert worktree_path.parent.is_dir()
+
+
+def test_setup_worktree_step_wraps_oserror_as_port_step_error(app_mock, git_mock, tmp_path):
+    git_mock.run.side_effect = OSError('already exists')
+
+    step = SetupWorktreeStep(
+        app_mock,
+        main_git=git_mock,
+        worktree_path=tmp_path / '.worktrees' / 'port-commit' / 'alice-x',
+        branch='alice/x',
+        target='master',
+    )
+    with pytest.raises(PortStepError, match='Failed to create worktree'):
+        step.execute()
+
+
+def test_teardown_worktree_step_removes_worktree(app_mock, git_mock, tmp_path):
+    worktree_path = tmp_path / '.worktrees' / 'port-commit' / 'alice-x'
+
+    step = TeardownWorktreeStep(app_mock, main_git=git_mock, worktree_path=worktree_path)
+    step.execute()
+
+    git_mock.run.assert_called_once_with('worktree', 'remove', '--force', str(worktree_path))
+
+
+def test_cherry_pick_clean(app_mock, git_mock):
+    step = CherryPickStep(app_mock, git=git_mock, sha='1234567890')
+    step.execute()
+    git_mock.run.assert_called_once_with('cherry-pick', '--no-commit', '1234567890')
+    git_mock.capture.assert_not_called()
+
+
+def test_cherry_pick_only_in_toto_conflict_is_resolved(app_mock, git_mock):
+    git_mock.run.side_effect = [OSError('conflict'), None, None]
+    git_mock.capture.side_effect = [
+        'path/file.in-toto.link\n',
+        '',
+    ]
+
+    step = CherryPickStep(app_mock, git=git_mock, sha='1234567890')
+    step.execute()
+
+    assert git_mock.run.call_args_list == [
+        call('cherry-pick', '--no-commit', '1234567890'),
+        call('checkout', '--ours', 'path/file.in-toto.link'),
+        call('add', 'path/file.in-toto.link'),
+    ]
+
+
+def test_cherry_pick_mixed_conflict_aborts(app_mock, git_mock):
+    git_mock.run.side_effect = [OSError('conflict'), None]
+    git_mock.capture.return_value = 'src/foo.py\npath/file.in-toto.link\n'
+
+    step = CherryPickStep(app_mock, git=git_mock, sha='1234567890')
+    with pytest.raises(PortStepError, match='non-`.in-toto`'):
+        step.execute()
+
+    git_mock.run.assert_any_call('cherry-pick', '--abort')
+
+
+def test_cherry_pick_failure_without_conflicts_aborts(app_mock, git_mock):
+    git_mock.run.side_effect = OSError('conflict')
+    git_mock.capture.return_value = ''
+
+    step = CherryPickStep(app_mock, git=git_mock, sha='1234567890')
+    with pytest.raises(PortStepError, match='without conflicts'):
+        step.execute()
+
+
+def test_preserve_in_toto_resets_staged_modifications(app_mock, git_mock):
+    git_mock.capture.side_effect = [
+        'src/foo.py\npath/file.in-toto.link\n',
+        '',
+    ]
+
+    step = PreserveInTotoStep(app_mock, git=git_mock)
+    step.execute()
+
+    git_mock.run.assert_called_once_with('checkout', 'HEAD', '--', 'path/file.in-toto.link')
+
+
+def test_preserve_in_toto_removes_files_not_in_head(app_mock, git_mock):
+    git_mock.capture.side_effect = [
+        'path/new.in-toto.link\n',
+        OSError('not in head'),
+    ]
+
+    step = PreserveInTotoStep(app_mock, git=git_mock)
+    step.execute()
+
+    git_mock.run.assert_called_once_with('rm', '--force', 'path/new.in-toto.link')
+
+
+def test_preserve_in_toto_noop_when_clean(app_mock, git_mock):
+    git_mock.capture.return_value = 'src/foo.py\n'
+
+    step = PreserveInTotoStep(app_mock, git=git_mock)
+    step.execute()
+
+    git_mock.run.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    'verify,expected_args',
+    [
+        (False, ('commit', '--no-verify', '-m', '[Backport] Fix bug')),
+        (True, ('commit', '-m', '[Backport] Fix bug')),
+    ],
+)
+def test_commit_step(app_mock, git_mock, verify, expected_args):
+    step = CommitStep(app_mock, git=git_mock, subject='Fix bug', verify=verify)
+    step.execute()
+    git_mock.run.assert_called_once_with(*expected_args)
+
+
+def test_create_pull_request_step(app_mock: MagicMock, fake_async_github: FakeAsyncGitHubClient) -> None:
+    app_mock.config.github.token = 'ghp_test'
+    fake_async_github.mock_response(
+        'create_pull_request',
+        PullRequest(number=7, html_url='https://github.com/x/pr/1'),
+    )
+
+    step = CreatePullRequestStep(
+        app_mock,
+        owner='DataDog',
+        repo='integrations-core',
+        title='[Backport] Fix bug',
+        head='alice/port-1234567890-to-7.62.x',
+        base='7.62.x',
+        body='body',
+        labels=['qa/skip-qa'],
+        draft=False,
+    )
+    step.execute()
+
+    fake_async_github.assert_called_once_with(
+        'create_pull_request',
+        owner='DataDog',
+        repo='integrations-core',
+        title='[Backport] Fix bug',
+        head='alice/port-1234567890-to-7.62.x',
+        base='7.62.x',
+        body='body',
+        draft=False,
+        timeout=None,
+    )
+    fake_async_github.assert_called_once_with(
+        'add_labels_to_issue',
+        owner='DataDog',
+        repo='integrations-core',
+        issue_number=7,
+        labels=['qa/skip-qa'],
+        timeout=None,
+    )
+    assert step.pr_url == 'https://github.com/x/pr/1'
+
+
+def test_create_pull_request_step_skips_label_call_when_no_labels(
+    app_mock: MagicMock, fake_async_github: FakeAsyncGitHubClient
+) -> None:
+    app_mock.config.github.token = 'ghp_test'
+
+    step = CreatePullRequestStep(
+        app_mock,
+        owner='DataDog',
+        repo='integrations-core',
+        title='[Backport] Fix',
+        head='alice/x',
+        base='master',
+        body='body',
+        labels=[],
+        draft=True,
+    )
+    step.execute()
+
+    fake_async_github.assert_called_once_with(
+        'create_pull_request',
+        owner='DataDog',
+        repo='integrations-core',
+        title='[Backport] Fix',
+        head='alice/x',
+        base='master',
+        body='body',
+        draft=True,
+        timeout=None,
+    )
+    fake_async_github.assert_not_called('add_labels_to_issue')
+
+
+def _setup_command_mocks(mocker, *, commit_sha='1234567890abcdef00', subject='Fix bug (#100)', in_toto=''):
+    run_mock = mocker.patch('ddev.utils.git.GitRepository.run')
+    capture_mock = mocker.patch('ddev.utils.git.GitRepository.capture')
+    capture_mock.side_effect = lambda *args: {
+        ('rev-parse', '--verify', f'{commit_sha}^{{commit}}'): commit_sha + '\n',
+        ('diff-tree', '--no-commit-id', '--name-only', '-r', commit_sha): in_toto,
+    }.get(args, '')
+    mocker.patch(
+        'ddev.utils.git.GitRepository.log',
+        return_value=[{'hash': commit_sha, 'subject': subject}],
+    )
+    mocker.patch(
+        'ddev.utils.git.GitRepository.latest_commit',
+        return_value=GitCommit(commit_sha, subject=subject),
+    )
+    return run_mock
+
+
+def test_command_happy_path(ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient) -> None:
+    run_mock = _setup_command_mocks(mocker)
+    fake_async_github.mock_response(
+        'create_pull_request',
+        PullRequest(number=1, html_url='https://github.com/x/pr/1'),
+    )
+    mocker.patch('click.confirm', return_value=True)
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
+
+    result = ddev('release', 'port-commit', '1234567890abcdef00')
+
+    assert result.exit_code == 0, result.output
+    assert 'Pull request created: https://github.com/x/pr/1' in result.output
+
+    pr_call = fake_async_github.last_call('create_pull_request')
+    assert pr_call.kwargs['owner'] == 'DataDog'
+    assert pr_call.kwargs['repo'] == 'integrations-core'
+    assert pr_call.kwargs['title'] == '[Backport] Fix bug'
+    assert pr_call.kwargs['head'] == 'alice/port-1234567890-to-master'
+    assert pr_call.kwargs['base'] == 'master'
+    assert pr_call.kwargs['draft'] is False
+    assert '**Backported commit**: `1234567890`' in pr_call.kwargs['body']
+    assert '**Original PR**: #100' in pr_call.kwargs['body']
+
+    fake_async_github.assert_called_once_with(
+        'add_labels_to_issue',
+        owner='DataDog',
+        repo='integrations-core',
+        issue_number=1,
+        labels=['qa/skip-qa'],
+        timeout=None,
+    )
+
+    git_calls = [c.args for c in run_mock.call_args_list]
+    assert ('fetch', 'origin') in git_calls
+    assert any(args[:2] == ('worktree', 'add') for args in git_calls)
+    assert any(args[:3] == ('worktree', 'remove', '--force') for args in git_calls)
+
+
+def test_command_draft_flag(ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient) -> None:
+    _setup_command_mocks(mocker)
+    mocker.patch('click.confirm', return_value=True)
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
+
+    result = ddev('release', 'port-commit', '--draft', '1234567890abcdef00')
+
+    assert result.exit_code == 0, result.output
+    assert fake_async_github.last_call('create_pull_request').kwargs['draft'] is True
+
+
+def test_command_no_pr(ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient) -> None:
+    _setup_command_mocks(mocker)
+    mocker.patch('click.confirm', return_value=True)
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
+
+    result = ddev('release', 'port-commit', '--no-pr', '1234567890abcdef00')
+
+    assert result.exit_code == 0, result.output
+    fake_async_github.assert_not_called('create_pull_request')
+    fake_async_github.assert_not_called('add_labels_to_issue')
+
+
+def test_command_dry_run_makes_no_mutating_calls(
+    ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
+) -> None:
+    run_mock = _setup_command_mocks(mocker)
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
+
+    result = ddev('release', 'port-commit', '--dry-run', '1234567890abcdef00')
+
+    assert result.exit_code == 0, result.output
+    assert '(dry-run)' in result.output
+    run_mock.assert_not_called()
+    fake_async_github.assert_not_called('create_pull_request')
+
+
+def test_create_pull_request_step_reports_partial_failure_when_labeling_fails(
+    app_mock: MagicMock, fake_async_github: FakeAsyncGitHubClient
+) -> None:
+    import httpx
+
+    app_mock.config.github.token = 'ghp_test'
+    fake_async_github.mock_response(
+        'create_pull_request',
+        PullRequest(number=7, html_url='https://github.com/x/pr/7'),
+    )
+    fake_async_github.mock_response(
+        'add_labels_to_issue',
+        httpx.HTTPStatusError('forbidden', request=httpx.Request('POST', 'https://x'), response=httpx.Response(403)),
+    )
+
+    step = CreatePullRequestStep(
+        app_mock,
+        owner='DataDog',
+        repo='integrations-core',
+        title='[Backport] Fix bug',
+        head='alice/x',
+        base='master',
+        body='body',
+        labels=['qa/skip-qa'],
+        draft=False,
+    )
+
+    with pytest.raises(PortStepError, match=r'created at https://github.com/x/pr/7 but labeling failed'):
+        step.execute()
+
+    assert step.pr_url == 'https://github.com/x/pr/7'
+
+
+def test_command_suppresses_worktree_warning_on_partial_pr_failure(
+    ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
+) -> None:
+    import httpx
+
+    _setup_command_mocks(mocker)
+    fake_async_github.mock_response(
+        'create_pull_request',
+        PullRequest(number=1, html_url='https://github.com/x/pr/1'),
+    )
+    fake_async_github.mock_response(
+        'add_labels_to_issue',
+        httpx.HTTPStatusError('forbidden', request=httpx.Request('POST', 'https://x'), response=httpx.Response(403)),
+    )
+    mocker.patch('click.confirm', return_value=True)
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
+
+    result = ddev('release', 'port-commit', '1234567890abcdef00')
+
+    assert result.exit_code == 1, result.output
+    assert 'Pull request created at https://github.com/x/pr/1 but labeling failed' in result.output
+    assert 'Worktree left at' not in result.output
+
+
+def test_command_leaves_worktree_on_failure(
+    ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
+) -> None:
+    run_mock = _setup_command_mocks(mocker)
+
+    def run_side_effect(*args):
+        if args[:2] == ('worktree', 'add'):
+            raise OSError('refusing to overwrite existing worktree')
+        return None
+
+    run_mock.side_effect = run_side_effect
+    mocker.patch('click.confirm', return_value=True)
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
+
+    result = ddev('release', 'port-commit', '1234567890abcdef00')
+
+    assert result.exit_code == 1, result.output
+    assert 'Worktree left at' in result.output
+    assert 'Failed to create worktree' in result.output
+    git_calls = [c.args for c in run_mock.call_args_list]
+    assert not any(args[:3] == ('worktree', 'remove', '--force') for args in git_calls)
+
+
+def test_command_aborts_when_no_github_user(ddev: CliRunner, mocker: MockerFixture) -> None:
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': '', 'GITHUB_USER': '', 'GITHUB_ACTOR': ''})
+
+    result = ddev('release', 'port-commit', '1234567890abcdef00')
+
+    assert result.exit_code == 1, result.output
+    assert 'No GitHub user configured' in result.output
+
+
+@pytest.mark.parametrize(
+    'extra_args,expected_exit,expected_output',
+    [
+        pytest.param([], 1, 'No GitHub token configured', id='pr-requested-aborts'),
+        pytest.param(['--no-pr'], 0, '', id='no-pr-allows-missing-token'),
+    ],
+)
+def test_command_token_guard(
+    ddev: CliRunner,
+    mocker: MockerFixture,
+    fake_async_github: FakeAsyncGitHubClient,
+    extra_args: list[str],
+    expected_exit: int,
+    expected_output: str,
+) -> None:
+    _setup_command_mocks(mocker)
+    mocker.patch('click.confirm', return_value=True)
+    mocker.patch.dict(
+        'os.environ',
+        {'DD_GITHUB_USER': 'alice', 'DD_GITHUB_TOKEN': '', 'GH_TOKEN': '', 'GITHUB_TOKEN': ''},
+    )
+
+    result = ddev('release', 'port-commit', *extra_args, '1234567890abcdef00')
+
+    assert result.exit_code == expected_exit, result.output
+    if expected_output:
+        assert expected_output in result.output
+    fake_async_github.assert_not_called('create_pull_request')
+
+
+def test_command_aborts_when_commit_does_not_exist(
+    ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
+) -> None:
+    mocker.patch('ddev.utils.git.GitRepository.run')
+    mocker.patch('ddev.utils.git.GitRepository.capture', side_effect=OSError('bad object'))
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
+
+    result = ddev('release', 'port-commit', '1234567890abcdef00')
+
+    assert result.exit_code == 1, result.output
+    assert 'does not exist' in result.output
+    fake_async_github.assert_not_called('create_pull_request')
+
+
+def test_command_aborts_when_commit_log_is_empty(
+    ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
+) -> None:
+    _setup_command_mocks(mocker)
+    mocker.patch('ddev.utils.git.GitRepository.log', return_value=[])
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
+
+    result = ddev('release', 'port-commit', '1234567890abcdef00')
+
+    assert result.exit_code == 1, result.output
+    assert 'Could not read commit' in result.output
+    fake_async_github.assert_not_called('create_pull_request')
+
+
+def test_command_aborts_on_unconfirmed(
+    ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
+) -> None:
+    _setup_command_mocks(mocker)
+    mocker.patch('click.confirm', return_value=False)
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
+
+    result = ddev('release', 'port-commit', '1234567890abcdef00')
+
+    assert result.exit_code == 1, result.output
+    assert 'Did not get confirmation' in result.output
+    fake_async_github.assert_not_called('create_pull_request')
+
+
+def test_command_uses_head_when_no_commit_given(
+    ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
+) -> None:
+    _setup_command_mocks(mocker)
+    mocker.patch('click.confirm', return_value=True)
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
+
+    result = ddev('release', 'port-commit')
+
+    assert result.exit_code == 0, result.output
+    assert 'No commit specified' in result.output
+    assert len(fake_async_github.calls_to('create_pull_request')) == 1
+
+
+def test_command_includes_worktree_path_in_dry_run_output(
+    ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
+) -> None:
+    _setup_command_mocks(mocker)
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
+
+    result = ddev('release', 'port-commit', '--dry-run', '1234567890abcdef00')
+
+    assert result.exit_code == 0, result.output
+    assert StdPath('.worktrees/port-commit/alice-port-1234567890-to-master').as_posix() in result.output.replace(
+        '\\', '/'
+    )

--- a/ddev/tests/cli/release/test_port_commit.py
+++ b/ddev/tests/cli/release/test_port_commit.py
@@ -74,9 +74,20 @@ def test_build_pr_body_uses_template(app_mock, tmp_path):
     template_file.write_text('### What does this PR do?\n\n<!-- describe -->\n\n### Motivation\n')
     app_mock.repo.path = tmp_path
 
-    body = build_pr_body(app_mock, sha='abcdef1234567890', subject='Fix bug', target='7.62.x', original_pr='12345')
+    body = build_pr_body(
+        app_mock,
+        sha='abcdef1234567890',
+        subject='Fix bug',
+        target='7.62.x',
+        original_pr='12345',
+        owner='DataDog',
+        repo='integrations-core',
+    )
 
-    assert '**Backported commit**: `abcdef1234`' in body
+    assert (
+        '**Backported commit**: [`abcdef1234`](https://github.com/DataDog/integrations-core/commit/abcdef1234567890)'
+        in body
+    )
     assert '**Original PR**: #12345' in body
     assert '**Target branch**: `7.62.x`' in body
     assert '### Motivation' in body
@@ -85,10 +96,21 @@ def test_build_pr_body_uses_template(app_mock, tmp_path):
 def test_build_pr_body_without_template(app_mock, tmp_path):
     app_mock.repo.path = tmp_path
 
-    body = build_pr_body(app_mock, sha='abcdef1234567890', subject='Fix bug', target='master', original_pr=None)
+    body = build_pr_body(
+        app_mock,
+        sha='abcdef1234567890',
+        subject='Fix bug',
+        target='master',
+        original_pr=None,
+        owner='DataDog',
+        repo='integrations-core',
+    )
 
     assert '### What does this PR do?' in body
-    assert '**Backported commit**: `abcdef1234`' in body
+    assert (
+        '**Backported commit**: [`abcdef1234`](https://github.com/DataDog/integrations-core/commit/abcdef1234567890)'
+        in body
+    )
     assert 'Original PR' not in body
 
 
@@ -125,9 +147,9 @@ def test_port_step_executes_and_emits_success(app_mock):
     step.run()
     assert step.executed is True
     app_mock.status.assert_not_called()
-    info_calls = [c.args[0] for c in app_mock.display_info.call_args_list]
-    assert any('Doing the thing' in line for line in info_calls)
-    app_mock.display_success.assert_called_once()
+    output_text = ' '.join(str(c.args[0]) for c in app_mock.output.call_args_list)
+    assert 'Doing the thing...' in output_text
+    assert 'Doing the thing: done.' in output_text
 
 
 def test_port_step_wraps_oserror_as_port_step_error(app_mock):
@@ -371,7 +393,8 @@ def test_command_happy_path(ddev: CliRunner, mocker: MockerFixture, fake_async_g
     result = ddev('release', 'port-commit', '1234567890abcdef00')
 
     assert result.exit_code == 0, result.output
-    assert 'Pull request created: https://github.com/x/pr/1' in result.output
+    assert 'Backport completed' in result.output
+    assert 'https://github.com/x/pr/1' in result.output
 
     pr_call = fake_async_github.last_call('create_pull_request')
     assert pr_call.kwargs['owner'] == 'DataDog'
@@ -380,7 +403,10 @@ def test_command_happy_path(ddev: CliRunner, mocker: MockerFixture, fake_async_g
     assert pr_call.kwargs['head'] == 'alice/port-1234567890-to-master'
     assert pr_call.kwargs['base'] == 'master'
     assert pr_call.kwargs['draft'] is False
-    assert '**Backported commit**: `1234567890`' in pr_call.kwargs['body']
+    assert (
+        '**Backported commit**: [`1234567890`](https://github.com/DataDog/integrations-core/commit/1234567890abcdef00)'
+        in pr_call.kwargs['body']
+    )
     assert '**Original PR**: #100' in pr_call.kwargs['body']
 
     fake_async_github.assert_called_once_with(

--- a/ddev/tests/cli/release/test_port_commit.py
+++ b/ddev/tests/cli/release/test_port_commit.py
@@ -124,7 +124,9 @@ def test_port_step_executes_and_emits_success(app_mock):
     step = _RunnableStep(app_mock)
     step.run()
     assert step.executed is True
-    app_mock.status.assert_called_once_with('Doing the thing')
+    app_mock.status.assert_not_called()
+    info_calls = [c.args[0] for c in app_mock.display_info.call_args_list]
+    assert any('Doing the thing' in line for line in info_calls)
     app_mock.display_success.assert_called_once()
 
 
@@ -394,6 +396,27 @@ def test_command_happy_path(ddev: CliRunner, mocker: MockerFixture, fake_async_g
     assert ('fetch', 'origin') in git_calls
     assert any(args[:2] == ('worktree', 'add') for args in git_calls)
     assert any(args[:3] == ('worktree', 'remove', '--force') for args in git_calls)
+
+
+def test_command_lowercases_branch_name(
+    ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
+) -> None:
+    run_mock = _setup_command_mocks(mocker)
+    fake_async_github.mock_response(
+        'create_pull_request',
+        PullRequest(number=1, html_url='https://github.com/x/pr/1'),
+    )
+    mocker.patch('click.confirm', return_value=True)
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'AAraKKe'})
+
+    result = ddev('release', 'port-commit', '1234567890abcdef00')
+
+    assert result.exit_code == 0, result.output
+    assert fake_async_github.last_call('create_pull_request').kwargs['head'] == 'aarakke/port-1234567890-to-master'
+
+    worktree_add = next(args for args in (c.args for c in run_mock.call_args_list) if args[:2] == ('worktree', 'add'))
+    assert 'aarakke/port-1234567890-to-master' in worktree_add
+    assert all('AAraKKe' not in str(part) for part in worktree_add)
 
 
 def test_command_draft_flag(ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient) -> None:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds `ddev release port-commit`: cherry-picks a commit onto a target branch, pushes a `<user>/port-<sha>-to-<target>` branch, and opens a PR (ready-for-review by default, `--draft` to opt in). Preserves `.in-toto` files from the target branch so package signatures stay intact.

The workflow runs in an isolated git worktree under `.worktrees/port-commit/<sanitized-branch>/` so the user's primary working tree is never mutated. On success the worktree is removed; on failure it is left in place and its path is surfaced so the user can inspect or finish the work manually.

### Motivation
<!-- What inspired you to submit this pull request? -->

Brings an existing personal backport script into `ddev` so the flow is consistent, discoverable, and reuses ddev's git + GitHub helpers.

Implementation notes:

- **Worktree-based execution.** A `SetupWorktreeStep` runs `git worktree add -B <port-branch> <path> origin/<target>` to create the working area; all cherry-pick / `.in-toto` sweep / commit / push steps run inside a `GitRepository` instance bound to that worktree. A `TeardownWorktreeStep` removes the worktree on a clean run, and is intentionally skipped on failure so partial state is recoverable.
- **Sequential `PortStep` workflow.** Each step has a uniform `describe` / `planned_commands` / `execute` interface; adding or reordering steps is a one-line change in `build_port_steps`. `--dry-run` is centralized in `PortStep.run` so every step prints its planned commands without executing them.
- **Preventive validation.** `resolve_port_plan` fails fast (before any mutation) if `github.user` is missing, or if `github.token` is missing while PR creation is enabled (skippable via `--no-pr` or `--dry-run`). It also verifies the commit exists, reads its subject, warns about touched `.in-toto` files, and confirms the resolved plan with the user.
- **Async GitHub client.** PR creation and label assignment go through `AsyncGitHubClient`, with `httpx.HTTPError` / `pydantic.ValidationError` wrapped into `PortStepError` so any HTTP / response-shape failure produces a clean abort instead of a raw traceback.

Stacks on top of #23685, which adds the async-client surface and `FakeAsyncGitHubClient` test helper this PR consumes.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged