### PR TITLE
gpu: document required system-probe.yaml flag and gpu.enabled for non-containerized Linux hosts

### DIFF
--- a/gpu/README.md
+++ b/gpu/README.md
@@ -33,21 +33,32 @@ The check also uses eBPF probes to assign GPU usage and performance metrics to p
 
 #### Host
 
-The agent needs to be configured to enable GPU-related features. Add the following parameters to the `/etc/datadog-agent/datadog.yaml` configuration file and then restart the Agent:
+GPU monitoring requires configuration in **both** `/etc/datadog-agent/datadog.yaml` and `/etc/datadog-agent/system-probe.yaml`. Configuring only one of these files results in incomplete metrics collection.
+
+**Step 1**: Add the following parameters to `/etc/datadog-agent/datadog.yaml`:
 
 ```yaml
+gpu:
+  enabled: true
 collect_gpu_tags: true
 enable_nvml_detection: true
 ```
 
-Enabling the `gpu` integration requires `system-probe` to have the configuration option enabled for collecting per-process metrics. Inside the `/etc/datadog-agent/system-probe.yaml` configuration file, the following parameters must be set:
+**Step 2**: Add the following parameters to `/etc/datadog-agent/system-probe.yaml`. This flag loads the eBPF module responsible for per-process GPU metrics and is required even for non-containerized hosts:
 
 ```yaml
 gpu_monitoring:
   enabled: true
 ```
 
-The check in the Agent configuration file is enabled by default whenever NVIDIA GPUs and their drivers are detected in the system, as long as the `enable_nvml_detection` parameter is set to `true`. However, it can also be configured manually following these steps:
+**Step 3**: Restart both the Agent and system-probe:
+
+```shell
+sudo systemctl restart datadog-agent
+sudo systemctl restart datadog-agent-sysprobe
+```
+
+The check in the Agent configuration file is also enabled by default whenever NVIDIA GPUs and their drivers are detected in the system, as long as the `enable_nvml_detection` parameter is set to `true`. However, it can also be configured manually following these steps:
 
 1. Edit the `gpu.d/conf.yaml` file, in the `conf.d/` folder at the root of your
    Agent's configuration directory, to start collecting your GPU performance data.

--- a/gpu/README.md
+++ b/gpu/README.md
@@ -33,9 +33,9 @@ The check also uses eBPF probes to assign GPU usage and performance metrics to p
 
 #### Host
 
-GPU monitoring requires configuration in **both** `/etc/datadog-agent/datadog.yaml` and `/etc/datadog-agent/system-probe.yaml`. Configuring only one of these files results in incomplete metrics collection.
+GPU monitoring requires configuration in both `/etc/datadog-agent/datadog.yaml` and `/etc/datadog-agent/system-probe.yaml`. Configuring only one of these files results in incomplete metrics collection.
 
-**Step 1**: Add the following parameters to `/etc/datadog-agent/datadog.yaml`:
+1. Add the following parameters to `/etc/datadog-agent/datadog.yaml`:
 
 ```yaml
 gpu:
@@ -44,21 +44,21 @@ collect_gpu_tags: true
 enable_nvml_detection: true
 ```
 
-**Step 2**: Add the following parameters to `/etc/datadog-agent/system-probe.yaml`. This flag loads the eBPF module responsible for per-process GPU metrics and is required even for non-containerized hosts:
+2. Add the following parameter to `/etc/datadog-agent/system-probe.yaml`. This flag loads the eBPF module responsible for per-process GPU metrics and is required even for non-containerized hosts:
 
 ```yaml
 gpu_monitoring:
   enabled: true
 ```
 
-**Step 3**: Restart both the Agent and system-probe:
+3. Restart both the Agent and system-probe:
 
 ```shell
 sudo systemctl restart datadog-agent
 sudo systemctl restart datadog-agent-sysprobe
 ```
 
-The check in the Agent configuration file is also enabled by default whenever NVIDIA GPUs and their drivers are detected in the system, as long as the `enable_nvml_detection` parameter is set to `true`. However, it can also be configured manually following these steps:
+The check in the Agent configuration file is enabled by default whenever NVIDIA GPUs and their drivers are detected in the system, as long as the `enable_nvml_detection` parameter is set to `true`. The check can also be configured manually following these steps:
 
 1. Edit the `gpu.d/conf.yaml` file, in the `conf.d/` folder at the root of your
    Agent's configuration directory, to start collecting your GPU performance data.


### PR DESCRIPTION
## Summary

- Fixes a documentation gap in the GPU integration README where the Linux (non-containerized) Host setup section was missing `gpu.enabled: true` from the `datadog.yaml` block and did not clearly communicate that `system-probe.yaml` must also be configured
- Restructures the Host configuration section into numbered steps to make it unambiguous that **both** `datadog.yaml` and `system-probe.yaml` require changes
- Adds an explicit note that `gpu_monitoring.enabled: true` in `system-probe.yaml` is required even for non-containerized hosts

## Motivation

Tracked in AGENT-16266. A customer (Norfolk Southern Corp) followed the official setup docs and the shipped `datadog.yaml.example`/`system-probe.yaml.example` templates, neither of which document the `system-probe.yaml` flag. The result was system-probe running healthy (eBPF loaded, T4 discovered, uprobes attached) while the core-agent GPU check never instantiated (`Last Check from Core Agent: 1969-12-31`). The integrations-core README already covered both files but the steps were easy to miss — this PR makes them explicit and sequential.

## Test plan

- [ ] Verify the rendered README displays the three-step Host configuration correctly
- [ ] Confirm `gpu.enabled: true` now appears in the `datadog.yaml` code block
- [ ] Confirm `gpu_monitoring.enabled: true` and the `system-probe.yaml` step are clearly presented alongside the `datadog.yaml` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)