### PR TITLE
Add new config use_ssl for Tibco EMS

### DIFF
--- a/tibco_ems/assets/configuration/spec.yaml
+++ b/tibco_ems/assets/configuration/spec.yaml
@@ -63,4 +63,12 @@ files:
       value:
         type: string
         require_trusted_provider: true
+    - name: use_ssl
+      description: |
+        Set to `true` to connect to the Tibco EMS server using SSL (`ssl://host:port`).
+        When `false`, the check uses `tcp://host:port`.
+      value:
+        type: boolean
+        default: false
+        example: false
     - template: instances/default

--- a/tibco_ems/assets/configuration/spec.yaml
+++ b/tibco_ems/assets/configuration/spec.yaml
@@ -70,5 +70,5 @@ files:
       value:
         type: boolean
         default: false
-        example: false
+        example: true
     - template: instances/default

--- a/tibco_ems/changelog.d/23732.added
+++ b/tibco_ems/changelog.d/23732.added
@@ -1,0 +1,1 @@
+Add new config ``use_ssl`` to connect via SSL instead of TCP.

--- a/tibco_ems/datadog_checks/tibco_ems/config_models/defaults.py
+++ b/tibco_ems/datadog_checks/tibco_ems/config_models/defaults.py
@@ -34,3 +34,7 @@ def instance_min_collection_interval():
 
 def instance_port():
     return 7222
+
+
+def instance_use_ssl():
+    return False

--- a/tibco_ems/datadog_checks/tibco_ems/config_models/instance.py
+++ b/tibco_ems/datadog_checks/tibco_ems/config_models/instance.py
@@ -49,6 +49,7 @@ class InstanceConfig(BaseModel):
     service: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None
     tibemsadmin: Optional[str] = None
+    use_ssl: Optional[bool] = None
     username: Optional[str] = None
 
     @model_validator(mode='before')

--- a/tibco_ems/datadog_checks/tibco_ems/data/conf.yaml.example
+++ b/tibco_ems/datadog_checks/tibco_ems/data/conf.yaml.example
@@ -58,6 +58,12 @@ instances:
     #
     # tibemsadmin: <TIBEMSADMIN>
 
+    ## @param use_ssl - boolean - optional - default: false
+    ## Set to `true` to connect to the Tibco EMS server using SSL (`ssl://host:port`).
+    ## When `false`, the check uses `tcp://host:port`.
+    #
+    # use_ssl: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/tibco_ems/datadog_checks/tibco_ems/data/conf.yaml.example
+++ b/tibco_ems/datadog_checks/tibco_ems/data/conf.yaml.example
@@ -62,7 +62,7 @@ instances:
     ## Set to `true` to connect to the Tibco EMS server using SSL (`ssl://host:port`).
     ## When `false`, the check uses `tcp://host:port`.
     #
-    # use_ssl: false
+    # use_ssl: true
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/tibco_ems/datadog_checks/tibco_ems/tibco_ems.py
+++ b/tibco_ems/datadog_checks/tibco_ems/tibco_ems.py
@@ -7,7 +7,6 @@ from typing import Any  # noqa: F401
 
 from datadog_checks.base import AgentCheck, is_affirmative
 
-
 from .constants import SHOW_METRIC_DATA, UNIT_PATTERN
 
 DEFAULT_HOST = 'localhost'

--- a/tibco_ems/datadog_checks/tibco_ems/tibco_ems.py
+++ b/tibco_ems/datadog_checks/tibco_ems/tibco_ems.py
@@ -5,8 +5,7 @@ import re
 import subprocess
 from typing import Any  # noqa: F401
 
-from datadog_checks.base import AgentCheck
-from datadog_checks.base.utils.common import is_affirmative
+from datadog_checks.base import AgentCheck, is_affirmative
 
 
 from .constants import SHOW_METRIC_DATA, UNIT_PATTERN

--- a/tibco_ems/datadog_checks/tibco_ems/tibco_ems.py
+++ b/tibco_ems/datadog_checks/tibco_ems/tibco_ems.py
@@ -6,13 +6,16 @@ import subprocess
 from typing import Any  # noqa: F401
 
 from datadog_checks.base import AgentCheck
+from datadog_checks.base.utils.common import is_affirmative
+
 
 from .constants import SHOW_METRIC_DATA, UNIT_PATTERN
 
 DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = 7222
 TO_BYTES = {'b': 1, 'kb': 1e3, 'mb': 1e6, 'gb': 1e9, 'tb': 1e12}
-CONNECTION_STRING = 'tcp://{}:{}'
+TCP_CONNECTION_STRING = 'tcp://{}:{}'
+SSL_CONNECTION_STRING = 'ssl://{}:{}'
 
 
 class TibcoEMSCheck(AgentCheck):
@@ -29,7 +32,11 @@ class TibcoEMSCheck(AgentCheck):
         username = self.instance.get('username')
         password = self.instance.get('password')
         script_path = self.instance.get('script_path')
-        server_string = CONNECTION_STRING.format(host, port)
+        use_ssl = is_affirmative(self.instance.get('use_ssl', False))
+        if not use_ssl:
+            server_string = TCP_CONNECTION_STRING.format(host, port)
+        else:
+            server_string = SSL_CONNECTION_STRING.format(host, port)
         self.tags = self.instance.get('tags', [])
 
         self.cmd = tibemsadmin_cmd + [

--- a/tibco_ems/tests/test_unit.py
+++ b/tibco_ems/tests/test_unit.py
@@ -164,7 +164,7 @@ def test_base_tags(dd_run_check, instance):
     # assert the lenght of tags does not grow indefinitely
     assert len(check.tags) == 3
 
+
 def test_use_ssl_server_string(instance):
     check = TibcoEMSCheck('tibco_ems', {}, [{**instance, 'use_ssl': True}])
     assert 'ssl://localhost:7222' in check.cmd
-

--- a/tibco_ems/tests/test_unit.py
+++ b/tibco_ems/tests/test_unit.py
@@ -163,3 +163,8 @@ def test_base_tags(dd_run_check, instance):
 
     # assert the lenght of tags does not grow indefinitely
     assert len(check.tags) == 3
+
+def test_use_ssl_server_string(instance):
+    check = TibcoEMSCheck('tibco_ems', {}, [{**instance, 'use_ssl': True}])
+    assert 'ssl://localhost:7222' in check.cmd
+


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds a new config ``use_ssl`` to connect via SSL instead of the default TCP protocol.

### Motivation
<!-- What inspired you to submit this pull request? -->

Customer's [FR](https://datadoghq.atlassian.net/browse/FRAGENT-3472). Customers were not able to securely connect via the ssl protocol for the integration since it was previously hardcoded to TCP only. This allows customers to now use the SSL protocol for connection. This helps customers who have sensitive data have a more secure connection.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
