### PR TITLE
Use registry.datadoghq.com for Datadog images

### DIFF
--- a/anthropic/README.md
+++ b/anthropic/README.md
@@ -90,7 +90,7 @@ docker run -d \
   -p 127.0.0.1:8125:8125/udp \
   -e DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true \
   -e DD_APM_ENABLED=true \
-  gcr.io/datadoghq/agent:latest
+  registry.datadoghq.com/agent:latest
 ```
 
 2. If you haven't already, install the `ddtrace` package:

--- a/azure_iot_edge/README.md
+++ b/azure_iot_edge/README.md
@@ -43,7 +43,7 @@ Follow the steps below to configure the IoT Edge device, runtime modules, and th
 
 3. Install and configure the Datadog Agent as a **custom module**:
     - Set the module name. For example: `datadog-agent`.
-    - Set the Agent image URI. For example: `datadog/agent:7`.
+    - Set the Agent image URI. For example: `registry.datadoghq.com/agent:7`.
     - Under "Environment Variables", configure your `DD_API_KEY`. You may also set extra Agent configuration here (see [Agent Environment Variables][6]).
     - Under "Container Create Options", enter the following configuration based on your device OS. **Note**: `NetworkId` must correspond to the network name set in the device `config.yaml` file.
 

--- a/crewai/README.md
+++ b/crewai/README.md
@@ -39,7 +39,7 @@ Use the CrewAI integration to monitor, troubleshoot, and evaluate your applicati
     -p 127.0.0.1:8125:8125/udp \
     -e DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true \
     -e DD_APM_ENABLED=true \
-    gcr.io/datadoghq/agent:latest
+    registry.datadoghq.com/agent:latest
   ```
 
 2. If you haven't already, install the `ddtrace` package:

--- a/datadog_checks_dev/changelog.d/23790.fixed
+++ b/datadog_checks_dev/changelog.d/23790.fixed
@@ -1,0 +1,1 @@
+Keep registry.datadoghq.com Agent 6 and 7 builds from receiving a Python suffix.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -73,7 +73,12 @@ class DockerInterface(object):
         # If we use a default non-RC build, and it's missing the py suffix, adds it
         if default_agent and self.agent_build and 'rc' not in self.agent_build and 'py' not in self.agent_build:
             # Agent 6 image no longer supports -pyX
-            if self.agent_build != 'datadog/agent:6' and self.agent_build != 'datadog/agent:7':
+            if self.agent_build not in {
+                'datadog/agent:6',
+                'datadog/agent:7',
+                'registry.datadoghq.com/agent:6',
+                'registry.datadoghq.com/agent:7',
+            }:
                 self.agent_build = f'{self.agent_build}-py{self.python_version}'
             echo_debug("Using default agent. Agent build: {}".format(self.agent_build))
 

--- a/ddev/changelog.d/23790.fixed
+++ b/ddev/changelog.d/23790.fixed
@@ -1,0 +1,1 @@
+Use registry.datadoghq.com in Agent image examples.

--- a/ddev/src/ddev/cli/env/start.py
+++ b/ddev/src/ddev/cli/env/start.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     '-a',
     'agent_build',
     help=(
-        'The Agent build to use e.g. a Docker image like `datadog/agent:latest`. You can '
+        'The Agent build to use e.g. a Docker image like `registry.datadoghq.com/agent:latest`. You can '
         'also use the name of an Agent defined in the `agents` configuration section.'
     ),
 )

--- a/ddev/src/ddev/cli/env/test.py
+++ b/ddev/src/ddev/cli/env/test.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     '-a',
     'agent_build',
     help=(
-        'The Agent build to use e.g. a Docker image like `datadog/agent:latest`. You can '
+        'The Agent build to use e.g. a Docker image like `registry.datadoghq.com/agent:latest`. You can '
         'also use the name of an Agent defined in the `agents` configuration section.'
     ),
 )

--- a/docker_daemon/README.md
+++ b/docker_daemon/README.md
@@ -44,7 +44,7 @@ For either option, your hosts need cgroup memory management enabled for the Dock
           -v /proc/:/host/proc/:ro \
           -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
           -e API_KEY={YOUR_DD_API_KEY} \
-          datadog/docker-dd-agent:latest
+          registry.datadoghq.com/docker-dd-agent:latest
 
 In the command above, you are able to pass your API key to the Datadog Agent using Docker's `-e` environment variable flag. Other variables include:
 
@@ -72,7 +72,7 @@ docker run -d --name dd-agent \
   -v /proc/:/host/proc/:ro \
   -v /cgroup/:/host/sys/fs/cgroup:ro \
   -e API_KEY={YOUR API KEY} \
-  datadog/docker-dd-agent:latest
+  registry.datadoghq.com/docker-dd-agent:latest
 ```
 
 #### Alpine Linux based container
@@ -87,7 +87,7 @@ docker run -d --name dd-agent \
   -v /proc/:/host/proc/:ro \
   -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
   -e API_KEY={YOUR API KEY} \
-  datadog/docker-dd-agent:latest-alpine
+  registry.datadoghq.com/docker-dd-agent:latest-alpine
 ```
 
 #### Image versioning

--- a/docs/developer/ddev/configuration.md
+++ b/docs/developer/ddev/configuration.md
@@ -43,11 +43,11 @@ Agent versions. For example, this configuration:
 agent = "master"
 
 [agents.master]
-docker = "datadog/agent-dev:master"
+docker = "registry.datadoghq.com/agent-dev:master-py3"
 local = "latest"
 
 [agents."7.18.1"]
-docker = "datadog/agent:7.18.1"
+docker = "registry.datadoghq.com/agent:7.18.1"
 local = "7.18.1"
 ```
 

--- a/docs/developer/e2e.md
+++ b/docs/developer/e2e.md
@@ -48,10 +48,10 @@ $ ddev env start postgres py3.9-14.0
  - Container compose-postgres_replica-1   Started                                            0.9s
  - Container compose-postgres-1           Started                                            0.9s
 
-master-py3: Pulling from datadog/agent-dev
+master-py3: Pulling from agent-dev
 Digest: sha256:72824c9a986b0ef017eabba4e2cc9872333c7e16eec453b02b2276a40518655c
-Status: Image is up to date for datadog/agent-dev:master-py3
-docker.io/datadog/agent-dev:master-py3
+Status: Image is up to date for registry.datadoghq.com/agent-dev:master-py3
+registry.datadoghq.com/agent-dev:master-py3
 
 Stop environment -> ddev env stop postgres py3.9-14.0
 Execute tests -> ddev env test postgres py3.9-14.0
@@ -70,16 +70,16 @@ Let's see what we have running:
 
 ```
 $ docker ps --format "table {{.Image}}\t{{.Status}}\t{{.Ports}}\t{{.Names}}"
-IMAGE                          STATUS                   PORTS                              NAMES
-datadog/agent-dev:master-py3   Up 3 minutes (healthy)                                      dd_postgres_py3.9-14.0
-postgres:14-alpine             Up 3 minutes (healthy)   5432/tcp, 0.0.0.0:5434->5434/tcp   compose-postgres_replica2-1
-postgres:14-alpine             Up 3 minutes (healthy)   0.0.0.0:5432->5432/tcp             compose-postgres-1
-postgres:14-alpine             Up 3 minutes (healthy)   5432/tcp, 0.0.0.0:5433->5433/tcp   compose-postgres_replica-1
+IMAGE                                             STATUS                   PORTS                              NAMES
+registry.datadoghq.com/agent-dev:master-py3      Up 3 minutes (healthy)                                      dd_postgres_py3.9-14.0
+postgres:14-alpine                                Up 3 minutes (healthy)   5432/tcp, 0.0.0.0:5434->5434/tcp   compose-postgres_replica2-1
+postgres:14-alpine                                Up 3 minutes (healthy)   0.0.0.0:5432->5432/tcp             compose-postgres-1
+postgres:14-alpine                                Up 3 minutes (healthy)   5432/tcp, 0.0.0.0:5433->5433/tcp   compose-postgres_replica-1
 ```
 
 ### Agent version
 
-You can select a particular build of the Agent to use with the `--agent`/`-a` option. Any Docker image is valid e.g. `datadog/agent:7.47.0`.
+You can select a particular build of the Agent to use with the `--agent`/`-a` option. Any Docker image is valid e.g. `registry.datadoghq.com/agent:7.47.0`.
 
 A custom nightly build will be used by default, which is re-built on every commit to the [Datadog Agent repository][datadog-agent].
 

--- a/eks_fargate/README.md
+++ b/eks_fargate/README.md
@@ -246,7 +246,7 @@ spec:
     # (...)
 
   - name: datadog-agent-injected
-    image: gcr.io/datadoghq/agent:7.64.0
+    image: registry.datadoghq.com/agent:7.64.0
     env:
       - name: DD_API_KEY
         valueFrom:
@@ -328,7 +328,7 @@ spec:
     # (...)
 
   - name: datadog-agent-injected
-    image: gcr.io/datadoghq/agent:7.64.0
+    image: registry.datadoghq.com/agent:7.64.0
     env:
       - name: DD_API_KEY
         valueFrom:
@@ -418,7 +418,7 @@ spec:
     # (...)
 
   - name: datadog-agent-injected
-    image: gcr.io/datadoghq/agent:7.64.0
+    image: registry.datadoghq.com/agent:7.64.0
     env:
       - name: DD_API_KEY
         valueFrom:
@@ -498,7 +498,7 @@ spec:
     # (...)
 
   - name: datadog-agent-injected
-    image: gcr.io/datadoghq/agent:7.64.0
+    image: registry.datadoghq.com/agent:7.64.0
     env:
       - name: DD_API_KEY
         valueFrom:
@@ -556,7 +556,7 @@ spec:
 
         # Running the Agent as a sidecar
         - name: datadog-agent
-          image: gcr.io/datadoghq/agent:7
+          image: registry.datadoghq.com/agent:7
           env:
             - name: DD_API_KEY
               valueFrom:
@@ -634,7 +634,7 @@ In both cases, you need to change the Datadog Agent sidecar manifest in order to
     containers:
     #(...)
     - name: datadog-agent
-      image: gcr.io/datadoghq/agent:7
+      image: registry.datadoghq.com/agent:7
       env:
         #(...)
         - name: DD_CLUSTER_NAME
@@ -693,7 +693,7 @@ spec:
 
       # Running the Agent as a sidecar
       - name: datadog-agent
-        image: gcr.io/datadoghq/agent:7
+        image: registry.datadoghq.com/agent:7
         env:
           - name: DD_API_KEY
             valueFrom:
@@ -856,7 +856,7 @@ spec:
 
       # Running the Agent as a sidecar
       - name: datadog-agent
-        image: gcr.io/datadoghq/agent:7
+        image: registry.datadoghq.com/agent:7
         env:
           - name: DD_API_KEY
             valueFrom:
@@ -959,7 +959,7 @@ Monitor EKS Fargate logs using the Datadog Agent to collect logs from the kubele
 
           # Running the Agent as a sidecar
           - name: datadog-agent
-            image: gcr.io/datadoghq/agent:7
+            image: registry.datadoghq.com/agent:7
             # Mount the empty dir to the Agent
             volumeMounts:
               - name: agent-option
@@ -1038,7 +1038,7 @@ Monitor EKS Fargate logs using the Datadog Agent to collect logs from the kubele
           containers:
             # Running the Agent as a sidecar
             - name: datadog-agent
-              image: gcr.io/datadoghq/agent:7
+              image: registry.datadoghq.com/agent:7
               env:
                 # Collect all container logs
                 - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
@@ -1106,7 +1106,7 @@ spec:
 
       # Running the Agent as a sidecar
       - name: datadog-agent
-        image: gcr.io/datadoghq/agent:7
+        image: registry.datadoghq.com/agent:7
         # (...)
 ```
 

--- a/fly_io/README.md
+++ b/fly_io/README.md
@@ -20,7 +20,7 @@ The Fly.io check is included in the [Datadog Agent][2] package. We recommend dep
 
     ```
     [build]
-        image = 'gcr.io/datadoghq/agent:7'
+        image = 'registry.datadoghq.com/agent:7'
     ```
 
 2. Set a [secret][17] for your Datadog API key called `DD_API_KEY`, and optionally your [site][14] as `DD_SITE`.

--- a/krakend/tests/lab/traffic_generator.py
+++ b/krakend/tests/lab/traffic_generator.py
@@ -260,7 +260,7 @@ def start(ctx, env: str):
         "-e",
         "DD_LOGS_ENABLED=true",
         # "-a",
-        # "datadog/agent:latest",
+        # "registry.datadoghq.com/agent:latest",
     ]
     process = subprocess.Popen(
         command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, start_new_session=True

--- a/langchain/README.md
+++ b/langchain/README.md
@@ -46,7 +46,7 @@ You can enable LLM Observability in different environments. Follow the appropria
      -p 127.0.0.1:8125:8125/udp \
      -e DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true \
      -e DD_APM_ENABLED=true \
-     gcr.io/datadoghq/agent:latest
+     registry.datadoghq.com/agent:latest
    ```
 
 2. Install the `ddtrace` package if it isn't installed yet:
@@ -124,7 +124,7 @@ This will display any errors related to data transmission or instrumentation, in
                  -p 127.0.0.1:8125:8125/udp \
                  -e DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true \
                  -e DD_APM_ENABLED=true \
-                 gcr.io/datadoghq/agent:latest
+                 registry.datadoghq.com/agent:latest
    ```
 
 2. Install the Datadog APM Python library.

--- a/mesos_master/README.md
+++ b/mesos_master/README.md
@@ -31,7 +31,7 @@ docker run -d --name datadog-agent \
   -e DD_API_KEY=<YOUR_DATADOG_API_KEY> \
   -e MESOS_MASTER=true \
   -e MARATHON_URL=http://leader.mesos:8080 \
-  datadog/agent:latest
+  registry.datadoghq.com/agent:latest
 ```
 
 Substitute your Datadog API key and Mesos Master's API URL into the command above.

--- a/mesos_slave/README.md
+++ b/mesos_slave/README.md
@@ -65,7 +65,7 @@ If you are not using DC/OS, use the Marathon web UI or post to the API URL the f
       }
     ],
     "docker": {
-      "image": "datadog/agent:latest",
+      "image": "registry.datadoghq.com/agent:latest",
       "network": "BRIDGE",
       "portMappings": [
         {

--- a/openai/README.md
+++ b/openai/README.md
@@ -114,7 +114,7 @@ You can enable LLM Observability in different environments. Follow the appropria
      -p 127.0.0.1:8125:8125/udp \
      -e DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true \
      -e DD_APM_ENABLED=true \
-     gcr.io/datadoghq/agent:latest
+     registry.datadoghq.com/agent:latest
    ```
 
 2. Install the `ddtrace` package if it isn't installed yet:
@@ -193,7 +193,7 @@ This will display detailed information about any errors or issues with tracing.
      -p 127.0.0.1:8125:8125/udp \
      -e DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true \
      -e DD_APM_ENABLED=true \
-     gcr.io/datadoghq/agent:latest
+     registry.datadoghq.com/agent:latest
    ```
 
 2. Install the Datadog APM Python library.
@@ -292,7 +292,7 @@ You can enable LLM Observability in different environments. Follow the appropria
      -p 127.0.0.1:8125:8125/udp \
      -e DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true \
      -e DD_APM_ENABLED=true \
-     gcr.io/datadoghq/agent:latest
+     registry.datadoghq.com/agent:latest
    ```
 
 2. Install the Datadog APM Node.js library.
@@ -367,7 +367,7 @@ This will display detailed information about any errors or issues with tracing.
      -p 127.0.0.1:8125:8125/udp \
      -e DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true \
      -e DD_APM_ENABLED=true \
-     gcr.io/datadoghq/agent:latest
+     registry.datadoghq.com/agent:latest
    ```
 
 2. Install the Datadog APM Node.js library.
@@ -443,7 +443,7 @@ Validate that the APM Node.js library can communicate with your Agent by examini
      -p 127.0.0.1:8125:8125/udp \
      -e DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true \
      -e DD_APM_ENABLED=true \
-     gcr.io/datadoghq/agent:latest
+     registry.datadoghq.com/agent:latest
    ```
 
 2. [Install the Datadog APM PHP library][16].

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -41,7 +41,7 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup/:ro \
               -v /run/systemd/:/host/run/systemd/:ro \
               -e DD_API_KEY=<YOUR_API_KEY> \
-              datadog/agent:latest
+              registry.datadoghq.com/agent:latest
 ```
 
 #### Helm


### PR DESCRIPTION
### What does this PR do?
Updates Datadog Agent image references in docs and ddev developer tooling to use `registry.datadoghq.com` where the replacement image exists.

This also adjusts ddev Agent build handling so registry-based `agent:6` and `agent:7` defaults keep the same no-`-py` behavior as the existing Docker Hub names.

### Motivation
Datadog-owned Agent image references should point at `registry.datadoghq.com` instead of legacy `gcr.io/datadoghq` or Docker Hub `datadog/...` references when the registry image is available. I checked candidate replacements with `docker manifest inspect`; test fixtures are intentionally left unchanged.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
