### PR TITLE
Add http_status_code tag to http metrics

### DIFF
--- a/http_check/changelog.d/23731.added
+++ b/http_check/changelog.d/23731.added
@@ -1,0 +1,1 @@
+Add http_status_code tag to http metrics.

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -183,6 +183,9 @@ class HTTPCheck(AgentCheck):
             raise
 
         else:
+            if r is not None:
+                http_status = r.status_code
+                tags_list.append("http_status_code:{}".format(http_status))
             if use_cert_from_response:
                 peer_cert = r.raw.connection.sock.getpeercert(binary_form=True)
 
@@ -271,6 +274,9 @@ class HTTPCheck(AgentCheck):
             tags_list = list(tags)
             tags_list.append("url:{}".format(addr))
             tags_list.append("instance:{}".format(instance_name))
+            if r is not None:
+                http_status = r.status_code
+                tags_list.append("http_status_code:{}".format(http_status))
             self.gauge("http.ssl.days_left", days_left, tags=tags_list)
             self.gauge("http.ssl.seconds_left", seconds_left, tags=tags_list)
 

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -274,9 +274,6 @@ class HTTPCheck(AgentCheck):
             tags_list = list(tags)
             tags_list.append("url:{}".format(addr))
             tags_list.append("instance:{}".format(instance_name))
-            if r is not None:
-                http_status = r.status_code
-                tags_list.append("http_status_code:{}".format(http_status))
             self.gauge("http.ssl.days_left", days_left, tags=tags_list)
             self.gauge("http.ssl.seconds_left", seconds_left, tags=tags_list)
 

--- a/http_check/tests/test_http_integration.py
+++ b/http_check/tests/test_http_integration.py
@@ -225,8 +225,11 @@ def test_check_ssl(aggregator, http_check):
         http_check.check(instance)
 
     good_cert_tags = ['url:https://valid.mock:443', 'instance:good_cert']
+    ssl_metric_tags = ['url:https://valid.mock:443','instance:good_cert','http_status_code:200',]
     aggregator.assert_service_check(HTTPCheck.SC_STATUS, status=HTTPCheck.OK, tags=good_cert_tags, count=1)
     aggregator.assert_service_check(HTTPCheck.SC_SSL_CERT, status=HTTPCheck.OK, tags=good_cert_tags, count=1)
+    aggregator.assert_metric('http.ssl.days_left', tags=ssl_metric_tags, count=1)
+    aggregator.assert_metric('http.ssl.seconds_left', tags=ssl_metric_tags, count=1)
 
     expiring_soon_cert_tags = ['url:https://valid.mock', 'instance:cert_exp_soon']
     aggregator.assert_service_check(HTTPCheck.SC_STATUS, status=HTTPCheck.OK, tags=expiring_soon_cert_tags, count=1)
@@ -430,11 +433,12 @@ def test_data_methods(aggregator, http_check):
 
         url_tag = ['url:{}'.format(instance.get('url'))]
         instance_tag = ['instance:{}'.format(instance.get('name'))]
+        http_status_tag = ['http_status_code:{}'.format('200')]
 
         aggregator.assert_service_check(HTTPCheck.SC_STATUS, status=AgentCheck.OK, tags=url_tag + instance_tag, count=1)
-        aggregator.assert_metric('network.http.can_connect', tags=url_tag + instance_tag, value=1.0, count=1)
-        aggregator.assert_metric('network.http.cant_connect', tags=url_tag + instance_tag, value=0.0, count=1)
-        aggregator.assert_metric('network.http.response_time', tags=url_tag + instance_tag, count=1)
+        aggregator.assert_metric('network.http.can_connect', tags=url_tag + instance_tag + http_status_tag, value=1.0, count=1)
+        aggregator.assert_metric('network.http.cant_connect', tags=url_tag + instance_tag + http_status_tag, value=0.0, count=1)
+        aggregator.assert_metric('network.http.response_time', tags=url_tag + instance_tag + http_status_tag, count=1)
 
         # Assert coverage for this check on this instance
         aggregator.assert_all_metrics_covered()

--- a/http_check/tests/test_http_integration.py
+++ b/http_check/tests/test_http_integration.py
@@ -225,11 +225,8 @@ def test_check_ssl(aggregator, http_check):
         http_check.check(instance)
 
     good_cert_tags = ['url:https://valid.mock:443', 'instance:good_cert']
-    ssl_metric_tags = ['url:https://valid.mock:443','instance:good_cert','http_status_code:200',]
     aggregator.assert_service_check(HTTPCheck.SC_STATUS, status=HTTPCheck.OK, tags=good_cert_tags, count=1)
     aggregator.assert_service_check(HTTPCheck.SC_SSL_CERT, status=HTTPCheck.OK, tags=good_cert_tags, count=1)
-    aggregator.assert_metric('http.ssl.days_left', tags=ssl_metric_tags, count=1)
-    aggregator.assert_metric('http.ssl.seconds_left', tags=ssl_metric_tags, count=1)
 
     expiring_soon_cert_tags = ['url:https://valid.mock', 'instance:cert_exp_soon']
     aggregator.assert_service_check(HTTPCheck.SC_STATUS, status=HTTPCheck.OK, tags=expiring_soon_cert_tags, count=1)

--- a/http_check/tests/test_http_integration.py
+++ b/http_check/tests/test_http_integration.py
@@ -433,8 +433,12 @@ def test_data_methods(aggregator, http_check):
         http_status_tag = ['http_status_code:{}'.format('200')]
 
         aggregator.assert_service_check(HTTPCheck.SC_STATUS, status=AgentCheck.OK, tags=url_tag + instance_tag, count=1)
-        aggregator.assert_metric('network.http.can_connect', tags=url_tag + instance_tag + http_status_tag, value=1.0, count=1)
-        aggregator.assert_metric('network.http.cant_connect', tags=url_tag + instance_tag + http_status_tag, value=0.0, count=1)
+        aggregator.assert_metric(
+            'network.http.can_connect', tags=url_tag + instance_tag + http_status_tag, value=1.0, count=1
+        )
+        aggregator.assert_metric(
+            'network.http.cant_connect', tags=url_tag + instance_tag + http_status_tag, value=0.0, count=1
+        )
         aggregator.assert_metric('network.http.response_time', tags=url_tag + instance_tag + http_status_tag, count=1)
 
         # Assert coverage for this check on this instance


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds an http_status_code tag for the following metrics:

- network.http.response_time
- network.http.can_connect
- network.http.cant_connect

### Motivation
<!-- What inspired you to submit this pull request? -->

[Customer feature request](https://datadoghq.atlassian.net/browse/FRAGENT-3384). 

Customers need to see which status codes their endpoints return. Today they work around this with the config http_response_status_code and manually configuring it on each instance, which doesn’t scale when many URLs intermittently return codes like 521

Previous workaround:
```python
http_response_status_code: (2)\d\d
    tags:
      - status:2xx 
``` 


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
