### PR TITLE
[databricks] Dashboard: group by workspace_name + add template variable

### DIFF
--- a/databricks/assets/dashboards/databricks_cost_overview.json
+++ b/databricks/assets/dashboards/databricks_cost_overview.json
@@ -23,7 +23,7 @@
               {
                 "data_source": "cloud_cost",
                 "name": "query1",
-                "query": "sum:custom.cost.amortized{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id}",
+                "query": "sum:custom.cost.amortized{providername:Databricks,$job_id,$workspace_id,$workspace_name,$servicename,$charge_description,$cluster_id}",
                 "aggregator": "sum"
               }
             ],
@@ -70,7 +70,7 @@
               {
                 "data_source": "cloud_cost",
                 "name": "query1",
-                "query": "sum:custom.cost.amortized{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id}",
+                "query": "sum:custom.cost.amortized{providername:Databricks,$job_id,$workspace_id,$workspace_name,$servicename,$charge_description,$cluster_id}",
                 "aggregator": "sum"
               }
             ],
@@ -115,7 +115,7 @@
             ],
             "queries": [
               {
-                "query": "sum:custom.cost.amortized{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id}",
+                "query": "sum:custom.cost.amortized{providername:Databricks,$job_id,$workspace_id,$workspace_name,$servicename,$charge_description,$cluster_id}",
                 "data_source": "cloud_cost",
                 "name": "query1",
                 "aggregator": "sum"
@@ -168,13 +168,13 @@
             ],
             "queries": [
               {
-                "query": "sum:custom.cost.amortized{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id}",
+                "query": "sum:custom.cost.amortized{providername:Databricks,$job_id,$workspace_id,$workspace_name,$servicename,$charge_description,$cluster_id}",
                 "data_source": "cloud_cost",
                 "name": "query1",
                 "aggregator": "sum"
               },
               {
-                "query": "sum:custom.cost.amortized{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id}",
+                "query": "sum:custom.cost.amortized{providername:Databricks,$job_id,$workspace_id,$workspace_name,$servicename,$charge_description,$cluster_id}",
                 "data_source": "cloud_cost",
                 "name": "query2",
                 "aggregator": "sum"
@@ -281,7 +281,7 @@
                     {
                       "data_source": "cloud_cost",
                       "name": "query1",
-                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id} by {servicename,charge_description}.rollup(sum, daily)"
+                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$workspace_name,$servicename,$charge_description,$cluster_id} by {servicename,charge_description}.rollup(sum, daily)"
                     }
                   ],
                   "response_format": "timeseries",
@@ -318,7 +318,7 @@
                     {
                       "data_source": "cloud_cost",
                       "name": "query1",
-                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id} by {servicename}",
+                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$workspace_name,$servicename,$charge_description,$cluster_id} by {servicename}",
                       "aggregator": "sum"
                     }
                   ],
@@ -370,7 +370,7 @@
                     {
                       "data_source": "cloud_cost",
                       "name": "query1",
-                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id} by {charge_description}",
+                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$workspace_name,$servicename,$charge_description,$cluster_id} by {charge_description}",
                       "aggregator": "sum"
                     }
                   ],
@@ -421,7 +421,7 @@
                     {
                       "data_source": "cloud_cost",
                       "name": "query1",
-                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id} by {workspace_id}",
+                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$workspace_name,$servicename,$charge_description,$cluster_id} by {workspace_name}",
                       "aggregator": "sum"
                     }
                   ],
@@ -487,7 +487,7 @@
                     {
                       "data_source": "cloud_cost",
                       "name": "query1",
-                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id} by {workspace_id}.rollup(sum, daily)"
+                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$workspace_name,$servicename,$charge_description,$cluster_id} by {workspace_name}.rollup(sum, daily)"
                     }
                   ],
                   "response_format": "timeseries",
@@ -523,13 +523,13 @@
                   "response_format": "scalar",
                   "queries": [
                     {
-                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id} by {servicename,charge_description}",
+                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$workspace_name,$servicename,$charge_description,$cluster_id} by {servicename,charge_description}",
                       "data_source": "cloud_cost",
                       "name": "query1",
                       "aggregator": "sum"
                     },
                     {
-                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id} by {servicename,charge_description}",
+                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$workspace_name,$servicename,$charge_description,$cluster_id} by {servicename,charge_description}",
                       "data_source": "cloud_cost",
                       "name": "query2",
                       "aggregator": "sum"
@@ -655,7 +655,7 @@
                     {
                       "data_source": "cloud_cost",
                       "name": "query1",
-                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id,cluster_id:*} by {cluster_id}",
+                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$workspace_name,$servicename,$charge_description,$cluster_id,cluster_id:*} by {cluster_id}",
                       "aggregator": "sum"
                     }
                   ],
@@ -722,7 +722,7 @@
                     {
                       "data_source": "cloud_cost",
                       "name": "query1",
-                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id,cluster_id:*} by {cluster_id}.rollup(sum, daily)"
+                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$workspace_name,$servicename,$charge_description,$cluster_id,cluster_id:*} by {cluster_id}.rollup(sum, daily)"
                     }
                   ],
                   "response_format": "timeseries",
@@ -759,7 +759,7 @@
                     {
                       "data_source": "cloud_cost",
                       "name": "query1",
-                      "query": "sum:all.cost{providername:Databricks,$workspace_id,$cluster_id,$job_id,$charge_description,$servicename,job_id:*} by {job_id}",
+                      "query": "sum:all.cost{providername:Databricks,$workspace_id,$workspace_name,$cluster_id,$job_id,$charge_description,$servicename,job_id:*} by {job_id}",
                       "aggregator": "sum"
                     }
                   ],
@@ -826,7 +826,7 @@
                     {
                       "data_source": "cloud_cost",
                       "name": "query1",
-                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id,job_id:*} by {job_id}.rollup(sum, daily)"
+                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$workspace_name,$servicename,$charge_description,$cluster_id,job_id:*} by {job_id}.rollup(sum, daily)"
                     }
                   ],
                   "response_format": "timeseries",
@@ -903,25 +903,25 @@
                     {
                       "data_source": "cloud_cost",
                       "name": "query1",
-                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$servicename,$charge_description,$cluster_id,cluster_id:*} by {cluster_id}",
+                      "query": "sum:all.cost{providername:Databricks,$job_id,$workspace_id,$workspace_name,$servicename,$charge_description,$cluster_id,cluster_id:*} by {cluster_id}",
                       "aggregator": "sum"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:system.cpu.system{$job_id,$workspace_id,$servicename,$charge_description,$cluster_id} by {cluster_id}",
+                      "query": "avg:system.cpu.system{$job_id,$workspace_id,$workspace_name,$servicename,$charge_description,$cluster_id} by {cluster_id}",
                       "aggregator": "avg"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query3",
-                      "query": "avg:system.mem.free{$job_id,$workspace_id,$servicename,$charge_description,$cluster_id} by {cluster_id}",
+                      "query": "avg:system.mem.free{$job_id,$workspace_id,$workspace_name,$servicename,$charge_description,$cluster_id} by {cluster_id}",
                       "aggregator": "avg"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query4",
-                      "query": "avg:system.mem.total{$job_id,$workspace_id,$servicename,$charge_description,$cluster_id} by {cluster_id}",
+                      "query": "avg:system.mem.total{$job_id,$workspace_id,$workspace_name,$servicename,$charge_description,$cluster_id} by {cluster_id}",
                       "aggregator": "avg"
                     }
                   ],
@@ -1017,6 +1017,12 @@
     {
       "name": "workspace_id",
       "prefix": "workspace_id",
+      "available_values": [],
+      "default": "*"
+    },
+    {
+      "name": "workspace_name",
+      "prefix": "workspace_name",
       "available_values": [],
       "default": "*"
     }


### PR DESCRIPTION
### What does this PR do?

Updates `databricks/assets/dashboards/databricks_cost_overview.json`:

- Switches the two "Cost by Workspace" graphs (scalar + timeseries) from `by {workspace_id}` to `by {workspace_name}`, so the grouped buckets surface the human-readable workspace name rather than the numeric Databricks workspace ID.
- Adds a new `workspace_name` template variable alongside the existing `workspace_id`, with `prefix: "workspace_name"` and `default: "*"`, following the pattern of the other template vars on this dashboard.
- Applies `$workspace_name` to every query on the dashboard alongside the existing `$workspace_id`, so the new template variable narrows all panels consistently.

Do not merge until https://github.com/DataDog/dogweb/pull/167610 is merged and deployed, which actually pulls in the "workspace_name" tag

### Motivation

The Databricks CCM crawler now emits a `workspace_name` tag on every line item (DataDog/dogweb#167610), which is the human-readable workspace label rather than the opaque numeric `workspace_id`. The cost-overview dashboard should take advantage of that tag:

- "Cost by Workspace" buckets become readable at a glance (e.g. "prod-analytics" instead of `8237401234567890`).
- Users can filter the dashboard by workspace using the friendly name.

Both tags continue to be available — this is purely additive on the filter side; the only group-by change is on the two panels explicitly titled "Cost by Workspace".

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)