### PR TITLE
Apply changelog/no-changelog label only to pure release PRs

### DIFF
--- a/.github/workflows/config/labeler.yml
+++ b/.github/workflows/config/labeler.yml
@@ -3,9 +3,12 @@ base_package:
   - any-glob-to-any-file: datadog_checks_base/**/*
 changelog/no-changelog:
 - changed-files:
-  - any-glob-to-any-file:
+  - any-glob-to-all-files:
     - requirements-agent-release.txt
     - '**/__about__.py'
+    - '**/CHANGELOG.md'
+    - '**/changelog.d/*'
+    - .in-toto/**
 ddev:
 - changed-files:
   - any-glob-to-any-file: ddev/**/*


### PR DESCRIPTION
### What does this PR do?

Tightens the `changelog/no-changelog` rule in `.github/workflows/config/labeler.yml` so it only applies when **every** changed file in the PR is a release-related file. The rule now uses `any-glob-to-all-files` (instead of `any-glob-to-any-file`) and recognises the full set of paths a typical release PR touches:

- `requirements-agent-release.txt`
- `**/__about__.py`
- `**/CHANGELOG.md`
- `**/changelog.d/*` (news fragments removed at release time)
- `.in-toto/**`

### Motivation

The previous rule applied `changelog/no-changelog` whenever *any* changed file matched `**/__about__.py` or `requirements-agent-release.txt`, regardless of what else was in the diff. That was fine for actual release commits, but it also triggered on any PR that happened to introduce or modify those files alongside real code changes that should have a changelog entry.

Concrete example: https://github.com/DataDog/integrations-core/pull/23451 adds the new `lparstats` integration (~22 files: check source, manifest, tests, README, conf example, etc.). Because the PR also adds `lparstats/datadog_checks/lparstats/__about__.py`, the labeler matched the `**/__about__.py` glob and automatically applied `changelog/no-changelog`, even though that PR clearly warrants a changelog entry.

After this change, the label only sticks when the diff is **exclusively** release-style files, which matches the documented intent of the label.

#### Notes

- `sync-labels: true` is still in effect, so existing PRs that currently hold `changelog/no-changelog` because of the looser rule will have it removed on the next labeler run if they don't fully match the stricter rule. This is the desired effect.
- PRs that only edit a `CHANGELOG.md` (e.g. a manual typo fix) will now receive the label. That seems correct: fixing an existing changelog entry doesn't need a new one.
- News fragments are deleted on the release PR; `**/changelog.d/*` matches deletions, so this works for the standard release flow.
- We could remove all together the no-changelog label from the labeler rules, I don't think that would have any impact on the usage and we can add the label manually when needed during releases

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
