### PR TITLE
Drop redundant mypy-args from prefect and ibm_spectrum_lsf

### DIFF
--- a/ibm_spectrum_lsf/hatch.toml
+++ b/ibm_spectrum_lsf/hatch.toml
@@ -1,8 +1,5 @@
 [env.collectors.datadog-checks]
 check-types = true
-mypy-args = [
-  "--explicit-package-bases",
-]
 mypy-files = [
   "datadog_checks/ibm_spectrum_lsf",
   "tests/",

--- a/prefect/hatch.toml
+++ b/prefect/hatch.toml
@@ -1,8 +1,5 @@
 [env.collectors.datadog-checks]
 check-types = true
-mypy-args = [
-    "--explicit-package-bases",
-]
 
 [[envs.default.matrix]]
 python = ["3.13"]


### PR DESCRIPTION
### What does this PR do?

Removes the now-redundant `mypy-args = ["--explicit-package-bases"]` block from `prefect/hatch.toml` and `ibm_spectrum_lsf/hatch.toml`. Both files keep `check-types = true`, so mypy still runs on them — the flag is now supplied by the `datadog-checks` Hatch environment collector instead of each integration's own config.

### Motivation

Follow-up to #23742, which made `--explicit-package-bases` a default in the collector. With that in place, integrations that opt into `check-types = true` no longer need to repeat the flag themselves. These were the only two integrations carrying the now-duplicate line.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged