### PR TITLE
kafka_consumer: add broker list to cluster monitoring heartbeat

### DIFF
--- a/kafka_consumer/changelog.d/23898.added
+++ b/kafka_consumer/changelog.d/23898.added
@@ -1,0 +1,1 @@
+Add broker list to the cluster monitoring heartbeat payload.

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -132,6 +132,12 @@ class KafkaCheck(AgentCheck):
         return sum(len(offsets) for offsets in consumer_offsets.values())
 
     def _send_cluster_monitoring_heartbeat(self, total_contexts: int, cluster_id: str) -> None:
+        brokers = []
+        cluster_metadata = self.client._cluster_metadata
+        if cluster_metadata and hasattr(cluster_metadata, 'brokers'):
+            for broker_id, broker_meta in cluster_metadata.brokers.items():
+                brokers.append({'id': broker_id, 'host': broker_meta.host, 'port': broker_meta.port})
+
         payload = {
             'collection_timestamp': int(time() * 1000),
             'kafka_cluster_id': cluster_id,
@@ -139,6 +145,7 @@ class KafkaCheck(AgentCheck):
             'contexts': total_contexts,
             'contexts_limit': self._context_limit,
             'bootstrap_servers': self.config._kafka_connect_str,
+            'brokers': brokers,
         }
         if self.config._kafka_cluster_id_override:
             payload['original_kafka_cluster_id'] = self.config._auto_detected_cluster_id

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -131,13 +131,16 @@ class KafkaCheck(AgentCheck):
     def count_consumer_contexts(self, consumer_offsets):
         return sum(len(offsets) for offsets in consumer_offsets.values())
 
-    def _send_cluster_monitoring_heartbeat(self, total_contexts: int, cluster_id: str) -> None:
-        brokers = []
+    def _get_broker_list(self) -> list[dict]:
         cluster_metadata = self.client._cluster_metadata
-        if cluster_metadata and hasattr(cluster_metadata, 'brokers'):
-            for broker_id, broker_meta in cluster_metadata.brokers.items():
-                brokers.append({'id': broker_id, 'host': broker_meta.host, 'port': broker_meta.port})
+        if not (cluster_metadata and hasattr(cluster_metadata, 'brokers')):
+            return []
+        return [
+            {'id': str(broker_meta.id), 'host': broker_meta.host, 'port': broker_meta.port}
+            for broker_meta in cluster_metadata.brokers.values()
+        ]
 
+    def _send_cluster_monitoring_heartbeat(self, total_contexts: int, cluster_id: str) -> None:
         payload = {
             'collection_timestamp': int(time() * 1000),
             'kafka_cluster_id': cluster_id,
@@ -145,7 +148,7 @@ class KafkaCheck(AgentCheck):
             'contexts': total_contexts,
             'contexts_limit': self._context_limit,
             'bootstrap_servers': self.config._kafka_connect_str,
-            'brokers': brokers,
+            'brokers': self._get_broker_list(),
         }
         if self.config._kafka_cluster_id_override:
             payload['original_kafka_cluster_id'] = self.config._auto_detected_cluster_id

--- a/kafka_consumer/tests/test_cluster_metadata.py
+++ b/kafka_consumer/tests/test_cluster_metadata.py
@@ -146,6 +146,7 @@ def seed_mock_kafka_client(cluster_id='test-cluster-id'):
 
     # Set kafka_client as an attribute (not a property mock)
     client.kafka_client = mock_admin_client
+    client._cluster_metadata = metadata
     client.get_topic_partitions.return_value = {'test-topic': [0, 1]}
 
     def mock_offsets_for_times(partitions, offset=-1):
@@ -1426,7 +1427,6 @@ def test_heartbeat_brokers_populated(check):
     instance = {'kafka_connect_str': 'localhost:9092', 'enable_cluster_monitoring': True}
     kafka_consumer_check = check(instance)
     mock_kafka_client = seed_mock_kafka_client()
-    mock_kafka_client._cluster_metadata = mock_kafka_client.kafka_client.list_topics.return_value
     kafka_consumer_check.client = mock_kafka_client
     kafka_consumer_check.event_platform_event = mock.Mock()
 

--- a/kafka_consumer/tests/test_cluster_metadata.py
+++ b/kafka_consumer/tests/test_cluster_metadata.py
@@ -1419,3 +1419,42 @@ def test_partition_out_of_sync_broker_id_tag(
         'kafka.partition.offline',
     ):
         aggregator.assert_metric(metric, tags=expected_tags)
+
+
+def test_heartbeat_brokers_populated(check):
+    """Heartbeat payload includes the broker list when metadata is available."""
+    instance = {'kafka_connect_str': 'localhost:9092', 'enable_cluster_monitoring': True}
+    kafka_consumer_check = check(instance)
+    mock_kafka_client = seed_mock_kafka_client()
+    mock_kafka_client._cluster_metadata = mock_kafka_client.kafka_client.list_topics.return_value
+    kafka_consumer_check.client = mock_kafka_client
+    kafka_consumer_check.event_platform_event = mock.Mock()
+
+    kafka_consumer_check._send_cluster_monitoring_heartbeat(total_contexts=5, cluster_id='test-cluster-id')
+
+    calls = kafka_consumer_check.event_platform_event.call_args_list
+    hb_events = [json.loads(c[0][0]) for c in calls if c[0][1] == 'data-streams-message']
+    hb_events = [e for e in hb_events if e.get('config_type') == 'heartbeat']
+    assert len(hb_events) == 1
+    assert hb_events[0]['brokers'] == [
+        {'id': '1', 'host': 'broker1', 'port': 9092},
+        {'id': '2', 'host': 'broker2', 'port': 9092},
+    ]
+
+
+def test_heartbeat_brokers_empty_when_no_metadata(check):
+    """Heartbeat payload has an empty broker list when _cluster_metadata is None."""
+    instance = {'kafka_connect_str': 'localhost:9092', 'enable_cluster_monitoring': True}
+    kafka_consumer_check = check(instance)
+    mock_kafka_client = seed_mock_kafka_client()
+    mock_kafka_client._cluster_metadata = None
+    kafka_consumer_check.client = mock_kafka_client
+    kafka_consumer_check.event_platform_event = mock.Mock()
+
+    kafka_consumer_check._send_cluster_monitoring_heartbeat(total_contexts=0, cluster_id='test-cluster-id')
+
+    calls = kafka_consumer_check.event_platform_event.call_args_list
+    hb_events = [json.loads(c[0][0]) for c in calls if c[0][1] == 'data-streams-message']
+    hb_events = [e for e in hb_events if e.get('config_type') == 'heartbeat']
+    assert len(hb_events) == 1
+    assert hb_events[0]['brokers'] == []


### PR DESCRIPTION
### What does this PR do?

Adds the list of brokers in the Kafka cluster to the cluster monitoring heartbeat payload. Each broker entry includes its `id`, `host`, and `port`.

### Motivation

The heartbeat already includes `bootstrap_servers` (the configured entry points), but not the full set of brokers discovered in the cluster. Including the broker list gives consumers of the heartbeat a complete picture of cluster topology at the time of each check run.

No additional Kafka requests are needed — `request_metadata_update()` is already called at the start of every check run and caches `ClusterMetadata` (including `.brokers`) in `self.client._cluster_metadata`. The heartbeat method reads from that cached object.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged