### PR TITLE
[kafka] Surface Kafka Monitoring above the fold in the integration README

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -2,12 +2,7 @@
 
 ![Kafka Dashboard][1]
 
-<div style="background:#f3edfa;border-left:4px solid #632ca6;padding:14px 18px;margin:24px 0;border-radius:4px;">
-  <p style="margin:0;line-height:1.5;">
-    <span style="display:inline-block;background:#632ca6;color:#fff;font-size:10px;font-weight:700;padding:2px 8px;border-radius:4px;letter-spacing:0.06em;text-transform:uppercase;margin-right:8px;vertical-align:middle;">New</span>
-    <strong>Kafka Monitoring</strong> tracks consumer lag, throughput, schemas, and adds message reading capabilities. <a href="https://docs.datadoghq.com/data_streams/kafka?utm_source=docs&utm_medium=callout&utm_campaign=DocsCTA-DSMKafka-IntegrationsKafka">Try Kafka Monitoring &rarr;</a>
-  </p>
-</div>
+**New:** [Kafka Monitoring][24] tracks consumer lag, throughput, schemas, and adds message reading capabilities.
 
 ## Overview
 
@@ -187,3 +182,4 @@ See [service_checks.json][15] for a list of service checks provided by this inte
 [21]: https://www.datadoghq.com/blog/monitor-kafka-with-datadog
 [22]: https://raw.githubusercontent.com/DataDog/dd-agent/5.2.1/conf.d/kafka.yaml.example
 [23]: https://www.datadoghq.com/knowledge-center/apache-kafka/
+[24]: https://docs.datadoghq.com/data_streams/kafka?utm_source=docs&utm_medium=callout&utm_campaign=DocsCTA-DSMKafka-IntegrationsKafka

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -2,13 +2,16 @@
 
 ![Kafka Dashboard][1]
 
-**Already collecting Kafka metrics with the Agent?** Pair them with [Data Streams Monitoring for Kafka][26] to track end-to-end producer/consumer lag, throughput, and message lineage.
+<div style="background:#f3edfa;border-left:4px solid #632ca6;padding:14px 18px;margin:24px 0;border-radius:4px;">
+  <p style="margin:0;line-height:1.5;">
+    <span style="display:inline-block;background:#632ca6;color:#fff;font-size:10px;font-weight:700;padding:2px 8px;border-radius:4px;letter-spacing:0.06em;text-transform:uppercase;margin-right:8px;vertical-align:middle;">New</span>
+    <strong>Kafka Monitoring</strong> tracks consumer lag, throughput, schemas, and adds message reading capabilities. <a href="https://docs.datadoghq.com/data_streams/kafka?utm_source=docs&utm_medium=callout&utm_campaign=DocsCTA-DSMKafka-IntegrationsKafka">Try Kafka Monitoring &rarr;</a>
+  </p>
+</div>
 
 ## Overview
 
 View Kafka broker metrics and logs for a 360-view of the health and performance of your Kafka clusters in real time.
-
-Add [Data Streams Monitoring][24] to your producers and consumers to visualize the application topology, root cause issues across services, and measure end to end latency, throughput and lag.
 
 **Note**:
 
@@ -26,8 +29,6 @@ To collect Kafka consumer metrics, see the [kafka_consumer check][3].
 ### Installation
 
 The Agent's Kafka check is included in the [Datadog Agent][4] package, no additional installation is needed on your Kafka nodes.
-
-Add [Data Streams Monitoring][24] to your producers and consumers to visualize the application topology, root cause issues across services, and measure end to end latency, throughput and lag.
 
 The check collects metrics from JMX with [JMXFetch][5]. A JVM is needed on each kafka node so the Agent can run JMXFetch. The same JVM that Kafka uses can be used for this.
 
@@ -186,6 +187,3 @@ See [service_checks.json][15] for a list of service checks provided by this inte
 [21]: https://www.datadoghq.com/blog/monitor-kafka-with-datadog
 [22]: https://raw.githubusercontent.com/DataDog/dd-agent/5.2.1/conf.d/kafka.yaml.example
 [23]: https://www.datadoghq.com/knowledge-center/apache-kafka/
-[24]: https://docs.datadoghq.com/data_streams/
-[25]: /data-streams
-[26]: https://docs.datadoghq.com/data_streams/kafka?utm_source=docs&utm_medium=callout&utm_campaign=DocsCTA-DSMKafka-IntegrationsKafka

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -2,7 +2,7 @@
 
 ![Kafka Dashboard][1]
 
-*Already collecting Kafka metrics with the Agent? **[Data Streams Monitoring for Kafka][26]** layers end-to-end lag, throughput, and message lineage across your producers and consumers.*
+**Already collecting Kafka metrics with the Agent?** Pair them with [Data Streams Monitoring for Kafka][26] to track end-to-end producer/consumer lag, throughput, and message lineage.
 
 ## Overview
 

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -2,6 +2,8 @@
 
 ![Kafka Dashboard][1]
 
+*Already collecting Kafka metrics with the Agent? **[Data Streams Monitoring for Kafka][26]** layers end-to-end lag, throughput, and message lineage across your producers and consumers.*
+
 ## Overview
 
 View Kafka broker metrics and logs for a 360-view of the health and performance of your Kafka clusters in real time.
@@ -186,3 +188,4 @@ See [service_checks.json][15] for a list of service checks provided by this inte
 [23]: https://www.datadoghq.com/knowledge-center/apache-kafka/
 [24]: https://docs.datadoghq.com/data_streams/
 [25]: /data-streams
+[26]: https://docs.datadoghq.com/data_streams/kafka?utm_source=docs&utm_medium=callout&utm_campaign=DocsCTA-DSMKafka-IntegrationsKafka


### PR DESCRIPTION
### What does this PR do?

Adds a single bold "New:" callout immediately under the dashboard image on the Kafka integration README, linking readers to `/data_streams/kafka` (the new Kafka Monitoring page on docs.datadoghq.com).

Also consolidates: removes two redundant mid-page lines that already mentioned Data Streams Monitoring (in Overview and Installation sections), and drops two now-orphan reference definitions (`[24]`, `[25]`).

### Motivation

The Kafka integration page is one of the top Datadog pages returned by Google for "kafka datadog". Surfacing the new Kafka Monitoring capability above the fold (instead of buried mid-page) gives readers landing from search a direct path to the new feature.

Wording is per @piochelepiotr's PR-review suggestion — concrete capabilities (consumer lag, throughput, schemas, message reading) instead of a generic "lag/throughput/lineage" pitch.

### Links

- **Production page (current):** https://docs.datadoghq.com/integrations/kafka/
- **Same content in the Datadog app:** https://app.datadoghq.com/integrations/kafka
- **Rendered branch (GitHub preview):** https://github.com/DataDog/integrations-core/blob/jj.botha/kafka-dsm-callout-readme/kafka/README.md
- **Destination being promoted:** https://docs.datadoghq.com/data_streams/kafka

### Tracking

UTM params on the destination link (`utm_campaign=DocsCTA-DSMKafka-IntegrationsKafka`) so click-through from this page is attributable in web analytics. Shared `DSMKafka` campaign rollup with the sibling PRs on documentation and corp-hugo.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the \`qa/skip-qa\` label if the PR doesn't need to be tested during QA.

_README-only change; tests N/A. Suggest applying \`qa/skip-qa\`._

### AI assistance

Drafted with Claude Code (Claude Opus 4.7); wording, placement, and consolidation reviewed by the author and refined per @piochelepiotr's feedback.

### Related PRs

Sibling PRs adding equivalent callouts to other high-traffic Kafka surfaces:
- DataDog/documentation#36702 — tracing/guide/monitor-kafka-queues
- DataDog/corp-hugo#23455 — dashboards/kafka-dashboard (merged)