### PR TITLE
DDS: GTI VirusTotal : Threat Intel Integration Without Assets

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -318,6 +318,11 @@ datadog_checks_base/datadog_checks/base/checks/windows/              @DataDog/wi
 /greenhouse/manifest.json                                             @DataDog/saas-integrations @DataDog/documentation
 /greenhouse/assets/logs/                                              @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
 
+/gti_virustotal/                                                      @DataDog/saas-integrations
+/gti_virustotal/*.md                                                  @DataDog/saas-integrations @DataDog/documentation
+/gti_virustotal/manifest.json                                         @DataDog/saas-integrations @DataDog/documentation
+/gti_virustotal/assets/logs/                                          @DataDog/saas-integrations @DataDog/documentation @DataDog/logs-integrations-reviewers
+
 /iboss/                                                              @DataDog/saas-integrations @DataDog/agent-integrations
 /iboss/*.md                                                          @DataDog/saas-integrations @DataDog/agent-integrations @DataDog/documentation
 /iboss/manifest.json                                                 @DataDog/saas-integrations @DataDog/agent-integrations @DataDog/documentation

--- a/.github/workflows/config/labeler.yml
+++ b/.github/workflows/config/labeler.yml
@@ -609,6 +609,10 @@ integration/greenhouse:
 - changed-files:
   - any-glob-to-any-file:
     - greenhouse/**/*
+integration/gti_virustotal:
+- changed-files:
+  - any-glob-to-any-file:
+    - gti_virustotal/**/*
 integration/guarddog:
 - changed-files:
   - any-glob-to-any-file:

--- a/gti_virustotal/CHANGELOG.md
+++ b/gti_virustotal/CHANGELOG.md
@@ -1,0 +1,7 @@
+# CHANGELOG - gti_virustotal
+
+## 1.0.0 / 2026-05-18
+
+***Added***:
+
+* Initial Release

--- a/gti_virustotal/README.md
+++ b/gti_virustotal/README.md
@@ -1,0 +1,39 @@
+# Agent Check: GTI VirusTotal
+
+## Overview
+
+This check monitors [GTI VirusTotal][1].
+
+## Setup
+
+### Installation
+
+The GTI VirusTotal check is included in the [Datadog Agent][2] package.
+No additional installation is needed on your server.
+
+### Configuration
+
+!!! Add list of steps to set up this integration !!!
+
+### Validation
+
+!!! Add steps to validate integration is functioning as expected !!!
+
+## Data Collected
+
+### Metrics
+
+GTI VirusTotal does not include any metrics.
+
+### Events
+
+GTI VirusTotal does not include any events.
+
+## Troubleshooting
+
+Need help? Contact [Datadog support][3].
+
+[1]: **LINK_TO_INTEGRATION_SITE**
+[2]: https://app.datadoghq.com/account/settings/agent/latest
+[3]: https://docs.datadoghq.com/help/
+

--- a/gti_virustotal/manifest.json
+++ b/gti_virustotal/manifest.json
@@ -7,7 +7,7 @@
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",
-    "support": "README.md#Support",
+    "support": "README.md#Troubleshooting",
     "changelog": "CHANGELOG.md",
     "description": "<FILL IN - A brief description of what this offering provides>",
     "title": "GTI VirusTotal",

--- a/gti_virustotal/manifest.json
+++ b/gti_virustotal/manifest.json
@@ -1,0 +1,36 @@
+{
+  "manifest_version": "2.0.0",
+  "app_uuid": "eb4af193-e43d-44b8-a6a8-5fea46e1752b",
+  "app_id": "gti-virustotal",
+  "owner": "saas-integrations",
+  "display_on_public_website": false,
+  "tile": {
+    "overview": "README.md#Overview",
+    "configuration": "README.md#Setup",
+    "support": "README.md#Support",
+    "changelog": "CHANGELOG.md",
+    "description": "<FILL IN - A brief description of what this offering provides>",
+    "title": "GTI VirusTotal",
+    "media": [],
+    "classifier_tags": [
+      "Category::Metrics",
+      "Offering::Integration"
+    ]
+  },
+  "assets": {
+    "integration": {
+      "auto_install": false,
+      "source_type_id": 72539026,
+      "source_type_name": "GTI VirusTotal",
+      "events": {
+        "creates_events": false
+      }
+    }
+  },
+  "author": {
+    "support_email": "help@datadoghq.com",
+    "name": "Datadog",
+    "homepage": "https://www.datadoghq.com",
+    "sales_email": "info@datadoghq.com"
+  }
+}


### PR DESCRIPTION
### What does this PR do?
PR includes skeleton of GTI VirusTotal threat intel integration without any assets like dashboards, image, README content, etc.

### Motivation
This is beta release of crawler integration and is intended for internal testing before going live. As per @nathanmadams's
 suggestion, we will raise separate PR with assets and all necessary information later.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
