### PR TITLE
[SAASINT-4960] Turn on public docs for vectra

### DIFF
--- a/vectra/manifest.json
+++ b/vectra/manifest.json
@@ -3,7 +3,7 @@
   "app_uuid": "ea75e670-67d1-4953-a6b8-63665fc27582",
   "app_id": "vectra",
   "owner": "saas-integrations",
-  "display_on_public_website": false,
+  "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?
Sets `display_on_public_website` to `true` in `vectra/manifest.json`, making the Vectra integration tile visible on the public Datadog docs/integrations site.

### Motivation
The Vectra integration landed in December 2025 (#22116, #22117) but was kept private (`display_on_public_website: false`). It is now ready to go live publicly. 