### PR TITLE
[azure_active_directory] Add grok parsers to extract port from IP:port

### DIFF
--- a/azure_active_directory/assets/logs/azure.activedirectory.yaml
+++ b/azure_active_directory/assets/logs/azure.activedirectory.yaml
@@ -305,6 +305,17 @@ pipeline:
       samples:
         - 15.113.255.209
         - 15.113.255.209:21341
+    - type: attribute-remapper
+      name: Map `network.client.port` to `network.client.port`
+      enabled: true
+      sources:
+        - network.client.port
+      sourceType: attribute
+      target: network.client.port
+      targetType: attribute
+      targetFormat: integer
+      preserveSource: false
+      overrideOnConflict: false
     - type: arithmetic-processor
       name: Compute duration in nanoseconds from durationMs in miliseconds
       enabled: true
@@ -584,6 +595,17 @@ pipeline:
           samples:
             - 15.113.255.209
             - 15.113.255.209:21341
+        - type: attribute-remapper
+          name: Map `ocsf.src_endpoint.port` to `ocsf.src_endpoint.port`
+          enabled: true
+          sources:
+            - ocsf.src_endpoint.port
+          sourceType: attribute
+          target: ocsf.src_endpoint.port
+          targetType: attribute
+          targetFormat: integer
+          preserveSource: false
+          overrideOnConflict: false
         - type: attribute-remapper
           name: Map `properties.resultReason` to `ocsf.status_code`
           enabled: true
@@ -1067,6 +1089,17 @@ pipeline:
           samples:
             - 15.113.255.209
             - 15.113.255.209:21341
+        - type: attribute-remapper
+          name: Map `ocsf.src_endpoint.port` to `ocsf.src_endpoint.port`
+          enabled: true
+          sources:
+            - ocsf.src_endpoint.port
+          sourceType: attribute
+          target: ocsf.src_endpoint.port
+          targetType: attribute
+          targetFormat: integer
+          preserveSource: false
+          overrideOnConflict: false
         - type: attribute-remapper
           name: Map `properties.deviceDetail.operatingSystem` to `ocsf.src_endpoint.os.name`
           enabled: true
@@ -1937,6 +1970,17 @@ pipeline:
           samples:
             - 15.113.255.209
             - 15.113.255.209:21341
+        - type: attribute-remapper
+          name: Map `ocsf.src_endpoint.port` to `ocsf.src_endpoint.port`
+          enabled: true
+          sources:
+            - ocsf.src_endpoint.port
+          sourceType: attribute
+          target: ocsf.src_endpoint.port
+          targetType: attribute
+          targetFormat: integer
+          preserveSource: false
+          overrideOnConflict: false
         - type: string-builder-processor
           name: Add dst_endpoint.hostname
           enabled: true

--- a/azure_active_directory/assets/logs/azure.activedirectory.yaml
+++ b/azure_active_directory/assets/logs/azure.activedirectory.yaml
@@ -84,6 +84,11 @@ facets:
     path: network.client.ip
     source: log
   - groups:
+      - Web Access
+    name: Client Port
+    path: network.client.port
+    source: log
+  - groups:
       - User
     name: User Email
     path: usr.email

--- a/azure_active_directory/assets/logs/azure.activedirectory.yaml
+++ b/azure_active_directory/assets/logs/azure.activedirectory.yaml
@@ -596,17 +596,6 @@ pipeline:
             - 15.113.255.209
             - 15.113.255.209:21341
         - type: attribute-remapper
-          name: Map `ocsf.src_endpoint.port` to `ocsf.src_endpoint.port`
-          enabled: true
-          sources:
-            - ocsf.src_endpoint.port
-          sourceType: attribute
-          target: ocsf.src_endpoint.port
-          targetType: attribute
-          targetFormat: integer
-          preserveSource: false
-          overrideOnConflict: false
-        - type: attribute-remapper
           name: Map `properties.resultReason` to `ocsf.status_code`
           enabled: true
           sources:
@@ -1089,17 +1078,6 @@ pipeline:
           samples:
             - 15.113.255.209
             - 15.113.255.209:21341
-        - type: attribute-remapper
-          name: Map `ocsf.src_endpoint.port` to `ocsf.src_endpoint.port`
-          enabled: true
-          sources:
-            - ocsf.src_endpoint.port
-          sourceType: attribute
-          target: ocsf.src_endpoint.port
-          targetType: attribute
-          targetFormat: integer
-          preserveSource: false
-          overrideOnConflict: false
         - type: attribute-remapper
           name: Map `properties.deviceDetail.operatingSystem` to `ocsf.src_endpoint.os.name`
           enabled: true
@@ -1970,17 +1948,6 @@ pipeline:
           samples:
             - 15.113.255.209
             - 15.113.255.209:21341
-        - type: attribute-remapper
-          name: Map `ocsf.src_endpoint.port` to `ocsf.src_endpoint.port`
-          enabled: true
-          sources:
-            - ocsf.src_endpoint.port
-          sourceType: attribute
-          target: ocsf.src_endpoint.port
-          targetType: attribute
-          targetFormat: integer
-          preserveSource: false
-          overrideOnConflict: false
         - type: string-builder-processor
           name: Add dst_endpoint.hostname
           enabled: true
@@ -2406,6 +2373,17 @@ pipeline:
             - ocsf.user.type_id
           sourceType: attribute
           target: ocsf.user.type_id
+          targetType: attribute
+          targetFormat: integer
+          preserveSource: false
+          overrideOnConflict: false
+        - type: attribute-remapper
+          name: Map `ocsf.src_endpoint.port` to `ocsf.src_endpoint.port`
+          enabled: true
+          sources:
+            - ocsf.src_endpoint.port
+          sourceType: attribute
+          target: ocsf.src_endpoint.port
           targetType: attribute
           targetFormat: integer
           preserveSource: false

--- a/azure_active_directory/assets/logs/azure.activedirectory.yaml
+++ b/azure_active_directory/assets/logs/azure.activedirectory.yaml
@@ -200,6 +200,13 @@ facets:
     name: Source IP Address
     path: ocsf.src_endpoint.ip
     source: log
+  - facetType: range
+    groups:
+      - OCSF
+    name: Src Endpoint Port
+    path: ocsf.src_endpoint.port
+    source: log
+    type: integer
   - groups:
       - OCSF
     name: Event Code
@@ -281,6 +288,18 @@ pipeline:
       overrideOnConflict: false
       sourceType: attribute
       targetType: attribute
+    - type: grok-parser
+      name: Parse `network.client.ip` to `network.client.ip`, `network.client.port`
+      enabled: true
+      source: network.client.ip
+      grok:
+        supportRules: |
+        matchRules: |
+          ipv4_rule %{ipv4:network.client.ip}(:%{port:network.client.port})?
+          ipv6_rule \[?%{ipv6:network.client.ip}\]?(:%{port:network.client.port})?
+      samples:
+        - 15.113.255.209
+        - 15.113.255.209:21341
     - type: arithmetic-processor
       name: Compute duration in nanoseconds from durationMs in miliseconds
       enabled: true
@@ -548,6 +567,18 @@ pipeline:
           targetType: attribute
           preserveSource: true
           overrideOnConflict: false
+        - type: grok-parser
+          name: Parse `ocsf.src_endpoint.ip` to `ocsf.src_endpoint.ip`, `ocsf.src_endpoint.port`
+          enabled: true
+          source: ocsf.src_endpoint.ip
+          grok:
+            supportRules: |
+            matchRules: |
+              ipv4_rule %{ipv4:ocsf.src_endpoint.ip}(:%{port:ocsf.src_endpoint.port})?
+              ipv6_rule \[?%{ipv6:ocsf.src_endpoint.ip}\]?(:%{port:ocsf.src_endpoint.port})?
+          samples:
+            - 15.113.255.209
+            - 15.113.255.209:21341
         - type: attribute-remapper
           name: Map `properties.resultReason` to `ocsf.status_code`
           enabled: true
@@ -1019,6 +1050,18 @@ pipeline:
           targetType: attribute
           preserveSource: true
           overrideOnConflict: false
+        - type: grok-parser
+          name: Parse `ocsf.src_endpoint.ip` to `ocsf.src_endpoint.ip`, `ocsf.src_endpoint.port`
+          enabled: true
+          source: ocsf.src_endpoint.ip
+          grok:
+            supportRules: |
+            matchRules: |
+              ipv4_rule %{ipv4:ocsf.src_endpoint.ip}(:%{port:ocsf.src_endpoint.port})?
+              ipv6_rule \[?%{ipv6:ocsf.src_endpoint.ip}\]?(:%{port:ocsf.src_endpoint.port})?
+          samples:
+            - 15.113.255.209
+            - 15.113.255.209:21341
         - type: attribute-remapper
           name: Map `properties.deviceDetail.operatingSystem` to `ocsf.src_endpoint.os.name`
           enabled: true
@@ -1877,6 +1920,18 @@ pipeline:
           targetType: attribute
           preserveSource: true
           overrideOnConflict: false
+        - type: grok-parser
+          name: Parse `ocsf.src_endpoint.ip` to `ocsf.src_endpoint.ip`, `ocsf.src_endpoint.port`
+          enabled: true
+          source: ocsf.src_endpoint.ip
+          grok:
+            supportRules: |
+            matchRules: |
+              ipv4_rule %{ipv4:ocsf.src_endpoint.ip}(:%{port:ocsf.src_endpoint.port})?
+              ipv6_rule \[?%{ipv6:ocsf.src_endpoint.ip}\]?(:%{port:ocsf.src_endpoint.port})?
+          samples:
+            - 15.113.255.209
+            - 15.113.255.209:21341
         - type: string-builder-processor
           name: Add dst_endpoint.hostname
           enabled: true

--- a/azure_active_directory/assets/logs/azure.activedirectory.yaml
+++ b/azure_active_directory/assets/logs/azure.activedirectory.yaml
@@ -2249,6 +2249,16 @@ pipeline:
           targetType: attribute
           preserveSource: false
           overrideOnConflict: false
+        - type: attribute-remapper
+          name: Map `ocsf.src_endpoint.port` to `network.client.port`
+          enabled: true
+          sources:
+            - ocsf.src_endpoint.port
+          sourceType: attribute
+          target: callerIpAddress
+          targetType: attribute
+          preserveSource: false
+          overrideOnConflict: false
     - type: pipeline
       name: OCSF post transformations
       enabled: true

--- a/azure_active_directory/assets/logs/azure.activedirectory_tests.yaml
+++ b/azure_active_directory/assets/logs/azure.activedirectory_tests.yaml
@@ -397,7 +397,7 @@ tests:
           client:
             geoip: {}
             ip: "192.182.149.21"
-            port: 43210
+            port: "43210"
         ocsf:
           activity_id: 6
           activity_name: "Delete"
@@ -428,7 +428,7 @@ tests:
           severity_id: 1
           src_endpoint:
             ip: "192.182.149.21"
-            port: 43210
+            port: "43210"
           status: "Success"
           status_code: ""
           status_id: 1

--- a/azure_active_directory/assets/logs/azure.activedirectory_tests.yaml
+++ b/azure_active_directory/assets/logs/azure.activedirectory_tests.yaml
@@ -397,7 +397,7 @@ tests:
           client:
             geoip: {}
             ip: "192.182.149.21"
-            port: "43210"
+            port: 43210
         ocsf:
           activity_id: 6
           activity_name: "Delete"
@@ -428,7 +428,7 @@ tests:
           severity_id: 1
           src_endpoint:
             ip: "192.182.149.21"
-            port: "43210"
+            port: 43210
           status: "Success"
           status_code: ""
           status_id: 1

--- a/azure_active_directory/assets/logs/azure.activedirectory_tests.yaml
+++ b/azure_active_directory/assets/logs/azure.activedirectory_tests.yaml
@@ -328,7 +328,7 @@ tests:
         "tenantId": "4d3bac44-0230-4732-9e70-cc00736f0a97",
         "resultSignature": "None",
         "durationMs": 0,
-        "callerIpAddress": "192.182.149.21",
+        "callerIpAddress": "192.182.149.21:43210",
         "correlationId": "a13bd0fa-70d0-4e60-ae23-b687377b4695",
         "Level": 4,
         "properties": {
@@ -353,7 +353,7 @@ tests:
               "id": "018af091-5465-4aed-9d6f-8c40981b2375",
               "displayName": null,
               "userPrincipalName": "test.test@datadoghq.com",
-              "ipAddress": "192.182.149.21",
+              "ipAddress": "192.182.149.21:43210",
               "roles": []
             }
           },
@@ -384,7 +384,7 @@ tests:
     result:
       custom:
         Level: 4
-        callerIpAddress: "192.182.149.21"
+        callerIpAddress: "192.182.149.21:43210"
         category: "AuditLogs"
         correlationId: "a13bd0fa-70d0-4e60-ae23-b687377b4695"
         duration: 0.0
@@ -397,6 +397,7 @@ tests:
           client:
             geoip: {}
             ip: "192.182.149.21"
+            port: 43210
         ocsf:
           activity_id: 6
           activity_name: "Delete"
@@ -427,6 +428,7 @@ tests:
           severity_id: 1
           src_endpoint:
             ip: "192.182.149.21"
+            port: 43210
           status: "Success"
           status_code: ""
           status_id: 1
@@ -453,7 +455,7 @@ tests:
           initiatedBy:
             user:
               id: "018af091-5465-4aed-9d6f-8c40981b2375"
-              ipAddress: "192.182.149.21"
+              ipAddress: "192.182.149.21:43210"
               userPrincipalName: "test.test@datadoghq.com"
           loggedByService: "Core Directory"
           operationName: "Delete user"
@@ -481,7 +483,7 @@ tests:
           name: "test.test@datadoghq.com"
       message: |-
         {
-          "callerIpAddress" : "192.182.149.21",
+          "callerIpAddress" : "192.182.149.21:43210",
           "resourceId" : "/tenants/4d3bac44-0230-4732-9e70-cc00736f0a97/providers/Microsoft.aadiam",
           "operationVersion" : "1.0",
           "tenantId" : "4d3bac44-0230-4732-9e70-cc00736f0a97",
@@ -522,7 +524,7 @@ tests:
             "resultType" : "",
             "initiatedBy" : {
               "user" : {
-                "ipAddress" : "192.182.149.21",
+                "ipAddress" : "192.182.149.21:43210",
                 "id" : "018af091-5465-4aed-9d6f-8c40981b2375",
                 "userPrincipalName" : "test.test@datadoghq.com"
               }


### PR DESCRIPTION
### What does this PR do?

Adds grok parsers to the Azure Active Directory pipeline to extract the port from `IP:port` formatted values in both `network.client.ip` and `ocsf.src_endpoint.ip`. Also adds the `ocsf.src_endpoint.port` facet definition.

- Adds a grok parser after the `callerIpAddress` → `network.client.ip` remapper to parse `network.client.ip` and `network.client.port`
- Adds grok parsers after each `ocsf.src_endpoint.ip` remapper (Audit Logs, Authentication [3002], API Activity [6003]) to parse `ocsf.src_endpoint.ip` and `ocsf.src_endpoint.port`
- Adds `ocsf.src_endpoint.port` facet (range type, integer)
- Updates one test sample to use `IP:port` format to validate the parsing

### Motivation

Some Azure AD log sources include a port number appended to the IP address (e.g., `192.168.1.1:21341`). Without parsing, this pollutes the IP field with non-IP data and the port information is lost.

