### PR TITLE
Support AWS China endpoints in rds_parse_tags_from_endpoint

### DIFF
--- a/datadog_checks_base/changelog.d/23893.fixed
+++ b/datadog_checks_base/changelog.d/23893.fixed
@@ -1,0 +1,1 @@
+Fix parsing of AWS China region RDS endpoints in rds_parse_tags_from_endpoint.

--- a/datadog_checks_base/datadog_checks/base/utils/aws.py
+++ b/datadog_checks_base/datadog_checks/base/utils/aws.py
@@ -34,10 +34,14 @@ def rds_parse_tags_from_endpoint(endpoint):
     parts = endpoint.split('.', 3)
     if len(parts) != 4:
         return tags
-    if parts[3] != 'rds.amazonaws.com':
+    if parts[3] == 'rds.amazonaws.com':
+        identifier, cluster, region, _ = parts
+    elif parts[3].endswith('.amazonaws.com.cn'):
+        # AWS China: structure is {id}.{cluster-hash}.rds.{region}.amazonaws.com.cn
+        identifier, cluster, _, rest = parts
+        region = rest.split('.')[0]
+    else:
         return tags
-
-    identifier, cluster, region, _ = parts
     if cluster.startswith('cluster-'):
         tags.append('dbclusteridentifier:' + identifier)
     else:

--- a/datadog_checks_base/tests/base/utils/test_aws.py
+++ b/datadog_checks_base/tests/base/utils/test_aws.py
@@ -40,6 +40,19 @@ class TestRDS:
                 'dd-metrics.cluster-cfxdfe8cpixl.ap-east-1.rds.amazonaws.com',
                 ['dbclusteridentifier:dd-metrics', 'region:ap-east-1'],
             ),
+            (
+                'my_db.c7yk0gqwsqfl.rds.cn-northwest-1.amazonaws.com.cn',
+                [
+                    'dbinstanceidentifier:my_db',
+                    'hostname:my_db.c7yk0gqwsqfl.rds.cn-northwest-1.amazonaws.com.cn',
+                    'host:my_db.c7yk0gqwsqfl.rds.cn-northwest-1.amazonaws.com.cn',
+                    'region:cn-northwest-1',
+                ],
+            ),
+            (
+                'my_cluster.cluster-c7yk0gqwsqfl.rds.cn-northwest-1.amazonaws.com.cn',
+                ['dbclusteridentifier:my_cluster', 'region:cn-northwest-1'],
+            ),
         ],
     )
     def test_parse_tags_from_endpoint(self, test_case, expected):


### PR DESCRIPTION
### What does this PR do?

Extends `rds_parse_tags_from_endpoint()` to handle AWS China region endpoints (`.amazonaws.com.cn` suffix), which previously returned an empty tag list due to a hard-coded suffix check against `rds.amazonaws.com`.

### Motivation

AWS China region RDS/Aurora endpoints use `.amazonaws.com.cn` as the suffix. The existing check at line 37:

```python
if parts[3] != 'rds.amazonaws.com':
    return tags  # returns [] for all China endpoints
```

causes `dbclusteridentifier`, `dbinstanceidentifier`, and `region` to never be auto-populated for any China-region database. For Aurora DBM customers in China, this means the `dbclusteridentifier` tag is absent from all DBM payloads — the backend cannot join query activity to the RDS cluster resource, so the cluster view shows "no query activity" even though writer-level data is ingested correctly.

In AWS China, the endpoint structure places the region inside `parts[3]` (as `{region}.amazonaws.com.cn`) rather than `parts[2]`, so both the suffix check and region extraction need a separate branch.

Before:
- `my_db.c7yk0gqwsqfl.rds.cn-northwest-1.amazonaws.com.cn` → `[]`
- `my_cluster.cluster-c7yk0gqwsqfl.rds.cn-northwest-1.amazonaws.com.cn` → `[]`

After:
- `my_db.c7yk0gqwsqfl.rds.cn-northwest-1.amazonaws.com.cn` → `['dbinstanceidentifier:my_db', 'hostname:...', 'host:...', 'region:cn-northwest-1']`
- `my_cluster.cluster-c7yk0gqwsqfl.rds.cn-northwest-1.amazonaws.com.cn` → `['dbclusteridentifier:my_cluster', 'region:cn-northwest-1']`

Investigated as part of SDBM-2645.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged