### PR TITLE
Decouple AI agent runtime construction

### DIFF
--- a/ddev/src/ddev/ai/agent/build.py
+++ b/ddev/src/ddev/ai/agent/build.py
@@ -4,207 +4,98 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 from ddev.ai.agent.anthropic_client import AnthropicAgent
 from ddev.ai.agent.base import BaseAgent
 from ddev.ai.phases.config import AgentConfig
-from ddev.ai.phases.goal import GOAL_REVIEWER_SYSTEM_PROMPT
 from ddev.ai.tools.fs.file_registry import FileRegistry
-from ddev.ai.tools.registry import ToolRegistry, filter_read_only
-
-SubagentBuilder = Callable[
-    [str, str, list[str]],  # (system_prompt, owner_id, tool_names)
-    tuple[BaseAgent[Any], ToolRegistry],
-]
-AgentBuilder = Callable[
-    [str, str, SubagentBuilder | None, Path | None],  # system_prompt, owner_id, subagent_builder, log_dir
-    tuple[BaseAgent[Any], ToolRegistry],
-]
-GoalAgentBuilder = Callable[
-    [str],  # owner_id
-    tuple[BaseAgent[Any], ToolRegistry],
-]
+from ddev.ai.tools.registry import ToolRegistry
 
 
-def _resolve_client(agent_clients: dict[str, Any], provider: str) -> Any:
-    client = agent_clients.get(provider)
-    if client is None:
-        raise ValueError(f"No client provided for agent provider {provider!r}")
-    return client
+@dataclass(frozen=True)
+class AgentRuntime:
+    agent: BaseAgent[Any]
+    tool_registry: ToolRegistry
 
 
-def _build_agent_and_registry(
-    agent_config: AgentConfig,
-    agent_clients: dict[str, Any],
-    system_prompt: str,
-    owner_id: str,
-    tool_names: list[str],
-    file_registry: FileRegistry,
-    subagent_builder: SubagentBuilder | None = None,
-    log_dir: Path | None = None,
-) -> tuple[BaseAgent[Any], ToolRegistry]:
-    tool_registry = ToolRegistry.from_names(
-        tool_names,
-        owner_id=owner_id,
-        file_registry=file_registry,
-        subagent_builder=subagent_builder,
-        log_dir=log_dir,
-    )
+class AgentRuntimeFactory(Protocol):
+    """Interface for constructing an agent runtime from explicit runtime inputs."""
 
-    if agent_config.provider == "anthropic":
-        kwargs: dict[str, Any] = {}
-        if agent_config.model is not None:
-            kwargs["model"] = agent_config.model
-        if agent_config.max_tokens is not None:
-            kwargs["max_tokens"] = agent_config.max_tokens
-        agent: BaseAgent[Any] = AnthropicAgent(
-            client=_resolve_client(agent_clients, "anthropic"),
-            tools=tool_registry,
-            system_prompt=system_prompt,
-            name=owner_id,
-            **kwargs,
-        )
-        return agent, tool_registry
-
-    raise ValueError(f"Unknown agent provider: {agent_config.provider!r}")
-
-
-def build_agent(
-    agent_config: AgentConfig,
-    agent_clients: dict[str, Any],
-    system_prompt: str,
-    owner_id: str,
-    file_registry: FileRegistry,
-    subagent_builder: SubagentBuilder | None = None,
-    log_dir: Path | None = None,
-) -> tuple[BaseAgent[Any], ToolRegistry]:
-    """Construct a provider-specific BaseAgent and its ToolRegistry from an AgentConfig."""
-    return _build_agent_and_registry(
-        agent_config=agent_config,
-        agent_clients=agent_clients,
-        system_prompt=system_prompt,
-        owner_id=owner_id,
-        tool_names=agent_config.tools,
-        file_registry=file_registry,
-        subagent_builder=subagent_builder,
-        log_dir=log_dir,
-    )
-
-
-def build_subagent(
-    parent_agent_config: AgentConfig,
-    agent_clients: dict[str, Any],
-    file_registry: FileRegistry,
-    system_prompt: str,
-    owner_id: str,
-    tool_names: list[str],
-) -> tuple[BaseAgent[Any], ToolRegistry]:
-    """Build a subagent + ToolRegistry using the shared FileRegistry.
-
-    Reuses the parent's provider/model/max_tokens. No subagent_builder or
-    log_dir is forwarded, so the subagent cannot recursively spawn subagents —
-    ToolRegistry.from_names will raise if spawn_subagent is in tool_names.
-    """
-    return _build_agent_and_registry(
-        agent_config=parent_agent_config,
-        agent_clients=agent_clients,
-        system_prompt=system_prompt,
-        owner_id=owner_id,
-        tool_names=tool_names,
-        file_registry=file_registry,
-    )
-
-
-def make_agent_builder(
-    agent_config: AgentConfig,
-    agent_clients: dict[str, Any],
-    file_registry: FileRegistry,
-) -> AgentBuilder:
-    """Return a closure that builds an agent+registry given system_prompt, owner_id, subagent_builder, log_dir."""
-
-    def builder(
+    def build_runtime(
+        self,
+        *,
+        agent_config: AgentConfig,
         system_prompt: str,
         owner_id: str,
-        subagent_builder: SubagentBuilder | None,
-        log_dir: Path | None,
-    ) -> tuple[BaseAgent[Any], ToolRegistry]:
-        return build_agent(
+    ) -> AgentRuntime: ...
+
+
+class DefaultAgentRuntimeFactory(AgentRuntimeFactory):
+    """Builds provider-specific agent runtimes from explicit runtime inputs."""
+
+    def __init__(
+        self,
+        *,
+        agent_clients: dict[str, Any],
+        file_registry: FileRegistry,
+        artifact_root: Path,
+    ) -> None:
+        self._agent_clients = agent_clients
+        self._file_registry = file_registry
+        self._artifact_root = artifact_root
+
+    def _resolve_client(self, provider: str) -> Any:
+        client = self._agent_clients.get(provider)
+        if client is None:
+            raise ValueError(f"No client provided for agent provider {provider!r}")
+        return client
+
+    def _build_provider_agent(
+        self,
+        *,
+        agent_config: AgentConfig,
+        system_prompt: str,
+        owner_id: str,
+        tool_registry: ToolRegistry,
+    ) -> BaseAgent[Any]:
+        if agent_config.provider == "anthropic":
+            kwargs: dict[str, Any] = {}
+            if agent_config.model is not None:
+                kwargs["model"] = agent_config.model
+            if agent_config.max_tokens is not None:
+                kwargs["max_tokens"] = agent_config.max_tokens
+            return AnthropicAgent(
+                client=self._resolve_client("anthropic"),
+                tools=tool_registry,
+                system_prompt=system_prompt,
+                name=owner_id,
+                **kwargs,
+            )
+        raise ValueError(f"Unknown agent provider: {agent_config.provider!r}")
+
+    def build_runtime(
+        self,
+        *,
+        agent_config: AgentConfig,
+        system_prompt: str,
+        owner_id: str,
+    ) -> AgentRuntime:
+        """Build an agent and its tools from the given configuration."""
+        tool_registry = ToolRegistry.from_names(
+            agent_config.tools,
+            owner_id=owner_id,
+            file_registry=self._file_registry,
             agent_config=agent_config,
-            agent_clients=agent_clients,
+            runtime_builder=self.build_runtime,
+            artifact_root=self._artifact_root,
+        )
+        agent = self._build_provider_agent(
+            agent_config=agent_config,
             system_prompt=system_prompt,
             owner_id=owner_id,
-            file_registry=file_registry,
-            subagent_builder=subagent_builder,
-            log_dir=log_dir,
+            tool_registry=tool_registry,
         )
-
-    return builder
-
-
-def make_subagent_builder(
-    parent_agent_config: AgentConfig,
-    agent_clients: dict[str, Any],
-    file_registry: FileRegistry,
-) -> SubagentBuilder:
-    """Return a closure that builds a subagent+registry given (system_prompt, owner_id, tool_names)."""
-
-    def builder(system_prompt: str, owner_id: str, tool_names: list[str]) -> tuple[BaseAgent[Any], ToolRegistry]:
-        return build_subagent(
-            parent_agent_config=parent_agent_config,
-            agent_clients=agent_clients,
-            file_registry=file_registry,
-            system_prompt=system_prompt,
-            owner_id=owner_id,
-            tool_names=tool_names,
-        )
-
-    return builder
-
-
-def build_goal_agent(
-    parent_agent_config: AgentConfig,
-    agent_clients: dict[str, Any],
-    file_registry: FileRegistry,
-    owner_id: str,
-) -> tuple[BaseAgent[Any], ToolRegistry]:
-    """Build the reviewer agent + its ToolRegistry.
-
-    Uses the same provider as the parent agent. Model and max_tokens are left at
-    provider defaults — the parent's overrides are intentionally not forwarded.
-    Tools are filtered to the read-only subset of the parent's tool list.
-    """
-    read_only_tool_names = filter_read_only(parent_agent_config.tools)
-    goal_agent_config = AgentConfig(
-        provider=parent_agent_config.provider,
-        tools=read_only_tool_names,
-    )
-
-    return _build_agent_and_registry(
-        agent_config=goal_agent_config,
-        agent_clients=agent_clients,
-        system_prompt=GOAL_REVIEWER_SYSTEM_PROMPT,
-        owner_id=owner_id,
-        tool_names=read_only_tool_names,
-        file_registry=file_registry,
-    )
-
-
-def make_goal_agent_builder(
-    parent_agent_config: AgentConfig,
-    agent_clients: dict[str, Any],
-    file_registry: FileRegistry,
-) -> GoalAgentBuilder:
-    """Return a closure that builds a (reviewer_agent, reviewer_registry) tuple."""
-
-    def builder(owner_id: str) -> tuple[BaseAgent[Any], ToolRegistry]:
-        return build_goal_agent(
-            parent_agent_config=parent_agent_config,
-            agent_clients=agent_clients,
-            file_registry=file_registry,
-            owner_id=owner_id,
-        )
-
-    return builder
+        return AgentRuntime(agent=agent, tool_registry=tool_registry)

--- a/ddev/src/ddev/ai/agent/build.py
+++ b/ddev/src/ddev/ai/agent/build.py
@@ -33,7 +33,19 @@ class AgentRuntimeFactory(Protocol):
     ) -> AgentRuntime: ...
 
 
-class DefaultAgentRuntimeFactory(AgentRuntimeFactory):
+class AgentRuntimeBuilder(Protocol):
+    """Callable interface for building an AgentRuntime from explicit keyword inputs."""
+
+    def __call__(
+        self,
+        *,
+        agent_config: AgentConfig,
+        system_prompt: str,
+        owner_id: str,
+    ) -> AgentRuntime: ...
+
+
+class DefaultAgentRuntimeFactory:
     """Builds provider-specific agent runtimes from explicit runtime inputs."""
 
     def __init__(

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -9,11 +9,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-from ddev.ai.agent.build import (
-    make_agent_builder,
-    make_goal_agent_builder,
-    make_subagent_builder,
-)
 from ddev.ai.phases.base import FlowContext, Phase, PhaseOutcome
 from ddev.ai.phases.checkpoint import CheckpointManager
 from ddev.ai.phases.config import AgentConfig, CheckpointConfig, FlowConfigError, PhaseConfig, TaskConfig
@@ -21,12 +16,11 @@ from ddev.ai.phases.goal import GOAL_TASK_SUFFIX, GoalValidationError, render_go
 from ddev.ai.phases.messages import PhaseFailedMessage
 from ddev.ai.phases.template import render_inline, render_prompt
 from ddev.ai.react.process import ReActProcess
-from ddev.ai.tools.registry import TOOL_MANIFEST
 from ddev.event_bus.exceptions import MessageProcessingError, ProcessorHookError
 
 if TYPE_CHECKING:
     from ddev.ai.agent.base import BaseAgent
-    from ddev.ai.agent.build import AgentBuilder, GoalAgentBuilder, SubagentBuilder
+    from ddev.ai.agent.build import AgentRuntimeFactory
     from ddev.ai.phases.goal import GoalLoopOutcome
     from ddev.ai.phases.orchestrator import ResourceProvider
     from ddev.ai.react.types import ReActResult
@@ -69,9 +63,8 @@ class AgenticPhase(Phase):
         config: PhaseConfig,
         checkpoint_manager: CheckpointManager,
         context: FlowContext,
-        agent_builder: AgentBuilder,
-        subagent_builder: SubagentBuilder | None = None,
-        goal_agent_builder: GoalAgentBuilder | None = None,
+        agent_config: AgentConfig,
+        runtime_factory: AgentRuntimeFactory,
     ) -> None:
         super().__init__(
             phase_id=phase_id,
@@ -80,15 +73,12 @@ class AgenticPhase(Phase):
             checkpoint_manager=checkpoint_manager,
             context=context,
         )
-        self._agent_builder = agent_builder
-        self._subagent_builder = subagent_builder
-        self._goal_agent_builder = goal_agent_builder
+        self._agent_name = cast(str, config.agent)
+        self._agent_config = agent_config
+        self._runtime_factory = runtime_factory
         self._goal_attempt_log: list[dict[str, Any]] = []
         self._total_input_tokens: int = 0
         self._total_output_tokens: int = 0
-        self._subagent_log_dir = (
-            checkpoint_manager.root / "subagents" / phase_id if subagent_builder is not None else None
-        )
 
     @classmethod
     def validate_config(
@@ -117,28 +107,7 @@ class AgenticPhase(Phase):
         # config.agent is guaranteed set & known by validate_config.
         agent_name = cast(str, config.agent)
         agent_config = resources.agent_config(agent_name)
-        agent_clients = resources.agent_clients()
-        file_registry = resources.file_registry()
-
-        subagent_builder = None
-        if any(
-            spec.requires_subagent_builder
-            for name in agent_config.tools
-            if (spec := TOOL_MANIFEST.get(name)) is not None
-        ):
-            subagent_builder = make_subagent_builder(
-                parent_agent_config=agent_config,
-                agent_clients=agent_clients,
-                file_registry=file_registry,
-            )
-
-        goal_agent_builder = None
-        if any((t.goal is not None or t.goal_path is not None) for t in config.tasks):
-            goal_agent_builder = make_goal_agent_builder(
-                parent_agent_config=agent_config,
-                agent_clients=agent_clients,
-                file_registry=file_registry,
-            )
+        runtime_factory = resources.agent_runtime_factory()
 
         return cls(
             phase_id=phase_id,
@@ -146,13 +115,8 @@ class AgenticPhase(Phase):
             config=config,
             checkpoint_manager=checkpoint_manager,
             context=context,
-            agent_builder=make_agent_builder(
-                agent_config=agent_config,
-                agent_clients=agent_clients,
-                file_registry=file_registry,
-            ),
-            subagent_builder=subagent_builder,
-            goal_agent_builder=goal_agent_builder,
+            agent_config=agent_config,
+            runtime_factory=runtime_factory,
         )
 
     def before_react(self) -> None:
@@ -199,8 +163,6 @@ class AgenticPhase(Phase):
             self._total_output_tokens += last_result.total_output_tokens
 
             if has_goal:
-                if self._goal_agent_builder is None:
-                    raise ValueError("Goal agent builder is required when tasks specify a goal")
                 goal_text = render_goal_text(task, self._config_dir, context, self._resolver)
                 try:
                     outcome: GoalLoopOutcome = await run_goal_loop(
@@ -209,7 +171,8 @@ class AgenticPhase(Phase):
                         rendered_task_prompt=prompt,
                         worker_process=process,
                         initial_result=last_result,
-                        goal_agent_builder=self._goal_agent_builder,
+                        parent_agent_config=self._agent_config,
+                        runtime_factory=self._runtime_factory,
                         callbacks=self._callbacks,
                         phase_id=self._phase_id,
                         log_root=self._checkpoint_manager.root,
@@ -237,26 +200,6 @@ class AgenticPhase(Phase):
                     }
                 )
 
-    def _build_agent_and_process(self, context: dict[str, Any]) -> tuple[BaseAgent[Any], ReActProcess]:
-        """Build the agent and ReAct process used to drive task execution."""
-        system_prompt = render_prompt(
-            self._config_dir / "prompts" / f"{self._config.agent}.md",
-            context,
-            self._resolver,
-        )
-        agent, tool_registry = self._agent_builder(
-            system_prompt,
-            self._phase_id,
-            self._subagent_builder,
-            self._subagent_log_dir,
-        )
-        process = ReActProcess(
-            agent=agent,
-            tool_registry=tool_registry,
-            callbacks=self._callbacks,
-        )
-        return agent, process
-
     async def _run_memory_step(
         self,
         agent: BaseAgent[Any],
@@ -275,11 +218,23 @@ class AgenticPhase(Phase):
 
     async def execute(self, context: dict[str, Any]) -> PhaseOutcome:
         self.before_react()
-        agent, process = self._build_agent_and_process(context)
+
+        system_prompt = render_prompt(
+            self._config_dir / "prompts" / f"{self._agent_name}.md",
+            context,
+            self._resolver,
+        )
+        runtime = self._runtime_factory.build_runtime(
+            agent_config=self._agent_config,
+            system_prompt=system_prompt,
+            owner_id=self._phase_id,
+        )
+        process = ReActProcess(runtime, callbacks=self._callbacks)
         await self.run_tasks(process, context)
+
         self.after_react()
 
-        memory_text, mem_in, mem_out = await self._run_memory_step(agent, context)
+        memory_text, mem_in, mem_out = await self._run_memory_step(runtime.agent, context)
 
         extra: dict[str, Any] = {}
         if self._goal_attempt_log:

--- a/ddev/src/ddev/ai/phases/goal.py
+++ b/ddev/src/ddev/ai/phases/goal.py
@@ -8,17 +8,16 @@ import json
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
+from ddev.ai.agent.build import AgentRuntimeFactory
 from ddev.ai.callbacks.callbacks import Callbacks
-from ddev.ai.phases.config import TaskConfig
+from ddev.ai.phases.config import AgentConfig, TaskConfig
 from ddev.ai.phases.template import render_inline, render_prompt
 from ddev.ai.react.process import ReActProcess
 from ddev.ai.react.types import ReActResult
 from ddev.ai.tools.agents.agent_logger import AgentLogger
-
-if TYPE_CHECKING:
-    from ddev.ai.agent.build import GoalAgentBuilder
+from ddev.ai.tools.registry import filter_read_only
 
 GOAL_REVIEWER_SYSTEM_PROMPT = """\
 You are a strict, independent reviewer. Your only job is to verify whether a
@@ -258,7 +257,8 @@ async def run_goal_loop(
     rendered_task_prompt: str,
     worker_process: ReActProcess,
     initial_result: ReActResult,
-    goal_agent_builder: GoalAgentBuilder,
+    parent_agent_config: AgentConfig,
+    runtime_factory: AgentRuntimeFactory,
     callbacks: Callbacks,
     phase_id: str,
     log_root: Path,
@@ -278,7 +278,15 @@ async def run_goal_loop(
         raise OSError(f"Goal reviewer log directory could not be created at {log_dir}: {e}") from e
 
     reviewer_owner_id = f"{phase_id}.goal.{task.name}"
-    reviewer_agent, reviewer_registry = goal_agent_builder(reviewer_owner_id)
+    reviewer_config = AgentConfig(
+        provider=parent_agent_config.provider,
+        tools=filter_read_only(parent_agent_config.tools),
+    )
+    reviewer_runtime = runtime_factory.build_runtime(
+        agent_config=reviewer_config,
+        system_prompt=GOAL_REVIEWER_SYSTEM_PROMPT,
+        owner_id=reviewer_owner_id,
+    )
 
     try:
         agent_logger = AgentLogger(log_path)
@@ -289,11 +297,10 @@ async def run_goal_loop(
         agent_logger.log_start(
             system_prompt=GOAL_REVIEWER_SYSTEM_PROMPT,
             prompt=f"<goal loop for task {task.name!r}>",
-            tools=[d["name"] for d in reviewer_registry.definitions],
+            tools=[d["name"] for d in reviewer_runtime.tool_registry.definitions],
         )
         reviewer_process = ReActProcess(
-            agent=reviewer_agent,
-            tool_registry=reviewer_registry,
+            reviewer_runtime,
             callbacks=agent_logger.build_callbacks(),
         )
 

--- a/ddev/src/ddev/ai/phases/orchestrator.py
+++ b/ddev/src/ddev/ai/phases/orchestrator.py
@@ -8,6 +8,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from ddev.ai.agent.build import AgentRuntimeFactory, DefaultAgentRuntimeFactory
 from ddev.ai.callbacks.callbacks import Callbacks
 from ddev.ai.phases.base import FlowContext, Phase
 from ddev.ai.phases.checkpoint import CheckpointManager
@@ -40,12 +41,12 @@ class ResourceUnavailableError(Exception):
 
 
 class ResourceProvider:
-    """Supplies the raw resources phases combine to build their agents/tools.
+    """Supplies the raw resources phases use to build their runtime factories.
 
     Holds raw infrastructure (agent clients, file access policy) and the flow's agent
-    definitions. Assembled objects (agent/subagent builders) are NOT stored here — phases
-    construct those inside build(). One instance is shared by every phase in a run, so
-    file_registry() is a lazily-constructed singleton (global read-before-write consistency).
+    definitions. Runtime factories are constructed on demand via agent_runtime_factory().
+    One instance is shared by every phase in a run, so file_registry() is a
+    lazily-constructed singleton (global read-before-write consistency).
     """
 
     def __init__(
@@ -53,10 +54,12 @@ class ResourceProvider:
         agent_clients: dict[str, Any],
         file_access_policy: FileAccessPolicy,
         agents: dict[str, AgentConfig],
+        artifact_root: Path,
     ) -> None:
         self._agent_clients = agent_clients
         self._file_access_policy = file_access_policy
         self._agents = agents
+        self._artifact_root = artifact_root
         self._file_registry: FileRegistry | None = None
 
     def agent_clients(self) -> dict[str, Any]:
@@ -75,6 +78,14 @@ class ResourceProvider:
             return self._agents[name]
         except KeyError as e:
             raise ResourceUnavailableError(f"No agent definition named {name!r}. Known: {sorted(self._agents)}") from e
+
+    def agent_runtime_factory(self) -> AgentRuntimeFactory:
+        """Return a ready-to-use generic runtime factory."""
+        return DefaultAgentRuntimeFactory(
+            agent_clients=self._agent_clients,
+            file_registry=self.file_registry(),
+            artifact_root=self._artifact_root,
+        )
 
 
 def _discover_and_register_phases(
@@ -115,7 +126,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
         """Initialize the orchestrator.
 
         ``agent_clients`` maps provider name (e.g. ``"anthropic"``) to a constructed
-        provider client. ``build_agent`` looks up the right one based on each
+        provider client. ``DefaultAgentRuntimeFactory`` resolves the right one based on each
         ``AgentConfig.provider``.
 
         ``file_access_policy`` must have ``write_root`` set to the integration
@@ -179,6 +190,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
             agent_clients=self._agent_clients,
             file_access_policy=self._file_access_policy,
             agents=config.agents,
+            artifact_root=checkpoint_manager.root,
         )
         context = FlowContext(
             runtime_variables=self._runtime_variables,

--- a/ddev/src/ddev/ai/phases/orchestrator.py
+++ b/ddev/src/ddev/ai/phases/orchestrator.py
@@ -61,6 +61,7 @@ class ResourceProvider:
         self._agents = agents
         self._artifact_root = artifact_root
         self._file_registry: FileRegistry | None = None
+        self._agent_runtime_factory: AgentRuntimeFactory | None = None
 
     def agent_clients(self) -> dict[str, Any]:
         """Raw provider-name -> SDK client map."""
@@ -81,11 +82,13 @@ class ResourceProvider:
 
     def agent_runtime_factory(self) -> AgentRuntimeFactory:
         """Return a ready-to-use generic runtime factory."""
-        return DefaultAgentRuntimeFactory(
-            agent_clients=self._agent_clients,
-            file_registry=self.file_registry(),
-            artifact_root=self._artifact_root,
-        )
+        if self._agent_runtime_factory is None:
+            self._agent_runtime_factory = DefaultAgentRuntimeFactory(
+                agent_clients=self._agent_clients,
+                file_registry=self.file_registry(),
+                artifact_root=self._artifact_root,
+            )
+        return self._agent_runtime_factory
 
 
 def _discover_and_register_phases(

--- a/ddev/src/ddev/ai/react/process.py
+++ b/ddev/src/ddev/ai/react/process.py
@@ -3,15 +3,13 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import asyncio
-from typing import Any
 
-from ddev.ai.agent.base import BaseAgent
+from ddev.ai.agent.build import AgentRuntime
 from ddev.ai.agent.exceptions import AgentError
 from ddev.ai.agent.types import AgentResponse, StopReason, ToolResultMessage
 from ddev.ai.callbacks.callbacks import Callbacks
 from ddev.ai.react.types import ReActResult
 from ddev.ai.tools.core.types import ToolResult
-from ddev.ai.tools.registry import ToolRegistry
 
 
 class ReActProcess:
@@ -24,21 +22,19 @@ class ReActProcess:
 
     def __init__(
         self,
-        agent: BaseAgent[Any],
-        tool_registry: ToolRegistry,
+        runtime: AgentRuntime,
         callbacks: Callbacks | None = None,
         compact_threshold_pct: float | None = 75.0,
     ) -> None:
         """
         Args:
-            agent: A BaseAgent subclass (e.g. AnthropicAgent).
-            tool_registry: Registry of tools available in this loop.
+            runtime: Agent runtime containing the agent and its tool registry.
             callbacks: Optional Callbacks instance to observe loop events.
             compact_threshold_pct: Context usage percentage at which the loop auto-compacts.
                 None disables auto-compaction entirely.
         """
-        self._agent = agent
-        self._tool_registry = tool_registry
+        self._agent = runtime.agent
+        self._tool_registry = runtime.tool_registry
         self._callbacks: Callbacks = callbacks or Callbacks()
         self._compact_threshold_pct = compact_threshold_pct
 

--- a/ddev/src/ddev/ai/tools/agents/spawn_subagent.py
+++ b/ddev/src/ddev/ai/tools/agents/spawn_subagent.py
@@ -2,17 +2,22 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 from pydantic import Field
 
-from ddev.ai.agent.build import SubagentBuilder
 from ddev.ai.agent.types import StopReason
 from ddev.ai.react.process import ReActProcess
 from ddev.ai.tools.agents.agent_logger import AgentLogger
 from ddev.ai.tools.core.base import BaseTool, BaseToolInput
 from ddev.ai.tools.core.types import ToolResult
+
+if TYPE_CHECKING:
+    from ddev.ai.phases.config import AgentConfig
+    from ddev.ai.tools.registry import AgentRuntimeBuilder
 
 
 class SpawnSubagentInput(BaseToolInput):
@@ -54,14 +59,15 @@ class SpawnSubagentTool(BaseTool[SpawnSubagentInput]):
     def __init__(
         self,
         owner_id: str,
-        subagent_builder: SubagentBuilder,
-        allowed_tools: list[str],
+        agent_config: AgentConfig,
+        runtime_builder: AgentRuntimeBuilder,
         log_dir: Path,
     ) -> None:
         self._owner_id = owner_id
-        self._subagent_builder = subagent_builder
+        self._agent_config = agent_config
+        self._runtime_builder = runtime_builder
         # Parent may itself have spawn_subagent; never offer it to children.
-        self._allowed_tools = set(allowed_tools) - {self.name}
+        self._allowed_tools = set(agent_config.tools) - {self.name}
         self._log_dir = log_dir
         self._counter = 0
 
@@ -122,10 +128,11 @@ class SpawnSubagentTool(BaseTool[SpawnSubagentInput]):
             )
 
             try:
-                agent, tool_registry = self._subagent_builder(
-                    tool_input.system_prompt,
-                    subagent_id,
-                    tool_input.tools,
+                child_config = self._agent_config.model_copy(update={"tools": tool_input.tools})
+                runtime = self._runtime_builder(
+                    agent_config=child_config,
+                    system_prompt=tool_input.system_prompt,
+                    owner_id=subagent_id,
                 )
             except Exception as e:
                 logger.log_finish(success=False, error=f"build failed: {type(e).__name__}: {e}")
@@ -135,8 +142,7 @@ class SpawnSubagentTool(BaseTool[SpawnSubagentInput]):
                 )
 
             process = ReActProcess(
-                agent=agent,
-                tool_registry=tool_registry,
+                runtime,
                 callbacks=logger.build_callbacks(),
             )
             try:

--- a/ddev/src/ddev/ai/tools/agents/spawn_subagent.py
+++ b/ddev/src/ddev/ai/tools/agents/spawn_subagent.py
@@ -16,8 +16,8 @@ from ddev.ai.tools.core.base import BaseTool, BaseToolInput
 from ddev.ai.tools.core.types import ToolResult
 
 if TYPE_CHECKING:
+    from ddev.ai.agent.build import AgentRuntimeBuilder
     from ddev.ai.phases.config import AgentConfig
-    from ddev.ai.tools.registry import AgentRuntimeBuilder
 
 
 class SpawnSubagentInput(BaseToolInput):

--- a/ddev/src/ddev/ai/tools/registry.py
+++ b/ddev/src/ddev/ai/tools/registry.py
@@ -18,10 +18,8 @@ from .core.protocol import ToolProtocol
 from .core.types import ToolResult
 
 if TYPE_CHECKING:
-    from ddev.ai.agent.build import AgentRuntime
+    from ddev.ai.agent.build import AgentRuntimeBuilder
     from ddev.ai.phases.config import AgentConfig
-
-    AgentRuntimeBuilder = Callable[..., AgentRuntime]
 
 
 @dataclass

--- a/ddev/src/ddev/ai/tools/registry.py
+++ b/ddev/src/ddev/ai/tools/registry.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from importlib import import_module
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -18,7 +18,10 @@ from .core.protocol import ToolProtocol
 from .core.types import ToolResult
 
 if TYPE_CHECKING:
-    from ddev.ai.agent.build import SubagentBuilder
+    from ddev.ai.agent.build import AgentRuntime
+    from ddev.ai.phases.config import AgentConfig
+
+    AgentRuntimeBuilder = Callable[..., AgentRuntime]
 
 
 @dataclass
@@ -27,9 +30,9 @@ class ToolContext:
 
     file_registry: FileRegistry
     owner_id: str
-    allowed_tool_names: tuple[str, ...] = field(default_factory=tuple)
-    subagent_builder: SubagentBuilder | None = None
-    log_dir: Path | None = None
+    agent_config: AgentConfig
+    runtime_builder: AgentRuntimeBuilder
+    artifact_root: Path
 
     @property
     def policy(self) -> FileAccessPolicy:
@@ -49,17 +52,11 @@ def _file_policy_factory(tool_cls: type, ctx: ToolContext) -> ToolProtocol:
 
 
 def _spawn_subagent_factory(tool_cls: type, ctx: ToolContext) -> ToolProtocol:
-    if ctx.subagent_builder is None or ctx.log_dir is None:
-        raise ValueError(
-            "Tool 'spawn_subagent' requires both 'subagent_builder' and 'log_dir' to be "
-            "passed to ToolRegistry.from_names."
-        )
-    allowed = [name for name in ctx.allowed_tool_names if name != "spawn_subagent"]
     return tool_cls(
         owner_id=ctx.owner_id,
-        subagent_builder=ctx.subagent_builder,
-        allowed_tools=allowed,
-        log_dir=ctx.log_dir,
+        agent_config=ctx.agent_config,
+        runtime_builder=ctx.runtime_builder,
+        log_dir=ctx.artifact_root / "subagents" / ctx.owner_id,
     )
 
 
@@ -70,14 +67,12 @@ class ToolSpec:
     ``module`` is relative to the registry's package (e.g. ``"fs.read_file"``).
     ``factory`` receives the already-imported class and the shared ToolContext
     and returns a constructed tool instance.
-    ``requires_subagent_builder`` marks agentic tools that need subagent wiring.
     ``read_only`` marks tools that only inspect state and never mutate it.
     """
 
     module: str
     cls: str
     factory: Callable[[type, ToolContext], ToolProtocol] = _plain_factory
-    requires_subagent_builder: bool = False
     read_only: bool = False
 
 
@@ -102,7 +97,6 @@ TOOL_MANIFEST: dict[str, ToolSpec] = {
         "agents.spawn_subagent",
         "SpawnSubagentTool",
         factory=_spawn_subagent_factory,
-        requires_subagent_builder=True,
         read_only=False,
     ),
 }
@@ -126,8 +120,9 @@ class ToolRegistry:
         *,
         owner_id: str,
         file_registry: FileRegistry,
-        subagent_builder: SubagentBuilder | None = None,
-        log_dir: Path | None = None,
+        agent_config: AgentConfig,
+        runtime_builder: AgentRuntimeBuilder,
+        artifact_root: Path,
     ) -> ToolRegistry:
         """Build a ToolRegistry from a list of tool name strings.
 
@@ -138,9 +133,9 @@ class ToolRegistry:
         ctx = ToolContext(
             file_registry=file_registry,
             owner_id=owner_id,
-            allowed_tool_names=tuple(tool_names),
-            subagent_builder=subagent_builder,
-            log_dir=log_dir,
+            agent_config=agent_config,
+            runtime_builder=runtime_builder,
+            artifact_root=artifact_root,
         )
         tools: list[ToolProtocol] = []
         for name in tool_names:

--- a/ddev/tests/ai/agent/test_build.py
+++ b/ddev/tests/ai/agent/test_build.py
@@ -124,3 +124,20 @@ def test_build_runtime_reuses_shared_file_registry(file_registry, clients):
     for tool in runtime.tool_registry._tools.values():
         assert tool._registry is file_registry
         assert tool._owner_id == "owner"
+
+
+async def test_shared_registry_does_not_share_parent_read_authorization(file_registry, clients, tmp_path):
+    config = AgentConfig(provider="anthropic", tools=[])
+    path = tmp_path / "file.txt"
+    path.write_text("before", encoding="utf-8")
+    file_registry.record("parent", str(path), "before")
+
+    factory = make_factory(clients, file_registry)
+    child_config = config.model_copy(update={"tools": ["edit_file"]})
+    runtime = build_runtime(factory, child_config, system_prompt="sys", owner_id="parent.sub.001-child")
+    registry = runtime.tool_registry
+    result = await registry.run("edit_file", {"path": str(path), "old_string": "before", "new_string": "after"})
+
+    assert result.success is False
+    assert "Not authorized" in result.error
+    assert path.read_text(encoding="utf-8") == "before"

--- a/ddev/tests/ai/agent/test_build.py
+++ b/ddev/tests/ai/agent/test_build.py
@@ -6,16 +6,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from ddev.ai.agent.anthropic_client import DEFAULT_MAX_TOKENS, DEFAULT_MODEL, AnthropicAgent
-from ddev.ai.agent.build import (
-    build_agent,
-    build_subagent,
-    make_agent_builder,
-    make_goal_agent_builder,
-    make_subagent_builder,
-)
+from ddev.ai.agent.anthropic_client import AnthropicAgent
+from ddev.ai.agent.build import AgentRuntime, DefaultAgentRuntimeFactory
 from ddev.ai.phases.config import AgentConfig
-from ddev.ai.phases.goal import GOAL_REVIEWER_SYSTEM_PROMPT
+from ddev.ai.tools.agents.spawn_subagent import SpawnSubagentTool
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.ai.tools.fs.file_registry import FileRegistry
 from ddev.ai.tools.registry import ToolRegistry
@@ -36,29 +30,56 @@ def clients() -> dict:
     return {"anthropic": MagicMock()}
 
 
-# ---------------------------------------------------------------------------
-# Core builder behaviour
-# ---------------------------------------------------------------------------
+def make_factory(
+    clients: dict,
+    file_registry: FileRegistry,
+) -> DefaultAgentRuntimeFactory:
+    return DefaultAgentRuntimeFactory(
+        agent_clients=clients,
+        file_registry=file_registry,
+        artifact_root=file_registry.policy.write_root / "artifacts",
+    )
+
+
+def build_runtime(
+    factory: DefaultAgentRuntimeFactory,
+    config: AgentConfig,
+    *,
+    system_prompt: str = "system",
+    owner_id: str = "p1",
+) -> AgentRuntime:
+    return factory.build_runtime(agent_config=config, system_prompt=system_prompt, owner_id=owner_id)
 
 
 def test_unknown_provider_raises(file_registry, clients):
     config = AgentConfig.model_construct(provider="bad_provider", tools=[])
+    factory = make_factory(clients, file_registry)
     with pytest.raises(ValueError, match="Unknown agent provider: 'bad_provider'"):
-        build_agent(config, clients, "sys", "p1", file_registry)
+        build_runtime(factory, config)
 
 
 def test_missing_client_raises(file_registry):
     config = AgentConfig(provider="anthropic", tools=[])
+    factory = make_factory({}, file_registry)
     with pytest.raises(ValueError, match="No client provided for agent provider 'anthropic'"):
-        build_agent(config, {}, "sys", "p1", file_registry)
+        build_runtime(factory, config)
 
 
-def test_builds_anthropic_agent_with_correct_types_and_name(file_registry, clients):
+def test_build_runtime_returns_agent_runtime(file_registry, clients):
     config = AgentConfig(provider="anthropic", tools=[])
-    agent, registry = build_agent(config, clients, "sys", "p1", file_registry)
-    assert isinstance(agent, AnthropicAgent)
-    assert isinstance(registry, ToolRegistry)
-    assert agent.name == "p1"
+    runtime = build_runtime(make_factory(clients, file_registry), config)
+
+    assert isinstance(runtime, AgentRuntime)
+    assert isinstance(runtime.agent, AnthropicAgent)
+    assert isinstance(runtime.tool_registry, ToolRegistry)
+    assert runtime.agent.name == "p1"
+
+
+def test_build_runtime_uses_explicit_system_prompt(file_registry, clients):
+    config = AgentConfig(provider="anthropic", tools=[])
+    runtime = build_runtime(make_factory(clients, file_registry), config, system_prompt="Project: integrations")
+
+    assert runtime.agent._system_prompt == "Project: integrations"
 
 
 @pytest.mark.parametrize(
@@ -68,117 +89,38 @@ def test_builds_anthropic_agent_with_correct_types_and_name(file_registry, clien
         ("claude-haiku-4-5", 512),
     ],
 )
-def test_model_and_max_tokens_forwarded(file_registry, clients, model, max_tokens):
+def test_build_runtime_forwards_model_and_max_tokens(file_registry, clients, model, max_tokens):
     config = AgentConfig(provider="anthropic", model=model, max_tokens=max_tokens, tools=[])
-    agent, _ = build_agent(config, clients, "sys", "p1", file_registry)
-    assert agent._model == model
-    assert agent._max_tokens == max_tokens
+    runtime = build_runtime(make_factory(clients, file_registry), config)
+
+    assert runtime.agent._model == model
+    assert runtime.agent._max_tokens == max_tokens
 
 
-def test_build_agent_uses_config_tools(file_registry, clients):
+def test_build_runtime_uses_config_tools(file_registry, clients):
     config = AgentConfig(provider="anthropic", tools=["read_file"])
-    _, registry = build_agent(config, clients, "sys", "p1", file_registry)
-    assert len(registry.definitions) == 1
-    assert registry.definitions[0]["name"] == "read_file"
+    runtime = build_runtime(make_factory(clients, file_registry), config)
+
+    assert len(runtime.tool_registry.definitions) == 1
+    assert runtime.tool_registry.definitions[0]["name"] == "read_file"
 
 
-# ---------------------------------------------------------------------------
-# build_subagent
-# ---------------------------------------------------------------------------
+def test_build_runtime_wires_spawn_subagent_tool(file_registry, clients):
+    config = AgentConfig(provider="anthropic", tools=["spawn_subagent"])
+    factory = make_factory(clients, file_registry)
+    runtime = build_runtime(factory, config)
+
+    tool = runtime.tool_registry._tools["spawn_subagent"]
+    assert isinstance(tool, SpawnSubagentTool)
+    assert tool._agent_config is config
+    assert tool._runtime_builder.__self__ is factory
+    assert tool._log_dir == file_registry.policy.write_root / "artifacts" / "subagents" / "p1"
 
 
-def test_build_subagent_reuses_shared_file_registry(file_registry, clients):
-    config = AgentConfig(provider="anthropic", tools=[])
-    _, registry = build_subagent(config, clients, file_registry, "sys", "child", ["read_file", "edit_file"])
+def test_build_runtime_reuses_shared_file_registry(file_registry, clients):
+    config = AgentConfig(provider="anthropic", tools=["read_file", "edit_file"])
+    runtime = build_runtime(make_factory(clients, file_registry), config, owner_id="owner")
 
-    for tool in registry._tools.values():
+    for tool in runtime.tool_registry._tools.values():
         assert tool._registry is file_registry
-        assert tool._owner_id == "child"
-
-
-def test_build_subagent_recursion_guard(file_registry, clients):
-    config = AgentConfig.model_construct(provider="anthropic", tools=[])
-    with pytest.raises(ValueError):
-        build_subagent(config, clients, file_registry, "sys", "sub", ["spawn_subagent"])
-
-
-async def test_shared_registry_does_not_share_parent_read_authorization(file_registry, clients, tmp_path):
-    config = AgentConfig(provider="anthropic", tools=[])
-    path = tmp_path / "file.txt"
-    path.write_text("before", encoding="utf-8")
-    file_registry.record("parent", str(path), "before")
-
-    _, registry = build_subagent(config, clients, file_registry, "sys", "parent.sub.001-child", ["edit_file"])
-    result = await registry.run("edit_file", {"path": str(path), "old_string": "before", "new_string": "after"})
-
-    assert result.success is False
-    assert "Not authorized" in result.error
-    assert path.read_text(encoding="utf-8") == "before"
-
-
-# ---------------------------------------------------------------------------
-# Closures — verify delegation works and signatures are correct
-# ---------------------------------------------------------------------------
-
-
-def test_make_agent_builder(file_registry, clients):
-    config = AgentConfig(provider="anthropic", tools=[])
-    builder = make_agent_builder(config, clients, file_registry)
-    agent, registry = builder("sys", "p1", None, None)
-    assert isinstance(agent, AnthropicAgent)
-    assert agent.name == "p1"
-
-
-def test_make_subagent_builder(file_registry, clients):
-    config = AgentConfig(provider="anthropic", tools=[])
-    builder = make_subagent_builder(config, clients, file_registry)
-    agent, registry = builder("sys", "sub-1", [])
-    assert isinstance(agent, AnthropicAgent)
-    assert agent.name == "sub-1"
-
-
-# ---------------------------------------------------------------------------
-# make_goal_agent_builder
-# ---------------------------------------------------------------------------
-
-
-def test_goal_agent_builder_unknown_provider_raises(file_registry, clients):
-    config = AgentConfig.model_construct(provider="bad_provider", tools=[])
-    builder = make_goal_agent_builder(config, clients, file_registry)
-    with pytest.raises(ValueError, match="Unknown agent provider: 'bad_provider'"):
-        builder("phase.goal.task")
-
-
-def test_make_goal_agent_builder_filters_read_only_tools(file_registry, clients):
-    config = AgentConfig(
-        provider="anthropic",
-        tools=["read_file", "edit_file", "grep", "create_file"],
-    )
-    builder = make_goal_agent_builder(config, clients, file_registry)
-    agent, registry = builder("phase.goal.task")
-
-    assert isinstance(agent, AnthropicAgent)
-    assert agent.name == "phase.goal.task"
-    tool_names = {d["name"] for d in registry.definitions}
-    assert tool_names == {"read_file", "grep"}
-
-
-def test_make_goal_agent_builder_uses_default_model(file_registry, clients):
-    config = AgentConfig(
-        provider="anthropic",
-        tools=["read_file"],
-        model="claude-opus-4-7",
-        max_tokens=999,
-    )
-    builder = make_goal_agent_builder(config, clients, file_registry)
-    agent, _ = builder("phase.goal.task")
-
-    assert agent._model == DEFAULT_MODEL
-    assert agent._max_tokens == DEFAULT_MAX_TOKENS
-
-
-def test_make_goal_agent_builder_uses_reviewer_system_prompt(file_registry, clients):
-    config = AgentConfig(provider="anthropic", tools=["read_file"])
-    builder = make_goal_agent_builder(config, clients, file_registry)
-    agent, _ = builder("phase.goal.task")
-    assert agent._system_prompt == GOAL_REVIEWER_SYSTEM_PROMPT
+        assert tool._owner_id == "owner"

--- a/ddev/tests/ai/phases/conftest.py
+++ b/ddev/tests/ai/phases/conftest.py
@@ -3,16 +3,18 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import asyncio
+from collections.abc import Callable
 from typing import Any
 
 import pytest
 
+from ddev.ai.agent.build import AgentRuntime
 from ddev.ai.agent.types import AgentResponse, ContextUsage, StopReason, TokenUsage, ToolResultMessage
 from ddev.ai.callbacks.callbacks import Callbacks
 from ddev.ai.phases.agentic_phase import AgenticPhase
 from ddev.ai.phases.base import FlowContext
 from ddev.ai.phases.checkpoint import CheckpointManager
-from ddev.ai.phases.config import PhaseConfig, TaskConfig
+from ddev.ai.phases.config import AgentConfig, PhaseConfig, TaskConfig
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.ai.tools.registry import ToolRegistry
 
@@ -86,23 +88,35 @@ class MockAgent:
         return None
 
 
-def make_agent_builder(mock_agent: MockAgent, captured_kwargs: dict[str, Any] | None = None):
-    """Create an agent_builder that returns the given mock and an empty ToolRegistry.
+class MockRuntimeFactory:
+    """Minimal AgentRuntimeFactory that injects a MockAgent for testing."""
 
-    If ``captured_kwargs`` is provided, every call records the system_prompt and
-    owner_id passed in — useful for asserting on prompt rendering.
-    """
+    def __init__(
+        self,
+        mock_agent: MockAgent,
+        captured_kwargs: dict[str, Any] | None = None,
+        goal_runtime_builder: Callable[[str], AgentRuntime] | None = None,
+    ) -> None:
+        self._mock_agent = mock_agent
+        self._captured = captured_kwargs
+        self._goal_runtime_builder = goal_runtime_builder
 
-    def builder(
-        system_prompt: str, owner_id: str, subagent_builder=None, log_dir=None
-    ) -> tuple[MockAgent, ToolRegistry]:
-        if captured_kwargs is not None:
-            captured_kwargs["system_prompt"] = system_prompt
-            captured_kwargs["owner_id"] = owner_id
-        mock_agent.name = owner_id
-        return mock_agent, ToolRegistry([])
-
-    return builder
+    def build_runtime(
+        self,
+        *,
+        agent_config: AgentConfig,
+        system_prompt: str,
+        owner_id: str,
+    ) -> AgentRuntime:
+        if self._goal_runtime_builder is not None and ".goal." in owner_id:
+            return self._goal_runtime_builder(owner_id)
+        if self._captured is not None:
+            self._captured["agent_config"] = agent_config
+            self._captured["system_prompt"] = system_prompt
+            self._captured["owner_id"] = owner_id
+        self._mock_agent.name = owner_id
+        self._mock_agent._system_prompt = system_prompt
+        return AgentRuntime(agent=self._mock_agent, tool_registry=ToolRegistry([]))
 
 
 def make_agent_phase(
@@ -119,13 +133,15 @@ def make_agent_phase(
     runtime_variables: dict[str, str] | None = None,
     context_compact_threshold_pct: int = 80,
     callbacks=None,
-    captured_agent_kwargs: dict[str, Any] | None = None,
-    goal_agent_builder=None,
+    captured_worker_kwargs: dict[str, Any] | None = None,
+    goal_runtime_builder: Callable[[str], AgentRuntime] | None = None,
+    agent_config: AgentConfig | None = None,
 ) -> tuple[AgenticPhase, CheckpointManager]:
     """Build an AgenticPhase ready for process_message-driven tests.
 
-    Injects a mock agent_builder so no real LLM or tools are constructed. Pass
-    ``captured_agent_kwargs`` (a dict) to record the rendered system_prompt and owner_id.
+    Injects a MockRuntimeFactory so no real LLM or tools are constructed. Pass
+    ``captured_worker_kwargs`` (a dict) to record build_runtime inputs.
+    Pass ``goal_runtime_builder`` as a callable (owner_id: str) -> AgentRuntime for goal tests.
     """
     config = PhaseConfig(
         agent="writer",
@@ -141,14 +157,19 @@ def make_agent_phase(
         callbacks=callbacks or Callbacks(),
     )
 
+    runtime_factory = MockRuntimeFactory(
+        mock_agent=mock_agent,
+        captured_kwargs=captured_worker_kwargs,
+        goal_runtime_builder=goal_runtime_builder,
+    )
     phase = AgenticPhase(
         phase_id=phase_id,
         dependencies=dependencies or [],
         config=config,
         checkpoint_manager=checkpoint_manager,
         context=context,
-        agent_builder=make_agent_builder(mock_agent, captured_agent_kwargs),
-        goal_agent_builder=goal_agent_builder,
+        agent_config=agent_config or AgentConfig(tools=[]),
+        runtime_factory=runtime_factory,
     )
     phase.queue = message_queue
     return phase, checkpoint_manager

--- a/ddev/tests/ai/phases/test_agentic_phase.py
+++ b/ddev/tests/ai/phases/test_agentic_phase.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from ddev.ai.agent.build import AgentRuntime
 from ddev.ai.agent.types import AgentResponse, StopReason, TokenUsage, ToolCall
 from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
 from ddev.ai.phases.agentic_phase import AgenticPhase, render_memory_prompt, render_task_prompt
@@ -191,8 +192,8 @@ async def test_react_hook_failure_fails_phase(flow_dir, monkeypatch, message_que
 # ---------------------------------------------------------------------------
 
 
-async def test_flow_variables_rendered_in_system_prompt(flow_dir, monkeypatch, message_queue):
-    (flow_dir / "prompts" / "writer.md").write_text("Project: ${project}")
+async def test_build_runtime_receives_rendered_flow_context(flow_dir, monkeypatch, message_queue):
+    (flow_dir / "prompts" / "writer.md").write_text("Project: ${project}", encoding="utf-8")
     mock_agent = MockAgent([make_response("done", 100, 50), make_response("summary", 10, 5)])
     captured: dict = {}
     phase, _ = make_agent_phase(
@@ -201,16 +202,18 @@ async def test_flow_variables_rendered_in_system_prompt(flow_dir, monkeypatch, m
         monkeypatch,
         message_queue,
         flow_variables={"project": "myproj"},
-        captured_agent_kwargs=captured,
+        captured_worker_kwargs=captured,
     )
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
+    assert captured["owner_id"] == "p1"
     assert captured["system_prompt"] == "Project: myproj"
+    assert captured["agent_config"] == AgentConfig(tools=[])
 
 
-async def test_runtime_variables_override_flow_variables(flow_dir, monkeypatch, message_queue):
-    (flow_dir / "prompts" / "writer.md").write_text("Project: ${project}")
+async def test_build_runtime_receives_runtime_overrides(flow_dir, monkeypatch, message_queue):
+    (flow_dir / "prompts" / "writer.md").write_text("Project: ${project}", encoding="utf-8")
     mock_agent = MockAgent([make_response("done", 100, 50), make_response("summary", 10, 5)])
     captured: dict = {}
     phase, _ = make_agent_phase(
@@ -220,12 +223,30 @@ async def test_runtime_variables_override_flow_variables(flow_dir, monkeypatch, 
         message_queue,
         flow_variables={"project": "flow"},
         runtime_variables={"project": "runtime"},
-        captured_agent_kwargs=captured,
+        captured_worker_kwargs=captured,
     )
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
     assert captured["system_prompt"] == "Project: runtime"
+
+
+async def test_build_runtime_receives_memory_resolver(flow_dir, monkeypatch, message_queue):
+    (flow_dir / "prompts" / "writer.md").write_text("Memory: ${draft_memory}", encoding="utf-8")
+    mock_agent = MockAgent([make_response("done", 100, 50), make_response("summary", 10, 5)])
+    captured: dict = {}
+    phase, mgr = make_agent_phase(
+        flow_dir,
+        mock_agent,
+        monkeypatch,
+        message_queue,
+        captured_worker_kwargs=captured,
+    )
+    mgr.write_memory("draft", "Created file.py")
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    assert captured["system_prompt"] == "Memory: Created file.py"
 
 
 async def test_task_prompt_resolves_memory_variable(flow_dir, monkeypatch, message_queue):
@@ -364,40 +385,8 @@ async def test_run_memory_step_returns_response_data_and_fires_callbacks(flow_di
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    ("tools", "expected"),
-    [(["spawn_subagent"], True), (["read_file"], False), ([], False)],
-    ids=["spawn", "regular_tool", "no_tools"],
-)
-def test_build_creates_subagent_builder_from_tool_metadata(
-    flow_context,
-    tools: list[str],
-    expected: bool,
-) -> None:
-    from ddev.ai.phases.checkpoint import CheckpointManager
-    from ddev.ai.phases.orchestrator import ResourceProvider
-
-    flow_dir = flow_context.config_dir
-    provider = ResourceProvider(
-        agent_clients={},
-        file_access_policy=FileAccessPolicy(write_root=flow_dir),
-        agents={"writer": AgentConfig(tools=tools)},
-    )
-    checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
-    phase = AgenticPhase.build(
-        phase_id="p1",
-        config=PhaseConfig(agent="writer", tasks=[TaskConfig(name="t1", prompt="Do the work.")]),
-        deps=[],
-        resources=provider,
-        checkpoint_manager=checkpoint_manager,
-        context=flow_context,
-    )
-
-    assert (phase._subagent_builder is not None) is expected
-
-
-async def test_spawn_subagent_wiring(flow_context, message_queue):
-    """Phase correctly passes subagent_builder + log_dir to the agent builder at execute time."""
+async def test_spawn_subagent_wiring(flow_context, monkeypatch, message_queue):
+    """Real runtime factory wires spawn_subagent logs under the checkpoint root."""
     flow_dir = flow_context.config_dir
 
     def make_usage() -> TokenUsage:
@@ -415,49 +404,34 @@ async def test_spawn_subagent_wiring(flow_context, message_queue):
             AgentResponse(stop_reason=StopReason.END_TURN, text="memory summary", tool_calls=[], usage=make_usage()),
         ]
     )
+    subagent = MockAgent([AgentResponse(stop_reason=StopReason.END_TURN, text="42", tool_calls=[], usage=make_usage())])
 
-    subagent_calls: list = []
+    agents = [parent_agent, subagent]
 
-    def mock_subagent_builder(system_prompt: str, owner_id: str, tool_names: list[str]):
-        subagent_calls.append(system_prompt)
-        return MockAgent(
-            [AgentResponse(stop_reason=StopReason.END_TURN, text="42", tool_calls=[], usage=make_usage())]
-        ), ToolRegistry([])
+    def fake_anthropic_agent(*, tools, system_prompt, name, **kwargs):
+        agent = agents.pop(0)
+        agent.name = name
+        agent._system_prompt = system_prompt
+        return agent
 
-    from ddev.ai.tools.agents.spawn_subagent import SpawnSubagentTool
+    monkeypatch.setattr("ddev.ai.agent.build.AnthropicAgent", fake_anthropic_agent)
 
-    captured_log_dirs: list[Path | None] = []
-
-    def agent_builder_fn(
-        system_prompt: str,
-        owner_id: str,
-        subagent_builder=None,
-        log_dir: Path | None = None,
-    ):
-        captured_log_dirs.append(log_dir)
-        assert subagent_builder is not None
-        assert log_dir is not None
-        parent_agent.name = owner_id
-        return parent_agent, ToolRegistry(
-            [
-                SpawnSubagentTool(
-                    owner_id=owner_id,
-                    subagent_builder=subagent_builder,
-                    allowed_tools=[],
-                    log_dir=log_dir,
-                )
-            ]
-        )
+    from ddev.ai.phases.orchestrator import ResourceProvider
 
     checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
-    phase = AgenticPhase(
+    resources = ResourceProvider(
+        agent_clients={"anthropic": object()},
+        file_access_policy=FileAccessPolicy(write_root=flow_dir),
+        agents={"writer": AgentConfig(tools=["spawn_subagent"])},
+        artifact_root=checkpoint_manager.root,
+    )
+    phase = AgenticPhase.build(
         phase_id="p1",
-        dependencies=[],
         config=PhaseConfig(agent="writer", tasks=[TaskConfig(name="t1", prompt="Do the work.")]),
+        deps=[],
+        resources=resources,
         checkpoint_manager=checkpoint_manager,
         context=flow_context,
-        agent_builder=agent_builder_fn,
-        subagent_builder=mock_subagent_builder,
     )
     phase.queue = message_queue
 
@@ -465,8 +439,7 @@ async def test_spawn_subagent_wiring(flow_context, message_queue):
 
     submitted = [message_queue.get_nowait() for _ in range(message_queue.qsize())]
     assert not any(isinstance(m, PhaseFailedMessage) for m in submitted)
-    assert subagent_calls == ["you are a helper"]
-    assert captured_log_dirs == [checkpoint_manager.root / "subagents" / "p1"]
+    assert subagent._system_prompt == "you are a helper"
 
     log_file = checkpoint_manager.root / "subagents" / "p1" / "001-child.jsonl"
     assert log_file.exists()
@@ -477,41 +450,6 @@ async def test_spawn_subagent_wiring(flow_context, message_queue):
 # ---------------------------------------------------------------------------
 # Goal validation integration tests
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "tasks,expect_builder",
-    [
-        ([TaskConfig(name="t1", prompt="x")], False),
-        ([TaskConfig(name="t1", prompt="x", goal="verify")], True),
-        ([TaskConfig(name="t1", prompt="x"), TaskConfig(name="t2", prompt="y", goal="verify")], True),
-    ],
-    ids=["no_goal", "single_goal", "mixed"],
-)
-def test_build_creates_goal_agent_builder_when_any_task_has_goal(
-    flow_context,
-    tasks,
-    expect_builder,
-):
-    from ddev.ai.phases.checkpoint import CheckpointManager
-    from ddev.ai.phases.orchestrator import ResourceProvider
-
-    flow_dir = flow_context.config_dir
-    provider = ResourceProvider(
-        agent_clients={},
-        file_access_policy=FileAccessPolicy(write_root=flow_dir),
-        agents={"writer": AgentConfig()},
-    )
-    checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
-    phase = AgenticPhase.build(
-        phase_id="p1",
-        config=PhaseConfig(agent="writer", tasks=tasks),
-        deps=[],
-        resources=provider,
-        checkpoint_manager=checkpoint_manager,
-        context=flow_context,
-    )
-    assert (phase._goal_agent_builder is not None) is expect_builder
 
 
 async def test_phase_with_goal_passes_first_attempt(flow_dir, monkeypatch, message_queue):
@@ -525,10 +463,10 @@ async def test_phase_with_goal_passes_first_attempt(flow_dir, monkeypatch, messa
 
     captured_builder_calls: list = []
 
-    def goal_builder(owner_id):
+    def goal_builder(owner_id: str) -> AgentRuntime:
         captured_builder_calls.append(owner_id)
         agent = MockAgent(list(reviewer_responses))
-        return agent, ToolRegistry([])
+        return AgentRuntime(agent=agent, tool_registry=ToolRegistry([]))
 
     phase, mgr = make_agent_phase(
         flow_dir,
@@ -536,7 +474,7 @@ async def test_phase_with_goal_passes_first_attempt(flow_dir, monkeypatch, messa
         monkeypatch,
         message_queue,
         tasks=[TaskConfig(name="t1", prompt="Do it.", goal="verify it")],
-        goal_agent_builder=goal_builder,
+        goal_runtime_builder=goal_builder,
     )
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
@@ -563,14 +501,14 @@ async def test_phase_with_goal_exhausts_attempts_fails_phase(flow_dir, monkeypat
         ]
     )
 
-    def goal_builder(owner_id):
+    def goal_builder(owner_id: str) -> AgentRuntime:
         agent = MockAgent(
             [
                 make_response('{"valid": false, "reason": "first miss"}', 0, 0),
                 make_response('{"valid": false, "reason": "second miss"}', 0, 0),
             ]
         )
-        return agent, ToolRegistry([])
+        return AgentRuntime(agent=agent, tool_registry=ToolRegistry([]))
 
     phase, mgr = make_agent_phase(
         flow_dir,
@@ -578,7 +516,7 @@ async def test_phase_with_goal_exhausts_attempts_fails_phase(flow_dir, monkeypat
         monkeypatch,
         message_queue,
         tasks=[TaskConfig(name="t1", prompt="Do it.", goal="g", max_goal_attempts=2)],
-        goal_agent_builder=goal_builder,
+        goal_runtime_builder=goal_builder,
     )
 
     from ddev.ai.phases.goal import GoalAttemptsExhausted
@@ -608,7 +546,7 @@ async def test_phase_goal_partial_progress_preserved_on_exhaustion(flow_dir, mon
 
     call_count = 0
 
-    def goal_builder(owner_id):
+    def goal_builder(owner_id: str) -> AgentRuntime:
         nonlocal call_count
         call_count += 1
         if call_count == 1:
@@ -620,7 +558,7 @@ async def test_phase_goal_partial_progress_preserved_on_exhaustion(flow_dir, mon
                     make_response('{"valid": false, "reason": "miss 2"}', 0, 0),
                 ]
             )
-        return agent, ToolRegistry([])
+        return AgentRuntime(agent=agent, tool_registry=ToolRegistry([]))
 
     phase, _ = make_agent_phase(
         flow_dir,
@@ -631,7 +569,7 @@ async def test_phase_goal_partial_progress_preserved_on_exhaustion(flow_dir, mon
             TaskConfig(name="t1", prompt="First.", goal="check t1", max_goal_attempts=2),
             TaskConfig(name="t2", prompt="Second.", goal="check t2", max_goal_attempts=2),
         ],
-        goal_agent_builder=goal_builder,
+        goal_runtime_builder=goal_builder,
     )
 
     from ddev.ai.phases.goal import GoalAttemptsExhausted
@@ -654,13 +592,16 @@ async def test_goal_exhaustion_tokens_captured_on_phase(flow_dir, monkeypatch, m
         ]
     )
 
-    def goal_builder(owner_id):
-        return MockAgent(
-            [
-                make_response('{"valid": false, "reason": "miss 1"}', 8, 4),
-                make_response('{"valid": false, "reason": "miss 2"}', 8, 4),
-            ]
-        ), ToolRegistry([])
+    def goal_builder(owner_id: str) -> AgentRuntime:
+        return AgentRuntime(
+            agent=MockAgent(
+                [
+                    make_response('{"valid": false, "reason": "miss 1"}', 8, 4),
+                    make_response('{"valid": false, "reason": "miss 2"}', 8, 4),
+                ]
+            ),
+            tool_registry=ToolRegistry([]),
+        )
 
     phase, _ = make_agent_phase(
         flow_dir,
@@ -668,7 +609,7 @@ async def test_goal_exhaustion_tokens_captured_on_phase(flow_dir, monkeypatch, m
         monkeypatch,
         message_queue,
         tasks=[TaskConfig(name="t1", prompt="Do it.", goal="g", max_goal_attempts=2)],
-        goal_agent_builder=goal_builder,
+        goal_runtime_builder=goal_builder,
     )
 
     from ddev.ai.phases.goal import GoalAttemptsExhausted
@@ -713,13 +654,16 @@ async def test_goal_parse_error_logged_and_tokens_captured(flow_dir, monkeypatch
 
     worker = MockAgent([make_response("worker done", 10, 5)])
 
-    def goal_builder(owner_id):
-        return MockAgent(
-            [
-                make_response("not json", 8, 4),
-                make_response("still not json", 6, 3),
-            ]
-        ), ToolRegistry([])
+    def goal_builder(owner_id: str) -> AgentRuntime:
+        return AgentRuntime(
+            agent=MockAgent(
+                [
+                    make_response("not json", 8, 4),
+                    make_response("still not json", 6, 3),
+                ]
+            ),
+            tool_registry=ToolRegistry([]),
+        )
 
     phase, _ = make_agent_phase(
         flow_dir,
@@ -727,7 +671,7 @@ async def test_goal_parse_error_logged_and_tokens_captured(flow_dir, monkeypatch
         monkeypatch,
         message_queue,
         tasks=[TaskConfig(name="t1", prompt="Do it.", goal="g")],
-        goal_agent_builder=goal_builder,
+        goal_runtime_builder=goal_builder,
     )
 
     with pytest.raises(GoalParseError):

--- a/ddev/tests/ai/phases/test_goal.py
+++ b/ddev/tests/ai/phases/test_goal.py
@@ -6,9 +6,11 @@ import json
 
 import pytest
 
+from ddev.ai.agent.build import AgentRuntime
 from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
-from ddev.ai.phases.config import TaskConfig
+from ddev.ai.phases.config import AgentConfig, TaskConfig
 from ddev.ai.phases.goal import (
+    GOAL_REVIEWER_SYSTEM_PROMPT,
     GoalAttemptsExhausted,
     GoalParseError,
     build_reviewer_user_message,
@@ -116,19 +118,25 @@ def test_build_reviewer_user_message_sections():
 def _make_worker_process(responses):
     """ReActProcess wired to a MockAgent — used as the worker."""
     agent = MockAgent(list(responses))
-    return ReActProcess(agent=agent, tool_registry=ToolRegistry([])), agent
+    return ReActProcess(AgentRuntime(agent=agent, tool_registry=ToolRegistry([]))), agent
 
 
-def _reviewer_builder(responses):
-    """A GoalAgentBuilder that returns a fresh MockAgent + empty ToolRegistry."""
-    agent = MockAgent(list(responses))
-    calls: list[str] = []
+class ReviewerRuntimeFactory:
+    """Runtime factory returning a fixed reviewer agent for run_goal_loop tests."""
 
-    def builder(owner_id):
-        calls.append(owner_id)
-        return agent, ToolRegistry([])
+    def __init__(self, responses) -> None:
+        self.agent = MockAgent(list(responses))
+        self.calls: list[dict[str, object]] = []
 
-    return builder, calls, agent
+    def build_runtime(self, *, agent_config: AgentConfig, system_prompt: str, owner_id: str) -> AgentRuntime:
+        self.calls.append({"agent_config": agent_config, "system_prompt": system_prompt, "owner_id": owner_id})
+        return AgentRuntime(agent=self.agent, tool_registry=ToolRegistry([]))
+
+
+def _reviewer_factory(responses) -> tuple[ReviewerRuntimeFactory, list[dict[str, object]], MockAgent]:
+    """Return a reviewer runtime factory plus its captured calls and agent."""
+    factory = ReviewerRuntimeFactory(responses)
+    return factory, factory.calls, factory.agent
 
 
 async def _noop_compact(_):
@@ -149,7 +157,7 @@ async def test_run_goal_loop_passes_on_first_attempt(tmp_path):
         total_output_tokens=50,
         context_usage=None,
     )
-    builder, builder_calls, _ = _reviewer_builder([make_response('{"valid": true, "reason": ""}', 20, 10)])
+    factory, builder_calls, _ = _reviewer_factory([make_response('{"valid": true, "reason": ""}', 20, 10)])
 
     outcome = await run_goal_loop(
         task=TaskConfig(name="t1", prompt="x", goal="verify"),
@@ -157,7 +165,8 @@ async def test_run_goal_loop_passes_on_first_attempt(tmp_path):
         rendered_task_prompt="TASK",
         worker_process=worker_process,
         initial_result=initial_result,
-        goal_agent_builder=builder,
+        parent_agent_config=AgentConfig(tools=[]),
+        runtime_factory=factory,
         callbacks=Callbacks(),
         phase_id="p1",
         log_root=tmp_path,
@@ -169,12 +178,53 @@ async def test_run_goal_loop_passes_on_first_attempt(tmp_path):
     assert outcome.total_output_tokens == 10
     assert outcome.final_result is initial_result
     assert worker_agent.send_calls == []
-    assert builder_calls == ["p1.goal.t1"]
+    assert builder_calls[0]["owner_id"] == "p1.goal.t1"
+    assert builder_calls[0]["system_prompt"] == GOAL_REVIEWER_SYSTEM_PROMPT
 
     log_path = tmp_path / "goal_agent" / "p1" / "t1.jsonl"
     assert log_path.exists()
     events = {json.loads(line)["event"] for line in log_path.read_text().splitlines() if line.strip()}
     assert {"start", "finish"} <= events
+
+
+async def test_run_goal_loop_derives_reviewer_runtime_policy(tmp_path):
+    worker_process, _ = _make_worker_process([])
+    initial_result = ReActResult(
+        final_response=make_response("did things"),
+        iterations=1,
+        total_input_tokens=100,
+        total_output_tokens=50,
+        context_usage=None,
+    )
+    factory, builder_calls, _ = _reviewer_factory([make_response('{"valid": true, "reason": ""}', 20, 10)])
+    parent_config = AgentConfig(
+        provider="anthropic",
+        tools=["read_file", "edit_file", "grep", "create_file"],
+        model="custom-model",
+        max_tokens=999,
+    )
+
+    await run_goal_loop(
+        task=TaskConfig(name="t1", prompt="x", goal="verify"),
+        goal_text="verify",
+        rendered_task_prompt="TASK",
+        worker_process=worker_process,
+        initial_result=initial_result,
+        parent_agent_config=parent_config,
+        runtime_factory=factory,
+        callbacks=Callbacks(),
+        phase_id="p1",
+        log_root=tmp_path,
+        compact_if_needed=_noop_compact,
+    )
+
+    reviewer_config = builder_calls[0]["agent_config"]
+    assert reviewer_config.provider == "anthropic"
+    assert reviewer_config.tools == ["read_file", "grep"]
+    assert reviewer_config.model is None
+    assert reviewer_config.max_tokens is None
+    assert builder_calls[0]["system_prompt"] == GOAL_REVIEWER_SYSTEM_PROMPT
+    assert builder_calls[0]["owner_id"] == "p1.goal.t1"
 
 
 async def test_run_goal_loop_one_retry_then_pass(tmp_path):
@@ -186,7 +236,7 @@ async def test_run_goal_loop_one_retry_then_pass(tmp_path):
         total_output_tokens=50,
         context_usage=None,
     )
-    builder, _, reviewer_agent = _reviewer_builder(
+    factory, _, reviewer_agent = _reviewer_factory(
         [
             make_response('{"valid": false, "reason": "missing X"}', 20, 10),
             make_response('{"valid": true, "reason": ""}', 25, 12),
@@ -199,7 +249,8 @@ async def test_run_goal_loop_one_retry_then_pass(tmp_path):
         rendered_task_prompt="TASK",
         worker_process=worker_process,
         initial_result=initial_result,
-        goal_agent_builder=builder,
+        parent_agent_config=AgentConfig(tools=[]),
+        runtime_factory=factory,
         callbacks=Callbacks(),
         phase_id="p1",
         log_root=tmp_path,
@@ -225,7 +276,7 @@ async def test_run_goal_loop_exhausts_attempts(tmp_path):
         total_output_tokens=5,
         context_usage=None,
     )
-    builder, _, _ = _reviewer_builder(
+    factory, _, _ = _reviewer_factory(
         [
             make_response('{"valid": false, "reason": "first miss"}', 5, 3),
             make_response('{"valid": false, "reason": "second miss"}', 7, 4),
@@ -239,7 +290,8 @@ async def test_run_goal_loop_exhausts_attempts(tmp_path):
             rendered_task_prompt="TASK",
             worker_process=worker_process,
             initial_result=initial_result,
-            goal_agent_builder=builder,
+            parent_agent_config=AgentConfig(tools=[]),
+            runtime_factory=factory,
             callbacks=Callbacks(),
             phase_id="p1",
             log_root=tmp_path,
@@ -268,7 +320,7 @@ async def test_run_goal_loop_parse_retry_succeeds(tmp_path):
         total_output_tokens=0,
         context_usage=None,
     )
-    builder, _, reviewer_agent = _reviewer_builder(
+    factory, _, reviewer_agent = _reviewer_factory(
         [
             make_response("not json", 5, 5),
             make_response('{"valid": true, "reason": ""}', 7, 7),
@@ -281,7 +333,8 @@ async def test_run_goal_loop_parse_retry_succeeds(tmp_path):
         rendered_task_prompt="TASK",
         worker_process=worker_process,
         initial_result=initial_result,
-        goal_agent_builder=builder,
+        parent_agent_config=AgentConfig(tools=[]),
+        runtime_factory=factory,
         callbacks=Callbacks(),
         phase_id="p1",
         log_root=tmp_path,
@@ -302,7 +355,7 @@ async def test_run_goal_loop_parse_retry_fails_raises(tmp_path):
         total_output_tokens=0,
         context_usage=None,
     )
-    builder, _, _ = _reviewer_builder(
+    factory, _, _ = _reviewer_factory(
         [
             make_response("not json", 5, 3),
             make_response("still not json", 7, 4),
@@ -316,7 +369,8 @@ async def test_run_goal_loop_parse_retry_fails_raises(tmp_path):
             rendered_task_prompt="TASK",
             worker_process=worker_process,
             initial_result=initial_result,
-            goal_agent_builder=builder,
+            parent_agent_config=AgentConfig(tools=[]),
+            runtime_factory=factory,
             callbacks=Callbacks(),
             phase_id="p1",
             log_root=tmp_path,
@@ -356,7 +410,7 @@ async def test_run_goal_loop_fires_callbacks(tmp_path):
         total_output_tokens=0,
         context_usage=None,
     )
-    builder, _, _ = _reviewer_builder(
+    factory, _, _ = _reviewer_factory(
         [
             make_response('{"valid": false, "reason": "fix X"}', 0, 0),
             make_response('{"valid": true, "reason": ""}', 0, 0),
@@ -369,7 +423,8 @@ async def test_run_goal_loop_fires_callbacks(tmp_path):
         rendered_task_prompt="TASK",
         worker_process=worker_process,
         initial_result=initial_result,
-        goal_agent_builder=builder,
+        parent_agent_config=AgentConfig(tools=[]),
+        runtime_factory=factory,
         callbacks=Callbacks([cb_set]),
         phase_id="p1",
         log_root=tmp_path,

--- a/ddev/tests/ai/phases/test_orchestrator.py
+++ b/ddev/tests/ai/phases/test_orchestrator.py
@@ -339,6 +339,7 @@ def test_resource_provider_agent_config_unknown_name_raises(file_access_policy):
         agent_clients={},
         file_access_policy=file_access_policy,
         agents={"a": MagicMock(), "b": MagicMock()},
+        artifact_root=file_access_policy.write_root,
     )
     with pytest.raises(ResourceUnavailableError, match="No agent definition named 'missing'"):
         provider.agent_config("missing")

--- a/ddev/tests/ai/react/test_process.py
+++ b/ddev/tests/ai/react/test_process.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 
 from ddev.ai.agent.base import BaseAgent
+from ddev.ai.agent.build import AgentRuntime
 from ddev.ai.agent.exceptions import AgentConnectionError
 from ddev.ai.agent.types import AgentResponse, ContextUsage, StopReason, TokenUsage, ToolCall, ToolResultMessage
 from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
@@ -168,8 +169,7 @@ def make_process(
     compact_threshold_pct: float | None = None,
 ) -> ReActProcess:
     return ReActProcess(
-        agent=agent,
-        tool_registry=registry or MockToolRegistry(),
+        AgentRuntime(agent=agent, tool_registry=registry or MockToolRegistry()),
         callbacks=callbacks,
         compact_threshold_pct=compact_threshold_pct,
     )
@@ -260,8 +260,7 @@ async def test_tool_exception_loop_continues_with_failure_result() -> None:
     )
 
     result = await ReActProcess(
-        agent=agent,
-        tool_registry=RaisingToolRegistry(RuntimeError("disk error")),
+        AgentRuntime(agent=agent, tool_registry=RaisingToolRegistry(RuntimeError("disk error"))),
     ).start("Do something")
 
     assert result.iterations == 2
@@ -283,8 +282,7 @@ async def test_tool_exception_on_tool_call_callback_fires_with_error_result() ->
     recorder = CallbackRecorder()
 
     await ReActProcess(
-        agent=agent,
-        tool_registry=RaisingToolRegistry(ValueError("oops")),
+        AgentRuntime(agent=agent, tool_registry=RaisingToolRegistry(ValueError("oops"))),
         callbacks=Callbacks([recorder.callback_set]),
     ).start("x")
 
@@ -312,8 +310,7 @@ async def test_tool_exception_error_message_format(exc: BaseException, expected_
     )
 
     await ReActProcess(
-        agent=agent,
-        tool_registry=RaisingToolRegistry(exc),
+        AgentRuntime(agent=agent, tool_registry=RaisingToolRegistry(exc)),
     ).start("x")
 
     sent_back: list[ToolResultMessage] = agent.send_calls[1]
@@ -337,7 +334,7 @@ async def test_partial_batch_failure_only_affects_raising_tool() -> None:
         }
     )
 
-    result = await ReActProcess(agent=agent, tool_registry=registry).start("Do both")
+    result = await ReActProcess(AgentRuntime(agent=agent, tool_registry=registry)).start("Do both")
 
     assert result.iterations == 2
     sent_back: list[ToolResultMessage] = agent.send_calls[1]
@@ -409,8 +406,7 @@ class ErrorAgent(BaseAgent[Any]):
 async def test_agent_error_notifies_and_reraises() -> None:
     recorder = CallbackRecorder()
     process = ReActProcess(
-        agent=ErrorAgent(),
-        tool_registry=MockToolRegistry(),
+        AgentRuntime(agent=ErrorAgent(), tool_registry=MockToolRegistry()),
         callbacks=Callbacks([recorder.callback_set]),
     )
 
@@ -436,8 +432,7 @@ class InterruptAgent(BaseAgent[Any]):
 async def test_keyboard_interrupt_notifies_and_reraises() -> None:
     recorder = CallbackRecorder()
     process = ReActProcess(
-        agent=InterruptAgent(),
-        tool_registry=MockToolRegistry(),
+        AgentRuntime(agent=InterruptAgent(), tool_registry=MockToolRegistry()),
         callbacks=Callbacks([recorder.callback_set]),
     )
 
@@ -462,8 +457,7 @@ class CancelledAgent(BaseAgent[Any]):
 async def test_cancelled_error_notifies_and_reraises() -> None:
     recorder = CallbackRecorder()
     process = ReActProcess(
-        agent=CancelledAgent(),
-        tool_registry=MockToolRegistry(),
+        AgentRuntime(agent=CancelledAgent(), tool_registry=MockToolRegistry()),
         callbacks=Callbacks([recorder.callback_set]),
     )
 

--- a/ddev/tests/ai/tools/agents/test_spawn_subagent.py
+++ b/ddev/tests/ai/tools/agents/test_spawn_subagent.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import json
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -11,9 +12,10 @@ import pytest
 from anthropic.types import ToolParam
 
 from ddev.ai.agent.base import BaseAgent
-from ddev.ai.agent.build import SubagentBuilder
+from ddev.ai.agent.build import AgentRuntime
 from ddev.ai.agent.exceptions import AgentError
 from ddev.ai.agent.types import AgentResponse, StopReason, TokenUsage, ToolCall, ToolResultMessage
+from ddev.ai.phases.config import AgentConfig
 from ddev.ai.tools.agents.spawn_subagent import SpawnSubagentInput, SpawnSubagentTool
 from ddev.ai.tools.core.types import ToolResult
 from ddev.ai.tools.registry import ToolRegistry
@@ -98,26 +100,30 @@ def make_response(
     )
 
 
-def make_builder(responses: list[AgentResponse], tool_result: ToolResult | None = None) -> SubagentBuilder:
+def make_builder(
+    responses: list[AgentResponse],
+    tool_result: ToolResult | None = None,
+) -> Callable[..., AgentRuntime]:
     """Return a builder closure that replays fixed responses."""
     tr = tool_result or ToolResult(success=True, data="ok")
 
-    def builder(system_prompt: str, owner_id: str, tool_names: list[str]) -> tuple[BaseAgent[Any], ToolRegistry]:
-        return MockAgent(list(responses)), MockToolRegistry(tr)
+    def builder(*, agent_config: AgentConfig, system_prompt: str, owner_id: str) -> AgentRuntime:
+        return AgentRuntime(agent=MockAgent(list(responses)), tool_registry=MockToolRegistry(tr))
 
     return builder
 
 
 def make_tool(
     log_dir: Path,
-    builder: SubagentBuilder,
-    allowed_tools: list[str] | None = None,
+    builder: Callable[..., AgentRuntime],
+    parent_tools: list[str] | None = None,
     owner_id: str = "parent",
+    agent_config: AgentConfig | None = None,
 ) -> SpawnSubagentTool:
     return SpawnSubagentTool(
         owner_id=owner_id,
-        subagent_builder=builder,
-        allowed_tools=allowed_tools if allowed_tools is not None else ["read_file", "edit_file"],
+        agent_config=agent_config or AgentConfig(tools=parent_tools or ["read_file", "edit_file"]),
+        runtime_builder=builder,
         log_dir=log_dir,
     )
 
@@ -140,7 +146,7 @@ def read_events(log_path: Path) -> list[dict]:
     ids=["recursive", "disallowed"],
 )
 async def test_input_validation_fails_before_logging(tmp_path, tools, allowed, error_fragment):
-    tool = make_tool(tmp_path, make_builder([make_response()]), allowed_tools=allowed)
+    tool = make_tool(tmp_path, make_builder([make_response()]), parent_tools=allowed)
     result = await tool(SpawnSubagentInput(system_prompt="s", prompt="p", tools=tools, name="x"))
 
     assert result.success is False
@@ -171,10 +177,11 @@ async def test_mkdir_failure(tmp_path):
 
 async def test_logger_open_failure_returns_tool_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     def builder(
+        *,
+        agent_config: AgentConfig,
         system_prompt: str,
         owner_id: str,
-        tool_names: list[str],
-    ) -> tuple[BaseAgent[Any], ToolRegistry]:
+    ) -> AgentRuntime:
         raise AssertionError("builder should not be called")
 
     def failing_logger(log_path: Path) -> None:
@@ -182,7 +189,7 @@ async def test_logger_open_failure_returns_tool_result(tmp_path: Path, monkeypat
 
     monkeypatch.setattr("ddev.ai.tools.agents.spawn_subagent.AgentLogger", failing_logger)
 
-    tool = make_tool(tmp_path, builder, allowed_tools=[])
+    tool = make_tool(tmp_path, builder, parent_tools=[])
     result = await tool(SpawnSubagentInput(system_prompt="s", prompt="p", tools=[], name="x"))
 
     assert result.success is False
@@ -231,7 +238,7 @@ async def test_multi_iteration_wires_callbacks(tmp_path):
             [make_response(stop_reason=StopReason.TOOL_USE, tool_calls=[tool_call]), make_response(text="done")],
             tool_result=ToolResult(success=True, data="content"),
         ),
-        allowed_tools=["read_file"],
+        parent_tools=["read_file"],
     )
 
     result = await tool(SpawnSubagentInput(system_prompt="sys", prompt="go", tools=["read_file"]))
@@ -239,6 +246,41 @@ async def test_multi_iteration_wires_callbacks(tmp_path):
     assert result.success is True
     assert result.data == "done"
     assert "tool_call" in [e["event"] for e in read_events(tmp_path / "001-unnamed.jsonl")]
+
+
+async def test_child_runtime_config_inherits_parent_settings_and_requested_tools(tmp_path):
+    captured: list[dict[str, object]] = []
+    parent_config = AgentConfig(
+        provider="anthropic",
+        tools=["read_file", "edit_file", "spawn_subagent"],
+        model="custom-model",
+        max_tokens=123,
+    )
+
+    def builder(*, agent_config: AgentConfig, system_prompt: str, owner_id: str) -> AgentRuntime:
+        captured.append({"agent_config": agent_config, "system_prompt": system_prompt, "owner_id": owner_id})
+        return AgentRuntime(agent=MockAgent([make_response(text="ok")]), tool_registry=MockToolRegistry())
+
+    tool = make_tool(
+        tmp_path,
+        builder,
+        parent_tools=["read_file", "edit_file", "spawn_subagent"],
+        agent_config=parent_config,
+    )
+
+    result = await tool(
+        SpawnSubagentInput(system_prompt="child system", prompt="go", tools=["read_file"], name="child")
+    )
+
+    assert result.success is True
+    child_config = captured[0]["agent_config"]
+    assert isinstance(child_config, AgentConfig)
+    assert child_config.provider == "anthropic"
+    assert child_config.model == "custom-model"
+    assert child_config.max_tokens == 123
+    assert child_config.tools == ["read_file"]
+    assert captured[0]["system_prompt"] == "child system"
+    assert captured[0]["owner_id"] == "parent.sub.001-child"
 
 
 async def test_max_tokens_response_prefixed(tmp_path):
@@ -260,13 +302,19 @@ async def test_max_tokens_response_prefixed(tmp_path):
 
 async def test_builder_failure(tmp_path):
     def failing_builder(
+        *,
+        agent_config: AgentConfig,
         system_prompt: str,
         owner_id: str,
-        tool_names: list[str],
-    ) -> tuple[BaseAgent[Any], ToolRegistry]:
+    ) -> AgentRuntime:
         raise ValueError("boom")
 
-    tool = SpawnSubagentTool(owner_id="parent", subagent_builder=failing_builder, allowed_tools=[], log_dir=tmp_path)
+    tool = SpawnSubagentTool(
+        owner_id="parent",
+        agent_config=AgentConfig(tools=[]),
+        runtime_builder=failing_builder,
+        log_dir=tmp_path,
+    )
     result = await tool(SpawnSubagentInput(system_prompt="s", prompt="p", tools=[], name="fail"))
 
     assert result.success is False
@@ -279,11 +327,12 @@ async def test_builder_failure(tmp_path):
 
 async def test_react_process_failure(tmp_path):
     def builder(
+        *,
+        agent_config: AgentConfig,
         system_prompt: str,
         owner_id: str,
-        tool_names: list[str],
-    ) -> tuple[BaseAgent[Any], ToolRegistry]:
-        return _RaisingAgent(AgentError("rate limit")), MockToolRegistry()
+    ) -> AgentRuntime:
+        return AgentRuntime(agent=_RaisingAgent(AgentError("rate limit")), tool_registry=MockToolRegistry())
 
     tool = make_tool(tmp_path, builder)
     result = await tool(SpawnSubagentInput(system_prompt="s", prompt="p", tools=[], name="rl"))
@@ -301,11 +350,12 @@ async def test_finally_close_runs_on_base_exception(tmp_path):
     """KeyboardInterrupt propagates but logger.close() still runs via finally."""
 
     def builder(
+        *,
+        agent_config: AgentConfig,
         system_prompt: str,
         owner_id: str,
-        tool_names: list[str],
-    ) -> tuple[BaseAgent[Any], ToolRegistry]:
-        return _RaisingAgent(KeyboardInterrupt()), MockToolRegistry()
+    ) -> AgentRuntime:
+        return AgentRuntime(agent=_RaisingAgent(KeyboardInterrupt()), tool_registry=MockToolRegistry())
 
     tool = make_tool(tmp_path, builder)
 
@@ -336,14 +386,20 @@ async def test_parallel_spawns_get_distinct_counters(tmp_path):
     owner_ids: list[str] = []
 
     def recording_builder(
+        *,
+        agent_config: AgentConfig,
         system_prompt: str,
         owner_id: str,
-        tool_names: list[str],
-    ) -> tuple[BaseAgent[Any], ToolRegistry]:
+    ) -> AgentRuntime:
         owner_ids.append(owner_id)
-        return MockAgent([make_response(text="ok")]), MockToolRegistry()
+        return AgentRuntime(agent=MockAgent([make_response(text="ok")]), tool_registry=MockToolRegistry())
 
-    tool = SpawnSubagentTool(owner_id="parent", subagent_builder=recording_builder, allowed_tools=[], log_dir=tmp_path)
+    tool = SpawnSubagentTool(
+        owner_id="parent",
+        agent_config=AgentConfig(tools=[]),
+        runtime_builder=recording_builder,
+        log_dir=tmp_path,
+    )
     results = await asyncio.gather(
         *[tool(SpawnSubagentInput(system_prompt="s", prompt="p", tools=[], name=n)) for n in ["x", "y", "z"]]
     )
@@ -351,28 +407,3 @@ async def test_parallel_spawns_get_distinct_counters(tmp_path):
     assert all(r.success for r in results)
     assert len(list(tmp_path.glob("*.jsonl"))) == 3
     assert len(set(owner_ids)) == 3
-
-
-# ---------------------------------------------------------------------------
-# Pydantic input validation (via BaseTool.run)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "raw",
-    [
-        {"prompt": "x"},
-        {"system_prompt": "s", "prompt": "p", "tools": [], "bad_field": True},
-        {"system_prompt": "s", "prompt": "p", "tools": [], "name": "../oops"},
-    ],
-    ids=["missing_field", "extra_field", "unsafe_name"],
-)
-async def test_pydantic_rejects_invalid_input(raw: dict[str, object]) -> None:
-    tool = SpawnSubagentTool(
-        owner_id="p",
-        subagent_builder=make_builder([make_response()]),
-        allowed_tools=[],
-        log_dir=Path("/tmp"),
-    )
-    result = await tool.run(raw)
-    assert result.success is False

--- a/ddev/tests/ai/tools/test_registry.py
+++ b/ddev/tests/ai/tools/test_registry.py
@@ -4,6 +4,9 @@
 
 import pytest
 
+from ddev.ai.agent.build import AgentRuntime
+from ddev.ai.phases.config import AgentConfig
+from ddev.ai.tools.agents.spawn_subagent import SpawnSubagentTool
 from ddev.ai.tools.core.types import ToolResult
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.ai.tools.fs.file_registry import FileRegistry
@@ -156,53 +159,60 @@ OWNER_ID = "test-agent"
 TOOLS_WITHOUT_EXTRA_DEPS = [n for n in ToolRegistry.available_tool_names() if n != "spawn_subagent"]
 
 
-def test_from_names_empty(tmp_path):
-    registry = ToolRegistry.from_names(
-        [], owner_id=OWNER_ID, file_registry=FileRegistry(policy=FileAccessPolicy(write_root=tmp_path))
+def runtime_builder(*, agent_config: AgentConfig, system_prompt: str, owner_id: str) -> AgentRuntime:
+    raise AssertionError("runtime builder should not be called during registry construction")
+
+
+def from_names(tool_names: list[str], tmp_path, *, owner_id: str = OWNER_ID) -> ToolRegistry:
+    return ToolRegistry.from_names(
+        tool_names,
+        owner_id=owner_id,
+        file_registry=FileRegistry(policy=FileAccessPolicy(write_root=tmp_path)),
+        agent_config=AgentConfig.model_construct(provider="anthropic", tools=tool_names),
+        runtime_builder=runtime_builder,
+        artifact_root=tmp_path / "artifacts",
     )
+
+
+def test_from_names_empty(tmp_path):
+    registry = from_names([], tmp_path)
     assert registry.definitions == []
 
 
 def test_from_names_unknown_raises(tmp_path):
     with pytest.raises(ValueError, match="Unknown tool name: 'teleport'"):
-        ToolRegistry.from_names(
-            ["teleport"], owner_id=OWNER_ID, file_registry=FileRegistry(policy=FileAccessPolicy(write_root=tmp_path))
-        )
+        from_names(["teleport"], tmp_path)
 
 
 @pytest.mark.parametrize("name", TOOLS_WITHOUT_EXTRA_DEPS)
 def test_from_names_each_known_tool(name, tmp_path):
-    registry = ToolRegistry.from_names(
-        [name], owner_id=OWNER_ID, file_registry=FileRegistry(policy=FileAccessPolicy(write_root=tmp_path))
-    )
+    registry = from_names([name], tmp_path)
     assert len(registry.definitions) == 1
     assert registry.definitions[0]["name"] == name
 
 
 def test_from_names_all_at_once(tmp_path):
     all_names = TOOLS_WITHOUT_EXTRA_DEPS
-    registry = ToolRegistry.from_names(
-        all_names, owner_id=OWNER_ID, file_registry=FileRegistry(policy=FileAccessPolicy(write_root=tmp_path))
-    )
+    registry = from_names(all_names, tmp_path)
     built_names = {d["name"] for d in registry.definitions}
     assert built_names == set(all_names)
 
 
-def test_from_names_spawn_subagent_without_deps_raises(tmp_path):
-    with pytest.raises(ValueError, match="requires both 'subagent_builder' and 'log_dir'"):
-        ToolRegistry.from_names(
-            ["spawn_subagent"],
-            owner_id=OWNER_ID,
-            file_registry=FileRegistry(policy=FileAccessPolicy(write_root=tmp_path)),
-        )
+def test_from_names_spawn_subagent_gets_runtime_context(tmp_path):
+    registry = from_names(["read_file", "spawn_subagent"], tmp_path)
+
+    tool = registry._tools["spawn_subagent"]
+    assert isinstance(tool, SpawnSubagentTool)
+    assert tool._agent_config == AgentConfig(tools=["read_file", "spawn_subagent"])
+    assert tool._runtime_builder is runtime_builder
+    assert tool._allowed_tools == {"read_file"}
+    assert tool._log_dir == tmp_path / "artifacts" / "subagents" / OWNER_ID
 
 
 def test_from_names_fs_tools_share_file_registry(tmp_path):
     """All tools that use the file registry in the same ToolRegistry share a single instance."""
     all_names = TOOLS_WITHOUT_EXTRA_DEPS
-    registry = ToolRegistry.from_names(
-        all_names, owner_id=OWNER_ID, file_registry=FileRegistry(policy=FileAccessPolicy(write_root=tmp_path))
-    )
+    registry = from_names(all_names, tmp_path)
     fs_tools = [t for t in registry._tools.values() if hasattr(t, "_registry")]
     if len(fs_tools) < 2:
         pytest.skip("Need at least 2 fs tools to test shared registry")
@@ -237,8 +247,22 @@ def test_filter_read_only_unknown_name_raises():
 def test_from_names_reuses_supplied_file_registry(tmp_path):
     """Multiple ToolRegistries can share one FileRegistry; tools carry their own owner_id."""
     shared = FileRegistry(policy=FileAccessPolicy(write_root=tmp_path))
-    reg_a = ToolRegistry.from_names(["read_file", "create_file"], owner_id="a", file_registry=shared)
-    reg_b = ToolRegistry.from_names(["read_file", "create_file"], owner_id="b", file_registry=shared)
+    reg_a = ToolRegistry.from_names(
+        ["read_file", "create_file"],
+        owner_id="a",
+        file_registry=shared,
+        agent_config=AgentConfig(tools=["read_file", "create_file"]),
+        runtime_builder=runtime_builder,
+        artifact_root=tmp_path / "artifacts",
+    )
+    reg_b = ToolRegistry.from_names(
+        ["read_file", "create_file"],
+        owner_id="b",
+        file_registry=shared,
+        agent_config=AgentConfig(tools=["read_file", "create_file"]),
+        runtime_builder=runtime_builder,
+        artifact_root=tmp_path / "artifacts",
+    )
 
     for tool in reg_a._tools.values():
         assert tool._registry is shared


### PR DESCRIPTION
### What does this PR do?

Refactors the AI framework runtime construction path so callers pass a single `AgentRuntime` through the ReAct flow instead of manually carrying separate agent and tool registry objects.

This PR:

- Replaces worker/subagent/goal-specific builders in `ddev.ai.agent.build` with one generic `AgentRuntimeFactory.build_runtime(...)` API.
- Keeps `AgentRuntime` as the pair of agent + tool registry, and updates `ReActProcess` to accept that runtime directly.
- Moves orchestration-specific policy out of the agent layer:
  - `AgenticPhase` renders the worker system prompt and provides the selected parent `AgentConfig`.
  - `phases.goal` derives the reviewer config, including read-only tools and the reviewer prompt.
  - `SpawnSubagentTool` derives child agent configs and allowed child tools from the parent config.
- Simplifies `ToolRegistry` context by removing subagent-specific builder/allowed-tool plumbing and passing generic runtime infrastructure to tool factories.
- Updates AI framework tests for runtime construction, ReAct process wiring, goal validation, subagent spawning, and registry construction.

### Motivation

The previous design introduced `AgentRuntime`, but `ReActProcess` and several call sites still unpacked runtime objects into separate agent and tool-registry values. The agent build layer also knew too much about goal reviewers and subagents, which made phase policy leak into generic agent construction.

This refactor keeps `agent.build` focused on constructing runtimes from explicit inputs, while goal and subagent-specific behavior stays in the modules that own those workflows. The result is a smaller builder API, clearer ownership boundaries, and less duplicated runtime wiring.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
