### PR TITLE
[kafka] Fix Kafka Monitoring callout UTM tracking (trailing slash)

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -182,4 +182,4 @@ See [service_checks.json][15] for a list of service checks provided by this inte
 [21]: https://www.datadoghq.com/blog/monitor-kafka-with-datadog
 [22]: https://raw.githubusercontent.com/DataDog/dd-agent/5.2.1/conf.d/kafka.yaml.example
 [23]: https://www.datadoghq.com/knowledge-center/apache-kafka/
-[24]: https://docs.datadoghq.com/data_streams/kafka?utm_source=docs&utm_medium=callout&utm_campaign=DocsCTA-DSMKafka-IntegrationsKafka
+[24]: https://docs.datadoghq.com/data_streams/kafka/?utm_source=docs&utm_medium=callout&utm_campaign=DocsCTA-DSMKafka-IntegrationsKafka


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes a UTM-tracking bug in the Kafka Monitoring callout that was previously merged. The current link points to `/data_streams/kafka?utm_*` (no trailing slash). That URL returns a 302 redirect to `/data_streams/kafka/` (with trailing slash) — and the redirect **strips the query string**, so all UTM tracking is lost before it reaches RUM.

### Verification

```
$ curl -I "https://docs.datadoghq.com/data_streams/kafka?utm_source=docs&utm_campaign=DocsCTA-DSMKafka-TracingGuide"
HTTP/2 302
location: /data_streams/kafka/      ← UTM query string dropped

$ curl -I "https://docs.datadoghq.com/data_streams/kafka/?utm_source=docs&utm_campaign=DocsCTA-DSMKafka-TracingGuide"
HTTP/2 200                          ← UTM preserved
```

Also verified empirically — the campaign tracking dashboard ([dz7-28r-bru](https://dd-corpsite.datadoghq.com/dashboard/dz7-28r-bru)) showed zero `utm_campaign:*DSMKafka*` views in RUM across the 4 days since the original PR merged.

### Fix

One-character change: add a trailing slash to the URL in the callout.

### Related PRs

Same fix landing in the sibling repos:
- DataDog/integrations-core (kafka README)
- DataDog/corp-hugo (kafka-dashboard page)

### Merge readiness
- [x] Ready for merge

### AI assistance
Drafted with Claude Code; root cause diagnosed via direct RUM query against the docs Documentation app.