### PR TITLE
Validate and safely pass setup-ddev ddev-version input

### DIFF
--- a/.github/actions/setup-ddev/action.yml
+++ b/.github/actions/setup-ddev/action.yml
@@ -29,6 +29,7 @@ runs:
       env:
         CACHE_PROFILE: ${{ inputs.cache-profile }}
         INSTALL_MODE: ${{ inputs.install-mode }}
+        DDEV_VERSION: ${{ inputs.ddev-version }}
       run: |-
         case "$INSTALL_MODE" in
           local|pypi) ;;
@@ -45,6 +46,11 @@ runs:
             exit 1
             ;;
         esac
+
+        if [[ -n "$DDEV_VERSION" && ! "$DDEV_VERSION" =~ ^(===|==|~=|!=|<=|>=|<|>)[A-Za-z0-9._*+!,-]+$ ]]; then
+          echo "::error::Invalid ddev-version '$DDEV_VERSION'. Use a PEP 440-style version specifier such as ==16.0.0."
+          exit 1
+        fi
 
     - name: Compute cache date
       id: cache-date
@@ -157,7 +163,9 @@ runs:
     - name: Install ddev from PyPI
       if: ${{ inputs.install-mode == 'pypi' }}
       shell: bash
-      run: uv pip install --system "ddev${{ inputs.ddev-version }}"
+      env:
+        DDEV_VERSION: ${{ inputs.ddev-version }}
+      run: uv pip install --system "ddev${DDEV_VERSION}"
 
     - name: Save local ddev cache
       if: ${{ inputs.install-mode == 'local' && inputs.cache-profile == 'local-ddev-base' && steps.restore-local-ddev-base-cache.outputs.cache-hit != 'true' }}

--- a/.github/actions/setup-ddev/action.yml
+++ b/.github/actions/setup-ddev/action.yml
@@ -47,8 +47,8 @@ runs:
             ;;
         esac
 
-        if [[ -n "$DDEV_VERSION" && ! "$DDEV_VERSION" =~ ^(===|==|~=|!=|<=|>=|<|>)[A-Za-z0-9._*+!,-]+$ ]]; then
-          echo "::error::Invalid ddev-version '$DDEV_VERSION'. Use a PEP 440-style version specifier such as ==16.0.0."
+        if [[ -n "$DDEV_VERSION" && ! "$DDEV_VERSION" =~ ^(===|==|~=|!=|<=|>=|<|>)[A-Za-z0-9._*+!-]+(,(===|==|~=|!=|<=|>=|<|>)[A-Za-z0-9._*+!-]+)*$ ]]; then
+          echo "::error::Invalid ddev-version '$DDEV_VERSION'. Use a PEP 440-style version specifier such as ==16.0.0 or >=16,<17."
           exit 1
         fi
 


### PR DESCRIPTION
### Motivation
- Prevent a shell command injection in the composite action where `inputs.ddev-version` was previously interpolated directly into a Bash `run` line, which could allow command substitution payloads to execute in CI.

### Description
- Add `DDEV_VERSION` to the `Validate inputs` step and reject values that do not match a PEP 440-style operator+version pattern via a Bash regex check.
- Change the PyPI install step to pass the version through an environment variable (`DDEV_VERSION`) and reference that variable in the `uv pip install --system "ddev${DDEV_VERSION}"` command instead of embedding the GitHub expression directly in the shell.

### Testing
- Performed local repository validations by printing and inspecting `.github/actions/setup-ddev/action.yml`, diffing the change, and committing the patch; these checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b0866f87083328f23683ea92cf050)