### PR TITLE
Add OCSF DNS Activity normalization to coredns pipeline

### DIFF
--- a/coredns/assets/logs/coredns.yaml
+++ b/coredns/assets/logs/coredns.yaml
@@ -114,12 +114,13 @@ facets:
     source: log
   - groups:
       - OCSF
-    name: Rcode ID
+    name: Response Code ID
     path: ocsf.rcode_id
     source: log
+    type: integer
   - groups:
       - OCSF
-    name: Rcode
+    name: Response Code
     path: ocsf.rcode
     source: log
   - groups:
@@ -129,17 +130,18 @@ facets:
     source: log
   - groups:
       - OCSF
-    name: Source Port
+    name: Src Endpoint Port
     path: ocsf.src_endpoint.port
     source: log
+    type: integer
   - groups:
       - OCSF
-    name: Query Hostname
+    name: DNS Query Hostname
     path: ocsf.query.hostname
     source: log
   - groups:
       - OCSF
-    name: Query Type
+    name: Query Resource Record Type
     path: ocsf.query.type
     source: log
   - groups:

--- a/coredns/assets/logs/coredns.yaml
+++ b/coredns/assets/logs/coredns.yaml
@@ -128,7 +128,8 @@ facets:
     name: Source IP Address
     path: ocsf.src_endpoint.ip
     source: log
-  - groups:
+  - facetType: range
+    groups:
       - OCSF
     name: Src Endpoint Port
     path: ocsf.src_endpoint.port

--- a/coredns/assets/logs/coredns.yaml
+++ b/coredns/assets/logs/coredns.yaml
@@ -62,6 +62,96 @@ facets:
     name: DNSSEC
     path: dns.dnssec
     source: log
+  - groups:
+      - OCSF
+    name: Activity ID
+    path: ocsf.activity_id
+    source: log
+  - groups:
+      - OCSF
+    name: Activity Name
+    path: ocsf.activity_name
+    source: log
+  - groups:
+      - OCSF
+    name: Category ID
+    path: ocsf.category_uid
+    source: log
+  - groups:
+      - OCSF
+    name: Category
+    path: ocsf.category_name
+    source: log
+  - groups:
+      - OCSF
+    name: Class ID
+    path: ocsf.class_uid
+    source: log
+  - groups:
+      - OCSF
+    name: Class
+    path: ocsf.class_name
+    source: log
+  - groups:
+      - OCSF
+    name: Status ID
+    path: ocsf.status_id
+    source: log
+  - groups:
+      - OCSF
+    name: Status
+    path: ocsf.status
+    source: log
+  - groups:
+      - OCSF
+    name: Severity ID
+    path: ocsf.severity_id
+    source: log
+  - groups:
+      - OCSF
+    name: Severity
+    path: ocsf.severity
+    source: log
+  - groups:
+      - OCSF
+    name: Rcode ID
+    path: ocsf.rcode_id
+    source: log
+  - groups:
+      - OCSF
+    name: Rcode
+    path: ocsf.rcode
+    source: log
+  - groups:
+      - OCSF
+    name: Source IP Address
+    path: ocsf.src_endpoint.ip
+    source: log
+  - groups:
+      - OCSF
+    name: Source Port
+    path: ocsf.src_endpoint.port
+    source: log
+  - groups:
+      - OCSF
+    name: Query Hostname
+    path: ocsf.query.hostname
+    source: log
+  - groups:
+      - OCSF
+    name: Query Type
+    path: ocsf.query.type
+    source: log
+  - groups:
+      - OCSF
+    name: Query Class
+    path: ocsf.query.class
+    source: log
+  - groups:
+      - OCSF
+    name: Protocol Name
+    path: ocsf.connection_info.protocol_name
+    source: log
 pipeline:
   type: pipeline
   name: CoreDNS
@@ -90,3 +180,329 @@ pipeline:
       enabled: true
       sources:
         - level
+    - type: pipeline
+      name: OCSF sub pipeline for class DNS Activity [4003]
+      enabled: true
+      ocsf:
+        isOcsf: true
+      filter:
+        query: "@dns.question.name:*"
+      processors:
+        - type: string-builder-processor
+          name: Add ocsf.metadata.product.name
+          enabled: true
+          template: CoreDNS
+          target: ocsf.metadata.product.name
+          replaceMissing: false
+        - type: string-builder-processor
+          name: Add ocsf.metadata.product.vendor_name
+          enabled: true
+          template: CoreDNS
+          target: ocsf.metadata.product.vendor_name
+          replaceMissing: false
+        - type: arithmetic-processor
+          name: Convert `duration` (ns) to `ocsf.response_time` (ms)
+          enabled: true
+          expression: duration / 1000000
+          target: ocsf.response_time
+          replaceMissing: false
+        - type: schema-processor
+          name: Apply OCSF schema for 4003
+          enabled: true
+          schema:
+            schemaType: ocsf
+            version: 1.5.0
+            className: DNS Activity
+            classUid: 4003
+            extensions: []
+            profiles: []
+          mappers:
+            - name: ocsf.activity_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Traffic
+                  id: 6
+              targets:
+                name: ocsf.activity_name
+                id: ocsf.activity_id
+              fallback:
+                values: {}
+                sources: {}
+              type: schema-category-mapper
+            - name: ocsf.connection_info.direction_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Inbound
+                  id: 1
+              targets:
+                name: ocsf.connection_info.direction
+                id: ocsf.connection_info.direction_id
+              fallback:
+                values: {}
+                sources: {}
+              type: schema-category-mapper
+            - name: ocsf.severity_id
+              categories:
+                - filter:
+                    query: "@level:(INFO OR DEBUG)"
+                  name: Informational
+                  id: 1
+                - filter:
+                    query: "@level:(WARN OR WARNING)"
+                  name: Medium
+                  id: 3
+                - filter:
+                    query: "@level:ERROR"
+                  name: High
+                  id: 4
+                - filter:
+                    query: "@level:FATAL"
+                  name: Fatal
+                  id: 6
+                - filter:
+                    query: "*"
+                  name: Other
+                  id: 99
+              targets:
+                name: ocsf.severity
+                id: ocsf.severity_id
+              fallback:
+                values:
+                  ocsf.severity: Other
+                  ocsf.severity_id: "99"
+                sources:
+                  ocsf.severity:
+                    - level
+              type: schema-category-mapper
+            - name: ocsf.status_id
+              categories:
+                - filter:
+                    query: "@dns.flags.rcode:NOERROR"
+                  name: Success
+                  id: 1
+                - filter:
+                    query: "*"
+                  name: Failure
+                  id: 2
+              targets:
+                name: ocsf.status
+                id: ocsf.status_id
+              fallback:
+                values: {}
+                sources: {}
+              type: schema-category-mapper
+            - name: ocsf.rcode_id
+              categories:
+                - filter:
+                    query: "@dns.flags.rcode:NOERROR"
+                  name: NoError
+                  id: 0
+                - filter:
+                    query: "@dns.flags.rcode:FORMERR"
+                  name: FormError
+                  id: 1
+                - filter:
+                    query: "@dns.flags.rcode:SERVFAIL"
+                  name: ServError
+                  id: 2
+                - filter:
+                    query: "@dns.flags.rcode:NXDOMAIN"
+                  name: NXDomain
+                  id: 3
+                - filter:
+                    query: "@dns.flags.rcode:(NOTIMP OR NOTIMPL)"
+                  name: NotImp
+                  id: 4
+                - filter:
+                    query: "@dns.flags.rcode:REFUSED"
+                  name: Refused
+                  id: 5
+                - filter:
+                    query: "@dns.flags.rcode:YXDOMAIN"
+                  name: YXDomain
+                  id: 6
+                - filter:
+                    query: "@dns.flags.rcode:YXRRSET"
+                  name: YXRRSet
+                  id: 7
+                - filter:
+                    query: "@dns.flags.rcode:NXRRSET"
+                  name: NXRRSet
+                  id: 8
+                - filter:
+                    query: "@dns.flags.rcode:NOTAUTH"
+                  name: NotAuth
+                  id: 9
+                - filter:
+                    query: "@dns.flags.rcode:NOTZONE"
+                  name: NotZone
+                  id: 10
+                - filter:
+                    query: "@dns.flags.rcode:(DSOTYPENI OR RCODE11)"
+                  name: DSOTYPENI
+                  id: 11
+                - filter:
+                    query: "@dns.flags.rcode:(BADSIG OR BADVERS)"
+                  name: BADSIG_VERS
+                  id: 16
+                - filter:
+                    query: "@dns.flags.rcode:BADKEY"
+                  name: BADKEY
+                  id: 17
+                - filter:
+                    query: "@dns.flags.rcode:BADTIME"
+                  name: BADTIME
+                  id: 18
+                - filter:
+                    query: "@dns.flags.rcode:BADMODE"
+                  name: BADMODE
+                  id: 19
+                - filter:
+                    query: "@dns.flags.rcode:BADNAME"
+                  name: BADNAME
+                  id: 20
+                - filter:
+                    query: "@dns.flags.rcode:BADALG"
+                  name: BADALG
+                  id: 21
+                - filter:
+                    query: "@dns.flags.rcode:BADTRUNC"
+                  name: BADTRUNC
+                  id: 22
+                - filter:
+                    query: "@dns.flags.rcode:BADCOOKIE"
+                  name: BADCOOKIE
+                  id: 23
+                - filter:
+                    query: "@dns.flags.rcode:(RCODE12 OR RCODE13 OR RCODE14 OR RCODE15)"
+                  name: Unassigned
+                  id: 24
+                - filter:
+                    query: "@dns.flags.rcode:RCODE65535"
+                  name: Reserved
+                  id: 25
+                - filter:
+                    query: "*"
+                  name: Other
+                  id: 99
+              targets:
+                name: ocsf.rcode
+                id: ocsf.rcode_id
+              fallback:
+                values:
+                  ocsf.rcode: Other
+                  ocsf.rcode_id: "99"
+                sources:
+                  ocsf.rcode:
+                    - dns.flags.rcode
+              type: schema-category-mapper
+            - name: Map `ocsf.metadata.product.name` to `ocsf.metadata.product.name`
+              sources:
+                - ocsf.metadata.product.name
+              sourceType: attribute
+              target: ocsf.metadata.product.name
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.metadata.product.vendor_name` to `ocsf.metadata.product.vendor_name`
+              sources:
+                - ocsf.metadata.product.vendor_name
+              sourceType: attribute
+              target: ocsf.metadata.product.vendor_name
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.response_time` to `ocsf.response_time`
+              sources:
+                - ocsf.response_time
+              sourceType: attribute
+              target: ocsf.response_time
+              targetFormat: integer
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `level` to `ocsf.metadata.log_level`
+              sources:
+                - level
+              sourceType: attribute
+              target: ocsf.metadata.log_level
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `timestamp` to `ocsf.time`
+              sources:
+                - timestamp
+              sourceType: attribute
+              target: ocsf.time
+              targetFormat: integer
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `network.client.ip` to `ocsf.src_endpoint.ip`
+              sources:
+                - network.client.ip
+              sourceType: attribute
+              target: ocsf.src_endpoint.ip
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `network.client.port` to `ocsf.src_endpoint.port`
+              sources:
+                - network.client.port
+              sourceType: attribute
+              target: ocsf.src_endpoint.port
+              targetFormat: integer
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `dns.question.name` to `ocsf.query.hostname`
+              sources:
+                - dns.question.name
+              sourceType: attribute
+              target: ocsf.query.hostname
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `dns.question.type` to `ocsf.query.type`
+              sources:
+                - dns.question.type
+              sourceType: attribute
+              target: ocsf.query.type
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `dns.question.class` to `ocsf.query.class`
+              sources:
+                - dns.question.class
+              sourceType: attribute
+              target: ocsf.query.class
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `dns.protocol` to `ocsf.connection_info.protocol_name`
+              sources:
+                - dns.protocol
+              sourceType: attribute
+              target: ocsf.connection_info.protocol_name
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `dns.flags.rcode` to `ocsf.status_code`
+              sources:
+                - dns.flags.rcode
+              sourceType: attribute
+              target: ocsf.status_code
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper

--- a/coredns/assets/logs/coredns.yaml
+++ b/coredns/assets/logs/coredns.yaml
@@ -229,9 +229,6 @@ pipeline:
               targets:
                 name: ocsf.activity_name
                 id: ocsf.activity_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: ocsf.connection_info.direction_id
               categories:
@@ -242,9 +239,6 @@ pipeline:
               targets:
                 name: ocsf.connection_info.direction
                 id: ocsf.connection_info.direction_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: ocsf.severity_id
               categories:
@@ -292,9 +286,6 @@ pipeline:
               targets:
                 name: ocsf.status
                 id: ocsf.status_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: ocsf.rcode_id
               categories:

--- a/coredns/assets/logs/coredns_tests.yaml
+++ b/coredns/assets/logs/coredns_tests.yaml
@@ -6,8 +6,8 @@ tests:
     custom:
       dns:
         answer:
-          size: 174.0
-        buffer: 512.0
+          size: 174
+        buffer: 512
         dnssec: "false"
         flags:
           list:
@@ -16,21 +16,54 @@ tests:
            - "rd"
            - "ra"
           rcode: "NXDOMAIN"
-        id: 21628.0
+        id: 21628
         protocol: "udp"
         question:
           class: "IN"
           name: "trace-k8s.agent.datadoghq.com.apm1.cluster.local."
-          size: 66.0
+          size: 66
           type: "AAAA"
-      duration: 78493.0
+      duration: 78493
       level: "INFO"
       network:
         client:
           ip: "10.145.105.176"
           port: "36008"
+      ocsf:
+        activity_id: 6
+        activity_name: "Traffic"
+        category_name: "Network Activity"
+        category_uid: 4
+        class_name: "DNS Activity"
+        class_uid: 4003
+        connection_info:
+          direction: "Inbound"
+          direction_id: 1
+          protocol_name: "udp"
+        metadata:
+          log_level: "INFO"
+          product:
+            name: "CoreDNS"
+            vendor_name: "CoreDNS"
+          version: "1.5.0"
+        query:
+          class: "IN"
+          hostname: "trace-k8s.agent.datadoghq.com.apm1.cluster.local."
+          type: "AAAA"
+        rcode: "NXDomain"
+        rcode_id: 3
+        response_time: 0
+        severity: "Informational"
+        severity_id: 1
+        src_endpoint:
+          ip: "10.145.105.176"
+          port: 36008
+        status: "Failure"
+        status_code: "NXDOMAIN"
+        status_id: 2
+        time: 1574952440550
       timestamp: 1574952440550
-    message: "2019-11-28T14:47:20.55Z [INFO] 10.145.105.176:36008 - 21628 \"AAAA IN trace-k8s.agent.datadoghq.com.apm1.cluster.local. udp 66 false 512\" NXDOMAIN qr,aa,rd,ra 174 0.000078493s"
+    message: '2019-11-28T14:47:20.55Z [INFO] 10.145.105.176:36008 - 21628 "AAAA IN trace-k8s.agent.datadoghq.com.apm1.cluster.local. udp 66 false 512" NXDOMAIN qr,aa,rd,ra 174 0.000078493s'
     status: "info"
     tags:
      - "source:LOGS_SOURCE"
@@ -41,8 +74,8 @@ tests:
     custom:
       dns:
         answer:
-          size: 68.0
-        buffer: 4096.0
+          size: 68
+        buffer: 4096
         dnssec: "false"
         flags:
           list:
@@ -51,22 +84,53 @@ tests:
            - "ra"
            - "ad"
           rcode: "NOERROR"
-        id: 29008.0
+        id: 29008
         protocol: "udp"
         question:
           class: "IN"
           name: "example.org."
-          size: 41.0
+          size: 41
           type: "A"
-      duration: 3.7990251E7
+      duration: 37990251
       level: "INFO"
       network:
         client:
           ip: "127.0.0.1"
           port: "50759"
-    message: "[INFO] 127.0.0.1:50759 - 29008 \"A IN example.org. udp 41 false 4096\" NOERROR qr,rd,ra,ad 68 0.037990251s"
+      ocsf:
+        activity_id: 6
+        activity_name: "Traffic"
+        category_name: "Network Activity"
+        category_uid: 4
+        class_name: "DNS Activity"
+        class_uid: 4003
+        connection_info:
+          direction: "Inbound"
+          direction_id: 1
+          protocol_name: "udp"
+        metadata:
+          log_level: "INFO"
+          product:
+            name: "CoreDNS"
+            vendor_name: "CoreDNS"
+          version: "1.5.0"
+        query:
+          class: "IN"
+          hostname: "example.org."
+          type: "A"
+        rcode: "NoError"
+        rcode_id: 0
+        response_time: 37
+        severity: "Informational"
+        severity_id: 1
+        src_endpoint:
+          ip: "127.0.0.1"
+          port: 50759
+        status: "Success"
+        status_code: "NOERROR"
+        status_id: 1
+    message: '[INFO] 127.0.0.1:50759 - 29008 "A IN example.org. udp 41 false 4096" NOERROR qr,rd,ra,ad 68 0.037990251s'
     status: "info"
     tags:
      - "source:LOGS_SOURCE"
     timestamp: 1
-


### PR DESCRIPTION
### What does this PR do?
Maps CoreDNS query/response logs to OCSF DNS Activity [4003]. Adds:
- A single-class `OCSF sub pipeline for class DNS Activity [4003]`  with metadata string-builders, an arithmetic-processor that converts `duration` (ns) → `ocsf.response_time` (ms), and a `schema-processor` with category-mappers for `activity_id`, `connection_info.direction_id`, `severity_id`, `status_id`, and `rcode_id` (covers all 23 OCSF rcode enum values), plus direct remappers for time, endpoint, query, and protocol fields.
- Generated expected OCSF blocks in `coredns_tests.yaml`.

### Motivation
Bring CoreDNS into the OCSF normalization effort so Cloud SIEM detections and dashboards that key off `ocsf.*` apply to CoreDNS DNS logs alongside other DNS sources (e.g., BlueCat Integrity, Cisco Umbrella DNS).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)