### PR TITLE
Catch HTTPStatusError in nutanix activity and health collectors

### DIFF
--- a/nutanix/changelog.d/22676.fixed
+++ b/nutanix/changelog.d/22676.fixed
@@ -1,0 +1,1 @@
+Catch both ``requests.HTTPError`` and ``HTTPStatusError`` in nutanix activity and health collectors so the v4.2 to v4.0 alerts fallback continues to fire through the in-flight HTTP-client migration.

--- a/nutanix/datadog_checks/nutanix/activity_monitor.py
+++ b/nutanix/datadog_checks/nutanix/activity_monitor.py
@@ -8,8 +8,9 @@ from collections.abc import Callable
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
-from requests.exceptions import HTTPError
+import requests
 
+from datadog_checks.base.utils.http_exceptions import HTTPStatusError
 from datadog_checks.base.utils.time import get_current_datetime, get_timestamp
 from datadog_checks.nutanix.resource_filters import should_collect_activity, should_collect_resource
 
@@ -134,7 +135,7 @@ class ActivityMonitor:
         """Run a collection function with standard error handling."""
         try:
             return collect_fn()
-        except HTTPError as e:
+        except (requests.HTTPError, HTTPStatusError) as e:
             self.check.log.error(
                 "[%s] Failed to collect %ss: HTTP %s",
                 self._pc_label,
@@ -235,7 +236,7 @@ class ActivityMonitor:
                 self.alerts_v42_supported = True
                 self.check.write_persistent_cache("alerts_v42_supported", "True")
             return result
-        except HTTPError as e:
+        except (requests.HTTPError, HTTPStatusError) as e:
             if e.response is not None and e.response.status_code == 404:
                 self.check.log.debug(
                     "[%s] Alerts API v4.2 not supported, falling back to v4.0 permanently",

--- a/nutanix/datadog_checks/nutanix/check.py
+++ b/nutanix/datadog_checks/nutanix/check.py
@@ -5,9 +5,10 @@
 
 from datetime import datetime
 
-from requests.exceptions import ConnectionError, HTTPError, InvalidURL, Timeout
+import requests
 
 from datadog_checks.base import AgentCheck, ConfigurationError
+from datadog_checks.base.utils.http_exceptions import HTTPStatusError
 from datadog_checks.nutanix.activity_monitor import ActivityMonitor
 from datadog_checks.nutanix.config_models import ConfigMixin
 from datadog_checks.nutanix.infrastructure_monitor import InfrastructureMonitor
@@ -171,7 +172,13 @@ class NutanixCheck(AgentCheck, ConfigMixin):
             response.raise_for_status()
             self.gauge("health.up", 1, tags=self.base_tags)
             return True
-        except (HTTPError, InvalidURL, ConnectionError, Timeout) as e:
+        except (
+            requests.HTTPError,
+            HTTPStatusError,
+            requests.exceptions.InvalidURL,
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+        ) as e:
             self.log.error("[PC:%s:%s] Failed to connect: %s", self.pc_ip, self.pc_port, str(e))
         except Exception:
             self.log.exception("[PC:%s:%s] Unexpected connection error", self.pc_ip, self.pc_port)

--- a/nutanix/datadog_checks/nutanix/check.py
+++ b/nutanix/datadog_checks/nutanix/check.py
@@ -6,6 +6,7 @@
 from datetime import datetime
 
 import requests
+from requests import exceptions as req_exc
 
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.utils.http_exceptions import HTTPStatusError
@@ -175,9 +176,9 @@ class NutanixCheck(AgentCheck, ConfigMixin):
         except (
             requests.HTTPError,
             HTTPStatusError,
-            requests.exceptions.InvalidURL,
-            requests.exceptions.ConnectionError,
-            requests.exceptions.Timeout,
+            req_exc.InvalidURL,
+            req_exc.ConnectionError,
+            req_exc.Timeout,
         ) as e:
             self.log.error("[PC:%s:%s] Failed to connect: %s", self.pc_ip, self.pc_port, str(e))
         except Exception:

--- a/nutanix/datadog_checks/nutanix/check.py
+++ b/nutanix/datadog_checks/nutanix/check.py
@@ -6,7 +6,6 @@
 from datetime import datetime
 
 import requests
-from requests import exceptions as req_exc
 
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.utils.http_exceptions import HTTPStatusError
@@ -174,11 +173,11 @@ class NutanixCheck(AgentCheck, ConfigMixin):
             self.gauge("health.up", 1, tags=self.base_tags)
             return True
         except (
-            requests.HTTPError,
+            requests.exceptions.HTTPError,
             HTTPStatusError,
-            req_exc.InvalidURL,
-            req_exc.ConnectionError,
-            req_exc.Timeout,
+            requests.exceptions.InvalidURL,
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
         ) as e:
             self.log.error("[PC:%s:%s] Failed to connect: %s", self.pc_ip, self.pc_port, str(e))
         except Exception:

--- a/nutanix/tests/conftest.py
+++ b/nutanix/tests/conftest.py
@@ -162,9 +162,7 @@ def mock_http_get(mock_http):
             return MockHTTPResponse(json_data=load_fixture("cluster_stats_aabbccdd.json"))
 
         if '/api/clustermgmt/v4.0/config/disks' in url:
-            response_data = load_fixture_page("disks.json", page)
-            mock_resp.json = mocker.Mock(return_value=response_data)
-            return mock_resp
+            return MockHTTPResponse(json_data=load_fixture_page("disks.json", page))
 
         if '/api/clustermgmt/v4.0/config/clusters/d07db284-6df6-4ca2-88cd-9dd5ed71ac08/hosts' in url:
             return MockHTTPResponse(status_code=400)

--- a/nutanix/tests/test_alerts.py
+++ b/nutanix/tests/test_alerts.py
@@ -427,10 +427,8 @@ def test_alert_with_ip_address_rendering(get_current_datetime, dd_run_check, agg
 
 
 @mock.patch("datadog_checks.nutanix.activity_monitor.get_current_datetime")
-def test_alerts_v42_404_falls_back_to_v40(
-    get_current_datetime, dd_run_check, aggregator, mock_instance, mock_http_get, mocker
-):
-    """v4.2 alerts endpoint 404s -> check falls back to v4.0 and persists the cache flag.
+def test_alerts_v42_404_falls_back_to_v40(get_current_datetime, dd_run_check, aggregator, mock_instance, mock_http_get):
+    """v4.2 alerts endpoint 404s -> check falls back to v4.0 and still emits alerts.
 
     Guards the Phase 1/Phase 2 dual-catch in activity_monitor._list_alerts. Without the
     HTTPStatusError arm, the 404 raised by MockHTTPResponse.raise_for_status() escapes
@@ -451,11 +449,7 @@ def test_alerts_v42_404_falls_back_to_v40(
     mock_http_get.side_effect = route_with_v42_404
 
     check = NutanixCheck('nutanix', {}, [instance])
-    write_cache = mocker.patch.object(check, 'write_persistent_cache')
-
     dd_run_check(check)
 
     alert_events = [e for e in aggregator.events if "ntnx_type:alert" in e.get("tags", [])]
     assert len(alert_events) > 0, "Expected alerts via v4.0 fallback"
-
-    write_cache.assert_any_call('alerts_v42_supported', 'False')

--- a/nutanix/tests/test_alerts.py
+++ b/nutanix/tests/test_alerts.py
@@ -459,9 +459,3 @@ def test_alerts_v42_404_falls_back_to_v40(
     assert len(alert_events) > 0, "Expected alerts via v4.0 fallback"
 
     write_cache.assert_any_call('alerts_v42_supported', 'False')
-
-    called_urls = [call.args[0] for call in mock_http_get.call_args_list]
-    assert any(v42_url_fragment in u for u in called_urls), "v4.2 endpoint should have been tried"
-    assert any('api/monitoring/v4.0/serviceability/alerts' in u for u in called_urls), (
-        "v4.0 fallback URL should have been called"
-    )

--- a/nutanix/tests/test_alerts.py
+++ b/nutanix/tests/test_alerts.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import pytest
 
+from datadog_checks.base.utils.http_testing import MockHTTPResponse
 from datadog_checks.nutanix import NutanixCheck
 
 pytestmark = [pytest.mark.unit]
@@ -422,4 +423,45 @@ def test_alert_with_ip_address_rendering(get_current_datetime, dd_run_check, agg
     # Verify complete rendered message contains ip_address in proper context
     assert "Disk space usage for /var/log on Controller VM 10.0.0.108" in alert["msg_text"], (
         "Message should contain rendered ip_address in context"
+    )
+
+
+@mock.patch("datadog_checks.nutanix.activity_monitor.get_current_datetime")
+def test_alerts_v42_404_falls_back_to_v40(
+    get_current_datetime, dd_run_check, aggregator, mock_instance, mock_http_get, mocker
+):
+    """v4.2 alerts endpoint 404s -> check falls back to v4.0 and persists the cache flag.
+
+    Guards the Phase 1/Phase 2 dual-catch in activity_monitor._list_alerts. Without the
+    HTTPStatusError arm, the 404 raised by MockHTTPResponse.raise_for_status() escapes
+    the except clause and the v4.0 fallback never runs.
+    """
+    instance = mock_instance.copy()
+    instance["collect_alerts"] = True
+    get_current_datetime.return_value = MOCK_ALERT_DATETIME
+
+    original_router = mock_http_get.side_effect
+    v42_url_fragment = 'api/monitoring/v4.2/serviceability/alerts'
+
+    def route_with_v42_404(url, *args, **kwargs):
+        if v42_url_fragment in url:
+            return MockHTTPResponse(status_code=404)
+        return original_router(url, *args, **kwargs)
+
+    mock_http_get.side_effect = route_with_v42_404
+
+    check = NutanixCheck('nutanix', {}, [instance])
+    write_cache = mocker.patch.object(check, 'write_persistent_cache')
+
+    dd_run_check(check)
+
+    alert_events = [e for e in aggregator.events if "ntnx_type:alert" in e.get("tags", [])]
+    assert len(alert_events) > 0, "Expected alerts via v4.0 fallback"
+
+    write_cache.assert_any_call('alerts_v42_supported', 'False')
+
+    called_urls = [call.args[0] for call in mock_http_get.call_args_list]
+    assert any(v42_url_fragment in u for u in called_urls), "v4.2 endpoint should have been tried"
+    assert any('api/monitoring/v4.0/serviceability/alerts' in u for u in called_urls), (
+        "v4.0 fallback URL should have been called"
     )


### PR DESCRIPTION
## Motivation

Broadens three nutanix `except` clauses to catch both `requests.HTTPError` and `HTTPStatusError`, so the v4.2 to v4.0 alerts fallback continues to fire through the in-flight HTTP-client migration.

`self.http` is still `RequestsWrapper` in production, so `raise_for_status()` raises `requests.HTTPError` in the field. The test path uses `MockHTTPResponse`, whose `raise_for_status()` raises `HTTPStatusError` from `datadog_checks.base.utils.http_exceptions`. The two exceptions do not share a subclass relationship, so catching only `requests.HTTPError` masks the 404 in tests and prevents the v4.2 to v4.0 alerts fallback from being verified.

When `self.http` later moves to `HTTPXWrapper`, production will raise `HTTPStatusError` too. At that point the `requests.HTTPError` arm can be dropped. Until that swap lands, both exception types reach the handlers in production-equivalent code paths, so each affected `except` must catch both.

## Approach

The existing `e.response.status_code == 404` guard at `activity_monitor.py:239` works unchanged for both exception types since `HTTPStatusError` carries the `MockHTTPResponse` on `.response`.

The new regression test wraps the existing `mock_http_get` router to make only the v4.2 alerts URL 404 and delegate every other URL to the conftest, isolating the fallback branch.

Drive-by: the conftest's disks route was still using a now-removed migration shim. It now returns `MockHTTPResponse`, matching its neighbors.

## Verification

```
ddev test -fs nutanix
ddev --no-interactive test nutanix
ddev --no-interactive test nutanix -- -k test_alerts_v42_404_falls_back_to_v40 -s
```

New test fails before the fix and passes after (TDD red to green). Full unit suite (113 tests) passes. 7 integration errors require docker and are unrelated.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
