### PR TITLE
[SDBM-2635] postgres: include dbms=postgresql in SQL obfuscation options

### DIFF
--- a/postgres/changelog.d/23926.fixed
+++ b/postgres/changelog.d/23926.fixed
@@ -1,0 +1,1 @@
+Set dbms=postgresql in obfuscation options to align query_signature with dbm-logs-processor

--- a/postgres/changelog.d/23926.fixed
+++ b/postgres/changelog.d/23926.fixed
@@ -1,1 +1,1 @@
-Set dbms=postgresql in obfuscation options to align query_signature with dbm-logs-processor
+Set dbms=postgresql in obfuscation options to align query_signature with dbm-logs-processor.

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -176,6 +176,7 @@ class PostgresStatementSamples(DBMAsyncJob):
         obfuscate_options['table_names'] = self._config.obfuscator_options.collect_tables
         obfuscate_options['dollar_quoted_func'] = self._config.obfuscator_options.keep_dollar_quoted_func
         obfuscate_options['return_json_metadata'] = self._config.obfuscator_options.collect_metadata
+        obfuscate_options['dbms'] = 'postgresql'
         self._obfuscate_options = to_native_string(json.dumps(obfuscate_options))
 
         self._collect_raw_query_statement = config.collect_raw_query_statement.enabled

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -195,6 +195,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
         obfuscate_options['table_names'] = self._config.obfuscator_options.collect_tables
         obfuscate_options['dollar_quoted_func'] = self._config.obfuscator_options.keep_dollar_quoted_func
         obfuscate_options['return_json_metadata'] = self._config.obfuscator_options.collect_metadata
+        obfuscate_options['dbms'] = 'postgresql'
         self._obfuscate_options = to_native_string(json.dumps(obfuscate_options))
         # full_statement_text_cache: limit the ingestion rate of full statement text events per query_signature
         self._full_statement_text_cache = TTLCache(

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -415,6 +415,29 @@ def test_statement_metrics_with_duplicates(aggregator, integration_check, dbm_in
     assert row['calls'] == 2
 
 
+def test_obfuscate_sql_options(aggregator, integration_check, dbm_instance, datadog_agent):
+    """Assert that obfuscate_sql is called with the expected options for both metrics and samples."""
+    dbm_instance['collect_schemas'] = {'enabled': False}
+
+    captured_options = []
+
+    def obfuscate_sql(query, options=None):
+        if options is not None:
+            captured_options.append(json.loads(options))
+        return json.dumps({'query': query, 'metadata': {}})
+
+    check = integration_check(dbm_instance)
+    check._connect()
+
+    with mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent:
+        mock_agent.side_effect = obfuscate_sql
+        run_one_check(check, cancel=False)
+
+    assert captured_options, "obfuscate_sql was never called with options"
+    for opts in captured_options:
+        assert opts.get('dbms') == 'postgresql', f"missing dbms=postgresql in obfuscation options: {opts}"
+
+
 @pytest.fixture
 def bob_conn():
     conn = psycopg.connect(host=HOST, dbname=DB_NAME, user="bob", password="bob")

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -427,7 +427,9 @@ def test_obfuscate_sql_options(aggregator, integration_check, dbm_instance, data
     for name, obj in [('statement_metrics', check.statement_metrics), ('statement_samples', check.statement_samples)]:
         opts = json.loads(obj._obfuscate_options)
         assert opts.get('dbms') == 'postgresql', f"{name}: missing dbms=postgresql in obfuscation options"
-        assert opts.get('return_json_metadata') is True, f"{name}: missing return_json_metadata=True in obfuscation options"
+        assert opts.get('return_json_metadata') is True, (
+            f"{name}: missing return_json_metadata=True in obfuscation options"
+        )
 
     captured_options = []
 

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -416,8 +416,18 @@ def test_statement_metrics_with_duplicates(aggregator, integration_check, dbm_in
 
 
 def test_obfuscate_sql_options(aggregator, integration_check, dbm_instance, datadog_agent):
-    """Assert that obfuscate_sql is called with the expected options for both metrics and samples."""
+    """Verify obfuscate_sql is called with dbms=postgresql for both metrics and samples."""
     dbm_instance['collect_schemas'] = {'enabled': False}
+
+    check = integration_check(dbm_instance)
+    check._connect()
+
+    # Unconditionally verify both classes have the correct options set at init time,
+    # independent of whether the DB produces any queries to obfuscate.
+    for name, obj in [('statement_metrics', check.statement_metrics), ('statement_samples', check.statement_samples)]:
+        opts = json.loads(obj._obfuscate_options)
+        assert opts.get('dbms') == 'postgresql', f"{name}: missing dbms=postgresql in obfuscation options"
+        assert opts.get('return_json_metadata') is True, f"{name}: missing return_json_metadata=True in obfuscation options"
 
     captured_options = []
 
@@ -425,9 +435,6 @@ def test_obfuscate_sql_options(aggregator, integration_check, dbm_instance, data
         if options is not None:
             captured_options.append(json.loads(options))
         return json.dumps({'query': query, 'metadata': {}})
-
-    check = integration_check(dbm_instance)
-    check._connect()
 
     with mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent:
         mock_agent.side_effect = obfuscate_sql


### PR DESCRIPTION
## What does this PR do?

Adds `dbms='postgresql'` to the `obfuscate_options` dict in both `PostgresStatementMetrics` and `PostgresStatementSamples`.

## Motivation

Both classes build an `obfuscate_options` dict by calling `ObfuscatorOptions.model_dump()` and then manually patching in field-name translations (`table_names`, `dollar_quoted_func`, `return_json_metadata`) because the Python names don't match the Go struct's JSON tags. The `dbms` field was never included, so the Go obfuscator received `DBMS=""` instead of `"postgresql"`. This diverges from `dbm-logs-processor`, which explicitly sets `DBMS: "postgresql"`, and leaves the integration unprotected against any future PostgreSQL-specific lexer paths in `go-sqllexer`.

Part of a series of fixes for `query_signature` parity between the agent and `dbm-logs-processor` (SDBM-2635).

## Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged