### PR TITLE
Add register_integration tool

### DIFF
--- a/ddev/src/ddev/ai/tools/registry.py
+++ b/ddev/src/ddev/ai/tools/registry.py
@@ -70,6 +70,9 @@ TOOL_MANIFEST: dict[str, ToolSpec] = {
     "ddev_env_stop": ToolSpec("shell.ddev.env_stop", "DdevEnvStopTool"),
     "ddev_env_test": ToolSpec("shell.ddev.env_test", "DdevEnvTestTool"),
     "ddev_release_changelog": ToolSpec("shell.ddev.release_changelog", "DdevReleaseChangelogTool"),
+    "register_integration": ToolSpec(
+        "repo.register_integration", "RegisterIntegrationTool", factory=_file_policy_factory
+    ),
 }
 
 

--- a/ddev/src/ddev/ai/tools/repo/__init__.py
+++ b/ddev/src/ddev/ai/tools/repo/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/ddev/src/ddev/ai/tools/repo/register_integration.py
+++ b/ddev/src/ddev/ai/tools/repo/register_integration.py
@@ -95,6 +95,17 @@ class RegisterIntegrationTool(BaseTool[RegisterIntegrationInput]):
         if tool_input.metrics_prefix is not None:
             planned.append(_PendingWrite(METRICS_PREFIX_PATH, tool_input.metrics_prefix, "metrics-prefix"))
 
+        for entry in planned:
+            conflict_at = _first_non_table_node(document, entry.path)
+            if conflict_at is not None:
+                return ToolResult(
+                    success=False,
+                    error=(
+                        f"{entry.label} for {integration!r} cannot be written to {config_path}: "
+                        f"{conflict_at} is not a table"
+                    ),
+                )
+
         to_write: list[_PendingWrite] = []
         for entry in planned:
             existing = _read_existing(document, entry.path, integration)
@@ -133,6 +144,22 @@ def _find_config(start: Path) -> Path | None:
     return None
 
 
+def _first_non_table_node(document: TOMLDocument, path: tuple[str, ...]) -> str | None:
+    """Return the dotted prefix of the first non-Table node along `path`, or None if writable."""
+    node: object = document
+    walked: list[str] = []
+    for part in path:
+        if not isinstance(node, (TOMLDocument, Table)):
+            return ".".join(walked)
+        if part not in node:
+            return None
+        walked.append(part)
+        node = node[part]
+    if not isinstance(node, (TOMLDocument, Table)):
+        return ".".join(walked)
+    return None
+
+
 def _read_existing(document: TOMLDocument, path: tuple[str, ...], key: str) -> object | None:
     node: object = document
     for part in path:
@@ -145,14 +172,16 @@ def _read_existing(document: TOMLDocument, path: tuple[str, ...], key: str) -> o
 
 
 def _set_at_path(document: TOMLDocument, path: tuple[str, ...], key: str, value: object) -> None:
+    """Set `key = value` inside the table at `path`, creating intermediate tables as needed.
+
+    Assumes the caller has preflighted `path` against the document so every existing
+    node along it is a Table — see `_first_non_table_node`.
+    """
     node: TOMLDocument | Table = document
     for part in path:
         if part not in node:
             node[part] = tomlkit.table()
-        child = node[part]
-        if not isinstance(child, (TOMLDocument, Table)):
-            raise TypeError(f"Expected table at {part!r}, found {type(child).__name__}")
-        node = child
+        node = node[part]
     node[key] = value
 
 

--- a/ddev/src/ddev/ai/tools/repo/register_integration.py
+++ b/ddev/src/ddev/ai/tools/repo/register_integration.py
@@ -1,0 +1,160 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from pathlib import Path
+from typing import Annotated, Literal
+
+import tomlkit
+from pydantic import Field
+from tomlkit import TOMLDocument
+from tomlkit.items import Table
+
+from ddev.ai.tools.core.base import BaseTool, BaseToolInput
+from ddev.ai.tools.core.types import ToolResult
+from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
+
+CONFIG_RELATIVE_PATH = Path(".ddev") / "config.toml"
+MANIFEST_PLATFORMS_PATH = ("overrides", "manifest", "platforms")
+DISPLAY_NAME_PATH = ("overrides", "display-name")
+METRICS_PREFIX_PATH = ("overrides", "metrics-prefix")
+
+
+class RegisterIntegrationInput(BaseToolInput):
+    platforms: Annotated[
+        list[Literal["linux", "windows", "mac_os"]],
+        Field(
+            description="Operating systems the integration supports.",
+            min_length=1,
+        ),
+    ]
+    display_name: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Human-readable display name. Provide only when it differs from the snake_case folder name.",
+        ),
+    ]
+    metrics_prefix: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Metric prefix used by the integration. Provide only when the prefix is non-default.",
+        ),
+    ]
+
+
+class RegisterIntegrationTool(BaseTool[RegisterIntegrationInput]):
+    """Registers this integration's metadata in the repo-wide configuration so
+    build and validation tooling can discover it. The integration is not fully
+    shipped until it has been registered — call this once the integration
+    directory has been scaffolded."""
+
+    def __init__(self, policy: FileAccessPolicy) -> None:
+        self._write_root = policy.write_root
+
+    @property
+    def name(self) -> str:
+        return "register_integration"
+
+    async def __call__(self, tool_input: RegisterIntegrationInput) -> ToolResult:
+        integration = self._write_root.name
+
+        config_path = _find_config(self._write_root)
+        if config_path is None:
+            return ToolResult(
+                success=False,
+                error=f"Could not locate {CONFIG_RELATIVE_PATH} walking up from {self._write_root}",
+            )
+
+        try:
+            document = tomlkit.parse(config_path.read_text(encoding="utf-8"))
+        except OSError as e:
+            return ToolResult(success=False, error=f"Failed to read {config_path}: {e}")
+        except tomlkit.exceptions.TOMLKitError as e:
+            return ToolResult(success=False, error=f"Failed to parse {config_path}: {e}")
+
+        planned: list[tuple[tuple[str, ...], object, str]] = [
+            (MANIFEST_PLATFORMS_PATH, list(tool_input.platforms), "manifest.platforms"),
+        ]
+        if tool_input.display_name is not None:
+            planned.append((DISPLAY_NAME_PATH, tool_input.display_name, "display-name"))
+        if tool_input.metrics_prefix is not None:
+            planned.append((METRICS_PREFIX_PATH, tool_input.metrics_prefix, "metrics-prefix"))
+
+        to_write: list[tuple[tuple[str, ...], object, str]] = []
+        for path, requested, label in planned:
+            existing = _read_existing(document, path, integration)
+            if existing is None:
+                to_write.append((path, requested, label))
+            elif not _equal(existing, requested):
+                return ToolResult(
+                    success=False,
+                    error=(
+                        f"{label} for {integration!r} already exists with a different value: "
+                        f"existing={_unwrap(existing)!r}, requested={requested!r}"
+                    ),
+                )
+
+        for path, value, _ in to_write:
+            _set_at_path(document, path, integration, value)
+
+        if to_write:
+            try:
+                config_path.write_text(tomlkit.dumps(document), encoding="utf-8")
+            except OSError as e:
+                return ToolResult(success=False, error=f"Failed to write {config_path}: {e}")
+
+        sections = ", ".join(label for _, _, label in planned)
+        return ToolResult(success=True, data=f"Registered {integration!r} in: {sections}")
+
+
+def _find_config(start: Path) -> Path | None:
+    """Walk up from `start` until a directory contains `.ddev/config.toml`."""
+    for candidate in (start, *start.parents):
+        config = candidate / CONFIG_RELATIVE_PATH
+        if config.is_file():
+            return config
+    return None
+
+
+def _read_existing(document: TOMLDocument, path: tuple[str, ...], key: str) -> object | None:
+    node: object = document
+    for part in path:
+        if not isinstance(node, (TOMLDocument, Table)) or part not in node:
+            return None
+        node = node[part]
+    if not isinstance(node, (TOMLDocument, Table)) or key not in node:
+        return None
+    return node[key]
+
+
+def _set_at_path(document: TOMLDocument, path: tuple[str, ...], key: str, value: object) -> None:
+    node: TOMLDocument | Table = document
+    for part in path:
+        if part not in node:
+            node[part] = tomlkit.table()
+        child = node[part]
+        if not isinstance(child, (TOMLDocument, Table)):
+            raise TypeError(f"Expected table at {part!r}, found {type(child).__name__}")
+        node = child
+    node[key] = value
+
+
+def _equal(existing: object, requested: object) -> bool:
+    """Compare a tomlkit-parsed value against the requested Python value.
+
+    tomlkit item types subclass their Python equivalents (e.g. Array extends
+    list, String extends str), so `==` already compares correctly. Lists are
+    compared element-wise for ordering, which is what we want for platforms.
+    """
+    if isinstance(requested, list):
+        return isinstance(existing, list) and list(existing) == requested
+    return existing == requested
+
+
+def _unwrap(value: object) -> object:
+    """Unwrap a tomlkit container to its plain-Python equivalent for display."""
+    if isinstance(value, list):
+        return list(value)
+    return value

--- a/ddev/src/ddev/ai/tools/repo/register_integration.py
+++ b/ddev/src/ddev/ai/tools/repo/register_integration.py
@@ -2,11 +2,12 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated, Literal
 
 import tomlkit
-from pydantic import Field
+from pydantic import AfterValidator, Field
 from tomlkit import TOMLDocument
 from tomlkit.items import Table
 
@@ -20,6 +21,10 @@ DISPLAY_NAME_PATH = ("overrides", "display-name")
 METRICS_PREFIX_PATH = ("overrides", "metrics-prefix")
 
 
+def _dedupe_preserve_order(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))
+
+
 class RegisterIntegrationInput(BaseToolInput):
     platforms: Annotated[
         list[Literal["linux", "windows", "mac_os"]],
@@ -27,6 +32,7 @@ class RegisterIntegrationInput(BaseToolInput):
             description="Operating systems the integration supports.",
             min_length=1,
         ),
+        AfterValidator(_dedupe_preserve_order),
     ]
     display_name: Annotated[
         str | None,
@@ -42,6 +48,13 @@ class RegisterIntegrationInput(BaseToolInput):
             description="Metric prefix used by the integration. Provide only when the prefix is non-default.",
         ),
     ]
+
+
+@dataclass(frozen=True)
+class _PendingWrite:
+    path: tuple[str, ...]
+    value: object
+    label: str
 
 
 class RegisterIntegrationTool(BaseTool[RegisterIntegrationInput]):
@@ -74,39 +87,41 @@ class RegisterIntegrationTool(BaseTool[RegisterIntegrationInput]):
         except tomlkit.exceptions.TOMLKitError as e:
             return ToolResult(success=False, error=f"Failed to parse {config_path}: {e}")
 
-        planned: list[tuple[tuple[str, ...], object, str]] = [
-            (MANIFEST_PLATFORMS_PATH, list(tool_input.platforms), "manifest.platforms"),
+        planned: list[_PendingWrite] = [
+            _PendingWrite(MANIFEST_PLATFORMS_PATH, list(tool_input.platforms), "manifest.platforms"),
         ]
         if tool_input.display_name is not None:
-            planned.append((DISPLAY_NAME_PATH, tool_input.display_name, "display-name"))
+            planned.append(_PendingWrite(DISPLAY_NAME_PATH, tool_input.display_name, "display-name"))
         if tool_input.metrics_prefix is not None:
-            planned.append((METRICS_PREFIX_PATH, tool_input.metrics_prefix, "metrics-prefix"))
+            planned.append(_PendingWrite(METRICS_PREFIX_PATH, tool_input.metrics_prefix, "metrics-prefix"))
 
-        to_write: list[tuple[tuple[str, ...], object, str]] = []
-        for path, requested, label in planned:
-            existing = _read_existing(document, path, integration)
+        to_write: list[_PendingWrite] = []
+        for entry in planned:
+            existing = _read_existing(document, entry.path, integration)
             if existing is None:
-                to_write.append((path, requested, label))
-            elif not _equal(existing, requested):
+                to_write.append(entry)
+            elif not _equal(existing, entry.value):
                 return ToolResult(
                     success=False,
                     error=(
-                        f"{label} for {integration!r} already exists with a different value: "
-                        f"existing={_unwrap(existing)!r}, requested={requested!r}"
+                        f"{entry.label} for {integration!r} already exists with a different value: "
+                        f"existing={_unwrap(existing)!r}, requested={entry.value!r}"
                     ),
                 )
 
-        for path, value, _ in to_write:
-            _set_at_path(document, path, integration, value)
+        for entry in to_write:
+            _set_at_path(document, entry.path, integration, entry.value)
 
         if to_write:
             try:
                 config_path.write_text(tomlkit.dumps(document), encoding="utf-8")
             except OSError as e:
                 return ToolResult(success=False, error=f"Failed to write {config_path}: {e}")
+            written = ", ".join(entry.label for entry in to_write)
+            return ToolResult(success=True, data=f"Registered {integration!r} in: {written}")
 
-        sections = ", ".join(label for _, _, label in planned)
-        return ToolResult(success=True, data=f"Registered {integration!r} in: {sections}")
+        sections = ", ".join(entry.label for entry in planned)
+        return ToolResult(success=True, data=f"{integration!r} already registered in: {sections}")
 
 
 def _find_config(start: Path) -> Path | None:

--- a/ddev/src/ddev/ai/tools/repo/register_integration.py
+++ b/ddev/src/ddev/ai/tools/repo/register_integration.py
@@ -2,6 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import os
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated, Literal
@@ -64,6 +66,7 @@ class RegisterIntegrationTool(BaseTool[RegisterIntegrationInput]):
     directory has been scaffolded."""
 
     def __init__(self, policy: FileAccessPolicy) -> None:
+        # Config lives outside write_root; policy deny patterns do not apply here.
         self._write_root = policy.write_root
 
     @property
@@ -95,6 +98,7 @@ class RegisterIntegrationTool(BaseTool[RegisterIntegrationInput]):
         if tool_input.metrics_prefix is not None:
             planned.append(_PendingWrite(METRICS_PREFIX_PATH, tool_input.metrics_prefix, "metrics-prefix"))
 
+        to_write: list[_PendingWrite] = []
         for entry in planned:
             conflict_at = _first_non_table_node(document, entry.path)
             if conflict_at is not None:
@@ -105,9 +109,6 @@ class RegisterIntegrationTool(BaseTool[RegisterIntegrationInput]):
                         f"{conflict_at} is not a table"
                     ),
                 )
-
-        to_write: list[_PendingWrite] = []
-        for entry in planned:
             existing = _read_existing(document, entry.path, integration)
             if existing is None:
                 to_write.append(entry)
@@ -125,7 +126,7 @@ class RegisterIntegrationTool(BaseTool[RegisterIntegrationInput]):
 
         if to_write:
             try:
-                config_path.write_text(tomlkit.dumps(document), encoding="utf-8")
+                _atomic_write(config_path, tomlkit.dumps(document))
             except OSError as e:
                 return ToolResult(success=False, error=f"Failed to write {config_path}: {e}")
             written = ", ".join(entry.label for entry in to_write)
@@ -133,6 +134,21 @@ class RegisterIntegrationTool(BaseTool[RegisterIntegrationInput]):
 
         sections = ", ".join(entry.label for entry in planned)
         return ToolResult(success=True, data=f"{integration!r} already registered in: {sections}")
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    fd, tmp_str = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    tmp_path = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        raise
 
 
 def _find_config(start: Path) -> Path | None:

--- a/ddev/tests/ai/tools/repo/__init__.py
+++ b/ddev/tests/ai/tools/repo/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/ddev/tests/ai/tools/repo/test_register_integration.py
+++ b/ddev/tests/ai/tools/repo/test_register_integration.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 
 import pytest
 import tomlkit
+from tomlkit import TOMLDocument
 
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.ai.tools.repo.register_integration import RegisterIntegrationTool
@@ -60,19 +61,19 @@ def existing_tool(repo_root: Path) -> RegisterIntegrationTool:
     return _build_tool(repo_root, "existing_integration")
 
 
-def _read_config(repo_root: Path) -> dict:
+def _read_config(repo_root: Path) -> TOMLDocument:
     return tomlkit.parse((repo_root / ".ddev" / "config.toml").read_text(encoding="utf-8"))
 
 
-def _platforms_for(doc, integration: str):
+def _platforms_for(doc: TOMLDocument, integration: str) -> list[str] | None:
     return doc["overrides"]["manifest"]["platforms"].get(integration)
 
 
-def _display_name_for(doc, integration: str):
+def _display_name_for(doc: TOMLDocument, integration: str) -> str | None:
     return doc["overrides"]["display-name"].get(integration)
 
 
-def _metrics_prefix_for(doc, integration: str):
+def _metrics_prefix_for(doc: TOMLDocument, integration: str) -> str | None:
     return doc["overrides"]["metrics-prefix"].get(integration)
 
 
@@ -289,7 +290,7 @@ async def test_missing_config_returns_failure(tmp_path):
     result = await tool.run({"platforms": ["linux"]})
 
     assert result.success is False
-    assert result.error is not None
+    assert result.error.startswith("Could not locate")
 
 
 async def test_walks_up_to_find_config(repo_root):

--- a/ddev/tests/ai/tools/repo/test_register_integration.py
+++ b/ddev/tests/ai/tools/repo/test_register_integration.py
@@ -10,6 +10,7 @@ import tomlkit
 from tomlkit import TOMLDocument
 
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
+from ddev.ai.tools.repo import register_integration as register_integration_module
 from ddev.ai.tools.repo.register_integration import RegisterIntegrationTool
 
 # ---------------------------------------------------------------------------
@@ -352,3 +353,75 @@ async def test_platform_list_ordering_preserved(repo_root, platforms):
     assert result.success is True
     doc = _read_config(repo_root)
     assert list(_platforms_for(doc, "kuma")) == platforms
+
+
+# ---------------------------------------------------------------------------
+# Dedup applied to platforms input
+# ---------------------------------------------------------------------------
+
+
+async def test_duplicate_platforms_are_deduped_preserving_order(tool, repo_root):
+    """Repeated entries in `platforms` are collapsed before being written."""
+    result = await tool.run({"platforms": ["linux", "windows", "linux"]})
+
+    assert result.success is True
+    doc = _read_config(repo_root)
+    assert list(_platforms_for(doc, "kuma")) == ["linux", "windows"]
+
+
+async def test_duplicate_platforms_matching_existing_are_noop(existing_tool, repo_root):
+    """An input with duplicates that dedups to the existing value is a silent noop."""
+    original_bytes = (repo_root / ".ddev" / "config.toml").read_bytes()
+
+    result = await existing_tool.run({"platforms": ["linux", "linux", "windows", "mac_os"]})
+
+    assert result.success is True
+    assert (repo_root / ".ddev" / "config.toml").read_bytes() == original_bytes
+
+
+# ---------------------------------------------------------------------------
+# IO and parse failure paths surface as clean tool errors
+# ---------------------------------------------------------------------------
+
+
+async def test_read_failure_returns_clean_error(tool, monkeypatch):
+    """An OSError raised while reading the config surfaces as a tool-level error."""
+
+    def fail_read(self, *args, **kwargs):
+        raise PermissionError(f"Permission denied: {self}")
+
+    monkeypatch.setattr(Path, "read_text", fail_read)
+
+    result = await tool.run({"platforms": ["linux"]})
+
+    assert result.success is False
+    assert result.error is not None
+    assert "Failed to read" in result.error
+
+
+async def test_malformed_config_returns_parse_failure(tmp_path):
+    """A config that doesn't parse surfaces as a parse error rather than an exception."""
+    (tmp_path / ".ddev").mkdir()
+    (tmp_path / ".ddev" / "config.toml").write_text("not = valid = toml", encoding="utf-8")
+    tool = _build_tool(tmp_path, "kuma")
+
+    result = await tool.run({"platforms": ["linux"]})
+
+    assert result.success is False
+    assert result.error is not None
+    assert "Failed to parse" in result.error
+
+
+async def test_write_failure_returns_clean_error(tool, monkeypatch):
+    """An OSError raised while writing the config surfaces as a tool-level error."""
+
+    def fail_write(path: Path, content: str) -> None:
+        raise PermissionError(f"Permission denied: {path}")
+
+    monkeypatch.setattr(register_integration_module, "_atomic_write", fail_write)
+
+    result = await tool.run({"platforms": ["linux"]})
+
+    assert result.success is False
+    assert result.error is not None
+    assert "Failed to write" in result.error

--- a/ddev/tests/ai/tools/repo/test_register_integration.py
+++ b/ddev/tests/ai/tools/repo/test_register_integration.py
@@ -1,0 +1,331 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+import tomlkit
+
+from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
+from ddev.ai.tools.repo.register_integration import RegisterIntegrationTool
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SEED_TOML = dedent(
+    """\
+    # Repo-wide validations.
+    validations = ["agent-reqs"]
+
+    [overrides.display-name]
+    existing_integration = "Existing Integration"
+
+    [overrides.metrics-prefix]
+    existing_integration = "existing."
+
+    # Use manifest-like platforms
+    [overrides.manifest.platforms]
+    existing_integration = ["linux", "windows", "mac_os"]
+    """
+)
+
+
+@pytest.fixture
+def repo_root(tmp_path: Path) -> Path:
+    """tmp_path-rooted repo containing a seeded .ddev/config.toml."""
+    (tmp_path / ".ddev").mkdir()
+    (tmp_path / ".ddev" / "config.toml").write_text(SEED_TOML, encoding="utf-8")
+    return tmp_path
+
+
+def _build_tool(repo_root: Path, integration: str) -> RegisterIntegrationTool:
+    """Builds a tool whose write_root's basename is the integration name."""
+    write_root = repo_root / integration
+    write_root.mkdir(parents=True, exist_ok=True)
+    return RegisterIntegrationTool(FileAccessPolicy(write_root=write_root))
+
+
+@pytest.fixture
+def tool(repo_root: Path) -> RegisterIntegrationTool:
+    """Tool for a fresh integration named 'kuma'."""
+    return _build_tool(repo_root, "kuma")
+
+
+@pytest.fixture
+def existing_tool(repo_root: Path) -> RegisterIntegrationTool:
+    """Tool for the already-registered 'existing_integration'."""
+    return _build_tool(repo_root, "existing_integration")
+
+
+def _read_config(repo_root: Path) -> dict:
+    return tomlkit.parse((repo_root / ".ddev" / "config.toml").read_text(encoding="utf-8"))
+
+
+def _platforms_for(doc, integration: str):
+    return doc["overrides"]["manifest"]["platforms"].get(integration)
+
+
+def _display_name_for(doc, integration: str):
+    return doc["overrides"]["display-name"].get(integration)
+
+
+def _metrics_prefix_for(doc, integration: str):
+    return doc["overrides"]["metrics-prefix"].get(integration)
+
+
+# ---------------------------------------------------------------------------
+# Mandatory-only and optional combinations on a fresh integration
+# ---------------------------------------------------------------------------
+
+
+async def test_registers_only_manifest_platforms_when_no_optionals(tool, repo_root):
+    result = await tool.run({"platforms": ["linux"]})
+
+    assert result.success is True
+    doc = _read_config(repo_root)
+    assert _platforms_for(doc, "kuma") == ["linux"]
+    assert _display_name_for(doc, "kuma") is None
+    assert _metrics_prefix_for(doc, "kuma") is None
+
+
+async def test_writes_display_name_when_supplied(tool, repo_root):
+    result = await tool.run({"platforms": ["linux"], "display_name": "Kuma Mesh"})
+
+    assert result.success is True
+    doc = _read_config(repo_root)
+    assert _display_name_for(doc, "kuma") == "Kuma Mesh"
+    assert _metrics_prefix_for(doc, "kuma") is None
+
+
+async def test_writes_metrics_prefix_when_supplied(tool, repo_root):
+    result = await tool.run({"platforms": ["linux"], "metrics_prefix": "kuma."})
+
+    assert result.success is True
+    doc = _read_config(repo_root)
+    assert _metrics_prefix_for(doc, "kuma") == "kuma."
+    assert _display_name_for(doc, "kuma") is None
+
+
+async def test_writes_all_three_when_both_optionals_supplied(tool, repo_root):
+    result = await tool.run(
+        {
+            "platforms": ["linux", "windows"],
+            "display_name": "Kuma Mesh",
+            "metrics_prefix": "kuma.",
+        }
+    )
+
+    assert result.success is True
+    doc = _read_config(repo_root)
+    assert _platforms_for(doc, "kuma") == ["linux", "windows"]
+    assert _display_name_for(doc, "kuma") == "Kuma Mesh"
+    assert _metrics_prefix_for(doc, "kuma") == "kuma."
+
+
+# ---------------------------------------------------------------------------
+# Integration name derives from write_root
+# ---------------------------------------------------------------------------
+
+
+async def test_integration_name_taken_from_write_root_basename(repo_root):
+    """Naming the write_root 'foo_bar' registers 'foo_bar' — not any other name."""
+    tool = _build_tool(repo_root, "foo_bar")
+
+    result = await tool.run({"platforms": ["linux"]})
+
+    assert result.success is True
+    doc = _read_config(repo_root)
+    assert _platforms_for(doc, "foo_bar") == ["linux"]
+    assert _platforms_for(doc, "kuma") is None
+
+
+# ---------------------------------------------------------------------------
+# Preservation: pre-existing entries and comments survive
+# ---------------------------------------------------------------------------
+
+
+async def test_preserves_unrelated_entries_in_every_section(tool, repo_root):
+    await tool.run(
+        {
+            "platforms": ["linux"],
+            "display_name": "Kuma",
+            "metrics_prefix": "kuma.",
+        }
+    )
+
+    doc = _read_config(repo_root)
+    assert _platforms_for(doc, "existing_integration") == ["linux", "windows", "mac_os"]
+    assert _display_name_for(doc, "existing_integration") == "Existing Integration"
+    assert _metrics_prefix_for(doc, "existing_integration") == "existing."
+
+
+async def test_preserves_comments(tool, repo_root):
+    await tool.run({"platforms": ["linux"]})
+
+    raw = (repo_root / ".ddev" / "config.toml").read_text(encoding="utf-8")
+    assert "# Repo-wide validations." in raw
+    assert "# Use manifest-like platforms" in raw
+
+
+# ---------------------------------------------------------------------------
+# Idempotency: re-registering with the SAME values is a noop success
+# ---------------------------------------------------------------------------
+
+
+async def test_idempotent_same_platforms_returns_success_without_changes(existing_tool, repo_root):
+    """Re-running with platforms matching the existing entry returns success and does not rewrite."""
+    original_bytes = (repo_root / ".ddev" / "config.toml").read_bytes()
+
+    result = await existing_tool.run({"platforms": ["linux", "windows", "mac_os"]})
+
+    assert result.success is True
+    assert (repo_root / ".ddev" / "config.toml").read_bytes() == original_bytes
+
+
+async def test_idempotent_same_display_name(repo_root):
+    """If only display_name was previously set, re-supplying matches and noops."""
+    config_path = repo_root / ".ddev" / "config.toml"
+    doc = tomlkit.parse(config_path.read_text(encoding="utf-8"))
+    del doc["overrides"]["manifest"]["platforms"]["existing_integration"]
+    del doc["overrides"]["metrics-prefix"]["existing_integration"]
+    config_path.write_text(tomlkit.dumps(doc), encoding="utf-8")
+
+    tool = _build_tool(repo_root, "existing_integration")
+    result = await tool.run({"platforms": ["linux"], "display_name": "Existing Integration"})
+
+    assert result.success is True
+    parsed = _read_config(repo_root)
+    assert _display_name_for(parsed, "existing_integration") == "Existing Integration"
+    assert _platforms_for(parsed, "existing_integration") == ["linux"]
+
+
+# ---------------------------------------------------------------------------
+# Mismatch: re-registering with a DIFFERENT value fails loudly
+# ---------------------------------------------------------------------------
+
+
+async def test_mismatch_on_platforms_fails_with_diff_in_error(existing_tool, repo_root):
+    result = await existing_tool.run({"platforms": ["linux"]})
+
+    assert result.success is False
+    assert "manifest.platforms" in result.error
+    assert "['linux']" in result.error
+    assert "linux" in result.error and "windows" in result.error and "mac_os" in result.error
+
+    doc = _read_config(repo_root)
+    assert _platforms_for(doc, "existing_integration") == ["linux", "windows", "mac_os"]
+
+
+async def test_mismatch_on_display_name_fails(repo_root):
+    config_path = repo_root / ".ddev" / "config.toml"
+    doc = tomlkit.parse(config_path.read_text(encoding="utf-8"))
+    del doc["overrides"]["manifest"]["platforms"]["existing_integration"]
+    config_path.write_text(tomlkit.dumps(doc), encoding="utf-8")
+
+    tool = _build_tool(repo_root, "existing_integration")
+    result = await tool.run(
+        {
+            "platforms": ["linux"],
+            "display_name": "Something Different",
+        }
+    )
+
+    assert result.success is False
+    assert "display-name" in result.error
+    assert "Something Different" in result.error
+    assert "Existing Integration" in result.error
+
+
+async def test_mismatch_on_metrics_prefix_fails(repo_root):
+    config_path = repo_root / ".ddev" / "config.toml"
+    doc = tomlkit.parse(config_path.read_text(encoding="utf-8"))
+    del doc["overrides"]["manifest"]["platforms"]["existing_integration"]
+    config_path.write_text(tomlkit.dumps(doc), encoding="utf-8")
+
+    tool = _build_tool(repo_root, "existing_integration")
+    result = await tool.run(
+        {
+            "platforms": ["linux"],
+            "metrics_prefix": "different.",
+        }
+    )
+
+    assert result.success is False
+    assert "metrics-prefix" in result.error
+    assert "different." in result.error
+    assert "existing." in result.error
+
+
+async def test_mismatch_leaves_other_sections_untouched(existing_tool, repo_root):
+    """A mismatch on the mandatory section must not partially-write the optionals."""
+    await existing_tool.run(
+        {
+            "platforms": ["linux"],
+            "display_name": "Should Not Apply",
+            "metrics_prefix": "should_not_apply.",
+        }
+    )
+
+    doc = _read_config(repo_root)
+    assert _display_name_for(doc, "existing_integration") == "Existing Integration"
+    assert _metrics_prefix_for(doc, "existing_integration") == "existing."
+    assert _platforms_for(doc, "existing_integration") == ["linux", "windows", "mac_os"]
+
+
+# ---------------------------------------------------------------------------
+# Locating .ddev/config.toml
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_config_returns_failure(tmp_path):
+    """No .ddev/config.toml anywhere walking up — clear failure."""
+    write_root = tmp_path / "scratch" / "kuma"
+    write_root.mkdir(parents=True)
+    tool = RegisterIntegrationTool(FileAccessPolicy(write_root=write_root))
+
+    result = await tool.run({"platforms": ["linux"]})
+
+    assert result.success is False
+    assert result.error is not None
+
+
+async def test_walks_up_to_find_config(repo_root):
+    """write_root nested several levels below repo root still resolves the config."""
+    deep = repo_root / "a" / "b" / "kuma"
+    deep.mkdir(parents=True)
+    tool = RegisterIntegrationTool(FileAccessPolicy(write_root=deep))
+
+    result = await tool.run({"platforms": ["linux"]})
+
+    assert result.success is True
+    doc = _read_config(repo_root)
+    assert _platforms_for(doc, "kuma") == ["linux"]
+
+
+# ---------------------------------------------------------------------------
+# Platform list ordering survives the round-trip on a write
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "platforms",
+    [
+        ["linux"],
+        ["windows"],
+        ["mac_os"],
+        ["linux", "windows"],
+        ["windows", "linux"],
+        ["linux", "windows", "mac_os"],
+        ["mac_os", "linux", "windows"],
+    ],
+)
+async def test_platform_list_ordering_preserved(repo_root, platforms):
+    tool = _build_tool(repo_root, "kuma")
+    result = await tool.run({"platforms": platforms})
+
+    assert result.success is True
+    doc = _read_config(repo_root)
+    assert list(_platforms_for(doc, "kuma")) == platforms

--- a/ddev/tests/ai/tools/repo/test_register_integration.py
+++ b/ddev/tests/ai/tools/repo/test_register_integration.py
@@ -260,6 +260,28 @@ async def test_mismatch_on_metrics_prefix_fails(repo_root):
     assert "existing." in result.error
 
 
+async def test_structural_conflict_returns_clean_error(tmp_path):
+    """A scalar where a table is expected surfaces with integration + config path context."""
+    (tmp_path / ".ddev").mkdir()
+    (tmp_path / ".ddev" / "config.toml").write_text(
+        dedent(
+            """\
+            [overrides]
+            manifest = "not a table"
+            """
+        ),
+        encoding="utf-8",
+    )
+    tool = _build_tool(tmp_path, "kuma")
+
+    result = await tool.run({"platforms": ["linux"]})
+
+    assert result.success is False
+    assert "manifest.platforms" in result.error
+    assert "kuma" in result.error
+    assert "overrides.manifest" in result.error
+
+
 async def test_mismatch_leaves_other_sections_untouched(existing_tool, repo_root):
     """A mismatch on the mandatory section must not partially-write the optionals."""
     await existing_tool.run(


### PR DESCRIPTION
### What does this PR do?

Adds a new AI-framework tool, `register_integration`, that registers a freshly-scaffolded integration in the repo-wide `.ddev/config.toml`. The tool lives in a new package `ddev/src/ddev/ai/tools/repo/` reserved for tools that mutate repo-wide state.

**Inputs**:
- `platforms: list["linux" | "windows" | "mac_os"]` — required, non-empty.
- `display_name: str | None` — optional.
- `metrics_prefix: str | None` — optional.

The integration's snake_case name is **derived from `policy.write_root.name`** — it is not passed as an input. The same convention lets the tool locate `.ddev/config.toml` by walking up from `write_root`. This keeps the agent's contract minimal (it never has to remember the integration name twice) and avoids any path-injection surface.

**Writes** (using `tomlkit` so comments and ordering survive the round-trip):
- `[overrides.manifest.platforms].<integration>` — always.
- `[overrides.display-name].<integration>` — only when `display_name` is supplied.
- `[overrides.metrics-prefix].<integration>` — only when `metrics_prefix` is supplied.

**Idempotent semantics** — safe to call more than once with the same arguments:
- Section absent → write it.
- Section present with the **same** value → silent noop (no rewrite, no churn on `config.toml`).
- Section present with a **different** value → hard failure surfacing both the existing and requested values, so a real conflict isn't silently clobbered.

The tool intentionally does **not** go through `FileAccessPolicy`. The policy exists to constrain *generic* file editors where the agent picks the path; here the path is hardcoded (located via `write_root`) and the inputs are schema-constrained, so there is no path-injection surface.

### Motivation

With the recent change on building integrations without manifest, new integrations need to update `.ddev/config.toml`, as shown in [this page](https://datadoghq.atlassian.net/wiki/spaces/AI/pages/6248108729/Building+Integrations+Without+a+Manifest). Until now, the only way for an integration-creation agent to update `.ddev/config.toml` would have been to grant the FS toolset write access to the repo root — defeating the policy's "agent writes are confined to the integration directory" guarantee. The alternatives — letting the agent edit arbitrary files outside its sandbox, or asking it to construct TOML edits by hand — are both worse than a single structured tool with a fixed contract.

`register_integration` solves this with the smallest possible surface area:
- A schema-constrained input (no free-form path, no free-form section name).
- A hardcoded target file located deterministically from the agent's own `write_root`.
- Idempotent writes, so a retry after a transient failure higher up the flow does the right thing instead of failing on its second attempt.

The integration is not considered fully shipped until `register_integration` has been called, so the tool description tells the agent to invoke it once scaffolding is complete.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged