### PR TITLE
DBMON-4906 - Update Postgres dashboard aggregation functions for postgresql.connections

### DIFF
--- a/postgres/assets/dashboards/postgresql_dashboard.json
+++ b/postgres/assets/dashboards/postgresql_dashboard.json
@@ -91,7 +91,7 @@
                             {
                                 "data_source": "metrics",
                                 "name": "query1",
-                                "query": "avg:postgresql.connections{$scope} by {db}",
+                                "query": "sum:postgresql.connections{$scope} by {db}.weighted()",
                                 "semantic_mode": "combined"
                             }
                         ],

--- a/postgres/assets/dashboards/postgresql_screenboard_dashboard.json
+++ b/postgres/assets/dashboards/postgresql_screenboard_dashboard.json
@@ -1021,7 +1021,7 @@
                   "on_right_yaxis": false,
                   "queries": [
                     {
-                      "query": "avg:postgresql.connections{$scope,$db,$host} by {db}.rollup(max)",
+                      "query": "sum:postgresql.connections{$scope,$db,$host} by {db}.rollup(max)",
                       "data_source": "metrics",
                       "name": "query1",
                       "semantic_mode": "combined"
@@ -1090,7 +1090,7 @@
                   "response_format": "scalar",
                   "queries": [
                     {
-                      "query": "max:postgresql.connections{$scope,$db,$host} by {db}",
+                      "query": "sum:postgresql.connections{$scope,$db,$host} by {db}.weighted()",
                       "data_source": "metrics",
                       "name": "query1",
                       "aggregator": "avg",


### PR DESCRIPTION
### What does this PR do?

It updates the 3 `postgresql.connections` queries on the Postgres Overview and Postgres Metrics dashboards to use `sum` instead of `avg`/`max`, and adds `.weighted()` for time-averaged values. The "Active connections" line keeps `.rollup(max)` to preserve the peak-vs-`max_connections` comparison.

### Motivation

Ensure that the out of the box dashboards are consistent with DBM use of the `postgresql.connections` metric.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
