### PR TITLE
Mark Kafka messages section as DSM only in kafka_consumer README

### DIFF
--- a/kafka_consumer/README.md
+++ b/kafka_consumer/README.md
@@ -105,7 +105,7 @@ instances:
 
 See [metadata.csv][9] for a list of metrics provided by this check.
 
-### Kafka messages
+### Kafka messages (DSM only)
 
 This integration is used by [Data Streams Monitoring][18] to [retrieve messages from Kafka on demand][21].
 


### PR DESCRIPTION
### What does this PR do?
Update the `Kafka messages` section heading in `kafka_consumer/README.md` to `Kafka messages (DSM only)` to make it explicit that on-demand Kafka message retrieval is a Data Streams Monitoring feature.

### Motivation
Requested in the Wayfair thread — make the DSM-only nature of the message read functionality visible in the public README, mirroring the convention being added to the metrics in #23819.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e) — N/A, documentation-only change.
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)