### PR TITLE
Honor source-repo-ref when checking out for release dispatch

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -58,6 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.source-repo-ref || github.sha }}
           fetch-depth: 0 # ddev needs full tag history
 
       - name: Checkout integrations-core actions


### PR DESCRIPTION
### What does this PR do?

Pass `inputs.source-repo-ref` (falling back to `github.sha`) to the `actions/checkout` step in `.github/workflows/release-dispatch.yml` so the working tree matches the ref the caller asked to release from.

### Motivation

The `release-trigger` workflow exposes a `source-repo-ref` input ("Commit SHA or ref to build from") and forwards it to the reusable `release-dispatch` workflow. However, `release-dispatch.yml` did not pass a `ref:` to `actions/checkout`, so the checkout always landed on `github.sha` (the commit the workflow itself ran from), not on the requested `source-repo-ref`.

This caused `ddev release tag` and the validation steps in `release_prepare.py` to operate on the wrong commit whenever someone dispatched a manual release against a non-HEAD ref: tags would be created from the workflow's own SHA instead of the user-supplied ref. The downstream `repository_dispatch` payload still carried the correct ref (because `release_dispatch.py` reads `REF` from the environment), so the symptom was specifically a tagging/validation mismatch upstream of the wheel build.

With this change the checkout honors the input, so the rest of the prepare step sees the correct tree.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
