### PR TITLE
[SEC-31850][k9] OCSF facets: add type: integer

### DIFF
--- a/azure_active_directory/assets/logs/azure.activedirectory.yaml
+++ b/azure_active_directory/assets/logs/azure.activedirectory.yaml
@@ -162,6 +162,7 @@ facets:
     name: Activity ID
     path: ocsf.activity_id
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Activity Name
@@ -172,6 +173,7 @@ facets:
     name: Category ID
     path: ocsf.category_uid
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Category
@@ -182,6 +184,7 @@ facets:
     name: Class ID
     path: ocsf.class_uid
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Class
@@ -212,6 +215,7 @@ facets:
     name: Status ID
     path: ocsf.status_id
     source: log
+    type: integer
 pipeline:
   type: pipeline
   name: Azure Active Directory

--- a/cisco_duo/assets/logs/cisco-duo.yaml
+++ b/cisco_duo/assets/logs/cisco-duo.yaml
@@ -35,6 +35,7 @@ facets:
     name: Activity ID
     path: ocsf.activity_id
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Activity Name
@@ -45,6 +46,7 @@ facets:
     name: Category ID
     path: ocsf.category_uid
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Category
@@ -55,6 +57,7 @@ facets:
     name: Class ID
     path: ocsf.class_uid
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Class
@@ -110,6 +113,7 @@ facets:
     name: Status ID
     path: ocsf.status_id
     source: log
+    type: integer
 pipeline:
   type: pipeline
   name: Cisco Duo

--- a/cisco_umbrella_dns/assets/logs/cisco-umbrella-dns.yaml
+++ b/cisco_umbrella_dns/assets/logs/cisco-umbrella-dns.yaml
@@ -190,11 +190,13 @@ facets:
     name: Activity ID
     path: ocsf.activity_id
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Category ID
     path: ocsf.category_uid
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Category
@@ -205,6 +207,7 @@ facets:
     name: Class ID
     path: ocsf.class_uid
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Class
@@ -230,6 +233,7 @@ facets:
     name: Status ID
     path: ocsf.status_id
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Request URL String

--- a/lastpass/assets/logs/lastpass.yaml
+++ b/lastpass/assets/logs/lastpass.yaml
@@ -59,6 +59,7 @@ facets:
     name: Activity ID
     path: ocsf.activity_id
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Activity Name
@@ -69,6 +70,7 @@ facets:
     name: Category ID
     path: ocsf.category_uid
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Category
@@ -79,6 +81,7 @@ facets:
     name: Class ID
     path: ocsf.class_uid
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Class
@@ -119,6 +122,7 @@ facets:
     name: Status ID
     path: ocsf.status_id
     source: log
+    type: integer
 pipeline:
   type: pipeline
   name: LastPass

--- a/ssh_check/assets/logs/sshd.yaml
+++ b/ssh_check/assets/logs/sshd.yaml
@@ -28,11 +28,13 @@ facets:
     name: Activity ID
     path: ocsf.activity_id
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Category ID
     path: ocsf.category_uid
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Category
@@ -43,6 +45,7 @@ facets:
     name: Class ID
     path: ocsf.class_uid
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Class
@@ -68,6 +71,7 @@ facets:
     name: Status ID
     path: ocsf.status_id
     source: log
+    type: integer
 pipeline:
   type: pipeline
   name: Sshd

--- a/tomcat/assets/logs/tomcat.yaml
+++ b/tomcat/assets/logs/tomcat.yaml
@@ -87,11 +87,13 @@ facets:
     name: Activity ID
     path: ocsf.activity_id
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Category ID
     path: ocsf.category_uid
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Category
@@ -102,6 +104,7 @@ facets:
     name: Class ID
     path: ocsf.class_uid
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Class
@@ -122,6 +125,7 @@ facets:
     name: Status ID
     path: ocsf.status_id
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Severity
@@ -132,6 +136,7 @@ facets:
     name: Severity ID
     path: ocsf.severity_id
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Request URL String

--- a/zeek/assets/logs/zeek.yaml
+++ b/zeek/assets/logs/zeek.yaml
@@ -395,6 +395,7 @@ facets:
     name: Activity ID
     path: ocsf.activity_id
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Activity Name
@@ -405,6 +406,7 @@ facets:
     name: Category ID
     path: ocsf.category_uid
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Category
@@ -415,6 +417,7 @@ facets:
     name: Class ID
     path: ocsf.class_uid
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Class
@@ -430,6 +433,7 @@ facets:
     name: Severity ID
     path: ocsf.severity_id
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Status
@@ -440,6 +444,7 @@ facets:
     name: Status ID
     path: ocsf.status_id
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Source IP Address


### PR DESCRIPTION
## Changes
Related to [SEC-31850](https://datadoghq.atlassian.net/browse/SEC-31850).

Add the missing `type: integer` field to OCSF integer facets (`ocsf.activity_id`, `ocsf.category_uid`, `ocsf.class_uid`, `ocsf.status_id`, `ocsf.severity_id`) in integrations that didn't declare it, for consistency with https://github.com/DataDog/integrations-internal-core/pull/3268. Without this, `validate-logs` rejects PRs because these facet paths are defined inconsistently across integrations.

[SEC-31850]: https://datadoghq.atlassian.net/browse/SEC-31850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ