### PR TITLE
[SDBM-2637] Restore agent hostname fallback resolution for SQL Server named instance configs

### DIFF
--- a/sqlserver/changelog.d/23862.fixed
+++ b/sqlserver/changelog.d/23862.fixed
@@ -1,0 +1,1 @@
+Restore agent hostname instrumentation for SQL Server named instance host configurations.

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -328,6 +328,9 @@ class SQLServer(DatabaseCheck):
         return self.host_and_port[1]
 
     def resolve_db_host(self):
+        if "\\" in self.host:
+            # SQL Server instance names are not resolvable, this preserves original fallback behavior prior to v7.79.0
+            return datadog_agent.get_hostname()
         return agent_host_resolver(self.host)
 
     @property

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -920,22 +920,15 @@ def agent_hostname_for_resolve_db_host():
 
 
 @pytest.mark.parametrize(
-    'instance_host,host_part,expected_resolved,expect_base_resolver_called,base_resolver_return',
+    'instance_host,host_part',
     [
-        (r'SQL-HOST01\INSTANCE01,1601', r'SQL-HOST01\INSTANCE01', AGENT_HOSTNAME, False, None),
-        (r'MY-SERVER\SQLEXPRESS,1433', r'MY-SERVER\SQLEXPRESS', AGENT_HOSTNAME, False, None),
-        (r'MY-SERVER\SQLEXPRESS', r'MY-SERVER\SQLEXPRESS', AGENT_HOSTNAME, False, None),
-        ('db.example.com,1433', 'db.example.com', 'resolved-db.example.com', True, 'resolved-db.example.com'),
-        ('192.0.2.10,1433', '192.0.2.10', '192.0.2.10', True, '192.0.2.10'),
+        (r'SQL-HOST01\INSTANCE01,1601', r'SQL-HOST01\INSTANCE01'),
+        (r'MY-SERVER\SQLEXPRESS,1433', r'MY-SERVER\SQLEXPRESS'),
+        (r'MY-SERVER\SQLEXPRESS', r'MY-SERVER\SQLEXPRESS'),
     ],
 )
-def test_resolve_db_host(
-    agent_hostname_for_resolve_db_host,
-    instance_host,
-    host_part,
-    expected_resolved,
-    expect_base_resolver_called,
-    base_resolver_return,
+def test_resolve_db_host_named_instance_returns_agent_hostname(
+    agent_hostname_for_resolve_db_host, instance_host, host_part
 ):
     instance = {
         'host': instance_host,
@@ -945,21 +938,40 @@ def test_resolve_db_host(
     check = SQLServer(CHECK_NAME, {}, [instance])
     assert check.host == host_part
 
-    if expect_base_resolver_called:
-        with mock.patch(
-            'datadog_checks.sqlserver.sqlserver.agent_host_resolver',
-            return_value=base_resolver_return,
-        ) as mock_resolver:
-            assert check.resolve_db_host() == expected_resolved
-            mock_resolver.assert_called_once_with(host_part)
-    else:
-        with mock.patch(
-            'datadog_checks.sqlserver.sqlserver.agent_host_resolver',
-            side_effect=AssertionError('base resolver must not be called for named instances'),
-        ):
-            assert check.resolve_db_host() == expected_resolved
-        assert check.resolved_hostname == expected_resolved
-        assert check.database_hostname == expected_resolved
+    # Agent 7.79+ base resolver returns the literal host string for unresolvable names.
+    with mock.patch(
+        'datadog_checks.sqlserver.sqlserver.agent_host_resolver',
+        return_value=host_part,
+    ):
+        assert check.resolve_db_host() == AGENT_HOSTNAME
+    assert check.resolved_hostname == AGENT_HOSTNAME
+    assert check.database_hostname == AGENT_HOSTNAME
+
+
+@pytest.mark.parametrize(
+    'instance_host,host_part,base_resolver_return',
+    [
+        ('db.example.com,1433', 'db.example.com', 'resolved-db.example.com'),
+        ('192.0.2.10,1433', '192.0.2.10', '192.0.2.10'),
+    ],
+)
+def test_resolve_db_host_plain_host_delegates_to_base_resolver(
+    agent_hostname_for_resolve_db_host, instance_host, host_part, base_resolver_return
+):
+    instance = {
+        'host': instance_host,
+        'username': 'datadog',
+        'password': 'secret',
+    }
+    check = SQLServer(CHECK_NAME, {}, [instance])
+    assert check.host == host_part
+
+    with mock.patch(
+        'datadog_checks.sqlserver.sqlserver.agent_host_resolver',
+        return_value=base_resolver_return,
+    ) as mock_resolver:
+        assert check.resolve_db_host() == base_resolver_return
+        mock_resolver.assert_called_once_with(host_part)
 
 
 @pytest.mark.parametrize(

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -11,6 +11,7 @@ from collections import namedtuple
 import mock
 import pytest
 
+from datadog_checks.base.stubs.datadog_agent import datadog_agent
 from datadog_checks.dev import EnvVars
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.connection import split_sqlserver_host_port
@@ -906,6 +907,59 @@ def test_parse_sqlserver_major_version(version, expected_major_version):
 def test_split_sqlserver_host(instance_host, split_host, split_port):
     s_host, s_port = split_sqlserver_host_port(instance_host)
     assert (s_host, s_port) == (split_host, split_port)
+
+
+AGENT_HOSTNAME = 'sql-agent-host.example.com'
+
+
+@pytest.fixture
+def agent_hostname_for_resolve_db_host():
+    datadog_agent.set_hostname(AGENT_HOSTNAME)
+    yield
+    datadog_agent.reset_hostname()
+
+
+@pytest.mark.parametrize(
+    'instance_host,host_part,expected_resolved,expect_base_resolver_called,base_resolver_return',
+    [
+        (r'SQL-HOST01\INSTANCE01,1601', r'SQL-HOST01\INSTANCE01', AGENT_HOSTNAME, False, None),
+        (r'MY-SERVER\SQLEXPRESS,1433', r'MY-SERVER\SQLEXPRESS', AGENT_HOSTNAME, False, None),
+        (r'MY-SERVER\SQLEXPRESS', r'MY-SERVER\SQLEXPRESS', AGENT_HOSTNAME, False, None),
+        ('db.example.com,1433', 'db.example.com', 'resolved-db.example.com', True, 'resolved-db.example.com'),
+        ('192.0.2.10,1433', '192.0.2.10', '192.0.2.10', True, '192.0.2.10'),
+    ],
+)
+def test_resolve_db_host(
+    agent_hostname_for_resolve_db_host,
+    instance_host,
+    host_part,
+    expected_resolved,
+    expect_base_resolver_called,
+    base_resolver_return,
+):
+    instance = {
+        'host': instance_host,
+        'username': 'datadog',
+        'password': 'secret',
+    }
+    check = SQLServer(CHECK_NAME, {}, [instance])
+    assert check.host == host_part
+
+    if expect_base_resolver_called:
+        with mock.patch(
+            'datadog_checks.sqlserver.sqlserver.agent_host_resolver',
+            return_value=base_resolver_return,
+        ) as mock_resolver:
+            assert check.resolve_db_host() == expected_resolved
+            mock_resolver.assert_called_once_with(host_part)
+    else:
+        with mock.patch(
+            'datadog_checks.sqlserver.sqlserver.agent_host_resolver',
+            side_effect=AssertionError('base resolver must not be called for named instances'),
+        ):
+            assert check.resolve_db_host() == expected_resolved
+        assert check.resolved_hostname == expected_resolved
+        assert check.database_hostname == expected_resolved
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?

Fixes hostname instrumentation for SQL Server instances configured with a named instance in the `host` option (for example `SQL-HOST01\INSTANCE01,1601`).

When the host contains a backslash, `resolve_db_host()` now returns the agent hostname instead of delegating to the base resolver. This restores the behavior customers had before Agent 7.79.0 for `resolved_hostname`, `database_hostname`, metric hostnames, and related tags.

Adds unit tests covering named-instance and plain-host configurations.

### Motivation

In Agent 7.79.0, `resolve_db_host` in `datadog_checks_base` changed its DNS failure fallback from the agent hostname to the literal configured host string ([#23181](https://github.com/DataDog/integrations-core/pull/23181)). For named SQL Server instances, the host segment (for example `SQL-HOST01\INSTANCE01`) is not a valid DNS name, so resolution fails and the check started reporting that literal string as the metric hostname. That created phantom hosts in the UI and broke DBM instance identity for customers using the standard `server\instance,port` connection format.

On Agent 7.78.x, the same configuration still resolved to the agent hostname because the base check fell back to `datadog_agent.get_hostname()` on lookup failure. This change restores that behavior for named instances only; plain hostnames continue to use the shared base resolver.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged