### PR TITLE
disk: apply device_include/exclude filtering to latency metrics

### DIFF
--- a/disk/changelog.d/23928.fixed
+++ b/disk/changelog.d/23928.fixed
@@ -1,0 +1,1 @@
+Apply device_include/device_exclude filtering to latency metrics so that read_time and write_time metrics are not emitted for excluded devices.

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -114,6 +114,7 @@ class Disk(AgentCheck):
         if self._tag_by_label and Platform.is_linux():
             self.devices_label = self._get_devices_label()
 
+        included_devices = set()
         for part in psutil.disk_partitions(all=self._include_all_devices):
             self.log.debug('Checking device %s', part.device)
             # we check all exclude conditions
@@ -149,6 +150,7 @@ class Disk(AgentCheck):
                 continue
 
             self.log.debug('Passed: %s', part.device)
+            included_devices.add(_base_device_name(part.device))
 
             tags = self._get_tags(part)
             for metric_name, metric_value in self._collect_part_metrics(part, disk_usage).items():
@@ -164,7 +166,10 @@ class Disk(AgentCheck):
                 else:
                     self.service_check('disk.read_write', AgentCheck.UNKNOWN, tags=tags)
 
-        self.collect_latency_metrics()
+        # Only pass the allowed set when a device filter is active; otherwise preserve
+        # the original behaviour of emitting latency metrics for all IO counter devices.
+        device_filter_active = self._device_include is not None or self._device_exclude is not None
+        self.collect_latency_metrics(included_devices if device_filter_active else None)
 
     def _get_tags(self, part):
         device_name = part.mountpoint if self._use_mount else part.device
@@ -323,10 +328,14 @@ class Disk(AgentCheck):
 
         return metrics
 
-    def collect_latency_metrics(self):
+    def collect_latency_metrics(self, included_devices=None):
         for disk_name, disk in psutil.disk_io_counters(perdisk=True).items():
             self.log.debug('IO Counters: %s -> %s', disk_name, disk)
-            if self._device_excluded(disk_name) or not self._device_included(disk_name):
+            # included_devices is a set of _base_device_name values derived from the partitions
+            # that passed exclude_disk() in check(). Using base names avoids mismatches between
+            # the full paths returned by disk_partitions (e.g. /dev/sda1) and the bare names
+            # returned by disk_io_counters on Linux (e.g. sda1).
+            if included_devices is not None and _base_device_name(disk_name) not in included_devices:
                 self.log.debug('Excluding IO counters for device %s', disk_name)
                 continue
             try:

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -326,6 +326,9 @@ class Disk(AgentCheck):
     def collect_latency_metrics(self):
         for disk_name, disk in psutil.disk_io_counters(perdisk=True).items():
             self.log.debug('IO Counters: %s -> %s', disk_name, disk)
+            if self._device_excluded(disk_name) or not self._device_included(disk_name):
+                self.log.debug('Excluding IO counters for device %s', disk_name)
+                continue
             try:
                 metric_tags = [] if self._custom_tags is None else self._custom_tags[:]
 

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -658,36 +658,29 @@ def test_device_include_exclude():
     assert c.exclude_disk(MockPart(device='/dev/sda4')) is True
 
 
-def test_latency_metrics_respect_device_include(aggregator, dd_run_check):
+def test_latency_metrics_respect_device_include(aggregator):
     """
-    Latency metrics must honour device_include/device_exclude.
+    collect_latency_metrics must only emit metrics for devices in included_devices.
 
-    On Linux, disk_partitions() returns full paths (e.g. /dev/sda1) while
-    disk_io_counters() returns bare names (e.g. sda1). The filter normalises both
-    sides via _base_device_name so that including /dev/sda1 correctly allows sda1's
-    latency metrics and excludes sdb1's. On Windows both sources use drive-letter
-    format (e.g. C:), so no normalisation is needed.
+    On Linux, disk_io_counters() returns bare names (e.g. sda1) while
+    disk_partitions() returns full paths (e.g. /dev/sda1). The included_devices
+    set is built from _base_device_name values, which normalises both formats to
+    the same bare name so matching works cross-platform.
     """
     if ON_WINDOWS:
-        partition_device = 'C:\\'
         included_io_key = 'C:'
         excluded_io_key = 'D:'
     else:
-        partition_device = '/dev/sda1'
-        included_io_key = 'sda1'  # bare name as returned by disk_io_counters on Linux
+        included_io_key = 'sda1'
         excluded_io_key = 'sdb1'
 
     io_counters = {included_io_key: MockDiskMetrics(), excluded_io_key: MockDiskMetrics()}
+    included_devices = {_base_device_name(included_io_key)}
 
-    instance = {'device_include': [partition_device], 'tag_by_label': False}
-    c = Disk('disk', {}, [instance])
+    c = Disk('disk', {}, [{'tag_by_label': False}])
 
-    with (
-        mock.patch('psutil.disk_partitions', return_value=[MockPart(device=partition_device)]),
-        mock.patch('psutil.disk_usage', return_value=MockDiskMetrics()),
-        mock.patch('psutil.disk_io_counters', return_value=io_counters),
-    ):
-        dd_run_check(c)
+    with mock.patch('psutil.disk_io_counters', return_value=io_counters):
+        c.collect_latency_metrics(included_devices)
 
     latency_metrics = [
         'system.disk.read_time',

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -13,7 +13,7 @@ from datadog_checks.base.utils.timeout import TimeoutException
 from datadog_checks.dev.testing import requires_linux, requires_windows
 from datadog_checks.dev.utils import ON_WINDOWS, get_metadata_metrics, mock_context_manager
 from datadog_checks.disk import Disk
-from datadog_checks.disk.disk import IGNORE_CASE
+from datadog_checks.disk.disk import IGNORE_CASE, _base_device_name
 
 if ON_WINDOWS:
     DEFAULT_DEVICE_NAME = 'c:'
@@ -685,8 +685,16 @@ def test_latency_metrics_respect_device_include(aggregator, dd_run_check):
         'system.disk.write_time_pct',
     ]
     for metric in latency_metrics:
-        aggregator.assert_metric(metric, tags=['device:{}'.format(included_device), 'device_name:sda1'], count=1)
-        aggregator.assert_metric(metric, tags=['device:{}'.format(excluded_device), 'device_name:sdb1'], count=0)
+        aggregator.assert_metric(
+            metric,
+            tags=['device:{}'.format(included_device), 'device_name:{}'.format(_base_device_name(included_device))],
+            count=1,
+        )
+        aggregator.assert_metric(
+            metric,
+            tags=['device:{}'.format(excluded_device), 'device_name:{}'.format(_base_device_name(excluded_device))],
+            count=0,
+        )
 
 
 def test_mount_point_include():

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -660,19 +660,24 @@ def test_device_include_exclude():
 
 def test_latency_metrics_respect_device_include(aggregator, dd_run_check):
     """
-    Latency metrics (read_time, write_time) must honour device_include/device_exclude,
-    not emit metrics for every disk regardless of configuration.
+    Latency metrics must honour device_include/device_exclude.
+
+    disk_partitions() returns full paths (e.g. /dev/sda1) while disk_io_counters()
+    returns bare names on Linux (e.g. sda1). The filter must normalise both sides
+    via _base_device_name so that including /dev/sda1 correctly allows sda1's latency
+    metrics and excludes sdb1's.
     """
-    included_device = '/dev/sda1'
-    excluded_device = '/dev/sdb1'
+    partition_device = '/dev/sda1'
+    included_io_key = 'sda1'  # bare name as returned by disk_io_counters on Linux
+    excluded_io_key = 'sdb1'
 
-    io_counters = {included_device: MockDiskMetrics(), excluded_device: MockDiskMetrics()}
+    io_counters = {included_io_key: MockDiskMetrics(), excluded_io_key: MockDiskMetrics()}
 
-    instance = {'device_include': [included_device], 'tag_by_label': False}
+    instance = {'device_include': [partition_device], 'tag_by_label': False}
     c = Disk('disk', {}, [instance])
 
     with (
-        mock.patch('psutil.disk_partitions', return_value=[MockPart(device=included_device)]),
+        mock.patch('psutil.disk_partitions', return_value=[MockPart(device=partition_device)]),
         mock.patch('psutil.disk_usage', return_value=MockDiskMetrics()),
         mock.patch('psutil.disk_io_counters', return_value=io_counters),
     ):
@@ -687,12 +692,12 @@ def test_latency_metrics_respect_device_include(aggregator, dd_run_check):
     for metric in latency_metrics:
         aggregator.assert_metric(
             metric,
-            tags=['device:{}'.format(included_device), 'device_name:{}'.format(_base_device_name(included_device))],
+            tags=['device:{}'.format(included_io_key), 'device_name:{}'.format(_base_device_name(included_io_key))],
             count=1,
         )
         aggregator.assert_metric(
             metric,
-            tags=['device:{}'.format(excluded_device), 'device_name:{}'.format(_base_device_name(excluded_device))],
+            tags=['device:{}'.format(excluded_io_key), 'device_name:{}'.format(_base_device_name(excluded_io_key))],
             count=0,
         )
 

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -678,13 +678,15 @@ def test_latency_metrics_respect_device_include(aggregator, dd_run_check):
     ):
         dd_run_check(c)
 
-    latency_metrics = ['system.disk.read_time', 'system.disk.write_time',
-                       'system.disk.read_time_pct', 'system.disk.write_time_pct']
+    latency_metrics = [
+        'system.disk.read_time',
+        'system.disk.write_time',
+        'system.disk.read_time_pct',
+        'system.disk.write_time_pct',
+    ]
     for metric in latency_metrics:
-        aggregator.assert_metric(metric, tags=['device:{}'.format(included_device),
-                                               'device_name:sda1'], count=1)
-        aggregator.assert_metric(metric, tags=['device:{}'.format(excluded_device),
-                                               'device_name:sdb1'], count=0)
+        aggregator.assert_metric(metric, tags=['device:{}'.format(included_device), 'device_name:sda1'], count=1)
+        aggregator.assert_metric(metric, tags=['device:{}'.format(excluded_device), 'device_name:sdb1'], count=0)
 
 
 def test_mount_point_include():

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -662,14 +662,20 @@ def test_latency_metrics_respect_device_include(aggregator, dd_run_check):
     """
     Latency metrics must honour device_include/device_exclude.
 
-    disk_partitions() returns full paths (e.g. /dev/sda1) while disk_io_counters()
-    returns bare names on Linux (e.g. sda1). The filter must normalise both sides
-    via _base_device_name so that including /dev/sda1 correctly allows sda1's latency
-    metrics and excludes sdb1's.
+    On Linux, disk_partitions() returns full paths (e.g. /dev/sda1) while
+    disk_io_counters() returns bare names (e.g. sda1). The filter normalises both
+    sides via _base_device_name so that including /dev/sda1 correctly allows sda1's
+    latency metrics and excludes sdb1's. On Windows both sources use drive-letter
+    format (e.g. C:), so no normalisation is needed.
     """
-    partition_device = '/dev/sda1'
-    included_io_key = 'sda1'  # bare name as returned by disk_io_counters on Linux
-    excluded_io_key = 'sdb1'
+    if ON_WINDOWS:
+        partition_device = 'C:\\'
+        included_io_key = 'C:'
+        excluded_io_key = 'D:'
+    else:
+        partition_device = '/dev/sda1'
+        included_io_key = 'sda1'  # bare name as returned by disk_io_counters on Linux
+        excluded_io_key = 'sdb1'
 
     io_counters = {included_io_key: MockDiskMetrics(), excluded_io_key: MockDiskMetrics()}
 

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -658,6 +658,35 @@ def test_device_include_exclude():
     assert c.exclude_disk(MockPart(device='/dev/sda4')) is True
 
 
+def test_latency_metrics_respect_device_include(aggregator, dd_run_check):
+    """
+    Latency metrics (read_time, write_time) must honour device_include/device_exclude,
+    not emit metrics for every disk regardless of configuration.
+    """
+    included_device = '/dev/sda1'
+    excluded_device = '/dev/sdb1'
+
+    io_counters = {included_device: MockDiskMetrics(), excluded_device: MockDiskMetrics()}
+
+    instance = {'device_include': [included_device], 'tag_by_label': False}
+    c = Disk('disk', {}, [instance])
+
+    with (
+        mock.patch('psutil.disk_partitions', return_value=[MockPart(device=included_device)]),
+        mock.patch('psutil.disk_usage', return_value=MockDiskMetrics()),
+        mock.patch('psutil.disk_io_counters', return_value=io_counters),
+    ):
+        dd_run_check(c)
+
+    latency_metrics = ['system.disk.read_time', 'system.disk.write_time',
+                       'system.disk.read_time_pct', 'system.disk.write_time_pct']
+    for metric in latency_metrics:
+        aggregator.assert_metric(metric, tags=['device:{}'.format(included_device),
+                                               'device_name:sda1'], count=1)
+        aggregator.assert_metric(metric, tags=['device:{}'.format(excluded_device),
+                                               'device_name:sdb1'], count=0)
+
+
 def test_mount_point_include():
     instance = {'mount_point_include': ['/dev/sda[1-3]', 'c:']}
     c = Disk('disk', {}, [instance])


### PR DESCRIPTION
### What does this PR do?

Applies `device_include`/`device_exclude` filtering to `collect_latency_metrics()` so that `system.disk.read_time`, `system.disk.write_time`, `system.disk.read_time_pct`, and `system.disk.write_time_pct` respect the same device filtering as space metrics.

### Motivation

`collect_latency_metrics()` iterated over `psutil.disk_io_counters(perdisk=True)` and emitted IO metrics for every disk on the system with no filtering applied, while space metrics (`system.disk.total`, `used`, `free`, etc.) correctly honoured `device_include`/`device_exclude`. This caused customers who configured `device_include` to still receive latency metrics tagged with excluded devices (e.g. `device:c:` appearing even when only `device:u:` was configured).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged