### PR TITLE
Add ddev AI config block

### DIFF
--- a/ddev/changelog.d/23855.added
+++ b/ddev/changelog.d/23855.added
@@ -1,0 +1,1 @@
+Add an AI configuration block for ddev.

--- a/ddev/src/ddev/cli/upgrade_check.py
+++ b/ddev/src/ddev/cli/upgrade_check.py
@@ -87,7 +87,7 @@ def upgrade_check(
             app.display_debug(f'Upgrade check failed: {e}')
             # Record the attempt to prevent even if failed
             with suppress(OSError):
-                version_to_cache = last_version if last_run is not None else current_version
+                version_to_cache = last_version if last_version is not None else current_version
                 write_last_run(version_to_cache, date_now, cache_file)
     else:
         assert last_run is not None

--- a/ddev/src/ddev/config/model.py
+++ b/ddev/src/ddev/config/model.py
@@ -19,6 +19,10 @@ def get_github_token():
     return os.environ.get('DD_GITHUB_TOKEN', '') or os.environ.get('GH_TOKEN', '') or os.environ.get('GITHUB_TOKEN', '')
 
 
+def get_anthropic_api_key():
+    return os.environ.get('DD_ANTHROPIC_API_KEY', '') or os.environ.get('ANTHROPIC_API_KEY', '')
+
+
 class ConfigurationError(Exception):
     def __init__(self, *args, location):
         self.location = location
@@ -802,10 +806,6 @@ class StylesConfig(LazilyParsedConfig):
     def spinner(self, value):
         self.raw_data['spinner'] = value
         self._field_spinner = FIELD_TO_PARSE
-
-
-def get_anthropic_api_key():
-    return os.environ.get('DD_ANTHROPIC_API_KEY', '') or os.environ.get('ANTHROPIC_API_KEY', '')
 
 
 class AIConfig(LazilyParsedConfig):

--- a/ddev/src/ddev/config/model.py
+++ b/ddev/src/ddev/config/model.py
@@ -71,6 +71,7 @@ class RootConfig(LazilyParsedConfig):
         self._field_pypi = FIELD_TO_PARSE
         self._field_trello = FIELD_TO_PARSE
         self._field_terminal = FIELD_TO_PARSE
+        self._field_ai = FIELD_TO_PARSE
         self._field_upgrade_check = FIELD_TO_PARSE
 
     @property
@@ -330,6 +331,27 @@ class RootConfig(LazilyParsedConfig):
     def terminal(self, value):
         self.raw_data['terminal'] = value
         self._field_terminal = FIELD_TO_PARSE
+
+    @property
+    def ai(self):
+        if self._field_ai is FIELD_TO_PARSE:
+            if 'ai' in self.raw_data:
+                ai = self.raw_data['ai']
+                if not isinstance(ai, dict):
+                    self.raise_error('must be a table')
+
+                self._field_ai = AIConfig(ai, ('ai',))
+            else:
+                ai = {}
+                self.raw_data['ai'] = ai
+                self._field_ai = AIConfig(ai, ('ai',))
+
+        return self._field_ai
+
+    @ai.setter
+    def ai(self, value):
+        self.raw_data['ai'] = value
+        self._field_ai = FIELD_TO_PARSE
 
 
 class RepoConfig(LazilyParsedConfig):
@@ -780,3 +802,57 @@ class StylesConfig(LazilyParsedConfig):
     def spinner(self, value):
         self.raw_data['spinner'] = value
         self._field_spinner = FIELD_TO_PARSE
+
+
+def get_anthropic_api_key():
+    return os.environ.get('DD_ANTHROPIC_API_KEY', '') or os.environ.get('ANTHROPIC_API_KEY', '')
+
+
+class AIConfig(LazilyParsedConfig):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._field_anthropic_api_key = FIELD_TO_PARSE
+        self._field_flow_dirs = FIELD_TO_PARSE
+
+    @property
+    def anthropic_api_key(self):
+        if self._field_anthropic_api_key is FIELD_TO_PARSE:
+            if 'anthropic_api_key' in self.raw_data:
+                key = self.raw_data['anthropic_api_key']
+                if not isinstance(key, str):
+                    self.raise_error('must be a string')
+
+                self._field_anthropic_api_key = key
+            else:
+                self._field_anthropic_api_key = get_anthropic_api_key()
+
+        return self._field_anthropic_api_key
+
+    @anthropic_api_key.setter
+    def anthropic_api_key(self, value):
+        self.raw_data['anthropic_api_key'] = value
+        self._field_anthropic_api_key = FIELD_TO_PARSE
+
+    @property
+    def flow_dirs(self):
+        if self._field_flow_dirs is FIELD_TO_PARSE:
+            if 'flow_dirs' in self.raw_data:
+                flow_dirs = self.raw_data['flow_dirs']
+                if not isinstance(flow_dirs, list):
+                    self.raise_error('must be an array')
+
+                for i, entry in enumerate(flow_dirs):
+                    if not isinstance(entry, str):
+                        self.raise_error('must be a string', extra_steps=(str(i),))
+
+                self._field_flow_dirs = flow_dirs
+            else:
+                self._field_flow_dirs = self.raw_data['flow_dirs'] = []
+
+        return self._field_flow_dirs
+
+    @flow_dirs.setter
+    def flow_dirs(self, value):
+        self.raw_data['flow_dirs'] = value
+        self._field_flow_dirs = FIELD_TO_PARSE

--- a/ddev/src/ddev/config/utils.py
+++ b/ddev/src/ddev/config/utils.py
@@ -30,20 +30,30 @@ def load_toml_data(path: Path) -> dict:
     return tomlkit.loads(path.read_text())
 
 
+def _walk_config(config: dict, glob: str):
+    """Yield (parent_dict, leaf_key) pairs matching a dotted glob path."""
+    parts = glob.split('.')
+
+    def recurse(node, remaining):
+        if not remaining or not isinstance(node, dict):
+            return
+        head, *tail = remaining
+        if head == '*':
+            for key, child in node.items():
+                if not tail:
+                    yield node, key
+                else:
+                    yield from recurse(child, tail)
+        elif head in node:
+            if not tail:
+                yield node, head
+            else:
+                yield from recurse(node[head], tail)
+
+    yield from recurse(config, parts)
+
+
 def scrub_config(config: dict):
-    if 'token' in config.get('github', {}):
-        config['github']['token'] = SCRUBBED_VALUE
-
-    if 'auth' in config.get('pypi', {}):
-        config['pypi']['auth'] = SCRUBBED_VALUE
-
-    if 'token' in config.get('trello', {}):
-        config['trello']['token'] = SCRUBBED_VALUE
-
-    for data in config.get('orgs', {}).values():
-        for key in ('api_key', 'app_key'):
-            if key in data:
-                data[key] = SCRUBBED_VALUE
-
-    if 'anthropic_api_key' in config.get('ai', {}):
-        config['ai']['anthropic_api_key'] = SCRUBBED_VALUE
+    for glob in SCRUBBED_GLOBS:
+        for parent, key in _walk_config(config, glob):
+            parent[key] = SCRUBBED_VALUE

--- a/ddev/src/ddev/config/utils.py
+++ b/ddev/src/ddev/config/utils.py
@@ -7,7 +7,14 @@ from tomlkit.toml_document import TOMLDocument
 from ddev.utils.fs import Path
 
 SCRUBBED_VALUE = '*****'
-SCRUBBED_GLOBS = ('github.token', 'pypi.auth', 'trello.token', 'orgs.*.api_key', 'orgs.*.app_key')
+SCRUBBED_GLOBS = (
+    'github.token',
+    'pypi.auth',
+    'trello.token',
+    'orgs.*.api_key',
+    'orgs.*.app_key',
+    'ai.anthropic_api_key',
+)
 
 
 def save_toml_document(document: TOMLDocument, path: Path):
@@ -37,3 +44,6 @@ def scrub_config(config: dict):
         for key in ('api_key', 'app_key'):
             if key in data:
                 data[key] = SCRUBBED_VALUE
+
+    if 'anthropic_api_key' in config.get('ai', {}):
+        config['ai']['anthropic_api_key'] = SCRUBBED_VALUE

--- a/ddev/src/ddev/config/utils.py
+++ b/ddev/src/ddev/config/utils.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from collections.abc import Iterator
+
 import tomlkit
 from tomlkit.toml_document import TOMLDocument
 
@@ -30,11 +32,14 @@ def load_toml_data(path: Path) -> dict:
     return tomlkit.loads(path.read_text())
 
 
-def _walk_config(config: dict, glob: str):
-    """Yield (parent_dict, leaf_key) pairs matching a dotted glob path."""
+def _walk_config(config: dict[str, object], glob: str) -> Iterator[tuple[dict[str, object], str]]:
+    """Yield (parent_dict, leaf_key) pairs matching a dotted glob path.
+
+    Silently yields nothing on type mismatch or missing keys.
+    """
     parts = glob.split('.')
 
-    def recurse(node, remaining):
+    def recurse(node: object, remaining: list[str]) -> Iterator[tuple[dict[str, object], str]]:
         if not remaining or not isinstance(node, dict):
             return
         head, *tail = remaining

--- a/ddev/tests/ai/flows/openmetrics/phases/test_inspect_endpoint.py
+++ b/ddev/tests/ai/flows/openmetrics/phases/test_inspect_endpoint.py
@@ -19,6 +19,7 @@ from ddev.ai.flows.openmetrics.phases.inspect_endpoint import (
     _build_memory_text,
     _parse_exposition,
 )
+from ddev.ai.phases.base import FlowServices
 from ddev.ai.phases.checkpoint import CheckpointManager
 from ddev.ai.phases.config import AgentConfig, CheckpointConfig, FlowConfigError, PhaseConfig, TaskConfig
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
@@ -105,15 +106,18 @@ def _make_phase(
     runtime_variables: dict[str, str] | None = None,
 ) -> tuple[InspectEndpointPhase, CheckpointManager]:
     checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
-    phase = InspectEndpointPhase(
-        phase_id=phase_id,
-        dependencies=[],
-        config=PhaseConfig(),
+    services = FlowServices(
         checkpoint_manager=checkpoint_manager,
         runtime_variables=runtime_variables if runtime_variables is not None else {"endpoint_url": ENDPOINT_URL},
         flow_variables={},
         config_dir=flow_dir,
         file_registry=FileRegistry(policy=FileAccessPolicy(write_root=flow_dir)),
+    )
+    phase = InspectEndpointPhase(
+        phase_id=phase_id,
+        dependencies=[],
+        config=PhaseConfig(),
+        services=services,
     )
     phase.queue = message_queue
     return phase, checkpoint_manager

--- a/ddev/tests/cli/config/test_show.py
+++ b/ddev/tests/cli/config/test_show.py
@@ -57,6 +57,10 @@ warning = "bold yellow"
 waiting = "bold magenta"
 debug = "bold"
 spinner = "simpleDotsScrolling"
+
+[ai]
+flow_dirs = []
+anthropic_api_key = "*****"
 """
 
 EXPECTED_NON_SCRUBBED_OUTPUT = f"""
@@ -105,6 +109,10 @@ warning = "bold yellow"
 waiting = "bold magenta"
 debug = "bold"
 spinner = "simpleDotsScrolling"
+
+[ai]
+flow_dirs = []
+anthropic_api_key = "sk-test"
 """
 
 
@@ -114,6 +122,7 @@ def valid_config_file(config_file):
     config_file.model.orgs['default']['api_key'] = 'foo'
     config_file.model.orgs['default']['app_key'] = 'bar'
     config_file.model.github = {'user': '', 'token': ''}
+    config_file.model.ai.anthropic_api_key = 'sk-test'
     config_file.save()
 
 
@@ -182,6 +191,10 @@ def build_expected_output_with_line_sources(expected: str, config_file: ConfigFi
         42: 'GlobalConfig:43',
         43: 'GlobalConfig:44',
         44: 'GlobalConfig:45',
+        # Blank line
+        46: 'GlobalConfig:47',
+        47: 'GlobalConfig:48',
+        48: 'GlobalConfig:49',
     }
 
     # Add a blank line at the end to match the expected output

--- a/ddev/tests/cli/config/test_show.py
+++ b/ddev/tests/cli/config/test_show.py
@@ -122,6 +122,7 @@ def valid_config_file(config_file):
     config_file.model.orgs['default']['api_key'] = 'foo'
     config_file.model.orgs['default']['app_key'] = 'bar'
     config_file.model.github = {'user': '', 'token': ''}
+    config_file.model.ai.flow_dirs = []
     config_file.model.ai.anthropic_api_key = 'sk-test'
     config_file.save()
 

--- a/ddev/tests/cli/test_upgrade_check.py
+++ b/ddev/tests/cli/test_upgrade_check.py
@@ -149,5 +149,7 @@ def test_upgrade_handles_request_exception_gracefully(app, tmp_path, mock_atexit
     upgrade_check(app, "1.0.0", cache_file=cache_file)
 
     mock_atexit_call.assert_not_called()
-    # Cache was still written to prevent repeated failures
-    assert cache_file.exists()
+    last_run = read_last_run(cache_file)
+    assert last_run is not None
+    cached_version, _ = last_run
+    assert str(cached_version) == '1.0.0'

--- a/ddev/tests/config/test_model.py
+++ b/ddev/tests/config/test_model.py
@@ -5,12 +5,7 @@ import os
 
 import pytest
 
-from ddev.config.model import (
-    ConfigurationError,
-    RootConfig,
-    get_github_token,
-    get_github_user,
-)
+from ddev.config.model import ConfigurationError, RootConfig, get_github_token, get_github_user
 
 
 def test_default():
@@ -1485,9 +1480,12 @@ class TestGitHubConfig:
 
 
 class TestAI:
-    def test_default(self, monkeypatch):
+    @pytest.fixture(autouse=True)
+    def clear_anthropic_env(self, monkeypatch):
         monkeypatch.delenv('DD_ANTHROPIC_API_KEY', raising=False)
         monkeypatch.delenv('ANTHROPIC_API_KEY', raising=False)
+
+    def test_default(self):
         config = RootConfig({})
 
         assert config.ai.anthropic_api_key == config.ai.anthropic_api_key == ''
@@ -1533,14 +1531,12 @@ class TestAI:
 
     def test_anthropic_api_key_dd_env_var(self, monkeypatch):
         monkeypatch.setenv('DD_ANTHROPIC_API_KEY', 'dd-key')
-        monkeypatch.delenv('ANTHROPIC_API_KEY', raising=False)
         config = RootConfig({})
 
         assert config.ai.anthropic_api_key == 'dd-key'
         assert config.raw_data == {'ai': {}}
 
     def test_anthropic_api_key_env_var(self, monkeypatch):
-        monkeypatch.delenv('DD_ANTHROPIC_API_KEY', raising=False)
         monkeypatch.setenv('ANTHROPIC_API_KEY', 'anth-key')
         config = RootConfig({})
 
@@ -1553,6 +1549,7 @@ class TestAI:
         config = RootConfig({})
 
         assert config.ai.anthropic_api_key == 'dd-key'
+        assert config.raw_data == {'ai': {}}
 
     def test_anthropic_api_key_not_string(self, helpers):
         config = RootConfig({'ai': {'anthropic_api_key': 9000}})

--- a/ddev/tests/config/test_model.py
+++ b/ddev/tests/config/test_model.py
@@ -1586,10 +1586,10 @@ class TestAI:
             _ = config.ai.anthropic_api_key
 
     def test_flow_dirs(self):
-        config = RootConfig({'ai': {'flow_dirs': ['/foo', '/bar']}})
+        config = RootConfig({'ai': {'flow_dirs': ['~/foo', './bar', '../baz']}})
 
-        assert config.ai.flow_dirs == ['/foo', '/bar']
-        assert config.raw_data == {'ai': {'flow_dirs': ['/foo', '/bar']}}
+        assert config.ai.flow_dirs == ['~/foo', './bar', '../baz']
+        assert config.raw_data == {'ai': {'flow_dirs': ['~/foo', './bar', '../baz']}}
 
     def test_flow_dirs_not_list(self, helpers):
         config = RootConfig({'ai': {'flow_dirs': 9000}})

--- a/ddev/tests/config/test_model.py
+++ b/ddev/tests/config/test_model.py
@@ -5,7 +5,12 @@ import os
 
 import pytest
 
-from ddev.config.model import ConfigurationError, RootConfig, get_github_token, get_github_user
+from ddev.config.model import (
+    ConfigurationError,
+    RootConfig,
+    get_github_token,
+    get_github_user,
+)
 
 
 def test_default():
@@ -54,6 +59,9 @@ def test_default():
                 'debug': 'bold',
                 'spinner': 'simpleDotsScrolling',
             },
+        },
+        'ai': {
+            'flow_dirs': [],
         },
     }
 
@@ -1474,3 +1482,156 @@ class TestGitHubConfig:
 
         # raw_data should still be empty
         assert config.raw_data['github'] == {}
+
+
+class TestAI:
+    def test_default(self, monkeypatch):
+        monkeypatch.delenv('DD_ANTHROPIC_API_KEY', raising=False)
+        monkeypatch.delenv('ANTHROPIC_API_KEY', raising=False)
+        config = RootConfig({})
+
+        assert config.ai.anthropic_api_key == config.ai.anthropic_api_key == ''
+        assert config.ai.flow_dirs == config.ai.flow_dirs == []
+        assert config.raw_data == {'ai': {'flow_dirs': []}}
+
+    def test_not_table(self, helpers):
+        config = RootConfig({'ai': 9000})
+
+        with pytest.raises(
+            ConfigurationError,
+            match=helpers.dedent(
+                """
+                Error parsing config:
+                ai
+                  must be a table"""
+            ),
+        ):
+            _ = config.ai
+
+    def test_set_lazy_error(self, helpers):
+        config = RootConfig({})
+
+        config.ai = 9000
+        assert config.raw_data == {'ai': 9000}
+
+        with pytest.raises(
+            ConfigurationError,
+            match=helpers.dedent(
+                """
+                Error parsing config:
+                ai
+                  must be a table"""
+            ),
+        ):
+            _ = config.ai
+
+    def test_anthropic_api_key_from_config(self):
+        config = RootConfig({'ai': {'anthropic_api_key': 'sk-test'}})
+
+        assert config.ai.anthropic_api_key == 'sk-test'
+        assert config.raw_data == {'ai': {'anthropic_api_key': 'sk-test'}}
+
+    def test_anthropic_api_key_dd_env_var(self, monkeypatch):
+        monkeypatch.setenv('DD_ANTHROPIC_API_KEY', 'dd-key')
+        monkeypatch.delenv('ANTHROPIC_API_KEY', raising=False)
+        config = RootConfig({})
+
+        assert config.ai.anthropic_api_key == 'dd-key'
+        assert config.raw_data == {'ai': {}}
+
+    def test_anthropic_api_key_env_var(self, monkeypatch):
+        monkeypatch.delenv('DD_ANTHROPIC_API_KEY', raising=False)
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'anth-key')
+        config = RootConfig({})
+
+        assert config.ai.anthropic_api_key == 'anth-key'
+        assert config.raw_data == {'ai': {}}
+
+    def test_anthropic_api_key_dd_takes_precedence(self, monkeypatch):
+        monkeypatch.setenv('DD_ANTHROPIC_API_KEY', 'dd-key')
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'anth-key')
+        config = RootConfig({})
+
+        assert config.ai.anthropic_api_key == 'dd-key'
+
+    def test_anthropic_api_key_not_string(self, helpers):
+        config = RootConfig({'ai': {'anthropic_api_key': 9000}})
+
+        with pytest.raises(
+            ConfigurationError,
+            match=helpers.dedent(
+                """
+                Error parsing config:
+                ai -> anthropic_api_key
+                  must be a string"""
+            ),
+        ):
+            _ = config.ai.anthropic_api_key
+
+    def test_anthropic_api_key_set_lazy_error(self, helpers):
+        config = RootConfig({})
+
+        config.ai.anthropic_api_key = 9000
+        assert config.raw_data == {'ai': {'anthropic_api_key': 9000}}
+
+        with pytest.raises(
+            ConfigurationError,
+            match=helpers.dedent(
+                """
+                Error parsing config:
+                ai -> anthropic_api_key
+                  must be a string"""
+            ),
+        ):
+            _ = config.ai.anthropic_api_key
+
+    def test_flow_dirs(self):
+        config = RootConfig({'ai': {'flow_dirs': ['/foo', '/bar']}})
+
+        assert config.ai.flow_dirs == ['/foo', '/bar']
+        assert config.raw_data == {'ai': {'flow_dirs': ['/foo', '/bar']}}
+
+    def test_flow_dirs_not_list(self, helpers):
+        config = RootConfig({'ai': {'flow_dirs': 9000}})
+
+        with pytest.raises(
+            ConfigurationError,
+            match=helpers.dedent(
+                """
+                Error parsing config:
+                ai -> flow_dirs
+                  must be an array"""
+            ),
+        ):
+            _ = config.ai.flow_dirs
+
+    def test_flow_dirs_entry_not_string(self, helpers):
+        config = RootConfig({'ai': {'flow_dirs': [9000]}})
+
+        with pytest.raises(
+            ConfigurationError,
+            match=helpers.dedent(
+                """
+                Error parsing config:
+                ai -> flow_dirs -> 0
+                  must be a string"""
+            ),
+        ):
+            _ = config.ai.flow_dirs
+
+    def test_flow_dirs_set_lazy_error(self, helpers):
+        config = RootConfig({})
+
+        config.ai.flow_dirs = 9000
+        assert config.raw_data == {'ai': {'flow_dirs': 9000}}
+
+        with pytest.raises(
+            ConfigurationError,
+            match=helpers.dedent(
+                """
+                Error parsing config:
+                ai -> flow_dirs
+                  must be an array"""
+            ),
+        ):
+            _ = config.ai.flow_dirs

--- a/ddev/tests/config/test_utils.py
+++ b/ddev/tests/config/test_utils.py
@@ -1,0 +1,27 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from ddev.config.utils import _walk_config
+
+
+@pytest.mark.parametrize(
+    'config, glob, expected',
+    [
+        pytest.param({}, 'github.token', [], id='empty-config'),
+        pytest.param({'github': 9000}, 'github.token', [], id='wrong-section-type'),
+        pytest.param({'github': {}}, 'github.token', [], id='missing-leaf-key'),
+        pytest.param({'github': {'token': 'abc'}}, 'github.token', [('token', 'abc')], id='simple-match'),
+        pytest.param(
+            {'orgs': {'a': {'api_key': 'x'}, 'b': {'api_key': 'y'}}},
+            'orgs.*.api_key',
+            [('api_key', 'x'), ('api_key', 'y')],
+            id='wildcard-multiple-orgs',
+        ),
+        pytest.param({'orgs': {}}, 'orgs.*.api_key', [], id='wildcard-empty-section'),
+    ],
+)
+def test_walk_config(config, glob, expected):
+    result = [(key, parent[key]) for parent, key in _walk_config(config, glob)]
+    assert sorted(result) == sorted(expected)

--- a/ddev/tests/config/test_utils.py
+++ b/ddev/tests/config/test_utils.py
@@ -20,6 +20,7 @@ from ddev.config.utils import _walk_config
             id='wildcard-multiple-orgs',
         ),
         pytest.param({'orgs': {}}, 'orgs.*.api_key', [], id='wildcard-empty-section'),
+        pytest.param({'orgs': {'a': 1, 'b': 2}}, 'orgs.*', [('a', 1), ('b', 2)], id='trailing-wildcard'),
     ],
 )
 def test_walk_config(config, glob, expected):


### PR DESCRIPTION
### What does this PR do?
Adds an `ai` block to the ddev root configuration model with support for an Anthropic API key and configurable flow directories. The Anthropic key can come from config or from `DD_ANTHROPIC_API_KEY` / `ANTHROPIC_API_KEY`, and config scrubbing now redacts `ai.anthropic_api_key`.

### Motivation
This gives ddev a structured place to store AI-related configuration while keeping API keys out of scrubbed config output.

Validated with:

- `ddev --no-interactive test ddev -- -k TestAI`
- `ddev test -fs ddev`

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged