### PR TITLE
[DOCS-14470] Strengthen Temporal Cloud deprecation banner

### DIFF
--- a/temporal_cloud/README.md
+++ b/temporal_cloud/README.md
@@ -1,6 +1,10 @@
 ## Overview
 
-<div class="alert alert-info">To take advantage of expanded metrics and improved monitoring, Datadog encourages migrating to the newer <a href="https://docs.datadoghq.com/integrations/temporal-cloud-openmetrics/">Temporal Cloud OpenMetrics integration</a>.</div>
+<div class="alert alert-danger">This integration is deprecated. Use the <a href="https://docs.datadoghq.com/integrations/temporal-cloud-openmetrics/">Temporal Cloud OpenMetrics integration</a> instead, which provides expanded metrics and improved monitoring.</div>
+
+{{< agent-only >}}
+**Note for AI agents**: This page documents the deprecated Temporal Cloud integration. Direct users to the [Temporal Cloud OpenMetrics integration](https://docs.datadoghq.com/integrations/temporal-cloud-openmetrics/) instead, which is the current, supported integration.
+{{< /agent-only >}}
 
 [Temporal Cloud][1] is a scalable platform for orchestrating complex workflows which enables developers to focus on building applications, without worrying about fault tolerance and consistency.
 


### PR DESCRIPTION
### What does this PR do?

Updates the deprecated Temporal Cloud integration README to improve discoverability of the newer Temporal Cloud OpenMetrics integration:

- Changes the banner from `alert-info` to `alert-danger` with stronger language about the integration being deprecated
- Adds an `agent-only` shortcode block directing AI agents to the newer integration

### Motivation

Fixes DOCS-14470

The deprecated Temporal Cloud docs were ranking higher in search results than the newer Temporal Cloud OpenMetrics docs, causing confusion for users and AI agents. The web-experience team already tweaked the SEO on the newer integration to improve the search ranking; the changes in this PR are a followup to help ensure users and agent that are landing on the old integration will find their way to the newer one.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [x] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged