### PR TITLE
Trigger days-since-last-pin workflow on PR changes

### DIFF
--- a/.github/workflows/days-since-last-pin.yml
+++ b/.github/workflows/days-since-last-pin.yml
@@ -19,7 +19,6 @@ jobs:
 
       - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
         id: octo-sts
-        if: github.event_name != 'pull_request'
         with:
           scope: DataDog/datadog-agent
           policy: integrations-core.github.read-release-json.schedule
@@ -27,11 +26,10 @@ jobs:
       - name: Compute days since last pin
         id: compute
         env:
-          GITHUB_TOKEN: ${{ github.event_name == 'pull_request' && github.token || steps.octo-sts.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: python3 .github/workflows/scripts/days_since_last_pin.py
 
       - name: Submit metric to Datadog
-        if: github.event_name != 'pull_request'
         env:
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
           DAYS: ${{ steps.compute.outputs.days }}

--- a/.github/workflows/days-since-last-pin.yml
+++ b/.github/workflows/days-since-last-pin.yml
@@ -1,6 +1,9 @@
 name: Days Since Last Pin
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/days-since-last-pin.yml
   schedule:
     - cron: "42 9 * * *"
   workflow_dispatch:

--- a/.github/workflows/days-since-last-pin.yml
+++ b/.github/workflows/days-since-last-pin.yml
@@ -19,6 +19,7 @@ jobs:
 
       - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
         id: octo-sts
+        if: github.event_name != 'pull_request'
         with:
           scope: DataDog/datadog-agent
           policy: integrations-core.github.read-release-json.schedule
@@ -26,10 +27,11 @@ jobs:
       - name: Compute days since last pin
         id: compute
         env:
-          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          GITHUB_TOKEN: ${{ github.event_name == 'pull_request' && github.token || steps.octo-sts.outputs.token }}
         run: python3 .github/workflows/scripts/days_since_last_pin.py
 
       - name: Submit metric to Datadog
+        if: github.event_name != 'pull_request'
         env:
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
           DAYS: ${{ steps.compute.outputs.days }}


### PR DESCRIPTION
### What does this PR do?

Adds a `pull_request` trigger to the `days-since-last-pin` workflow, scoped to changes to the workflow file itself. This allows the workflow to run in CI when the file is modified in a PR, making it easier to validate changes before merging.

### Motivation

Previously the workflow only ran on a daily schedule and via manual dispatch, so there was no way to test changes to it in CI without waiting for the next scheduled run or triggering it manually.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged