### PR TITLE
Wait for gamesim_primary index online before running couchbase tests

### DIFF
--- a/couchbase/tests/conftest.py
+++ b/couchbase/tests/conftest.py
@@ -75,9 +75,8 @@ def dd_environment():
         WaitFor(bucket_stats),
         WaitFor(load_sample_bucket),
         WaitFor(create_syncgw_database),
+        WaitFor(gamesim_primary_index_ready),
     ]
-    if COUCHBASE_MAJOR_VERSION >= 7:
-        conditions.append(WaitFor(gamesim_primary_index_ready))
     with docker_run(
         compose_file=os.path.join(HERE, 'compose', 'docker-compose.yaml'),
         env_vars={
@@ -217,6 +216,9 @@ def load_sample_bucket():
         if task["sample"] == "gamesim-sample":
             task_id = task["taskId"]
 
+    if task_id is None:
+        return False
+
     while True:
         # Loop until the task ID is gone, meaning the task is done.
         r = requests.get(
@@ -237,26 +239,25 @@ def load_sample_bucket():
 
 def gamesim_primary_index_ready():
     """
-    Wait until the indexer reports stats for the gamesim_primary GSI index.
+    Wait until the indexer reports gamesim_primary as fully built.
 
     The /sampleBuckets/install task completing only guarantees the sample data
     has been loaded; the indexer may still be building the bundled GSI indexes.
-    test_index_stats_metrics asserts metrics for gamesim_primary, so wait for
-    the indexer to report a keyspace for it before yielding the environment.
+    The indexer publishes per-keyspace stats during the build too, so we have
+    to check `initial_build_progress == 100` to confirm the index is online.
     """
     r = requests.get(
         '{}/api/v1/stats'.format(INDEX_STATS_URL),
         auth=(USER, PASSWORD),
     )
-    if r.status_code != requests.codes.ok:
-        return False
+    r.raise_for_status()
 
-    for keyspace in r.json():
+    for keyspace, stats in r.json().items():
         if keyspace == "indexer":
             continue
         parts = keyspace.split(":")
         if parts[0] == "gamesim-sample" and parts[-1] == "gamesim_primary":
-            return True
+            return stats.get("initial_build_progress") == 100
     return False
 
 

--- a/couchbase/tests/conftest.py
+++ b/couchbase/tests/conftest.py
@@ -252,13 +252,16 @@ def gamesim_primary_index_ready():
     )
     r.raise_for_status()
 
+    found = False
     for keyspace, stats in r.json().items():
         if keyspace == "indexer":
             continue
         parts = keyspace.split(":")
         if parts[0] == "gamesim-sample" and parts[-1] == "gamesim_primary":
-            return stats.get("initial_build_progress") == 100
-    return False
+            if stats.get("initial_build_progress") != 100:
+                return False
+            found = True
+    return found
 
 
 def create_syncgw_database():

--- a/couchbase/tests/conftest.py
+++ b/couchbase/tests/conftest.py
@@ -238,14 +238,7 @@ def load_sample_bucket():
 
 
 def gamesim_primary_index_ready():
-    """
-    Wait until the indexer reports gamesim_primary as fully built.
-
-    The /sampleBuckets/install task completing only guarantees the sample data
-    has been loaded; the indexer may still be building the bundled GSI indexes.
-    The indexer publishes per-keyspace stats during the build too, so we have
-    to check `initial_build_progress == 100` to confirm the index is online.
-    """
+    """Wait until every gamesim_primary keyspace reports initial_build_progress == 100."""
     r = requests.get(
         '{}/api/v1/stats'.format(INDEX_STATS_URL),
         auth=(USER, PASSWORD),

--- a/couchbase/tests/conftest.py
+++ b/couchbase/tests/conftest.py
@@ -216,6 +216,10 @@ def load_sample_bucket():
         if task["sample"] == "gamesim-sample":
             task_id = task["taskId"]
 
+    # No matching task in the install response — the bucket is likely loading
+    # under a task we can't observe. WaitFor will retry; on the retry the install
+    # POST takes the already-loaded shortcut, and gamesim_primary_index_ready is
+    # the authoritative gate that blocks until the bundled GSI is online.
     if task_id is None:
         return False
 
@@ -245,16 +249,18 @@ def gamesim_primary_index_ready():
     )
     r.raise_for_status()
 
-    found = False
-    for keyspace, stats in r.json().items():
-        if keyspace == "indexer":
-            continue
-        parts = keyspace.split(":")
-        if parts[0] == "gamesim-sample" and parts[-1] == "gamesim_primary":
-            if stats.get("initial_build_progress") != 100:
-                return False
-            found = True
-    return found
+    data = r.json()
+    matches = [
+        stats
+        for keyspace, stats in data.items()
+        if keyspace != "indexer"
+        and keyspace.split(":")[0] == "gamesim-sample"
+        and keyspace.split(":")[-1] == "gamesim_primary"
+    ]
+    if not matches:
+        print("gamesim_primary not yet visible; keyspaces seen: {}".format(list(data.keys())))
+        return False
+    return all(s.get("initial_build_progress") == 100 for s in matches)
 
 
 def create_syncgw_database():

--- a/couchbase/tests/conftest.py
+++ b/couchbase/tests/conftest.py
@@ -76,6 +76,8 @@ def dd_environment():
         WaitFor(load_sample_bucket),
         WaitFor(create_syncgw_database),
     ]
+    if COUCHBASE_MAJOR_VERSION >= 7:
+        conditions.append(WaitFor(gamesim_primary_index_ready))
     with docker_run(
         compose_file=os.path.join(HERE, 'compose', 'docker-compose.yaml'),
         env_vars={
@@ -217,8 +219,6 @@ def load_sample_bucket():
 
     while True:
         # Loop until the task ID is gone, meaning the task is done.
-        task_is_done = False
-
         r = requests.get(
             '{}/pools/default/tasks'.format(URL),
             auth=(USER, PASSWORD),
@@ -226,16 +226,38 @@ def load_sample_bucket():
         r.raise_for_status()
         result = r.json()
 
-        for task in result:
-            if task.get("task_id", "") == task_id:
-                task_is_done = True
-
-        if task_is_done:
+        task_still_running = any(task.get("task_id") == task_id for task in result)
+        if not task_still_running:
             break
 
         time.sleep(1)
 
     return True
+
+
+def gamesim_primary_index_ready():
+    """
+    Wait until the indexer reports stats for the gamesim_primary GSI index.
+
+    The /sampleBuckets/install task completing only guarantees the sample data
+    has been loaded; the indexer may still be building the bundled GSI indexes.
+    test_index_stats_metrics asserts metrics for gamesim_primary, so wait for
+    the indexer to report a keyspace for it before yielding the environment.
+    """
+    r = requests.get(
+        '{}/api/v1/stats'.format(INDEX_STATS_URL),
+        auth=(USER, PASSWORD),
+    )
+    if r.status_code != requests.codes.ok:
+        return False
+
+    for keyspace in r.json():
+        if keyspace == "indexer":
+            continue
+        parts = keyspace.split(":")
+        if parts[0] == "gamesim-sample" and parts[-1] == "gamesim_primary":
+            return True
+    return False
 
 
 def create_syncgw_database():


### PR DESCRIPTION
### What does this PR do?

Adds a `WaitFor` to the couchbase test environment that blocks until the indexer reports `gamesim_primary` on `gamesim-sample` with `initial_build_progress == 100`. Also fixes an inverted exit condition (and a `None`-comparison hole) in the `load_sample_bucket` polling loop.

### Motivation

`test_index_stats_metrics` is flaky on Couchbase 7.2 because the environment fixture returns before the bundled GSI index for `gamesim-sample` finishes building, so `/api/v1/stats` doesn't emit a keyspace for `gamesim_primary` when the check runs. The previous setup waited on the `/sampleBuckets/install` task as a proxy, but the polling loop's exit condition was inverted (broke when the task was still running instead of when it disappeared), so even that proxy didn't actually block.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add \`qa/required\` if this PR needs QA validation, or \`qa/skip-qa\` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the \`backport/<branch-name>\` label to the PR and it will automatically open a backport PR once this one is merged

---

_This PR has been created and validated using the paired-review skill from agent-integrations._