### PR TITLE
Pin aiohttp<3.14 in ddev test dependencies

### DIFF
--- a/ddev/hatch.toml
+++ b/ddev/hatch.toml
@@ -10,6 +10,8 @@ e2e-env = false
 dependencies = [
   "pyyaml",
   "vcrpy",
+  # vcrpy uses aiohttp.streams.AsyncStreamReaderMixin, removed in aiohttp 3.14
+  "aiohttp<3.14",
 ]
 # TODO: remove this when the old CLI is gone
 pre-install-commands = [


### PR DESCRIPTION
### What does this PR do?

Pins `aiohttp<3.14` in `ddev`'s test dependencies.

### Motivation

`aiohttp 3.14.0` (released 2026-06-02) removed `AsyncStreamReaderMixin` from `aiohttp.streams`. `vcrpy` (unpinned) references this attribute in its `MockStream` class to stub out aiohttp responses. Every `ddev` test using the `network_replay` fixture now fails with:

```
AttributeError: module 'aiohttp.streams' has no attribute 'AsyncStreamReaderMixin'
```

This pin holds at `<3.14` until `vcrpy` ships a release that drops the dependency on the removed attribute.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged