### PR TITLE
Keep release tooling separate from source refs

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -21,7 +21,7 @@ on:
         required: false
         type: string
       source-repo-branch:
-        description: "Branch that contains source-repo-ref"
+        description: "Branch that contains source-repo-ref, used to determine stable vs pre-release behavior"
         required: false
         type: string
       dry-run:

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -20,6 +20,10 @@ on:
         description: "Commit SHA or ref to build from"
         required: false
         type: string
+      source-repo-branch:
+        description: "Branch that contains source-repo-ref"
+        required: false
+        type: string
       dry-run:
         description: >-
           When true, print what would be released and where without pushing tags
@@ -56,20 +60,42 @@ jobs:
       batches: ${{ steps.release-dispatch.outputs.batches }}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # Workflow tooling (composite actions + release scripts) always comes from
+      # integrations-core at the workflow's own commit. When called from another
+      # repo we don't have that commit available locally, so we fall back to
+      # master. This is decoupled from inputs.source-repo-ref on purpose so the
+      # release pipeline can build older refs without losing recent tooling.
+      - name: Checkout workflow tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: DataDog/integrations-core
+          ref: ${{ github.repository == 'DataDog/integrations-core' && github.sha || 'master' }}
+          fetch-depth: 1
+          sparse-checkout: .github
+          path: tooling
+
+      # Source tree to tag and validate. ddev release tag operates on HEAD of
+      # this checkout, so it must be at the ref the caller asked to release.
+      - name: Checkout source repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.source-repo-ref || github.sha }}
           fetch-depth: 0 # ddev needs full tag history
+          path: source
 
-      - name: Checkout integrations-core actions
-        if: github.repository != 'DataDog/integrations-core'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: "DataDog/integrations-core"
-          ref: master
-          fetch-depth: 1
-          sparse-checkout: .github/actions
-          path: core-temp
+      - name: Verify source ref is on release branch
+        if: inputs.source-repo-branch != ''
+        working-directory: source
+        env:
+          SOURCE_REF: ${{ inputs.source-repo-ref || github.sha }}
+          SOURCE_BRANCH: ${{ inputs.source-repo-branch }}
+        run: |
+          branch="${SOURCE_BRANCH#refs/heads/}"
+          git fetch --no-tags origin "+refs/heads/${branch}:refs/remotes/origin/${branch}"
+          if ! git merge-base --is-ancestor HEAD "refs/remotes/origin/${branch}"; then
+            echo "::error::source-repo-ref '${SOURCE_REF}' is not contained in source-repo-branch '${SOURCE_BRANCH}'"
+            exit 1
+          fi
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -77,47 +103,42 @@ jobs:
           python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Install ddev
-        if: github.repository == 'DataDog/integrations-core'
-        uses: ./.github/actions/setup-ddev
-        with:
-          install-mode: pypi
-          ddev-version: "==${{ inputs.ddev-version || env.DEFAULT_DDEV_VERSION }}"
-
-      - name: Install ddev
-        if: github.repository != 'DataDog/integrations-core'
-        uses: ./core-temp/.github/actions/setup-ddev
+        uses: ./tooling/.github/actions/setup-ddev
         with:
           install-mode: pypi
           ddev-version: "==${{ inputs.ddev-version || env.DEFAULT_DDEV_VERSION }}"
 
       - name: Configure ddev
+        working-directory: source
         env:
           SOURCE_REPO: ${{ inputs.source-repo || 'integrations-core' }}
         run: |
           REPO_SHORT="${SOURCE_REPO#integrations-}"
           ddev config set upgrade_check false
-          ddev config set repos.${REPO_SHORT} .
+          ddev config set repos.${REPO_SHORT} "$PWD"
           ddev config set repo ${REPO_SHORT}
 
       - name: Prepare dispatch
         id: prepare
+        working-directory: source
         env:
           DRY_RUN: ${{ inputs.dry-run }}
           SELECTED_PACKAGES: ${{ inputs.packages }}
           SOURCE_REPO: ${{ inputs.source-repo || 'integrations-core' }}
           REF: ${{ inputs.source-repo-ref || github.sha }}
           IS_STABLE_RELEASE: ${{ inputs.is-stable-release }}
-        run: python .github/workflows/scripts/release_prepare.py
+        run: python "$GITHUB_WORKSPACE/tooling/.github/workflows/scripts/release_prepare.py"
 
       - name: Build dispatch batches
         id: release-dispatch
         if: steps.prepare.outputs.has_packages == 'true'
+        working-directory: source
         env:
           PACKAGES: ${{ steps.prepare.outputs.packages }}
           SOURCE_REPO: ${{ inputs.source-repo || 'integrations-core' }}
           REF: ${{ inputs.source-repo-ref || github.sha }}
           DRY_RUN: ${{ inputs.dry-run }}
-        run: python .github/workflows/scripts/release_dispatch.py
+        run: python "$GITHUB_WORKSPACE/tooling/.github/workflows/scripts/release_dispatch.py"
 
   dispatch:
     name: Dispatch wheel builds (batch ${{ strategy.job-index }})

--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -27,6 +27,10 @@ on:
         description: "Commit SHA or ref to build from"
         required: true
         type: string
+      source-repo-branch:
+        description: "Branch that contains source-repo-ref, used to determine stable vs pre-release behavior"
+        required: true
+        type: string
       dry-run:
         description: "Print what would be released without pushing tags or starting builds"
         required: false
@@ -45,10 +49,14 @@ jobs:
       is-stable-release: ${{ steps.detect.outputs.is-stable-release }}
     steps:
       - id: detect
-        # Sets is-stable-release based on the branch: true for master/X.Y.x, false otherwise.
-        # Manual runs on master get "true", which blocks pre-release packages — conservative and intentional.
+        # Stable for master/X.Y.x, pre-release for alpha/beta/rc branches.
+        # Manual dispatches use source-repo-branch instead of GITHUB_REF so the
+        # release behavior follows the branch that contains source-repo-ref.
+        env:
+          RELEASE_BRANCH: ${{ github.event_name == 'workflow_dispatch' && inputs.source-repo-branch || github.ref_name }}
         run: |
-          if [[ "$GITHUB_REF" =~ ^refs/heads/(master|[0-9]+\.[0-9]+\.x)$ ]]; then
+          branch="${RELEASE_BRANCH#refs/heads/}"
+          if [[ "$branch" =~ ^(master|[0-9]+\.[0-9]+\.x)$ ]]; then
             echo "is-stable-release=true" >> "$GITHUB_OUTPUT"
           else
             echo "is-stable-release=false" >> "$GITHUB_OUTPUT"
@@ -70,6 +78,7 @@ jobs:
       source-repo: integrations-core
       packages: ${{ inputs.packages || '' }}
       source-repo-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.source-repo-ref || github.sha }}
+      source-repo-branch: ${{ github.event_name == 'workflow_dispatch' && inputs.source-repo-branch || github.ref_name }}
       dry-run: ${{ inputs.dry-run || false }}
       ddev-version: ${{ inputs.ddev-version || '' }}
       is-stable-release: ${{ needs.context.outputs.is-stable-release }}


### PR DESCRIPTION
### What does this PR do?

Splits the release dispatch prepare job into two checkouts:

- `tooling/` checks out current `integrations-core` workflow tooling under `.github/`.
- `source/` checks out the requested `source-repo-ref`, which is where `ddev release tag` and validation run.

This keeps release pipeline tooling current while still tagging and validating the requested source ref.

This also adds a manual `source-repo-branch` input to `release-trigger.yml`, passes it to `release-dispatch.yml`, and verifies that the checked-out source ref is contained in that branch before tagging. The branch also drives stable (`master`/`X.Y.x`) versus pre-release (`alpha/*`, `beta/*`, `rc/*`) validation.

### Motivation

PR #23836 made `actions/checkout` honor `source-repo-ref`, but that also made workflow-local tooling come from the older source ref. Manual releases from refs that predate `.github/actions/setup-ddev` then fail because the composite action is not present in the workspace.

The prepare job needs current workflow tooling but must run `ddev` against the requested source tree. Separate checkouts preserve both requirements.

For stable/pre-release validation, using `GITHUB_REF` is incorrect for manual dispatches because it describes the branch that launched the workflow, not necessarily the branch containing `source-repo-ref`. The new `source-repo-branch` input makes that context explicit and the dispatch workflow checks that the ref is actually contained in the provided branch.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
