### PR TITLE
Make CI action bumps easier to validate

### DIFF
--- a/.github/workflows/flaky-tests.yml
+++ b/.github/workflows/flaky-tests.yml
@@ -1,6 +1,9 @@
 name: Daily Flaky Tests (every 8 hours)
 
 on:
+  pull_request:
+    paths:
+    - .github/workflows/test-results-master.yml
   workflow_dispatch:
     inputs:
       dry_run:
@@ -53,5 +56,5 @@ jobs:
 
     uses: ./.github/workflows/test-results-master.yml
     with:
-      dry_run: ${{ inputs.dry_run || false }}
+      dry_run: ${{ github.event_name == 'pull_request' || inputs.dry_run || false }}
     secrets: inherit

--- a/.github/workflows/flaky-tests.yml
+++ b/.github/workflows/flaky-tests.yml
@@ -2,6 +2,12 @@ name: Daily Flaky Tests (every 8 hours)
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Skip committing the test-results badge; used to validate action bumps without moving the public badge."
+        required: false
+        default: false
+        type: boolean
   schedule:
   # 4 AM, 12 PM, 8 PM UTC
   - cron: "0 4,12,20 * * *"
@@ -46,4 +52,6 @@ jobs:
       pull-requests: write # Needed for test-results-master
 
     uses: ./.github/workflows/test-results-master.yml
+    with:
+      dry_run: ${{ inputs.dry_run || false }}
     secrets: inherit

--- a/.github/workflows/flaky-tests.yml
+++ b/.github/workflows/flaky-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "Skip committing the test-results badge; used to validate action bumps without moving the public badge."
+        description: "Skip committing the test-results badge."
         required: false
         default: false
         type: boolean

--- a/.github/workflows/release-hash-check.yml
+++ b/.github/workflows/release-hash-check.yml
@@ -7,6 +7,8 @@ on:
       - '7.[0-9]+.x'
     paths:
       - .in-toto/*.link
+      # Also run when this workflow changes so action bumps are exercised on the PR that introduces them.
+      - .github/workflows/release-hash-check.yml
 
 jobs:
   build:
@@ -29,4 +31,7 @@ jobs:
       with:
         files: .in-toto/*.link
 
-    - run: python .github/workflows/release-hash-check.py ${{ steps.changed-files.outputs.all_changed_files }}
+    # Only validate hashes when a link file actually changed; on a workflow-only change the
+    # step above still exercises the action, but there is nothing to hash-check.
+    - if: steps.changed-files.outputs.any_changed == 'true'
+      run: python .github/workflows/release-hash-check.py ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/release-hash-check.yml
+++ b/.github/workflows/release-hash-check.yml
@@ -7,7 +7,6 @@ on:
       - '7.[0-9]+.x'
     paths:
       - .in-toto/*.link
-      # Also run when this workflow changes so action bumps are exercised on the PR that introduces them.
       - .github/workflows/release-hash-check.yml
 
 jobs:
@@ -31,7 +30,5 @@ jobs:
       with:
         files: .in-toto/*.link
 
-    # Only validate hashes when a link file actually changed; on a workflow-only change the
-    # step above still exercises the action, but there is nothing to hash-check.
     - if: steps.changed-files.outputs.any_changed == 'true'
       run: python .github/workflows/release-hash-check.py ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/test-results-master.yml
+++ b/.github/workflows/test-results-master.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       dry_run:
-        description: "Run the badge step but skip committing to the badges branch; used to validate action bumps without moving the public badge."
+        description: "Run the badge step but skip committing to the badges branch."
         required: false
         default: false
         type: boolean

--- a/.github/workflows/test-results-master.yml
+++ b/.github/workflows/test-results-master.yml
@@ -2,6 +2,12 @@ name: Test results for the master branch
 
 on:
   workflow_call:
+    inputs:
+      dry_run:
+        description: "Run the badge step but skip committing to the badges branch; used to validate action bumps without moving the public badge."
+        required: false
+        default: false
+        type: boolean
 
 defaults:
   run:
@@ -66,6 +72,7 @@ jobs:
         git config --local user.email "github-actions[bot]@users.noreply.github.com"
 
     - name: Commit if stats have changed
+      if: ${{ !inputs.dry_run }}
       run: |-
         git add "${{ env.BADGE_PATH }}"
         if git commit -m "Update test results from ${{ github.sha }}"; then


### PR DESCRIPTION
### What does this PR do?

Makes two CI workflows able to exercise their actions on demand, so version bumps (e.g. Renovate updates) can be validated without risky side effects:

- **`release-hash-check.yml`**: adds the workflow file to the `pull_request` `paths` filter and guards the hash-check script on `steps.changed-files.outputs.any_changed == 'true'`. The `tj-actions/changed-files` step now runs on PRs that edit the workflow (validating action bumps), while the script step is skipped when no `.in-toto/*.link` file changed so the check stays green.
- **`test-results-master.yml`** / **`flaky-tests.yml`**: adds a `dry_run` input to the reusable `test-results-master.yml` that runs the badge step but skips the commit/push to the `badges` branch, and exposes it as a `workflow_dispatch` input on `flaky-tests.yml`. This lets `emibcn/badge-action` bumps be validated by dispatching `flaky-tests` with `dry_run: true`, without moving the public test-results badge.

### Motivation

Several actions used in this repo never run on normal PRs because their workflows are triggered by push-to-master, tags, schedules, or `workflow_call`. As a result, Renovate action bumps to those workflows merge without ever being exercised in CI. These two changes give `tj-actions/changed-files` and `emibcn/badge-action` a safe validation path. Existing callers of `test-results-master.yml` (`master.yml`, `master-windows.yml`) pass no `dry_run`, so they default to `false` and continue committing the badge as before.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add \`qa/required\` if this PR needs QA validation, or \`qa/skip-qa\` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the \`backport/<branch-name>\` label to the PR and it will automatically open a backport PR once this one is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)