### PR TITLE
Replace extra_init_kwargs with polymorphic Phase.build() factory and ResourceProvider

### DIFF
--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -7,14 +7,15 @@ from __future__ import annotations
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from ddev.ai.agent.build import (
     make_agent_builder,
     make_goal_agent_builder,
     make_subagent_builder,
 )
-from ddev.ai.phases.base import FlowServices, Phase, PhaseOutcome
+from ddev.ai.phases.base import FlowContext, Phase, PhaseOutcome
+from ddev.ai.phases.checkpoint import CheckpointManager
 from ddev.ai.phases.config import AgentConfig, CheckpointConfig, FlowConfigError, PhaseConfig, TaskConfig
 from ddev.ai.phases.goal import GOAL_TASK_SUFFIX, GoalValidationError, render_goal_text, run_goal_loop
 from ddev.ai.phases.messages import PhaseFailedMessage
@@ -27,6 +28,7 @@ if TYPE_CHECKING:
     from ddev.ai.agent.base import BaseAgent
     from ddev.ai.agent.build import AgentBuilder, GoalAgentBuilder, SubagentBuilder
     from ddev.ai.phases.goal import GoalLoopOutcome
+    from ddev.ai.phases.orchestrator import ResourceProvider
     from ddev.ai.react.types import ReActResult
 
 
@@ -65,7 +67,8 @@ class AgenticPhase(Phase):
         phase_id: str,
         dependencies: list[str],
         config: PhaseConfig,
-        services: FlowServices,
+        checkpoint_manager: CheckpointManager,
+        context: FlowContext,
         agent_builder: AgentBuilder,
         subagent_builder: SubagentBuilder | None = None,
         goal_agent_builder: GoalAgentBuilder | None = None,
@@ -74,7 +77,8 @@ class AgenticPhase(Phase):
             phase_id=phase_id,
             dependencies=dependencies,
             config=config,
-            services=services,
+            checkpoint_manager=checkpoint_manager,
+            context=context,
         )
         self._agent_builder = agent_builder
         self._subagent_builder = subagent_builder
@@ -83,7 +87,7 @@ class AgenticPhase(Phase):
         self._total_input_tokens: int = 0
         self._total_output_tokens: int = 0
         self._subagent_log_dir = (
-            services.checkpoint_manager.root / "subagents" / phase_id if subagent_builder is not None else None
+            checkpoint_manager.root / "subagents" / phase_id if subagent_builder is not None else None
         )
 
     @classmethod
@@ -101,52 +105,55 @@ class AgenticPhase(Phase):
             raise FlowConfigError(f"Phase {phase_id!r} (AgenticPhase) must have at least one task")
 
     @classmethod
-    def extra_init_kwargs(  # type: ignore[override]
+    def build(
         cls,
-        *,
         phase_id: str,
-        phase_config: PhaseConfig,
-        agents: dict[str, AgentConfig],
-        agent_clients: dict[str, Any],
-        services: FlowServices,
-        **_: Any,
-    ) -> dict[str, Any]:
-        if phase_config.agent is None:
-            raise FlowConfigError(f"Phase {phase_id!r} (AgenticPhase) requires 'agent'")
-        agent_config = agents[phase_config.agent]
-        file_registry = services.file_registry
+        config: PhaseConfig,
+        deps: list[str],
+        resources: ResourceProvider,
+        checkpoint_manager: CheckpointManager,
+        context: FlowContext,
+    ) -> AgenticPhase:
+        # config.agent is guaranteed set & known by validate_config.
+        agent_name = cast(str, config.agent)
+        agent_config = resources.agent_config(agent_name)
+        agent_clients = resources.agent_clients()
+        file_registry = resources.file_registry()
 
         subagent_builder = None
-        requires_subagent_builder = any(
+        if any(
             spec.requires_subagent_builder
             for name in agent_config.tools
             if (spec := TOOL_MANIFEST.get(name)) is not None
-        )
-        if requires_subagent_builder:
+        ):
             subagent_builder = make_subagent_builder(
                 parent_agent_config=agent_config,
                 agent_clients=agent_clients,
                 file_registry=file_registry,
             )
 
-        any_goal = any((t.goal is not None or t.goal_path is not None) for t in phase_config.tasks)
         goal_agent_builder = None
-        if any_goal:
+        if any((t.goal is not None or t.goal_path is not None) for t in config.tasks):
             goal_agent_builder = make_goal_agent_builder(
                 parent_agent_config=agent_config,
                 agent_clients=agent_clients,
                 file_registry=file_registry,
             )
 
-        return {
-            "agent_builder": make_agent_builder(
+        return cls(
+            phase_id=phase_id,
+            dependencies=deps,
+            config=config,
+            checkpoint_manager=checkpoint_manager,
+            context=context,
+            agent_builder=make_agent_builder(
                 agent_config=agent_config,
                 agent_clients=agent_clients,
                 file_registry=file_registry,
             ),
-            "subagent_builder": subagent_builder,
-            "goal_agent_builder": goal_agent_builder,
-        }
+            subagent_builder=subagent_builder,
+            goal_agent_builder=goal_agent_builder,
+        )
 
     def before_react(self) -> None:
         """Called once before agent/tools are created. Override for phase-specific setup."""

--- a/ddev/src/ddev/ai/phases/base.py
+++ b/ddev/src/ddev/ai/phases/base.py
@@ -109,8 +109,11 @@ class Phase(AsyncProcessor[PhaseTrigger]):
         checkpoint_manager: CheckpointManager,
         context: FlowContext,
     ) -> Phase:
-        """Uniform polymorphic factory. Subclasses with a richer __init__
-        override this to assemble their extras."""
+        """Uniform polymorphic factory called by the orchestrator for every phase.
+
+        Subclasses that need infrastructure (agent builders, file registry)
+        pull it from ``resources`` inside their own ``build()`` override.
+        """
         return cls(
             phase_id=phase_id,
             dependencies=deps,

--- a/ddev/src/ddev/ai/phases/base.py
+++ b/ddev/src/ddev/ai/phases/base.py
@@ -2,32 +2,34 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+from __future__ import annotations
+
 import logging
 from abc import abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ddev.ai.callbacks.callbacks import Callbacks
 from ddev.ai.phases.checkpoint import CheckpointManager
 from ddev.ai.phases.config import AgentConfig, PhaseConfig
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
-from ddev.ai.tools.fs.file_registry import FileRegistry
 from ddev.event_bus.exceptions import MessageProcessingError, ProcessorHookError
 from ddev.event_bus.orchestrator import AsyncProcessor, BaseMessage
 
+if TYPE_CHECKING:
+    from ddev.ai.phases.orchestrator import ResourceProvider
+
 
 @dataclass(frozen=True)
-class FlowServices:
-    """Shared pipeline-level infrastructure passed to every phase."""
+class FlowContext:
+    """Ambient, flow-scoped execution context shared by every phase."""
 
-    checkpoint_manager: CheckpointManager
     runtime_variables: dict[str, str]
     flow_variables: dict[str, str]
     config_dir: Path
-    file_registry: FileRegistry
     callbacks: Callbacks = field(default_factory=Callbacks)
     logger: logging.Logger = field(default_factory=lambda: logging.getLogger(__name__))
 
@@ -40,28 +42,11 @@ class PhaseOutcome:
     extra_checkpoint: dict[str, Any] = field(default_factory=dict)
 
 
-class PhaseRegistry:
-    def __init__(self) -> None:
-        self._registry: dict[str, type["Phase"]] = {}
-
-    def register(self, name: str, phase_cls: type["Phase"]) -> None:
-        self._registry[name] = phase_cls
-
-    def known_names(self) -> list[str]:
-        return sorted(self._registry)
-
-    def get(self, name: str) -> type["Phase"]:
-        if name not in self._registry:
-            raise ValueError(f"Unknown phase type: {name!r}. Known: {self.known_names()}")
-        return self._registry[name]
-
-
 class Phase(AsyncProcessor[PhaseTrigger]):
     """Lifecycle base for all phases.
 
     process_message() implements the immutable pipeline skeleton.
     Subclasses implement execute() to provide phase-specific logic.
-    Registered in PhaseRegistry by _discover_and_register_phases() at startup.
     """
 
     def __init__(
@@ -69,20 +54,19 @@ class Phase(AsyncProcessor[PhaseTrigger]):
         phase_id: str,
         dependencies: list[str],
         config: PhaseConfig,
-        services: FlowServices,
+        checkpoint_manager: CheckpointManager,
+        context: FlowContext,
     ) -> None:
         super().__init__(name=phase_id)
         self._phase_id = phase_id
-        self._dependencies = set(dependencies)
         self._remaining_dependencies = set(dependencies)
         self._config = config
-        self._checkpoint_manager = services.checkpoint_manager
-        self._runtime_variables = services.runtime_variables
-        self._flow_variables = services.flow_variables
-        self._config_dir = services.config_dir
-        self._file_registry = services.file_registry
-        self._callbacks = services.callbacks
-        self._logger = services.logger
+        self._checkpoint_manager = checkpoint_manager
+        self._runtime_variables = context.runtime_variables
+        self._flow_variables = context.flow_variables
+        self._config_dir = context.config_dir
+        self._callbacks = context.callbacks
+        self._logger = context.logger
         self._started_at: datetime | None = None
         self._resolver: Callable[[str], str] | None = None
         self._executed = False
@@ -91,11 +75,11 @@ class Phase(AsyncProcessor[PhaseTrigger]):
         if isinstance(message, PhaseTrigger):
             if message.phase_id is None:
                 # Initial trigger — only root phases (no declared dependencies) respond
-                if self._dependencies:
+                if self._remaining_dependencies:
                     return False
             else:
                 # Phase-completion trigger — check dependency tracking
-                if message.phase_id not in self._dependencies:
+                if message.phase_id not in self._remaining_dependencies:
                     return False
                 self._remaining_dependencies.discard(message.phase_id)
                 if self._remaining_dependencies:
@@ -116,14 +100,24 @@ class Phase(AsyncProcessor[PhaseTrigger]):
         return None
 
     @classmethod
-    def extra_init_kwargs(cls, **kwargs: Any) -> dict[str, Any]:
-        """Override to inject subclass-specific kwargs into __init__ at construction time.
-
-        The orchestrator passes phase_id, phase_config, agents, agent_clients, and services
-        (FlowServices) as keyword arguments. Subclasses declare the ones they need
-        explicitly and accept the rest via **kwargs.
-        """
-        return {}
+    def build(
+        cls,
+        phase_id: str,
+        config: PhaseConfig,
+        deps: list[str],
+        resources: ResourceProvider,
+        checkpoint_manager: CheckpointManager,
+        context: FlowContext,
+    ) -> Phase:
+        """Uniform polymorphic factory. Subclasses with a richer __init__
+        override this to assemble their extras."""
+        return cls(
+            phase_id=phase_id,
+            dependencies=deps,
+            config=config,
+            checkpoint_manager=checkpoint_manager,
+            context=context,
+        )
 
     @abstractmethod
     async def execute(self, context: dict[str, Any]) -> PhaseOutcome: ...

--- a/ddev/src/ddev/ai/phases/orchestrator.py
+++ b/ddev/src/ddev/ai/phases/orchestrator.py
@@ -9,14 +9,74 @@ from pathlib import Path
 from typing import Any
 
 from ddev.ai.callbacks.callbacks import Callbacks
-from ddev.ai.phases.base import FlowServices, Phase, PhaseRegistry
+from ddev.ai.phases.base import FlowContext, Phase
 from ddev.ai.phases.checkpoint import CheckpointManager
-from ddev.ai.phases.config import FlowConfig, FlowConfigError
+from ddev.ai.phases.config import AgentConfig, FlowConfig, FlowConfigError
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.ai.tools.fs.file_registry import FileRegistry
 from ddev.event_bus.exceptions import FatalProcessingError
 from ddev.event_bus.orchestrator import BaseMessage, EventBusOrchestrator
+
+
+class PhaseRegistry:
+    def __init__(self) -> None:
+        self._registry: dict[str, type[Phase]] = {}
+
+    def register(self, name: str, phase_cls: type[Phase]) -> None:
+        self._registry[name] = phase_cls
+
+    def known_names(self) -> list[str]:
+        return sorted(self._registry)
+
+    def get(self, name: str) -> type[Phase]:
+        if name not in self._registry:
+            raise ValueError(f"Unknown phase type: {name!r}. Known: {self.known_names()}")
+        return self._registry[name]
+
+
+class ResourceUnavailableError(Exception):
+    """Raised when a phase requests a resource the provider cannot supply."""
+
+
+class ResourceProvider:
+    """Supplies the raw resources phases combine to build their agents/tools.
+
+    Holds raw infrastructure (agent clients, file access policy) and the flow's agent
+    definitions. Assembled objects (agent/subagent builders) are NOT stored here — phases
+    construct those inside build(). One instance is shared by every phase in a run, so
+    file_registry() is a lazily-constructed singleton (global read-before-write consistency).
+    """
+
+    def __init__(
+        self,
+        agent_clients: dict[str, Any],
+        file_access_policy: FileAccessPolicy,
+        agents: dict[str, AgentConfig],
+    ) -> None:
+        self._agent_clients = agent_clients
+        self._file_access_policy = file_access_policy
+        self._agents = agents
+        self._file_registry: FileRegistry | None = None
+
+    def agent_clients(self) -> dict[str, Any]:
+        """Raw provider-name -> SDK client map."""
+        return self._agent_clients
+
+    def file_registry(self) -> FileRegistry:
+        """Lazily-built, run-wide singleton FileRegistry."""
+        if self._file_registry is None:
+            self._file_registry = FileRegistry(policy=self._file_access_policy)
+        return self._file_registry
+
+    def agent_config(self, name: str) -> AgentConfig:
+        """Resolve a flow agent definition by name; typed error if absent."""
+        try:
+            return self._agents[name]
+        except KeyError:
+            raise ResourceUnavailableError(
+                f"No agent definition named {name!r}. Known: {sorted(self._agents)}"
+            ) from None
 
 
 def _discover_and_register_phases(
@@ -68,11 +128,12 @@ class PhaseOrchestrator(EventBusOrchestrator):
         self._checkpoint_path = checkpoint_path
         self._runtime_variables = runtime_variables
         self._agent_clients = agent_clients
+        self._file_access_policy = file_access_policy
         self._callbacks: Callbacks = callbacks or Callbacks()
         self._phase_registry = PhaseRegistry()
         self._failed_phase: str | None = None
         self._failed_error: str | None = None
-        self._file_registry = FileRegistry(policy=file_access_policy)
+        self._resources: ResourceProvider | None = None
 
     async def on_initialize(self) -> None:
         """Discover custom phases, parse flow.yaml, construct phases, submit PhaseTrigger."""
@@ -114,15 +175,17 @@ class PhaseOrchestrator(EventBusOrchestrator):
             phase_cls.validate_config(phase_id, phase_config, config.agents)
 
         checkpoint_manager = CheckpointManager(self._checkpoint_path)
-
         dependency_map: dict[str, list[str]] = {entry.phase: entry.dependencies for entry in config.flow}
 
-        services = FlowServices(
-            checkpoint_manager=checkpoint_manager,
+        self._resources = ResourceProvider(
+            agent_clients=self._agent_clients,
+            file_access_policy=self._file_access_policy,
+            agents=config.agents,
+        )
+        context = FlowContext(
             runtime_variables=self._runtime_variables,
             flow_variables=config.variables,
             config_dir=config_dir,
-            file_registry=self._file_registry,
             callbacks=self._callbacks,
             logger=self._logger,
         )
@@ -130,27 +193,16 @@ class PhaseOrchestrator(EventBusOrchestrator):
         for entry in config.flow:
             phase_id = entry.phase
             phase_config = config.phases[phase_id]
-            dependencies = dependency_map[phase_id]
-
+            deps = dependency_map[phase_id]
             phase_cls = self._phase_registry.get(phase_config.type)
-            phase_kwargs: dict[str, Any] = {
-                "phase_id": phase_id,
-                "dependencies": dependencies,
-                "config": phase_config,
-                "services": services,
-            }
-            phase_kwargs.update(
-                phase_cls.extra_init_kwargs(
-                    phase_id=phase_id,
-                    phase_config=phase_config,
-                    agents=config.agents,
-                    agent_clients=self._agent_clients,
-                    services=services,
-                )
+            phase = phase_cls.build(
+                phase_id=phase_id,
+                config=phase_config,
+                deps=deps,
+                resources=self._resources,
+                checkpoint_manager=checkpoint_manager,
+                context=context,
             )
-
-            phase = phase_cls(**phase_kwargs)
-
             self.register_processor(phase, [PhaseTrigger])
 
         self.submit_message(PhaseTrigger(id="start", phase_id=None))

--- a/ddev/src/ddev/ai/phases/orchestrator.py
+++ b/ddev/src/ddev/ai/phases/orchestrator.py
@@ -61,7 +61,7 @@ class ResourceProvider:
 
     def agent_clients(self) -> dict[str, Any]:
         """Raw provider-name -> SDK client map."""
-        return self._agent_clients
+        return dict(self._agent_clients)
 
     def file_registry(self) -> FileRegistry:
         """Lazily-built, run-wide singleton FileRegistry."""

--- a/ddev/src/ddev/ai/phases/orchestrator.py
+++ b/ddev/src/ddev/ai/phases/orchestrator.py
@@ -73,10 +73,8 @@ class ResourceProvider:
         """Resolve a flow agent definition by name; typed error if absent."""
         try:
             return self._agents[name]
-        except KeyError:
-            raise ResourceUnavailableError(
-                f"No agent definition named {name!r}. Known: {sorted(self._agents)}"
-            ) from None
+        except KeyError as e:
+            raise ResourceUnavailableError(f"No agent definition named {name!r}. Known: {sorted(self._agents)}") from e
 
 
 def _discover_and_register_phases(
@@ -150,10 +148,10 @@ class PhaseOrchestrator(EventBusOrchestrator):
             ai_root = Path(__file__).parent.parent
             try:
                 rel = flow_phases_dir.relative_to(ai_root)
-            except ValueError:
+            except ValueError as e:
                 raise FlowConfigError(
                     f"Flow phases directory {flow_phases_dir} must be inside the ddev.ai package tree ({ai_root})"
-                ) from None
+                ) from e
             flow_import_prefix = "ddev.ai." + ".".join(rel.parts)
             _discover_and_register_phases(
                 self._phase_registry,

--- a/ddev/tests/ai/flows/openmetrics/phases/test_inspect_endpoint.py
+++ b/ddev/tests/ai/flows/openmetrics/phases/test_inspect_endpoint.py
@@ -19,11 +19,10 @@ from ddev.ai.flows.openmetrics.phases.inspect_endpoint import (
     _build_memory_text,
     _parse_exposition,
 )
+from ddev.ai.phases.base import FlowContext
 from ddev.ai.phases.checkpoint import CheckpointManager
 from ddev.ai.phases.config import AgentConfig, CheckpointConfig, FlowConfigError, PhaseConfig, TaskConfig
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
-from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
-from ddev.ai.tools.fs.file_registry import FileRegistry
 from ddev.event_bus.exceptions import MessageProcessingError
 
 ENDPOINT_URL = "http://example.test:9100/metrics"
@@ -105,15 +104,17 @@ def _make_phase(
     runtime_variables: dict[str, str] | None = None,
 ) -> tuple[InspectEndpointPhase, CheckpointManager]:
     checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
+    context = FlowContext(
+        runtime_variables=runtime_variables if runtime_variables is not None else {"endpoint_url": ENDPOINT_URL},
+        flow_variables={},
+        config_dir=flow_dir,
+    )
     phase = InspectEndpointPhase(
         phase_id=phase_id,
         dependencies=[],
         config=PhaseConfig(),
         checkpoint_manager=checkpoint_manager,
-        runtime_variables=runtime_variables if runtime_variables is not None else {"endpoint_url": ENDPOINT_URL},
-        flow_variables={},
-        config_dir=flow_dir,
-        file_registry=FileRegistry(policy=FileAccessPolicy(write_root=flow_dir)),
+        context=context,
     )
     phase.queue = message_queue
     return phase, checkpoint_manager

--- a/ddev/tests/ai/phases/conftest.py
+++ b/ddev/tests/ai/phases/conftest.py
@@ -174,6 +174,15 @@ def flow_dir(tmp_path):
 
 
 @pytest.fixture
+def flow_context(flow_dir):
+    return FlowContext(
+        runtime_variables={},
+        flow_variables={},
+        config_dir=flow_dir,
+    )
+
+
+@pytest.fixture
 def message_queue():
     """An asyncio.Queue that can be attached to a Phase for submit_message."""
     return asyncio.Queue()

--- a/ddev/tests/ai/phases/conftest.py
+++ b/ddev/tests/ai/phases/conftest.py
@@ -10,11 +10,10 @@ import pytest
 from ddev.ai.agent.types import AgentResponse, ContextUsage, StopReason, TokenUsage, ToolResultMessage
 from ddev.ai.callbacks.callbacks import Callbacks
 from ddev.ai.phases.agentic_phase import AgenticPhase
-from ddev.ai.phases.base import FlowServices
+from ddev.ai.phases.base import FlowContext
 from ddev.ai.phases.checkpoint import CheckpointManager
 from ddev.ai.phases.config import PhaseConfig, TaskConfig
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
-from ddev.ai.tools.fs.file_registry import FileRegistry
 from ddev.ai.tools.registry import ToolRegistry
 
 # ---------------------------------------------------------------------------
@@ -135,12 +134,10 @@ def make_agent_phase(
         context_compact_threshold_pct=context_compact_threshold_pct,
     )
     checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
-    services = FlowServices(
-        checkpoint_manager=checkpoint_manager,
+    context = FlowContext(
         runtime_variables=runtime_variables or {},
         flow_variables=flow_variables or {},
         config_dir=flow_dir,
-        file_registry=FileRegistry(policy=FileAccessPolicy(write_root=flow_dir)),
         callbacks=callbacks or Callbacks(),
     )
 
@@ -148,7 +145,8 @@ def make_agent_phase(
         phase_id=phase_id,
         dependencies=dependencies or [],
         config=config,
-        services=services,
+        checkpoint_manager=checkpoint_manager,
+        context=context,
         agent_builder=make_agent_builder(mock_agent, captured_agent_kwargs),
         goal_agent_builder=goal_agent_builder,
     )

--- a/ddev/tests/ai/phases/test_agentic_phase.py
+++ b/ddev/tests/ai/phases/test_agentic_phase.py
@@ -370,35 +370,35 @@ async def test_run_memory_step_returns_response_data_and_fires_callbacks(flow_di
     ids=["spawn", "regular_tool", "no_tools"],
 )
 def test_build_creates_subagent_builder_from_tool_metadata(
-    flow_dir: Path,
+    flow_context,
     tools: list[str],
     expected: bool,
 ) -> None:
-    from ddev.ai.phases.base import FlowContext
     from ddev.ai.phases.checkpoint import CheckpointManager
     from ddev.ai.phases.orchestrator import ResourceProvider
 
+    flow_dir = flow_context.config_dir
     provider = ResourceProvider(
         agent_clients={},
         file_access_policy=FileAccessPolicy(write_root=flow_dir),
         agents={"writer": AgentConfig(tools=tools)},
     )
     checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
-    context = FlowContext(runtime_variables={}, flow_variables={}, config_dir=flow_dir)
     phase = AgenticPhase.build(
         phase_id="p1",
         config=PhaseConfig(agent="writer", tasks=[TaskConfig(name="t1", prompt="Do the work.")]),
         deps=[],
         resources=provider,
         checkpoint_manager=checkpoint_manager,
-        context=context,
+        context=flow_context,
     )
 
     assert (phase._subagent_builder is not None) is expected
 
 
-async def test_spawn_subagent_wiring(flow_dir, message_queue):
+async def test_spawn_subagent_wiring(flow_context, message_queue):
     """Phase correctly passes subagent_builder + log_dir to the agent builder at execute time."""
+    flow_dir = flow_context.config_dir
 
     def make_usage() -> TokenUsage:
         return TokenUsage(input_tokens=100, output_tokens=50, cache_read_input_tokens=0, cache_creation_input_tokens=0)
@@ -449,20 +449,13 @@ async def test_spawn_subagent_wiring(flow_dir, message_queue):
             ]
         )
 
-    from ddev.ai.phases.base import FlowContext
-
     checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
-    context = FlowContext(
-        runtime_variables={},
-        flow_variables={},
-        config_dir=flow_dir,
-    )
     phase = AgenticPhase(
         phase_id="p1",
         dependencies=[],
         config=PhaseConfig(agent="writer", tasks=[TaskConfig(name="t1", prompt="Do the work.")]),
         checkpoint_manager=checkpoint_manager,
-        context=context,
+        context=flow_context,
         agent_builder=agent_builder_fn,
         subagent_builder=mock_subagent_builder,
     )
@@ -496,28 +489,27 @@ async def test_spawn_subagent_wiring(flow_dir, message_queue):
     ids=["no_goal", "single_goal", "mixed"],
 )
 def test_build_creates_goal_agent_builder_when_any_task_has_goal(
-    flow_dir,
+    flow_context,
     tasks,
     expect_builder,
 ):
-    from ddev.ai.phases.base import FlowContext
     from ddev.ai.phases.checkpoint import CheckpointManager
     from ddev.ai.phases.orchestrator import ResourceProvider
 
+    flow_dir = flow_context.config_dir
     provider = ResourceProvider(
         agent_clients={},
         file_access_policy=FileAccessPolicy(write_root=flow_dir),
         agents={"writer": AgentConfig()},
     )
     checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
-    context = FlowContext(runtime_variables={}, flow_variables={}, config_dir=flow_dir)
     phase = AgenticPhase.build(
         phase_id="p1",
         config=PhaseConfig(agent="writer", tasks=tasks),
         deps=[],
         resources=provider,
         checkpoint_manager=checkpoint_manager,
-        context=context,
+        context=flow_context,
     )
     assert (phase._goal_agent_builder is not None) is expect_builder
 

--- a/ddev/tests/ai/phases/test_agentic_phase.py
+++ b/ddev/tests/ai/phases/test_agentic_phase.py
@@ -14,7 +14,6 @@ from ddev.ai.phases.checkpoint import CheckpointManager
 from ddev.ai.phases.config import AgentConfig, CheckpointConfig, FlowConfigError, PhaseConfig, TaskConfig
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
-from ddev.ai.tools.fs.file_registry import FileRegistry
 from ddev.ai.tools.registry import ToolRegistry
 
 from .conftest import MockAgent, make_agent_phase, make_response, resolve_key
@@ -370,30 +369,32 @@ async def test_run_memory_step_returns_response_data_and_fires_callbacks(flow_di
     [(["spawn_subagent"], True), (["read_file"], False), ([], False)],
     ids=["spawn", "regular_tool", "no_tools"],
 )
-def test_extra_init_kwargs_creates_subagent_builder_from_tool_metadata(
+def test_build_creates_subagent_builder_from_tool_metadata(
     flow_dir: Path,
     tools: list[str],
     expected: bool,
 ) -> None:
-    from ddev.ai.phases.base import FlowServices
+    from ddev.ai.phases.base import FlowContext
     from ddev.ai.phases.checkpoint import CheckpointManager
+    from ddev.ai.phases.orchestrator import ResourceProvider
 
-    services = FlowServices(
-        checkpoint_manager=CheckpointManager(flow_dir / "checkpoints.yaml"),
-        runtime_variables={},
-        flow_variables={},
-        config_dir=flow_dir,
-        file_registry=FileRegistry(policy=FileAccessPolicy(write_root=flow_dir)),
-    )
-    kwargs = AgenticPhase.extra_init_kwargs(
-        phase_id="p1",
-        phase_config=PhaseConfig(agent="writer", tasks=[TaskConfig(name="t1", prompt="Do the work.")]),
-        agents={"writer": AgentConfig(tools=tools)},
+    provider = ResourceProvider(
         agent_clients={},
-        services=services,
+        file_access_policy=FileAccessPolicy(write_root=flow_dir),
+        agents={"writer": AgentConfig(tools=tools)},
+    )
+    checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
+    context = FlowContext(runtime_variables={}, flow_variables={}, config_dir=flow_dir)
+    phase = AgenticPhase.build(
+        phase_id="p1",
+        config=PhaseConfig(agent="writer", tasks=[TaskConfig(name="t1", prompt="Do the work.")]),
+        deps=[],
+        resources=provider,
+        checkpoint_manager=checkpoint_manager,
+        context=context,
     )
 
-    assert (kwargs["subagent_builder"] is not None) is expected
+    assert (phase._subagent_builder is not None) is expected
 
 
 async def test_spawn_subagent_wiring(flow_dir, message_queue):
@@ -448,21 +449,20 @@ async def test_spawn_subagent_wiring(flow_dir, message_queue):
             ]
         )
 
-    from ddev.ai.phases.base import FlowServices
+    from ddev.ai.phases.base import FlowContext
 
     checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
-    services = FlowServices(
-        checkpoint_manager=checkpoint_manager,
+    context = FlowContext(
         runtime_variables={},
         flow_variables={},
         config_dir=flow_dir,
-        file_registry=FileRegistry(policy=FileAccessPolicy(write_root=flow_dir)),
     )
     phase = AgenticPhase(
         phase_id="p1",
         dependencies=[],
         config=PhaseConfig(agent="writer", tasks=[TaskConfig(name="t1", prompt="Do the work.")]),
-        services=services,
+        checkpoint_manager=checkpoint_manager,
+        context=context,
         agent_builder=agent_builder_fn,
         subagent_builder=mock_subagent_builder,
     )
@@ -495,29 +495,31 @@ async def test_spawn_subagent_wiring(flow_dir, message_queue):
     ],
     ids=["no_goal", "single_goal", "mixed"],
 )
-def test_extra_init_kwargs_creates_goal_agent_builder_when_any_task_has_goal(
+def test_build_creates_goal_agent_builder_when_any_task_has_goal(
     flow_dir,
     tasks,
     expect_builder,
 ):
-    from ddev.ai.phases.base import FlowServices
+    from ddev.ai.phases.base import FlowContext
     from ddev.ai.phases.checkpoint import CheckpointManager
+    from ddev.ai.phases.orchestrator import ResourceProvider
 
-    services = FlowServices(
-        checkpoint_manager=CheckpointManager(flow_dir / "checkpoints.yaml"),
-        runtime_variables={},
-        flow_variables={},
-        config_dir=flow_dir,
-        file_registry=FileRegistry(policy=FileAccessPolicy(write_root=flow_dir)),
-    )
-    kwargs = AgenticPhase.extra_init_kwargs(
-        phase_id="p1",
-        phase_config=PhaseConfig(agent="writer", tasks=tasks),
-        agents={"writer": AgentConfig()},
+    provider = ResourceProvider(
         agent_clients={},
-        services=services,
+        file_access_policy=FileAccessPolicy(write_root=flow_dir),
+        agents={"writer": AgentConfig()},
     )
-    assert (kwargs["goal_agent_builder"] is not None) is expect_builder
+    checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
+    context = FlowContext(runtime_variables={}, flow_variables={}, config_dir=flow_dir)
+    phase = AgenticPhase.build(
+        phase_id="p1",
+        config=PhaseConfig(agent="writer", tasks=tasks),
+        deps=[],
+        resources=provider,
+        checkpoint_manager=checkpoint_manager,
+        context=context,
+    )
+    assert (phase._goal_agent_builder is not None) is expect_builder
 
 
 async def test_phase_with_goal_passes_first_attempt(flow_dir, monkeypatch, message_queue):

--- a/ddev/tests/ai/phases/test_base.py
+++ b/ddev/tests/ai/phases/test_base.py
@@ -51,6 +51,42 @@ def _make_stub_phase(
 
 
 # ---------------------------------------------------------------------------
+# Phase.build
+# ---------------------------------------------------------------------------
+
+
+def test_build_creates_properly_initialized_instance(flow_dir):
+    checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
+    context = FlowContext(
+        runtime_variables={"var1": "val1"},
+        flow_variables={"var2": "val2"},
+        config_dir=flow_dir,
+    )
+    config = PhaseConfig()
+
+    phase = _StubPhase.build(
+        phase_id="p1",
+        config=config,
+        deps=["dep1", "dep2"],
+        resources=object(),
+        checkpoint_manager=checkpoint_manager,
+        context=context,
+    )
+
+    assert isinstance(phase, _StubPhase)
+    assert phase._phase_id == "p1"
+    assert phase._remaining_dependencies == {"dep1", "dep2"}
+    assert phase._config is config
+    assert phase._checkpoint_manager is checkpoint_manager
+    assert phase._runtime_variables == {"var1": "val1"}
+    assert phase._flow_variables == {"var2": "val2"}
+    assert phase._config_dir == flow_dir
+    assert phase._callbacks is context.callbacks
+    assert phase._logger is context.logger
+    assert phase._executed is False
+
+
+# ---------------------------------------------------------------------------
 # Phase.on_success
 # ---------------------------------------------------------------------------
 

--- a/ddev/tests/ai/phases/test_base.py
+++ b/ddev/tests/ai/phases/test_base.py
@@ -6,12 +6,10 @@ from datetime import UTC, datetime
 
 import pytest
 
-from ddev.ai.phases.base import FlowServices, Phase, PhaseOutcome
+from ddev.ai.phases.base import FlowContext, Phase, PhaseOutcome
 from ddev.ai.phases.checkpoint import CheckpointManager
 from ddev.ai.phases.config import PhaseConfig
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
-from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
-from ddev.ai.tools.fs.file_registry import FileRegistry
 from ddev.event_bus.exceptions import HookName, MessageProcessingError, ProcessorHookError
 
 
@@ -35,18 +33,17 @@ def _make_stub_phase(
     outcome=None,
 ):
     checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
-    services = FlowServices(
-        checkpoint_manager=checkpoint_manager,
+    context = FlowContext(
         runtime_variables={},
         flow_variables={},
         config_dir=flow_dir,
-        file_registry=FileRegistry(policy=FileAccessPolicy(write_root=flow_dir)),
     )
     phase = _StubPhase(
         phase_id=phase_id,
         dependencies=dependencies or [],
         config=PhaseConfig(),
-        services=services,
+        checkpoint_manager=checkpoint_manager,
+        context=context,
         outcome=outcome,
     )
     phase.queue = message_queue

--- a/ddev/tests/ai/phases/test_base.py
+++ b/ddev/tests/ai/phases/test_base.py
@@ -25,25 +25,20 @@ class _StubPhase(Phase):
 
 
 def _make_stub_phase(
-    flow_dir,
+    flow_context,
     message_queue,
     *,
     phase_id="p1",
     dependencies=None,
     outcome=None,
 ):
-    checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
-    context = FlowContext(
-        runtime_variables={},
-        flow_variables={},
-        config_dir=flow_dir,
-    )
+    checkpoint_manager = CheckpointManager(flow_context.config_dir / "checkpoints.yaml")
     phase = _StubPhase(
         phase_id=phase_id,
         dependencies=dependencies or [],
         config=PhaseConfig(),
         checkpoint_manager=checkpoint_manager,
-        context=context,
+        context=flow_context,
         outcome=outcome,
     )
     phase.queue = message_queue
@@ -91,8 +86,8 @@ def test_build_creates_properly_initialized_instance(flow_dir):
 # ---------------------------------------------------------------------------
 
 
-async def test_on_success_emits_finished_message(flow_dir, message_queue):
-    phase, _ = _make_stub_phase(flow_dir, message_queue)
+async def test_on_success_emits_finished_message(flow_context, message_queue):
+    phase, _ = _make_stub_phase(flow_context, message_queue)
 
     await phase.on_success(PhaseTrigger(id="start", phase_id=None))
 
@@ -107,8 +102,8 @@ async def test_on_success_emits_finished_message(flow_dir, message_queue):
 # ---------------------------------------------------------------------------
 
 
-async def test_on_error_writes_failed_checkpoint(flow_dir, message_queue):
-    phase, mgr = _make_stub_phase(flow_dir, message_queue)
+async def test_on_error_writes_failed_checkpoint(flow_context, message_queue):
+    phase, mgr = _make_stub_phase(flow_context, message_queue)
 
     wrapped = MessageProcessingError("p1", PhaseTrigger(id="start", phase_id=None), RuntimeError("boom"))
     await phase.on_error(wrapped)
@@ -119,8 +114,8 @@ async def test_on_error_writes_failed_checkpoint(flow_dir, message_queue):
     assert checkpoint["started_at"] is None  # not started yet
 
 
-async def test_on_error_emits_failed_message(flow_dir, message_queue):
-    phase, _ = _make_stub_phase(flow_dir, message_queue)
+async def test_on_error_emits_failed_message(flow_context, message_queue):
+    phase, _ = _make_stub_phase(flow_context, message_queue)
 
     wrapped = ProcessorHookError(
         HookName.ON_SUCCESS, "p1", PhaseTrigger(id="start", phase_id=None), RuntimeError("boom")
@@ -133,8 +128,8 @@ async def test_on_error_emits_failed_message(flow_dir, message_queue):
     assert msg.error == "boom"
 
 
-async def test_on_error_writes_failed_checkpoint_after_start(flow_dir, message_queue):
-    phase, mgr = _make_stub_phase(flow_dir, message_queue)
+async def test_on_error_writes_failed_checkpoint_after_start(flow_context, message_queue):
+    phase, mgr = _make_stub_phase(flow_context, message_queue)
     phase._started_at = datetime.now(UTC)
 
     wrapped = MessageProcessingError("p1", PhaseTrigger(id="start", phase_id=None), RuntimeError("boom"))
@@ -150,8 +145,8 @@ async def test_on_error_writes_failed_checkpoint_after_start(flow_dir, message_q
 # ---------------------------------------------------------------------------
 
 
-def test_should_process_returns_true_for_initial_trigger_on_root_phase(flow_dir, message_queue):
-    phase, _ = _make_stub_phase(flow_dir, message_queue)
+def test_should_process_returns_true_for_initial_trigger_on_root_phase(flow_context, message_queue):
+    phase, _ = _make_stub_phase(flow_context, message_queue)
 
     result = phase.should_process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -159,8 +154,8 @@ def test_should_process_returns_true_for_initial_trigger_on_root_phase(flow_dir,
     assert phase._executed is True
 
 
-def test_should_process_returns_false_for_initial_trigger_on_dependent_phase(flow_dir, message_queue):
-    phase, _ = _make_stub_phase(flow_dir, message_queue, dependencies=["dep1"])
+def test_should_process_returns_false_for_initial_trigger_on_dependent_phase(flow_context, message_queue):
+    phase, _ = _make_stub_phase(flow_context, message_queue, dependencies=["dep1"])
 
     result = phase.should_process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -168,8 +163,8 @@ def test_should_process_returns_false_for_initial_trigger_on_dependent_phase(flo
     assert phase._executed is False
 
 
-def test_should_process_returns_false_for_unrelated_dep(flow_dir, message_queue):
-    phase, _ = _make_stub_phase(flow_dir, message_queue, dependencies=["dep1"])
+def test_should_process_returns_false_for_unrelated_dep(flow_context, message_queue):
+    phase, _ = _make_stub_phase(flow_context, message_queue, dependencies=["dep1"])
 
     result = phase.should_process_message(PhaseTrigger(id="msg1", phase_id="other"))
 
@@ -177,8 +172,8 @@ def test_should_process_returns_false_for_unrelated_dep(flow_dir, message_queue)
     assert phase._executed is False
 
 
-def test_should_process_returns_false_while_deps_pending(flow_dir, message_queue):
-    phase, _ = _make_stub_phase(flow_dir, message_queue, dependencies=["dep1", "dep2"])
+def test_should_process_returns_false_while_deps_pending(flow_context, message_queue):
+    phase, _ = _make_stub_phase(flow_context, message_queue, dependencies=["dep1", "dep2"])
 
     result = phase.should_process_message(PhaseTrigger(id="msg1", phase_id="dep1"))
 
@@ -187,8 +182,8 @@ def test_should_process_returns_false_while_deps_pending(flow_dir, message_queue
     assert phase._executed is False
 
 
-def test_should_process_returns_true_when_last_dep_arrives(flow_dir, message_queue):
-    phase, _ = _make_stub_phase(flow_dir, message_queue, dependencies=["dep1", "dep2"])
+def test_should_process_returns_true_when_last_dep_arrives(flow_context, message_queue):
+    phase, _ = _make_stub_phase(flow_context, message_queue, dependencies=["dep1", "dep2"])
 
     phase.should_process_message(PhaseTrigger(id="msg1", phase_id="dep1"))
     result = phase.should_process_message(PhaseTrigger(id="msg2", phase_id="dep2"))
@@ -197,8 +192,8 @@ def test_should_process_returns_true_when_last_dep_arrives(flow_dir, message_que
     assert phase._executed is True
 
 
-def test_should_process_returns_false_after_already_executed(flow_dir, message_queue):
-    phase, _ = _make_stub_phase(flow_dir, message_queue)
+def test_should_process_returns_false_after_already_executed(flow_context, message_queue):
+    phase, _ = _make_stub_phase(flow_context, message_queue)
 
     phase.should_process_message(PhaseTrigger(id="start", phase_id=None))
     result = phase.should_process_message(PhaseTrigger(id="start2", phase_id=None))
@@ -211,7 +206,7 @@ def test_should_process_returns_false_after_already_executed(flow_dir, message_q
 # ---------------------------------------------------------------------------
 
 
-async def test_process_message_writes_memory_and_checkpoint(flow_dir, message_queue):
+async def test_process_message_writes_memory_and_checkpoint(flow_context, message_queue):
     """End-to-end Phase contract: memory_text is persisted, extra_checkpoint merges,
     token totals land in the checkpoint, and the success metadata is recorded.
     """
@@ -221,7 +216,7 @@ async def test_process_message_writes_memory_and_checkpoint(flow_dir, message_qu
         total_output_tokens=45,
         extra_checkpoint={"custom_field": "custom_value", "count": 7},
     )
-    phase, mgr = _make_stub_phase(flow_dir, message_queue, outcome=outcome)
+    phase, mgr = _make_stub_phase(flow_context, message_queue, outcome=outcome)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -241,9 +236,9 @@ async def test_process_message_writes_memory_and_checkpoint(flow_dir, message_qu
     "reserved_key",
     ["status", "started_at", "finished_at", "tokens", "memory_path"],
 )
-async def test_extra_checkpoint_cannot_override_reserved_keys(flow_dir, message_queue, reserved_key):
+async def test_extra_checkpoint_cannot_override_reserved_keys(flow_context, message_queue, reserved_key):
     outcome = PhaseOutcome(memory_text="m", extra_checkpoint={reserved_key: "evil"})
-    phase, mgr = _make_stub_phase(flow_dir, message_queue, outcome=outcome)
+    phase, mgr = _make_stub_phase(flow_context, message_queue, outcome=outcome)
 
     with pytest.raises(ValueError, match=f"reserved keys.*{reserved_key}"):
         await phase.process_message(PhaseTrigger(id="start", phase_id=None))
@@ -252,8 +247,8 @@ async def test_extra_checkpoint_cannot_override_reserved_keys(flow_dir, message_
     assert not mgr.memory_path("p1").exists()
 
 
-async def test_failed_phase_omits_memory_path(flow_dir, message_queue):
-    phase, mgr = _make_stub_phase(flow_dir, message_queue)
+async def test_failed_phase_omits_memory_path(flow_context, message_queue):
+    phase, mgr = _make_stub_phase(flow_context, message_queue)
 
     wrapped = MessageProcessingError("p1", PhaseTrigger(id="start", phase_id=None), RuntimeError("boom"))
     await phase.on_error(wrapped)

--- a/ddev/tests/ai/phases/test_orchestrator.py
+++ b/ddev/tests/ai/phases/test_orchestrator.py
@@ -11,10 +11,10 @@ from unittest.mock import MagicMock
 import pytest
 
 from ddev.ai.phases.agentic_phase import AgenticPhase
-from ddev.ai.phases.base import Phase, PhaseRegistry
+from ddev.ai.phases.base import Phase
 from ddev.ai.phases.config import FlowConfigError
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
-from ddev.ai.phases.orchestrator import PhaseOrchestrator, _discover_and_register_phases
+from ddev.ai.phases.orchestrator import PhaseOrchestrator, PhaseRegistry, _discover_and_register_phases
 from ddev.event_bus.exceptions import FatalProcessingError
 
 
@@ -236,8 +236,8 @@ async def test_on_initialize_wires_dependencies(minimal_flow, make_orchestrator)
 
     processors = orchestrator._subscribers.get(PhaseTrigger, [])
     phases_by_name = {p.name: p for p in processors}
-    assert phases_by_name["a"]._dependencies == set()
-    assert phases_by_name["b"]._dependencies == {"a"}
+    assert phases_by_name["a"]._remaining_dependencies == set()
+    assert phases_by_name["b"]._remaining_dependencies == {"a"}
 
 
 async def test_on_initialize_submits_initial_phase_trigger(minimal_flow, make_orchestrator):
@@ -324,9 +324,9 @@ async def test_on_initialize_missing_agent_raises(tmp_path, make_orchestrator):
 async def test_on_initialize_phases_share_file_registry(minimal_flow, make_orchestrator):
     orchestrator = make_orchestrator(minimal_flow)
     await orchestrator.on_initialize()
-    phases = orchestrator._subscribers.get(PhaseTrigger, [])
-    assert len(phases) >= 2
-    assert all(p._file_registry is phases[0]._file_registry for p in phases[1:])
+    # The ResourceProvider is the run-wide singleton — file_registry() is idempotent
+    assert orchestrator._resources is not None
+    assert orchestrator._resources.file_registry() is orchestrator._resources.file_registry()
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/ai/phases/test_orchestrator.py
+++ b/ddev/tests/ai/phases/test_orchestrator.py
@@ -14,7 +14,13 @@ from ddev.ai.phases.agentic_phase import AgenticPhase
 from ddev.ai.phases.base import Phase
 from ddev.ai.phases.config import FlowConfigError
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
-from ddev.ai.phases.orchestrator import PhaseOrchestrator, PhaseRegistry, _discover_and_register_phases
+from ddev.ai.phases.orchestrator import (
+    PhaseOrchestrator,
+    PhaseRegistry,
+    ResourceProvider,
+    ResourceUnavailableError,
+    _discover_and_register_phases,
+)
 from ddev.event_bus.exceptions import FatalProcessingError
 
 
@@ -321,12 +327,21 @@ async def test_on_initialize_missing_agent_raises(tmp_path, make_orchestrator):
         await orchestrator.on_initialize()
 
 
-async def test_on_initialize_phases_share_file_registry(minimal_flow, make_orchestrator):
+async def test_file_registry_getter_is_idempotent(minimal_flow, make_orchestrator):
     orchestrator = make_orchestrator(minimal_flow)
     await orchestrator.on_initialize()
-    # The ResourceProvider is the run-wide singleton — file_registry() is idempotent
     assert orchestrator._resources is not None
     assert orchestrator._resources.file_registry() is orchestrator._resources.file_registry()
+
+
+def test_resource_provider_agent_config_unknown_name_raises(file_access_policy):
+    provider = ResourceProvider(
+        agent_clients={},
+        file_access_policy=file_access_policy,
+        agents={"a": MagicMock(), "b": MagicMock()},
+    )
+    with pytest.raises(ResourceUnavailableError, match="No agent definition named 'missing'"):
+        provider.agent_config("missing")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### What does this PR do?

Replaces the untyped `extra_init_kwargs` dict-merge construction path with a typed, polymorphic `Phase.build()` factory fed by a `ResourceProvider`. Every phase is now constructed through one uniform call — `phase_cls.build(phase_id, config, deps, resources, checkpoint_manager, context)` — with no dict splat, no `type: ignore[override]`, and no orchestrator knowledge of how each phase assembles its agent or tools.

Concretely:
- **`Phase.build()`** — new polymorphic classmethod factory on the base class; `AgenticPhase` overrides it to source agent/tool builders from the provider
- **`ResourceProvider`** — new class in `orchestrator.py` that serves raw infrastructure (agent clients, file registry singleton, agent configs) to phases during construction; typed `ResourceUnavailableError` on unknown names
- **`FlowContext`** — replaces `FlowServices`; holds only the ambient, non-resource half (variables, `config_dir`, callbacks, logger); `checkpoint_manager` and `file_registry` are no longer bundled here
- **`PhaseRegistry`** — moved from `base.py` to `orchestrator.py` where it is exclusively used
- **`extra_init_kwargs`** and its `type: ignore[override]` suppression are removed entirely

This is a construction-seam refactor only. Flow YAML schema, phase runtime behavior, and generated-integration output are unchanged.

### Motivation

Tracked in [AI-6918](https://datadoghq.atlassian.net/browse/AI-6918).

The old `extra_init_kwargs` hook was a dict bag that required the orchestrator to merge kwargs it did not understand, forced subclasses to re-declare and re-validate inputs the base class had already validated, and needed a `type: ignore[override]` to suppress a legitimate Mypy violation. Any new phase that needed extra resources had to either fit into the existing bag or widen the bag further.

`Phase.build()` gives each phase class full ownership of its construction: it decides what it needs from the provider, assembles the right builders, and returns a fully-initialized instance. The orchestrator loop stays uniform and type-clean regardless of how complex a phase's construction is.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

[AI-6918]: https://datadoghq.atlassian.net/browse/AI-6918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ