### PR TITLE
[kong] strengthen tests to lift mutation score

### DIFF
--- a/kong/tests/test_unit.py
+++ b/kong/tests/test_unit.py
@@ -2,11 +2,15 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
+from collections import namedtuple
+from unittest.mock import MagicMock
 
 import pytest
+import requests
 
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.kong import Kong
+from datadog_checks.kong.check import KongCheck
 
 from .common import HERE, METRICS_URL
 
@@ -115,3 +119,300 @@ def test_check(aggregator, dd_run_check, mock_http_response):
         tags=['address:localhost:1004', 'endpoint:{}'.format(METRICS_URL), 'target:target4', 'upstream:upstream4'],
         count=1,
     )
+
+
+Sample = namedtuple('Sample', ['name', 'labels', 'value', 'timestamp'])
+
+
+def _make_kong_check_for_transformer():
+    check = KongCheck('kong', {}, [{'openmetrics_endpoint': METRICS_URL}])
+    check.service_check = MagicMock()
+    return check
+
+
+def test_kong_check_default_metric_limit_is_zero():
+    assert KongCheck.DEFAULT_METRIC_LIMIT == 0
+
+
+def test_upstream_target_health_skips_when_sample_value_is_not_one():
+    check = _make_kong_check_for_transformer()
+    service_check = check.configure_transformer_upstream_target_health()
+    sample = Sample('kong_upstream_target_health', {'state': 'healthy'}, 0, 0)
+    sample_data = [(sample, ['state:healthy', 'target:t1'], 'host')]
+
+    service_check(None, sample_data, None)
+
+    check.service_check.assert_not_called()
+
+
+def test_upstream_target_health_skips_when_sample_value_is_greater_than_one():
+    check = _make_kong_check_for_transformer()
+    service_check = check.configure_transformer_upstream_target_health()
+    sample = Sample('kong_upstream_target_health', {'state': 'healthy'}, 2, 0)
+    sample_data = [(sample, ['state:healthy', 'target:t1'], 'host')]
+
+    service_check(None, sample_data, None)
+
+    check.service_check.assert_not_called()
+
+
+def test_upstream_target_health_skips_healthchecks_off_state():
+    check = _make_kong_check_for_transformer()
+    service_check = check.configure_transformer_upstream_target_health()
+    sample = Sample('kong_upstream_target_health', {'state': 'healthchecks_off'}, 1, 0)
+    sample_data = [(sample, ['state:healthchecks_off', 'target:t1'], 'host')]
+
+    service_check(None, sample_data, None)
+
+    check.service_check.assert_not_called()
+
+
+def test_upstream_target_health_continues_past_skipped_sample():
+    check = _make_kong_check_for_transformer()
+    service_check = check.configure_transformer_upstream_target_health()
+    skipped = Sample('kong_upstream_target_health', {'state': 'healthy'}, 0, 0)
+    processed = Sample('kong_upstream_target_health', {'state': 'healthy'}, 1, 0)
+    sample_data = [
+        (skipped, ['state:healthy', 'target:t0'], 'host0'),
+        (processed, ['state:healthy', 'target:t1'], 'host1'),
+    ]
+
+    service_check(None, sample_data, None)
+
+    assert check.service_check.call_count == 1
+    call = check.service_check.call_args
+    assert call.args[0] == 'upstream.target.health'
+    assert call.args[1] == check.OK
+    assert call.kwargs['hostname'] == 'host1'
+    assert 'state:healthy' not in call.kwargs['tags']
+    assert 'target:t1' in call.kwargs['tags']
+
+
+def test_upstream_target_health_maps_states_to_service_check_statuses():
+    check = _make_kong_check_for_transformer()
+    service_check = check.configure_transformer_upstream_target_health()
+    samples = [
+        (Sample('m', {'state': 'healthy'}, 1, 0), ['state:healthy'], 'h'),
+        (Sample('m', {'state': 'unhealthy'}, 1, 0), ['state:unhealthy'], 'h'),
+        (Sample('m', {'state': 'dns_error'}, 1, 0), ['state:dns_error'], 'h'),
+        (Sample('m', {'state': 'mystery'}, 1, 0), ['state:mystery'], 'h'),
+    ]
+
+    service_check(None, samples, None)
+
+    statuses = [call.args[1] for call in check.service_check.call_args_list]
+    assert statuses == [check.OK, check.CRITICAL, check.CRITICAL, check.UNKNOWN]
+
+
+def test_new_returns_kong_check_when_openmetrics_endpoint_present():
+    check = Kong('kong', {}, [{'openmetrics_endpoint': METRICS_URL}])
+
+    assert isinstance(check, KongCheck)
+
+
+def test_new_returns_legacy_kong_without_openmetrics_endpoint():
+    check = Kong('kong', {}, [{'kong_status_url': 'http://kong:8001/status/'}])
+
+    assert isinstance(check, Kong)
+    assert not isinstance(check, KongCheck)
+
+
+def test_new_uses_first_instance_for_routing_decision():
+    check = Kong(
+        'kong',
+        {},
+        [
+            {'openmetrics_endpoint': METRICS_URL},
+            {'kong_status_url': 'http://kong:8001/status/'},
+        ],
+    )
+
+    assert isinstance(check, KongCheck)
+
+
+def test_new_uses_first_instance_for_routing_decision_legacy_first():
+    check = Kong(
+        'kong',
+        {},
+        [
+            {'kong_status_url': 'http://kong:8001/status/'},
+            {'openmetrics_endpoint': METRICS_URL},
+        ],
+    )
+
+    assert isinstance(check, Kong)
+    assert not isinstance(check, KongCheck)
+
+
+def _make_legacy_kong(instance):
+    return Kong('kong', {}, [instance])
+
+
+def test_legacy_check_calls_gauge_for_each_server_metric(mock_http_response):
+    mock_http_response(json_data={'server': {'connections_active': 5, 'connections_waiting': 1}})
+    check = _make_legacy_kong({'kong_status_url': 'http://kong:8001/status/', 'tags': []})
+    check.gauge = MagicMock()
+
+    check.check(None)
+
+    gauged = {call.args[0]: call.args[1] for call in check.gauge.call_args_list}
+    assert gauged == {'kong.connections_active': 5, 'kong.connections_waiting': 1}
+
+
+def test_legacy_check_logs_error_when_gauge_submission_raises(mock_http_response):
+    mock_http_response(json_data={'server': {'ok': 1}})
+    check = _make_legacy_kong({'kong_status_url': 'http://kong:8001/status/'})
+
+    def bad_gauge(*_args, **_kwargs):
+        raise ValueError('boom')
+
+    check.gauge = bad_gauge
+    check.log = MagicMock()
+
+    check.check(None)
+
+    check.log.error.assert_called_once()
+    assert 'Could not submit metric' in check.log.error.call_args.args[0]
+
+
+def test_legacy_fetch_data_raises_when_status_url_missing():
+    check = _make_legacy_kong({'kong_status_url': 'http://kong:8001/status/'})
+    check.instance.pop('kong_status_url')
+
+    with pytest.raises(Exception, match='missing "kong_status_url" value'):
+        check._fetch_data()
+
+
+def test_legacy_fetch_data_defaults_port_to_80_when_url_omits_port(mock_http_response, aggregator):
+    mock_http_response(json_data={'server': {}})
+    check = _make_legacy_kong({'kong_status_url': 'http://kong-host/status/', 'tags': []})
+
+    check._fetch_data()
+
+    aggregator.assert_service_check(
+        'kong.can_connect',
+        status=Kong.OK,
+        tags=['kong_host:kong-host', 'kong_port:80'],
+        count=1,
+    )
+
+
+def test_legacy_fetch_data_uses_port_from_url_when_present(mock_http_response, aggregator):
+    mock_http_response(json_data={'server': {}})
+    check = _make_legacy_kong({'kong_status_url': 'http://kong-host:9000/status/', 'tags': []})
+
+    check._fetch_data()
+
+    aggregator.assert_service_check(
+        'kong.can_connect',
+        status=Kong.OK,
+        tags=['kong_host:kong-host', 'kong_port:9000'],
+        count=1,
+    )
+
+
+def test_legacy_fetch_data_service_check_includes_user_tags(mock_http_response, aggregator):
+    mock_http_response(json_data={'server': {}})
+    check = _make_legacy_kong(
+        {'kong_status_url': 'http://kong-host:9000/status/', 'tags': ['env:test', 'team:platform']}
+    )
+
+    check._fetch_data()
+
+    aggregator.assert_service_check(
+        'kong.can_connect',
+        status=Kong.OK,
+        tags=['kong_host:kong-host', 'kong_port:9000', 'env:test', 'team:platform'],
+        count=1,
+    )
+
+
+def test_legacy_fetch_data_service_check_critical_on_request_exception(mock_http_response, aggregator):
+    mock_http_response(json_data={'server': {}}, status_code=500)
+    check = _make_legacy_kong({'kong_status_url': 'http://kong-host:9000/status/', 'tags': []})
+
+    with pytest.raises(requests.HTTPError):
+        check._fetch_data()
+
+    aggregator.assert_service_check(
+        'kong.can_connect',
+        status=Kong.CRITICAL,
+        tags=['kong_host:kong-host', 'kong_port:9000'],
+        count=1,
+    )
+
+
+def test_legacy_fetch_data_service_check_critical_when_status_code_not_200(mock_http_response, aggregator):
+    mock_http_response(json_data={'server': {}}, status_code=201)
+    check = _make_legacy_kong({'kong_status_url': 'http://kong-host:9000/status/', 'tags': []})
+
+    check._fetch_data()
+
+    aggregator.assert_service_check(
+        'kong.can_connect',
+        status=Kong.CRITICAL,
+        tags=['kong_host:kong-host', 'kong_port:9000'],
+        count=1,
+    )
+
+
+def test_legacy_fetch_data_service_check_critical_when_status_code_below_200(mock_http_response, aggregator):
+    mock_http_response(json_data={'server': {}}, status_code=199)
+    check = _make_legacy_kong({'kong_status_url': 'http://kong-host:9000/status/', 'tags': []})
+
+    check._fetch_data()
+
+    aggregator.assert_service_check(
+        'kong.can_connect',
+        status=Kong.CRITICAL,
+        tags=['kong_host:kong-host', 'kong_port:9000'],
+        count=1,
+    )
+
+
+def test_legacy_fetch_data_service_check_ok_only_when_status_code_is_200(mock_http_response, aggregator):
+    mock_http_response(json_data={'server': {}}, status_code=200)
+    check = _make_legacy_kong({'kong_status_url': 'http://kong-host:9000/status/', 'tags': []})
+
+    check._fetch_data()
+
+    aggregator.assert_service_check(
+        'kong.can_connect',
+        status=Kong.OK,
+        tags=['kong_host:kong-host', 'kong_port:9000'],
+        count=1,
+    )
+
+
+def test_legacy_parse_json_prefixes_metric_names_with_kong():
+    check = _make_legacy_kong({'kong_status_url': 'http://kong:8001/status/'})
+
+    parsed = check._parse_json(b'{"server": {"connections_active": 7}}', tags=['env:test'])
+
+    assert parsed == [('kong.connections_active', 7, ['env:test'])]
+
+
+def test_legacy_parse_json_iterates_every_server_entry():
+    check = _make_legacy_kong({'kong_status_url': 'http://kong:8001/status/'})
+
+    parsed = check._parse_json(b'{"server": {"a": 1, "b": 2, "c": 3}}', tags=[])
+
+    metric_names = {row[0] for row in parsed}
+    assert metric_names == {'kong.a', 'kong.b', 'kong.c'}
+    assert len(parsed) == 3
+
+
+def test_legacy_parse_json_defaults_tags_to_empty_list_when_none():
+    check = _make_legacy_kong({'kong_status_url': 'http://kong:8001/status/'})
+
+    parsed = check._parse_json(b'{"server": {"x": 1}}', tags=None)
+
+    assert parsed == [('kong.x', 1, [])]
+
+
+def test_legacy_parse_json_preserves_caller_tags_when_provided():
+    check = _make_legacy_kong({'kong_status_url': 'http://kong:8001/status/'})
+
+    parsed = check._parse_json(b'{"server": {"x": 1}}', tags=['env:test'])
+
+    assert parsed == [('kong.x', 1, ['env:test'])]

--- a/kong/tests/test_unit.py
+++ b/kong/tests/test_unit.py
@@ -134,36 +134,19 @@ def test_kong_check_default_metric_limit_is_zero():
     assert KongCheck.DEFAULT_METRIC_LIMIT == 0
 
 
-def test_upstream_target_health_skips_when_sample_value_is_not_one():
+@pytest.mark.parametrize(
+    'value, state',
+    [
+        pytest.param(0, 'healthy', id='value_zero'),
+        pytest.param(2, 'healthy', id='value_above_one'),
+        pytest.param(1, 'healthchecks_off', id='healthchecks_off_state'),
+    ],
+)
+def test_upstream_target_health_skips_sample(value, state):
     check = _make_kong_check_for_transformer()
     service_check = check.configure_transformer_upstream_target_health()
-    sample = Sample('kong_upstream_target_health', {'state': 'healthy'}, 0, 0)
-    sample_data = [(sample, ['state:healthy', 'target:t1'], 'host')]
-
-    service_check(None, sample_data, None)
-
-    check.service_check.assert_not_called()
-
-
-def test_upstream_target_health_skips_when_sample_value_is_greater_than_one():
-    check = _make_kong_check_for_transformer()
-    service_check = check.configure_transformer_upstream_target_health()
-    sample = Sample('kong_upstream_target_health', {'state': 'healthy'}, 2, 0)
-    sample_data = [(sample, ['state:healthy', 'target:t1'], 'host')]
-
-    service_check(None, sample_data, None)
-
-    check.service_check.assert_not_called()
-
-
-def test_upstream_target_health_skips_healthchecks_off_state():
-    check = _make_kong_check_for_transformer()
-    service_check = check.configure_transformer_upstream_target_health()
-    sample = Sample('kong_upstream_target_health', {'state': 'healthchecks_off'}, 1, 0)
-    sample_data = [(sample, ['state:healthchecks_off', 'target:t1'], 'host')]
-
-    service_check(None, sample_data, None)
-
+    sample = Sample('kong_upstream_target_health', {'state': state}, value, 0)
+    service_check(None, [(sample, [f'state:{state}', 'target:t1'], 'host')], None)
     check.service_check.assert_not_called()
 
 
@@ -342,43 +325,23 @@ def test_legacy_fetch_data_service_check_critical_on_request_exception(mock_http
     )
 
 
-def test_legacy_fetch_data_service_check_critical_when_status_code_not_200(mock_http_response, aggregator):
-    mock_http_response(json_data={'server': {}}, status_code=201)
+@pytest.mark.parametrize(
+    'status_code, expected_status',
+    [
+        pytest.param(200, Kong.OK, id='exactly_200_is_ok'),
+        pytest.param(201, Kong.CRITICAL, id='201_is_critical'),
+        pytest.param(199, Kong.CRITICAL, id='199_is_critical'),
+    ],
+)
+def test_legacy_fetch_data_service_check_status_by_code(mock_http_response, aggregator, status_code, expected_status):
+    mock_http_response(json_data={'server': {}}, status_code=status_code)
     check = _make_legacy_kong({'kong_status_url': 'http://kong-host:9000/status/', 'tags': []})
 
     check._fetch_data()
 
     aggregator.assert_service_check(
         'kong.can_connect',
-        status=Kong.CRITICAL,
-        tags=['kong_host:kong-host', 'kong_port:9000'],
-        count=1,
-    )
-
-
-def test_legacy_fetch_data_service_check_critical_when_status_code_below_200(mock_http_response, aggregator):
-    mock_http_response(json_data={'server': {}}, status_code=199)
-    check = _make_legacy_kong({'kong_status_url': 'http://kong-host:9000/status/', 'tags': []})
-
-    check._fetch_data()
-
-    aggregator.assert_service_check(
-        'kong.can_connect',
-        status=Kong.CRITICAL,
-        tags=['kong_host:kong-host', 'kong_port:9000'],
-        count=1,
-    )
-
-
-def test_legacy_fetch_data_service_check_ok_only_when_status_code_is_200(mock_http_response, aggregator):
-    mock_http_response(json_data={'server': {}}, status_code=200)
-    check = _make_legacy_kong({'kong_status_url': 'http://kong-host:9000/status/', 'tags': []})
-
-    check._fetch_data()
-
-    aggregator.assert_service_check(
-        'kong.can_connect',
-        status=Kong.OK,
+        status=expected_status,
         tags=['kong_host:kong-host', 'kong_port:9000'],
         count=1,
     )
@@ -410,9 +373,3 @@ def test_legacy_parse_json_defaults_tags_to_empty_list_when_none():
     assert parsed == [('kong.x', 1, [])]
 
 
-def test_legacy_parse_json_preserves_caller_tags_when_provided():
-    check = _make_legacy_kong({'kong_status_url': 'http://kong:8001/status/'})
-
-    parsed = check._parse_json(b'{"server": {"x": 1}}', tags=['env:test'])
-
-    assert parsed == [('kong.x', 1, ['env:test'])]


### PR DESCRIPTION
### What does this PR do?

Adds tests to `kong/tests/test_unit.py` covering previously-untested public surface:

- `KongCheck.DEFAULT_METRIC_LIMIT`.
- The inner `service_check` helper inside `KongCheck.configure_transformer_upstream_target_health`: `sample.value != 1` skip (including `value > 1`), `state == 'healthchecks_off'` skip, continue-vs-break iteration past skipped samples, and the healthy / unhealthy / dns_error / unknown state-to-status mapping.
- Legacy `Kong.__new__` routing across all four combinations of `openmetrics_endpoint` / `kong_status_url` placement, including first-instance selection.
- Legacy `Kong.check()` gauge-submission and error logging when submission raises.
- Legacy `Kong._fetch_data` missing-status-url validation, default port 80, port-from-url, service-check tags (host / port / user-tags), HTTP error path, and status-code 200 OK vs 199 / 201 CRITICAL branches.
- Legacy `Kong._parse_json` metric prefixing, iteration over server entries, and `tags=None` default.

No source changes. No changelog entry (tests-only).

### Motivation

A mutation-testing sweep across integrations-core found kong scoring 23.3% — only 20 of 86 mutants killed. The existing `test_unit.py` only exercised the OpenMetrics V2 path through `KongCheck`, which left the legacy `Kong` AgentCheck in `kong/datadog_checks/kong/kong.py` (`__new__` routing, `check`, `_fetch_data`, `_parse_json`) and the inner service-check transformer in `check.py` effectively untested at the mutation level.

The new tests instantiate real check classes and assert on the real outputs (`gauge`, `service_check`); `MagicMock` is only used on those *output sinks* to verify what would be submitted.

Local cosmic-ray result with the new tests: **86 mutants generated, 86 killed, 0 survived (23.3% → 100%)**.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged