### PR TITLE
Fix TailFile CRC file descriptor leak

### DIFF
--- a/datadog_checks_base/changelog.d/23904.fixed
+++ b/datadog_checks_base/changelog.d/23904.fixed
@@ -1,0 +1,1 @@
+Fix `TailFile` to close the temporary CRC file handle.

--- a/datadog_checks_base/datadog_checks/base/utils/tailfile.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tailfile.py
@@ -35,8 +35,8 @@ class TailFile(object):
         # Compute CRC of the beginning of the file
         crc = None
         if size >= self.CRC_SIZE:
-            tmp_file = open(self._path, 'r')
-            data = ensure_bytes(tmp_file.read(self.CRC_SIZE))
+            with open(self._path, 'r') as tmp_file:
+                data = ensure_bytes(tmp_file.read(self.CRC_SIZE))
             crc = binascii.crc32(data)
 
         self._log.debug(

--- a/datadog_checks_base/tests/base/utils/test_tailfile.py
+++ b/datadog_checks_base/tests/base/utils/test_tailfile.py
@@ -1,0 +1,38 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from pathlib import Path
+from typing import Any, TextIO
+
+import pytest
+from mock import MagicMock
+
+import datadog_checks.base.utils.tailfile as tailfile_utils
+from datadog_checks.base.utils.tailfile import TailFile
+
+
+def test_open_file_closes_crc_file_handle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    log_file = tmp_path / "test.log"
+    log_file.write_text("a" * TailFile.CRC_SIZE)
+    opened_files: list[TextIO] = []
+    original_open = open
+
+    def tracked_open(*args: Any, **kwargs: Any) -> TextIO:
+        file_handle = original_open(*args, **kwargs)
+        opened_files.append(file_handle)
+        return file_handle
+
+    def callback(_line: str) -> bool:
+        return True
+
+    monkeypatch.setattr(tailfile_utils, "open", tracked_open, raising=False)
+    tail_file = TailFile(MagicMock(), str(log_file), callback)
+
+    try:
+        tail_file._open_file()
+
+        assert len(opened_files) == 2
+        assert opened_files[0].closed
+        assert not opened_files[1].closed
+    finally:
+        tail_file.close()


### PR DESCRIPTION
### What does this PR do?
Fixes a file descriptor leak in `TailFile._open_file` by closing the temporary file handle used to compute the CRC for rotation/truncation detection before opening the persistent tail handle.

Adds a regression test that tracks the CRC probe handle and verifies it is closed while the active tail handle remains open.

### Motivation
`TailFile._open_file` opened one file handle to read the CRC prefix, then opened a second handle for tailing. The CRC handle was never closed, so every reopen path could leak a descriptor. On long-running Agents tailing files through rotations, truncations, or periodic reopens, this can eventually exhaust `ulimit -n` and cause unrelated I/O to fail with `too many open files`.

Validation:
- `ddev -x test -fs datadog_checks_base`
- `ddev -x --no-interactive test datadog_checks_base -- -k tailfile`
- `ddev -x --no-interactive test datadog_checks_base` reached `1475 passed, 40 skipped`, then errored in Docker-backed Kerberos/SOCKS5 tests because local Docker is unavailable (`docker` points at a missing Colima socket and `docker compose` is not available in this environment).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged