### PR TITLE
Remove gh artifact fetching and add branch tag to disk usage metrics

### DIFF
--- a/.github/workflows/measure-disk-usage-master.yml
+++ b/.github/workflows/measure-disk-usage-master.yml
@@ -51,12 +51,14 @@ jobs:
       - name: Measure disk usage (Uncompressed)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ddev -v size status --commit "${{ github.sha }}" --format json --to-dd-key ${{ steps.dd-sts.outputs.api_key }}
+          DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
+        run: ddev -v size status --commit "${{ github.sha }}" --branch "${{ github.ref_name }}" --format json --to-dd-key "$DD_API_KEY"
 
       - name: Measure disk usage (Compressed)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ddev -v size status --commit "${{ github.sha }}" --format json --to-dd-key ${{ steps.dd-sts.outputs.api_key }} --compressed
+          DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
+        run: ddev -v size status --commit "${{ github.sha }}" --branch "${{ github.ref_name }}" --format json --to-dd-key "$DD_API_KEY" --compressed
 
       - name: Upload JSON uncompressed sizes artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/measure-disk-usage.yml
+++ b/.github/workflows/measure-disk-usage.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        ref: ${{ github.event.workflow_run.head_sha }}
         fetch-depth: 0
 
     - name: Set up Python ${{ env.PYTHON_VERSION }}
@@ -49,20 +50,16 @@ jobs:
       id: cmd
       env:
         HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-        EVENT_NAME: ${{ github.event.workflow_run.event }}
         HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
       run: |
-        cmd="ddev -v size status --commit \"$HEAD_SHA\" --format json"
-
-        if [ "$EVENT_NAME" = "push" ] && [ "$HEAD_BRANCH" = "master" ]; then 
-          cmd="$cmd --to-dd-key ${{ steps.dd-sts.outputs.api_key }}"
-        fi
+        cmd="ddev -v size status --commit \"$HEAD_SHA\" --branch \"$HEAD_BRANCH\" --format json --to-dd-key \"\$DD_API_KEY\""
         echo "cmd=$cmd" >> $GITHUB_OUTPUT
     
 
     - name: Measure disk usage (Uncompressed)
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
       run: |
         echo "Running for uncompressed sizes"
         ${{ steps.cmd.outputs.cmd }}
@@ -70,6 +67,7 @@ jobs:
     - name: Measure disk usage (Compressed)
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
       run: |
         echo "Running for compressed sizes"
         ${{ steps.cmd.outputs.cmd }} --compressed

--- a/ddev/src/ddev/cli/size/status.py
+++ b/ddev/src/ddev/cli/size/status.py
@@ -24,8 +24,8 @@ if TYPE_CHECKING:
 @click.option("--to-dd-org", type=str, help="Send metrics to Datadog using the specified organization name.")
 @click.option("--to-dd-key", type=str, help="Send metrics to datadoghq.com using the specified API key.")
 @click.option("--python", "version", help="Python version (e.g 3.12).  If not specified, all versions will be analyzed")
-@click.option("--dependency-sizes", type=click.Path(exists=True), help="Path to the dependency sizes file. If no")
-@click.option("--commit", help="Commit hash to check the status of. It takes the commit's dependency sizes file.")
+@click.option("--commit", help="Commit hash used when sending metrics to Datadog.")
+@click.option("--branch", help="Branch name used to tag metrics sent to Datadog.")
 @common_params  # platform, compressed, format, show_gui
 @click.pass_obj
 def status(
@@ -38,8 +38,8 @@ def status(
     wheels_storage: str,
     to_dd_org: str | None,
     to_dd_key: str | None,
-    dependency_sizes: Path | None,
     commit: str | None,
+    branch: str | None,
 ) -> None:
     """
     Show the current size of all integrations and dependencies in your local repo.
@@ -65,7 +65,6 @@ def status(
             format,
             to_dd_org,
             commit,
-            dependency_sizes,
             to_dd_key,
             app,
         )
@@ -76,15 +75,6 @@ def status(
         combinations = [(p, v) for p in platforms for v in versions]
 
         for plat, ver in combinations:
-            if commit:
-                from ddev.cli.size.utils.common_funcs import get_last_dependency_sizes_artifact
-
-                dependency_sizes = get_last_dependency_sizes_artifact(app, commit, plat, ver, compressed)
-                if not dependency_sizes:
-                    app.display_error(
-                        "Could not find dependency sizes in the artifacts: falling back to local lockfiles"
-                    )
-
             parameters: CLIParameters = {
                 "app": app,
                 "platform": plat,
@@ -98,7 +88,6 @@ def status(
                 status_mode(
                     repo_path,
                     parameters,
-                    dependency_sizes,
                 )
             )
         if format:
@@ -108,7 +97,7 @@ def status(
         if (to_dd_org or to_dd_key) and commit:
             from ddev.cli.size.utils.common_funcs import send_metrics_to_dd
 
-            send_metrics_to_dd(app, commit, modules_plat_ver, to_dd_org, to_dd_key, compressed)
+            send_metrics_to_dd(app, commit, modules_plat_ver, to_dd_org, to_dd_key, compressed, branch or "unknown")
     except Exception as e:
         app.abort(str(e))
 
@@ -121,7 +110,6 @@ def validate_parameters(
     format: list[str],
     to_dd_org: str | None,
     commit: str | None,
-    dependency_sizes: Path | None,
     to_dd_key: str | None,
     app: Application,
 ) -> None:
@@ -132,16 +120,10 @@ def validate_parameters(
     if version and version not in valid_versions:
         errors.append(f"Invalid version: {version!r}")
 
-    if commit and dependency_sizes:
-        errors.append("Pass either 'commit' or 'dependency-sizes'. Both options cannot be supplied.")
-
     if format:
         for fmt in format:
             if fmt not in ["png", "csv", "markdown", "json"]:
                 errors.append(f"Invalid format: {fmt!r}. Only png, csv, markdown, and json are supported.")
-
-    if dependency_sizes and not dependency_sizes.is_file():
-        errors.append(f"Dependency sizes file does not exist: {dependency_sizes!r}")
 
     if to_dd_org and to_dd_key:
         errors.append("Specify either --to-dd-org or --to-dd-key, not both")
@@ -156,7 +138,6 @@ def validate_parameters(
 def status_mode(
     repo_path: Path,
     params: CLIParameters,
-    dependency_sizes: Path | None,
 ) -> list[FileDataEntryPlatformVersion]:
     from ddev.cli.size.utils.common_funcs import (
         format_modules,
@@ -166,23 +147,10 @@ def status_mode(
     )
 
     with params["app"].status("Calculating sizes..."):
-        if dependency_sizes:
-            from ddev.cli.size.utils.common_funcs import get_dependencies_from_json
-
-            params["app"].display_debug(
-                f"Getting dependencies from artifacts for {params['platform']} {params['version']}"
-            )
-            modules = get_files(repo_path, params["compressed"], params["version"]) + get_dependencies_from_json(
-                dependency_sizes, params["platform"], params["version"], params["compressed"]
-            )
-
-        else:
-            params["app"].display_debug(
-                f"Getting dependencies from lockfiles for {params['platform']} {params['version']}"
-            )
-            modules = get_files(repo_path, params["compressed"], params["version"]) + get_dependencies(
-                repo_path, params["platform"], params["version"], params["compressed"], params["wheels_storage"]
-            )
+        params["app"].display_debug(f"Getting dependencies from lockfiles for {params['platform']} {params['version']}")
+        modules = get_files(repo_path, params["compressed"], params["version"]) + get_dependencies(
+            repo_path, params["platform"], params["version"], params["compressed"], params["wheels_storage"]
+        )
 
     formatted_modules = format_modules(modules, params["platform"], params["version"])
     formatted_modules.sort(key=lambda x: x["Size_Bytes"], reverse=True)

--- a/ddev/src/ddev/cli/size/utils/common_funcs.py
+++ b/ddev/src/ddev/cli/size/utils/common_funcs.py
@@ -13,7 +13,6 @@ import tempfile
 import zipfile
 import zlib
 from datetime import date
-from functools import cache
 from types import TracebackType
 from typing import TYPE_CHECKING, Literal, Optional, Type, TypedDict
 
@@ -26,9 +25,6 @@ from ddev.utils.fs import Path
 from ddev.utils.toml import load_toml_file
 
 METRIC_VERSION = 2
-
-RESOLVE_BUILD_DEPS_WORKFLOW = '.github/workflows/resolve-build-deps.yaml'
-MEASURE_DISK_USAGE_WORKFLOW = '.github/workflows/measure-disk-usage.yml'
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -414,23 +410,6 @@ def get_dependencies_sizes(
         )
 
     return file_data
-
-
-def get_dependencies_from_json(
-    dependency_sizes: Path, platform: str, version: str, compressed: bool
-) -> list[FileDataEntry]:
-    data = json.loads(dependency_sizes.read_text())
-    size_key = "compressed" if compressed else "uncompressed"
-    return [
-        {
-            "Name": name,
-            "Version": sizes.get("version", ""),
-            "Size_Bytes": int(sizes.get(size_key, 0)),
-            "Size": convert_to_human_readable_size(sizes.get(size_key, 0)),
-            "Type": "Dependency",
-        }
-        for name, sizes in data.items()
-    ]
 
 
 def is_excluded_from_wheel(path: str) -> bool:
@@ -869,6 +848,7 @@ def send_metrics_to_dd(
     org: str | None,
     key: str | None,
     compressed: bool,
+    branch: str,
 ) -> None:
     metric_name = "datadog.agent_integrations"
     size_type = "compressed" if compressed else "uncompressed"
@@ -907,6 +887,7 @@ def send_metrics_to_dd(
                     "team:agent-integrations",
                     f"compression:{size_type}",
                     f"metrics_version:{METRIC_VERSION}",
+                    f"branch:{branch}",
                     f"jira_ticket:{tickets[0]}",
                     f"pr_number:{prs[-1]}",
                     f"commit_message:{message}",
@@ -943,6 +924,7 @@ def send_metrics_to_dd(
                     f"python_version:{py_version}",
                     "team:agent-integrations",
                     f"metrics_version:{METRIC_VERSION}",
+                    f"branch:{branch}",
                 ],
             }
         )
@@ -957,6 +939,7 @@ def send_metrics_to_dd(
                     f"python_version:{py_version}",
                     "team:agent-integrations",
                     f"metrics_version:{METRIC_VERSION}",
+                    f"branch:{branch}",
                 ],
             }
         )
@@ -1014,245 +997,6 @@ def get_commit_data(commit: str) -> tuple[int, str, list[str], list[str]]:
     if not prs:
         prs = [""]
     return int(timestamp), message, tickets, prs
-
-
-@cache
-def get_last_dependency_sizes_artifact(
-    app: Application, commit: str, platform: str, py_version: str, compressed: bool
-) -> Path | None:
-    '''
-    Lockfiles of dependencies are not updated in the same commit as the dependencies are updated.
-    So in each commit, there is an artifact with the sizes of the wheels that were built to get the actual
-    size of that commit.
-    '''
-    size_type = 'compressed' if compressed else 'uncompressed'
-    app.display(f"\nRetrieving dependency sizes for {commit} ({platform}, py{py_version}, {size_type})")
-
-    dep_sizes_json = get_dep_sizes_json(app, commit, platform, py_version)
-    if not dep_sizes_json:
-        app.display_debug("No dependency sizes in current commit, searching ancestors")
-        try:
-            base_commit = app.repo.git.merge_base(commit, "origin/master")
-        except Exception as e:
-            app.display_error(f"Failed to find merge base for {commit}: {e}")
-            return None
-        if base_commit != commit:
-            app.display_debug(f"Found base commit: {base_commit}")
-            previous_commit = base_commit
-        else:
-            app.display_debug("No base commit found, using previous commit")
-            previous_commit = app.repo.git.log(["hash:%H"], n=2, source=commit)[1]["hash"]
-
-        app.display(f"\n -> Searching for dependency sizes in previous commit: {previous_commit}")
-
-        dep_sizes_json = get_previous_dep_sizes(app, previous_commit, platform, py_version, compressed)
-    return Path(dep_sizes_json) if dep_sizes_json else None
-
-
-@cache
-def get_dep_sizes_json(app: Application, current_commit: str, platform: str, py_version: str) -> Path | None:
-    '''
-    Gets the dependency sizes json for a given commit and platform when dependencies were resolved.
-    '''
-    app.display(f"\n -> Checking if dependency sizes were resolved in commit: {current_commit}")
-
-    run_id = get_run_id(app, current_commit, RESOLVE_BUILD_DEPS_WORKFLOW)
-    if run_id:
-        dep_sizes_json = get_current_sizes_json(app, run_id, platform, py_version)
-        return dep_sizes_json
-    else:
-        return None
-
-
-@cache
-def get_run_id(app: Application, commit: str, workflow: str) -> str | None:
-    app.display_debug(f"Fetching workflow run ID for {commit} ({os.path.basename(workflow)})")
-
-    result = subprocess.run(
-        [
-            'gh',
-            'run',
-            'list',
-            '--workflow',
-            workflow,
-            '-c',
-            commit,
-            '--json',
-            'databaseId,name',
-            '--jq',
-            '.[-1].databaseId',
-        ],
-        capture_output=True,
-        text=True,
-    )
-    run_id = result.stdout.strip() if result.stdout else None
-    if run_id:
-        app.display_debug(f"Workflow run ID: {run_id}")
-    else:
-        app.display_warning(f"No workflow run found for {commit} ({os.path.basename(workflow)})")
-
-    return run_id
-
-
-@cache
-def get_run_id_measure_disk_usage(app: Application, commit: str) -> str | None:
-    workflow_name = os.path.basename(MEASURE_DISK_USAGE_WORKFLOW)
-    wanted_name = f"Measure Disk Usage [{commit}]"
-
-    app.display_debug(f"Fetching workflow run ID for {commit} ({workflow_name})")
-
-    per_page = 100
-    max_pages = 5
-
-    for page in range(1, max_pages + 1):
-        app.display_debug(f"Fetching workflow run ID for {commit} ({workflow_name}) - Page {page} of {max_pages}")
-        result = subprocess.run(
-            [
-                "gh",
-                "api",
-                f"repos/DataDog/integrations-core/actions/workflows/{workflow_name}/runs",
-                "-X",
-                "GET",
-                "-f",
-                f"per_page={per_page}",
-                "-f",
-                f"page={page}",
-                "--jq",
-                (f'[.workflow_runs[] | select(.name == "{wanted_name}") | .id] | first // empty'),
-            ],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode != 0:
-            app.display_warning(f"No workflow run found for {commit} ({workflow_name}) ")
-            return None
-
-        out = (result.stdout or "").strip()
-        if out:
-            app.display_debug(f"Workflow run ID: {out}")
-            return out
-    return None
-
-
-@cache
-def get_current_sizes_json(app: Application, run_id: str, platform: str, py_version: str) -> Path | None:
-    '''
-    Downloads the dependency sizes json for a given run id and platform when dependencies were resolved.
-    '''
-    app.display(f"\nRetrieving dependency sizes artifact (run={run_id}, platform={platform})")
-    with tempfile.TemporaryDirectory() as tmpdir:
-        app.display_debug(f"Downloading artifacts to {tmpdir}...")
-        try:
-            subprocess.run(
-                [
-                    'gh',
-                    'run',
-                    'download',
-                    run_id,
-                    '--name',
-                    f'target-{platform}',
-                    '--dir',
-                    tmpdir,
-                ],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-        except subprocess.CalledProcessError as e:
-            if e.stderr and "no valid artifacts found" in e.stderr:
-                app.display_warning(f"No resolved dependencies found for platform {platform} (run {run_id})")
-            else:
-                app.display_error(f"Failed to download dependency sizes (run={run_id}, platform={platform}): {e}")
-                app.display_warning(e.stderr)
-
-            return None
-
-        app.display_debug("Artifact extraction complete")
-        sizes_file = Path(tmpdir) / platform / 'py3' / 'sizes.json'
-
-        if not sizes_file.is_file():
-            app.display_warning(f"Dependency sizes artifact missing: {sizes_file.name}")
-            return None
-
-        app.display_debug(f"Found dependency sizes: {sizes_file.name}")
-        dest_path = sizes_file.rename(f"{platform}_{py_version}.json")
-        return dest_path
-
-
-@cache
-def get_artifact(app: Application, run_id: str, artifact_name: str, target_dir: str | None = None) -> Path | None:
-    app.display(f"Downloading artifact '{artifact_name}' (run {run_id})...")
-    try:
-        cmd = [
-            'gh',
-            'run',
-            'download',
-            run_id,
-            '--name',
-            artifact_name,
-        ]
-        if target_dir:
-            cmd.extend(['--dir', target_dir])
-
-        subprocess.run(cmd, check=True, text=True, capture_output=True)
-    except subprocess.CalledProcessError as e:
-        app.display_warning(f"Failed to download artifact '{artifact_name}' (run {run_id}): {e}")
-        app.display_warning(e.stderr)
-        return None
-
-    artifact_path = Path(target_dir) / artifact_name if target_dir else Path(artifact_name)
-    app.display_debug(f"Saved to {artifact_path}")
-    return artifact_path
-
-
-@cache
-def get_previous_dep_sizes(
-    app: Application, base_commit: str, platform: str, py_version: str, compressed: bool
-) -> Path | None:
-    '''
-    Gets the dependency sizes for a given commit when dependencies were not resolved.
-    '''
-    with tempfile.TemporaryDirectory() as tmpdir:
-        if (run_id := get_run_id_measure_disk_usage(app, base_commit)) is None:
-            return None
-
-        artifact_name = 'status_compressed.json' if compressed else 'status_uncompressed.json'
-        sizes_json = get_artifact(app, run_id, artifact_name, tmpdir)
-
-        if not sizes_json:
-            app.display_error(f"No dependency sizes found for {platform} py{py_version} in commit {base_commit}\n")
-            return None
-
-        sizes = parse_sizes_json(sizes_json, platform, py_version, compressed)
-
-        sizes_path = Path(tmpdir) / f"{platform}_{py_version}.json"
-        with open(sizes_path, "w") as f:
-            json.dump(sizes, f, indent=2)
-
-        target_path = f"{platform}_{py_version}.json"
-        shutil.copy(sizes_path, target_path)
-        return Path(target_path)
-
-
-@cache
-def parse_sizes_json(
-    sizes_json_path: Path, platform: str, py_version: str, compressed: bool
-) -> dict[str, dict[str, int]]:
-    sizes_list = list(json.loads(sizes_json_path.read_text()))
-    size_key = "compressed" if compressed else "uncompressed"
-    sizes = {
-        dep["Name"]: {
-            size_key: int(dep["Size_Bytes"]),
-            "version": dep.get("Version"),
-            "compression": compressed,
-        }
-        for dep in sizes_list
-        if dep.get("Type") == "Dependency"
-        and dep.get("Platform") == platform
-        and dep.get("Python_Version") == py_version
-    }
-
-    return sizes
 
 
 class WrongDependencyFormat(Exception):

--- a/ddev/tests/cli/size/test_status.py
+++ b/ddev/tests/cli/size/test_status.py
@@ -70,51 +70,37 @@ def mock_size_status():
 
 
 @pytest.mark.parametrize(
-    "args, use_dependency_sizes",
+    "args",
     [
-        ([], False),
-        (["--compressed"], False),
-        (["--format", "csv,markdown,json,png"], False),
-        (["--show-gui"], False),
-        (["--platform", "linux-aarch64", "--python", "3.12"], False),
-        (["--platform", "linux-aarch64", "--python", "3.12", "--compressed"], False),
-        (["--platform", "linux-aarch64", "--python", "3.12", "--format", "csv,markdown,json,png"], False),
-        (["--platform", "linux-aarch64", "--python", "3.12", "--show-gui"], False),
+        [],
+        ["--compressed"],
+        ["--format", "csv,markdown,json,png"],
+        ["--show-gui"],
+        ["--commit", "1234567890"],
+        ["--commit", "1234567890", "--branch", "feature/branch"],
+        ["--platform", "linux-aarch64", "--python", "3.12"],
+        ["--platform", "linux-aarch64", "--python", "3.12", "--compressed"],
+        ["--platform", "linux-aarch64", "--python", "3.12", "--format", "csv,markdown,json,png"],
+        ["--platform", "linux-aarch64", "--python", "3.12", "--show-gui"],
     ],
     ids=[
         "no_args",
         "compressed",
         "format",
         "show_gui",
+        "commit",
+        "commit_with_branch",
         "platform_and_version",
         "platform_version_compressed",
         "platform_version_format",
         "platform_version_show_gui",
     ],
 )
-def test_status(ddev, mock_size_status, tmp_path, args, use_dependency_sizes):
+def test_status(ddev, mock_size_status, args):
     command = ["size", "status"] + args
 
-    if use_dependency_sizes:
-        fake_deps = [
-            {
-                "Name": "dep1",
-                "Version": "1.1.1",
-                "Size_Bytes": 5678,
-                "Size": 123,
-                "Type": "Dependency",
-            }
-        ]
-        dependency_sizes_file = tmp_path / "sizes"
-        dependency_sizes_file.write_text("{}")
-        command.extend(["--dependency-sizes", str(dependency_sizes_file)])
-
-        with patch("ddev.cli.size.utils.common_funcs.get_dependencies_from_json", return_value=fake_deps):
-            result = ddev(*command)
-            assert result.exit_code == 0
-    else:
-        result = ddev(*command)
-        assert result.exit_code == 0
+    result = ddev(*command)
+    assert result.exit_code == 0
 
 
 @pytest.mark.parametrize(
@@ -125,35 +111,20 @@ def test_status(ddev, mock_size_status, tmp_path, args, use_dependency_sizes):
         "to_dd_org",
         "to_dd_key",
         "commit",
-        "dependency_sizes_path",
-        "create_dependency_sizes_file",
         "should_abort",
     ),
     [
         # Valid cases
-        ("linux-x86_64", "3.12", ["csv"], None, None, None, None, False, False),
-        ("macos-x86_64", "3.12", [], None, None, "1234567890", None, False, False),
-        ("linux-aarch64", "3.12", [], None, None, None, Path("sizes"), True, False),
+        ("linux-x86_64", "3.12", ["csv"], None, None, None, False),
+        ("macos-x86_64", "3.12", [], None, None, "1234567890", False),
         # Invalid platform
-        ("invalid-platform", "3.12", [], None, None, None, None, False, True),
+        ("invalid-platform", "3.12", [], None, None, None, True),
         # Invalid version
-        ("linux-x86_64", "2.7", [], None, None, None, None, False, True),
-        # Invalid dependency sizes file
-        ("linux-x86_64", "3.12", [], None, None, None, Path("sizes"), False, True),
-        # Both commit and dependency_sizes
-        (
-            "linux-x86_64",
-            "3.12",
-            [],
-            None,
-            None,
-            "1234567890",
-            Path("sizes"),
-            True,
-            True,
-        ),
+        ("linux-x86_64", "2.7", [], None, None, None, True),
         # Invalid format
-        ("linux-x86_64", "3.12", ["invalid-format"], None, None, None, None, False, True),
+        ("linux-x86_64", "3.12", ["invalid-format"], None, None, None, True),
+        # Missing commit for Datadog metrics
+        ("linux-x86_64", "3.12", [], "test-org", None, None, True),
         # Both to_dd_org and to_dd_key
         (
             "linux-x86_64",
@@ -162,8 +133,6 @@ def test_status(ddev, mock_size_status, tmp_path, args, use_dependency_sizes):
             "test-org",
             "test-key",
             None,
-            None,
-            False,
             True,
         ),
         # Multiple errors
@@ -174,20 +143,16 @@ def test_status(ddev, mock_size_status, tmp_path, args, use_dependency_sizes):
             "test-org",
             "test-key",
             "1234567890",
-            Path("sizes"),
-            True,
             True,
         ),
     ],
     ids=[
         "valid_simple",
         "valid_with_commit",
-        "valid_with_dependency_sizes",
         "invalid_platform",
         "invalid_version",
-        "invalid_dependency_sizes_file",
-        "commit_and_dependency_sizes",
         "invalid_format",
+        "to_dd_without_commit",
         "to_dd_org_and_to_dd_key",
         "multiple_errors",
     ],
@@ -199,19 +164,11 @@ def test_validate_parameters(
     to_dd_org,
     to_dd_key,
     commit,
-    dependency_sizes_path,
-    create_dependency_sizes_file,
     should_abort,
-    tmp_path,
 ):
     valid_platforms = ["linux-x86_64", "macos-x86_64", "linux-aarch64", "macos-aarch64", "windows-x86_64"]
     valid_versions = ["3.12"]
 
-    dependency_sizes = None
-    if dependency_sizes_path:
-        dependency_sizes = tmp_path / dependency_sizes_path
-        if create_dependency_sizes_file:
-            dependency_sizes.touch()
     app = MagicMock()
     app.abort.side_effect = SystemExit
 
@@ -225,7 +182,6 @@ def test_validate_parameters(
                 format,
                 to_dd_org,
                 commit,
-                dependency_sizes,
                 to_dd_key,
                 app,
             )
@@ -239,7 +195,6 @@ def test_validate_parameters(
             format,
             to_dd_org,
             commit,
-            dependency_sizes,
             to_dd_key,
             app,
         )

--- a/ddev/tests/size/test_common.py
+++ b/ddev/tests/size/test_common.py
@@ -13,7 +13,6 @@ from ddev.cli.size.utils.common_funcs import (
     convert_to_human_readable_size,
     extract_version_from_about_py,
     format_modules,
-    get_dependencies_from_json,
     get_dependencies_list,
     get_dependencies_sizes,
     get_files,
@@ -22,10 +21,10 @@ from ddev.cli.size.utils.common_funcs import (
     get_valid_versions,
     is_correct_dependency,
     is_valid_integration_file,
-    parse_sizes_json,
     save_csv,
     save_json,
     save_markdown,
+    send_metrics_to_dd,
 )
 from ddev.utils.fs import Path
 
@@ -393,62 +392,37 @@ def test_extract_version_from_about_py(file_content, expected_version):
     assert version == expected_version
 
 
-def test_parse_sizes_json(tmp_path):
-    compressed_data = json.dumps(
-        [
-            {
-                "Name": "dep1",
-                "Size_Bytes": 123,
-                "Size": "2 B",
-                "Type": "Dependency",
-                "Platform": "linux-x86_64",
-                "Python_Version": "3.12",
-            },
-            {
-                "Name": "dep2",
-                "Size_Bytes": 123,
-                "Size": "2 B",
-                "Type": "Dependency",
-                "Platform": "macos-x86_64",
-                "Python_Version": "3.12",
-            },
-            {
-                "Name": "module1",
-                "Size_Bytes": 123,
-                "Size": "2 B",
-                "Type": "Integration",
-                "Platform": "linux-x86_64",
-                "Python_Version": "3.12",
-            },
-        ]
-    )
-
-    expected_output = {
-        "dep1": {
-            "compressed": 123,
-            "compression": True,
-            "version": None,
-        }
-    }
-    compressed_json_path = tmp_path / "compressed.json"
-    compressed_json_path.write_text(compressed_data)
-
-    result = parse_sizes_json(compressed_json_path, "linux-x86_64", "3.12", True)
-
-    assert result == expected_output
-
-
-def test_get_dependencies_from_json():
-    dep_size_dict = (
-        '{"dep1": {"compressed": 1, "uncompressed": 2, "version": "1.1.1"},\n'
-        '"dep2": {"compressed": 10, "uncompressed": 20, "version": "1.1.1"}}'
-    )
-    expected = [
-        {"Name": "dep1", "Version": "1.1.1", "Size_Bytes": 1, "Size": "1 B", "Type": "Dependency"},
-        {"Name": "dep2", "Version": "1.1.1", "Size_Bytes": 10, "Size": "10 B", "Type": "Dependency"},
+def test_send_metrics_to_dd_adds_branch_tag():
+    app = MagicMock()
+    app.config.orgs = {}
+    modules = [
+        {
+            "Name": "module1",
+            "Version": "1.2.3",
+            "Size_Bytes": 123,
+            "Size": "123 B",
+            "Type": "Integration",
+            "Platform": "linux-x86_64",
+            "Python_Version": "3.13",
+        },
+        {
+            "Name": "dep1",
+            "Version": "4.5.6",
+            "Size_Bytes": 456,
+            "Size": "456 B",
+            "Type": "Dependency",
+            "Platform": "linux-x86_64",
+            "Python_Version": "3.13",
+        },
     ]
 
-    with patch('ddev.utils.fs.Path') as mock_path:
-        mock_path.read_text.return_value = dep_size_dict
-        result = get_dependencies_from_json(mock_path, "linux-x86_64", "3.12", True)
-    assert result == expected
+    with (
+        patch("ddev.cli.size.utils.common_funcs.get_commit_data", return_value=(1234567890, "message", [""], [""])),
+        patch("ddev.cli.size.utils.common_funcs.initialize"),
+        patch("ddev.cli.size.utils.common_funcs.api.Metric.send") as metric_send,
+    ):
+        send_metrics_to_dd(app, "abcdef123", modules, None, "test-key", False, "feature/branch")
+
+    for call in metric_send.call_args_list:
+        for metric in call.kwargs["metrics"]:
+            assert "branch:feature/branch" in metric["tags"]


### PR DESCRIPTION
### What does this PR do?

Removes the `--dependency-sizes` CLI option and all associated `gh` CLI calls that fetched dependency size artifacts from GitHub Actions. The `ddev size status` command now always resolves dependency sizes from local lockfiles.

Adds a `--branch` flag so metrics sent to Datadog include a `branch:` tag, and updates the disk-usage workflows so size metrics are sent for PR branches as well as master.

### Motivation

Dependency resolution is now done in one step, so dependency sizes are already represented by the lockfiles merged into the repository. There is no need to fetch dependency sizes from GitHub Actions artifacts anymore.

Sending the branch as a metric tag allows Datadog to receive and distinguish size metrics from PR branches as well as master.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
