### PR TITLE
Add troubleshooting steps for OpenShift ClusterResourceQuota metrics

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -159,6 +159,33 @@ The OpenShift check does not include any Service Checks.
 
 ## Troubleshooting
 
+### Missing cluster quota metrics
+
+In an OpenShift cluster most of the Agent and Cluster Agent reported metrics are the same as other Kubernetes clusters. The only OpenShift specific metrics are the ones listed above starting with `openshift.*`. These correspond to the optional [OpenShift `ClusterResourceQuota` objects][19] that you can deploy in your clusters. If you are using native [Kubernetes `ResourceQuotas` objects][20] those are reported in the `kubernetes_state_core` (KSM) check as the `kubernetes_state.resourcequota.*` metrics.
+
+These OpenShift metrics are reported per *active* `ClusterResourceQuota` as part of the Cluster Agent's [`kubernetes_apiserver` check][1]. For a `ClusterResourceQuota` to be active it needs to be able to identify an OpenShift project (Kubernetes namespace) with the matching label or annotation selectors.
+
+You can confirm that you have these resources by running `oc get clusterresourcequotas` to confirm they exist. Then run `oc describe clusterresourcequotas <NAME>` relative to them to confirm if they are active. An active quota looks like:
+
+```
+$ oc describe clusterresourcequota example-cluster-quota
+Name: example-cluster-quota
+Created: 2 weeks ago
+Labels: <none>
+Annotations: <none>
+Namespace Selector: []
+Label Selector:
+AnnotationSelector: map[example-annotation:value]
+Resource Used Hard
+-------- ---- ----
+pods      1     10
+secrets   9     20
+```
+
+In this above sample, metrics for this quota are reported for its pods and secrets usage only. As you apply quotas towards the [different resources][21] like CPU, storage, ConfigMaps, etc, those are reported accordingly.
+
+If your `ClusterResourceQuota` describe output is not showing any resources and their Used/Hard values, the quota is not actively applied relative to its selectors. There is no data reported relative to these non active quotas.
+
 Need help? Contact [Datadog support][14].
 
 [1]: https://github.com/DataDog/datadog-agent/blob/master/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
@@ -179,3 +206,6 @@ Need help? Contact [Datadog support][14].
 [16]: https://github.com/DataDog/helm-charts/blob/main/examples/datadog/agent_on_openshift_values.yaml
 [17]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-on-openshift.yaml
 [18]: https://docs.datadoghq.com/containers/kubernetes/apm
+[19]: https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/building_applications/quotas#setting-quotas-across-multiple-projects
+[20]: https://kubernetes.io/docs/concepts/policy/resource-quotas/
+[21]: https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/building_applications/quotas#quotas-resources-managed_quotas-setting-per-project

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -161,11 +161,11 @@ The OpenShift check does not include any Service Checks.
 
 ### Missing cluster quota metrics
 
-In an OpenShift cluster most of the Agent and Cluster Agent reported metrics are the same as other Kubernetes clusters. The only OpenShift specific metrics are the ones listed above starting with `openshift.*`. These correspond to the optional [OpenShift `ClusterResourceQuota` objects][19] that you can deploy in your clusters. If you are using native [Kubernetes `ResourceQuotas` objects][20] those are reported in the `kubernetes_state_core` (KSM) check as the `kubernetes_state.resourcequota.*` metrics.
+In an OpenShift cluster, most of the Agent and Cluster Agent reported metrics are the same as in other Kubernetes clusters. The only OpenShift-specific metrics are the ones listed above starting with `openshift.*`. These correspond to the optional [OpenShift `ClusterResourceQuota` objects][19] that you can deploy in your clusters. If you use native [Kubernetes `ResourceQuotas` objects][20], those are reported by the `kubernetes_state_core` (KSM) check as `kubernetes_state.resourcequota.*` metrics.
 
-These OpenShift metrics are reported per *active* `ClusterResourceQuota` as part of the Cluster Agent's [`kubernetes_apiserver` check][1]. For a `ClusterResourceQuota` to be active it needs to be able to identify an OpenShift project (Kubernetes namespace) with the matching label or annotation selectors.
+These OpenShift metrics are reported per *active* `ClusterResourceQuota` as part of the Cluster Agent's [`kubernetes_apiserver` check][1]. For a `ClusterResourceQuota` to be active, it must be able to identify an OpenShift project (Kubernetes namespace) with the matching label or annotation selectors.
 
-You can confirm that you have these resources by running `oc get clusterresourcequotas` to confirm they exist. Then run `oc describe clusterresourcequotas <NAME>` relative to them to confirm if they are active. An active quota looks like:
+You can confirm that these resources exist by running `oc get clusterresourcequotas`. Then, run `oc describe clusterresourcequotas <NAME>` to check whether a quota is active. An active quota looks like:
 
 ```
 $ oc describe clusterresourcequota example-cluster-quota
@@ -182,9 +182,9 @@ pods      1     10
 secrets   9     20
 ```
 
-In this above sample, metrics for this quota are reported for its pods and secrets usage only. As you apply quotas towards the [different resources][21] like CPU, storage, ConfigMaps, etc, those are reported accordingly.
+In the example above, metrics for this quota are reported only for pod and secret usage. As you apply quotas to [different resources][21] like CPU, storage, ConfigMaps, the corresponding usage metrics are reported.
 
-If your `ClusterResourceQuota` describe output is not showing any resources and their Used/Hard values, the quota is not actively applied relative to its selectors. There is no data reported relative to these non active quotas.
+If your `ClusterResourceQuota` describe output does not show any resources or their Used/Hard values, the quota is not actively applied by its selectors. No data is reported for these non-active quotas.
 
 Need help? Contact [Datadog support][14].
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add some troubleshooting steps for the `openshift.*` quota metrics that we report. Largely clarifying what these are/aren't and how to validate that your quotas are actively in use. 

### Motivation
<!-- What inspired you to submit this pull request? -->
https://datadoghq.atlassian.net/browse/TEEP-5980
We have internal troubleshooting documentation on this, exposing the mainline steps of it that cover the large majority of cases. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
