### PR TITLE
[amazon_msk] [amazon_msk] Fix dashboard check status widget grouping

### DIFF
--- a/amazon_msk/assets/dashboards/overview.json
+++ b/amazon_msk/assets/dashboards/overview.json
@@ -54,12 +54,13 @@
                         "definition": {
                             "check": "aws.msk.can_connect",
                             "group_by": [
-                                "$cluster_arn",
-                                "$region_name"
+                                "cluster_arn",
+                                "region_name"
                             ],
                             "grouping": "cluster",
                             "tags": [
-                                "*"
+                                "$cluster_arn",
+                                "$region_name"
                             ],
                             "title": "Brokers",
                             "title_align": "left",


### PR DESCRIPTION
Generated by FBO — DRAFT for human review

Closes FRAGENT-2223

## Reality-check reasoning

The check status widget in `amazon_msk/assets/dashboards/overview.json` (widget id 2169915587455394) still uses template variable references `$cluster_arn` and `$region_name` in the `group_by` field, which is the exact bug described in FRAGENT-2223. The FR says these should be used as filters in `tags` instead of in `group_by`, and `group_by` should use actual tag key names (not template variable syntax). The current dashboard code has not been updated to fix this grouping/filtering issue.

This PR was opened as a Draft. A human should review the diff, 
re-run validators if needed, and mark Ready for Review.