### PR TITLE
Add missing envoy.vhost.vcluster.upstream_rq_time.99_5percentile to metadata.csv

### DIFF
--- a/envoy/changelog.d/23770.fixed
+++ b/envoy/changelog.d/23770.fixed
@@ -1,0 +1,1 @@
+Add missing ``envoy.vhost.vcluster.upstream_rq_time.99_5percentile`` metric to metadata.csv.

--- a/envoy/changelog.d/23770.fixed
+++ b/envoy/changelog.d/23770.fixed
@@ -1,1 +1,0 @@
-Add missing ``envoy.vhost.vcluster.upstream_rq_time.99_5percentile`` metric to metadata.csv.

--- a/envoy/metadata.csv
+++ b/envoy/metadata.csv
@@ -801,7 +801,6 @@ envoy.vhost.vcluster.upstream_rq_time.75percentile,gauge,,millisecond,,[Legacy] 
 envoy.vhost.vcluster.upstream_rq_time.90percentile,gauge,,millisecond,,[Legacy] Request time milliseconds 90-percentile,-1,envoy,,
 envoy.vhost.vcluster.upstream_rq_time.95percentile,gauge,,millisecond,,[Legacy] Request time milliseconds 95-percentile,-1,envoy,,
 envoy.vhost.vcluster.upstream_rq_time.99percentile,gauge,,millisecond,,[Legacy] Request time milliseconds 99-percentile,-1,envoy,,
-envoy.vhost.vcluster.upstream_rq_time.99_5percentile,gauge,,millisecond,,[Legacy] Request time milliseconds 99.5-percentile,-1,envoy,,
 envoy.vhost.vcluster.upstream_rq_time.99_9percentile,gauge,,millisecond,,[Legacy] Request time milliseconds 99.9-percentile,-1,envoy,,
 envoy.vhost.vcluster.upstream_rq_time.100percentile,gauge,,millisecond,,[Legacy] Request time milliseconds 100-percentile,-1,envoy,,
 envoy.http.dynamodb.operation.upstream_rq_time.0percentile,gauge,,millisecond,,[Legacy] Time spent on operation_name tag 0-percentile,-1,envoy,,

--- a/envoy/metadata.csv
+++ b/envoy/metadata.csv
@@ -801,6 +801,7 @@ envoy.vhost.vcluster.upstream_rq_time.75percentile,gauge,,millisecond,,[Legacy] 
 envoy.vhost.vcluster.upstream_rq_time.90percentile,gauge,,millisecond,,[Legacy] Request time milliseconds 90-percentile,-1,envoy,,
 envoy.vhost.vcluster.upstream_rq_time.95percentile,gauge,,millisecond,,[Legacy] Request time milliseconds 95-percentile,-1,envoy,,
 envoy.vhost.vcluster.upstream_rq_time.99percentile,gauge,,millisecond,,[Legacy] Request time milliseconds 99-percentile,-1,envoy,,
+envoy.vhost.vcluster.upstream_rq_time.99_5percentile,gauge,,millisecond,,[Legacy] Request time milliseconds 99.5-percentile,-1,envoy,,
 envoy.vhost.vcluster.upstream_rq_time.99_9percentile,gauge,,millisecond,,[Legacy] Request time milliseconds 99.9-percentile,-1,envoy,,
 envoy.vhost.vcluster.upstream_rq_time.100percentile,gauge,,millisecond,,[Legacy] Request time milliseconds 100-percentile,-1,envoy,,
 envoy.http.dynamodb.operation.upstream_rq_time.0percentile,gauge,,millisecond,,[Legacy] Time spent on operation_name tag 0-percentile,-1,envoy,,

--- a/envoy/tests/conftest.py
+++ b/envoy/tests/conftest.py
@@ -35,20 +35,17 @@ def dd_environment():
         attempts=5,
         attempts_wait=10,
     ):
-        # Exercising envoy a bit will trigger extra metrics
-        requests.get('http://{}:8000/service/1'.format(HOST))
-        requests.get('http://{}:8000/service/2'.format(HOST))
         yield instance
 
 
 @pytest.fixture
 def exercise_envoy():
-    # Re-fire requests through Envoy's listener immediately before the check
+    # Fire requests through Envoy's listener immediately before the check
     # scrapes /stats so the vhost.vcluster histograms have samples in Envoy's
-    # current flush window. The session-scoped dd_environment requests can be
-    # multiple 5s flush intervals in the past by the time an E2E check runs,
-    # at which point the histogram interval values have been reset to nan and
-    # the parser drops them silently.
+    # current flush window. Without this, the time between env setup and the
+    # check invocation can span multiple 5s flush intervals, by which point
+    # the histogram interval values have been reset to nan and the parser
+    # drops them silently.
     requests.get('http://{}:8000/service/1'.format(HOST))
     requests.get('http://{}:8000/service/2'.format(HOST))
 

--- a/envoy/tests/conftest.py
+++ b/envoy/tests/conftest.py
@@ -56,6 +56,14 @@ def exercise_envoy():
     # libcircllhist), which the parser would then filter out. Spreading
     # requests across the window keeps the interval quantiles populated
     # regardless of where the test lands in Envoy's flush cycle.
+    #
+    # Budget note: this buys us roughly one full flush interval of safe
+    # scrape window after the fixture yields, before the next empty flush
+    # wipes the interval values. The agent's --check-rate scrape typically
+    # takes 3-7s, so it lands comfortably inside that window. If the agent
+    # invocation ever gets significantly slower (e.g. longer rate delays
+    # or extra setup work) raise stats_flush_interval in front-envoy.yaml
+    # instead of leaning on this buffer.
     deadline = time.monotonic() + ENVOY_STATS_FLUSH_INTERVAL + 1
     while time.monotonic() < deadline:
         requests.get('http://{}:8000/service/1'.format(HOST))

--- a/envoy/tests/conftest.py
+++ b/envoy/tests/conftest.py
@@ -35,10 +35,18 @@ def dd_environment():
         attempts=5,
         attempts_wait=10,
     ):
-        # Exercising envoy a bit will trigger extra metrics
-        requests.get('http://{}:8000/service/1'.format(HOST))
-        requests.get('http://{}:8000/service/2'.format(HOST))
         yield instance
+
+
+@pytest.fixture
+def exercise_envoy():
+    # Fire requests through Envoy's listener immediately before the check scrapes
+    # /stats so the vhost.vcluster histograms have samples in Envoy's current
+    # flush window. Without this, the time between env setup and the check
+    # invocation can span multiple 5s flush intervals, reducing the interval
+    # values to nan (which the parser filters out).
+    requests.get('http://{}:8000/service/1'.format(HOST))
+    requests.get('http://{}:8000/service/2'.format(HOST))
 
 
 @pytest.fixture

--- a/envoy/tests/conftest.py
+++ b/envoy/tests/conftest.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import copy
 import os
+import threading
 import time
 
 import pytest
@@ -48,27 +49,35 @@ def dd_environment():
 
 @pytest.fixture
 def exercise_envoy():
-    # Drive continuous traffic through Envoy's listener for one full stats
-    # flush interval so the most recent flush window always has samples.
-    # Envoy's text /stats endpoint reports per-interval quantile values
-    # that get recomputed on every flush; an empty flush resets the
-    # interval percentiles to nan (see hist_approx_quantile in
-    # libcircllhist), which the parser would then filter out. Spreading
-    # requests across the window keeps the interval quantiles populated
-    # regardless of where the test lands in Envoy's flush cycle.
-    #
-    # Budget note: this buys us roughly one full flush interval of safe
-    # scrape window after the fixture yields, before the next empty flush
-    # wipes the interval values. The agent's --check-rate scrape typically
-    # takes 3-7s, so it lands comfortably inside that window. If the agent
-    # invocation ever gets significantly slower (e.g. longer rate delays
-    # or extra setup work) raise stats_flush_interval in front-envoy.yaml
-    # instead of leaning on this buffer.
-    deadline = time.monotonic() + ENVOY_STATS_FLUSH_INTERVAL + 1
-    while time.monotonic() < deadline:
-        requests.get('http://{}:8000/service/1'.format(HOST))
-        requests.get('http://{}:8000/service/2'.format(HOST))
-        time.sleep(ENVOY_STATS_FLUSH_INTERVAL / 10)
+    # Drive continuous traffic through Envoy's listener for the entire
+    # lifetime of the test. A background thread keeps firing requests
+    # until the fixture tears down, so every flush window — including
+    # those that close while the agent's check is in flight — has
+    # samples. Envoy's text /stats endpoint reports per-interval
+    # quantile values that get recomputed on every flush; an empty
+    # flush resets the interval percentiles to nan (see
+    # hist_approx_quantile in libcircllhist), which the parser would
+    # then filter out.
+    stop = threading.Event()
+
+    def fire_loop():
+        while not stop.is_set():
+            try:
+                requests.get('http://{}:8000/service/1'.format(HOST))
+                requests.get('http://{}:8000/service/2'.format(HOST))
+            except requests.RequestException:
+                pass
+            stop.wait(ENVOY_STATS_FLUSH_INTERVAL / 10)
+
+    thread = threading.Thread(target=fire_loop, daemon=True)
+    thread.start()
+    # Wait one full flush interval so the first non-empty flush rolls
+    # samples into the interval percentile view before the test body
+    # starts scraping.
+    time.sleep(ENVOY_STATS_FLUSH_INTERVAL + 1)
+    yield
+    stop.set()
+    thread.join(timeout=2)
 
 
 @pytest.fixture

--- a/envoy/tests/conftest.py
+++ b/envoy/tests/conftest.py
@@ -14,6 +14,13 @@ from datadog_checks.envoy import Envoy
 from .common import DEFAULT_INSTANCE, DOCKER_DIR, FIXTURE_DIR, HOST, URL
 from .legacy.common import FLAVOR, INSTANCES
 
+# Envoy's default stats_flush_interval (seconds). The exercise_envoy
+# fixture drives traffic for one full interval so the most recent
+# completed flush window always has samples; if Envoy's default changes
+# (or we ever set the interval explicitly in the test bootstrap config),
+# update this constant and the fixture timings follow.
+ENVOY_STATS_FLUSH_INTERVAL = 5
+
 
 @pytest.fixture(scope='session')
 def fixture_path():
@@ -44,16 +51,16 @@ def exercise_envoy():
     # Drive continuous traffic through Envoy's listener for one full stats
     # flush interval so the most recent flush window always has samples.
     # Envoy's text /stats endpoint reports per-interval quantile values
-    # that get recomputed on every 5s flush; an empty flush resets the
+    # that get recomputed on every flush; an empty flush resets the
     # interval percentiles to nan (see hist_approx_quantile in
     # libcircllhist), which the parser would then filter out. Spreading
     # requests across the window keeps the interval quantiles populated
     # regardless of where the test lands in Envoy's flush cycle.
-    deadline = time.monotonic() + 6
+    deadline = time.monotonic() + ENVOY_STATS_FLUSH_INTERVAL + 1
     while time.monotonic() < deadline:
         requests.get('http://{}:8000/service/1'.format(HOST))
         requests.get('http://{}:8000/service/2'.format(HOST))
-        time.sleep(0.5)
+        time.sleep(ENVOY_STATS_FLUSH_INTERVAL / 10)
 
 
 @pytest.fixture

--- a/envoy/tests/conftest.py
+++ b/envoy/tests/conftest.py
@@ -41,18 +41,19 @@ def dd_environment():
 
 @pytest.fixture
 def exercise_envoy():
-    # Fire requests through Envoy's listener and wait long enough for at
-    # least one stats flush to roll the samples into the histogram interval
-    # view. Envoy's text /stats endpoint reports per-interval quantile values
-    # that update on each 5s flush; the parser drops any percentile whose
-    # interval value is nan. Without the sleep the scrape can land before
-    # the first flush after the requests (interval=nan, no metric emitted)
-    # or after multiple empty flushes have wiped the values (also nan).
-    # 6 seconds reliably lands us in the "one flush has captured the
-    # requests, next empty flush hasn't reset yet" window.
-    requests.get('http://{}:8000/service/1'.format(HOST))
-    requests.get('http://{}:8000/service/2'.format(HOST))
-    time.sleep(6)
+    # Drive continuous traffic through Envoy's listener for one full stats
+    # flush interval so the most recent flush window always has samples.
+    # Envoy's text /stats endpoint reports per-interval quantile values
+    # that get recomputed on every 5s flush; an empty flush resets the
+    # interval percentiles to nan (see hist_approx_quantile in
+    # libcircllhist), which the parser would then filter out. Spreading
+    # requests across the window keeps the interval quantiles populated
+    # regardless of where the test lands in Envoy's flush cycle.
+    deadline = time.monotonic() + 6
+    while time.monotonic() < deadline:
+        requests.get('http://{}:8000/service/1'.format(HOST))
+        requests.get('http://{}:8000/service/2'.format(HOST))
+        time.sleep(0.5)
 
 
 @pytest.fixture

--- a/envoy/tests/conftest.py
+++ b/envoy/tests/conftest.py
@@ -35,16 +35,20 @@ def dd_environment():
         attempts=5,
         attempts_wait=10,
     ):
+        # Exercising envoy a bit will trigger extra metrics
+        requests.get('http://{}:8000/service/1'.format(HOST))
+        requests.get('http://{}:8000/service/2'.format(HOST))
         yield instance
 
 
 @pytest.fixture
 def exercise_envoy():
-    # Fire requests through Envoy's listener immediately before the check scrapes
-    # /stats so the vhost.vcluster histograms have samples in Envoy's current
-    # flush window. Without this, the time between env setup and the check
-    # invocation can span multiple 5s flush intervals, reducing the interval
-    # values to nan (which the parser filters out).
+    # Re-fire requests through Envoy's listener immediately before the check
+    # scrapes /stats so the vhost.vcluster histograms have samples in Envoy's
+    # current flush window. The session-scoped dd_environment requests can be
+    # multiple 5s flush intervals in the past by the time an E2E check runs,
+    # at which point the histogram interval values have been reset to nan and
+    # the parser drops them silently.
     requests.get('http://{}:8000/service/1'.format(HOST))
     requests.get('http://{}:8000/service/2'.format(HOST))
 

--- a/envoy/tests/conftest.py
+++ b/envoy/tests/conftest.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import copy
 import os
+import time
 
 import pytest
 import requests
@@ -40,14 +41,18 @@ def dd_environment():
 
 @pytest.fixture
 def exercise_envoy():
-    # Fire requests through Envoy's listener immediately before the check
-    # scrapes /stats so the vhost.vcluster histograms have samples in Envoy's
-    # current flush window. Without this, the time between env setup and the
-    # check invocation can span multiple 5s flush intervals, by which point
-    # the histogram interval values have been reset to nan and the parser
-    # drops them silently.
+    # Fire requests through Envoy's listener and wait long enough for at
+    # least one stats flush to roll the samples into the histogram interval
+    # view. Envoy's text /stats endpoint reports per-interval quantile values
+    # that update on each 5s flush; the parser drops any percentile whose
+    # interval value is nan. Without the sleep the scrape can land before
+    # the first flush after the requests (interval=nan, no metric emitted)
+    # or after multiple empty flushes have wiped the values (also nan).
+    # 6 seconds reliably lands us in the "one flush has captured the
+    # requests, next empty flush hasn't reset yet" window.
     requests.get('http://{}:8000/service/1'.format(HOST))
     requests.get('http://{}:8000/service/2'.format(HOST))
+    time.sleep(6)
 
 
 @pytest.fixture

--- a/envoy/tests/legacy/test_e2e.py
+++ b/envoy/tests/legacy/test_e2e.py
@@ -282,7 +282,7 @@ METRICS_V3 = [
 ]
 
 
-def test_e2e(dd_agent_check):
+def test_e2e(dd_agent_check, exercise_envoy):
     instance = {"stats_url": "http://{}:8001/stats".format(HOST)}
     aggregator = dd_agent_check(instance, rate=True)
     for metric in METRICS:

--- a/envoy/tests/legacy/test_integration.py
+++ b/envoy/tests/legacy/test_integration.py
@@ -12,7 +12,11 @@ from .common import ENVOY_VERSION, EXT_AUTHZ_METRICS, INSTANCES, RBAC_METRICS
 CHECK_NAME = 'envoy'
 UNIQUE_METRICS = EXT_AUTHZ_METRICS + RBAC_METRICS
 
-pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment'), pytest.mark.flaky]
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.usefixtures('dd_environment', 'exercise_envoy'),
+    pytest.mark.flaky,
+]
 
 
 def test_success(aggregator, check, dd_run_check):

--- a/envoy/tests/test_e2e.py
+++ b/envoy/tests/test_e2e.py
@@ -21,7 +21,7 @@ pytestmark = [requires_new_environment]
 
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check):
+def test_e2e(dd_agent_check, exercise_envoy):
     aggregator = dd_agent_check(DEFAULT_INSTANCE, rate=True)
 
     for metric in PROMETHEUS_METRICS + LOCAL_RATE_LIMIT_METRICS + CONNECTION_LIMIT_METRICS + TLS_INSPECTOR_METRICS:

--- a/envoy/tests/test_integration.py
+++ b/envoy/tests/test_integration.py
@@ -22,7 +22,7 @@ from .common import (
 pytestmark = [
     requires_new_environment,
     pytest.mark.integration,
-    pytest.mark.usefixtures('dd_environment'),
+    pytest.mark.usefixtures('dd_environment', 'exercise_envoy'),
     pytest.mark.flaky,
 ]
 


### PR DESCRIPTION
### What does this PR do?

Adds the missing `envoy.vhost.vcluster.upstream_rq_time.99_5percentile` entry to `envoy/metadata.csv` and pins the Envoy listener warm-up timing so any future histogram-percentile gap is caught in regular CI rather than only at agent-release time.

### Motivation

The legacy Envoy E2E test was failing in the Test Agent release workflow for the 7.80.x release branch with `Expect envoy.vhost.vcluster.upstream_rq_time.99_5percentile to be in metadata.csv`. Envoy 1.14+ emits a P99.5 by default for every histogram, but emission of this specific quantile only reliably appears at scrape time when (1) the listener has had recent traffic and (2) the scrape lands inside the narrow Envoy flush window where that traffic was captured. With the old `dd_environment`-scoped warm-up, master CI's `--base` install delay pushed the scrape past that window so the metric was filtered out — masking the missing metadata. Test-agent's faster path happened to land inside the window, so the gap only surfaced there.

This PR pulls the warm-up into a function-scoped `exercise_envoy` fixture used by every test that needs Envoy traffic, with a sleep to deterministically straddle an Envoy stats flush, and adds the missing metadata entry.

### Test plan

- [x] Validation round (commit `25cb8d8b5f`, [run 26217085835](https://github.com/DataDog/integrations-core/actions/runs/26217085835)): metadata entry removed, fixture in place. Envoy `test` and `test-minimum-base-package` py3.13-3 jobs both **fail** consistently with `Expect envoy.vhost.vcluster.upstream_rq_time.99_5percentile to be in metadata.csv` — proving the fixture makes emission reliable on master.
- [x] Green round (commit `e1bbc96076`, [run 26217273574](https://github.com/DataDog/integrations-core/actions/runs/26217273574)): metadata entry restored. All 4 envoy jobs pass.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged