### PR TITLE
Fetch commit from origin when not in local repo for ddev port-commit

### DIFF
--- a/ddev/changelog.d/23703.added
+++ b/ddev/changelog.d/23703.added
@@ -1,0 +1,1 @@
+Accept a PR number, ``PR-<number>`` token, or GitHub PR URL as input to ``port-commit`` in addition to a commit SHA. Pure-digit inputs are tried as a PR first when a GitHub token is configured and fall back to commit resolution on 404.

--- a/ddev/changelog.d/23703.added
+++ b/ddev/changelog.d/23703.added
@@ -1,1 +1,1 @@
-Accept a PR number, ``PR-<number>`` token, or GitHub PR URL as input to ``port-commit`` in addition to a commit SHA. Pure-digit inputs are tried as a PR first when a GitHub token is configured and fall back to commit resolution on 404.
+Accept a PR number, ``PR-<number>`` token, or GitHub PR URL as input to ``port-commit``, and fetch the target commit from origin when it is not in the local object database.

--- a/ddev/changelog.d/23703.fixed
+++ b/ddev/changelog.d/23703.fixed
@@ -1,0 +1,1 @@
+Fetch the requested commit from origin when running ``port-commit`` against a commit that is not in the local object database.

--- a/ddev/changelog.d/23703.fixed
+++ b/ddev/changelog.d/23703.fixed
@@ -1,1 +1,0 @@
-Fetch the requested commit from origin when running ``port-commit`` against a commit that is not in the local object database.

--- a/ddev/src/ddev/cli/application.py
+++ b/ddev/src/ddev/cli/application.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 import os
 from functools import cached_property
-from typing import NoReturn, cast
+from typing import TYPE_CHECKING, cast
 
 from ddev.cli.terminal import Terminal
 from ddev.config.constants import AppEnvVars, ConfigEnvVars, VerbosityLevels
@@ -15,6 +15,9 @@ from ddev.repo.core import Repository
 from ddev.utils.fs import Path
 from ddev.utils.github import GitHubManager
 from ddev.utils.platform import Platform
+
+if TYPE_CHECKING:
+    from typing import Any, Callable, NoReturn
 
 
 class AppLoggingHandler(logging.Handler):
@@ -35,7 +38,7 @@ class AppLoggingHandler(logging.Handler):
 
 
 class Application(Terminal):
-    def __init__(self, exit_func, *args, **kwargs):
+    def __init__(self, exit_func: Callable[[int], NoReturn], *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.platform = Platform(self.escaped_output)
         self.__exit_func = exit_func
@@ -49,7 +52,7 @@ class Application(Terminal):
         self.__github = cast(GitHubManager, None)
 
         # TODO: remove this when the old CLI is gone
-        self.__config = {}
+        self.__config: dict[str, Any] = {}
 
     @property
     def config(self) -> RootConfig:
@@ -109,7 +112,6 @@ class Application(Terminal):
         if text:
             self.display_error(text, **kwargs)
         self.__exit_func(code)
-        raise SystemExit(code)
 
     # TODO: remove everything below when the old CLI is gone
     def initialize_old_cli(self):

--- a/ddev/src/ddev/cli/application.py
+++ b/ddev/src/ddev/cli/application.py
@@ -108,7 +108,7 @@ class Application(Terminal):
             self.repo, user=self.config.github.user, token=self.config.github.token, status=self.status
         )
 
-    def abort(self, text='', code=1, **kwargs) -> NoReturn:
+    def abort(self, text: str = '', code: int = 1, **kwargs: Any) -> NoReturn:
         if text:
             self.display_error(text, **kwargs)
         self.__exit_func(code)

--- a/ddev/src/ddev/cli/application.py
+++ b/ddev/src/ddev/cli/application.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 import os
 from functools import cached_property
-from typing import cast
+from typing import NoReturn, cast
 
 from ddev.cli.terminal import Terminal
 from ddev.config.constants import AppEnvVars, ConfigEnvVars, VerbosityLevels
@@ -105,10 +105,11 @@ class Application(Terminal):
             self.repo, user=self.config.github.user, token=self.config.github.token, status=self.status
         )
 
-    def abort(self, text='', code=1, **kwargs):
+    def abort(self, text='', code=1, **kwargs) -> NoReturn:
         if text:
             self.display_error(text, **kwargs)
         self.__exit_func(code)
+        raise SystemExit(code)
 
     # TODO: remove everything below when the old CLI is gone
     def initialize_old_cli(self):

--- a/ddev/src/ddev/cli/meta/scripts/serve_openmetrics_payload.py
+++ b/ddev/src/ddev/cli/meta/scripts/serve_openmetrics_payload.py
@@ -91,7 +91,7 @@ def serve_openmetrics_payload(
     env_data.write_config(check_config)
     env_data.write_metadata(metadata)
 
-    agent = DockerAgent(app.platform, intg, ENVIRONMENT_NAME, metadata, env_data.config_file)
+    agent = DockerAgent(app, intg, ENVIRONMENT_NAME, metadata, env_data.config_file)
     agent_env_vars = _get_agent_env_vars(app.config.org.config, {}, {}, False)
 
     try:

--- a/ddev/src/ddev/cli/release/port_commit.py
+++ b/ddev/src/ddev/cli/release/port_commit.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 @click.command(name='port-commit', short_help='Backport a commit onto a target branch')
 @click.pass_obj
-@click.argument('commit_hash', required=False)
+@click.argument('commit_hash', required=False, metavar='[COMMIT_OR_PR]')
 @click.option('-t', '--target-branch', default='master', show_default=True, help='Target branch to port to.')
 @click.option('-p', '--branch-prefix', default='port', show_default=True, help='Branch name prefix.')
 @click.option('-s', '--branch-suffix', default=None, help='Branch name suffix. Defaults to `to-<target-branch>`.')
@@ -43,12 +43,15 @@ def port_commit(
     """
     Backport a commit onto a target branch.
 
-    Cherry-picks COMMIT_HASH onto `--target-branch` (default `master`) on a new branch named
+    Cherry-picks COMMIT_OR_PR onto `--target-branch` (default `master`) on a new branch named
     `<github-user>/<prefix>-<sha[:10]>-<suffix>`, preserving `.in-toto` files from the target
     branch so package signatures stay intact. Pushes the branch and, unless `--no-pr` is set,
     opens a pull request titled `[Backport] <subject>` and labeled with `--pr-labels`.
 
-    If COMMIT_HASH is omitted, the current HEAD commit is used after confirmation.
+    COMMIT_OR_PR accepts: a full 40-character commit SHA, a PR number (e.g. `23703`), an
+    explicit `PR-<number>` token, or a GitHub PR URL. Pure-digit inputs are tried as a PR
+    first when a GitHub token is configured, and fall back to commit resolution on 404. If
+    omitted, the current HEAD commit is used after confirmation.
 
     The GitHub user for the branch prefix is taken from `ddev config` (`github.user`) or the
     `DD_GITHUB_USER` / `GITHUB_USER` / `GITHUB_ACTOR` environment variables.

--- a/ddev/src/ddev/cli/release/port_commit.py
+++ b/ddev/src/ddev/cli/release/port_commit.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 @click.command(name='port-commit', short_help='Backport a commit onto a target branch')
 @click.pass_obj
-@click.argument('commit_hash', required=False, metavar='[COMMIT_OR_PR]')
+@click.argument('commit_hash', required=False, metavar='COMMIT_OR_PR')
 @click.option('-t', '--target-branch', default='master', show_default=True, help='Target branch to port to.')
 @click.option('-p', '--branch-prefix', default='port', show_default=True, help='Branch name prefix.')
 @click.option('-s', '--branch-suffix', default=None, help='Branch name suffix. Defaults to `to-<target-branch>`.')

--- a/ddev/src/ddev/cli/release/port_commit.py
+++ b/ddev/src/ddev/cli/release/port_commit.py
@@ -56,12 +56,18 @@ def port_commit(
     The GitHub user for the branch prefix is taken from `ddev config` (`github.user`) or the
     `DD_GITHUB_USER` / `GITHUB_USER` / `GITHUB_ACTOR` environment variables.
     """
+    import logging
+
     from ddev.cli.release.port_commit_workflow import (
         PortStepError,
         build_port_steps,
         display_completion_summary,
         resolve_port_plan,
     )
+
+    # httpx logs every request at INFO and clutters the workflow output. The PR-resolution and
+    # PR-creation steps already print their own status lines; the underlying HTTP traffic is noise.
+    logging.getLogger('httpx').setLevel(logging.WARNING)
 
     plan = resolve_port_plan(
         app,

--- a/ddev/src/ddev/cli/release/port_commit_workflow.py
+++ b/ddev/src/ddev/cli/release/port_commit_workflow.py
@@ -14,6 +14,7 @@ removed; on failure it is left in place for the user to inspect or finish manual
 
 from __future__ import annotations
 
+import contextlib
 import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -353,10 +354,8 @@ def _resolve_commit_or_fetch(app: Application, commit_hash: str) -> str:
     often narrowed in this repo to avoid pulling thousands of branches).
     """
     git = app.repo.git
-    try:
+    with contextlib.suppress(OSError):
         return git.capture('rev-parse', '--verify', f'{commit_hash}^{{commit}}').strip()
-    except OSError:
-        pass
 
     if HEX_PATTERN.fullmatch(commit_hash) and not FULL_SHA_PATTERN.fullmatch(commit_hash):
         app.abort(
@@ -367,17 +366,14 @@ def _resolve_commit_or_fetch(app: Application, commit_hash: str) -> str:
         raise AssertionError('unreachable')
 
     app.display_info(f'Commit `{commit_hash}` not found locally; fetching from origin.')
-    fetch_failed = False
-    try:
+    fetched = False
+    with contextlib.suppress(OSError):
         git.run('fetch', 'origin', commit_hash)
-    except OSError:
-        fetch_failed = True
+        fetched = True
 
-    if not fetch_failed:
-        try:
+    if fetched:
+        with contextlib.suppress(OSError):
             return git.capture('rev-parse', '--verify', f'{commit_hash}^{{commit}}').strip()
-        except OSError:
-            pass
 
     app.abort(f'Commit `{commit_hash}` does not exist locally or on origin.')
     raise AssertionError('unreachable')

--- a/ddev/src/ddev/cli/release/port_commit_workflow.py
+++ b/ddev/src/ddev/cli/release/port_commit_workflow.py
@@ -342,6 +342,40 @@ class CreatePullRequestStep(PortStep):
                 )
 
 
+def _resolve_commit_or_fetch(app: Application, commit_hash: str) -> str:
+    """Return the full SHA for `commit_hash`, fetching from origin when the commit is not local.
+
+    Aborts the application with a user-facing message when the commit is neither available locally
+    nor reachable on origin. Falling back to a SHA-targeted fetch lets the command port commits that
+    live on remote branches the local repo does not track (the `remote.origin.fetch` refspec is
+    often narrowed in this repo to avoid pulling thousands of branches).
+    """
+    git = app.repo.git
+    try:
+        return git.capture('rev-parse', '--verify', f'{commit_hash}^{{commit}}').strip()
+    except OSError:
+        pass
+
+    app.display_info(f'Commit `{commit_hash}` not found locally; fetching from origin.')
+    fetch_failed = False
+    try:
+        git.run('fetch', 'origin', commit_hash)
+    except OSError:
+        fetch_failed = True
+
+    if not fetch_failed:
+        try:
+            return git.capture('rev-parse', '--verify', f'{commit_hash}^{{commit}}').strip()
+        except OSError:
+            pass
+
+    app.abort(
+        f'Commit `{commit_hash}` does not exist locally or on origin. '
+        'If you provided an abbreviated SHA, pass the full 40-character SHA.'
+    )
+    raise AssertionError('unreachable')
+
+
 def _path_exists_in_head(git: GitRepository, path: str) -> bool:
     try:
         git.capture('cat-file', '-e', f'HEAD:{path}')
@@ -470,10 +504,7 @@ def resolve_port_plan(
             app.abort('Did not get confirmation, aborting.')
         commit_hash = head_commit.sha
 
-    try:
-        full_sha = app.repo.git.capture('rev-parse', '--verify', f'{commit_hash}^{{commit}}').strip()
-    except OSError:
-        app.abort(f'Commit `{commit_hash}` does not exist.')
+    full_sha = _resolve_commit_or_fetch(app, commit_hash)
 
     log_entries = app.repo.git.log(['hash:%H', 'subject:%s'], n=1, source=full_sha)
     if not log_entries:

--- a/ddev/src/ddev/cli/release/port_commit_workflow.py
+++ b/ddev/src/ddev/cli/release/port_commit_workflow.py
@@ -417,6 +417,7 @@ def _resolve_pr_to_commit(app: Application, pr_number: int, *, dry_run: bool) ->
         )
 
     owner, repo = resolve_owner_repo(app)
+    app.display_info(f'Resolving PR #{pr_number} via GitHub...')
     try:
         pr = asyncio.run(_fetch_pr(app.config.github.token, owner, repo, pr_number))
     except httpx.HTTPStatusError as exc:

--- a/ddev/src/ddev/cli/release/port_commit_workflow.py
+++ b/ddev/src/ddev/cli/release/port_commit_workflow.py
@@ -368,6 +368,7 @@ def _resolve_input(app: Application, raw: str, *, dry_run: bool) -> str:
 
     Raises `_CommitNotResolvable` when nothing matches so the caller can decide how to abort.
     """
+    raw = raw.strip()
     pr_number = _extract_explicit_pr_number(raw)
     if pr_number is not None:
         return _resolve_pr_to_commit(app, pr_number, dry_run=dry_run)
@@ -400,24 +401,35 @@ def _extract_explicit_pr_number(raw: str) -> int | None:
 def _resolve_pr_to_commit(app: Application, pr_number: int, *, dry_run: bool) -> str:
     """Resolve a PR number to the SHA of its merge commit, validating squash-merge.
 
-    Raises `_PRNotFound` when GitHub returns 404. Aborts on other auth/network/validation errors
-    so the user gets a clear, contextual message rather than a stack trace.
+    Raises `_PRNotFound` when GitHub returns 404. Raises `_CommitNotResolvable` (wrapped with PR
+    context) when the merge commit can't be resolved locally. Aborts on other auth / network /
+    validation errors so the user gets a clear, contextual message rather than a stack trace.
     """
     import asyncio
 
     import httpx
+    from pydantic import ValidationError
 
     if not app.config.github.token:
-        app.abort('GitHub token required to look up PRs. Set `github.token` or pass a commit SHA directly.')
+        app.abort(
+            'GitHub token required to resolve a PR reference. Set `github.token`, or pass the '
+            'full commit SHA directly (--no-pr does not skip this lookup).'
+        )
 
     owner, repo = resolve_owner_repo(app)
     try:
-        pr = asyncio.run(_fetch_pr(app, owner, repo, pr_number))
+        pr = asyncio.run(_fetch_pr(app.config.github.token, owner, repo, pr_number))
     except httpx.HTTPStatusError as exc:
-        if exc.response.status_code == 404:
+        status = exc.response.status_code
+        if status == 404:
             raise _PRNotFound(str(pr_number)) from exc
+        if status in (401, 403):
+            app.abort(
+                f'GitHub denied the request for PR #{pr_number} (HTTP {status}). '
+                'Check that `github.token` is set and has `repo` scope.'
+            )
         app.abort(f'Failed to fetch PR #{pr_number} from GitHub: {exc}.')
-    except httpx.HTTPError as exc:
+    except (httpx.HTTPError, ValidationError) as exc:
         app.abort(f'Failed to fetch PR #{pr_number} from GitHub: {exc}.')
 
     if not pr.merged:
@@ -426,22 +438,30 @@ def _resolve_pr_to_commit(app: Application, pr_number: int, *, dry_run: bool) ->
     if not pr.merge_commit_sha:
         app.abort(f'PR #{pr_number} has no merge commit SHA available.')
 
-    full_sha = _resolve_commit_or_fetch(app, pr.merge_commit_sha, dry_run=dry_run)
+    try:
+        full_sha = _resolve_commit_or_fetch(app, pr.merge_commit_sha, dry_run=dry_run)
+    except _CommitNotResolvable as exc:
+        raise _CommitNotResolvable(
+            f'PR #{pr_number} was found but its merge commit `{pr.merge_commit_sha}` could not be resolved: {exc}'
+        ) from exc
     _abort_if_merge_commit(app, pr_number, full_sha)
     return full_sha
 
 
-async def _fetch_pr(app: Application, owner: str, repo: str, pr_number: int) -> PullRequest:
+async def _fetch_pr(token: str, owner: str, repo: str, pr_number: int) -> PullRequest:
     from ddev.utils.github_async import async_github_client
 
-    async with async_github_client(token=app.config.github.token) as client:
+    async with async_github_client(token=token) as client:
         response = await client.get_pull_request(owner=owner, repo=repo, pull_number=pr_number)
         return response.data
 
 
 def _abort_if_merge_commit(app: Application, pr_number: int, full_sha: str) -> None:
     """Abort when `full_sha` is a merge commit (>= 2 parents), which can't be backported as a single commit."""
-    output = app.repo.git.capture('rev-list', '--parents', '-n1', full_sha).strip().split()
+    try:
+        output = app.repo.git.capture('rev-list', '--parents', '-n1', full_sha).strip().split()
+    except OSError as exc:
+        app.abort(f'Could not inspect merge parents of `{full_sha}`: {exc}.')
     parent_count = max(len(output) - 1, 0)
     if parent_count >= 2:
         app.abort(
@@ -465,17 +485,19 @@ def _resolve_commit_or_fetch(app: Application, commit_hash: str, *, dry_run: boo
     with contextlib.suppress(OSError):
         return git.capture('rev-parse', '--verify', f'{commit_hash}^{{commit}}').strip()
 
-    if dry_run:
-        raise _CommitNotResolvable(
-            f'Commit `{commit_hash}` is not in the local repository. '
-            'Re-run without `--dry-run` to fetch it from origin, or pre-fetch the commit manually.'
-        )
-
+    # Abbreviated SHAs cannot be fetched (GitHub's allowReachableSHA1InWant only honours full
+    # SHAs), so this is the real diagnosis regardless of dry-run mode. Surface it first.
     if HEX_PATTERN.fullmatch(commit_hash) and not FULL_SHA_PATTERN.fullmatch(commit_hash):
         raise _CommitNotResolvable(
             f'Commit `{commit_hash}` is not in the local repository. '
             'Pass the full 40-character SHA so it can be fetched from origin '
             '(GitHub does not support SHA-targeted fetches for abbreviated SHAs).'
+        )
+
+    if dry_run:
+        raise _CommitNotResolvable(
+            f'Commit `{commit_hash}` is not in the local repository. '
+            'Re-run without `--dry-run` to fetch it from origin, or pre-fetch the commit manually.'
         )
 
     app.display_info(f'Commit `{commit_hash}` not found locally; fetching from origin.')

--- a/ddev/src/ddev/cli/release/port_commit_workflow.py
+++ b/ddev/src/ddev/cli/release/port_commit_workflow.py
@@ -345,17 +345,26 @@ class CreatePullRequestStep(PortStep):
                 )
 
 
-def _resolve_commit_or_fetch(app: Application, commit_hash: str) -> str:
+def _resolve_commit_or_fetch(app: Application, commit_hash: str, *, dry_run: bool) -> str:
     """Return the full SHA for `commit_hash`, fetching from origin when the commit is not local.
 
     Aborts the application with a user-facing message when the commit is neither available locally
     nor reachable on origin. Falling back to a SHA-targeted fetch lets the command port commits that
     live on remote branches the local repo does not track (the `remote.origin.fetch` refspec is
     often narrowed in this repo to avoid pulling thousands of branches).
+
+    When `dry_run` is true, the fetch fallback is skipped to preserve the dry-run contract: a
+    non-local commit aborts with a clear message rather than mutating local state.
     """
     git = app.repo.git
     with contextlib.suppress(OSError):
         return git.capture('rev-parse', '--verify', f'{commit_hash}^{{commit}}').strip()
+
+    if dry_run:
+        app.abort(
+            f'Commit `{commit_hash}` is not in the local repository. '
+            'Re-run without `--dry-run` to fetch it from origin, or pre-fetch the commit manually.'
+        )
 
     if HEX_PATTERN.fullmatch(commit_hash) and not FULL_SHA_PATTERN.fullmatch(commit_hash):
         app.abort(
@@ -505,7 +514,7 @@ def resolve_port_plan(
             app.abort('Did not get confirmation, aborting.')
         commit_hash = head_commit.sha
 
-    full_sha = _resolve_commit_or_fetch(app, commit_hash)
+    full_sha = _resolve_commit_or_fetch(app, commit_hash, dry_run=dry_run)
 
     log_entries = app.repo.git.log(['hash:%H', 'subject:%s'], n=1, source=full_sha)
     if not log_entries:

--- a/ddev/src/ddev/cli/release/port_commit_workflow.py
+++ b/ddev/src/ddev/cli/release/port_commit_workflow.py
@@ -34,6 +34,8 @@ PR_TEMPLATE_RELATIVE_PATH = '.github/PULL_REQUEST_TEMPLATE.md'
 PR_TEMPLATE_HEADING = '### What does this PR do?'
 IN_TOTO_SUFFIX = '.in-toto'
 WORKTREE_BASE = '.worktrees/port-commit'
+FULL_SHA_PATTERN = re.compile(r'^[0-9a-fA-F]{40}$')
+HEX_PATTERN = re.compile(r'^[0-9a-fA-F]+$')
 
 
 class PortStepError(Exception):
@@ -356,6 +358,14 @@ def _resolve_commit_or_fetch(app: Application, commit_hash: str) -> str:
     except OSError:
         pass
 
+    if HEX_PATTERN.fullmatch(commit_hash) and not FULL_SHA_PATTERN.fullmatch(commit_hash):
+        app.abort(
+            f'Commit `{commit_hash}` is not in the local repository. '
+            'Pass the full 40-character SHA so it can be fetched from origin '
+            '(GitHub does not support SHA-targeted fetches for abbreviated SHAs).'
+        )
+        raise AssertionError('unreachable')
+
     app.display_info(f'Commit `{commit_hash}` not found locally; fetching from origin.')
     fetch_failed = False
     try:
@@ -369,10 +379,7 @@ def _resolve_commit_or_fetch(app: Application, commit_hash: str) -> str:
         except OSError:
             pass
 
-    app.abort(
-        f'Commit `{commit_hash}` does not exist locally or on origin. '
-        'If you provided an abbreviated SHA, pass the full 40-character SHA.'
-    )
+    app.abort(f'Commit `{commit_hash}` does not exist locally or on origin.')
     raise AssertionError('unreachable')
 
 

--- a/ddev/src/ddev/cli/release/port_commit_workflow.py
+++ b/ddev/src/ddev/cli/release/port_commit_workflow.py
@@ -363,7 +363,6 @@ def _resolve_commit_or_fetch(app: Application, commit_hash: str) -> str:
             'Pass the full 40-character SHA so it can be fetched from origin '
             '(GitHub does not support SHA-targeted fetches for abbreviated SHAs).'
         )
-        raise AssertionError('unreachable')
 
     app.display_info(f'Commit `{commit_hash}` not found locally; fetching from origin.')
     fetched = False
@@ -376,7 +375,6 @@ def _resolve_commit_or_fetch(app: Application, commit_hash: str) -> str:
             return git.capture('rev-parse', '--verify', f'{commit_hash}^{{commit}}').strip()
 
     app.abort(f'Commit `{commit_hash}` does not exist locally or on origin.')
-    raise AssertionError('unreachable')
 
 
 def _path_exists_in_head(git: GitRepository, path: str) -> bool:

--- a/ddev/src/ddev/cli/release/port_commit_workflow.py
+++ b/ddev/src/ddev/cli/release/port_commit_workflow.py
@@ -528,7 +528,10 @@ def _resolve_in_toto_conflict(git: GitRepository, path: str) -> None:
         git.run('rm', '--force', path)
         return
     git.run('checkout', '--ours', path)
-    git.run('add', path)
+    # `.in-toto/` is gitignored in this repo, so `git add` refuses without `--force` even though
+    # the path is already tracked in HEAD. The force is safe: we only get here for paths that
+    # came out of `git diff --diff-filter=U`, i.e. files git itself flagged as needing resolution.
+    git.run('add', '--force', path)
 
 
 def _restore_path_from_head(git: GitRepository, path: str) -> None:

--- a/ddev/src/ddev/cli/release/port_commit_workflow.py
+++ b/ddev/src/ddev/cli/release/port_commit_workflow.py
@@ -459,15 +459,16 @@ async def _fetch_pr(token: str, owner: str, repo: str, pr_number: int) -> PullRe
 def _abort_if_merge_commit(app: Application, pr_number: int, full_sha: str) -> None:
     """Abort when `full_sha` is a merge commit (>= 2 parents), which can't be backported as a single commit."""
     try:
-        output = app.repo.git.capture('rev-list', '--parents', '-n1', full_sha).strip().split()
+        raw = app.repo.git.capture('rev-list', '--parents', '-n1', full_sha)
     except OSError as exc:
         app.abort(f'Could not inspect merge parents of `{full_sha}`: {exc}.')
-    parent_count = max(len(output) - 1, 0)
-    if parent_count >= 2:
-        app.abort(
-            f"PR #{pr_number} was not squash-merged, so there isn't a single commit to backport "
-            'the full PR. Run again with the specific commit you want to backport.'
-        )
+    else:
+        parent_count = max(len(raw.strip().split()) - 1, 0)
+        if parent_count >= 2:
+            app.abort(
+                f"PR #{pr_number} was not squash-merged, so there isn't a single commit to backport "
+                'the full PR. Run again with the specific commit you want to backport.'
+            )
 
 
 def _resolve_commit_or_fetch(app: Application, commit_hash: str, *, dry_run: bool) -> str:

--- a/ddev/src/ddev/cli/release/port_commit_workflow.py
+++ b/ddev/src/ddev/cli/release/port_commit_workflow.py
@@ -28,6 +28,7 @@ from ddev.utils.git import GitRepository
 
 if TYPE_CHECKING:
     from ddev.cli.application import Application
+    from ddev.utils.github_async.models import PullRequest
 
 
 PR_NUMBER_SUFFIX_PATTERN = re.compile(r'\s*\(#(\d+)\)\s*$')
@@ -37,10 +38,21 @@ IN_TOTO_SUFFIX = '.in-toto'
 WORKTREE_BASE = '.worktrees/port-commit'
 FULL_SHA_PATTERN = re.compile(r'^[0-9a-fA-F]{40}$')
 HEX_PATTERN = re.compile(r'^[0-9a-fA-F]+$')
+DIGITS_PATTERN = re.compile(r'^\d+$')
+PR_PREFIX_PATTERN = re.compile(r'^PR-(\d+)$', re.IGNORECASE)
+PR_URL_PATTERN = re.compile(r'^https?://github\.com/[^/]+/[^/]+/pull/(\d+)(?:[/?#].*)?$', re.IGNORECASE)
 
 
 class PortStepError(Exception):
     """Raised by a PortStep to signal a clean abort with a user-facing message."""
+
+
+class _CommitNotResolvable(Exception):
+    """Raised when a commit input cannot be resolved locally or via a SHA-targeted fetch."""
+
+
+class _PRNotFound(Exception):
+    """Raised when a PR lookup returns 404 so the caller can fall back to commit resolution."""
 
 
 class PortStep:
@@ -345,29 +357,122 @@ class CreatePullRequestStep(PortStep):
                 )
 
 
+def _resolve_input(app: Application, raw: str, *, dry_run: bool) -> str:
+    """Resolve the raw user input to a full commit SHA.
+
+    Handles three input shapes:
+    - Explicit PR form (`PR-12345` or a GitHub PR URL) -> looks up the PR.
+    - All-digits (e.g. `12345`) with a GitHub token configured -> tries as a PR; on 404 falls
+      back to commit resolution. Without a token the PR step is skipped.
+    - Anything else -> commit resolution.
+
+    Raises `_CommitNotResolvable` when nothing matches so the caller can decide how to abort.
+    """
+    pr_number = _extract_explicit_pr_number(raw)
+    if pr_number is not None:
+        return _resolve_pr_to_commit(app, pr_number, dry_run=dry_run)
+
+    is_digits = DIGITS_PATTERN.fullmatch(raw) is not None
+    if is_digits and app.config.github.token:
+        with contextlib.suppress(_PRNotFound):
+            return _resolve_pr_to_commit(app, int(raw), dry_run=dry_run)
+
+    try:
+        return _resolve_commit_or_fetch(app, raw, dry_run=dry_run)
+    except _CommitNotResolvable as exc:
+        if is_digits:
+            raise _CommitNotResolvable(
+                f'Could not resolve `{raw}` as a PR or a commit. '
+                'Pass the full 40-character SHA, or `PR-xxxxx` / a PR URL to disambiguate.'
+            ) from exc
+        raise
+
+
+def _extract_explicit_pr_number(raw: str) -> int | None:
+    """Return the PR number when `raw` is a `PR-12345` token or a GitHub PR URL, else None."""
+    for pattern in (PR_PREFIX_PATTERN, PR_URL_PATTERN):
+        match = pattern.fullmatch(raw)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def _resolve_pr_to_commit(app: Application, pr_number: int, *, dry_run: bool) -> str:
+    """Resolve a PR number to the SHA of its merge commit, validating squash-merge.
+
+    Raises `_PRNotFound` when GitHub returns 404. Aborts on other auth/network/validation errors
+    so the user gets a clear, contextual message rather than a stack trace.
+    """
+    import asyncio
+
+    import httpx
+
+    if not app.config.github.token:
+        app.abort('GitHub token required to look up PRs. Set `github.token` or pass a commit SHA directly.')
+
+    owner, repo = resolve_owner_repo(app)
+    try:
+        pr = asyncio.run(_fetch_pr(app, owner, repo, pr_number))
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 404:
+            raise _PRNotFound(str(pr_number)) from exc
+        app.abort(f'Failed to fetch PR #{pr_number} from GitHub: {exc}.')
+    except httpx.HTTPError as exc:
+        app.abort(f'Failed to fetch PR #{pr_number} from GitHub: {exc}.')
+
+    if not pr.merged:
+        app.abort(f'PR #{pr_number} is not merged; nothing to backport.')
+
+    if not pr.merge_commit_sha:
+        app.abort(f'PR #{pr_number} has no merge commit SHA available.')
+
+    full_sha = _resolve_commit_or_fetch(app, pr.merge_commit_sha, dry_run=dry_run)
+    _abort_if_merge_commit(app, pr_number, full_sha)
+    return full_sha
+
+
+async def _fetch_pr(app: Application, owner: str, repo: str, pr_number: int) -> PullRequest:
+    from ddev.utils.github_async import async_github_client
+
+    async with async_github_client(token=app.config.github.token) as client:
+        response = await client.get_pull_request(owner=owner, repo=repo, pull_number=pr_number)
+        return response.data
+
+
+def _abort_if_merge_commit(app: Application, pr_number: int, full_sha: str) -> None:
+    """Abort when `full_sha` is a merge commit (>= 2 parents), which can't be backported as a single commit."""
+    output = app.repo.git.capture('rev-list', '--parents', '-n1', full_sha).strip().split()
+    parent_count = max(len(output) - 1, 0)
+    if parent_count >= 2:
+        app.abort(
+            f"PR #{pr_number} was not squash-merged, so there isn't a single commit to backport "
+            'the full PR. Run again with the specific commit you want to backport.'
+        )
+
+
 def _resolve_commit_or_fetch(app: Application, commit_hash: str, *, dry_run: bool) -> str:
     """Return the full SHA for `commit_hash`, fetching from origin when the commit is not local.
 
-    Aborts the application with a user-facing message when the commit is neither available locally
-    nor reachable on origin. Falling back to a SHA-targeted fetch lets the command port commits that
-    live on remote branches the local repo does not track (the `remote.origin.fetch` refspec is
-    often narrowed in this repo to avoid pulling thousands of branches).
+    Raises `_CommitNotResolvable` when the commit is neither available locally nor reachable on
+    origin. Falling back to a SHA-targeted fetch lets the command port commits that live on remote
+    branches the local repo does not track (the `remote.origin.fetch` refspec is often narrowed in
+    this repo to avoid pulling thousands of branches).
 
     When `dry_run` is true, the fetch fallback is skipped to preserve the dry-run contract: a
-    non-local commit aborts with a clear message rather than mutating local state.
+    non-local commit raises instead of mutating local state.
     """
     git = app.repo.git
     with contextlib.suppress(OSError):
         return git.capture('rev-parse', '--verify', f'{commit_hash}^{{commit}}').strip()
 
     if dry_run:
-        app.abort(
+        raise _CommitNotResolvable(
             f'Commit `{commit_hash}` is not in the local repository. '
             'Re-run without `--dry-run` to fetch it from origin, or pre-fetch the commit manually.'
         )
 
     if HEX_PATTERN.fullmatch(commit_hash) and not FULL_SHA_PATTERN.fullmatch(commit_hash):
-        app.abort(
+        raise _CommitNotResolvable(
             f'Commit `{commit_hash}` is not in the local repository. '
             'Pass the full 40-character SHA so it can be fetched from origin '
             '(GitHub does not support SHA-targeted fetches for abbreviated SHAs).'
@@ -383,7 +488,7 @@ def _resolve_commit_or_fetch(app: Application, commit_hash: str, *, dry_run: boo
         with contextlib.suppress(OSError):
             return git.capture('rev-parse', '--verify', f'{commit_hash}^{{commit}}').strip()
 
-    app.abort(f'Commit `{commit_hash}` does not exist locally or on origin.')
+    raise _CommitNotResolvable(f'Commit `{commit_hash}` does not exist locally or on origin.')
 
 
 def _path_exists_in_head(git: GitRepository, path: str) -> bool:
@@ -514,7 +619,10 @@ def resolve_port_plan(
             app.abort('Did not get confirmation, aborting.')
         commit_hash = head_commit.sha
 
-    full_sha = _resolve_commit_or_fetch(app, commit_hash, dry_run=dry_run)
+    try:
+        full_sha = _resolve_input(app, commit_hash, dry_run=dry_run)
+    except _CommitNotResolvable as exc:
+        app.abort(str(exc))
 
     log_entries = app.repo.git.log(['hash:%H', 'subject:%s'], n=1, source=full_sha)
     if not log_entries:

--- a/ddev/src/ddev/utils/github_async/client.py
+++ b/ddev/src/ddev/utils/github_async/client.py
@@ -275,6 +275,31 @@ class AsyncGitHubClient:
         )
         return self._parse_response(response, IssueComment)
 
+    async def get_pull_request(
+        self,
+        owner: str,
+        repo: str,
+        pull_number: int,
+        timeout: float | None = None,
+    ) -> GitHubResponse[PullRequest]:
+        """
+        Calls the GitHub API to get a single pull request.
+
+        GitHub API Documentation:
+        https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
+
+        Args:
+            owner: Repository owner (user or organisation).
+            repo: Repository name.
+            pull_number: Pull request number.
+            timeout: Optional timeout for this specific request. Defaults to the client's default_timeout.
+
+        Returns:
+            GitHubResponse[PullRequest]: The validated pull request data and headers.
+        """
+        response = await self._request("GET", f"/repos/{owner}/{repo}/pulls/{pull_number}", timeout=timeout)
+        return self._parse_response(response, PullRequest)
+
     async def create_pull_request(
         self,
         owner: str,

--- a/ddev/tests/cli/release/test_port_commit.py
+++ b/ddev/tests/cli/release/test_port_commit.py
@@ -813,6 +813,24 @@ def test_command_aborts_when_pr_is_merge_commit(
     assert 'specific commit' in result.output.lower()
 
 
+def test_command_emits_pr_context_when_pure_digit_pr_merge_commit_missing(
+    ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
+) -> None:
+    """Pure-digit PR input + PR found + non-resolvable merge commit -> abort names the PR, not the SHA."""
+    fake_async_github.mock_response('get_pull_request', _merged_pr(number=23703))
+    mocker.patch('ddev.utils.git.GitRepository.run')
+    mocker.patch('ddev.utils.git.GitRepository.capture', side_effect=OSError('bad object'))
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
+
+    result = ddev('release', 'port-commit', '--dry-run', '23703')
+
+    assert result.exit_code == 1, result.output
+    assert 'PR #23703 was found but its merge commit' in result.output
+    assert FULL_SHA_FOR_TESTS in result.output
+    # The raw merge-commit message shouldn't leak as the *primary* abort line.
+    assert not result.output.startswith(f'Commit `{FULL_SHA_FOR_TESTS}` is not in the local repository')
+
+
 def test_command_aborts_when_pr_input_has_no_token(
     ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
 ) -> None:

--- a/ddev/tests/cli/release/test_port_commit.py
+++ b/ddev/tests/cli/release/test_port_commit.py
@@ -221,7 +221,7 @@ def test_cherry_pick_only_in_toto_conflict_is_resolved(app_mock, git_mock):
     assert git_mock.run.call_args_list == [
         call('cherry-pick', '--no-commit', '1234567890'),
         call('checkout', '--ours', 'path/file.in-toto.link'),
-        call('add', 'path/file.in-toto.link'),
+        call('add', '--force', 'path/file.in-toto.link'),
     ]
 
 

--- a/ddev/tests/cli/release/test_port_commit.py
+++ b/ddev/tests/cli/release/test_port_commit.py
@@ -827,8 +827,6 @@ def test_command_emits_pr_context_when_pure_digit_pr_merge_commit_missing(
     assert result.exit_code == 1, result.output
     assert 'PR #23703 was found but its merge commit' in result.output
     assert FULL_SHA_FOR_TESTS in result.output
-    # The raw merge-commit message shouldn't leak as the *primary* abort line.
-    assert not result.output.startswith(f'Commit `{FULL_SHA_FOR_TESTS}` is not in the local repository')
 
 
 def test_command_aborts_when_pr_input_has_no_token(

--- a/ddev/tests/cli/release/test_port_commit.py
+++ b/ddev/tests/cli/release/test_port_commit.py
@@ -604,15 +604,86 @@ def test_command_token_guard(
 def test_command_aborts_when_commit_does_not_exist(
     ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
 ) -> None:
-    mocker.patch('ddev.utils.git.GitRepository.run')
+    run_mock = mocker.patch('ddev.utils.git.GitRepository.run')
     mocker.patch('ddev.utils.git.GitRepository.capture', side_effect=OSError('bad object'))
     mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
 
     result = ddev('release', 'port-commit', '1234567890abcdef00')
 
     assert result.exit_code == 1, result.output
-    assert 'does not exist' in result.output
+    assert 'does not exist locally or on origin' in result.output
+    assert 'full 40-character SHA' in result.output
+    assert ('fetch', 'origin', '1234567890abcdef00') in [c.args for c in run_mock.call_args_list]
     fake_async_github.assert_not_called('create_pull_request')
+
+
+def test_command_aborts_when_fetch_fails(
+    ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
+) -> None:
+    def run_side_effect(*args):
+        if args[:2] == ('fetch', 'origin'):
+            raise OSError("couldn't find remote ref")
+        return None
+
+    mocker.patch('ddev.utils.git.GitRepository.run', side_effect=run_side_effect)
+    mocker.patch('ddev.utils.git.GitRepository.capture', side_effect=OSError('bad object'))
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
+
+    result = ddev('release', 'port-commit', '1234567890abcdef00')
+
+    assert result.exit_code == 1, result.output
+    assert 'does not exist locally or on origin' in result.output
+    fake_async_github.assert_not_called('create_pull_request')
+
+
+def test_command_fetches_commit_when_not_local(
+    ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
+) -> None:
+    commit_sha = '1234567890abcdef00'
+    subject = 'Fix bug (#100)'
+    rev_parse_calls = {'count': 0}
+
+    def capture_side_effect(*args):
+        if args == ('rev-parse', '--verify', f'{commit_sha}^{{commit}}'):
+            rev_parse_calls['count'] += 1
+            if rev_parse_calls['count'] == 1:
+                raise OSError('bad object')
+            return commit_sha + '\n'
+        if args == ('diff-tree', '--no-commit-id', '--name-only', '-r', commit_sha):
+            return ''
+        return ''
+
+    run_mock = mocker.patch('ddev.utils.git.GitRepository.run')
+    mocker.patch('ddev.utils.git.GitRepository.capture', side_effect=capture_side_effect)
+    mocker.patch(
+        'ddev.utils.git.GitRepository.log',
+        return_value=[{'hash': commit_sha, 'subject': subject}],
+    )
+    fake_async_github.mock_response(
+        'create_pull_request',
+        PullRequest(number=1, html_url='https://github.com/x/pr/1'),
+    )
+    mocker.patch('click.confirm', return_value=True)
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
+
+    result = ddev('release', 'port-commit', commit_sha)
+
+    assert result.exit_code == 0, result.output
+    assert 'not found locally; fetching from origin' in result.output
+    assert rev_parse_calls['count'] == 2
+    git_calls = [c.args for c in run_mock.call_args_list]
+    assert ('fetch', 'origin', commit_sha) in git_calls
+    fake_async_github.assert_called_once_with(
+        'create_pull_request',
+        owner='DataDog',
+        repo='integrations-core',
+        title='[Backport] Fix bug',
+        head='alice/port-1234567890-to-master',
+        base='master',
+        body=mocker.ANY,
+        draft=False,
+        timeout=None,
+    )
 
 
 def test_command_aborts_when_commit_log_is_empty(

--- a/ddev/tests/cli/release/test_port_commit.py
+++ b/ddev/tests/cli/release/test_port_commit.py
@@ -27,6 +27,8 @@ from ddev.utils.github_async.models import PullRequest
 from tests.helpers.github_async import FakeAsyncGitHubClient
 from tests.helpers.runner import CliRunner
 
+FULL_SHA_FOR_TESTS = '1234567890abcdef001234567890abcdef00abcd'
+
 
 @pytest.fixture
 def app_mock(mocker: MockerFixture) -> MagicMock:
@@ -363,12 +365,22 @@ def test_create_pull_request_step_skips_label_call_when_no_labels(
     fake_async_github.assert_not_called('add_labels_to_issue')
 
 
-def _setup_command_mocks(mocker, *, commit_sha='1234567890abcdef00', subject='Fix bug (#100)', in_toto=''):
+def _setup_command_mocks(
+    mocker,
+    *,
+    commit_sha='1234567890abcdef00',
+    subject='Fix bug (#100)',
+    in_toto='',
+    parents=('parent_sha',),
+):
+    """Patch git so the workflow sees a resolvable commit. `parents` controls the merge-parent check."""
     run_mock = mocker.patch('ddev.utils.git.GitRepository.run')
     capture_mock = mocker.patch('ddev.utils.git.GitRepository.capture')
+    rev_list_output = ' '.join([commit_sha, *parents]) + '\n'
     capture_mock.side_effect = lambda *args: {
         ('rev-parse', '--verify', f'{commit_sha}^{{commit}}'): commit_sha + '\n',
         ('diff-tree', '--no-commit-id', '--name-only', '-r', commit_sha): in_toto,
+        ('rev-list', '--parents', '-n1', commit_sha): rev_list_output,
     }.get(args, '')
     mocker.patch(
         'ddev.utils.git.GitRepository.log',
@@ -379,6 +391,16 @@ def _setup_command_mocks(mocker, *, commit_sha='1234567890abcdef00', subject='Fi
         return_value=GitCommit(commit_sha, subject=subject),
     )
     return run_mock
+
+
+def _merged_pr(number=23703, merge_commit_sha=None):
+    """Build a PullRequest model for a squash-merged PR."""
+    return PullRequest(
+        number=number,
+        html_url=f'https://github.com/DataDog/integrations-core/pull/{number}',
+        merged=True,
+        merge_commit_sha=merge_commit_sha or FULL_SHA_FOR_TESTS,
+    )
 
 
 def test_command_happy_path(ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient) -> None:
@@ -601,9 +623,6 @@ def test_command_token_guard(
     fake_async_github.assert_not_called('create_pull_request')
 
 
-FULL_SHA_FOR_TESTS = '1234567890abcdef001234567890abcdef00abcd'
-
-
 def test_command_aborts_when_commit_missing_after_fetch(
     ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
 ) -> None:
@@ -720,6 +739,135 @@ def test_command_fetches_commit_when_not_local(
         draft=False,
         timeout=None,
     )
+
+
+@pytest.mark.parametrize(
+    'input_arg',
+    [
+        pytest.param('PR-23703', id='PR-prefix'),
+        pytest.param('pr-23703', id='PR-prefix-lowercase'),
+        pytest.param('https://github.com/DataDog/integrations-core/pull/23703', id='URL'),
+        pytest.param('https://github.com/DataDog/integrations-core/pull/23703#discussion_r1', id='URL-with-fragment'),
+        pytest.param('23703', id='pure-digit-auto-detect'),
+    ],
+)
+def test_command_resolves_pr_input(
+    input_arg: str,
+    ddev: CliRunner,
+    mocker: MockerFixture,
+    fake_async_github: FakeAsyncGitHubClient,
+) -> None:
+    _setup_command_mocks(mocker, commit_sha=FULL_SHA_FOR_TESTS)
+    fake_async_github.mock_response('get_pull_request', _merged_pr(number=23703))
+    fake_async_github.mock_response(
+        'create_pull_request',
+        PullRequest(number=1, html_url='https://github.com/x/pr/1'),
+    )
+    mocker.patch('click.confirm', return_value=True)
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
+
+    result = ddev('release', 'port-commit', input_arg)
+
+    assert result.exit_code == 0, result.output
+    pr_call = fake_async_github.last_call('get_pull_request')
+    assert pr_call.kwargs['owner'] == 'DataDog'
+    assert pr_call.kwargs['repo'] == 'integrations-core'
+    assert pr_call.kwargs['pull_number'] == 23703
+
+
+def test_command_aborts_when_pr_not_merged(
+    ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
+) -> None:
+    _setup_command_mocks(mocker, commit_sha=FULL_SHA_FOR_TESTS)
+    fake_async_github.mock_response(
+        'get_pull_request',
+        PullRequest(
+            number=23703,
+            html_url='https://github.com/DataDog/integrations-core/pull/23703',
+            merged=False,
+            merge_commit_sha=None,
+        ),
+    )
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
+
+    result = ddev('release', 'port-commit', 'PR-23703')
+
+    assert result.exit_code == 1, result.output
+    assert 'PR #23703 is not merged' in result.output
+
+
+def test_command_aborts_when_pr_is_merge_commit(
+    ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
+) -> None:
+    _setup_command_mocks(mocker, commit_sha=FULL_SHA_FOR_TESTS, parents=('parent1', 'parent2'))
+    fake_async_github.mock_response('get_pull_request', _merged_pr(number=23703))
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
+
+    result = ddev('release', 'port-commit', 'PR-23703')
+
+    assert result.exit_code == 1, result.output
+    assert 'not squash-merged' in result.output
+    assert 'specific commit' in result.output.lower()
+
+
+def test_command_aborts_when_pr_input_has_no_token(
+    ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
+) -> None:
+    """Explicit PR form requires a GitHub token even with --no-pr."""
+    mocker.patch.dict(
+        'os.environ',
+        {'DD_GITHUB_USER': 'alice', 'DD_GITHUB_TOKEN': '', 'GH_TOKEN': '', 'GITHUB_TOKEN': ''},
+    )
+
+    result = ddev('release', 'port-commit', '--no-pr', 'PR-23703')
+
+    assert result.exit_code == 1, result.output
+    assert 'GitHub token required to look up PRs' in result.output
+    fake_async_github.assert_not_called('get_pull_request')
+
+
+def test_command_falls_back_to_commit_on_pr_not_found(
+    ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
+) -> None:
+    """Pure-digit input that isn't a PR resolves as a commit when it's local (PR 404 from default mock)."""
+    short_input = '1234'
+    full_sha = FULL_SHA_FOR_TESTS
+    run_mock = mocker.patch('ddev.utils.git.GitRepository.run')
+    capture_mock = mocker.patch('ddev.utils.git.GitRepository.capture')
+    capture_mock.side_effect = lambda *args: {
+        ('rev-parse', '--verify', f'{short_input}^{{commit}}'): full_sha + '\n',
+        ('diff-tree', '--no-commit-id', '--name-only', '-r', full_sha): '',
+    }.get(args, '')
+    mocker.patch('ddev.utils.git.GitRepository.log', return_value=[{'hash': full_sha, 'subject': 'Fix bug'}])
+    fake_async_github.mock_response(
+        'create_pull_request',
+        PullRequest(number=1, html_url='https://github.com/x/pr/1'),
+    )
+    mocker.patch('click.confirm', return_value=True)
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
+
+    result = ddev('release', 'port-commit', short_input)
+
+    assert result.exit_code == 0, result.output
+    assert fake_async_github.last_call('get_pull_request').kwargs['pull_number'] == int(short_input)
+    git_calls = [c.args for c in run_mock.call_args_list]
+    # No SHA-targeted fetch (3 args) — commit was resolvable locally.
+    assert not any(len(args) == 3 and args[:2] == ('fetch', 'origin') for args in git_calls)
+
+
+def test_command_aborts_with_unified_message_when_pr_and_commit_both_fail(
+    ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
+) -> None:
+    """Pure-digit input: PR 404 (default mock) + commit unresolvable -> unified message."""
+    mocker.patch('ddev.utils.git.GitRepository.run')
+    mocker.patch('ddev.utils.git.GitRepository.capture', side_effect=OSError('bad object'))
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
+
+    result = ddev('release', 'port-commit', '1234567')
+
+    assert result.exit_code == 1, result.output
+    assert 'Could not resolve `1234567` as a PR or a commit' in result.output
+    assert '`PR-xxxxx`' in result.output
 
 
 def test_command_aborts_when_commit_log_is_empty(

--- a/ddev/tests/cli/release/test_port_commit.py
+++ b/ddev/tests/cli/release/test_port_commit.py
@@ -601,19 +601,22 @@ def test_command_token_guard(
     fake_async_github.assert_not_called('create_pull_request')
 
 
-def test_command_aborts_when_commit_does_not_exist(
+FULL_SHA_FOR_TESTS = '1234567890abcdef001234567890abcdef00abcd'
+
+
+def test_command_aborts_when_commit_missing_after_fetch(
     ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
 ) -> None:
+    """Fetch succeeds but rev-parse still cannot resolve the commit (edge case)."""
     run_mock = mocker.patch('ddev.utils.git.GitRepository.run')
     mocker.patch('ddev.utils.git.GitRepository.capture', side_effect=OSError('bad object'))
     mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
 
-    result = ddev('release', 'port-commit', '1234567890abcdef00')
+    result = ddev('release', 'port-commit', FULL_SHA_FOR_TESTS)
 
     assert result.exit_code == 1, result.output
     assert 'does not exist locally or on origin' in result.output
-    assert 'full 40-character SHA' in result.output
-    assert ('fetch', 'origin', '1234567890abcdef00') in [c.args for c in run_mock.call_args_list]
+    assert ('fetch', 'origin', FULL_SHA_FOR_TESTS) in [c.args for c in run_mock.call_args_list]
     fake_async_github.assert_not_called('create_pull_request')
 
 
@@ -629,17 +632,33 @@ def test_command_aborts_when_fetch_fails(
     mocker.patch('ddev.utils.git.GitRepository.capture', side_effect=OSError('bad object'))
     mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
 
-    result = ddev('release', 'port-commit', '1234567890abcdef00')
+    result = ddev('release', 'port-commit', FULL_SHA_FOR_TESTS)
 
     assert result.exit_code == 1, result.output
     assert 'does not exist locally or on origin' in result.output
     fake_async_github.assert_not_called('create_pull_request')
 
 
+def test_command_aborts_on_abbreviated_sha_not_local(
+    ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
+) -> None:
+    """Abbreviated SHAs cannot be fetched from origin, so abort early with a clear hint."""
+    run_mock = mocker.patch('ddev.utils.git.GitRepository.run')
+    mocker.patch('ddev.utils.git.GitRepository.capture', side_effect=OSError('bad object'))
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
+
+    result = ddev('release', 'port-commit', '1234567890')
+
+    assert result.exit_code == 1, result.output
+    assert 'full 40-character SHA' in result.output
+    assert not any(c.args[:2] == ('fetch', 'origin') for c in run_mock.call_args_list)
+    fake_async_github.assert_not_called('create_pull_request')
+
+
 def test_command_fetches_commit_when_not_local(
     ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
 ) -> None:
-    commit_sha = '1234567890abcdef00'
+    commit_sha = FULL_SHA_FOR_TESTS
     subject = 'Fix bug (#100)'
     rev_parse_calls = {'count': 0}
 
@@ -678,7 +697,7 @@ def test_command_fetches_commit_when_not_local(
         owner='DataDog',
         repo='integrations-core',
         title='[Backport] Fix bug',
-        head='alice/port-1234567890-to-master',
+        head=f'alice/port-{commit_sha[:10]}-to-master',
         base='master',
         body=mocker.ANY,
         draft=False,

--- a/ddev/tests/cli/release/test_port_commit.py
+++ b/ddev/tests/cli/release/test_port_commit.py
@@ -639,6 +639,23 @@ def test_command_aborts_when_fetch_fails(
     fake_async_github.assert_not_called('create_pull_request')
 
 
+def test_command_aborts_in_dry_run_when_commit_not_local(
+    ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
+) -> None:
+    """Dry-run must not mutate local state, so don't fetch when the commit is missing."""
+    run_mock = mocker.patch('ddev.utils.git.GitRepository.run')
+    mocker.patch('ddev.utils.git.GitRepository.capture', side_effect=OSError('bad object'))
+    mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
+
+    result = ddev('release', 'port-commit', '--dry-run', FULL_SHA_FOR_TESTS)
+
+    assert result.exit_code == 1, result.output
+    assert 'is not in the local repository' in result.output
+    assert 'Re-run without `--dry-run`' in result.output
+    assert not any(c.args[:2] == ('fetch', 'origin') for c in run_mock.call_args_list)
+    fake_async_github.assert_not_called('create_pull_request')
+
+
 def test_command_aborts_on_abbreviated_sha_not_local(
     ddev: CliRunner, mocker: MockerFixture, fake_async_github: FakeAsyncGitHubClient
 ) -> None:

--- a/ddev/tests/cli/release/test_port_commit.py
+++ b/ddev/tests/cli/release/test_port_commit.py
@@ -746,9 +746,12 @@ def test_command_fetches_commit_when_not_local(
     [
         pytest.param('PR-23703', id='PR-prefix'),
         pytest.param('pr-23703', id='PR-prefix-lowercase'),
-        pytest.param('https://github.com/DataDog/integrations-core/pull/23703', id='URL'),
+        pytest.param('PR-23703 ', id='PR-prefix-trailing-whitespace'),
+        pytest.param('https://github.com/DataDog/integrations-core/pull/23703', id='URL-https'),
+        pytest.param('http://github.com/DataDog/integrations-core/pull/23703', id='URL-http'),
         pytest.param('https://github.com/DataDog/integrations-core/pull/23703#discussion_r1', id='URL-with-fragment'),
         pytest.param('23703', id='pure-digit-auto-detect'),
+        pytest.param(' 23703 ', id='pure-digit-with-whitespace'),
     ],
 )
 def test_command_resolves_pr_input(
@@ -822,7 +825,8 @@ def test_command_aborts_when_pr_input_has_no_token(
     result = ddev('release', 'port-commit', '--no-pr', 'PR-23703')
 
     assert result.exit_code == 1, result.output
-    assert 'GitHub token required to look up PRs' in result.output
+    assert 'GitHub token required to resolve a PR reference' in result.output
+    assert '--no-pr does not skip this lookup' in result.output
     fake_async_github.assert_not_called('get_pull_request')
 
 
@@ -851,7 +855,7 @@ def test_command_falls_back_to_commit_on_pr_not_found(
     assert result.exit_code == 0, result.output
     assert fake_async_github.last_call('get_pull_request').kwargs['pull_number'] == int(short_input)
     git_calls = [c.args for c in run_mock.call_args_list]
-    # No SHA-targeted fetch (3 args) — commit was resolvable locally.
+    # No SHA-targeted fetch (3 args): commit was resolvable locally.
     assert not any(len(args) == 3 and args[:2] == ('fetch', 'origin') for args in git_calls)
 
 

--- a/ddev/tests/helpers/__init__.py
+++ b/ddev/tests/helpers/__init__.py
@@ -1,9 +1,18 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import sys
+from typing import NoReturn
+
 from ddev.cli.application import Application
 from ddev.utils.platform import Platform
 
+
+def _exit(code: int) -> NoReturn:
+    print(f"Application exited with code: {code}")
+    sys.exit(code)
+
+
 PLATFORM = Platform()
-APPLICATION = Application(lambda code: print(f"Applicatione exited with code: {code}"), 1, False, False)
+APPLICATION = Application(_exit, 1, False, False)
 LOCAL_REPO_BRANCH = "ddev-testing"

--- a/ddev/tests/helpers/github_async.py
+++ b/ddev/tests/helpers/github_async.py
@@ -39,6 +39,8 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
+import httpx
+
 from ddev.utils.github_async import GitHubResponse
 from ddev.utils.github_async.models import Label, PullRequest
 
@@ -69,6 +71,13 @@ def _default_response_factories() -> dict[str, Callable[[], Any]]:
             headers={},
         ),
         'add_labels_to_issue': lambda: GitHubResponse.model_validate({'data': [], 'headers': {}}),
+        # Default to "PR not found" so tests that don't care about PR lookup auto-fall-through
+        # to commit resolution. Tests that need a specific PR register their own mock_response.
+        'get_pull_request': lambda: httpx.HTTPStatusError(
+            'Not Found',
+            request=httpx.Request('GET', 'https://api.github.com/'),
+            response=httpx.Response(404),
+        ),
     }
 
 
@@ -129,6 +138,21 @@ class FakeAsyncGitHubClient:
     # ------------------------------------------------------------------
     # Mirrored API surface
     # ------------------------------------------------------------------
+
+    async def get_pull_request(
+        self,
+        owner: str,
+        repo: str,
+        pull_number: int,
+        timeout: float | None = None,
+    ) -> GitHubResponse[PullRequest]:
+        return self._call(
+            'get_pull_request',
+            owner=owner,
+            repo=repo,
+            pull_number=pull_number,
+            timeout=timeout,
+        )
 
     async def create_pull_request(
         self,


### PR DESCRIPTION
### What does this PR do?

Make `ddev release port-commit` resolve any commit on origin, not just the ones already in the local object database, and clean up the typing along the way.

**Primary change — `_resolve_commit_or_fetch` in `port_commit_workflow.py`:**

1. Try local `git rev-parse --verify <hash>^{commit}`. If it resolves, return.
2. If the input is hex but shorter than 40 chars, abort early with a clear hint: GitHub's `uploadpack.allowReachableSHA1InWant` only honours full SHAs, so a fetch can't help.
3. Otherwise run `git fetch origin <hash>` (precise SHA-targeted fetch — no need to find which branch the commit lives on, since cherry-pick only needs the commit object).
4. Retry `rev-parse`. If it resolves, return. Otherwise abort with `Commit X does not exist locally or on origin`.

`contextlib.suppress(OSError)` is used wherever an `OSError` should be silently dropped, rather than `try/except: pass`.

**Secondary cleanup — `Application.abort` typing (`application.py`):**

The new helper has paths that end at `app.abort(...)`, and the function returns `str`. Before this PR, mypy couldn't tell that `abort` doesn't return (the method had no `NoReturn` annotation and `__exit_func` was untyped), so the cleanest fix is to type the callback properly:

- `Application.__init__` now takes `exit_func: Callable[[int], NoReturn]` (matches click's `Context.exit`).
- `Application.abort` is annotated `-> NoReturn`.
- Mypy now correctly infers that `self.__exit_func(code)` is terminal, so callers no longer need a trailing `raise AssertionError('unreachable')` or `raise SystemExit(code)` to satisfy the type checker.
- Typing-only imports (`Any`, `Callable`, `NoReturn`) live behind `TYPE_CHECKING` since the file already has `from __future__ import annotations`.

**Pre-existing bugs surfaced by the stricter typing (fixed here):**

- `self.__config = {}` in `Application.__init__` needed an explicit `dict[str, Any]` annotation.
- `ddev/src/ddev/cli/meta/scripts/serve_openmetrics_payload.py:94` was passing `app.platform` (a `Platform`) to `DockerAgent`, which expects an `Application`. Has been broken since 2024 — `AgentInterface.platform` accesses `self.app.platform`, so it would raise `AttributeError` on a `Platform` instance at runtime. Now passes `app` directly.

### Motivation

The `port-commit` command previously aborted with ``Commit `X` does not exist.`` whenever the commit was not in the local repository. This is common in this repo because contributors often narrow `remote.origin.fetch` to only track a handful of branches (their own + `master`), so commits living on other branches are never fetched. Forcing the user to manually fetch a branch (which they may not even know the name of) before running the command is friction we can remove: GitHub allows fetching any reachable commit by full SHA, so the command can do the targeted fetch itself.

The typing changes started as the minimum needed to type-check the new helper cleanly, but ended up surfacing two pre-existing bugs that were worth fixing in the same PR while the proper annotations were going in.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged