### PR TITLE
amazon_msk: migrate test fixtures to mock_openmetrics_http

### DIFF
--- a/amazon_msk/changelog.d/22676.fixed
+++ b/amazon_msk/changelog.d/22676.fixed
@@ -1,0 +1,1 @@
+Migrate test fixtures to mock_openmetrics_http.

--- a/amazon_msk/tests/conftest.py
+++ b/amazon_msk/tests/conftest.py
@@ -7,8 +7,8 @@ from urllib.parse import urlparse
 import mock
 import pytest
 
+from datadog_checks.base.utils.http_testing import MockHTTPResponse
 from datadog_checks.dev import docker_run
-from datadog_checks.dev.http import MockResponse
 
 from . import common
 
@@ -27,17 +27,13 @@ def dd_environment():
 
 def mock_requests_get(url, *args, **kwargs):
     exporter_type = 'jmx' if urlparse(url).port == common.JMX_PORT else 'node'
-    return MockResponse(file_path=common.get_metrics_fixture_path(exporter_type))
+    return MockHTTPResponse(file_path=common.get_metrics_fixture_path(exporter_type))
 
 
 @pytest.fixture
-def mock_data():
-    # Mock requests.get because it is used internally within boto3
-    with (
-        mock.patch('requests.get', side_effect=mock_requests_get, autospec=True),
-        mock.patch('requests.Session.get', side_effect=mock_requests_get),
-    ):
-        yield
+def mock_data(mock_openmetrics_http):
+    mock_openmetrics_http.get.side_effect = mock_requests_get
+    yield
 
 
 @pytest.fixture

--- a/amazon_msk/tests/conftest.py
+++ b/amazon_msk/tests/conftest.py
@@ -25,14 +25,14 @@ def dd_environment():
         yield common.INSTANCE, common.E2E_METADATA
 
 
-def mock_requests_get(url, *args, **kwargs):
+def route_metrics_fixture(url, *args, **kwargs):
     exporter_type = 'jmx' if urlparse(url).port == common.JMX_PORT else 'node'
     return MockHTTPResponse(file_path=common.get_metrics_fixture_path(exporter_type))
 
 
 @pytest.fixture
 def mock_data(mock_openmetrics_http):
-    mock_openmetrics_http.get.side_effect = mock_requests_get
+    mock_openmetrics_http.get.side_effect = route_metrics_fixture
     yield
 
 


### PR DESCRIPTION
### What does this PR do?

Migrates `amazon_msk/tests/conftest.py` away from `requests`-level patching. The `mock_data` fixture now consumes `mock_openmetrics_http`, which patches `OpenMetricsScraperMixin.get_http_handler` so the v1 scraper hits the same `mock_http` client the rest of the test suite uses. `MockResponse` is swapped for `MockHTTPResponse`. No production code changes.

### Motivation

The planned httpx migration will replace `AgentCheck`'s `requests`-based HTTP client with an `httpx`-backed one. Tests that pin behavior to `requests.get` or `requests.Session.get` will silently stop intercepting once the swap lands. This PR removes the last `requests`-level patches in amazon_msk so its tests survive that future swap.

Context: [Step 6 PR Breakdown](https://datadoghq.atlassian.net/wiki/spaces/AI/pages/6691455636), [amazon_msk migration details](https://datadoghq.atlassian.net/wiki/spaces/AI/pages/6526435974), [6.2 plan](https://datadoghq.atlassian.net/wiki/spaces/AI/pages/6718784707).

The boto3 `requests.get` patch was dropped along with `requests.Session.get`. The old comment claimed `requests.get` was used internally by boto3, but that is not the case. botocore stopped using the `requests` library in [v1.11.0 (2018)](https://aws.amazon.com/blogs/developer/removing-the-vendored-version-of-requests-from-botocore/) and now uses `urllib3` directly through `botocore.httpsession.URLLib3Session`. The old comment was added during flake debugging in [PR #20179](https://github.com/DataDog/integrations-core/pull/20179) and was never accurate. In every test that uses `mock_data`, `mock_client` already replaces `boto3.client` entirely, so no real boto3 Session is ever constructed. All 17 unit tests pass with both patches removed.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged