### PR TITLE
Fix Cilium e2e metric readiness

### DIFF
--- a/cilium/tests/conftest.py
+++ b/cilium/tests/conftest.py
@@ -111,9 +111,11 @@ def setup_cilium():
     )
     if result.stderr:
         raise Exception(result.stderr)
-    pods = result.stdout.split(" ")
+    cilium_pods = result.stdout.split()
+    if not cilium_pods:
+        raise AssertionError("No Cilium pods found")
 
-    for pod in pods:
+    for pod in cilium_pods:
         result = run_command(
             [
                 "kubectl",
@@ -122,7 +124,7 @@ def setup_cilium():
                 "cilium",
                 "-c",
                 "cilium-agent",
-                pod.strip(),
+                pod,
                 "--",
                 "cilium",
                 "endpoint",
@@ -138,7 +140,7 @@ def setup_cilium():
         attempts=60,
         wait=2,
         args=(
-            pods[0].strip(),
+            cilium_pods,
             [
                 "cilium_forward_bytes_total",
                 "cilium_forward_count_total",
@@ -149,31 +151,32 @@ def setup_cilium():
     )()
 
 
-def wait_for_cilium_metric_families(pod, families):
+def wait_for_cilium_metric_families(pods, families):
     missing = []
-    for family in families:
-        result = run_command(
-            [
-                "kubectl",
-                "exec",
-                "-n",
-                "cilium",
-                "-c",
-                "cilium-agent",
-                pod,
-                "--",
-                "cilium",
-                "metrics",
-                "list",
-                "--match-pattern",
-                family,
-            ],
-            capture=True,
-        )
-        if result.stderr:
-            raise Exception(result.stderr)
-        if family not in result.stdout:
-            missing.append(family)
+    for pod in pods:
+        for family in families:
+            result = run_command(
+                [
+                    "kubectl",
+                    "exec",
+                    "-n",
+                    "cilium",
+                    "-c",
+                    "cilium-agent",
+                    pod,
+                    "--",
+                    "cilium",
+                    "metrics",
+                    "list",
+                    "--match-pattern",
+                    family,
+                ],
+                capture=True,
+            )
+            if result.stderr:
+                raise Exception(result.stderr)
+            if family not in result.stdout:
+                missing.append("{} on {}".format(family, pod))
 
     if missing:
         raise AssertionError("Cilium metric families are not available yet: {}".format(", ".join(missing)))

--- a/cilium/tests/conftest.py
+++ b/cilium/tests/conftest.py
@@ -9,6 +9,7 @@ import pytest
 from datadog_checks.base.utils.common import get_docker_hostname
 from datadog_checks.cilium import CiliumCheck
 from datadog_checks.dev import run_command
+from datadog_checks.dev.conditions import WaitFor
 from datadog_checks.dev.kind import kind_run
 from datadog_checks.dev.kube_port_forward import port_forward
 from datadog_checks.dev.utils import get_active_env
@@ -131,6 +132,51 @@ def setup_cilium():
         )
         if result.stderr:
             raise Exception(result.stderr)
+
+    WaitFor(
+        wait_for_cilium_metric_families,
+        attempts=60,
+        wait=2,
+        args=(
+            pods[0].strip(),
+            [
+                "cilium_forward_bytes_total",
+                "cilium_forward_count_total",
+                "cilium_endpoint_regeneration_time_stats_seconds",
+                "cilium_policy_regeneration_time_stats_seconds",
+            ],
+        ),
+    )()
+
+
+def wait_for_cilium_metric_families(pod, families):
+    missing = []
+    for family in families:
+        result = run_command(
+            [
+                "kubectl",
+                "exec",
+                "-n",
+                "cilium",
+                "-c",
+                "cilium-agent",
+                pod,
+                "--",
+                "cilium",
+                "metrics",
+                "list",
+                "--match-pattern",
+                family,
+            ],
+            capture=True,
+        )
+        if result.stderr:
+            raise Exception(result.stderr)
+        if family not in result.stdout:
+            missing.append(family)
+
+    if missing:
+        raise AssertionError("Cilium metric families are not available yet: {}".format(", ".join(missing)))
 
 
 def get_instances(agent_host, agent_port, operator_host, operator_port, use_openmetrics):

--- a/cilium/tests/conftest.py
+++ b/cilium/tests/conftest.py
@@ -173,8 +173,8 @@ def wait_for_cilium_metric_families(pods, families):
                 ],
                 capture=True,
             )
-            if result.stderr:
-                raise Exception(result.stderr)
+            if result.code != 0:
+                raise Exception(result.stderr or result.stdout)
             if family not in result.stdout:
                 missing.append("{} on {}".format(family, pod))
 


### PR DESCRIPTION
### What does this PR do?

Fixes Cilium e2e flakes in the `Test Agent release` workflow.

The test was starting as soon as the Cilium pods were ready, but some Cilium metrics were not available yet. This PR waits for the Cilium metric families that the test needs before running the check.

Recent examples of Cilium failures:

- https://github.com/DataDog/integrations-core/actions/runs/25448878009/job/74660438051 — Cilium was the only failed job; 276 jobs passed.
- https://github.com/DataDog/integrations-core/actions/runs/26047075885/job/76574000060 — Cilium failed; 276 jobs passed and 3 jobs failed total.
- https://github.com/DataDog/integrations-core/actions/runs/26047517716/job/76575517505 — Cilium failed; 275 jobs passed and 4 jobs failed total.
- https://github.com/DataDog/integrations-core/actions/runs/24676313075/job/72161169866 — Cilium failed; 272 jobs passed and 6 jobs failed total.

### Motivation

This is a test fixture race, not a Cilium check change.

Kubernetes can report the Cilium pods as ready before Cilium has exposed all of the metrics asserted by the e2e test. When that happens, the test can fail with errors like:

```text
Needed at least 1 candidates for 'cilium.forward_bytes.count', got 0
```

Instead of adding a fixed sleep, this PR waits for Cilium itself to report that the needed metric families exist.

### Testing

Reproduced the failure locally before the fix with warm `--new-env` and rc.3 agent. Verified after the fix:

```bash
hatch run -- ddev --no-interactive env test \
  --new-env \
  --agent registry.datadoghq.com/agent:7.79.0-rc.3 \
  cilium py3.13-1.11 \
  -- -k 'test_check_ok and not fips'
```

Reran the Cilium `py3.13-1.11` GitHub Actions job 20 times on this PR. All 20 reruns passed.

Run: https://github.com/DataDog/integrations-core/actions/runs/26150418240

First 10 rerun job attempts:

- https://github.com/DataDog/integrations-core/actions/runs/26150418240/job/76966220255
- https://github.com/DataDog/integrations-core/actions/runs/26150418240/job/76967133421
- https://github.com/DataDog/integrations-core/actions/runs/26150418240/job/76968030568
- https://github.com/DataDog/integrations-core/actions/runs/26150418240/job/76968900840
- https://github.com/DataDog/integrations-core/actions/runs/26150418240/job/76969860952
- https://github.com/DataDog/integrations-core/actions/runs/26150418240/job/76970824169
- https://github.com/DataDog/integrations-core/actions/runs/26150418240/job/76971933185
- https://github.com/DataDog/integrations-core/actions/runs/26150418240/job/76972881151
- https://github.com/DataDog/integrations-core/actions/runs/26150418240/job/76973870165
- https://github.com/DataDog/integrations-core/actions/runs/26150418240/job/76974801246

Additional 10 rerun job attempts:

- https://github.com/DataDog/integrations-core/actions/runs/26150418240/job/76998883655
- https://github.com/DataDog/integrations-core/actions/runs/26150418240/job/76999805267
- https://github.com/DataDog/integrations-core/actions/runs/26150418240/job/77000681282
- https://github.com/DataDog/integrations-core/actions/runs/26150418240/job/77001537598
- https://github.com/DataDog/integrations-core/actions/runs/26150418240/job/77002352424
- https://github.com/DataDog/integrations-core/actions/runs/26150418240/job/77003257114
- https://github.com/DataDog/integrations-core/actions/runs/26150418240/job/77004400303
- https://github.com/DataDog/integrations-core/actions/runs/26150418240/job/77006160546
- https://github.com/DataDog/integrations-core/actions/runs/26150418240/job/77007533481
- https://github.com/DataDog/integrations-core/actions/runs/26150418240/job/77009131509

Also started a full `Test Agent release` validation run against the PR branch with the rc.3 images:

- Workflow run: https://github.com/DataDog/integrations-core/actions/runs/26175294614
- Ref: `nubtron/fix-cilium-e2e-readiness`
- Agent image: `registry.datadoghq.com/agent:7.79.0-rc.3`
- Windows image: `registry.datadoghq.com/agent:7.79.0-rc.3-servercore`
- Current Cilium result: 5/5 attempts passed so far; the overall workflow still has unrelated failures in other integrations.

Cilium job attempts from that full Test Agent release run:

- https://github.com/DataDog/integrations-core/actions/runs/26175294614/job/77003746035
- https://github.com/DataDog/integrations-core/actions/runs/26175294614/job/77008240002
- https://github.com/DataDog/integrations-core/actions/runs/26175294614/job/77125287322
- https://github.com/DataDog/integrations-core/actions/runs/26175294614/job/77129286395
- https://github.com/DataDog/integrations-core/actions/runs/26175294614/job/77133499025

Additional local verification:

- `py3.13-1.11`: 3/3 warm attempts passed
- `py3.13-1.10`: 1/1 warm attempt passed
- `py3.13-1.9`: 1/1 warm attempt passed

