### PR TITLE
Enable QA label validation in the repo

### DIFF
--- a/.ddev/config.toml
+++ b/.ddev/config.toml
@@ -22,6 +22,7 @@ validations = [
     "readmes",
     "saved-views",
     "version",
+    "qa-label"
 ]
 
 [overrides.display-name]


### PR DESCRIPTION
### What does this PR do?

Adds `qa-label` to the list of enabled validations in `.ddev/config.toml` so the validate-all CI check enforces that every pull request carries exactly one of `qa/required` or `qa/skip-qa`.

### Motivation

The `qa-label` validator was introduced in #23748 but is not yet active for this repo. Enabling it here ensures the QA decision is consistently declared on every PR, which is already required by the contribution guidelines.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged