### PR TITLE
Add nightly CI job to check TUF root metadata

### DIFF
--- a/.github/workflows/check-tuf-root.yml
+++ b/.github/workflows/check-tuf-root.yml
@@ -1,0 +1,26 @@
+name: Check TUF root metadata
+
+on:
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+    inputs:
+      debug:
+        description: "Post a debug Slack message showing whether the files match and when the metadata expires, without triggering alerts"
+        type: boolean
+        default: false
+
+jobs:
+  check-tuf-root:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check TUF root metadata
+        env:
+          SLACK_API_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
+          SLACK_CHANNEL_IDS: ${{ secrets.SLACK_CHANNEL_ID }},${{ secrets.SLACK_CHANNEL_ID_AGENT_INTEGRATIONS_REVIEWS }}
+          DEBUG_RUN: ${{ inputs.debug }}
+        run: python3 .github/workflows/scripts/check_tuf_root.py

--- a/.github/workflows/scripts/check_tuf_root.py
+++ b/.github/workflows/scripts/check_tuf_root.py
@@ -1,26 +1,49 @@
 """Check TUF root metadata: verify local file matches remote and warn when close to expiring."""
 
+import difflib
 import json
 import os
 import sys
+import time
+import urllib.error
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
-REMOTE_URL = "https://dd-integrations-core-wheels-build-stable.datadoghq.com/metadata.staged/root.json"
-LOCAL_PATH = Path("datadog_checks_downloader/datadog_checks/downloader/data/repo/metadata/root.json")
+
+S3_BUCKET_ROOT = "https://dd-integrations-core-wheels-build-stable.datadoghq.com/metadata.staged/root.json"
+DOWNLOADER_ROOT = Path("datadog_checks_downloader/datadog_checks/downloader/data/repo/metadata/root.json")
 
 WARN_DAYS = [60, 30, 14]
 DAILY_WARN_THRESHOLD = 10
+
+REQUEST_TIMEOUT = 30
+MAX_RETRIES = 10
+BACKOFF_BASE = 5
+BACKOFF_MAX = 600
+
+GITHUB_SERVER_URL = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+GITHUB_REPOSITORY = os.environ.get("GITHUB_REPOSITORY", "")
+GITHUB_RUN_ID = os.environ.get("GITHUB_RUN_ID", "")
+CI_LOGS_URL = f"{GITHUB_SERVER_URL}/{GITHUB_REPOSITORY}/actions/runs/{GITHUB_RUN_ID}"
 
 SLACK_API_TOKEN = os.environ["SLACK_API_TOKEN"]
 SLACK_CHANNEL_IDS = os.environ["SLACK_CHANNEL_IDS"].split(",")
 DEBUG_RUN = os.environ.get("DEBUG_RUN", "").lower() == "true"
 
 
-def fetch_remote() -> dict:
-    with urllib.request.urlopen(REMOTE_URL) as resp:
-        return json.loads(resp.read().decode())
+def urlopen_with_retry(url: str | urllib.request.Request) -> bytes:
+    for attempt in range(MAX_RETRIES + 1):
+        try:
+            with urllib.request.urlopen(url, timeout=REQUEST_TIMEOUT) as resp:
+                return resp.read()
+        except urllib.error.URLError as e:
+            if attempt == MAX_RETRIES:
+                raise
+            delay = min(BACKOFF_BASE * 2**attempt, BACKOFF_MAX)
+            print(f"Request failed ({e}), retrying in {delay}s (attempt {attempt + 1}/{MAX_RETRIES})")
+            time.sleep(delay)
+    raise RuntimeError("unreachable")
 
 
 def post_slack_message(text: str) -> None:
@@ -35,29 +58,28 @@ def post_slack_message(text: str) -> None:
             },
             method="POST",
         )
-        with urllib.request.urlopen(req) as resp:
-            result = json.loads(resp.read().decode())
+        try:
+            data = urlopen_with_retry(req)
+            result = json.loads(data.decode())
             if not result.get("ok"):
                 print(f"Slack error for channel {channel_id}: {result.get('error')}", file=sys.stderr)
-
-
-def should_warn(days_remaining: int) -> bool:
-    if days_remaining <= DAILY_WARN_THRESHOLD:
-        return True
-    return days_remaining in WARN_DAYS
+        except urllib.error.URLError as e:
+            print(f"Slack request failed for channel {channel_id}: {e}", file=sys.stderr)
 
 
 def main() -> None:
     errors: list[str] = []
 
-    remote = fetch_remote()
-    local = json.loads(LOCAL_PATH.read_text())
+    remote_raw = urlopen_with_retry(S3_BUCKET_ROOT)
+    remote = json.loads(remote_raw.decode())
+    local = json.loads(DOWNLOADER_ROOT.read_text())
 
     if local != remote:
-        errors.append(
-            f":x: TUF root mismatch: `{LOCAL_PATH}` does not match `{REMOTE_URL}`. "
-            "The local file needs to be updated."
-        )
+        local_lines = json.dumps(local, indent=2, sort_keys=True).splitlines(keepends=True)
+        remote_lines = json.dumps(remote, indent=2, sort_keys=True).splitlines(keepends=True)
+        diff = "".join(difflib.unified_diff(local_lines, remote_lines, fromfile="downloader/root.json", tofile="s3-bucket/root.json"))
+        print(diff)
+        errors.append(f":x: TUF root mismatch between `downloader/root.json` and `s3-bucket/root.json`. See diff in CI logs: {CI_LOGS_URL}")
 
     expires_str = local["signed"]["expires"]
     expires = datetime.fromisoformat(expires_str.replace("Z", "+00:00"))
@@ -67,19 +89,22 @@ def main() -> None:
     print(f"TUF root expires: {expires_str} ({days_remaining} days remaining)")
 
     if DEBUG_RUN:
-        match_status = ":white_check_mark: Local and remote `root.json` match." if not errors else ":x: Local and remote `root.json` do *not* match."
+        match_status = (
+            ":white_check_mark: Local and remote `root.json` match."
+            if not errors
+            else ":x: Local and remote `root.json` do *not* match."
+        )
         post_slack_message(
             f":ladybug: *Debug run*\n"
             f"{match_status}\n"
             f"Metadata expires on `{expires_str}` ({days_remaining} days remaining)."
         )
-        return
 
     if errors:
         post_slack_message("\n".join(errors))
         sys.exit(1)
 
-    if should_warn(days_remaining):
+    if days_remaining <= DAILY_WARN_THRESHOLD or days_remaining in WARN_DAYS:
         if days_remaining <= DAILY_WARN_THRESHOLD:
             emoji = ":rotating_light:"
         elif days_remaining <= 14:
@@ -87,13 +112,19 @@ def main() -> None:
         else:
             emoji = ":bell:"
 
-        message = (
+        post_slack_message(
             f"{emoji} TUF root metadata expires in *{days_remaining} days* "
             f"(on `{expires_str}`). "
-            "Time to rotate: `datadog_checks_downloader/datadog_checks/downloader/data/repo/metadata/root.json`"
+            f"Time to rotate: `{DOWNLOADER_ROOT}`"
         )
-        post_slack_message(message)
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as e:
+        try:
+            post_slack_message(f":x: TUF root check failed with an unexpected error: `{e}`")
+        except Exception:
+            pass
+        raise

--- a/.github/workflows/scripts/check_tuf_root.py
+++ b/.github/workflows/scripts/check_tuf_root.py
@@ -1,0 +1,99 @@
+"""Check TUF root metadata: verify local file matches remote and warn when close to expiring."""
+
+import json
+import os
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+REMOTE_URL = "https://dd-integrations-core-wheels-build-stable.datadoghq.com/metadata.staged/root.json"
+LOCAL_PATH = Path("datadog_checks_downloader/datadog_checks/downloader/data/repo/metadata/root.json")
+
+WARN_DAYS = [60, 30, 14]
+DAILY_WARN_THRESHOLD = 10
+
+SLACK_API_TOKEN = os.environ["SLACK_API_TOKEN"]
+SLACK_CHANNEL_IDS = os.environ["SLACK_CHANNEL_IDS"].split(",")
+DEBUG_RUN = os.environ.get("DEBUG_RUN", "").lower() == "true"
+
+
+def fetch_remote() -> dict:
+    with urllib.request.urlopen(REMOTE_URL) as resp:
+        return json.loads(resp.read().decode())
+
+
+def post_slack_message(text: str) -> None:
+    for channel_id in SLACK_CHANNEL_IDS:
+        payload = json.dumps({"channel": channel_id.strip(), "text": text}).encode()
+        req = urllib.request.Request(
+            "https://slack.com/api/chat.postMessage",
+            data=payload,
+            headers={
+                "Authorization": f"Bearer {SLACK_API_TOKEN}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req) as resp:
+            result = json.loads(resp.read().decode())
+            if not result.get("ok"):
+                print(f"Slack error for channel {channel_id}: {result.get('error')}", file=sys.stderr)
+
+
+def should_warn(days_remaining: int) -> bool:
+    if days_remaining <= DAILY_WARN_THRESHOLD:
+        return True
+    return days_remaining in WARN_DAYS
+
+
+def main() -> None:
+    errors: list[str] = []
+
+    remote = fetch_remote()
+    local = json.loads(LOCAL_PATH.read_text())
+
+    if local != remote:
+        errors.append(
+            f":x: TUF root mismatch: `{LOCAL_PATH}` does not match `{REMOTE_URL}`. "
+            "The local file needs to be updated."
+        )
+
+    expires_str = local["signed"]["expires"]
+    expires = datetime.fromisoformat(expires_str.replace("Z", "+00:00"))
+    now = datetime.now(timezone.utc)
+    days_remaining = (expires - now).days
+
+    print(f"TUF root expires: {expires_str} ({days_remaining} days remaining)")
+
+    if DEBUG_RUN:
+        match_status = ":white_check_mark: Local and remote `root.json` match." if not errors else ":x: Local and remote `root.json` do *not* match."
+        post_slack_message(
+            f":ladybug: *Debug run*\n"
+            f"{match_status}\n"
+            f"Metadata expires on `{expires_str}` ({days_remaining} days remaining)."
+        )
+        return
+
+    if errors:
+        post_slack_message("\n".join(errors))
+        sys.exit(1)
+
+    if should_warn(days_remaining):
+        if days_remaining <= DAILY_WARN_THRESHOLD:
+            emoji = ":rotating_light:"
+        elif days_remaining <= 14:
+            emoji = ":warning:"
+        else:
+            emoji = ":bell:"
+
+        message = (
+            f"{emoji} TUF root metadata expires in *{days_remaining} days* "
+            f"(on `{expires_str}`). "
+            "Time to rotate: `datadog_checks_downloader/datadog_checks/downloader/data/repo/metadata/root.json`"
+        )
+        post_slack_message(message)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### What does this PR do?

Adds a nightly GitHub Actions workflow that:
- Verifies `datadog_checks_downloader/datadog_checks/downloader/data/repo/metadata/root.json` matches the authoritative copy at `https://dd-integrations-core-wheels-build-stable.datadoghq.com/metadata.staged/root.json`, printing a unified diff to CI logs on mismatch.
- Warns on Slack when the metadata is approaching expiry: at 60, 30, and 14 days out, then daily from 10 days onward. Emoji escalates from 🔔 to ⚠️ to 🚨.

A `debug` input is available on manual runs to post a Slack summary of current state (match status + expiry) without altering normal job behavior.

### Motivation

TUF root metadata has an expiry date. If it expires or drifts from the authoritative remote without anyone noticing, the downloader breaks silently. This job surfaces both problems early.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged