### PR TITLE
Remove datadog-csi-driver from agent release requirements

### DIFF
--- a/datadog_csi_driver/CHANGELOG.md
+++ b/datadog_csi_driver/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Agent 7.80.0
 
-* Starting from Agent 6.70.0, this integration has been moved as a core check to the Datadog Agent. Only assets are maintained in this repository.
+* Starting from Agent 7.80.0, this integration has been moved as a core check to the Datadog Agent. Only assets are maintained in this repository.
 
 ## 1.5.1 / 2026-04-15
 

--- a/datadog_csi_driver/CHANGELOG.md
+++ b/datadog_csi_driver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - datadog_csi_driver
 
+## Agent 7.80.0
+
+* Starting from Agent 6.70.0, this integration has been moved as a core check to the Datadog Agent. Only assets are maintained in this repository.
+
 ## 1.5.1 / 2026-04-15
 
 ***Fixed***:

--- a/datadog_csi_driver/CHANGELOG.md
+++ b/datadog_csi_driver/CHANGELOG.md
@@ -1,9 +1,5 @@
 # CHANGELOG - datadog_csi_driver
 
-## Agent 7.80.0
-
-* Starting from Agent 7.80.0, this integration has been moved as a core check to the Datadog Agent. Only assets are maintained in this repository.
-
 ## 1.5.1 / 2026-04-15
 
 ***Fixed***:

--- a/datadog_csi_driver/README.md
+++ b/datadog_csi_driver/README.md
@@ -2,6 +2,8 @@
 
 ## Overview
 
+**Note:** Starting from Datadog Agent 7.80.0, this integration has been moved as a core check inside the Datadog Agent. Only assets are maintained in this repository.
+
 This check monitors [`datadog_csi_driver`][1] through the Datadog Agent. 
 
 The Datadog CSI Driver is a DaemonSet that runs a gRPC server implementing the CSI specifications on each node of your Kubernetes cluster.

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -57,7 +57,6 @@ datadog-couch==9.4.0
 datadog-couchbase==6.5.0
 datadog-crio==5.4.0
 datadog-datadog-cluster-agent==6.5.0
-datadog-datadog-csi-driver==1.5.1; sys_platform != 'win32'
 datadog-dcgm==4.4.1
 datadog-delinea-privilege-manager==1.2.0
 datadog-delinea-secret-server==1.3.0


### PR DESCRIPTION
### What does this PR do?
Removes the `datadog-datadog-csi-driver` entry from `requirements-agent-release.txt`, which was left behind after the CSI Driver integration was dropped in #23222.

### Motivation
The integration no longer exists in the repository, so it should not appear in the agent release requirements.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged