### PR TITLE
Handle closed indices in search stats endpoint query

### DIFF
--- a/elastic/changelog.d/23824.fixed
+++ b/elastic/changelog.d/23824.fixed
@@ -1,0 +1,1 @@
+Handle closed indices in search stats endpoint query

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -292,7 +292,9 @@ class ESCheck(AgentCheck):
         # This endpoint can return more data, all of what the /_cat/indices endpoint returns except index health.
         # The health we can get from /_cluster/health if we pass level=indices query param. Reference:
         # https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html#cluster-health-api-query-params # noqa: E501
-        indices = self._get_data(self._join_url('/_stats/search', admin_forwarder))['indices']
+        indices = self._get_data(self._join_url('/_stats/search?forbid_closed_indices=false', admin_forwarder))[
+            'indices'
+        ]
         for (idx_name, data), (m_name, path) in product(indices.items(), INDEX_SEARCH_STATS):
             tags = base_tags + ['index_name:' + idx_name]
             self._process_metric(data, m_name, 'gauge', path, tags=tags)

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -60,6 +60,10 @@ class AuthenticationError(requests.exceptions.HTTPError):
     """Authentication Error, unable to reach server"""
 
 
+class RequestError(requests.exceptions.HTTPError):
+    """Request Error, unable to get data from server"""
+
+
 def get_dynamic_tags(columns):
     dynamic_tags = []  # This is a list of (path to tag, name of tag)
     for column in columns:
@@ -270,7 +274,7 @@ class ESCheck(AgentCheck):
             tags = base_tags + ['index_name:' + idx['index']]
             for metric, desc in index_stats_for_version(version).items():
                 self._process_metric(index_data, metric, *desc, tags=tags)
-        self._get_index_search_stats(admin_forwarder, base_tags)
+        self._get_index_search_stats(admin_forwarder, version, base_tags)
 
     def _get_template_metrics(self, admin_forwarder, base_tags):
         try:
@@ -284,7 +288,7 @@ class ESCheck(AgentCheck):
         for metric, desc in TEMPLATE_METRICS.items():
             self._process_metric({'templates': filtered_templates}, metric, *desc, tags=base_tags)
 
-    def _get_index_search_stats(self, admin_forwarder, base_tags):
+    def _get_index_search_stats(self, admin_forwarder, version, base_tags):
         """
         Stats for searches in every index.
         """
@@ -292,9 +296,16 @@ class ESCheck(AgentCheck):
         # This endpoint can return more data, all of what the /_cat/indices endpoint returns except index health.
         # The health we can get from /_cluster/health if we pass level=indices query param. Reference:
         # https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html#cluster-health-api-query-params # noqa: E501
-        indices = self._get_data(self._join_url('/_stats/search?forbid_closed_indices=false', admin_forwarder))[
-            'indices'
-        ]
+        index_stats_url = "/_stats/search"
+        if version >= [7, 2, 0]:
+            index_stats_url += "?forbid_closed_indices=false"
+
+        try:
+            indices = self._get_data(self._join_url(index_stats_url, admin_forwarder))['indices']
+        except RequestError as e:
+            self.log.debug("Error reading index search stats from servers (%s) - index search stats will be missing", e)
+            return
+
         for (idx_name, data), (m_name, path) in product(indices.items(), INDEX_SEARCH_STATS):
             tags = base_tags + ['index_name:' + idx_name]
             self._process_metric(data, m_name, 'gauge', path, tags=tags)
@@ -338,9 +349,14 @@ class ESCheck(AgentCheck):
                 resp = self.http.get(url)
             resp.raise_for_status()
         except Exception as e:
-            # this means we've hit a particular kind of auth error that means the config is broken
             if isinstance(resp, requests.Response) and resp.status_code == 400:
-                raise AuthenticationError("The ElasticSearch credentials are incorrect")
+                # A request was made with an invalid argument
+                if 'illegal_argument_exception' in resp.text:
+                    raise RequestError("The ElasticSearch request returned an illegal argument exception")
+
+                # this means we've hit a particular kind of auth error that means the config is broken
+                else:
+                    raise AuthenticationError("The ElasticSearch credentials are incorrect")
 
             if send_sc:
                 self.service_check(

--- a/elastic/tests/test_unit.py
+++ b/elastic/tests/test_unit.py
@@ -10,7 +10,7 @@ import pytest
 from datadog_checks.base import ConfigurationError, is_affirmative
 from datadog_checks.dev.http import MockResponse
 from datadog_checks.elastic import ESCheck
-from datadog_checks.elastic.elastic import AuthenticationError, get_value_from_path
+from datadog_checks.elastic.elastic import AuthenticationError, RequestError, get_value_from_path
 from datadog_checks.elastic.metrics import INDEX_STATS_METRICS, stats_for_version
 
 from .common import URL, get_fixture_path
@@ -160,6 +160,17 @@ def test__get_data_throws_authentication_error(instance):
             check._get_data(url='test.com')
 
 
+def test__get_data_throws_request_error(instance):
+    with mock.patch(
+        'requests.Session.get',
+        return_value=MockResponse(status_code=400, json_data={"error": {"type": "illegal_argument_exception"}}),
+    ):
+        check = ESCheck('elastic', {}, instances=[instance])
+
+        with pytest.raises(RequestError):
+            check._get_data(url='test.com')
+
+
 def test__get_data_creates_critical_service_alert(aggregator, instance):
     with mock.patch(
         'requests.Session.get',
@@ -272,3 +283,59 @@ def test__get_index_metrics_empty_key(aggregator, instance, mock_http_response):
             aggregator.assert_metric(m, count=0)
         else:
             aggregator.assert_metric(m)
+
+
+@pytest.mark.parametrize(
+    'version',
+    [
+        pytest.param([5, 1, 0]),
+        pytest.param([7, 0, 1]),
+        pytest.param([7, 2, 0]),
+        pytest.param([8, 0, 0]),
+    ],
+)
+def test__get_index_search_stats(aggregator, instance, mock_http_response, version):
+    mock_http_response(
+        json_data={
+            'indices': {
+                'testindex': {
+                    'total': {'search': {'query_total': 3, 'query_time_in_millis': 200}},
+                }
+            }
+        },
+    )
+    check = ESCheck('elastic', {}, instances=[instance])
+
+    check._get_index_search_stats(admin_forwarder=False, version=version, base_tags=[])
+
+    aggregator.assert_metric(
+        "elasticsearch.index.search.query.total", metric_type=aggregator.GAUGE, tags=['index_name:testindex'], value=3
+    )
+    aggregator.assert_metric(
+        "elasticsearch.index.search.query.time", metric_type=aggregator.GAUGE, tags=['index_name:testindex'], value=200
+    )
+
+
+def test__get_index_search_stats_handles_illegal_argument_exception(aggregator, instance):
+    with mock.patch(
+        'requests.Session.get',
+        return_value=MockResponse(status_code=400, json_data={"error": {"type": "illegal_argument_exception"}}),
+    ):
+        check = ESCheck('elastic', {}, instances=[instance])
+
+        # Make sure we do not throw an exception and move on
+        check._get_index_search_stats(admin_forwarder=False, version=[7, 1, 0], base_tags=[])
+
+    aggregator.assert_metric("elasticsearch.index.search.query.total", count=0)
+    aggregator.assert_metric("elasticsearch.index.search.query.time", count=0)
+
+
+def test__get_index_search_stats_raises_on_authentication_error(aggregator, instance):
+    with mock.patch(
+        'requests.Session.get',
+        return_value=MockResponse(status_code=400, json_data={"error": {"type": "cluster_block_exception"}}),
+    ):
+        check = ESCheck('elastic', {}, instances=[instance])
+
+        with pytest.raises(AuthenticationError):
+            check._get_index_search_stats(admin_forwarder=False, version=[8, 8, 2], base_tags=[])


### PR DESCRIPTION
### What does this PR do?

- Update the query to get stats for searches by index to handle closed indices instead of returning an error

### Motivation

Elasticsearch 7.3+ returns an error on `/_stats/search` if there are closed indices in the cluster: https://github.com/elastic/elasticsearch/issues/88752. 

Elasticsearch can have closed indices that are hidden, such as `.ds-ilm-history-*` and `.internal.alerts-observability`. These indices are system-managed. However, because these indices can exist and can be closed, they trigger error responses from the query in `_get_index_search_stats`:
```
{
	"error": {
		"root_cause": [
			{
				"type": "index_closed_exception",
				"reason": "closed",
				"index_uuid": "xxxxx",
				"index": ".internal.alerts-security.alerts-default-000001"
			}
		],
		"type": "index_closed_exception",
		"reason": "closed",
		"index_uuid": "xxxxx",
		"index": ".internal.alerts-security.alerts-default-000001"
	},
	"status": 400
}
```
These errors end up being surfaced in the Datadog integration as an AuthenticationError, which is not accurate: https://github.com/DataDog/integrations-core/blob/master/elastic/datadog_checks/elastic/elastic.py#L341

To resolve this problem, I considered two options:
1. Gather stats from closed indices by passing query parameter `forbid_closed_indices=false` (https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-stats#operation-indices-stats-forbid_closed_indices)
2. Skip stats on closed indices by passing query parameter `ignore_unavailable=true`

I opted to pursue the first option because although the second option worked for me, it is not documented on https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-stats.

This is my first contribution to this repository. Apologies for any mistakes or omissions.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
