### PR TITLE
Run n8n queue-mode test environment on Postgres

### DIFF
--- a/n8n/changelog.d/23735.fixed
+++ b/n8n/changelog.d/23735.fixed
@@ -1,0 +1,1 @@
+Run n8n queue-mode test environment on Postgres.

--- a/n8n/changelog.d/23735.fixed
+++ b/n8n/changelog.d/23735.fixed
@@ -1,1 +1,0 @@
-Run n8n queue-mode test environment on Postgres.

--- a/n8n/tests/docker/docker-compose.yaml
+++ b/n8n/tests/docker/docker-compose.yaml
@@ -36,6 +36,7 @@ services:
       - DB_POSTGRESDB_DATABASE=n8n
       - DB_POSTGRESDB_USER=n8n
       - DB_POSTGRESDB_PASSWORD=n8n
+      - N8N_ENCRYPTION_KEY=test-encryption-key-not-a-secret
       - N8N_LOG_LEVEL=debug
       - N8N_LOG_OUTPUT=console
       - N8N_HOST=0.0.0.0
@@ -89,6 +90,7 @@ services:
       - DB_POSTGRESDB_DATABASE=n8n
       - DB_POSTGRESDB_USER=n8n
       - DB_POSTGRESDB_PASSWORD=n8n
+      - N8N_ENCRYPTION_KEY=test-encryption-key-not-a-secret
       - N8N_LOG_LEVEL=info
       - N8N_LOG_OUTPUT=console
       - N8N_RUNNERS_ENABLED=false

--- a/n8n/tests/docker/docker-compose.yaml
+++ b/n8n/tests/docker/docker-compose.yaml
@@ -8,6 +8,19 @@ services:
       timeout: 3s
       retries: 5
 
+  postgres:
+    image: postgres:16-alpine
+    container_name: n8n-test-postgres
+    environment:
+      - POSTGRES_USER=n8n
+      - POSTGRES_PASSWORD=n8n
+      - POSTGRES_DB=n8n
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U n8n -d n8n"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
   n8n:
     image: n8nio/n8n:${N8N_VERSION:-1.118.1}
     container_name: n8n-test
@@ -17,6 +30,12 @@ services:
       - EXECUTIONS_MODE=queue
       - QUEUE_BULL_REDIS_HOST=redis
       - QUEUE_BULL_REDIS_PORT=6379
+      - DB_TYPE=postgresdb
+      - DB_POSTGRESDB_HOST=postgres
+      - DB_POSTGRESDB_PORT=5432
+      - DB_POSTGRESDB_DATABASE=n8n
+      - DB_POSTGRESDB_USER=n8n
+      - DB_POSTGRESDB_PASSWORD=n8n
       - N8N_LOG_LEVEL=debug
       - N8N_LOG_OUTPUT=console
       - N8N_HOST=0.0.0.0
@@ -45,6 +64,8 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+      postgres:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:5678/healthz"]
       interval: 10s
@@ -62,6 +83,12 @@ services:
       - EXECUTIONS_MODE=queue
       - QUEUE_BULL_REDIS_HOST=redis
       - QUEUE_BULL_REDIS_PORT=6379
+      - DB_TYPE=postgresdb
+      - DB_POSTGRESDB_HOST=postgres
+      - DB_POSTGRESDB_PORT=5432
+      - DB_POSTGRESDB_DATABASE=n8n
+      - DB_POSTGRESDB_USER=n8n
+      - DB_POSTGRESDB_PASSWORD=n8n
       - N8N_LOG_LEVEL=info
       - N8N_LOG_OUTPUT=console
       - N8N_RUNNERS_ENABLED=false
@@ -75,8 +102,6 @@ services:
       - N8N_METRICS_INCLUDE_WORKFLOW_STATISTICS=true
       - QUEUE_HEALTH_CHECK_ACTIVE=true
       - QUEUE_HEALTH_CHECK_PORT=5680
-    volumes:
-      - n8n_data:/home/node/.n8n
     depends_on:
       n8n:
         condition: service_healthy


### PR DESCRIPTION
### What does this PR do?

Adds a Postgres service to the n8n integration test docker-compose and switches both n8n containers (main and worker) from the default SQLite database to Postgres. The `n8n-worker` container no longer mounts the shared `/home/node/.n8n` volume, since all shared state now lives in the database.

### Motivation

Triggered by a Codex review comment on #23733: https://github.com/DataDog/integrations-core/pull/23733#discussion_r3264583241

The test environment runs n8n in queue mode (`EXECUTIONS_MODE=queue`) with a separate worker container, but it left n8n on its default SQLite database and shared the `/home/node/.n8n` volume between the main and worker processes. n8n's official documentation explicitly states that queue mode with SQLite [isn't recommended](https://docs.n8n.io/hosting/scaling/queue-mode/) and that "running a distributed system with this setup over SQLite isn't supported."

Concretely, two separate n8n processes writing to the same SQLite file through a shared volume hits SQLite's single-writer file-lock contention, which the n8n project itself has documented as a flake source (see [n8n-io/n8n#29665](https://github.com/n8n-io/n8n/issues/29665), [#22380](https://github.com/n8n-io/n8n/issues/22380)). For an e2e environment that needs deterministic webhook + worker behavior, this risks intermittent `SQLITE_BUSY` errors on queued executions.

Switching to Postgres matches what n8n's own queue-mode setup guidance recommends and removes a class of test flakiness.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged