### PR TITLE
Emit Warning Events for Consul Integration

### DIFF
--- a/consul/assets/configuration/spec.yaml
+++ b/consul/assets/configuration/spec.yaml
@@ -178,6 +178,16 @@ files:
         example: 3600
         minimum: 1
 
+    - name: health_check_warning_events
+      fleet_configurable: true
+      description: |
+        Whether to emit a Datadog event when a Consul health check transitions to `warning`.
+        Critical health check events are always emitted when `collect_health_checks` is enabled.
+      value:
+        type: boolean
+        example: true
+        default: false
+  
     - template: instances/http
     - template: instances/default
   - template: logs

--- a/consul/assets/configuration/spec.yaml
+++ b/consul/assets/configuration/spec.yaml
@@ -181,7 +181,7 @@ files:
     - name: health_check_warning_events
       fleet_configurable: true
       description: |
-        Whether to emit a Datadog event when a Consul health check transitions to `warning`.
+        Whether to emit an event when a Consul health check transitions to `warning`.
         Critical health check events are always emitted when `collect_health_checks` is enabled.
       value:
         type: boolean

--- a/consul/assets/configuration/spec.yaml
+++ b/consul/assets/configuration/spec.yaml
@@ -182,7 +182,7 @@ files:
       fleet_configurable: true
       description: |
         Whether to emit an event when a Consul health check transitions to `warning`.
-        Critical health check events are always emitted when `collect_health_checks` is enabled.
+        Events for critical health checks are always emitted when `collect_health_checks` is enabled.
       value:
         type: boolean
         example: true

--- a/consul/changelog.d/23779.added
+++ b/consul/changelog.d/23779.added
@@ -1,0 +1,1 @@
+Add new config `health_check_warning_events` to emit an event when a Consul health check transitions to `warning`.

--- a/consul/datadog_checks/consul/config_models/defaults.py
+++ b/consul/datadog_checks/consul/config_models/defaults.py
@@ -48,6 +48,10 @@ def instance_enable_legacy_tags_normalization():
     return True
 
 
+def instance_health_check_warning_events():
+    return False
+
+
 def instance_health_checks_cache_size():
     return 5000
 

--- a/consul/datadog_checks/consul/config_models/instance.py
+++ b/consul/datadog_checks/consul/config_models/instance.py
@@ -76,6 +76,7 @@ class InstanceConfig(BaseModel):
     enable_legacy_tags_normalization: Optional[bool] = None
     extra_headers: Optional[MappingProxyType[str, Any]] = None
     headers: Optional[MappingProxyType[str, Any]] = None
+    health_check_warning_events: Optional[bool] = None
     health_checks_cache_size: Optional[int] = Field(None, ge=1)
     health_checks_cache_ttl: Optional[int] = Field(None, ge=1)
     kerberos_auth: Optional[Literal['required', 'optional', 'disabled']] = None

--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -116,6 +116,12 @@ class ConsulCheck(OpenMetricsBaseCheck):
         self.collect_health_checks = self.instance.get(
             'collect_health_checks', self.init_config.get('collect_health_checks', False)
         )
+        self.health_check_warning_events = is_affirmative(
+            self.instance.get(
+            'health_check_warning_events',
+            self.init_config.get('health_check_warning_events', False),
+                            )
+        )
 
         if self.threads_count > 1:
             self.thread_pool = ThreadPool(self.threads_count)
@@ -407,22 +413,34 @@ class ConsulCheck(OpenMetricsBaseCheck):
                         self.gauge(HEALTH_CHECK_METRIC, status_value, tags=main_tags + node_tags)
                         self.health_checks[hc_id] = status_value
 
-                        if last_hc_value != status_value and status_value == 3:
-                            check_name = check.get("Name", "Consul Health Check")
-                            check_output = check.get("Output", "")
-                            self.event(
-                                {
-                                    "timestamp": timestamp(),
-                                    "event_type": "consul.check_failed",
-                                    "alert_type": "error",
-                                    "source_type_name": SOURCE_TYPE_NAME,
-                                    "msg_title": f"{check_name} Failed",
-                                    "aggregation_key": "consul.status_check",
-                                    "msg_text": f"Check {check_id} for service {service_name}, id: {service_id}"
-                                    f"failed on node {node_name}: {check_output}",
-                                    "tags": node_tags,
-                                }
-                            )
+                        if last_hc_value != status_value:
+                            if status_value == 3 or (status_value == 2 and self.health_check_warning_events):
+                                check_name = check.get("Name", "Consul Health Check")
+                                check_output = check.get("Output", "")
+                                
+                                if status_value == 3:
+                                    event_type = "consul.check_failed"
+                                    alert_type = "error"
+                                    label = "failed"
+                                else:
+                                    event_type = "consul.check_warning"
+                                    alert_type = "warning"
+                                    label = "warning"
+
+                                self.event(
+                                    {
+                                        "timestamp": timestamp(),
+                                        "event_type": event_type,
+                                        "alert_type": alert_type,
+                                        "source_type_name": SOURCE_TYPE_NAME,
+                                        "msg_title": f"{check_name} {label.capitalize()}",
+                                        "aggregation_key": "consul.status_check",
+                                        "msg_text": f"Check {check_id} for service {service_name}, id: {service_id} "
+                                        f"{label} on node {node_name}: {check_output}",
+                                        "tags": node_tags,
+                                    }
+                                )
+                            
 
                     if sc_id not in service_checks:
                         service_checks[sc_id] = {'status': status, 'tags': tags}

--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -118,9 +118,9 @@ class ConsulCheck(OpenMetricsBaseCheck):
         )
         self.health_check_warning_events = is_affirmative(
             self.instance.get(
-            'health_check_warning_events',
-            self.init_config.get('health_check_warning_events', False),
-                            )
+                'health_check_warning_events',
+                self.init_config.get('health_check_warning_events', False),
+            )
         )
 
         if self.threads_count > 1:
@@ -417,7 +417,7 @@ class ConsulCheck(OpenMetricsBaseCheck):
                             if status_value == 3 or (status_value == 2 and self.health_check_warning_events):
                                 check_name = check.get("Name", "Consul Health Check")
                                 check_output = check.get("Output", "")
-                                
+
                                 if status_value == 3:
                                     event_type = "consul.check_failed"
                                     alert_type = "error"
@@ -440,7 +440,6 @@ class ConsulCheck(OpenMetricsBaseCheck):
                                         "tags": node_tags,
                                     }
                                 )
-                            
 
                     if sc_id not in service_checks:
                         service_checks[sc_id] = {'status': status, 'tags': tags}

--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -435,7 +435,7 @@ class ConsulCheck(OpenMetricsBaseCheck):
                                         "source_type_name": SOURCE_TYPE_NAME,
                                         "msg_title": f"{check_name} {label.capitalize()}",
                                         "aggregation_key": "consul.status_check",
-                                        "msg_text": f"Check {check_id} for service {service_name}, id: {service_id} "
+                                        "msg_text": f"Check {check_id} for service {service_name}, id: {service_id}"
                                         f"{label} on node {node_name}: {check_output}",
                                         "tags": node_tags,
                                     }

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -161,7 +161,7 @@ instances:
     # health_checks_cache_ttl: 3600
 
     ## @param health_check_warning_events - boolean - optional - default: false
-    ## Whether to emit a Datadog event when a Consul health check transitions to `warning`.
+    ## Whether to emit an event when a Consul health check transitions to `warning`.
     ## Critical health check events are always emitted when `collect_health_checks` is enabled.
     #
     # health_check_warning_events: true

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -162,7 +162,7 @@ instances:
 
     ## @param health_check_warning_events - boolean - optional - default: false
     ## Whether to emit an event when a Consul health check transitions to `warning`.
-    ## Critical health check events are always emitted when `collect_health_checks` is enabled.
+    ## Events for critical health checks are always emitted when `collect_health_checks` is enabled.
     #
     # health_check_warning_events: true
 

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -160,6 +160,12 @@ instances:
     #
     # health_checks_cache_ttl: 3600
 
+    ## @param health_check_warning_events - boolean - optional - default: false
+    ## Whether to emit a Datadog event when a Consul health check transitions to `warning`.
+    ## Critical health check events are always emitted when `collect_health_checks` is enabled.
+    #
+    # health_check_warning_events: true
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/consul/tests/consul_mocks.py
+++ b/consul/tests/consul_mocks.py
@@ -306,6 +306,13 @@ def mock_get_coord_nodes_benchmark(num_nodes):
     return nodes
 
 
+def mock_get_health_check_with_warning(_):
+    checks = mock_get_health_check(_)
+    checks[0]["Status"] = "warning"
+    checks[0]["Output"] = "disk usage high"
+    return checks
+
+
 def mock_get_health_check(_):
     return [
         {

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -331,6 +331,39 @@ def test_health_checks(aggregator, collect_health_checks, expected_metric_count,
     aggregator.assert_event(exact_match=False, count=expected_metric_count, **event)
 
 
+@pytest.mark.parametrize(
+    'health_check_warning_events, expected_warning_events',
+    [
+        pytest.param(True, 1, id="warning events enabled"),
+        pytest.param(False, 0, id="warning events disabled"),
+    ],
+)
+def test_health_check_warning_events(aggregator, health_check_warning_events, expected_warning_events):
+    config = consul_mocks.MOCK_CONFIG_DISABLE_SERVICE_TAG.copy()
+    config['collect_health_checks'] = True
+    config['health_check_warning_events'] = health_check_warning_events
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, [config])
+    my_mocks = consul_mocks._get_consul_mocks()
+    my_mocks['consul_request'] = consul_mocks.mock_get_health_check_with_warning
+    consul_mocks.mock_check(consul_check, my_mocks)
+    consul_check.check(None)
+
+    warning_events = [e for e in aggregator.events if e['event_type'] == 'consul.check_warning']
+    assert len(warning_events) == expected_warning_events
+    if expected_warning_events:
+        assert warning_events[0]['alert_type'] == 'warning'
+        assert warning_events[0]['msg_title'] == "Service 'server-loadbalancer' check Warning"
+        assert (
+            warning_events[0]['msg_text']
+            == "Check server-loadbalancer for service server-loadbalancer, id: server-loadbalancerwarning "
+            "on node node-2: disk usage high"
+        )
+
+        consul_check.check(None)
+        warning_events = [e for e in aggregator.events if e['event_type'] == 'consul.check_warning']
+        assert len(warning_events) == 1
+
+
 def test_service_checks_disable_service_tag(aggregator):
     consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG_DISABLE_SERVICE_TAG])
     my_mocks = consul_mocks._get_consul_mocks()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds optional warning events when Consul health checks transition to warning, via a new config option `health_check_warning_events`. The config option makes it so existing customers do not have their monitors interferred with

When `collect_health_checks` is enabled, the check already emits events on transitions to critical (`consul.check_failed, alert_type: error`). With `health_check_warning_events`: true, it also emits events on transitions to warning (`consul.check_warning`, `alert_type: warning`).

### Motivation
<!-- What inspired you to submit this pull request? -->

Customer [FR](https://datadoghq.atlassian.net/browse/FRAGENT-3582) for the need to have warning events emitted as well.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
