### PR TITLE
Pin coverage-upload-github-action to v1.0.3

### DIFF
--- a/.github/workflows/master-windows.yml
+++ b/.github/workflows/master-windows.yml
@@ -102,7 +102,7 @@ jobs:
     - name: Upload coverage to Datadog
       if: always()
       continue-on-error: true
-      uses: DataDog/coverage-upload-github-action@9bbbf86d16f7db1b14c5b885e61cf0d96053686a # v1.0.0
+      uses: DataDog/coverage-upload-github-action@6c4bd935248daa6f0ef94e3e6ba71ad5ad079998 # v1.0.3
       with:
         api_key: ${{ secrets.DD_API_KEY }}
         files: coverage-reports

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -3,27 +3,27 @@ name: Master
 on:
   push:
     branches:
-    - master
+      - master
     paths:
       # List of files/paths that should trigger the run. The intention is to avoid running all tests if the commit only includes changes on assets or README
-    - '*/datadog_checks/**'
-    - '*/tests/**'
-    - 'ddev/**'
-    - 'datadog_checks_base/**'
-    - 'datadog_checks_dev/**'
-    # Contains overrides for testing
-    - '.ddev/**'
-    # Want to ensure any change in workflows is validated
-    - '.github/workflows/**'
-    # Test matrices and dependencies
-    - '*/hatch.toml'
-    - '*/pyproject.toml'
-    # Some integrations might use this file to validate metrics emission
-    - '*/metadata.csv'
-    # In case some linting formatting config has changed
-    - 'pyproject.toml'
+      - "*/datadog_checks/**"
+      - "*/tests/**"
+      - "ddev/**"
+      - "datadog_checks_base/**"
+      - "datadog_checks_dev/**"
+      # Contains overrides for testing
+      - ".ddev/**"
+      # Want to ensure any change in workflows is validated
+      - ".github/workflows/**"
+      # Test matrices and dependencies
+      - "*/hatch.toml"
+      - "*/pyproject.toml"
+      # Some integrations might use this file to validate metrics emission
+      - "*/metadata.csv"
+      # In case some linting formatting config has changed
+      - "pyproject.toml"
   schedule:
-    - cron: '0 2 * * *'
+    - cron: "0 2 * * *"
 
 jobs:
   cache:
@@ -31,7 +31,7 @@ jobs:
 
   test:
     needs:
-    - cache
+      - cache
 
     uses: ./.github/workflows/test-all.yml
     with:
@@ -48,12 +48,12 @@ jobs:
     secrets: inherit
 
     permissions:
-       # needed for compute-matrix in test-target.yml
-       contents: read
+      # needed for compute-matrix in test-target.yml
+      contents: read
 
   publish-test-results:
     needs:
-    - test
+      - test
 
     if: success() || failure()
     concurrency:
@@ -69,7 +69,7 @@ jobs:
 
   upload-coverage:
     needs:
-    - test
+      - test
     if: >
       !github.event.repository.private &&
       (success() || failure())
@@ -80,27 +80,27 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Download all coverage artifacts
-      uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
-      with:
-        pattern: coverage-*
-        path: coverage-reports
-        merge-multiple: false
+      - name: Download all coverage artifacts
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          pattern: coverage-*
+          path: coverage-reports
+          merge-multiple: false
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
-      with:
-        use_oidc: true
-        directory: coverage-reports
-        fail_ci_if_error: false
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
+        with:
+          use_oidc: true
+          directory: coverage-reports
+          fail_ci_if_error: false
 
-    - name: Upload coverage to Datadog
-      if: always()
-      continue-on-error: true
-      uses: DataDog/coverage-upload-github-action@9bbbf86d16f7db1b14c5b885e61cf0d96053686a # v1.0.0
-      with:
-        api_key: ${{ secrets.DD_API_KEY }}
-        files: coverage-reports
-        format: cobertura
+      - name: Upload coverage to Datadog
+        if: always()
+        continue-on-error: true
+        uses: DataDog/coverage-upload-github-action@6c4bd935248daa6f0ef94e3e6ba71ad5ad079998 # v1.0.3
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          files: coverage-reports
+          format: cobertura

--- a/.github/workflows/pr-all-windows.yml
+++ b/.github/workflows/pr-all-windows.yml
@@ -5,17 +5,17 @@ name: PR All Windows
 on:
   pull_request:
     paths:
-    - datadog_checks_base/datadog_checks/**
-    - datadog_checks_dev/datadog_checks/dev/*.py
-    - ddev/src/**
-    - "!agent_requirements.in"
-    # Also run if we modify the workflow files
-    - '.github/workflows/pr-all-windows.yml'
-    - '.github/workflows/test-target.yml'
-    - '.github/workflows/test-all-windows.yml'
-    # Also run in the action to install test-target scripts changes
-    - '.github/actions/setup-test-target-scripts/**'
-    - '.github/actions/setup-ddev/**'
+      - datadog_checks_base/datadog_checks/**
+      - datadog_checks_dev/datadog_checks/dev/*.py
+      - ddev/src/**
+      - "!agent_requirements.in"
+      # Also run if we modify the workflow files
+      - ".github/workflows/pr-all-windows.yml"
+      - ".github/workflows/test-target.yml"
+      - ".github/workflows/test-all-windows.yml"
+      # Also run in the action to install test-target scripts changes
+      - ".github/actions/setup-test-target-scripts/**"
+      - ".github/actions/setup-ddev/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref }}
@@ -26,8 +26,8 @@ jobs:
     uses: ./.github/workflows/test-all-windows.yml
 
     permissions:
-       # needed for compute-matrix in test-target.yml
-       contents: read
+      # needed for compute-matrix in test-target.yml
+      contents: read
 
     with:
       repo: core
@@ -39,14 +39,14 @@ jobs:
 
   save-event:
     needs:
-    - test
+      - test
     if: success() || failure()
 
     uses: ./.github/workflows/save-event.yml
 
   upload-coverage:
     needs:
-    - test
+      - test
     if: >
       !github.event.repository.private &&
       (success() || failure())
@@ -57,27 +57,27 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Download all coverage artifacts
-      uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
-      with:
-        pattern: coverage-*
-        path: coverage-reports
-        merge-multiple: false
+      - name: Download all coverage artifacts
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          pattern: coverage-*
+          path: coverage-reports
+          merge-multiple: false
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
-      with:
-        use_oidc: true
-        directory: coverage-reports
-        fail_ci_if_error: false
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
+        with:
+          use_oidc: true
+          directory: coverage-reports
+          fail_ci_if_error: false
 
-    - name: Upload coverage to Datadog
-      if: always()
-      continue-on-error: true
-      uses: DataDog/coverage-upload-github-action@9bbbf86d16f7db1b14c5b885e61cf0d96053686a # v1.0.0
-      with:
-        api_key: ${{ secrets.DD_API_KEY }}
-        files: coverage-reports
-        format: cobertura
+      - name: Upload coverage to Datadog
+        if: always()
+        continue-on-error: true
+        uses: DataDog/coverage-upload-github-action@6c4bd935248daa6f0ef94e3e6ba71ad5ad079998 # v1.0.3
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          files: coverage-reports
+          format: cobertura

--- a/.github/workflows/pr-all.yml
+++ b/.github/workflows/pr-all.yml
@@ -3,20 +3,20 @@ name: PR All
 on:
   pull_request:
     paths:
-    - datadog_checks_base/datadog_checks/**
-    - datadog_checks_base/pyproject.toml
-    - datadog_checks_dev/datadog_checks/dev/*.py
-    - datadog_checks_dev/pyproject.toml
-    - ddev/src/**
-    - ddev/pyproject.toml
-    - "!agent_requirements.in"
-    # Also run if we modify the workflow files
-    - '.github/workflows/pr-all.yml'
-    - '.github/workflows/test-target.yml'
-    - '.github/workflows/test-all.yml'
-    # Also run if the action to install test-target scripts changes
-    - '.github/actions/setup-test-target-scripts/**'
-    - '.github/actions/setup-ddev/**'
+      - datadog_checks_base/datadog_checks/**
+      - datadog_checks_base/pyproject.toml
+      - datadog_checks_dev/datadog_checks/dev/*.py
+      - datadog_checks_dev/pyproject.toml
+      - ddev/src/**
+      - ddev/pyproject.toml
+      - "!agent_requirements.in"
+      # Also run if we modify the workflow files
+      - ".github/workflows/pr-all.yml"
+      - ".github/workflows/test-target.yml"
+      - ".github/workflows/test-all.yml"
+      # Also run if the action to install test-target scripts changes
+      - ".github/actions/setup-test-target-scripts/**"
+      - ".github/actions/setup-ddev/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref }}
@@ -27,8 +27,8 @@ jobs:
     uses: ./.github/workflows/test-all.yml
 
     permissions:
-       # needed for compute-matrix in test-target.yml
-       contents: read
+      # needed for compute-matrix in test-target.yml
+      contents: read
 
     with:
       repo: core
@@ -42,14 +42,14 @@ jobs:
 
   save-event:
     needs:
-    - test
+      - test
     if: success() || failure()
 
     uses: ./.github/workflows/save-event.yml
 
   upload-coverage:
     needs:
-    - test
+      - test
     if: >
       !github.event.repository.private &&
       (success() || failure())
@@ -60,27 +60,27 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Download all coverage artifacts
-      uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
-      with:
-        pattern: coverage-*
-        path: coverage-reports
-        merge-multiple: false
+      - name: Download all coverage artifacts
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          pattern: coverage-*
+          path: coverage-reports
+          merge-multiple: false
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
-      with:
-        use_oidc: true
-        directory: coverage-reports
-        fail_ci_if_error: false
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
+        with:
+          use_oidc: true
+          directory: coverage-reports
+          fail_ci_if_error: false
 
-    - name: Upload coverage to Datadog
-      if: always()
-      continue-on-error: true
-      uses: DataDog/coverage-upload-github-action@9bbbf86d16f7db1b14c5b885e61cf0d96053686a # v1.0.0
-      with:
-        api_key: ${{ secrets.DD_API_KEY }}
-        files: coverage-reports
-        format: cobertura
+      - name: Upload coverage to Datadog
+        if: always()
+        continue-on-error: true
+        uses: DataDog/coverage-upload-github-action@6c4bd935248daa6f0ef94e3e6ba71ad5ad079998 # v1.0.3
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          files: coverage-reports
+          format: cobertura

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -33,7 +33,7 @@ jobs:
 
   test:
     needs:
-    - compute-matrix
+      - compute-matrix
     if: needs.compute-matrix.outputs.matrix != '[]' && github.event_name != 'merge_group'
     strategy:
       fail-fast: false
@@ -64,7 +64,7 @@ jobs:
 
   test-minimum-base-package:
     needs:
-    - compute-matrix
+      - compute-matrix
     if: needs.compute-matrix.outputs.matrix != '[]' && github.event_name != 'merge_group'
     strategy:
       fail-fast: false
@@ -96,16 +96,16 @@ jobs:
 
   save-event:
     needs:
-    - test
-    - test-minimum-base-package
+      - test
+      - test-minimum-base-package
     if: success() || failure()
 
     uses: ./.github/workflows/save-event.yml
 
   upload-coverage:
     needs:
-    - test
-    - test-minimum-base-package
+      - test
+      - test-minimum-base-package
     if: >
       !github.event.repository.private &&
       (success() || failure()) &&
@@ -117,35 +117,35 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Download all coverage artifacts
-      uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
-      with:
-        pattern: coverage-*
-        path: coverage-reports
-        merge-multiple: false
+      - name: Download all coverage artifacts
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          pattern: coverage-*
+          path: coverage-reports
+          merge-multiple: false
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
-      with:
-        use_oidc: true
-        directory: coverage-reports
-        fail_ci_if_error: false
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
+        with:
+          use_oidc: true
+          directory: coverage-reports
+          fail_ci_if_error: false
 
-    - name: Upload coverage to Datadog
-      if: always()
-      continue-on-error: true
-      uses: DataDog/coverage-upload-github-action@9bbbf86d16f7db1b14c5b885e61cf0d96053686a # v1.0.0
-      with:
-        api_key: ${{ secrets.DD_API_KEY }}
-        files: coverage-reports
-        format: cobertura
+      - name: Upload coverage to Datadog
+        if: always()
+        continue-on-error: true
+        uses: DataDog/coverage-upload-github-action@6c4bd935248daa6f0ef94e3e6ba71ad5ad079998 # v1.0.3
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          files: coverage-reports
+          format: cobertura
 
   check:
     needs:
-    - test
-    - test-minimum-base-package
+      - test
+      - test-minimum-base-package
     # In integrations-core and integrations-extras repos the tests are flaky enough that
     # it would be a pain to merge PRs with the Merge Queue enabled.
     # While we work on the tests, we skip the job if it's triggered by Merge Queue.
@@ -154,8 +154,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Check status of required jobs
-      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
-      with:
-        jobs: ${{ toJSON(needs) }}
-        allowed-skips: test, test-minimum-base-package
+      - name: Check status of required jobs
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}
+          allowed-skips: test, test-minimum-base-package

--- a/.github/workflows/test-fips-e2e.yml
+++ b/.github/workflows/test-fips-e2e.yml
@@ -17,10 +17,10 @@ on:
         type: string
   pull_request:
     paths:
-    - datadog_checks_base/datadog_checks/**
-    - datadog_checks_base/pyproject.toml
+      - datadog_checks_base/datadog_checks/**
+      - datadog_checks_base/pyproject.toml
   schedule:
-    - cron: '0 0,8,16 * * *'
+    - cron: "0 0,8,16 * * *"
 
 defaults:
   run:
@@ -43,103 +43,102 @@ jobs:
       DD_TRACE_ANALYTICS_ENABLED: "true"
 
     permissions:
-       # needed for dd-sts and codecov in test-target.yml, allows the action to get a JWT signed by Github
-       id-token: write
-       # needed for compute-matrix in test-target.yml
-       contents: read
+      # needed for dd-sts and codecov in test-target.yml, allows the action to get a JWT signed by Github
+      id-token: write
+      # needed for compute-matrix in test-target.yml
+      contents: read
 
     steps:
+      - name: Set environment variables with sanitized paths
+        run: |
+          JOB_NAME="test-fips-e2e"
 
-    - name: Set environment variables with sanitized paths
-      run: |
-        JOB_NAME="test-fips-e2e"
+          echo "TEST_RESULTS_DIR=$TEST_RESULTS_BASE_DIR/$JOB_NAME" >> $GITHUB_ENV
+          echo "TRACE_CAPTURE_FILE=$TRACE_CAPTURE_BASE_DIR/$JOB_NAME" >> $GITHUB_ENV
 
-        echo "TEST_RESULTS_DIR=$TEST_RESULTS_BASE_DIR/$JOB_NAME" >> $GITHUB_ENV
-        echo "TRACE_CAPTURE_FILE=$TRACE_CAPTURE_BASE_DIR/$JOB_NAME" >> $GITHUB_ENV
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
 
-    - name: Set up Python ${{ env.PYTHON_VERSION }}
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      with:
-        python-version: "${{ env.PYTHON_VERSION }}"
+      - name: Get Datadog credentials
+        id: dd-sts
+        uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
+        with:
+          policy: integrations-core-api-key
 
-    - name: Get Datadog credentials
-      id: dd-sts
-      uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
-      with:
-        policy: integrations-core-api-key
+      - name: Install ddev from local folder
+        uses: ./.github/actions/setup-ddev
+        with:
+          install-mode: local
+          cache-profile: local-ddev-base
 
-    - name: Install ddev from local folder
-      uses: ./.github/actions/setup-ddev
-      with:
-        install-mode: local
-        cache-profile: local-ddev-base
+      - name: Configure ddev
+        run: |-
+          ddev config set upgrade_check false
+          ddev config set repos.core .
+          ddev config set repo core
 
-    - name: Configure ddev
-      run: |-
-        ddev config set upgrade_check false
-        ddev config set repos.core .
-        ddev config set repo core
+      - name: Prepare for testing
+        env:
+          PYTHONUNBUFFERED: "1"
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+          ORACLE_DOCKER_USERNAME: ${{ secrets.ORACLE_DOCKER_USERNAME }}
+          ORACLE_DOCKER_PASSWORD: ${{ secrets.ORACLE_DOCKER_PASSWORD }}
+          DD_GITHUB_USER: ${{ github.actor }}
+          DD_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ddev ci setup ${{ inputs.target || 'tls' }}
 
-    - name: Prepare for testing
-      env:
-        PYTHONUNBUFFERED: "1"
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-        ORACLE_DOCKER_USERNAME: ${{ secrets.ORACLE_DOCKER_USERNAME }}
-        ORACLE_DOCKER_PASSWORD: ${{ secrets.ORACLE_DOCKER_PASSWORD }}
-        DD_GITHUB_USER: ${{ github.actor }}
-        DD_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: ddev ci setup ${{ inputs.target || 'tls' }}
+      - name: Run E2E tests with FIPS disabled
+        env:
+          DDEV_E2E_AGENT: "${{ inputs.agent-image || 'registry.datadoghq.com/agent-dev:master-py3' }}"
+          DD_API_KEY: "${{ steps.dd-sts.outputs.api_key }}"
+        run: |
+          ddev env test --base --new-env --junit ${{ inputs.target || 'tls' }} -- all -m "fips_off"
 
-    - name: Run E2E tests with FIPS disabled
-      env:
-        DDEV_E2E_AGENT: "${{ inputs.agent-image || 'registry.datadoghq.com/agent-dev:master-py3' }}"
-        DD_API_KEY: "${{ steps.dd-sts.outputs.api_key }}"
-      run: |
-        ddev env test --base --new-env --junit ${{ inputs.target || 'tls' }} -- all -m "fips_off"
+      - name: Run E2E tests with FIPS enabled
+        env:
+          DDEV_E2E_AGENT: "${{ inputs.agent-image-fips || 'registry.datadoghq.com/agent-dev:master-fips' }}"
+          DD_API_KEY: "${{ steps.dd-sts.outputs.api_key }}"
+        run: |
+          ddev env test --base --new-env --junit ${{ inputs.target || 'tls' }} -- all -k "fips_on"
 
-    - name: Run E2E tests with FIPS enabled
-      env:
-        DDEV_E2E_AGENT: "${{ inputs.agent-image-fips || 'registry.datadoghq.com/agent-dev:master-fips' }}" 
-        DD_API_KEY: "${{ steps.dd-sts.outputs.api_key }}"
-      run: |
-        ddev env test --base --new-env --junit ${{ inputs.target || 'tls' }} -- all -k "fips_on"
+      - name: Finalize test results
+        if: always()
+        run: |-
+          mkdir -p "${{ env.TEST_RESULTS_DIR }}"
+          if [[ -d ${{ inputs.target || 'tls' }}/junit ]]; then
+            mv ${{ inputs.target || 'tls' }}/junit/*.xml "${{ env.TEST_RESULTS_DIR }}"
+          fi
 
-    - name: Finalize test results
-      if: always()
-      run: |-
-        mkdir -p "${{ env.TEST_RESULTS_DIR }}"
-        if [[ -d ${{ inputs.target || 'tls' }}/junit ]]; then
-          mv ${{ inputs.target || 'tls' }}/junit/*.xml "${{ env.TEST_RESULTS_DIR }}"
-        fi
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: "test-results-${{ inputs.target || 'tls' }}"
+          path: "${{ env.TEST_RESULTS_BASE_DIR }}"
 
-    - name: Upload test results
-      if: always()
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-      with:
-        name: "test-results-${{ inputs.target || 'tls' }}"
-        path: "${{ env.TEST_RESULTS_BASE_DIR }}"
+      - name: Upload coverage data
+        if: >
+          !github.event.repository.private &&
+          always()
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
+        with:
+          use_oidc: true
+          files: "${{ inputs.target || 'tls' }}/coverage.xml"
+          flags: "${{ inputs.target || 'tls' }}"
 
-    - name: Upload coverage data
-      if: >
-        !github.event.repository.private &&
-        always()
-      uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
-      with:
-        use_oidc: true
-        files: "${{ inputs.target || 'tls' }}/coverage.xml"
-        flags: "${{ inputs.target || 'tls' }}"
-
-    - name: Upload coverage to Datadog
-      if: >
-        !github.event.repository.private &&
-        always()
-      continue-on-error: true
-      uses: DataDog/coverage-upload-github-action@9bbbf86d16f7db1b14c5b885e61cf0d96053686a # v1.0.0
-      with:
-        api_key: ${{ secrets.DD_API_KEY }}
-        files: "${{ inputs.target || 'tls' }}/coverage.xml"
-        format: cobertura
-        flags: "${{ inputs.target || 'tls' }}"
+      - name: Upload coverage to Datadog
+        if: >
+          !github.event.repository.private &&
+          always()
+        continue-on-error: true
+        uses: DataDog/coverage-upload-github-action@6c4bd935248daa6f0ef94e3e6ba71ad5ad079998 # v1.0.3
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          files: "${{ inputs.target || 'tls' }}/coverage.xml"
+          format: cobertura
+          flags: "${{ inputs.target || 'tls' }}"


### PR DESCRIPTION
### What does this PR do?

Bump `DataDog/coverage-upload-github-action` from `v1.0.0` (`9bbbf86d`) to `v1.0.3` (`6c4bd935`) in every workflow that uploads coverage to Datadog: `master.yml`, `master-windows.yml`, `pr-all.yml`, `pr-all-windows.yml`, `pr-test.yml`, and `test-fips-e2e.yml`. The touched workflow files were also reformatted (list indentation and quote style) by the editor's YAML formatter; behaviour is unchanged.

### Motivation

Older version was not pinning hash of a transitive action but somehow was running properly before. Now it is getting blocked, as it should.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged