### PR TITLE
Instrument metric metadata coverage reporting

### DIFF
--- a/.github/actions/setup-test-target-scripts/src/run-e2e-tests.sh
+++ b/.github/actions/setup-test-target-scripts/src/run-e2e-tests.sh
@@ -30,6 +30,11 @@ else
   E2E_FLAGS="--dev"
 fi
 
+# Temporary experiment: collect one JSON line per assert_metrics_using_metadata call.
+mkdir -p "$TEST_RESULTS_DIR"
+export DD_INTEGRATION_METRIC_COVERAGE="1"
+export DD_INTEGRATION_METRIC_COVERAGE_FILE="$TEST_RESULTS_DIR/metric-metadata-coverage-${DD_TEST_SESSION_NAME}.jsonl"
+
 # Build target arguments
 # For latest: INPUT_TARGET already contains "target:latest", no separate env
 # For regular: INPUT_TARGET is just the target, INPUT_TARGET_ENV is the env

--- a/.github/actions/setup-test-target-scripts/src/run-unit-integration-tests.sh
+++ b/.github/actions/setup-test-target-scripts/src/run-unit-integration-tests.sh
@@ -28,6 +28,11 @@ else
   VERBOSE_FLAG="-v"
 fi
 
+# Temporary experiment: collect one JSON line per assert_metrics_using_metadata call.
+mkdir -p "$TEST_RESULTS_DIR"
+export DD_INTEGRATION_METRIC_COVERAGE="1"
+export DD_INTEGRATION_METRIC_COVERAGE_FILE="$TEST_RESULTS_DIR/metric-metadata-coverage-${DD_TEST_SESSION_NAME}.jsonl"
+
 # Parse INPUT_PYTEST_ARGS with proper quote handling using eval
 # This allows passing args like '-m "not flaky"' correctly
 if [[ -n "$INPUT_PYTEST_ARGS" ]]; then

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -425,38 +425,22 @@ class AggregatorStub(object):
             msg += '\nFound metrics that are not asserted:{}{}'.format(prefix, prefix.join(sorted(self.not_asserted())))
         assert condition, msg
 
-    def assert_metrics_using_metadata(
+    def calculate_metric_metadata_coverage(
         self,
         metadata_metrics,
         check_metric_type=True,
         check_submission_type=False,
         exclude=None,
-        check_symmetric_inclusion=False,
     ):
-        """
-        Assert metrics using metadata.csv. The assertion fails if there are metrics emitted that are
-        not in metadata.csv. Metrics passed in the `exclude` parameter are ignored.
-
-        Pass `check_symmetric_inclusion=True` to assert that both set of metrics, those submitted and
-        those in metadata.csv, are the same.
-
-        Checking type: By default we are asserting the in-app metric type (`check_submission_type=False`),
-        asserting this type make sense for e2e (metrics collected from agent).
-        For integrations tests, we can check the submission type with `check_submission_type=True`, or
-        use `check_metric_type=False` not to check types.
-
-        Usage:
-
-            from datadog_checks.dev.utils import get_metadata_metrics
-            aggregator.assert_metrics_using_metadata(get_metadata_metrics())
-
-        """
-
+        """Calculate metric coverage against metadata.csv without changing assertion behavior."""
         exclude = exclude or []
+        excluded_metrics = set(exclude)
         errors = set()
         submitted_metrics = set()
+        type_mismatches = []
+
         for metric_name, metric_stubs in self._metrics.items():
-            if metric_name in exclude:
+            if metric_name in excluded_metrics:
                 continue
             for metric_stub in metric_stubs:
                 metric_stub_name = backend_normalize_metric_name(metric_stub.name)
@@ -485,15 +469,133 @@ class AggregatorStub(object):
 
                 if check_metric_type:
                     if expected_metric_type != actual_metric_type:
+                        type_mismatches.append(
+                            {
+                                'metric_name': metric_stub_name,
+                                'expected_type': expected_metric_type,
+                                'actual_type': actual_metric_type,
+                            }
+                        )
                         errors.add(
                             "Expect `{}` to have type `{}` but got `{}`.".format(
                                 metric_stub_name, expected_metric_type, actual_metric_type
                             )
                         )
 
+        metadata_metric_names = set(metadata_metrics)
+        covered_metrics = submitted_metrics & metadata_metric_names
+        missing_from_metadata = submitted_metrics - metadata_metric_names
+        missing_from_submissions = metadata_metric_names - submitted_metrics
+        metadata_count = len(metadata_metric_names)
+        coverage_percent = len(covered_metrics) / metadata_count * 100 if metadata_count else 100
+
+        return {
+            'submitted_metrics': submitted_metrics,
+            'metadata_metrics': metadata_metric_names,
+            'covered_metrics': covered_metrics,
+            'missing_from_metadata': missing_from_metadata,
+            'missing_from_submissions': missing_from_submissions,
+            'type_mismatches': type_mismatches,
+            'excluded_metrics': excluded_metrics,
+            'submitted_count': len(submitted_metrics),
+            'metadata_count': metadata_count,
+            'covered_count': len(covered_metrics),
+            'missing_from_metadata_count': len(missing_from_metadata),
+            'missing_from_submissions_count': len(missing_from_submissions),
+            'type_mismatch_count': len(type_mismatches),
+            'excluded_count': len(excluded_metrics),
+            'coverage_percent': coverage_percent,
+            'errors': errors,
+        }
+
+    def _report_metric_metadata_coverage(self, coverage):
+        coverage_enabled = os.environ.get('DD_INTEGRATION_METRIC_COVERAGE')
+        # Temporary CI experiment: if test-target CI exposes TEST_RESULTS_DIR, emit reports even
+        # when an individual ddev/hatch process does not inherit the explicit opt-in flag.
+        ci_results_dir = os.environ.get('TEST_RESULTS_DIR') if os.environ.get('GITHUB_ACTIONS') else ''
+        if not coverage_enabled and not ci_results_dir:
+            return
+
+        payload = self._format_metric_metadata_coverage_report(coverage)
+        coverage_file = os.environ.get('DD_INTEGRATION_METRIC_COVERAGE_FILE')
+        if not coverage_file and ci_results_dir:
+            coverage_file = os.path.join(ci_results_dir, 'metric-metadata-coverage.jsonl')
+
+        if coverage_file:
+            coverage_dir = os.path.dirname(coverage_file)
+            if coverage_dir:
+                os.makedirs(coverage_dir, exist_ok=True)
+            with open(coverage_file, 'a') as f:
+                f.write(json.dumps(payload, sort_keys=True) + '\n')
+
+        print('DD_INTEGRATION_METRIC_COVERAGE ' + json.dumps(payload, sort_keys=True))
+
+    @staticmethod
+    def _format_metric_metadata_coverage_report(coverage):
+        pytest_current_test = os.environ.get('PYTEST_CURRENT_TEST', '')
+        pytest_nodeid = pytest_current_test.rsplit(' ', 1)[0] if pytest_current_test else ''
+        payload = {
+            'event': 'integration_metric_metadata_coverage',
+            'integration': os.environ.get('INPUT_TARGET') or os.environ.get('DD_INTEGRATION') or '',
+            'check_name': os.environ.get('DD_CHECK_NAME') or os.environ.get('INPUT_TARGET') or '',
+            'pytest_nodeid': pytest_nodeid,
+            'pytest_current_test': pytest_current_test,
+            'submitted_count': coverage['submitted_count'],
+            'metadata_count': coverage['metadata_count'],
+            'covered_count': coverage['covered_count'],
+            'missing_from_metadata_count': coverage['missing_from_metadata_count'],
+            'missing_from_submissions_count': coverage['missing_from_submissions_count'],
+            'type_mismatch_count': coverage['type_mismatch_count'],
+            'excluded_count': coverage['excluded_count'],
+            'coverage_percent': round(coverage['coverage_percent'], 2),
+            'missing_metric_names': sorted(coverage['missing_from_submissions']),
+            'emitted_not_in_metadata': sorted(coverage['missing_from_metadata']),
+            'type_mismatches': sorted(coverage['type_mismatches'], key=lambda item: item['metric_name']),
+            'excluded_metrics': sorted(coverage['excluded_metrics']),
+        }
+        return payload
+
+    def assert_metrics_using_metadata(
+        self,
+        metadata_metrics,
+        check_metric_type=True,
+        check_submission_type=False,
+        exclude=None,
+        check_symmetric_inclusion=False,
+    ):
+        """
+        Assert metrics using metadata.csv. The assertion fails if there are metrics emitted that are
+        not in metadata.csv. Metrics passed in the `exclude` parameter are ignored.
+
+        Pass `check_symmetric_inclusion=True` to assert that both set of metrics, those submitted and
+        those in metadata.csv, are the same.
+
+        Checking type: By default we are asserting the in-app metric type (`check_submission_type=False`),
+        asserting this type make sense for e2e (metrics collected from agent).
+        For integrations tests, we can check the submission type with `check_submission_type=True`, or
+        use `check_metric_type=False` not to check types.
+
+        Usage:
+
+            from datadog_checks.dev.utils import get_metadata_metrics
+            aggregator.assert_metrics_using_metadata(get_metadata_metrics())
+
+        """
+
+        coverage = self.calculate_metric_metadata_coverage(
+            metadata_metrics,
+            check_metric_type=check_metric_type,
+            check_submission_type=check_submission_type,
+            exclude=exclude,
+        )
+        errors = coverage['errors']
+        submitted_metrics = coverage['submitted_metrics']
+
         if check_symmetric_inclusion:
             missing_metrics = metadata_metrics.keys() - submitted_metrics
             errors.update(f"Expect `{m}` from metadata.csv but not submitted." for m in missing_metrics)
+
+        self._report_metric_metadata_coverage(coverage)
 
         assert not errors, "Metadata assertion errors using metadata.csv:" + "\n\t- ".join([''] + sorted(errors))
 

--- a/datadog_checks_base/tests/stubs/test_aggregator_metadata_coverage.py
+++ b/datadog_checks_base/tests/stubs/test_aggregator_metadata_coverage.py
@@ -1,0 +1,138 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+
+import pytest
+
+from datadog_checks.base import AgentCheck
+
+
+def test_calculate_metric_metadata_coverage(aggregator):
+    check = AgentCheck()
+    check.gauge('test.covered', 1)
+    check.gauge('test.missing_metadata', 1)
+    check.count('test.type_mismatch', 1)
+    check.gauge('test.excluded', 1)
+
+    coverage = aggregator.calculate_metric_metadata_coverage(
+        {
+            'test.covered': {'metric_type': 'gauge'},
+            'test.type_mismatch': {'metric_type': 'gauge'},
+            'test.missing_submission': {'metric_type': 'gauge'},
+            'test.excluded': {'metric_type': 'gauge'},
+        },
+        check_submission_type=True,
+        exclude=['test.excluded'],
+    )
+
+    assert coverage['submitted_metrics'] == {'test.covered', 'test.missing_metadata', 'test.type_mismatch'}
+    assert coverage['metadata_metrics'] == {
+        'test.covered',
+        'test.type_mismatch',
+        'test.missing_submission',
+        'test.excluded',
+    }
+    assert coverage['covered_metrics'] == {'test.covered', 'test.type_mismatch'}
+    assert coverage['missing_from_metadata'] == {'test.missing_metadata'}
+    assert coverage['missing_from_submissions'] == {'test.missing_submission', 'test.excluded'}
+    assert coverage['excluded_metrics'] == {'test.excluded'}
+    assert coverage['submitted_count'] == 3
+    assert coverage['metadata_count'] == 4
+    assert coverage['covered_count'] == 2
+    assert coverage['missing_from_metadata_count'] == 1
+    assert coverage['missing_from_submissions_count'] == 2
+    assert coverage['excluded_count'] == 1
+    assert coverage['coverage_percent'] == 50
+    assert coverage['type_mismatches'] == [
+        {'metric_name': 'test.type_mismatch', 'expected_type': 'gauge', 'actual_type': 'count'}
+    ]
+    assert coverage['errors'] == {
+        'Expect `test.missing_metadata` to be in metadata.csv.',
+        'Expect `test.type_mismatch` to have type `gauge` but got `count`.',
+    }
+
+
+def test_metric_metadata_coverage_reporting_to_file(aggregator, monkeypatch, tmpdir):
+    check = AgentCheck()
+    check.gauge('test.covered', 1)
+    coverage_file = tmpdir.join('coverage.jsonl')
+
+    monkeypatch.setenv('DD_INTEGRATION_METRIC_COVERAGE', '1')
+    monkeypatch.setenv('DD_INTEGRATION_METRIC_COVERAGE_FILE', str(coverage_file))
+    monkeypatch.setenv('INPUT_TARGET', 'test_integration')
+    monkeypatch.setenv('PYTEST_CURRENT_TEST', 'tests/test_example.py::test_metadata (call)')
+
+    aggregator.assert_metrics_using_metadata(
+        {
+            'test.covered': {'metric_type': 'gauge'},
+            'test.missing': {'metric_type': 'gauge'},
+        },
+        check_symmetric_inclusion=False,
+    )
+
+    [line] = coverage_file.readlines()
+    payload = json.loads(line)
+    assert payload['event'] == 'integration_metric_metadata_coverage'
+    assert payload['integration'] == 'test_integration'
+    assert payload['check_name'] == 'test_integration'
+    assert payload['pytest_nodeid'] == 'tests/test_example.py::test_metadata'
+    assert payload['submitted_count'] == 1
+    assert payload['metadata_count'] == 2
+    assert payload['covered_count'] == 1
+    assert payload['coverage_percent'] == 50
+    assert payload['missing_metric_names'] == ['test.missing']
+    assert payload['emitted_not_in_metadata'] == []
+    assert payload['excluded_metrics'] == []
+
+
+def test_metric_metadata_coverage_reporting_to_stdout(aggregator, monkeypatch, capsys):
+    check = AgentCheck()
+    check.gauge('test.covered', 1)
+
+    monkeypatch.setenv('DD_INTEGRATION_METRIC_COVERAGE', '1')
+    monkeypatch.delenv('DD_INTEGRATION_METRIC_COVERAGE_FILE', raising=False)
+
+    aggregator.assert_metrics_using_metadata({'test.covered': {'metric_type': 'gauge'}})
+
+    stdout = capsys.readouterr().out.strip()
+    assert stdout.startswith('DD_INTEGRATION_METRIC_COVERAGE ')
+    payload = json.loads(stdout.split(' ', 1)[1])
+    assert payload['submitted_count'] == 1
+    assert payload['coverage_percent'] == 100
+
+
+def test_metric_metadata_coverage_reporting_preserves_assertion_behavior(aggregator, monkeypatch, tmpdir):
+    check = AgentCheck()
+    check.gauge('test.extra', 1)
+    coverage_file = tmpdir.join('coverage.jsonl')
+
+    monkeypatch.setenv('DD_INTEGRATION_METRIC_COVERAGE', '1')
+    monkeypatch.setenv('DD_INTEGRATION_METRIC_COVERAGE_FILE', str(coverage_file))
+
+    with pytest.raises(AssertionError, match='Expect `test.extra` to be in metadata.csv'):
+        aggregator.assert_metrics_using_metadata({'test.covered': {'metric_type': 'gauge'}})
+
+    [line] = coverage_file.readlines()
+    payload = json.loads(line)
+    assert payload['emitted_not_in_metadata'] == ['test.extra']
+
+
+def test_metric_metadata_coverage_reporting_uses_ci_results_dir(aggregator, monkeypatch, tmpdir, capsys):
+    check = AgentCheck()
+    check.gauge('test.covered', 1)
+    results_dir = tmpdir.mkdir('results')
+
+    monkeypatch.delenv('DD_INTEGRATION_METRIC_COVERAGE', raising=False)
+    monkeypatch.delenv('DD_INTEGRATION_METRIC_COVERAGE_FILE', raising=False)
+    monkeypatch.setenv('GITHUB_ACTIONS', 'true')
+    monkeypatch.setenv('TEST_RESULTS_DIR', str(results_dir))
+
+    aggregator.assert_metrics_using_metadata({'test.covered': {'metric_type': 'gauge'}})
+
+    coverage_file = results_dir.join('metric-metadata-coverage.jsonl')
+    [line] = coverage_file.readlines()
+    payload = json.loads(line)
+    assert payload['submitted_count'] == 1
+    assert payload['coverage_percent'] == 100
+    assert capsys.readouterr().out.startswith('DD_INTEGRATION_METRIC_COVERAGE ')

--- a/metric_metadata_coverage_pr_notes.md
+++ b/metric_metadata_coverage_pr_notes.md
@@ -1,0 +1,35 @@
+### What does this PR do?
+
+Temporarily instruments `AggregatorStub.assert_metrics_using_metadata` so each assertion can emit one metric metadata coverage JSON object during CI. The existing metadata assertion behavior is intentionally unchanged: submitted metrics that are not in `metadata.csv`, type mismatches, and symmetric missing submissions still fail only in the same situations as before.
+
+When `DD_INTEGRATION_METRIC_COVERAGE=1` is set, each assertion writes a JSON line to `DD_INTEGRATION_METRIC_COVERAGE_FILE`. In GitHub test-target CI, it also falls back to `$TEST_RESULTS_DIR/metric-metadata-coverage.jsonl` so reports are uploaded with the existing test-results artifact. Each report is also printed as a greppable line prefixed with `DD_INTEGRATION_METRIC_COVERAGE `. The PR enables this in the GitHub test-target unit/integration and E2E scripts and stores the JSONL file under the existing test-results artifact directory.
+
+Key fields:
+
+- `integration` / `check_name`: best-effort CI target/check context.
+- `pytest_nodeid`: test node from `PYTEST_CURRENT_TEST` when pytest provides it.
+- `submitted_count`: unique submitted metric names considered by the assertion after `exclude` is applied.
+- `metadata_count`: metric names present in `metadata.csv` for the assertion input.
+- `covered_count`: metric names present in both submissions and metadata.
+- `coverage_percent`: `covered_count / metadata_count * 100`.
+- `missing_metric_names`: metadata rows not observed in this assertion.
+- `emitted_not_in_metadata`: submitted metric names without metadata rows.
+- `type_mismatches`: metrics whose observed type does not match metadata.
+- `excluded_metrics`: metrics passed through the assertion's `exclude` parameter.
+
+### Motivation
+
+This is a draft PR experiment to measure integration metric metadata coverage in CI before deciding whether and where to add stricter gates. The output should make low-coverage tests and integrations visible without broadly failing on missing submitted coverage.
+
+Interpretation guidance:
+
+- Low `coverage_percent` means the test only emitted a subset of metadata-defined metrics; this is expected for some narrow tests and useful for finding E2E gaps.
+- Non-empty `emitted_not_in_metadata` is already assertion-failing behavior today unless that metric is excluded.
+- Non-empty `type_mismatches` is already assertion-failing behavior today when type checks are enabled.
+- `excluded_metrics` should be treated as intentional blind spots. Per-test exclusions should include a nearby code comment explaining why each metric is excluded, for example dynamic version behavior, optional backend features, or known fixture limitations. Avoid adding unexplained broad exclusions because they reduce the usefulness of coverage stats.
+
+### Review checklist (to be filled by reviewers)
+
+- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
+- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
+- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


### PR DESCRIPTION
### What does this PR do?

Temporarily instruments `AggregatorStub.assert_metrics_using_metadata` so each assertion can emit one metric metadata coverage JSON object during CI. The existing metadata assertion behavior is intentionally unchanged: submitted metrics that are not in `metadata.csv`, type mismatches, and symmetric missing submissions still fail only in the same situations as before.

When `DD_INTEGRATION_METRIC_COVERAGE=1` is set, each assertion writes a JSON line to `DD_INTEGRATION_METRIC_COVERAGE_FILE`. If no file is configured, it prints a greppable line prefixed with `DD_INTEGRATION_METRIC_COVERAGE `. The PR enables this in the GitHub test-target unit/integration and E2E scripts and stores the JSONL file under the existing test-results artifact directory.

Key fields:

- `integration` / `check_name`: best-effort CI target/check context.
- `pytest_nodeid`: test node from `PYTEST_CURRENT_TEST` when pytest provides it.
- `submitted_count`: unique submitted metric names considered by the assertion after `exclude` is applied.
- `metadata_count`: metric names present in `metadata.csv` for the assertion input.
- `covered_count`: metric names present in both submissions and metadata.
- `coverage_percent`: `covered_count / metadata_count * 100`.
- `missing_metric_names`: metadata rows not observed in this assertion.
- `emitted_not_in_metadata`: submitted metric names without metadata rows.
- `type_mismatches`: metrics whose observed type does not match metadata.
- `excluded_metrics`: metrics passed through the assertion's `exclude` parameter.

### Motivation

This is a draft PR experiment to measure integration metric metadata coverage in CI before deciding whether and where to add stricter gates. The output should make low-coverage tests and integrations visible without broadly failing on missing submitted coverage.

Interpretation guidance:

- Low `coverage_percent` means the test only emitted a subset of metadata-defined metrics; this is expected for some narrow tests and useful for finding E2E gaps.
- Non-empty `emitted_not_in_metadata` is already assertion-failing behavior today unless that metric is excluded.
- Non-empty `type_mismatches` is already assertion-failing behavior today when type checks are enabled.
- `excluded_metrics` should be treated as intentional blind spots. Per-test exclusions should include a nearby code comment explaining why each metric is excluded, for example dynamic version behavior, optional backend features, or known fixture limitations. Avoid adding unexplained broad exclusions because they reduce the usefulness of coverage stats.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
