### PR TITLE
Introduce FlowServices to group shared phase dependencies

### DIFF
--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -14,7 +14,7 @@ from ddev.ai.agent.build import (
     make_goal_agent_builder,
     make_subagent_builder,
 )
-from ddev.ai.phases.base import Phase, PhaseOutcome, PipelineContext
+from ddev.ai.phases.base import FlowServices, Phase, PhaseOutcome
 from ddev.ai.phases.config import AgentConfig, CheckpointConfig, FlowConfigError, PhaseConfig, TaskConfig
 from ddev.ai.phases.goal import GOAL_TASK_SUFFIX, GoalValidationError, render_goal_text, run_goal_loop
 from ddev.ai.phases.messages import PhaseFailedMessage
@@ -65,7 +65,7 @@ class AgenticPhase(Phase):
         phase_id: str,
         dependencies: list[str],
         config: PhaseConfig,
-        ctx: PipelineContext,
+        services: FlowServices,
         agent_builder: AgentBuilder,
         subagent_builder: SubagentBuilder | None = None,
         goal_agent_builder: GoalAgentBuilder | None = None,
@@ -74,7 +74,7 @@ class AgenticPhase(Phase):
             phase_id=phase_id,
             dependencies=dependencies,
             config=config,
-            ctx=ctx,
+            services=services,
         )
         self._agent_builder = agent_builder
         self._subagent_builder = subagent_builder
@@ -83,7 +83,7 @@ class AgenticPhase(Phase):
         self._total_input_tokens: int = 0
         self._total_output_tokens: int = 0
         self._subagent_log_dir = (
-            ctx.checkpoint_manager.root / "subagents" / phase_id if subagent_builder is not None else None
+            services.checkpoint_manager.root / "subagents" / phase_id if subagent_builder is not None else None
         )
 
     @classmethod
@@ -108,13 +108,13 @@ class AgenticPhase(Phase):
         phase_config: PhaseConfig,
         agents: dict[str, AgentConfig],
         agent_clients: dict[str, Any],
-        ctx: PipelineContext,
+        services: FlowServices,
         **_: Any,
     ) -> dict[str, Any]:
         if phase_config.agent is None:
             raise FlowConfigError(f"Phase {phase_id!r} (AgenticPhase) requires 'agent'")
         agent_config = agents[phase_config.agent]
-        file_registry = ctx.file_registry
+        file_registry = services.file_registry
 
         subagent_builder = None
         requires_subagent_builder = any(

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
@@ -15,15 +14,12 @@ from ddev.ai.agent.build import (
     make_goal_agent_builder,
     make_subagent_builder,
 )
-from ddev.ai.callbacks.callbacks import Callbacks
-from ddev.ai.phases.base import Phase, PhaseOutcome
-from ddev.ai.phases.checkpoint import CheckpointManager
+from ddev.ai.phases.base import Phase, PhaseOutcome, PipelineContext
 from ddev.ai.phases.config import AgentConfig, CheckpointConfig, FlowConfigError, PhaseConfig, TaskConfig
 from ddev.ai.phases.goal import GOAL_TASK_SUFFIX, GoalValidationError, render_goal_text, run_goal_loop
 from ddev.ai.phases.messages import PhaseFailedMessage
 from ddev.ai.phases.template import render_inline, render_prompt
 from ddev.ai.react.process import ReActProcess
-from ddev.ai.tools.fs.file_registry import FileRegistry
 from ddev.ai.tools.registry import TOOL_MANIFEST
 from ddev.event_bus.exceptions import MessageProcessingError, ProcessorHookError
 
@@ -69,28 +65,16 @@ class AgenticPhase(Phase):
         phase_id: str,
         dependencies: list[str],
         config: PhaseConfig,
+        ctx: PipelineContext,
         agent_builder: AgentBuilder,
-        checkpoint_manager: CheckpointManager,
-        runtime_variables: dict[str, str],
-        flow_variables: dict[str, str],
-        config_dir: Path,
-        file_registry: FileRegistry,
         subagent_builder: SubagentBuilder | None = None,
         goal_agent_builder: GoalAgentBuilder | None = None,
-        callbacks: Callbacks | None = None,
-        logger: logging.Logger | None = None,
     ) -> None:
         super().__init__(
             phase_id=phase_id,
             dependencies=dependencies,
             config=config,
-            checkpoint_manager=checkpoint_manager,
-            runtime_variables=runtime_variables,
-            flow_variables=flow_variables,
-            config_dir=config_dir,
-            file_registry=file_registry,
-            callbacks=callbacks,
-            logger=logger,
+            ctx=ctx,
         )
         self._agent_builder = agent_builder
         self._subagent_builder = subagent_builder
@@ -99,7 +83,7 @@ class AgenticPhase(Phase):
         self._total_input_tokens: int = 0
         self._total_output_tokens: int = 0
         self._subagent_log_dir = (
-            checkpoint_manager.root / "subagents" / phase_id if subagent_builder is not None else None
+            ctx.checkpoint_manager.root / "subagents" / phase_id if subagent_builder is not None else None
         )
 
     @classmethod
@@ -124,12 +108,13 @@ class AgenticPhase(Phase):
         phase_config: PhaseConfig,
         agents: dict[str, AgentConfig],
         agent_clients: dict[str, Any],
-        file_registry: FileRegistry,
+        ctx: PipelineContext,
         **_: Any,
     ) -> dict[str, Any]:
         if phase_config.agent is None:
             raise FlowConfigError(f"Phase {phase_id!r} (AgenticPhase) requires 'agent'")
         agent_config = agents[phase_config.agent]
+        file_registry = ctx.file_registry
 
         subagent_builder = None
         requires_subagent_builder = any(

--- a/ddev/src/ddev/ai/phases/base.py
+++ b/ddev/src/ddev/ai/phases/base.py
@@ -19,6 +19,19 @@ from ddev.event_bus.exceptions import MessageProcessingError, ProcessorHookError
 from ddev.event_bus.orchestrator import AsyncProcessor, BaseMessage
 
 
+@dataclass(frozen=True)
+class PipelineContext:
+    """Shared pipeline-level infrastructure passed to every phase."""
+
+    checkpoint_manager: CheckpointManager
+    runtime_variables: dict[str, str]
+    flow_variables: dict[str, str]
+    config_dir: Path
+    file_registry: FileRegistry
+    callbacks: Callbacks = field(default_factory=Callbacks)
+    logger: logging.Logger = field(default_factory=lambda: logging.getLogger(__name__))
+
+
 @dataclass
 class PhaseOutcome:
     memory_text: str
@@ -56,26 +69,20 @@ class Phase(AsyncProcessor[PhaseTrigger]):
         phase_id: str,
         dependencies: list[str],
         config: PhaseConfig,
-        checkpoint_manager: CheckpointManager,
-        runtime_variables: dict[str, str],
-        flow_variables: dict[str, str],
-        config_dir: Path,
-        file_registry: FileRegistry,
-        callbacks: Callbacks | None = None,
-        logger: logging.Logger | None = None,
+        ctx: PipelineContext,
     ) -> None:
         super().__init__(name=phase_id)
         self._phase_id = phase_id
         self._dependencies = set(dependencies)
         self._remaining_dependencies = set(dependencies)
         self._config = config
-        self._checkpoint_manager = checkpoint_manager
-        self._runtime_variables = runtime_variables
-        self._flow_variables = flow_variables
-        self._config_dir = config_dir
-        self._callbacks: Callbacks = callbacks or Callbacks()
-        self._file_registry = file_registry
-        self._logger = logger or logging.getLogger(__name__)
+        self._checkpoint_manager = ctx.checkpoint_manager
+        self._runtime_variables = ctx.runtime_variables
+        self._flow_variables = ctx.flow_variables
+        self._config_dir = ctx.config_dir
+        self._file_registry = ctx.file_registry
+        self._callbacks = ctx.callbacks
+        self._logger = ctx.logger
         self._started_at: datetime | None = None
         self._resolver: Callable[[str], str] | None = None
         self._executed = False
@@ -112,10 +119,9 @@ class Phase(AsyncProcessor[PhaseTrigger]):
     def extra_init_kwargs(cls, **kwargs: Any) -> dict[str, Any]:
         """Override to inject subclass-specific kwargs into __init__ at construction time.
 
-        The orchestrator passes every framework-level dep (phase_id, phase_config, agents,
-        agent_clients, file_registry, checkpoint_manager, ...) as keyword arguments.
-        Subclasses pick the ones they need by declaring them explicitly and accept the
-        rest via **kwargs.
+        The orchestrator passes phase_id, phase_config, agents, agent_clients, and ctx
+        (PipelineContext) as keyword arguments. Subclasses declare the ones they need
+        explicitly and accept the rest via **kwargs.
         """
         return {}
 

--- a/ddev/src/ddev/ai/phases/base.py
+++ b/ddev/src/ddev/ai/phases/base.py
@@ -20,7 +20,7 @@ from ddev.event_bus.orchestrator import AsyncProcessor, BaseMessage
 
 
 @dataclass(frozen=True)
-class PipelineContext:
+class FlowServices:
     """Shared pipeline-level infrastructure passed to every phase."""
 
     checkpoint_manager: CheckpointManager
@@ -69,20 +69,20 @@ class Phase(AsyncProcessor[PhaseTrigger]):
         phase_id: str,
         dependencies: list[str],
         config: PhaseConfig,
-        ctx: PipelineContext,
+        services: FlowServices,
     ) -> None:
         super().__init__(name=phase_id)
         self._phase_id = phase_id
         self._dependencies = set(dependencies)
         self._remaining_dependencies = set(dependencies)
         self._config = config
-        self._checkpoint_manager = ctx.checkpoint_manager
-        self._runtime_variables = ctx.runtime_variables
-        self._flow_variables = ctx.flow_variables
-        self._config_dir = ctx.config_dir
-        self._file_registry = ctx.file_registry
-        self._callbacks = ctx.callbacks
-        self._logger = ctx.logger
+        self._checkpoint_manager = services.checkpoint_manager
+        self._runtime_variables = services.runtime_variables
+        self._flow_variables = services.flow_variables
+        self._config_dir = services.config_dir
+        self._file_registry = services.file_registry
+        self._callbacks = services.callbacks
+        self._logger = services.logger
         self._started_at: datetime | None = None
         self._resolver: Callable[[str], str] | None = None
         self._executed = False
@@ -119,8 +119,8 @@ class Phase(AsyncProcessor[PhaseTrigger]):
     def extra_init_kwargs(cls, **kwargs: Any) -> dict[str, Any]:
         """Override to inject subclass-specific kwargs into __init__ at construction time.
 
-        The orchestrator passes phase_id, phase_config, agents, agent_clients, and ctx
-        (PipelineContext) as keyword arguments. Subclasses declare the ones they need
+        The orchestrator passes phase_id, phase_config, agents, agent_clients, and services
+        (FlowServices) as keyword arguments. Subclasses declare the ones they need
         explicitly and accept the rest via **kwargs.
         """
         return {}

--- a/ddev/src/ddev/ai/phases/orchestrator.py
+++ b/ddev/src/ddev/ai/phases/orchestrator.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from ddev.ai.callbacks.callbacks import Callbacks
-from ddev.ai.phases.base import Phase, PhaseRegistry, PipelineContext
+from ddev.ai.phases.base import FlowServices, Phase, PhaseRegistry
 from ddev.ai.phases.checkpoint import CheckpointManager
 from ddev.ai.phases.config import FlowConfig, FlowConfigError
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
@@ -94,7 +94,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
 
         dependency_map: dict[str, list[str]] = {entry.phase: entry.dependencies for entry in config.flow}
 
-        ctx = PipelineContext(
+        services = FlowServices(
             checkpoint_manager=checkpoint_manager,
             runtime_variables=self._runtime_variables,
             flow_variables=config.variables,
@@ -114,7 +114,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
                 "phase_id": phase_id,
                 "dependencies": dependencies,
                 "config": phase_config,
-                "ctx": ctx,
+                "services": services,
             }
             phase_kwargs.update(
                 phase_cls.extra_init_kwargs(
@@ -122,7 +122,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
                     phase_config=phase_config,
                     agents=config.agents,
                     agent_clients=self._agent_clients,
-                    ctx=ctx,
+                    services=services,
                 )
             )
 

--- a/ddev/src/ddev/ai/phases/orchestrator.py
+++ b/ddev/src/ddev/ai/phases/orchestrator.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from ddev.ai.callbacks.callbacks import Callbacks
-from ddev.ai.phases.base import Phase, PhaseRegistry
+from ddev.ai.phases.base import Phase, PhaseRegistry, PipelineContext
 from ddev.ai.phases.checkpoint import CheckpointManager
 from ddev.ai.phases.config import FlowConfig, FlowConfigError
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
@@ -94,6 +94,16 @@ class PhaseOrchestrator(EventBusOrchestrator):
 
         dependency_map: dict[str, list[str]] = {entry.phase: entry.dependencies for entry in config.flow}
 
+        ctx = PipelineContext(
+            checkpoint_manager=checkpoint_manager,
+            runtime_variables=self._runtime_variables,
+            flow_variables=config.variables,
+            config_dir=config_dir,
+            file_registry=self._file_registry,
+            callbacks=self._callbacks,
+            logger=self._logger,
+        )
+
         for entry in config.flow:
             phase_id = entry.phase
             phase_config = config.phases[phase_id]
@@ -104,13 +114,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
                 "phase_id": phase_id,
                 "dependencies": dependencies,
                 "config": phase_config,
-                "checkpoint_manager": checkpoint_manager,
-                "runtime_variables": self._runtime_variables,
-                "flow_variables": config.variables,
-                "config_dir": config_dir,
-                "file_registry": self._file_registry,
-                "callbacks": self._callbacks,
-                "logger": self._logger,
+                "ctx": ctx,
             }
             phase_kwargs.update(
                 phase_cls.extra_init_kwargs(
@@ -118,7 +122,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
                     phase_config=phase_config,
                     agents=config.agents,
                     agent_clients=self._agent_clients,
-                    file_registry=self._file_registry,
+                    ctx=ctx,
                 )
             )
 

--- a/ddev/tests/ai/phases/conftest.py
+++ b/ddev/tests/ai/phases/conftest.py
@@ -8,7 +8,9 @@ from typing import Any
 import pytest
 
 from ddev.ai.agent.types import AgentResponse, ContextUsage, StopReason, TokenUsage, ToolResultMessage
+from ddev.ai.callbacks.callbacks import Callbacks
 from ddev.ai.phases.agentic_phase import AgenticPhase
+from ddev.ai.phases.base import PipelineContext
 from ddev.ai.phases.checkpoint import CheckpointManager
 from ddev.ai.phases.config import PhaseConfig, TaskConfig
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
@@ -133,18 +135,21 @@ def make_agent_phase(
         context_compact_threshold_pct=context_compact_threshold_pct,
     )
     checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
-
-    phase = AgenticPhase(
-        phase_id=phase_id,
-        dependencies=dependencies or [],
-        config=config,
-        agent_builder=make_agent_builder(mock_agent, captured_agent_kwargs),
+    ctx = PipelineContext(
         checkpoint_manager=checkpoint_manager,
         runtime_variables=runtime_variables or {},
         flow_variables=flow_variables or {},
         config_dir=flow_dir,
         file_registry=FileRegistry(policy=FileAccessPolicy(write_root=flow_dir)),
-        callbacks=callbacks,
+        callbacks=callbacks or Callbacks(),
+    )
+
+    phase = AgenticPhase(
+        phase_id=phase_id,
+        dependencies=dependencies or [],
+        config=config,
+        ctx=ctx,
+        agent_builder=make_agent_builder(mock_agent, captured_agent_kwargs),
         goal_agent_builder=goal_agent_builder,
     )
     phase.queue = message_queue

--- a/ddev/tests/ai/phases/conftest.py
+++ b/ddev/tests/ai/phases/conftest.py
@@ -10,7 +10,7 @@ import pytest
 from ddev.ai.agent.types import AgentResponse, ContextUsage, StopReason, TokenUsage, ToolResultMessage
 from ddev.ai.callbacks.callbacks import Callbacks
 from ddev.ai.phases.agentic_phase import AgenticPhase
-from ddev.ai.phases.base import PipelineContext
+from ddev.ai.phases.base import FlowServices
 from ddev.ai.phases.checkpoint import CheckpointManager
 from ddev.ai.phases.config import PhaseConfig, TaskConfig
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
@@ -135,7 +135,7 @@ def make_agent_phase(
         context_compact_threshold_pct=context_compact_threshold_pct,
     )
     checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
-    ctx = PipelineContext(
+    services = FlowServices(
         checkpoint_manager=checkpoint_manager,
         runtime_variables=runtime_variables or {},
         flow_variables=flow_variables or {},
@@ -148,7 +148,7 @@ def make_agent_phase(
         phase_id=phase_id,
         dependencies=dependencies or [],
         config=config,
-        ctx=ctx,
+        services=services,
         agent_builder=make_agent_builder(mock_agent, captured_agent_kwargs),
         goal_agent_builder=goal_agent_builder,
     )

--- a/ddev/tests/ai/phases/test_agentic_phase.py
+++ b/ddev/tests/ai/phases/test_agentic_phase.py
@@ -375,10 +375,10 @@ def test_extra_init_kwargs_creates_subagent_builder_from_tool_metadata(
     tools: list[str],
     expected: bool,
 ) -> None:
-    from ddev.ai.phases.base import PipelineContext
+    from ddev.ai.phases.base import FlowServices
     from ddev.ai.phases.checkpoint import CheckpointManager
 
-    ctx = PipelineContext(
+    services = FlowServices(
         checkpoint_manager=CheckpointManager(flow_dir / "checkpoints.yaml"),
         runtime_variables={},
         flow_variables={},
@@ -390,7 +390,7 @@ def test_extra_init_kwargs_creates_subagent_builder_from_tool_metadata(
         phase_config=PhaseConfig(agent="writer", tasks=[TaskConfig(name="t1", prompt="Do the work.")]),
         agents={"writer": AgentConfig(tools=tools)},
         agent_clients={},
-        ctx=ctx,
+        services=services,
     )
 
     assert (kwargs["subagent_builder"] is not None) is expected
@@ -448,10 +448,10 @@ async def test_spawn_subagent_wiring(flow_dir, message_queue):
             ]
         )
 
-    from ddev.ai.phases.base import PipelineContext
+    from ddev.ai.phases.base import FlowServices
 
     checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
-    ctx = PipelineContext(
+    services = FlowServices(
         checkpoint_manager=checkpoint_manager,
         runtime_variables={},
         flow_variables={},
@@ -462,7 +462,7 @@ async def test_spawn_subagent_wiring(flow_dir, message_queue):
         phase_id="p1",
         dependencies=[],
         config=PhaseConfig(agent="writer", tasks=[TaskConfig(name="t1", prompt="Do the work.")]),
-        ctx=ctx,
+        services=services,
         agent_builder=agent_builder_fn,
         subagent_builder=mock_subagent_builder,
     )
@@ -500,10 +500,10 @@ def test_extra_init_kwargs_creates_goal_agent_builder_when_any_task_has_goal(
     tasks,
     expect_builder,
 ):
-    from ddev.ai.phases.base import PipelineContext
+    from ddev.ai.phases.base import FlowServices
     from ddev.ai.phases.checkpoint import CheckpointManager
 
-    ctx = PipelineContext(
+    services = FlowServices(
         checkpoint_manager=CheckpointManager(flow_dir / "checkpoints.yaml"),
         runtime_variables={},
         flow_variables={},
@@ -515,7 +515,7 @@ def test_extra_init_kwargs_creates_goal_agent_builder_when_any_task_has_goal(
         phase_config=PhaseConfig(agent="writer", tasks=tasks),
         agents={"writer": AgentConfig()},
         agent_clients={},
-        ctx=ctx,
+        services=services,
     )
     assert (kwargs["goal_agent_builder"] is not None) is expect_builder
 

--- a/ddev/tests/ai/phases/test_agentic_phase.py
+++ b/ddev/tests/ai/phases/test_agentic_phase.py
@@ -375,12 +375,22 @@ def test_extra_init_kwargs_creates_subagent_builder_from_tool_metadata(
     tools: list[str],
     expected: bool,
 ) -> None:
+    from ddev.ai.phases.base import PipelineContext
+    from ddev.ai.phases.checkpoint import CheckpointManager
+
+    ctx = PipelineContext(
+        checkpoint_manager=CheckpointManager(flow_dir / "checkpoints.yaml"),
+        runtime_variables={},
+        flow_variables={},
+        config_dir=flow_dir,
+        file_registry=FileRegistry(policy=FileAccessPolicy(write_root=flow_dir)),
+    )
     kwargs = AgenticPhase.extra_init_kwargs(
         phase_id="p1",
         phase_config=PhaseConfig(agent="writer", tasks=[TaskConfig(name="t1", prompt="Do the work.")]),
         agents={"writer": AgentConfig(tools=tools)},
         agent_clients={},
-        file_registry=FileRegistry(policy=FileAccessPolicy(write_root=flow_dir)),
+        ctx=ctx,
     )
 
     assert (kwargs["subagent_builder"] is not None) is expected
@@ -438,17 +448,22 @@ async def test_spawn_subagent_wiring(flow_dir, message_queue):
             ]
         )
 
+    from ddev.ai.phases.base import PipelineContext
+
     checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
-    phase = AgenticPhase(
-        phase_id="p1",
-        dependencies=[],
-        config=PhaseConfig(agent="writer", tasks=[TaskConfig(name="t1", prompt="Do the work.")]),
-        agent_builder=agent_builder_fn,
+    ctx = PipelineContext(
         checkpoint_manager=checkpoint_manager,
         runtime_variables={},
         flow_variables={},
         config_dir=flow_dir,
         file_registry=FileRegistry(policy=FileAccessPolicy(write_root=flow_dir)),
+    )
+    phase = AgenticPhase(
+        phase_id="p1",
+        dependencies=[],
+        config=PhaseConfig(agent="writer", tasks=[TaskConfig(name="t1", prompt="Do the work.")]),
+        ctx=ctx,
+        agent_builder=agent_builder_fn,
         subagent_builder=mock_subagent_builder,
     )
     phase.queue = message_queue
@@ -485,12 +500,22 @@ def test_extra_init_kwargs_creates_goal_agent_builder_when_any_task_has_goal(
     tasks,
     expect_builder,
 ):
+    from ddev.ai.phases.base import PipelineContext
+    from ddev.ai.phases.checkpoint import CheckpointManager
+
+    ctx = PipelineContext(
+        checkpoint_manager=CheckpointManager(flow_dir / "checkpoints.yaml"),
+        runtime_variables={},
+        flow_variables={},
+        config_dir=flow_dir,
+        file_registry=FileRegistry(policy=FileAccessPolicy(write_root=flow_dir)),
+    )
     kwargs = AgenticPhase.extra_init_kwargs(
         phase_id="p1",
         phase_config=PhaseConfig(agent="writer", tasks=tasks),
         agents={"writer": AgentConfig()},
         agent_clients={},
-        file_registry=FileRegistry(policy=FileAccessPolicy(write_root=flow_dir)),
+        ctx=ctx,
     )
     assert (kwargs["goal_agent_builder"] is not None) is expect_builder
 

--- a/ddev/tests/ai/phases/test_base.py
+++ b/ddev/tests/ai/phases/test_base.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 
 import pytest
 
-from ddev.ai.phases.base import Phase, PhaseOutcome, PipelineContext
+from ddev.ai.phases.base import FlowServices, Phase, PhaseOutcome
 from ddev.ai.phases.checkpoint import CheckpointManager
 from ddev.ai.phases.config import PhaseConfig
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
@@ -35,7 +35,7 @@ def _make_stub_phase(
     outcome=None,
 ):
     checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
-    ctx = PipelineContext(
+    services = FlowServices(
         checkpoint_manager=checkpoint_manager,
         runtime_variables={},
         flow_variables={},
@@ -46,7 +46,7 @@ def _make_stub_phase(
         phase_id=phase_id,
         dependencies=dependencies or [],
         config=PhaseConfig(),
-        ctx=ctx,
+        services=services,
         outcome=outcome,
     )
     phase.queue = message_queue

--- a/ddev/tests/ai/phases/test_base.py
+++ b/ddev/tests/ai/phases/test_base.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 
 import pytest
 
-from ddev.ai.phases.base import Phase, PhaseOutcome
+from ddev.ai.phases.base import Phase, PhaseOutcome, PipelineContext
 from ddev.ai.phases.checkpoint import CheckpointManager
 from ddev.ai.phases.config import PhaseConfig
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
@@ -35,15 +35,18 @@ def _make_stub_phase(
     outcome=None,
 ):
     checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
-    phase = _StubPhase(
-        phase_id=phase_id,
-        dependencies=dependencies or [],
-        config=PhaseConfig(),
+    ctx = PipelineContext(
         checkpoint_manager=checkpoint_manager,
         runtime_variables={},
         flow_variables={},
         config_dir=flow_dir,
         file_registry=FileRegistry(policy=FileAccessPolicy(write_root=flow_dir)),
+    )
+    phase = _StubPhase(
+        phase_id=phase_id,
+        dependencies=dependencies or [],
+        config=PhaseConfig(),
+        ctx=ctx,
         outcome=outcome,
     )
     phase.queue = message_queue


### PR DESCRIPTION
### What does this PR do?

Introduces `FlowServices`, a frozen dataclass that groups the seven flow-level dependencies shared by every phase in a run: `checkpoint_manager`, `runtime_variables`, `flow_variables`, `config_dir`, `file_registry`, `callbacks`, and `logger`.

`Phase.__init__` is reduced from 10 parameters to 4 (`phase_id`, `dependencies`, `config`, `services`). `AgenticPhase.__init__` drops from 13 to 7. The orchestrator builds `FlowServices` once before the phase loop, and `phase_kwargs` shrinks from 10 keys to 4. `extra_init_kwargs` receives `services` instead of individual pieces.

`callbacks` and `logger` have sensible defaults on `FlowServices` so callers that do not care can omit them.

### Motivation

Adding any new shared dependency to the pipeline previously required touching `Phase.__init__`, `AgenticPhase.__init__`, the orchestrator's `phase_kwargs` dict, and every test helper — a 4-file cascade for a 1-concept change. With `FlowServices`, the same change requires only adding a field to the dataclass and populating it in the orchestrator.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged