### PR TITLE
fix(datadog_checks_base): support AWS China endpoints in rds_parse_tags_from_endpoint

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/aws.py
+++ b/datadog_checks_base/datadog_checks/base/utils/aws.py
@@ -34,10 +34,14 @@ def rds_parse_tags_from_endpoint(endpoint):
     parts = endpoint.split('.', 3)
     if len(parts) != 4:
         return tags
-    if parts[3] != 'rds.amazonaws.com':
+    if parts[3] == 'rds.amazonaws.com':
+        identifier, cluster, region, _ = parts
+    elif parts[3].endswith('.amazonaws.com.cn'):
+        # AWS China: structure is {id}.{cluster-hash}.rds.{region}.amazonaws.com.cn
+        identifier, cluster, _, rest = parts
+        region = rest.split('.')[0]
+    else:
         return tags
-
-    identifier, cluster, region, _ = parts
     if cluster.startswith('cluster-'):
         tags.append('dbclusteridentifier:' + identifier)
     else:

--- a/datadog_checks_base/tests/base/utils/test_aws.py
+++ b/datadog_checks_base/tests/base/utils/test_aws.py
@@ -40,6 +40,19 @@ class TestRDS:
                 'dd-metrics.cluster-cfxdfe8cpixl.ap-east-1.rds.amazonaws.com',
                 ['dbclusteridentifier:dd-metrics', 'region:ap-east-1'],
             ),
+            (
+                'my_db.c7yk0gqwsqfl.rds.cn-northwest-1.amazonaws.com.cn',
+                [
+                    'dbinstanceidentifier:my_db',
+                    'hostname:my_db.c7yk0gqwsqfl.rds.cn-northwest-1.amazonaws.com.cn',
+                    'host:my_db.c7yk0gqwsqfl.rds.cn-northwest-1.amazonaws.com.cn',
+                    'region:cn-northwest-1',
+                ],
+            ),
+            (
+                'my_cluster.cluster-c7yk0gqwsqfl.rds.cn-northwest-1.amazonaws.com.cn',
+                ['dbclusteridentifier:my_cluster', 'region:cn-northwest-1'],
+            ),
         ],
     )
     def test_parse_tags_from_endpoint(self, test_case, expected):


### PR DESCRIPTION
## Motivation

`rds_parse_tags_from_endpoint()` hard-checks `parts[3] != 'rds.amazonaws.com'` and returns early with an empty tag list for any endpoint that doesn't match exactly. AWS China region endpoints use the `.amazonaws.com.cn` suffix:

```
my_db.c7yk0gqwsqfl.rds.cn-northwest-1.amazonaws.com.cn
                                       ^^^^^^^^^^^^^^^^^
                                       parts[3] — does not match
```

As a result, zero RDS tags (`dbclusteridentifier`, `dbinstanceidentifier`, `region`) are auto-populated for any China-region RDS or Aurora instance. For Aurora DBM customers in China, this means the `dbclusteridentifier` tag is never added to DBM payloads, so the backend cannot join query activity data with the RDS cluster resource — the cluster view shows "no query activity" even though writer-level data is present.

Reported in SDBM-2645.

## Specification

Add a second branch for the `.cn` partition endpoint structure. In China endpoints, the parts after `split('.', 3)` place the region in `parts[3]` (as `{region}.amazonaws.com.cn`) rather than `parts[2]`. The `cluster`/`identifier` parts at positions 0 and 1 follow the same pattern as standard AWS.

Before:
- `my_db.c7yk0gqwsqfl.rds.cn-northwest-1.amazonaws.com.cn` → `[]`
- `my_cluster.cluster-c7yk0gqwsqfl.rds.cn-northwest-1.amazonaws.com.cn` → `[]`

After:
- `my_db.c7yk0gqwsqfl.rds.cn-northwest-1.amazonaws.com.cn` → `['dbinstanceidentifier:my_db', 'hostname:...', 'host:...', 'region:cn-northwest-1']`
- `my_cluster.cluster-c7yk0gqwsqfl.rds.cn-northwest-1.amazonaws.com.cn` → `['dbclusteridentifier:my_cluster', 'region:cn-northwest-1']`

All existing tests continue to pass.

## Risk

Low. The change only adds a new `elif` branch for endpoints ending in `.amazonaws.com.cn`. The existing `rds.amazonaws.com` path is unchanged. Non-RDS endpoints still return `[]`.

## Testing

All 10 parametrized test cases pass (8 existing + 2 new China cases). Tests run inline against the modified `aws.py` file since the full `datadog_checks.dev` environment is not available locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)