### PR TITLE
[Backport 7.80.x] Bump curl version to 8.20.0

### DIFF
--- a/.builders/images/linux-aarch64/Dockerfile
+++ b/.builders/images/linux-aarch64/Dockerfile
@@ -157,8 +157,8 @@ RUN \
 # curl
 RUN \
  DOWNLOAD_URL="https://curl.haxx.se/download/curl-{{version}}.tar.gz" \
- VERSION="8.19.0" \
- SHA256="2a2c11db4c122691aa23b4363befda1bfd801770bfebf41e1d21cee4f2ab0f71" \
+ VERSION="8.20.0" \
+ SHA256="fc5819cad3f9f5482669adcdc49a782c15f36d2a0715b395b06d9173593d2dc0" \
  RELATIVE_PATH="curl-{{version}}" \
   bash install-from-source.sh \
     --disable-manual \

--- a/.builders/images/linux-x86_64/Dockerfile
+++ b/.builders/images/linux-x86_64/Dockerfile
@@ -161,8 +161,8 @@ RUN \
 # curl
 RUN \
  DOWNLOAD_URL="https://curl.haxx.se/download/curl-{{version}}.tar.gz" \
- VERSION="8.19.0" \
- SHA256="2a2c11db4c122691aa23b4363befda1bfd801770bfebf41e1d21cee4f2ab0f71" \
+ VERSION="8.20.0" \
+ SHA256="fc5819cad3f9f5482669adcdc49a782c15f36d2a0715b395b06d9173593d2dc0" \
  RELATIVE_PATH="curl-{{version}}" \
   bash install-from-source.sh \
     --disable-manual \

--- a/.builders/images/macos/builder_setup.sh
+++ b/.builders/images/macos/builder_setup.sh
@@ -70,8 +70,8 @@ RELATIVE_PATH="libxslt-{{version}}" \
 
 # curl
 DOWNLOAD_URL="https://curl.haxx.se/download/curl-{{version}}.tar.gz" \
-VERSION="8.19.0" \
-SHA256="2a2c11db4c122691aa23b4363befda1bfd801770bfebf41e1d21cee4f2ab0f71" \
+VERSION="8.20.0" \
+SHA256="fc5819cad3f9f5482669adcdc49a782c15f36d2a0715b395b06d9173593d2dc0" \
 RELATIVE_PATH="curl-{{version}}" \
   install-from-source \
     --disable-manual \

--- a/.builders/images/windows-x86_64/Dockerfile
+++ b/.builders/images/windows-x86_64/Dockerfile
@@ -154,7 +154,7 @@ RUN Get-RemoteFile `
     RunOnVSConsole -Command 'C:\perl\perl\bin\perl.exe install.pl C:\postgresql' && `
     Add-ToPath -Append "C:\postgresql\bin"
 
-ENV CURL_VERSION="8.19.0"
+ENV CURL_VERSION="8.20.0"
 
 # Set up runner
 COPY runner_dependencies.txt C:\runner_dependencies.txt

--- a/.builders/images/windows-x86_64/build_script.ps1
+++ b/.builders/images/windows-x86_64/build_script.ps1
@@ -24,7 +24,7 @@ Remove-Item "librdkafka-${kafka_version}.tar.gz"
 $triplet = "x64-windows"
 $vcpkg_dir = "C:\vcpkg"
 $librdkafka_dir = "C:\librdkafka\librdkafka-${kafka_version}"
-$desired_commit = "36118ef68885436fd2a999188216337365856ad4"
+$desired_commit = "3e797c57a635d3ce8f3473ef344ea44c09c246c8"
 
 # Clone and configure vcpkg
 if (-Not (Test-Path -Path "$vcpkg_dir\.git")) {


### PR DESCRIPTION
### What does this PR do?
Manual backport of #23771 to `7.80.x`. Bumps the curl version used in `.builders` from 8.19.0 to 8.20.0 across all four builder images (Linux x86_64, Linux aarch64, macOS, Windows). Also bumps the vcpkg `desired_commit` pin in the Windows `build_script.ps1` to the upstream commit that adds the curl 8.20.0 port.

The auto-backport bot was unable to open this PR (likely due to `.deps/*` lockfile drift on the release branch); the dependency-resolution bot will regenerate `.deps/*` against this branch automatically once this PR is open.

### Motivation
Addresses [CVE-2026-5773](https://curl.se/docs/CVE-2026-5773.html) — libcurl could reuse the wrong SMB(S) connection from the pool because the share name was not part of the connection-match criteria. Affected versions: 7.40.0 through 8.19.0. Fixed in curl 8.20.0 (released 2026-04-29).

Fixes: [VULN-82927](https://datadoghq.atlassian.net/browse/VULN-82927)

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

[VULN-82927]: https://datadoghq.atlassian.net/browse/VULN-82927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ