### PR TITLE
kafka_consumer: emit connection_error event when Kafka is unreachable

### DIFF
--- a/kafka_consumer/changelog.d/23902.added
+++ b/kafka_consumer/changelog.d/23902.added
@@ -1,0 +1,1 @@
+Emit connection_error DSM event when the integration cannot connect to Kafka.

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -151,11 +151,13 @@ class KafkaCheck(AgentCheck):
         self.event_platform_event(json.dumps(payload), "data-streams-message")
 
     def _send_cluster_monitoring_connection_error(self, reason: str) -> None:
-        self._emit_cluster_monitoring_event({
-            'kafka_cluster_id': self.config._kafka_cluster_id_override or '',
-            'config_type': 'connection_error',
-            'reason': reason,
-        })
+        self._emit_cluster_monitoring_event(
+            {
+                'kafka_cluster_id': self.config._kafka_cluster_id_override or '',
+                'config_type': 'connection_error',
+                'reason': reason,
+            }
+        )
 
     def _send_cluster_monitoring_heartbeat(self, total_contexts: int, cluster_id: str) -> None:
         payload = {

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -42,10 +42,12 @@ class KafkaCheck(AgentCheck):
 
         try:
             self.client.request_metadata_update()
-        except:
+        except Exception as e:
+            if self.config._cluster_monitoring_enabled:
+                self._send_cluster_monitoring_connection_error(str(e))
             raise Exception(
                 "Unable to connect to the AdminClient. This is likely due to an error in the configuration."
-            )
+            ) from e
 
         try:
             # Fetch consumer offsets
@@ -139,6 +141,16 @@ class KafkaCheck(AgentCheck):
             {'id': str(broker_meta.id), 'host': broker_meta.host, 'port': broker_meta.port}
             for broker_meta in cluster_metadata.brokers.values()
         ]
+
+    def _send_cluster_monitoring_connection_error(self, reason: str) -> None:
+        payload = {
+            'collection_timestamp': int(time() * 1000),
+            'kafka_cluster_id': self.config._kafka_cluster_id_override or '',
+            'config_type': 'connection_error',
+            'bootstrap_servers': self.config._kafka_connect_str,
+            'reason': reason,
+        }
+        self.event_platform_event(json.dumps(payload), "data-streams-message")
 
     def _send_cluster_monitoring_heartbeat(self, total_contexts: int, cluster_id: str) -> None:
         payload = {

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -44,7 +44,10 @@ class KafkaCheck(AgentCheck):
             self.client.request_metadata_update()
         except Exception as e:
             if self.config._cluster_monitoring_enabled:
-                self._send_cluster_monitoring_connection_error(str(e))
+                try:
+                    self._send_cluster_monitoring_connection_error(str(e))
+                except Exception:
+                    self.log.warning("Failed to emit connection_error DSM event", exc_info=True)
             raise Exception(
                 "Unable to connect to the AdminClient. This is likely due to an error in the configuration."
             ) from e
@@ -142,29 +145,29 @@ class KafkaCheck(AgentCheck):
             for broker_meta in cluster_metadata.brokers.values()
         ]
 
+    def _emit_cluster_monitoring_event(self, payload: dict) -> None:
+        payload.setdefault('collection_timestamp', int(time() * 1000))
+        payload.setdefault('bootstrap_servers', self.config._kafka_connect_str)
+        self.event_platform_event(json.dumps(payload), "data-streams-message")
+
     def _send_cluster_monitoring_connection_error(self, reason: str) -> None:
-        payload = {
-            'collection_timestamp': int(time() * 1000),
+        self._emit_cluster_monitoring_event({
             'kafka_cluster_id': self.config._kafka_cluster_id_override or '',
             'config_type': 'connection_error',
-            'bootstrap_servers': self.config._kafka_connect_str,
             'reason': reason,
-        }
-        self.event_platform_event(json.dumps(payload), "data-streams-message")
+        })
 
     def _send_cluster_monitoring_heartbeat(self, total_contexts: int, cluster_id: str) -> None:
         payload = {
-            'collection_timestamp': int(time() * 1000),
             'kafka_cluster_id': cluster_id,
             'config_type': 'heartbeat',
             'contexts': total_contexts,
             'contexts_limit': self._context_limit,
-            'bootstrap_servers': self.config._kafka_connect_str,
             'brokers': self._get_broker_list(),
         }
         if self.config._kafka_cluster_id_override:
             payload['original_kafka_cluster_id'] = self.config._auto_detected_cluster_id
-        self.event_platform_event(json.dumps(payload), "data-streams-message")
+        self._emit_cluster_monitoring_event(payload)
 
     def get_consumer_offsets(self):
         # {(consumer_group, topic, partition): offset}

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -715,8 +715,7 @@ def _connection_error_events(check_instance):
     return [
         json.loads(c[0][0])
         for c in check_instance.event_platform_event.call_args_list
-        if c[0][1] == 'data-streams-message'
-        and json.loads(c[0][0]).get('config_type') == 'connection_error'
+        if c[0][1] == 'data-streams-message' and json.loads(c[0][0]).get('config_type') == 'connection_error'
     ]
 
 

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -1,13 +1,12 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import json
 import logging
 from contextlib import nullcontext as does_not_raise
 
 import mock
 import pytest
-
-import json
 
 from datadog_checks.kafka_consumer import KafkaCheck
 from datadog_checks.kafka_consumer.client import KafkaClient
@@ -712,62 +711,49 @@ def test_kafka_cluster_id_override(check, kafka_instance, dd_run_check, aggregat
                 assert tag in metric.tags, f"{tag} not in {metric.tags} for {metric_name}"
 
 
-def test_connection_error_emits_dsm_event(check, kafka_instance, dd_run_check):
-    """A connection_error event is emitted when request_metadata_update fails and cluster monitoring is on."""
-    kafka_instance['enable_cluster_monitoring'] = True
+def _connection_error_events(check_instance):
+    return [
+        json.loads(c[0][0])
+        for c in check_instance.event_platform_event.call_args_list
+        if c[0][1] == 'data-streams-message'
+        and json.loads(c[0][0]).get('config_type') == 'connection_error'
+    ]
+
+
+def _setup_failing_check(check, kafka_instance, dd_run_check):
     kafka_consumer_check = check(kafka_instance)
     kafka_consumer_check.client = seed_mock_client()
     kafka_consumer_check.client.request_metadata_update.side_effect = Exception('broker down')
     kafka_consumer_check.event_platform_event = mock.Mock()
-
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="Unable to connect to the AdminClient"):
         dd_run_check(kafka_consumer_check)
+    return kafka_consumer_check
 
-    calls = kafka_consumer_check.event_platform_event.call_args_list
-    error_events = [
-        json.loads(c[0][0]) for c in calls if c[0][1] == 'data-streams-message'
-        if json.loads(c[0][0]).get('config_type') == 'connection_error'
-    ]
-    assert len(error_events) == 1
-    assert error_events[0]['reason'] == 'broker down'
-    assert error_events[0]['bootstrap_servers'] == kafka_instance['kafka_connect_str']
-    assert 'collection_timestamp' in error_events[0]
+
+def test_connection_error_emits_dsm_event(check, kafka_instance, dd_run_check):
+    """A connection_error event is emitted when request_metadata_update fails and cluster monitoring is on."""
+    kafka_instance['enable_cluster_monitoring'] = True
+    kafka_consumer_check = _setup_failing_check(check, kafka_instance, dd_run_check)
+
+    events = _connection_error_events(kafka_consumer_check)
+    assert len(events) == 1
+    assert events[0]['reason'] == 'broker down'
+    assert events[0]['bootstrap_servers'] == kafka_instance['kafka_connect_str']
+    assert 'collection_timestamp' in events[0]
 
 
 def test_connection_error_includes_cluster_id_override(check, kafka_instance, dd_run_check):
     """connection_error event uses kafka_cluster_id_override when configured."""
     kafka_instance['enable_cluster_monitoring'] = True
     kafka_instance['kafka_cluster_id_override'] = 'my-cluster'
-    kafka_consumer_check = check(kafka_instance)
-    kafka_consumer_check.client = seed_mock_client()
-    kafka_consumer_check.client.request_metadata_update.side_effect = Exception('timeout')
-    kafka_consumer_check.event_platform_event = mock.Mock()
+    kafka_consumer_check = _setup_failing_check(check, kafka_instance, dd_run_check)
 
-    with pytest.raises(Exception):
-        dd_run_check(kafka_consumer_check)
-
-    calls = kafka_consumer_check.event_platform_event.call_args_list
-    error_events = [
-        json.loads(c[0][0]) for c in calls if c[0][1] == 'data-streams-message'
-        if json.loads(c[0][0]).get('config_type') == 'connection_error'
-    ]
-    assert len(error_events) == 1
-    assert error_events[0]['kafka_cluster_id'] == 'my-cluster'
+    events = _connection_error_events(kafka_consumer_check)
+    assert len(events) == 1
+    assert events[0]['kafka_cluster_id'] == 'my-cluster'
 
 
 def test_connection_error_not_emitted_without_cluster_monitoring(check, kafka_instance, dd_run_check):
     """No connection_error event is emitted when cluster monitoring is disabled."""
-    kafka_consumer_check = check(kafka_instance)
-    kafka_consumer_check.client = seed_mock_client()
-    kafka_consumer_check.client.request_metadata_update.side_effect = Exception('broker down')
-    kafka_consumer_check.event_platform_event = mock.Mock()
-
-    with pytest.raises(Exception):
-        dd_run_check(kafka_consumer_check)
-
-    calls = kafka_consumer_check.event_platform_event.call_args_list
-    error_events = [
-        c for c in calls if c[0][1] == 'data-streams-message'
-        if json.loads(c[0][0]).get('config_type') == 'connection_error'
-    ]
-    assert len(error_events) == 0
+    kafka_consumer_check = _setup_failing_check(check, kafka_instance, dd_run_check)
+    assert not _connection_error_events(kafka_consumer_check)

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -7,6 +7,8 @@ from contextlib import nullcontext as does_not_raise
 import mock
 import pytest
 
+import json
+
 from datadog_checks.kafka_consumer import KafkaCheck
 from datadog_checks.kafka_consumer.client import KafkaClient
 from datadog_checks.kafka_consumer.kafka_consumer import _get_interpolated_timestamp
@@ -708,3 +710,64 @@ def test_kafka_cluster_id_override(check, kafka_instance, dd_run_check, aggregat
         for metric in aggregator.metrics(metric_name):
             for tag in expected_override_tags:
                 assert tag in metric.tags, f"{tag} not in {metric.tags} for {metric_name}"
+
+
+def test_connection_error_emits_dsm_event(check, kafka_instance, dd_run_check):
+    """A connection_error event is emitted when request_metadata_update fails and cluster monitoring is on."""
+    kafka_instance['enable_cluster_monitoring'] = True
+    kafka_consumer_check = check(kafka_instance)
+    kafka_consumer_check.client = seed_mock_client()
+    kafka_consumer_check.client.request_metadata_update.side_effect = Exception('broker down')
+    kafka_consumer_check.event_platform_event = mock.Mock()
+
+    with pytest.raises(Exception):
+        dd_run_check(kafka_consumer_check)
+
+    calls = kafka_consumer_check.event_platform_event.call_args_list
+    error_events = [
+        json.loads(c[0][0]) for c in calls if c[0][1] == 'data-streams-message'
+        if json.loads(c[0][0]).get('config_type') == 'connection_error'
+    ]
+    assert len(error_events) == 1
+    assert error_events[0]['reason'] == 'broker down'
+    assert error_events[0]['bootstrap_servers'] == kafka_instance['kafka_connect_str']
+    assert 'collection_timestamp' in error_events[0]
+
+
+def test_connection_error_includes_cluster_id_override(check, kafka_instance, dd_run_check):
+    """connection_error event uses kafka_cluster_id_override when configured."""
+    kafka_instance['enable_cluster_monitoring'] = True
+    kafka_instance['kafka_cluster_id_override'] = 'my-cluster'
+    kafka_consumer_check = check(kafka_instance)
+    kafka_consumer_check.client = seed_mock_client()
+    kafka_consumer_check.client.request_metadata_update.side_effect = Exception('timeout')
+    kafka_consumer_check.event_platform_event = mock.Mock()
+
+    with pytest.raises(Exception):
+        dd_run_check(kafka_consumer_check)
+
+    calls = kafka_consumer_check.event_platform_event.call_args_list
+    error_events = [
+        json.loads(c[0][0]) for c in calls if c[0][1] == 'data-streams-message'
+        if json.loads(c[0][0]).get('config_type') == 'connection_error'
+    ]
+    assert len(error_events) == 1
+    assert error_events[0]['kafka_cluster_id'] == 'my-cluster'
+
+
+def test_connection_error_not_emitted_without_cluster_monitoring(check, kafka_instance, dd_run_check):
+    """No connection_error event is emitted when cluster monitoring is disabled."""
+    kafka_consumer_check = check(kafka_instance)
+    kafka_consumer_check.client = seed_mock_client()
+    kafka_consumer_check.client.request_metadata_update.side_effect = Exception('broker down')
+    kafka_consumer_check.event_platform_event = mock.Mock()
+
+    with pytest.raises(Exception):
+        dd_run_check(kafka_consumer_check)
+
+    calls = kafka_consumer_check.event_platform_event.call_args_list
+    error_events = [
+        c for c in calls if c[0][1] == 'data-streams-message'
+        if json.loads(c[0][0]).get('config_type') == 'connection_error'
+    ]
+    assert len(error_events) == 0

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -756,3 +756,14 @@ def test_connection_error_not_emitted_without_cluster_monitoring(check, kafka_in
     """No connection_error event is emitted when cluster monitoring is disabled."""
     kafka_consumer_check = _setup_failing_check(check, kafka_instance, dd_run_check)
     assert not _connection_error_events(kafka_consumer_check)
+
+
+def test_connection_error_sink_failure_does_not_mask_broker_error(check, kafka_instance, dd_run_check):
+    """Sink failure during connection_error emission does not mask the original AdminClient error."""
+    kafka_instance['enable_cluster_monitoring'] = True
+    kafka_consumer_check = check(kafka_instance)
+    kafka_consumer_check.client = seed_mock_client()
+    kafka_consumer_check.client.request_metadata_update.side_effect = Exception('broker down')
+    kafka_consumer_check.event_platform_event = mock.Mock(side_effect=Exception('intake unavailable'))
+    with pytest.raises(Exception, match="Unable to connect to the AdminClient"):
+        dd_run_check(kafka_consumer_check)


### PR DESCRIPTION
### What does this PR do?

When `enable_cluster_monitoring` is on and the integration fails to connect to Kafka (i.e. `request_metadata_update()` raises), emits a `data-streams-message` event with `config_type: connection_error` and a `reason` field carrying the exception message.

This is a separate event type from the regular `heartbeat` so that consumers of the pipeline can unambiguously distinguish "cluster is healthy, here is its state" from "cluster could not be reached, here is why".

**Payload shape:**
\`\`\`json
{
  "collection_timestamp": 1234567890000,
  "kafka_cluster_id": "<override if configured, else empty string>",
  "config_type": "connection_error",
  "bootstrap_servers": "broker:9092",
  "reason": "KafkaError{code=_ALL_BROKERS_DOWN,...}"
}
\`\`\`

The event is only emitted when `enable_cluster_monitoring: true`; no change in behaviour for users who have it disabled.

### Motivation

Surface connection errors in the UI, and help users fix them

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged