### PR TITLE
[DOCS-14494] Use region-param shortcode for webhook URLs

### DIFF
--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -140,7 +140,7 @@ Send Prometheus Alertmanager alerts in the event stream. Natively, Alertmanager 
     - name: datadog
       webhook_configs: 
       - send_resolved: true
-        url: https://app.datadoghq.com/intake/webhook/prometheus?api_key=<DATADOG_API_KEY>
+        url: https://{{< region-param key="dd_full_site" >}}/intake/webhook/prometheus?api_key=<DATADOG_API_KEY>
     route:
       group_by: ['alertname']
       group_wait: 10s

--- a/solarwinds/README.md
+++ b/solarwinds/README.md
@@ -20,12 +20,7 @@ To create a new trigger action in SolarWinds:
 6. Fill in the Action Pane with the following details:
 
         a. **Name of Action**: Send Alert to Datadog (or whatever you prefer)
-        b. **URL**: https://<YOUR-DC-INTAKE-URL>/intake/webhook/solarwinds?api_key=<DATADOG_API_KEY>
-        c. **Select**: Use HTTP/S POST
-        d. **Body to Post**: Copy and paste from alert template below
-        e. **Time of Day**: Leave as is
-        f. **Execution Settings**: Leave as is
-        b. **URL**: https://app.datadoghq.com/intake/webhook/solarwinds?api_key=<DATADOG_API_KEY>
+        b. **URL**: https://{{< region-param key="dd_full_site" >}}/intake/webhook/solarwinds?api_key=<DATADOG_API_KEY>
         c. **Select**: Use HTTP/S POST
         d. **Body to Post**: Copy and paste from alert template below
         e. **Time of Day**: Leave as is


### PR DESCRIPTION
### What does this PR do?

Replaces the hardcoded `https://app.datadoghq.com/intake/webhook/...` host in the SolarWinds and Prometheus integration READMEs with the `{{< region-param key="dd_full_site" >}}` shortcode, so the webhook URL resolves to the reader's Datadog site. Also removes a duplicated set of trigger-action configuration steps in the SolarWinds README.

### Motivation

Customers not on the US1 site otherwise have to know that the host needs to change. This matches the pattern already used in the `github` and `azure_devops` READMEs and the Amazon SNS update (DataDog/integrations-internal-core#3306).

Fixes DOCS-14494

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
