### PR TITLE
Pin uv version in tagger

### DIFF
--- a/.gitlab/tagger/Dockerfile
+++ b/.gitlab/tagger/Dockerfile
@@ -1,7 +1,8 @@
 FROM registry.ddbuild.io/images/mirror/ubuntu:25.04
 
 # Get uv — manages Python installations on demand, no system Python pinning needed
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+# To update: check https://github.com/astral-sh/uv/pkgs/container/uv for the latest digest. 
+COPY --from=ghcr.io/astral-sh/uv:0.11.16@sha256:440fd6477af86a2f1b38080c539f1672cd22acb1b1a47e321dba5158ab08864d /uv /usr/local/bin/uv
 
 # Update sources and install required packages
 RUN apt-get update \

--- a/.gitlab/tagger/Dockerfile
+++ b/.gitlab/tagger/Dockerfile
@@ -1,7 +1,6 @@
 FROM registry.ddbuild.io/images/mirror/ubuntu:25.04
 
 # Get uv — manages Python installations on demand, no system Python pinning needed
-# To update: check https://github.com/astral-sh/uv/pkgs/container/uv for the latest digest. 
 COPY --from=ghcr.io/astral-sh/uv:0.11.16@sha256:440fd6477af86a2f1b38080c539f1672cd22acb1b1a47e321dba5158ab08864d /uv /usr/local/bin/uv
 
 # Update sources and install required packages
@@ -31,8 +30,6 @@ RUN mkdir -p ~/.ssh \
  && ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
 
 # dd-octo-sts CLI for GitHub token exchange (replaces SSH deploy key)
-# To update: crane ls registry.ddbuild.io/dd-octo-sts | sort -V | tail -1
-#            crane digest registry.ddbuild.io/dd-octo-sts:<version>
 COPY --from=registry.ddbuild.io/dd-octo-sts:v1.10.4@sha256:20edc79b3fc3f9cd58eb0aeba7391a8e63ccb79c0b969a4a62a745cf5b2e39c2 /usr/local/bin/dd-octo-sts /usr/local/bin/dd-octo-sts
 
 # Locales are required to be set to use click

--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,7 @@
     },
     {
       "customType": "regex",
-      "description": "Track image:tag@digest references in the tagger Dockerfile (uv, dd-octo-sts).",
+      "description": "Track image:tag@digest references in Dockerfiles.",
       "managerFilePatterns": [
         "/^\\.gitlab/tagger/Dockerfile$/"
       ],
@@ -136,15 +136,15 @@
       "matchManagers": [
         "custom.regex"
       ],
-      "matchFileNames": [
-        ".gitlab/tagger/Dockerfile"
+      "matchDatasources": [
+        "docker"
       ],
-      "groupName": "tagger image deps",
+      "groupName": "docker images",
       "schedule": [
         "before 6am on Monday"
       ],
       "labels": [
-        "renovate/tagger-image",
+        "renovate/docker-images",
         "qa/skip-qa"
       ],
       "minimumReleaseAge": "7 days"

--- a/renovate.json
+++ b/renovate.json
@@ -7,8 +7,8 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": [
-        "^\\.github/workflows/[^/]+\\.ya?ml$"
+      "managerFilePatterns": [
+        "/^\\.github/workflows/[^/]+\\.ya?ml$/"
       ],
       "matchStrings": [
         "(?<depName>[a-zA-Z][a-zA-Z0-9._-]*)==(?<currentValue>[0-9]+(?:\\.[0-9]+){1,2})",
@@ -19,8 +19,8 @@
     {
       "customType": "regex",
       "description": "Track image:tag@digest references in the tagger Dockerfile (uv, dd-octo-sts).",
-      "fileMatch": [
-        "^\\.gitlab/tagger/Dockerfile$"
+      "managerFilePatterns": [
+        "/^\\.gitlab/tagger/Dockerfile$/"
       ],
       "matchStrings": [
         "(?:COPY --from=|FROM )(?<depName>[^\\s:@]+):(?<currentValue>[^\\s@]+)@(?<currentDigest>sha256:[a-f0-9]+)"

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,17 @@
         "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[a-zA-Z][a-zA-Z0-9._-]*)\\s+[A-Z][A-Z0-9_]*: \"(?<currentValue>[0-9]+(?:\\.[0-9]+){1,2})\""
       ],
       "datasourceTemplate": "pypi"
+    },
+    {
+      "customType": "regex",
+      "description": "Track image:tag@digest references in the tagger Dockerfile (uv, dd-octo-sts).",
+      "fileMatch": [
+        "^\\.gitlab/tagger/Dockerfile$"
+      ],
+      "matchStrings": [
+        "(?:COPY --from=|FROM )(?<depName>[^\\s:@]+):(?<currentValue>[^\\s@]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+      ],
+      "datasourceTemplate": "docker"
     }
   ],
   "packageRules": [
@@ -108,12 +119,32 @@
       "matchManagers": [
         "custom.regex"
       ],
+      "matchFileNames": [
+        ".github/workflows/**"
+      ],
       "groupName": "workflow python deps",
       "schedule": [
         "before 6am on Monday"
       ],
       "labels": [
         "renovate/workflow-deps",
+        "qa/skip-qa"
+      ],
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchFileNames": [
+        ".gitlab/tagger/Dockerfile"
+      ],
+      "groupName": "tagger image deps",
+      "schedule": [
+        "before 6am on Monday"
+      ],
+      "labels": [
+        "renovate/tagger-image",
         "qa/skip-qa"
       ],
       "minimumReleaseAge": "7 days"


### PR DESCRIPTION
### What does this PR do?
Pins a uv version in the tagger and adds a matcher so that uv and dd-octo-sts in the tagger are tracked by Renovate.

### Motivation


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
