### PR TITLE
Fix kerberos tests

### DIFF
--- a/datadog_checks_base/tests/compose/kerberos/kerberos-agent.yaml
+++ b/datadog_checks_base/tests/compose/kerberos/kerberos-agent.yaml
@@ -54,7 +54,7 @@ services:
       - "464:8464"
 
   web:
-    image: kerberos-nginx:1.20.2
+    image: kerberos-nginx:1.26.2
     build: ./kerberos-nginx
     environment:
       KRB5_KEYTAB: ${KRB5_KEYTAB}

--- a/datadog_checks_base/tests/compose/kerberos/kerberos-nginx/Dockerfile
+++ b/datadog_checks_base/tests/compose/kerberos/kerberos-nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.20.2
+FROM nginx:1.26.3
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -15,11 +15,12 @@ RUN apt-get update -y -qq && apt-get install -y --no-install-recommends \
   git
 
 RUN cd /usr/src && mkdir nginx \
-  && curl -kfSL https://nginx.org/download/nginx-1.20.2.tar.gz -o nginx.tar.gz \
+  && curl -kfSL https://nginx.org/download/nginx-1.26.3.tar.gz -o nginx.tar.gz \
   && tar -xzf nginx.tar.gz -C nginx --strip-components=1
 
 RUN cd /usr/src/nginx \
-  && git clone http://github.com/stnoonan/spnego-http-auth-nginx-module.git
+  && git clone http://github.com/stnoonan/spnego-http-auth-nginx-module.git \
+  && git -C spnego-http-auth-nginx-module checkout 7fa3864a86d5
 
 RUN cd /usr/src/nginx \
   && ./configure --with-compat --add-dynamic-module=spnego-http-auth-nginx-module \

--- a/datadog_checks_base/tests/compose/kerberos/kerberos.yaml
+++ b/datadog_checks_base/tests/compose/kerberos/kerberos.yaml
@@ -26,7 +26,7 @@ services:
       - "464:8464"
 
   web:
-    image: kerberos-nginx:1.20.2
+    image: kerberos-nginx:1.26.2
     build: ./kerberos-nginx
     container_name: kerberos-nginx
     environment:


### PR DESCRIPTION
### What does this PR do?
Fixes base check kerberos tests, example failure: https://github.com/DataDog/integrations-core/actions/runs/26889825095/job/79319445320

A new `spnego` release was incompatible with the version of `nginx` we were using. This PR does two things to address the issue:
- pin `nginx` to a newer version so it's more up to date
- pin `spnego` to a stable commit so we avoid failures like this in the future 

### Motivation
These tests are already marked as flaky so they do not appear as failing all the time, but they were broken when running agent release tests.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
