### PR TITLE
Pass --explicit-package-bases to mypy by default

### DIFF
--- a/ddev/changelog.d/23742.added
+++ b/ddev/changelog.d/23742.added
@@ -1,0 +1,1 @@
+Add --explicit-package-bases to default mypy_args

--- a/ddev/src/ddev/plugin/external/hatch/environment_collector.py
+++ b/ddev/src/ddev/plugin/external/hatch/environment_collector.py
@@ -63,7 +63,9 @@ class DatadogChecksEnvironmentCollector(EnvironmentCollectorInterface):
 
     @cached_property
     def mypy_args(self):
-        return self.config.get('mypy-args', []) + ['--install-types', '--non-interactive']
+        return (
+            ['--explicit-package-bases'] + self.config.get('mypy-args', []) + ['--install-types', '--non-interactive']
+        )
 
     @cached_property
     def mypy_files(self):


### PR DESCRIPTION
### What does this PR do?

Always prepend `--explicit-package-bases` to the `mypy` invocation built by the `datadog-checks` Hatch environment collector (`ddev/src/ddev/plugin/external/hatch/environment_collector.py`). `mypy_args` is only consumed when `check-types = true`, so this default has no observable effect on the ~99% of integrations that don't opt into type checking. For those that do, they no longer need to repeat the flag in their own `hatch.toml`.

Verified by running `ddev test --lint` on every integration that currently sets `check-types = true` — the only ones for which the change is observable.

### Motivation

Most integrations in this repo use a PEP 420 namespace-package layout (no `datadog_checks/__init__.py`), which `mypy` cannot resolve correctly without `--explicit-package-bases` — it would either error out on ambiguous package roots or assign wrong module names. Until now, every integration that enabled `check-types = true` had to remember to add `mypy-args = ["--explicit-package-bases"]` to its own `hatch.toml`.

Follow-up: once this lands, the redundant `mypy-args` blocks in `prefect/hatch.toml` and `ibm_spectrum_lsf/hatch.toml` can be dropped (and similarly in the create-check template via #23705).

Motivated by the discussion in https://github.com/DataDog/integrations-core/pull/23705#discussion_r3257993244.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged