### PR TITLE
Add SAP HANA schema collection and diagnostics

### DIFF
--- a/sap_hana/README.md
+++ b/sap_hana/README.md
@@ -141,6 +141,7 @@ The Agent can collect SAP HANA catalog metadata (schemas, tables, views, and col
      enabled: true
      collection_interval: 600
      max_tables: 2000
+     max_views: 2000
      max_columns: 500
 ```
 

--- a/sap_hana/README.md
+++ b/sap_hana/README.md
@@ -134,7 +134,7 @@ To learn how to set the port number for HANA tenant, single-tenant, and system d
 
 #### Schema collection
 
-The Agent can collect SAP HANA catalog metadata (schemas, tables, views, and columns) for Data Quality features in Data Observability. When the monitoring user has access to `SYS.M_TABLE_STATISTICS`, the Agent also collects row counts and last modification times for tables. Collection is disabled by default. To enable it, ensure that the monitoring user can read the required views (see [Granting privileges](#granting-privileges)) and add the following block to your `sap_hana.d/conf.yaml` file:
+The Agent can collect SAP HANA catalog metadata (schemas, tables, views, and columns) for Data Quality features in Data Observability. When the monitoring user has access to `SYS.M_TABLE_STATISTICS`, the Agent also collects row counts and last modification times for tables. Collection is disabled by default. To enable schema collection, ensure that the monitoring user can read the required views (see [Granting privileges](#granting-privileges)) and add the following block to your `sap_hana.d/conf.yaml` file:
 
 ```yaml
    collect_schemas:

--- a/sap_hana/README.md
+++ b/sap_hana/README.md
@@ -86,8 +86,8 @@ To learn how to set the port number for HANA tenant, single-tenant, and system d
    ```shell
    GRANT SELECT ON SYS.SCHEMAS TO DD_MONITOR;
    GRANT SELECT ON SYS.M_TABLES TO DD_MONITOR;
-   GRANT SELECT ON SYS.VIEWS TO DD_MONITOR;
    GRANT SELECT ON SYS.TABLE_COLUMNS TO DD_MONITOR;
+   GRANT SELECT ON SYS.VIEWS TO DD_MONITOR;
    GRANT SELECT ON SYS.VIEW_COLUMNS TO DD_MONITOR;
    GRANT SELECT ON SYS.M_TABLE_STATISTICS TO DD_MONITOR;
    ```
@@ -140,8 +140,8 @@ The Agent can collect SAP HANA catalog metadata (schemas, tables, views, and col
    collect_schemas:
      enabled: true
      collection_interval: 600
-     max_tables: 300
-     max_columns: 50
+     max_tables: 2000
+     max_columns: 500
 ```
 
 See the [sample sap_hana.d/conf.yaml][4] for all available schema collection options, including `include_schemas` and `exclude_schemas`.

--- a/sap_hana/README.md
+++ b/sap_hana/README.md
@@ -81,12 +81,15 @@ To learn how to set the port number for HANA tenant, single-tenant, and system d
    GRANT SELECT ON SYS_DATABASES.M_VOLUME_IO_TOTAL_STATISTICS TO DD_MONITOR;
    ```
 
-   To collect schema metadata for Data Quality features in Data Observability, grant select on the catalog views that store schema, table, and column definitions. These are already covered by the `GRANT CATALOG READ` in step 2, so this is only needed if you skipped that grant:
+   To collect schema metadata for Data Quality features in Data Observability, grant select on the catalog and monitoring views that store schema, table, and column definitions. These are already covered by the `GRANT CATALOG READ` in step 2, so this is only needed if you skipped that grant:
 
    ```shell
    GRANT SELECT ON SYS.SCHEMAS TO DD_MONITOR;
-   GRANT SELECT ON SYS.TABLES TO DD_MONITOR;
+   GRANT SELECT ON SYS.M_TABLES TO DD_MONITOR;
+   GRANT SELECT ON SYS.VIEWS TO DD_MONITOR;
    GRANT SELECT ON SYS.TABLE_COLUMNS TO DD_MONITOR;
+   GRANT SELECT ON SYS.VIEW_COLUMNS TO DD_MONITOR;
+   GRANT SELECT ON SYS.M_TABLE_STATISTICS TO DD_MONITOR;
    ```
 
 4. Finally, run the following command to assign the monitoring role to the desired user:
@@ -131,7 +134,7 @@ To learn how to set the port number for HANA tenant, single-tenant, and system d
 
 #### Schema collection
 
-The Agent can collect SAP HANA catalog metadata (schemas, tables, and columns) for Data Quality features in Data Observability. Collection is disabled by default. To enable it, ensure that the monitoring user can read the catalog views (see [Granting privileges](#granting-privileges)) and add the following block to your `sap_hana.d/conf.yaml` file:
+The Agent can collect SAP HANA catalog metadata (schemas, tables, views, and columns) for Data Quality features in Data Observability. When the monitoring user has access to `SYS.M_TABLE_STATISTICS`, the Agent also collects row counts and last modification times for tables. Collection is disabled by default. To enable it, ensure that the monitoring user can read the required views (see [Granting privileges](#granting-privileges)) and add the following block to your `sap_hana.d/conf.yaml` file:
 
 ```yaml
    collect_schemas:

--- a/sap_hana/README.md
+++ b/sap_hana/README.md
@@ -81,7 +81,7 @@ To learn how to set the port number for HANA tenant, single-tenant, and system d
    GRANT SELECT ON SYS_DATABASES.M_VOLUME_IO_TOTAL_STATISTICS TO DD_MONITOR;
    ```
 
-   To collect schema metadata for Database Monitoring (see [Schema collection](#schema-collection)), grant select on the catalog views that store schema, table, and column definitions. These are already covered by the `GRANT CATALOG READ` in step 2, so this is only needed if you skipped that grant:
+   To collect schema metadata for Data Quality features in Data Observability, grant select on the catalog views that store schema, table, and column definitions. These are already covered by the `GRANT CATALOG READ` in step 2, so this is only needed if you skipped that grant:
 
    ```shell
    GRANT SELECT ON SYS.SCHEMAS TO DD_MONITOR;
@@ -131,7 +131,7 @@ To learn how to set the port number for HANA tenant, single-tenant, and system d
 
 #### Schema collection
 
-The Agent can collect SAP HANA catalog metadata (schemas, tables, and columns) for Database Monitoring's Schema Explorer. Collection is disabled by default. To enable it, ensure that the monitoring user can read the catalog views (see [Granting privileges](#granting-privileges)) and add the following block to your `sap_hana.d/conf.yaml` file:
+The Agent can collect SAP HANA catalog metadata (schemas, tables, and columns) for Data Quality features in Data Observability. Collection is disabled by default. To enable it, ensure that the monitoring user can read the catalog views (see [Granting privileges](#granting-privileges)) and add the following block to your `sap_hana.d/conf.yaml` file:
 
 ```yaml
    collect_schemas:

--- a/sap_hana/README.md
+++ b/sap_hana/README.md
@@ -81,6 +81,14 @@ To learn how to set the port number for HANA tenant, single-tenant, and system d
    GRANT SELECT ON SYS_DATABASES.M_VOLUME_IO_TOTAL_STATISTICS TO DD_MONITOR;
    ```
 
+   To collect schema metadata for Database Monitoring (see [Schema collection](#schema-collection)), also grant select on the catalog views that store schema, table, and column definitions. These are already covered by the `GRANT CATALOG READ` in step 2, so this is only needed if you skipped that grant:
+
+   ```shell
+   GRANT SELECT ON SYS.SCHEMAS TO DD_MONITOR;
+   GRANT SELECT ON SYS.TABLES TO DD_MONITOR;
+   GRANT SELECT ON SYS.TABLE_COLUMNS TO DD_MONITOR;
+   ```
+
 4. Finally, run the following command to assign the monitoring role to the desired user:
 
    ```shell
@@ -120,6 +128,20 @@ To learn how to set the port number for HANA tenant, single-tenant, and system d
     See the [sample sap_hana.d/conf.yaml][4] for all available configuration options.
 
 3. [Restart the Agent][5].
+
+#### Schema collection
+
+The Agent can collect SAP HANA catalog metadata (schemas, tables, and columns) for Database Monitoring's Schema Explorer. Collection is disabled by default. To enable it, make sure the monitoring user can read the catalog views (see [Granting privileges](#granting-privileges)) and add the following block to your `sap_hana.d/conf.yaml` file:
+
+```yaml
+   collect_schemas:
+     enabled: true
+     collection_interval: 600
+     max_tables: 300
+     max_columns: 50
+```
+
+See the [sample sap_hana.d/conf.yaml][4] for all available schema collection options, including `include_schemas` and `exclude_schemas`.
 
 ### Validation
 

--- a/sap_hana/README.md
+++ b/sap_hana/README.md
@@ -81,7 +81,7 @@ To learn how to set the port number for HANA tenant, single-tenant, and system d
    GRANT SELECT ON SYS_DATABASES.M_VOLUME_IO_TOTAL_STATISTICS TO DD_MONITOR;
    ```
 
-   To collect schema metadata for Database Monitoring (see [Schema collection](#schema-collection)), also grant select on the catalog views that store schema, table, and column definitions. These are already covered by the `GRANT CATALOG READ` in step 2, so this is only needed if you skipped that grant:
+   To collect schema metadata for Database Monitoring (see [Schema collection](#schema-collection)), grant select on the catalog views that store schema, table, and column definitions. These are already covered by the `GRANT CATALOG READ` in step 2, so this is only needed if you skipped that grant:
 
    ```shell
    GRANT SELECT ON SYS.SCHEMAS TO DD_MONITOR;
@@ -131,7 +131,7 @@ To learn how to set the port number for HANA tenant, single-tenant, and system d
 
 #### Schema collection
 
-The Agent can collect SAP HANA catalog metadata (schemas, tables, and columns) for Database Monitoring's Schema Explorer. Collection is disabled by default. To enable it, make sure the monitoring user can read the catalog views (see [Granting privileges](#granting-privileges)) and add the following block to your `sap_hana.d/conf.yaml` file:
+The Agent can collect SAP HANA catalog metadata (schemas, tables, and columns) for Database Monitoring's Schema Explorer. Collection is disabled by default. To enable it, ensure that the monitoring user can read the catalog views (see [Granting privileges](#granting-privileges)) and add the following block to your `sap_hana.d/conf.yaml` file:
 
 ```yaml
    collect_schemas:

--- a/sap_hana/assets/configuration/spec.yaml
+++ b/sap_hana/assets/configuration/spec.yaml
@@ -136,7 +136,7 @@ files:
           - name: include_schemas
             description: |
               A list of schema names to include. Any schema whose name is in
-              this list are included. If empty, all schemas (other than
+              this list is included. If empty, all schemas (other than
               those excluded) are included.
             value:
               type: array

--- a/sap_hana/assets/configuration/spec.yaml
+++ b/sap_hana/assets/configuration/spec.yaml
@@ -127,6 +127,12 @@ files:
             value:
               type: integer
               example: 500
+          - name: max_views
+            description: |
+              Maximum number of views to collect per cycle across all schemas.
+            value:
+              type: integer
+              example: 2000
           - name: include_schemas
             description: |
               A list of schema names to include. Any schema whose name is in

--- a/sap_hana/assets/configuration/spec.yaml
+++ b/sap_hana/assets/configuration/spec.yaml
@@ -98,13 +98,13 @@ files:
         hidden: true
         description: |
           Configure collection of SAP HANA catalog metadata (schemas, tables,
-          columns) for Data Quality features in Data Observability.
+          views, and columns) for Data Quality features in Data Observability.
         options:
           - name: enabled
             description: |
               Enable collection of catalog metadata. When enabled, the Agent
-              queries `SYS.SCHEMAS`, `SYS.TABLES`, and `SYS.TABLE_COLUMNS` and
-              emits schema metadata payloads.
+              queries `SYS.M_TABLES`, `SYS.VIEWS`, `SYS.TABLE_COLUMNS`, and
+              `SYS.VIEW_COLUMNS` and emits schema metadata payloads.
             value:
               type: boolean
               example: false

--- a/sap_hana/assets/configuration/spec.yaml
+++ b/sap_hana/assets/configuration/spec.yaml
@@ -136,7 +136,7 @@ files:
           - name: include_schemas
             description: |
               A list of schema names to include. Any schema whose name is in
-              this list will be included. If empty, all schemas (other than
+              this list are included. If empty, all schemas (other than
               those excluded) are included.
             value:
               type: array
@@ -147,7 +147,7 @@ files:
           - name: exclude_schemas
             description: |
               A list of schema names to exclude. Any schema whose name is in
-              this list will be excluded. SAP HANA system schemas are always
+              this list is excluded. SAP HANA system schemas are always
               excluded regardless of this setting.
             value:
               type: array

--- a/sap_hana/assets/configuration/spec.yaml
+++ b/sap_hana/assets/configuration/spec.yaml
@@ -95,6 +95,7 @@ files:
           type: boolean
       - template: instances/tls
       - name: collect_schemas
+        hidden: true
         description: |
           Configure collection of SAP HANA catalog metadata (schemas, tables,
           columns) for Data Quality features in Data Observability.

--- a/sap_hana/assets/configuration/spec.yaml
+++ b/sap_hana/assets/configuration/spec.yaml
@@ -94,6 +94,60 @@ files:
           example: false
           type: boolean
       - template: instances/tls
+      - name: collect_schemas
+        description: |
+          Configure collection of SAP HANA catalog metadata (schemas, tables,
+          columns) for Database Monitoring's Schema Explorer.
+        options:
+          - name: enabled
+            description: |
+              Enable collection of catalog metadata. When enabled, the Agent
+              queries `SYS.SCHEMAS`, `SYS.TABLES`, and `SYS.TABLE_COLUMNS` and
+              emits schema metadata payloads.
+            value:
+              type: boolean
+              example: false
+          - name: collection_interval
+            description: |
+              Set the schema collection interval (in seconds). Catalog data
+              changes slowly; 600s (10 min) is a reasonable default.
+            value:
+              type: number
+              example: 600
+          - name: max_tables
+            description: |
+              Maximum number of tables to collect per cycle across all schemas.
+            value:
+              type: integer
+              example: 300
+          - name: max_columns
+            description: |
+              Maximum number of columns to collect per table.
+            value:
+              type: integer
+              example: 50
+          - name: include_schemas
+            description: |
+              A list of schema names to include. Any schema whose name is in
+              this list will be included. If empty, all schemas (other than
+              those excluded) are included.
+            value:
+              type: array
+              items:
+                type: string
+              example:
+                - "MY_SCHEMA"
+          - name: exclude_schemas
+            description: |
+              A list of schema names to exclude. Any schema whose name is in
+              this list will be excluded. SAP HANA system schemas are always
+              excluded regardless of this setting.
+            value:
+              type: array
+              items:
+                type: string
+              example:
+                - "TMP_SCHEMA"
       - template: instances/default
   - template: logs
     example:

--- a/sap_hana/assets/configuration/spec.yaml
+++ b/sap_hana/assets/configuration/spec.yaml
@@ -97,7 +97,7 @@ files:
       - name: collect_schemas
         description: |
           Configure collection of SAP HANA catalog metadata (schemas, tables,
-          columns) for Database Monitoring's Schema Explorer.
+          columns) for Data Quality features in Data Observability.
         options:
           - name: enabled
             description: |

--- a/sap_hana/assets/configuration/spec.yaml
+++ b/sap_hana/assets/configuration/spec.yaml
@@ -119,13 +119,13 @@ files:
               Maximum number of tables to collect per cycle across all schemas.
             value:
               type: integer
-              example: 300
+              example: 2000
           - name: max_columns
             description: |
               Maximum number of columns to collect per table.
             value:
               type: integer
-              example: 50
+              example: 500
           - name: include_schemas
             description: |
               A list of schema names to include. Any schema whose name is in

--- a/sap_hana/benchmarks/schema_collection_memory/README.md
+++ b/sap_hana/benchmarks/schema_collection_memory/README.md
@@ -1,0 +1,57 @@
+# Schema Collection Memory Benchmark
+
+Demonstrates the memory impact of the `max_tables` and `max_columns` limits added to
+`HanaSchemaCollector`. It stands up a SAP HANA Express container, fills it with a 1000×1000
+schema (1000 tables, 1000 columns each), then runs the real `collect_schemas()` code path
+twice — once with limits enabled and once effectively unlimited — in isolated subprocesses
+and compares peak RSS.
+
+## Prerequisites
+
+- Docker with sufficient memory (≥8 GB recommended for HANA Express).
+- A Python environment with the following installed:
+  ```
+  pip install -e ../../..                  # datadog_checks_base (repo root)
+  pip install -e ../..                     # sap_hana integration
+  pip install hdbcli==2.21.28
+  ```
+  The integration's hatch test environment already satisfies this.
+
+## Run
+
+```bash
+cd sap_hana/benchmarks/schema_collection_memory
+
+# 1. Start SAP HANA Express (startup takes 5–10 minutes).
+PASSWORD=Admin1337 docker compose up -d
+docker logs -f saphanabenchmark   # wait for "Startup finished!"
+
+# 2. Populate the database and run both modes.
+python benchmark.py
+
+# Re-run measurements without recreating the schema:
+python benchmark.py --skip-setup
+
+# 3. Tear down.
+docker compose down --volumes
+```
+
+Results are written to `results/benchmark_results.txt`.
+
+## Tuning
+
+| Constant | File | Default | Notes |
+|---|---|---|---|
+| `SAP_HANA_VERSION` | `docker-compose.yaml` env var | `2.00.076.00.20231004.2` | Pin to a known-good image tag. |
+| `NUM_TABLES` | `setup_database.py` | 1000 | Lower if setup is too slow. |
+| `NUM_COLUMNS` | `setup_database.py` | 1000 | Lower if HANA Express rejects wide tables. |
+
+HANA Express has resource constraints. If `CREATE TABLE` fails with a column-count or
+memory error, set `NUM_COLUMNS` to 500 or lower.
+
+## Expected outcome
+
+The limited run (max\_tables=300, max\_columns=50) processes 300 tables × 50 columns =
+15 000 column dicts. The unlimited run processes 1000 tables × 1000 columns = 1 000 000
+column dicts, all held in memory at once before the single `json.dumps` flush. The
+unlimited peak RSS is expected to be several times to an order of magnitude larger.

--- a/sap_hana/benchmarks/schema_collection_memory/README.md
+++ b/sap_hana/benchmarks/schema_collection_memory/README.md
@@ -49,6 +49,17 @@ Results are written to `results/benchmark_results.txt`.
 HANA Express has resource constraints. If `CREATE TABLE` fails with a column-count or
 memory error, set `NUM_COLUMNS` to 500 or lower.
 
+## Notes on memory investigation
+
+During development, `cursor.setfetchsize(10_000)` was tried on the hdbcli cursor before
+`execute()` to reduce the C-layer result buffer. It had no measurable effect on peak RSS
+(1042 MiB → 1043 MiB). The reason: the dominant memory consumer is the Python-side
+`_queued_rows` list accumulating all table dicts before the single `json.dumps` flush —
+not the hdbcli C layer. The base `SchemaCollector` flushes when `len(_queued_rows) >=
+payload_chunk_size` (default 10,000) or on the last database. Since HANA always reports
+one database and a 1000-table schema is below the 10,000 threshold, everything flushes
+at once. The `max_tables` / `max_columns` limits are the effective control.
+
 ## Expected outcome
 
 The limited run (max\_tables=300, max\_columns=50) processes 300 tables × 50 columns =

--- a/sap_hana/benchmarks/schema_collection_memory/README.md
+++ b/sap_hana/benchmarks/schema_collection_memory/README.md
@@ -51,14 +51,32 @@ memory error, set `NUM_COLUMNS` to 500 or lower.
 
 ## Notes on memory investigation
 
-During development, `cursor.setfetchsize(10_000)` was tried on the hdbcli cursor before
-`execute()` to reduce the C-layer result buffer. It had no measurable effect on peak RSS
-(1042 MiB → 1043 MiB). The reason: the dominant memory consumer is the Python-side
-`_queued_rows` list accumulating all table dicts before the single `json.dumps` flush —
-not the hdbcli C layer. The base `SchemaCollector` flushes when `len(_queued_rows) >=
-payload_chunk_size` (default 10,000) or on the last database. Since HANA always reports
-one database and a 1000-table schema is below the 10,000 threshold, everything flushes
-at once. The `max_tables` / `max_columns` limits are the effective control.
+**`setfetchsize` (no effect on memory)**
+`cursor.setfetchsize(10_000)` was tried on the hdbcli cursor before `execute()` to reduce
+the C-layer result buffer. It had no measurable effect on peak RSS (1042 MiB → 1043 MiB).
+The reason: the dominant memory consumer is the Python-side `_queued_rows` list
+accumulating all table dicts before the single `json.dumps` flush — not the hdbcli C
+layer. The base `SchemaCollector` flushes when `len(_queued_rows) >= payload_chunk_size`
+(default 10,000) or on the last database. Since HANA always reports one database and a
+1000-table schema is below the 10,000 threshold, everything flushes at once. The
+`max_tables` / `max_columns` limits are the effective memory control.
+
+**SQL column limit via `ROW_NUMBER()` (5× faster, no memory change)**
+The original query joined `SYS.TABLE_COLUMNS` without a column count cap, so the server
+returned all 1000 columns per table regardless of `max_columns`; Python discarded the
+excess. Pushing the limit into SQL with a `limited_columns` CTE using `ROW_NUMBER() OVER
+(PARTITION BY schema, table ORDER BY position)` means the server only sends the first
+`max_columns` columns per table. Result on the 1000×1000 schema:
+
+| Mode    | Duration before | Duration after |
+|---------|-----------------|----------------|
+| limited (max_tables=300, max_columns=50)         | 8.1s | 1.6s |
+| unlimited (max_tables=10M, max_columns=10M)      | 48.8s | 50.6s |
+
+Peak RSS was unchanged in both modes — the Python-side column dicts are bounded by
+`max_columns` either way, so peak Python heap stays the same. The gain is query
+efficiency: 285,000 fewer rows sent from the server (300 tables × 950 discarded
+columns) in the limited case.
 
 ## Expected outcome
 

--- a/sap_hana/benchmarks/schema_collection_memory/README.md
+++ b/sap_hana/benchmarks/schema_collection_memory/README.md
@@ -29,7 +29,7 @@ docker logs -f saphanabenchmark   # wait for "Startup finished!"
 # 2. Populate the database and run both modes.
 python benchmark.py
 
-# Re-run measurements without recreating the schema:
+# Re-run measurements without recreating the schema.
 python benchmark.py --skip-setup
 
 # 3. Tear down.
@@ -51,7 +51,7 @@ memory error, set `NUM_COLUMNS` to 500 or lower.
 
 ## Notes on memory investigation
 
-**`setfetchsize` (no effect on memory)**
+### `setfetchsize` (no effect on memory)
 `cursor.setfetchsize(10_000)` was tried on the hdbcli cursor before `execute()` to reduce
 the C-layer result buffer. It had no measurable effect on peak RSS (1042 MiB → 1043 MiB).
 The reason: the dominant memory consumer is the Python-side `_queued_rows` list
@@ -61,10 +61,10 @@ layer. The base `SchemaCollector` flushes when `len(_queued_rows) >= payload_chu
 1000-table schema is below the 10,000 threshold, everything flushes at once. The
 `max_tables` / `max_columns` limits are the effective memory control.
 
-**Column-based flush threshold (1.5x RSS reduction with limits)**
+### Column-based flush threshold (1.5x RSS reduction with limits)
 The base class `payload_chunk_size` counts tables, which is a poor proxy for memory when
 tables are wide. `HanaSchemaCollector` overrides `maybe_flush` to flush after every
-`PAYLOAD_COLUMN_CHUNK_SIZE` (50,000) columns instead. For 1000-column tables this flushes
+`PAYLOAD_COLUMN_CHUNK_SIZE` (50,000) columns instead. For 1000-column tables, this flushes
 every 50 tables, keeping `_queued_rows` from growing unboundedly. Result on the 1000×1000
 schema (RSS before = without column-flush override; RSS after = with override):
 
@@ -76,7 +76,7 @@ schema (RSS before = without column-flush override; RSS after = with override):
 The limited case is unaffected: 300 × 50 = 15,000 columns never reaches the 50,000
 threshold so it still flushes once at the end.
 
-**SQL column limit via `ROW_NUMBER()`**
+### SQL column limit via `ROW_NUMBER()`
 The original query joined `SYS.TABLE_COLUMNS` without a column count cap, so the server
 returned all 1000 columns per table regardless of `max_columns`; Python discarded the
 excess. Pushing the limit into SQL with a `limited_columns` CTE using `ROW_NUMBER() OVER
@@ -97,6 +97,6 @@ columns) in the limited case.
 ## Expected outcome
 
 The limited run (max\_tables=300, max\_columns=50) processes 300 tables × 50 columns =
-15 000 column dicts. The unlimited run processes 1000 tables × 1000 columns = 1 000 000
+15,000 column dicts. The unlimited run processes 1000 tables × 1000 columns = 1,000,000
 column dicts, all held in memory at once before the single `json.dumps` flush. The
 unlimited peak RSS is expected to be ~1.5x larger than the limited run.

--- a/sap_hana/benchmarks/schema_collection_memory/README.md
+++ b/sap_hana/benchmarks/schema_collection_memory/README.md
@@ -61,32 +61,33 @@ layer. The base `SchemaCollector` flushes when `len(_queued_rows) >= payload_chu
 1000-table schema is below the 10,000 threshold, everything flushes at once. The
 `max_tables` / `max_columns` limits are the effective memory control.
 
-**Column-based flush threshold (11× RSS reduction for unlimited)**
+**Column-based flush threshold (1.5x RSS reduction with limits)**
 The base class `payload_chunk_size` counts tables, which is a poor proxy for memory when
 tables are wide. `HanaSchemaCollector` overrides `maybe_flush` to flush after every
 `PAYLOAD_COLUMN_CHUNK_SIZE` (50,000) columns instead. For 1000-column tables this flushes
 every 50 tables, keeping `_queued_rows` from growing unboundedly. Result on the 1000×1000
-schema:
+schema (RSS before = without column-flush override; RSS after = with override):
 
 | Mode | RSS before | RSS after | Payloads |
 |------|-----------|-----------|---------|
 | unlimited (no limits) | 1,038 MiB | 93.7 MiB | 21 |
-| limited (300 tables × 50 cols) | 56.4 MiB | 56.9 MiB | 1 |
+| limited (300 tables × 50 cols) | 56.4 MiB | 61.5 MiB | 1 |
 
 The limited case is unaffected: 300 × 50 = 15,000 columns never reaches the 50,000
 threshold so it still flushes once at the end.
 
-**SQL column limit via `ROW_NUMBER()` (5× faster, no memory change)**
+**SQL column limit via `ROW_NUMBER()`**
 The original query joined `SYS.TABLE_COLUMNS` without a column count cap, so the server
 returned all 1000 columns per table regardless of `max_columns`; Python discarded the
 excess. Pushing the limit into SQL with a `limited_columns` CTE using `ROW_NUMBER() OVER
 (PARTITION BY schema, table ORDER BY position)` means the server only sends the first
-`max_columns` columns per table. Result on the 1000×1000 schema:
+`max_columns` columns per table. Result on the 1000×1000 schema (duration before = without
+ROW_NUMBER cap; duration after = with cap):
 
 | Mode    | Duration before | Duration after |
 |---------|-----------------|----------------|
-| limited (max_tables=300, max_columns=50)         | 8.1s | 1.6s |
-| unlimited (max_tables=10M, max_columns=10M)      | 48.8s | 50.6s |
+| limited (max_tables=300, max_columns=50)         | 8.1s | 2.2s |
+| unlimited (max_tables=10M, max_columns=10M)      | 48.8s | 50.7s |
 
 Peak RSS was unchanged in both modes — the Python-side column dicts are bounded by
 `max_columns` either way, so peak Python heap stays the same. The gain is query
@@ -98,4 +99,4 @@ columns) in the limited case.
 The limited run (max\_tables=300, max\_columns=50) processes 300 tables × 50 columns =
 15 000 column dicts. The unlimited run processes 1000 tables × 1000 columns = 1 000 000
 column dicts, all held in memory at once before the single `json.dumps` flush. The
-unlimited peak RSS is expected to be several times to an order of magnitude larger.
+unlimited peak RSS is expected to be ~1.5x larger than the limited run.

--- a/sap_hana/benchmarks/schema_collection_memory/README.md
+++ b/sap_hana/benchmarks/schema_collection_memory/README.md
@@ -61,6 +61,21 @@ layer. The base `SchemaCollector` flushes when `len(_queued_rows) >= payload_chu
 1000-table schema is below the 10,000 threshold, everything flushes at once. The
 `max_tables` / `max_columns` limits are the effective memory control.
 
+**Column-based flush threshold (11× RSS reduction for unlimited)**
+The base class `payload_chunk_size` counts tables, which is a poor proxy for memory when
+tables are wide. `HanaSchemaCollector` overrides `maybe_flush` to flush after every
+`PAYLOAD_COLUMN_CHUNK_SIZE` (50,000) columns instead. For 1000-column tables this flushes
+every 50 tables, keeping `_queued_rows` from growing unboundedly. Result on the 1000×1000
+schema:
+
+| Mode | RSS before | RSS after | Payloads |
+|------|-----------|-----------|---------|
+| unlimited (no limits) | 1,038 MiB | 93.7 MiB | 21 |
+| limited (300 tables × 50 cols) | 56.4 MiB | 56.9 MiB | 1 |
+
+The limited case is unaffected: 300 × 50 = 15,000 columns never reaches the 50,000
+threshold so it still flushes once at the end.
+
 **SQL column limit via `ROW_NUMBER()` (5× faster, no memory change)**
 The original query joined `SYS.TABLE_COLUMNS` without a column count cap, so the server
 returned all 1000 columns per table regardless of `max_columns`; Python discarded the

--- a/sap_hana/benchmarks/schema_collection_memory/benchmark.py
+++ b/sap_hana/benchmarks/schema_collection_memory/benchmark.py
@@ -16,7 +16,7 @@ RUN_COLLECTOR = os.path.join(os.path.dirname(__file__), 'run_collector.py')
 SETUP_DATABASE = os.path.join(os.path.dirname(__file__), 'setup_database.py')
 
 HOST = 'localhost'
-PORT = 39017
+PORT = 39019
 
 
 def wait_for_hana(host: str, port: int, timeout: int = 600) -> None:

--- a/sap_hana/benchmarks/schema_collection_memory/benchmark.py
+++ b/sap_hana/benchmarks/schema_collection_memory/benchmark.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Orchestrate limited vs unlimited schema collection runs and compare peak memory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+RESULTS_DIR = os.path.join(os.path.dirname(__file__), 'results')
+RESULTS_FILE = os.path.join(RESULTS_DIR, 'benchmark_results.txt')
+RUN_COLLECTOR = os.path.join(os.path.dirname(__file__), 'run_collector.py')
+SETUP_DATABASE = os.path.join(os.path.dirname(__file__), 'setup_database.py')
+
+HOST = 'localhost'
+PORT = 39017
+
+
+def wait_for_hana(host: str, port: int, timeout: int = 600) -> None:
+    print(f'Waiting for SAP HANA at {host}:{port} (up to {timeout}s)...', flush=True)
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            from hdbcli.dbapi import Connection as HanaConnection
+
+            conn = HanaConnection(address=host, port=port, user='system', password='Admin1337')
+            conn.close()
+            print('HANA is ready.', flush=True)
+            return
+        except Exception:
+            time.sleep(5)
+    print('ERROR: HANA did not become ready in time.', file=sys.stderr)
+    sys.exit(1)
+
+
+def run_mode(python: str, mode: str, host: str, port: int) -> dict:
+    print(f'Running mode={mode}...', flush=True)
+    result = subprocess.run(
+        [python, RUN_COLLECTOR, '--mode', mode, '--host', host, '--port', str(port)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f'ERROR running mode={mode}:\n{result.stderr}', file=sys.stderr)
+        sys.exit(1)
+    return json.loads(result.stdout.strip())
+
+
+def mib(value_bytes: int) -> str:
+    return f'{value_bytes / 1024 / 1024:.1f} MiB'
+
+
+def build_report(limited: dict, unlimited: dict) -> str:
+    rss_ratio = unlimited['peak_rss_kb'] / max(limited['peak_rss_kb'], 1)
+    lines = [
+        'SAP HANA Schema Collection Memory Benchmark',
+        '=' * 60,
+        '',
+        f"{'Mode':<12} {'Peak RSS':>12} {'Tracemalloc':>14} {'Payloads':>10} {'Payload bytes':>15} {'Duration':>10}",
+        '-' * 75,
+    ]
+    for r in (limited, unlimited):
+        lines.append(
+            f"{r['mode']:<12}"
+            f" {mib(r['peak_rss_kb'] * 1024):>12}"
+            f" {mib(r['tracemalloc_peak_bytes']):>14}"
+            f" {r['payloads']:>10}"
+            f" {r['total_payload_bytes']:>15,}"
+            f" {r['duration_s']:>9.1f}s"
+        )
+    lines += [
+        '',
+        f"Memory reduction: {rss_ratio:.1f}x less peak RSS with limits enabled",
+        "  limited  : max_tables=300, max_columns=50",
+        "  unlimited: max_tables=10_000_000, max_columns=10_000_000",
+        '',
+    ]
+    return '\n'.join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Run the schema collection memory benchmark.')
+    parser.add_argument('--skip-setup', action='store_true', help='Skip database setup (schema already populated).')
+    parser.add_argument('--python', default=sys.executable, help='Python interpreter for child runs.')
+    parser.add_argument('--host', default=HOST)
+    parser.add_argument('--port', type=int, default=PORT)
+    args = parser.parse_args()
+
+    wait_for_hana(args.host, args.port)
+
+    if not args.skip_setup:
+        print('Running database setup...', flush=True)
+        result = subprocess.run(
+            [args.python, SETUP_DATABASE, '--host', args.host, '--port', str(args.port)],
+            check=True,
+        )
+        _ = result
+
+    limited = run_mode(args.python, 'limited', args.host, args.port)
+    unlimited = run_mode(args.python, 'unlimited', args.host, args.port)
+
+    report = build_report(limited, unlimited)
+    print(report)
+
+    os.makedirs(RESULTS_DIR, exist_ok=True)
+    with open(RESULTS_FILE, 'w') as f:
+        f.write(report)
+    print(f'Results written to {RESULTS_FILE}')
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/sap_hana/benchmarks/schema_collection_memory/benchmark.py
+++ b/sap_hana/benchmarks/schema_collection_memory/benchmark.py
@@ -1,3 +1,6 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
 #!/usr/bin/env python3
 """Orchestrate limited vs unlimited schema collection runs and compare peak memory."""
 

--- a/sap_hana/benchmarks/schema_collection_memory/docker-compose.yaml
+++ b/sap_hana/benchmarks/schema_collection_memory/docker-compose.yaml
@@ -1,0 +1,19 @@
+services:
+  saphanabenchmark:
+    container_name: saphanabenchmark
+    image: saplabs/hanaexpress:${SAP_HANA_VERSION:-2.00.076.00.20231004.2}
+    ulimits:
+      nofile:
+        soft: 1048576
+        hard: 1048576
+    sysctls:
+      kernel.shmmax: 1073741824
+      net.ipv4.ip_local_port_range: "40000 60999"
+    ports:
+      - "39017:39017"
+    environment:
+      - PASSWORD=${PASSWORD}
+    entrypoint:
+      - sh
+      - -c
+      - echo "{\"master_password\":\"$$PASSWORD\"}" > /tmp/hana_password.json;cat /tmp/hana_password.json;/run_hana --agree-to-sap-license --passwords-url file:///tmp/hana_password.json

--- a/sap_hana/benchmarks/schema_collection_memory/docker-compose.yaml
+++ b/sap_hana/benchmarks/schema_collection_memory/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   saphanabenchmark:
     container_name: saphanabenchmark
-    image: saplabs/hanaexpress:${SAP_HANA_VERSION:-2.00.076.00.20231004.2}
+    image: saplabs/hanaexpress:${SAP_HANA_VERSION:-latest}
     ulimits:
       nofile:
         soft: 1048576
@@ -10,7 +10,7 @@ services:
       kernel.shmmax: 1073741824
       net.ipv4.ip_local_port_range: "40000 60999"
     ports:
-      - "39017:39017"
+      - "39019:39017"
     environment:
       - PASSWORD=${PASSWORD}
     entrypoint:

--- a/sap_hana/benchmarks/schema_collection_memory/results/benchmark_results.txt
+++ b/sap_hana/benchmarks/schema_collection_memory/results/benchmark_results.txt
@@ -1,0 +1,11 @@
+SAP HANA Schema Collection Memory Benchmark
+============================================================
+
+Mode             Peak RSS    Tracemalloc   Payloads   Payload bytes   Duration
+---------------------------------------------------------------------------
+limited          45.0 MiB        1.2 MiB          1         243,885       0.3s
+unlimited        45.0 MiB        1.2 MiB          1         243,885       0.3s
+
+Memory reduction: 1.0x less peak RSS with limits enabled
+  limited  : max_tables=300, max_columns=50
+  unlimited: max_tables=10_000_000, max_columns=10_000_000

--- a/sap_hana/benchmarks/schema_collection_memory/results/benchmark_results.txt
+++ b/sap_hana/benchmarks/schema_collection_memory/results/benchmark_results.txt
@@ -3,8 +3,8 @@ SAP HANA Schema Collection Memory Benchmark
 
 Mode             Peak RSS    Tracemalloc   Payloads   Payload bytes   Duration
 ---------------------------------------------------------------------------
-limited          56.6 MiB        7.2 MiB          1       1,461,385       8.4s
-unlimited      1042.3 MiB      478.4 MiB          1      95,072,385      49.5s
+limited          56.5 MiB        7.2 MiB          1       1,461,385       1.6s
+unlimited      1042.2 MiB      478.4 MiB          1      95,072,385      50.6s
 
 Memory reduction: 18.4x less peak RSS with limits enabled
   limited  : max_tables=300, max_columns=50

--- a/sap_hana/benchmarks/schema_collection_memory/results/benchmark_results.txt
+++ b/sap_hana/benchmarks/schema_collection_memory/results/benchmark_results.txt
@@ -3,9 +3,9 @@ SAP HANA Schema Collection Memory Benchmark
 
 Mode             Peak RSS    Tracemalloc   Payloads   Payload bytes   Duration
 ---------------------------------------------------------------------------
-limited          56.9 MiB        7.2 MiB          1       1,461,385       1.4s
-unlimited        93.7 MiB       24.2 MiB         21      95,079,446      47.9s
+limited          61.5 MiB        8.6 MiB          1       1,772,208       2.2s
+unlimited        93.7 MiB       24.2 MiB         21      95,425,468      50.7s
 
-Memory reduction: 1.6x less peak RSS with limits enabled
+Memory reduction: 1.5x less peak RSS with limits enabled
   limited  : max_tables=300, max_columns=50
   unlimited: max_tables=10_000_000, max_columns=10_000_000

--- a/sap_hana/benchmarks/schema_collection_memory/results/benchmark_results.txt
+++ b/sap_hana/benchmarks/schema_collection_memory/results/benchmark_results.txt
@@ -3,9 +3,9 @@ SAP HANA Schema Collection Memory Benchmark
 
 Mode             Peak RSS    Tracemalloc   Payloads   Payload bytes   Duration
 ---------------------------------------------------------------------------
-limited          45.0 MiB        1.2 MiB          1         243,885       0.3s
-unlimited        45.0 MiB        1.2 MiB          1         243,885       0.3s
+limited          56.6 MiB        7.2 MiB          1       1,461,385       8.4s
+unlimited      1042.3 MiB      478.4 MiB          1      95,072,385      49.5s
 
-Memory reduction: 1.0x less peak RSS with limits enabled
+Memory reduction: 18.4x less peak RSS with limits enabled
   limited  : max_tables=300, max_columns=50
   unlimited: max_tables=10_000_000, max_columns=10_000_000

--- a/sap_hana/benchmarks/schema_collection_memory/results/benchmark_results.txt
+++ b/sap_hana/benchmarks/schema_collection_memory/results/benchmark_results.txt
@@ -3,9 +3,9 @@ SAP HANA Schema Collection Memory Benchmark
 
 Mode             Peak RSS    Tracemalloc   Payloads   Payload bytes   Duration
 ---------------------------------------------------------------------------
-limited          56.5 MiB        7.2 MiB          1       1,461,385       1.6s
-unlimited      1042.2 MiB      478.4 MiB          1      95,072,385      50.6s
+limited          56.9 MiB        7.2 MiB          1       1,461,385       1.4s
+unlimited        93.7 MiB       24.2 MiB         21      95,079,446      47.9s
 
-Memory reduction: 18.4x less peak RSS with limits enabled
+Memory reduction: 1.6x less peak RSS with limits enabled
   limited  : max_tables=300, max_columns=50
   unlimited: max_tables=10_000_000, max_columns=10_000_000

--- a/sap_hana/benchmarks/schema_collection_memory/results/benchmark_results_50x50.txt
+++ b/sap_hana/benchmarks/schema_collection_memory/results/benchmark_results_50x50.txt
@@ -1,0 +1,11 @@
+SAP HANA Schema Collection Memory Benchmark
+============================================================
+
+Mode             Peak RSS    Tracemalloc   Payloads   Payload bytes   Duration
+---------------------------------------------------------------------------
+limited          45.0 MiB        1.2 MiB          1         243,885       0.3s
+unlimited        45.0 MiB        1.2 MiB          1         243,885       0.3s
+
+Memory reduction: 1.0x less peak RSS with limits enabled
+  limited  : max_tables=300, max_columns=50
+  unlimited: max_tables=10_000_000, max_columns=10_000_000

--- a/sap_hana/benchmarks/schema_collection_memory/run_collector.py
+++ b/sap_hana/benchmarks/schema_collection_memory/run_collector.py
@@ -1,3 +1,6 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
 #!/usr/bin/env python3
 """Run HanaSchemaCollector in one mode (limited or unlimited) and print peak memory as JSON.
 

--- a/sap_hana/benchmarks/schema_collection_memory/run_collector.py
+++ b/sap_hana/benchmarks/schema_collection_memory/run_collector.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Run HanaSchemaCollector in one mode (limited or unlimited) and print peak memory as JSON.
+
+Invoked by benchmark.py as a subprocess so each mode gets a clean high-water mark.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import sys
+import time
+import tracemalloc
+from resource import RUSAGE_SELF, getrusage
+
+DATADOG_USER = "datadog"
+DATADOG_PASSWORD = "Datadog9000"
+HOST = "localhost"
+PORT = 39017
+
+MODES = {
+    "limited": {"enabled": True, "max_tables": 300, "max_columns": 50},
+    "unlimited": {"enabled": True, "max_tables": 10_000_000, "max_columns": 10_000_000},
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--mode', choices=list(MODES), required=True)
+    parser.add_argument('--host', default=HOST)
+    parser.add_argument('--port', type=int, default=PORT)
+    args = parser.parse_args()
+
+    from hdbcli.dbapi import Connection as HanaConnection
+
+    from datadog_checks.sap_hana import SapHanaCheck
+
+    instance = {
+        'server': args.host,
+        'port': args.port,
+        'username': DATADOG_USER,
+        'password': DATADOG_PASSWORD,
+        'collect_schemas': MODES[args.mode],
+    }
+    check = SapHanaCheck('sap_hana', {}, [instance])
+    check._conn = HanaConnection(address=args.host, port=args.port, user=DATADOG_USER, password=DATADOG_PASSWORD)
+
+    payload_count = 0
+    total_payload_bytes = 0
+
+    def record_payload(raw: str) -> None:
+        nonlocal payload_count, total_payload_bytes
+        payload_count += 1
+        total_payload_bytes += len(raw.encode())
+
+    check.database_monitoring_metadata = record_payload
+    check.histogram = lambda *a, **kw: None
+    check.gauge = lambda *a, **kw: None
+
+    gc.collect()
+    tracemalloc.start()
+    t0 = time.perf_counter()
+
+    check._schema_collector.collect_schemas()
+
+    duration_s = time.perf_counter() - t0
+    peak_rss_kb = getrusage(RUSAGE_SELF).ru_maxrss
+    _, tracemalloc_peak_bytes = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    result = {
+        'mode': args.mode,
+        'peak_rss_kb': peak_rss_kb,
+        'tracemalloc_peak_bytes': tracemalloc_peak_bytes,
+        'payloads': payload_count,
+        'total_payload_bytes': total_payload_bytes,
+        'duration_s': round(duration_s, 3),
+    }
+    print(json.dumps(result))
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/sap_hana/benchmarks/schema_collection_memory/run_collector.py
+++ b/sap_hana/benchmarks/schema_collection_memory/run_collector.py
@@ -17,7 +17,7 @@ from resource import RUSAGE_SELF, getrusage
 DATADOG_USER = "datadog"
 DATADOG_PASSWORD = "Datadog9000"
 HOST = "localhost"
-PORT = 39017
+PORT = 39019
 
 MODES = {
     "limited": {"enabled": True, "max_tables": 300, "max_columns": 50},

--- a/sap_hana/benchmarks/schema_collection_memory/setup_database.py
+++ b/sap_hana/benchmarks/schema_collection_memory/setup_database.py
@@ -7,8 +7,8 @@ import argparse
 import sys
 from contextlib import closing
 
-NUM_TABLES = 1000
-NUM_COLUMNS = 1000
+NUM_TABLES = 50
+NUM_COLUMNS = 50
 
 ADMIN_USER = "system"
 ADMIN_PASSWORD = "Admin1337"
@@ -16,13 +16,13 @@ DATADOG_USER = "datadog"
 DATADOG_PASSWORD = "Datadog9000"
 SCHEMA = "BENCH"
 HOST = "localhost"
-PORT = 39017
+PORT = 39019
 
 
-def connect(user: str, password: str):
+def connect(user: str, password: str, host: str = HOST, port: int = PORT):
     from hdbcli.dbapi import Connection as HanaConnection
 
-    return HanaConnection(address=HOST, port=PORT, user=user, password=password)
+    return HanaConnection(address=host, port=port, user=user, password=password)
 
 
 def setup_user(cursor) -> None:
@@ -34,6 +34,8 @@ def setup_user(cursor) -> None:
     cursor.execute(f'ALTER USER {DATADOG_USER} ENABLE CLIENT CONNECT')
     cursor.execute(f'ALTER USER {DATADOG_USER} DISABLE PASSWORD LIFETIME')
     cursor.execute(f'GRANT CATALOG READ TO {DATADOG_USER}')
+    for view in ('SYS.M_DATABASE', 'SYS.TABLES', 'SYS.SCHEMAS', 'SYS.TABLE_COLUMNS'):
+        cursor.execute(f'GRANT SELECT ON {view} TO {DATADOG_USER}')
 
 
 def setup_schema(cursor) -> None:
@@ -69,12 +71,8 @@ def main() -> None:
     parser.add_argument('--port', type=int, default=PORT)
     args = parser.parse_args()
 
-    global HOST, PORT
-    HOST = args.host
-    PORT = args.port
-
-    print(f'Connecting to {HOST}:{PORT} as {ADMIN_USER}...', flush=True)
-    with closing(connect(ADMIN_USER, ADMIN_PASSWORD)) as conn:
+    print(f'Connecting to {args.host}:{args.port} as {ADMIN_USER}...', flush=True)
+    with closing(connect(ADMIN_USER, ADMIN_PASSWORD, host=args.host, port=args.port)) as conn:
         with closing(conn.cursor()) as cursor:
             print('Setting up monitoring user...', flush=True)
             setup_user(cursor)

--- a/sap_hana/benchmarks/schema_collection_memory/setup_database.py
+++ b/sap_hana/benchmarks/schema_collection_memory/setup_database.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Create the datadog monitoring user and populate the BENCH schema with NUM_TABLES x NUM_COLUMNS tables."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from contextlib import closing
+
+NUM_TABLES = 1000
+NUM_COLUMNS = 1000
+
+ADMIN_USER = "system"
+ADMIN_PASSWORD = "Admin1337"
+DATADOG_USER = "datadog"
+DATADOG_PASSWORD = "Datadog9000"
+SCHEMA = "BENCH"
+HOST = "localhost"
+PORT = 39017
+
+
+def connect(user: str, password: str):
+    from hdbcli.dbapi import Connection as HanaConnection
+
+    return HanaConnection(address=HOST, port=PORT, user=user, password=password)
+
+
+def setup_user(cursor) -> None:
+    try:
+        cursor.execute(f'DROP USER {DATADOG_USER} CASCADE')
+    except Exception:
+        pass
+    cursor.execute(f'CREATE RESTRICTED USER {DATADOG_USER} PASSWORD "{DATADOG_PASSWORD}"')
+    cursor.execute(f'ALTER USER {DATADOG_USER} ENABLE CLIENT CONNECT')
+    cursor.execute(f'ALTER USER {DATADOG_USER} DISABLE PASSWORD LIFETIME')
+    cursor.execute(f'GRANT CATALOG READ TO {DATADOG_USER}')
+
+
+def setup_schema(cursor) -> None:
+    try:
+        cursor.execute(f'DROP SCHEMA {SCHEMA} CASCADE')
+    except Exception:
+        pass
+    cursor.execute(f'CREATE SCHEMA {SCHEMA}')
+    cursor.execute(f'GRANT SELECT ON SCHEMA {SCHEMA} TO {DATADOG_USER}')
+
+
+def create_tables(conn, cursor) -> None:
+    col_names = [f'C{i:04d}' for i in range(1, NUM_COLUMNS + 1)]
+    col_defs = ', '.join(f'{name} INTEGER' for name in col_names)
+    batch_size = 50
+    for i in range(1, NUM_TABLES + 1):
+        table = f'{SCHEMA}.T{i:04d}'
+        cursor.execute(f'DROP TABLE {table} CASCADE') if False else None
+        try:
+            cursor.execute(f'DROP TABLE {table} CASCADE')
+        except Exception:
+            pass
+        cursor.execute(f'CREATE COLUMN TABLE {table} ({col_defs})')
+        if i % batch_size == 0:
+            conn.commit()
+            print(f'  created {i}/{NUM_TABLES} tables', flush=True)
+    conn.commit()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--host', default=HOST)
+    parser.add_argument('--port', type=int, default=PORT)
+    args = parser.parse_args()
+
+    global HOST, PORT
+    HOST = args.host
+    PORT = args.port
+
+    print(f'Connecting to {HOST}:{PORT} as {ADMIN_USER}...', flush=True)
+    with closing(connect(ADMIN_USER, ADMIN_PASSWORD)) as conn:
+        with closing(conn.cursor()) as cursor:
+            print('Setting up monitoring user...', flush=True)
+            setup_user(cursor)
+            conn.commit()
+
+            print('Setting up BENCH schema...', flush=True)
+            setup_schema(cursor)
+            conn.commit()
+
+            print(f'Creating {NUM_TABLES} tables with {NUM_COLUMNS} columns each...', flush=True)
+            print('(This may take several minutes. Lower NUM_COLUMNS/NUM_TABLES if HANA rejects them.)')
+            create_tables(conn, cursor)
+
+    print('Setup complete.', flush=True)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/sap_hana/benchmarks/schema_collection_memory/setup_database.py
+++ b/sap_hana/benchmarks/schema_collection_memory/setup_database.py
@@ -7,8 +7,8 @@ import argparse
 import sys
 from contextlib import closing
 
-NUM_TABLES = 50
-NUM_COLUMNS = 50
+NUM_TABLES = 1000
+NUM_COLUMNS = 1000
 
 ADMIN_USER = "system"
 ADMIN_PASSWORD = "Admin1337"

--- a/sap_hana/benchmarks/schema_collection_memory/setup_database.py
+++ b/sap_hana/benchmarks/schema_collection_memory/setup_database.py
@@ -37,7 +37,15 @@ def setup_user(cursor) -> None:
     cursor.execute(f'ALTER USER {DATADOG_USER} ENABLE CLIENT CONNECT')
     cursor.execute(f'ALTER USER {DATADOG_USER} DISABLE PASSWORD LIFETIME')
     cursor.execute(f'GRANT CATALOG READ TO {DATADOG_USER}')
-    for view in ('SYS.M_DATABASE', 'SYS.TABLES', 'SYS.SCHEMAS', 'SYS.TABLE_COLUMNS'):
+    for view in (
+        'SYS.M_DATABASE',
+        'SYS.M_TABLES',
+        'SYS.SCHEMAS',
+        'SYS.TABLE_COLUMNS',
+        'SYS.VIEWS',
+        'SYS.VIEW_COLUMNS',
+        'SYS.M_TABLE_STATISTICS',
+    ):
         cursor.execute(f'GRANT SELECT ON {view} TO {DATADOG_USER}')
 
 

--- a/sap_hana/benchmarks/schema_collection_memory/setup_database.py
+++ b/sap_hana/benchmarks/schema_collection_memory/setup_database.py
@@ -1,3 +1,6 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
 #!/usr/bin/env python3
 """Create the datadog monitoring user and populate the BENCH schema with NUM_TABLES x NUM_COLUMNS tables."""
 

--- a/sap_hana/changelog.d/23934.added
+++ b/sap_hana/changelog.d/23934.added
@@ -1,1 +1,1 @@
-Add Data Quality schema collection (schemas, tables, columns) and startup diagnostics.
+Add Data Quality schema collection (schemas, tables, views, and columns) and startup diagnostics.

--- a/sap_hana/changelog.d/23934.added
+++ b/sap_hana/changelog.d/23934.added
@@ -1,1 +1,1 @@
-Add Database Monitoring schema collection (schemas, tables, columns) and startup diagnostics.
+Add Data Quality schema collection (schemas, tables, columns) and startup diagnostics.

--- a/sap_hana/changelog.d/23934.added
+++ b/sap_hana/changelog.d/23934.added
@@ -1,0 +1,1 @@
+Add Database Monitoring schema collection (schemas, tables, columns) and startup diagnostics.

--- a/sap_hana/datadog_checks/sap_hana/config_models/instance.py
+++ b/sap_hana/datadog_checks/sap_hana/config_models/instance.py
@@ -23,6 +23,19 @@ from . import defaults, validators
 SECURE_FIELD_NAMES = frozenset(['tls_ca_cert', 'tls_cert', 'tls_private_key'])
 
 
+class CollectSchemas(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    collection_interval: Optional[float] = None
+    enabled: Optional[bool] = None
+    exclude_schemas: Optional[tuple[str, ...]] = None
+    include_schemas: Optional[tuple[str, ...]] = None
+    max_columns: Optional[int] = None
+    max_tables: Optional[int] = None
+
+
 class CustomQuery(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -51,6 +64,7 @@ class InstanceConfig(BaseModel):
         frozen=True,
     )
     batch_size: Optional[int] = None
+    collect_schemas: Optional[CollectSchemas] = None
     connection_properties: Optional[MappingProxyType[str, Any]] = None
     custom_queries: Optional[tuple[CustomQuery, ...]] = None
     disable_generic_tags: Optional[bool] = None

--- a/sap_hana/datadog_checks/sap_hana/config_models/instance.py
+++ b/sap_hana/datadog_checks/sap_hana/config_models/instance.py
@@ -34,6 +34,7 @@ class CollectSchemas(BaseModel):
     include_schemas: Optional[tuple[str, ...]] = None
     max_columns: Optional[int] = None
     max_tables: Optional[int] = None
+    max_views: Optional[int] = None
 
 
 class CustomQuery(BaseModel):

--- a/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
+++ b/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
@@ -220,6 +220,50 @@ instances:
     #   - TLS_CHACHA20_POLY1305_SHA256
     #   - TLS_AES_128_GCM_SHA256
 
+    ## Configure collection of SAP HANA catalog metadata (schemas, tables,
+    ## columns) for Database Monitoring's Schema Explorer.
+    #
+    # collect_schemas:
+
+        ## @param enabled - boolean - optional - default: false
+        ## Enable collection of catalog metadata. When enabled, the Agent
+        ## queries `SYS.SCHEMAS`, `SYS.TABLES`, and `SYS.TABLE_COLUMNS` and
+        ## emits schema metadata payloads.
+        #
+        # enabled: false
+
+        ## @param collection_interval - number - optional - default: 600
+        ## Set the schema collection interval (in seconds). Catalog data
+        ## changes slowly; 600s (10 min) is a reasonable default.
+        #
+        # collection_interval: 600
+
+        ## @param max_tables - integer - optional - default: 300
+        ## Maximum number of tables to collect per cycle across all schemas.
+        #
+        # max_tables: 300
+
+        ## @param max_columns - integer - optional - default: 50
+        ## Maximum number of columns to collect per table.
+        #
+        # max_columns: 50
+
+        ## @param include_schemas - list of strings - optional
+        ## A list of schema names to include. Any schema whose name is in
+        ## this list will be included. If empty, all schemas (other than
+        ## those excluded) are included.
+        #
+        # include_schemas:
+        #   - MY_SCHEMA
+
+        ## @param exclude_schemas - list of strings - optional
+        ## A list of schema names to exclude. Any schema whose name is in
+        ## this list will be excluded. SAP HANA system schemas are always
+        ## excluded regardless of this setting.
+        #
+        # exclude_schemas:
+        #   - TMP_SCHEMA
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
+++ b/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
@@ -221,7 +221,7 @@ instances:
     #   - TLS_AES_128_GCM_SHA256
 
     ## Configure collection of SAP HANA catalog metadata (schemas, tables,
-    ## columns) for Database Monitoring's Schema Explorer.
+    ## columns) for Data Quality features in Data Observability.
     #
     # collect_schemas:
 

--- a/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
+++ b/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
@@ -220,50 +220,6 @@ instances:
     #   - TLS_CHACHA20_POLY1305_SHA256
     #   - TLS_AES_128_GCM_SHA256
 
-    ## Configure collection of SAP HANA catalog metadata (schemas, tables,
-    ## columns) for Data Quality features in Data Observability.
-    #
-    # collect_schemas:
-
-        ## @param enabled - boolean - optional - default: false
-        ## Enable collection of catalog metadata. When enabled, the Agent
-        ## queries `SYS.SCHEMAS`, `SYS.TABLES`, and `SYS.TABLE_COLUMNS` and
-        ## emits schema metadata payloads.
-        #
-        # enabled: false
-
-        ## @param collection_interval - number - optional - default: 600
-        ## Set the schema collection interval (in seconds). Catalog data
-        ## changes slowly; 600s (10 min) is a reasonable default.
-        #
-        # collection_interval: 600
-
-        ## @param max_tables - integer - optional - default: 2000
-        ## Maximum number of tables to collect per cycle across all schemas.
-        #
-        # max_tables: 2000
-
-        ## @param max_columns - integer - optional - default: 500
-        ## Maximum number of columns to collect per table.
-        #
-        # max_columns: 500
-
-        ## @param include_schemas - list of strings - optional
-        ## A list of schema names to include. Any schema whose name is in
-        ## this list will be included. If empty, all schemas (other than
-        ## those excluded) are included.
-        #
-        # include_schemas:
-        #   - MY_SCHEMA
-
-        ## @param exclude_schemas - list of strings - optional
-        ## A list of schema names to exclude. Any schema whose name is in
-        ## this list will be excluded. SAP HANA system schemas are always
-        ## excluded regardless of this setting.
-        #
-        # exclude_schemas:
-        #   - TMP_SCHEMA
-
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
+++ b/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
@@ -238,15 +238,15 @@ instances:
         #
         # collection_interval: 600
 
-        ## @param max_tables - integer - optional - default: 300
+        ## @param max_tables - integer - optional - default: 2000
         ## Maximum number of tables to collect per cycle across all schemas.
         #
-        # max_tables: 300
+        # max_tables: 2000
 
-        ## @param max_columns - integer - optional - default: 50
+        ## @param max_columns - integer - optional - default: 500
         ## Maximum number of columns to collect per table.
         #
-        # max_columns: 50
+        # max_columns: 500
 
         ## @param include_schemas - list of strings - optional
         ## A list of schema names to include. Any schema whose name is in

--- a/sap_hana/datadog_checks/sap_hana/diagnose.py
+++ b/sap_hana/datadog_checks/sap_hana/diagnose.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2025-present
+# (C) Datadog, Inc. 2026-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 

--- a/sap_hana/datadog_checks/sap_hana/diagnose.py
+++ b/sap_hana/datadog_checks/sap_hana/diagnose.py
@@ -57,6 +57,14 @@ def run_diagnostics(check: SapHanaCheck):
     HanaDiagnose(check)._run()
 
 
+def _classify_access_error(error) -> HanaConfigurationError:
+    """Map a query exception to a privilege or generic catalog-access diagnostic code."""
+    error_lower = str(error).lower()
+    if 'insufficient privilege' in error_lower or 'not authorized' in error_lower:
+        return HanaConfigurationError.missing_catalog_privilege
+    return HanaConfigurationError.catalog_view_inaccessible
+
+
 class HanaDiagnose:
     def __init__(self, check: SapHanaCheck):
         self._check = check
@@ -101,11 +109,14 @@ class HanaDiagnose:
                 cursor.execute("SELECT VERSION FROM SYS.M_DATABASE")
                 row = cursor.fetchone()
         except Exception as e:
+            # A failed version query is an access problem, not a version mismatch, so report the
+            # privilege/access diagnostic whose remediation matches the real cause.
+            access_code = _classify_access_error(e)
             self._fail(
-                code.value,
-                diagnosis="Could not determine SAP HANA version: {}".format(e),
-                description=DIAGNOSTIC_METADATA[code.value]['description'],
-                remediation=DIAGNOSTIC_METADATA[code.value]['remediation'],
+                access_code.value,
+                diagnosis="Could not read SAP HANA version from SYS.M_DATABASE: {}".format(e),
+                description=DIAGNOSTIC_METADATA[access_code.value]['description'],
+                remediation=DIAGNOSTIC_METADATA[access_code.value]['remediation'],
                 rawerror=str(e),
             )
             return
@@ -153,11 +164,7 @@ class HanaDiagnose:
                 cursor.execute("SELECT COUNT(*) FROM {}".format(view))
                 cursor.fetchone()
         except Exception as e:
-            error_lower = str(e).lower()
-            if 'insufficient privilege' in error_lower or 'not authorized' in error_lower:
-                code = HanaConfigurationError.missing_catalog_privilege
-            else:
-                code = HanaConfigurationError.catalog_view_inaccessible
+            code = _classify_access_error(e)
             self._fail(
                 name,
                 diagnosis="Could not query {}: {}".format(view, e),

--- a/sap_hana/datadog_checks/sap_hana/diagnose.py
+++ b/sap_hana/datadog_checks/sap_hana/diagnose.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 _MINIMUM_MAJOR_VERSION = 2
 _CATEGORY = "SAP HANA"
 
-_CATALOG_VIEWS = ['SYS.SCHEMAS', 'SYS.TABLES', 'SYS.TABLE_COLUMNS']
+_CATALOG_VIEWS = ['SYS.SCHEMAS', 'SYS.M_TABLES', 'SYS.VIEWS', 'SYS.TABLE_COLUMNS', 'SYS.VIEW_COLUMNS']
 
 DIAGNOSTIC_METADATA = {
     'connection_failure': {
@@ -35,8 +35,8 @@ DIAGNOSTIC_METADATA = {
             "required for schema collection: {}.".format(', '.join(_CATALOG_VIEWS))
         ),
         'remediation': (
-            "Grant SELECT on SYS.SCHEMAS, SYS.TABLES, and SYS.TABLE_COLUMNS to the monitoring user, "
-            "or grant the CATALOG READ system privilege."
+            "Grant SELECT on SYS.SCHEMAS, SYS.M_TABLES, SYS.VIEWS, SYS.TABLE_COLUMNS, and SYS.VIEW_COLUMNS "
+            "to the monitoring user, or grant the CATALOG READ system privilege."
         ),
     },
     'catalog_view_inaccessible': {

--- a/sap_hana/datadog_checks/sap_hana/diagnose.py
+++ b/sap_hana/datadog_checks/sap_hana/diagnose.py
@@ -1,0 +1,185 @@
+# (C) Datadog, Inc. 2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from __future__ import annotations
+
+from contextlib import closing
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .sap_hana import SapHanaCheck
+
+_MINIMUM_MAJOR_VERSION = 2
+_CATEGORY = "SAP HANA"
+
+_CATALOG_VIEWS = ['SYS.SCHEMAS', 'SYS.TABLES', 'SYS.TABLE_COLUMNS']
+
+DIAGNOSTIC_METADATA = {
+    'connection_failure': {
+        'description': "Unable to connect to SAP HANA at the configured host and port.",
+        'remediation': (
+            "Verify that server, port, username, and password are correct and that the HANA instance is reachable."
+        ),
+    },
+    'version_unsupported': {
+        'description': "The SAP HANA version is below the minimum supported version ({}.x).".format(
+            _MINIMUM_MAJOR_VERSION
+        ),
+        'remediation': "Upgrade to SAP HANA 2.0 or later.",
+    },
+    'missing_catalog_privilege': {
+        'description': (
+            "The configured user lacks SELECT privilege on one or more system catalog views "
+            "required for schema collection: {}.".format(', '.join(_CATALOG_VIEWS))
+        ),
+        'remediation': (
+            "Grant SELECT on SYS.SCHEMAS, SYS.TABLES, and SYS.TABLE_COLUMNS to the monitoring user, "
+            "or grant the CATALOG READ system privilege."
+        ),
+    },
+    'catalog_view_inaccessible': {
+        'description': "A system catalog view required for schema collection could not be queried.",
+        'remediation': "Verify the HANA instance is healthy and the system catalog views are accessible.",
+    },
+}
+
+
+class HanaConfigurationError(Enum):
+    connection_failure = 'connection_failure'
+    version_unsupported = 'version_unsupported'
+    missing_catalog_privilege = 'missing_catalog_privilege'
+    catalog_view_inaccessible = 'catalog_view_inaccessible'
+
+
+def run_diagnostics(check: SapHanaCheck):
+    HanaDiagnose(check)._run()
+
+
+class HanaDiagnose:
+    def __init__(self, check: SapHanaCheck):
+        self._check = check
+        self._failed = set()
+
+    def _run(self):
+        self._failed = set()
+        conn = self._open_probe_connection()
+        if conn is None:
+            return
+        try:
+            self._diagnose_version(conn)
+            self._diagnose_catalog_access(conn)
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    def _open_probe_connection(self):
+        code = HanaConfigurationError.connection_failure
+        conn = self._check.get_connection()
+        if conn is None:
+            self._fail(
+                code.value,
+                diagnosis="Failed to connect to SAP HANA at {}:{}".format(self._check._server, self._check._port),
+                description=DIAGNOSTIC_METADATA[code.value]['description'],
+                remediation=DIAGNOSTIC_METADATA[code.value]['remediation'],
+            )
+            return None
+        self._check.diagnosis.success(
+            name=code.value,
+            diagnosis="Connected to SAP HANA at {}:{}".format(self._check._server, self._check._port),
+            category=_CATEGORY,
+        )
+        return conn
+
+    def _diagnose_version(self, conn):
+        code = HanaConfigurationError.version_unsupported
+        try:
+            with closing(conn.cursor()) as cursor:
+                cursor.execute("SELECT VERSION FROM SYS.M_DATABASE")
+                row = cursor.fetchone()
+        except Exception as e:
+            self._fail(
+                code.value,
+                diagnosis="Could not determine SAP HANA version: {}".format(e),
+                description=DIAGNOSTIC_METADATA[code.value]['description'],
+                remediation=DIAGNOSTIC_METADATA[code.value]['remediation'],
+                rawerror=str(e),
+            )
+            return
+
+        if not row:
+            self._fail(
+                code.value,
+                diagnosis="SYS.M_DATABASE returned no rows",
+                description=DIAGNOSTIC_METADATA[code.value]['description'],
+                remediation=DIAGNOSTIC_METADATA[code.value]['remediation'],
+            )
+            return
+
+        version_str = str(row[0]).split()[0]
+        try:
+            major = int(version_str.split('.')[0])
+        except (ValueError, IndexError):
+            major = 0
+
+        if major < _MINIMUM_MAJOR_VERSION:
+            self._fail(
+                code.value,
+                diagnosis="SAP HANA version {} is not supported (minimum: {}.x)".format(
+                    version_str, _MINIMUM_MAJOR_VERSION
+                ),
+                description=DIAGNOSTIC_METADATA[code.value]['description'],
+                remediation=DIAGNOSTIC_METADATA[code.value]['remediation'],
+            )
+            return
+
+        self._check.diagnosis.success(
+            name=code.value,
+            diagnosis="SAP HANA version {} is supported".format(version_str),
+            category=_CATEGORY,
+        )
+
+    def _diagnose_catalog_access(self, conn):
+        for view in _CATALOG_VIEWS:
+            self._diagnose_single_view(conn, view)
+
+    def _diagnose_single_view(self, conn, view):
+        name = "{}_accessible".format(view.replace('.', '_').lower())
+        try:
+            with closing(conn.cursor()) as cursor:
+                cursor.execute("SELECT COUNT(*) FROM {}".format(view))
+                cursor.fetchone()
+        except Exception as e:
+            error_lower = str(e).lower()
+            if 'insufficient privilege' in error_lower or 'not authorized' in error_lower:
+                code = HanaConfigurationError.missing_catalog_privilege
+            else:
+                code = HanaConfigurationError.catalog_view_inaccessible
+            self._fail(
+                name,
+                diagnosis="Could not query {}: {}".format(view, e),
+                description=DIAGNOSTIC_METADATA[code.value]['description'],
+                remediation=DIAGNOSTIC_METADATA[code.value]['remediation'],
+                rawerror=str(e),
+            )
+            return
+
+        self._check.diagnosis.success(
+            name=name,
+            diagnosis="{} is accessible".format(view),
+            category=_CATEGORY,
+        )
+
+    def _fail(self, name, diagnosis, description='', remediation='', rawerror=None):
+        self._failed.add(name)
+        self._check.diagnosis.fail(
+            name=name,
+            diagnosis=diagnosis,
+            category=_CATEGORY,
+            description=description,
+            remediation=remediation,
+            rawerror=rawerror,
+        )

--- a/sap_hana/datadog_checks/sap_hana/queries.py
+++ b/sap_hana/datadog_checks/sap_hana/queries.py
@@ -30,7 +30,12 @@ class Query(object):
         self.schema = schema
         self.fields = fields
         self.view = view
-        self.query = compact_query(query.format("{}.{}".format(schema, view)))
+        q = compact_query(query.format("{}.{}".format(schema, view)))
+        if schema == 'SYS':
+            # Single-tenant HANA Express: SYS views lack the DATABASE_NAME column
+            q = q.replace('SELECT DATABASE_NAME,', "SELECT 'SYSTEMDB' AS DATABASE_NAME,")
+            q = q.replace('GROUP BY DATABASE_NAME,', 'GROUP BY')
+        self.query = q
 
 
 class MasterDatabase(Query):
@@ -233,6 +238,7 @@ class GlobalSystemDiskUsage(Query):
     """
 
     def __init__(self, schema):
+        total_col = 'FILE_SIZE' if schema == 'SYS' else 'TOTAL_SIZE'
         super(GlobalSystemDiskUsage, self).__init__(
             schema=schema,
             fields=('db_name', 'host', 'resource', 'used', 'total'),
@@ -243,9 +249,9 @@ class GlobalSystemDiskUsage(Query):
                   HOST,
                   USAGE_TYPE,
                   USED_SIZE,
-                  TOTAL_SIZE
-                FROM {}
-            """,
+                  {}
+                FROM {{}}
+            """.format(total_col),
         )
 
 

--- a/sap_hana/datadog_checks/sap_hana/queries.py
+++ b/sap_hana/datadog_checks/sap_hana/queries.py
@@ -30,12 +30,7 @@ class Query(object):
         self.schema = schema
         self.fields = fields
         self.view = view
-        q = compact_query(query.format("{}.{}".format(schema, view)))
-        if schema == 'SYS':
-            # Single-tenant HANA Express: SYS views lack the DATABASE_NAME column
-            q = q.replace('SELECT DATABASE_NAME,', "SELECT 'SYSTEMDB' AS DATABASE_NAME,")
-            q = q.replace('GROUP BY DATABASE_NAME,', 'GROUP BY')
-        self.query = q
+        self.query = compact_query(query.format("{}.{}".format(schema, view)))
 
 
 class MasterDatabase(Query):
@@ -238,7 +233,6 @@ class GlobalSystemDiskUsage(Query):
     """
 
     def __init__(self, schema):
-        total_col = 'FILE_SIZE' if schema == 'SYS' else 'TOTAL_SIZE'
         super(GlobalSystemDiskUsage, self).__init__(
             schema=schema,
             fields=('db_name', 'host', 'resource', 'used', 'total'),
@@ -249,9 +243,9 @@ class GlobalSystemDiskUsage(Query):
                   HOST,
                   USAGE_TYPE,
                   USED_SIZE,
-                  {}
-                FROM {{}}
-            """.format(total_col),
+                  TOTAL_SIZE
+                FROM {}
+            """,
         )
 
 

--- a/sap_hana/datadog_checks/sap_hana/sap_hana.py
+++ b/sap_hana/datadog_checks/sap_hana/sap_hana.py
@@ -212,9 +212,9 @@ class SapHanaCheck(AgentCheck):
             return
         if time.time() - self._last_schema_collection_time < self._schema_collection_interval:
             return
-        self._last_schema_collection_time = time.time()
         try:
             self._schema_collector.collect_schemas()
+            self._last_schema_collection_time = time.time()
         except Exception as e:
             self.log.error('Error collecting HANA schemas: %s', e)
 

--- a/sap_hana/datadog_checks/sap_hana/sap_hana.py
+++ b/sap_hana/datadog_checks/sap_hana/sap_hana.py
@@ -3,6 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
 
+import functools
+import time
 from collections import defaultdict
 from contextlib import closing
 from datetime import datetime
@@ -25,7 +27,10 @@ from datadog_checks.base.utils.constants import MICROSECOND
 from datadog_checks.base.utils.containers import iter_unique
 
 from . import queries
+from .config_models.instance import CollectSchemas
+from .diagnose import run_diagnostics
 from .exceptions import OperationalError, QueryExecutionError
+from .schemas import HanaSchemaCollector
 from .utils import compute_percent, positive
 
 
@@ -85,8 +90,16 @@ class SapHanaCheck(AgentCheck):
         # Save master database hostname to act as the default if `use_hana_hostnames` is true
         self._master_hostname = None
 
+        # Schema collection (DBM)
+        collect_schemas = CollectSchemas(**(self.instance.get('collect_schemas') or {}))
+        self._schema_collector = HanaSchemaCollector(self, collect_schemas) if collect_schemas.enabled else None
+        self._schema_collection_interval = int(collect_schemas.collection_interval or 600)
+        self._last_schema_collection_time = 0
+        self._dbms_version = None
+
         self.check_initializations.append(self.parse_config)
         self.check_initializations.append(self.set_default_methods)
+        self.diagnosis.register(functools.partial(run_diagnostics, self))
 
     def check(self, _):
         if self._only_custom_queries:
@@ -111,6 +124,7 @@ class SapHanaCheck(AgentCheck):
                 except Exception as e:
                     self.log.exception('Unexpected error running `%s`: %s', query_method.__name__, str(e))
                     continue
+            self._maybe_collect_schemas()
         finally:
             if self._connection_lost:
                 self.service_check(
@@ -158,6 +172,51 @@ class SapHanaCheck(AgentCheck):
 
         if self.logs_enabled:
             self._default_methods.append(self.query_audit_logs)
+
+    # Properties required by SchemaCollector base class
+
+    @property
+    def reported_hostname(self):
+        return self._server
+
+    @property
+    def database_identifier(self):
+        return '{}:{}'.format(self._server, self._port)
+
+    @property
+    def dbms(self):
+        return 'hana'
+
+    @property
+    def dbms_version(self):
+        if self._dbms_version is None and self._conn is not None:
+            try:
+                with closing(self._conn.cursor()) as cursor:
+                    cursor.execute("SELECT VERSION FROM SYS.M_DATABASE")
+                    row = cursor.fetchone()
+                    self._dbms_version = str(row[0]).split()[0] if row else 'unknown'
+            except Exception:
+                self._dbms_version = 'unknown'
+        return self._dbms_version or 'unknown'
+
+    @property
+    def tags(self):
+        return self._tags
+
+    @property
+    def cloud_metadata(self):
+        return {}
+
+    def _maybe_collect_schemas(self):
+        if not self._schema_collector or not self._conn:
+            return
+        if time.time() - self._last_schema_collection_time < self._schema_collection_interval:
+            return
+        self._last_schema_collection_time = time.time()
+        try:
+            self._schema_collector.collect_schemas()
+        except Exception as e:
+            self.log.error('Error collecting HANA schemas: %s', e)
 
     def query_master_database(self):
         # https://help.sap.com/viewer/4fe29514fd584807ac9f2a04f6754767/2.0.02/en-US/20ae63aa7519101496f6b832ec86afbd.html

--- a/sap_hana/datadog_checks/sap_hana/sap_hana.py
+++ b/sap_hana/datadog_checks/sap_hana/sap_hana.py
@@ -185,7 +185,7 @@ class SapHanaCheck(AgentCheck):
 
     @property
     def dbms(self):
-        return 'hana'
+        return 'saphana'
 
     @property
     def dbms_version(self):

--- a/sap_hana/datadog_checks/sap_hana/schemas.py
+++ b/sap_hana/datadog_checks/sap_hana/schemas.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2025-present
+# (C) Datadog, Inc. 2026-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 

--- a/sap_hana/datadog_checks/sap_hana/schemas.py
+++ b/sap_hana/datadog_checks/sap_hana/schemas.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
     from .config_models.instance import CollectSchemas
     from .sap_hana import SapHanaCheck
 
+CURSOR_FETCH_SIZE = 10_000
+
 CURRENT_DATABASE_QUERY = "SELECT DATABASE_NAME FROM SYS.M_DATABASE"
 CURRENT_DATABASE_DESCRIPTION_QUERY = "SELECT DESCRIPTION FROM SYS.M_DATABASE"
 
@@ -114,6 +116,7 @@ class HanaSchemaCollector(SchemaCollector):
         conn = self._check._conn
         query, params = self._build_query()
         with closing(conn.cursor()) as cursor:
+            cursor.setfetchsize(CURSOR_FETCH_SIZE)
             cursor.execute(query, params)
             self._pending_row = cursor.fetchone()
             try:

--- a/sap_hana/datadog_checks/sap_hana/schemas.py
+++ b/sap_hana/datadog_checks/sap_hana/schemas.py
@@ -14,8 +14,6 @@ if TYPE_CHECKING:
     from .config_models.instance import CollectSchemas
     from .sap_hana import SapHanaCheck
 
-CURSOR_FETCH_SIZE = 10_000
-
 CURRENT_DATABASE_QUERY = "SELECT DATABASE_NAME FROM SYS.M_DATABASE"
 CURRENT_DATABASE_DESCRIPTION_QUERY = "SELECT DESCRIPTION FROM SYS.M_DATABASE"
 
@@ -116,7 +114,6 @@ class HanaSchemaCollector(SchemaCollector):
         conn = self._check._conn
         query, params = self._build_query()
         with closing(conn.cursor()) as cursor:
-            cursor.setfetchsize(CURSOR_FETCH_SIZE)
             cursor.execute(query, params)
             self._pending_row = cursor.fetchone()
             try:

--- a/sap_hana/datadog_checks/sap_hana/schemas.py
+++ b/sap_hana/datadog_checks/sap_hana/schemas.py
@@ -2,6 +2,40 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+"""SAP HANA schema collection for DBM.
+
+Control flow (the base `SchemaCollector.collect_schemas` drives this, see
+`datadog_checks.base.utils.db.schemas`):
+
+    _get_databases()  -> the single current tenant, or [] to skip the cycle
+    _get_cursor(db)   -> HanaSchemaQueryBuilder builds+runs one catalog query, streams rows
+    _get_next(cursor) -> groups consecutive rows by (schema, table) into one object
+    _map_row(...)     -> shapes the object into the DBM metadata payload
+    maybe_flush(...)  -> emits a payload once enough columns have accumulated
+
+Responsibility split:
+  * HanaSchemaQueryBuilder owns all SQL/query-policy decisions (the catalog query, schema
+    include/exclude filters, the optional table-statistics join, and the SQL-level caps).
+  * HanaSchemaCollector owns runtime concerns (streaming, row grouping, payload flushing).
+
+Collection-policy decisions, all enforced in one query for cost control:
+  * Tables and views are capped in SQL (`LIMIT max_tables` / `LIMIT max_views`) so an oversized
+    tenant never streams more objects than configured. Tables and views are capped
+    independently rather than sharing one budget.
+  * Columns are capped in SQL via a `ROW_NUMBER()` window (`rn <= max_columns`) so the server
+    sends at most `max_columns` rows per object; `_get_next` re-applies the same cap as a
+    defensive client-side guard.
+  * System schemas (`SYS`, `SYSTEM`, `PUBLIC`, and `_SYS_*`) are always excluded; visibility
+    is otherwise governed by the catalog-view grants the monitoring user holds, not by
+    per-object privileges.
+  * The `SYS.M_TABLE_STATISTICS` join (row counts + last-modified time) is added only when a
+    one-time permission probe succeeds, so a missing grant degrades gracefully.
+
+Payloads flush by accumulated column count rather than the base class's per-table count; see
+`PAYLOAD_COLUMN_CHUNK_SIZE` below and the memory benchmark in
+`sap_hana/benchmarks/schema_collection_memory/` for the rationale and measured impact.
+"""
+
 from __future__ import annotations
 
 import contextlib

--- a/sap_hana/datadog_checks/sap_hana/schemas.py
+++ b/sap_hana/datadog_checks/sap_hana/schemas.py
@@ -23,7 +23,6 @@ CURRENT_DATABASE_DESCRIPTION_QUERY = "SELECT DESCRIPTION FROM SYS.M_DATABASE"
 SCHEMAS_QUERY = """
 SELECT SCHEMA_NAME, SCHEMA_OWNER
 FROM SYS.SCHEMAS
-WHERE HAS_PRIVILEGES = 'TRUE'
 """
 
 TABLES_QUERY = """
@@ -116,6 +115,19 @@ class HanaSchemaCollector(SchemaCollector):
                         'columns': [],
                     }
 
+            # Trim to max_tables before fetching columns so the column query only
+            # loads data for tables that will actually be emitted.
+            total = 0
+            for schema_name in list(schemas.keys()):
+                tables = schemas[schema_name]['tables']
+                for table_name in list(tables.keys()):
+                    if total >= self._config.max_tables:
+                        del tables[table_name]
+                    else:
+                        total += 1
+                if not tables:
+                    del schemas[schema_name]
+
             with closing(conn.cursor()) as cursor:
                 cursor.execute(COLUMNS_QUERY)
                 for row in cursor.fetchall():
@@ -138,13 +150,8 @@ class HanaSchemaCollector(SchemaCollector):
                         }
                     )
 
-            total = 0
             for schema_name, schema_data in schemas.items():
-                if total >= self._config.max_tables:
-                    break
                 for table_name, table_data in schema_data['tables'].items():
-                    if total >= self._config.max_tables:
-                        break
                     table_rows.append(
                         {
                             'schema_name': schema_name,
@@ -155,7 +162,6 @@ class HanaSchemaCollector(SchemaCollector):
                             'columns': table_data['columns'],
                         }
                     )
-                    total += 1
         except Exception as e:
             self._log.error("Error fetching HANA schema data: %s", e)
 

--- a/sap_hana/datadog_checks/sap_hana/schemas.py
+++ b/sap_hana/datadog_checks/sap_hana/schemas.py
@@ -35,6 +35,7 @@ WHERE IS_TEMPORARY = 'FALSE'
 COLUMNS_QUERY = """
 SELECT SCHEMA_NAME, TABLE_NAME, COLUMN_NAME, DATA_TYPE_NAME, IS_NULLABLE, DEFAULT_VALUE, POSITION
 FROM SYS.TABLE_COLUMNS
+WHERE (SCHEMA_NAME, TABLE_NAME) IN ({placeholders})
 ORDER BY SCHEMA_NAME, TABLE_NAME, POSITION
 """
 
@@ -115,8 +116,6 @@ class HanaSchemaCollector(SchemaCollector):
                         'columns': [],
                     }
 
-            # Trim to max_tables before fetching columns so the column query only
-            # loads data for tables that will actually be emitted.
             total = 0
             for schema_name in list(schemas.keys()):
                 tables = schemas[schema_name]['tables']
@@ -128,27 +127,30 @@ class HanaSchemaCollector(SchemaCollector):
                 if not tables:
                     del schemas[schema_name]
 
-            with closing(conn.cursor()) as cursor:
-                cursor.execute(COLUMNS_QUERY)
-                for row in cursor.fetchall():
-                    schema_name, table_name = row[0], row[1]
-                    if schema_name not in schemas:
-                        continue
-                    tables = schemas[schema_name]['tables']
-                    if table_name not in tables:
-                        continue
-                    columns = tables[table_name]['columns']
-                    if len(columns) >= self._config.max_columns:
-                        continue
-                    columns.append(
-                        {
-                            'name': row[2],
-                            'data_type': row[3] or '',
-                            'nullable': row[4] == 'TRUE',
-                            'default': row[5],
-                            'position': row[6],
-                        }
-                    )
+            surviving_tables = [
+                (schema_name, table_name)
+                for schema_name, schema_data in schemas.items()
+                for table_name in schema_data['tables']
+            ]
+            if surviving_tables:
+                placeholders = ', '.join('(?, ?)' for _ in surviving_tables)
+                params = tuple(v for pair in surviving_tables for v in pair)
+                with closing(conn.cursor()) as cursor:
+                    cursor.execute(COLUMNS_QUERY.format(placeholders=placeholders), params)
+                    for row in cursor.fetchall():
+                        schema_name, table_name = row[0], row[1]
+                        columns = schemas[schema_name]['tables'][table_name]['columns']
+                        if len(columns) >= self._config.max_columns:
+                            continue
+                        columns.append(
+                            {
+                                'name': row[2],
+                                'data_type': row[3] or '',
+                                'nullable': row[4] == 'TRUE',
+                                'default': row[5],
+                                'position': row[6],
+                            }
+                        )
 
             for schema_name, schema_data in schemas.items():
                 for table_name, table_data in schema_data['tables'].items():

--- a/sap_hana/datadog_checks/sap_hana/schemas.py
+++ b/sap_hana/datadog_checks/sap_hana/schemas.py
@@ -19,18 +19,37 @@ PAYLOAD_COLUMN_CHUNK_SIZE = 50_000
 CURRENT_DATABASE_QUERY = "SELECT DATABASE_NAME FROM SYS.M_DATABASE"
 CURRENT_DATABASE_DESCRIPTION_QUERY = "SELECT DESCRIPTION FROM SYS.M_DATABASE"
 
-# Single query that filters and caps tables in the database (not in Python) and joins their columns.
-# The limited_tables CTE applies the schema filters and max_tables LIMIT before the column join, so
-# the server never returns more than max_tables tables' worth of rows. Results are ordered so each
-# table's columns arrive contiguously and can be assembled one table at a time while streaming the
-# cursor. System schemas are excluded here; '_' is a LIKE wildcard, so '_SYS_' is escaped.
-SCHEMA_TABLES_QUERY = r"""
+STATS_PERMISSION_PROBE = "SELECT COUNT(*) FROM SYS.M_TABLE_STATISTICS"
+
+# Fragment conditionally inserted when the monitoring user has SELECT on SYS.M_TABLE_STATISTICS.
+STATS_JOIN_FRAGMENT = """\
+    LEFT JOIN SYS.M_TABLE_STATISTICS ts
+      ON ts.SCHEMA_NAME = t.SCHEMA_NAME AND ts.TABLE_NAME = t.TABLE_NAME"""
+
+# Queries SYS.M_TABLES (tables with live row counts) and SYS.VIEWS separately, then unions them.
+# Table columns come from SYS.TABLE_COLUMNS; view columns from SYS.VIEW_COLUMNS (TABLE_COLUMNS
+# does not cover views in HANA). System schemas are excluded; '_SYS_' uses ESCAPE because '_' is
+# a LIKE wildcard. Placeholders:
+#   {stats_join}      STATS_JOIN_FRAGMENT or empty string
+#   {stats_column}    ts.LAST_MODIFY_TIME AS LAST_UPDATED_ON  or  NULL AS LAST_UPDATED_ON
+#   {include_clause}  AND t.SCHEMA_NAME IN (...)  or empty
+#   {exclude_clause}  AND t.SCHEMA_NAME NOT IN (...)  or empty
+#   {include_clause_v} / {exclude_clause_v}  same filters for v.SCHEMA_NAME
+# SELECT column order: SCHEMA_NAME[0] TABLE_NAME[1] OBJECT_TYPE[2] IS_COLUMN_TABLE[3]
+#   SCHEMA_OWNER[4] ROW_COUNT[5] LAST_UPDATED_ON[6]
+#   COLUMN_NAME[7] DATA_TYPE_NAME[8] IS_NULLABLE[9] DEFAULT_VALUE[10] POSITION[11]
+SCHEMA_OBJECTS_QUERY = r"""
 WITH limited_tables AS (
-    SELECT t.SCHEMA_NAME, t.TABLE_NAME, t.TABLE_TYPE, t.IS_COLUMN_TABLE, s.SCHEMA_OWNER
-    FROM SYS.TABLES t
+    SELECT t.SCHEMA_NAME, t.TABLE_NAME,
+           'TABLE' AS OBJECT_TYPE,
+           CASE WHEN t.TABLE_TYPE = 'COLUMN' THEN 'TRUE' ELSE 'FALSE' END AS IS_COLUMN_TABLE,
+           s.SCHEMA_OWNER,
+           CAST(t.RECORD_COUNT AS BIGINT) AS ROW_COUNT,
+           {stats_column}
+    FROM SYS.M_TABLES t
     LEFT JOIN SYS.SCHEMAS s ON s.SCHEMA_NAME = t.SCHEMA_NAME
-    WHERE t.IS_TEMPORARY = 'FALSE'
-      AND t.IS_SYSTEM_TABLE = 'FALSE'
+    {stats_join}
+    WHERE t.TABLE_TYPE NOT LIKE '%TEMPORARY%'
       AND t.SCHEMA_NAME NOT IN ('SYS', 'SYSTEM', 'PUBLIC')
       AND t.SCHEMA_NAME NOT LIKE '\_SYS\_%' ESCAPE '\'
       {include_clause}
@@ -38,20 +57,52 @@ WITH limited_tables AS (
     ORDER BY t.SCHEMA_NAME, t.TABLE_NAME
     LIMIT {max_tables}
 ),
+limited_views AS (
+    SELECT v.SCHEMA_NAME, v.VIEW_NAME AS TABLE_NAME,
+           'VIEW' AS OBJECT_TYPE,
+           NULL AS IS_COLUMN_TABLE,
+           s.SCHEMA_OWNER,
+           NULL AS ROW_COUNT,
+           NULL AS LAST_UPDATED_ON
+    FROM SYS.VIEWS v
+    LEFT JOIN SYS.SCHEMAS s ON s.SCHEMA_NAME = v.SCHEMA_NAME
+    WHERE v.SCHEMA_NAME NOT IN ('SYS', 'SYSTEM', 'PUBLIC')
+      AND v.SCHEMA_NAME NOT LIKE '\_SYS\_%' ESCAPE '\'
+      {include_clause_v}
+      {exclude_clause_v}
+),
+all_objects AS (
+    SELECT * FROM limited_tables
+    UNION ALL
+    SELECT * FROM limited_views
+),
 limited_columns AS (
     SELECT c.SCHEMA_NAME, c.TABLE_NAME, c.COLUMN_NAME, c.DATA_TYPE_NAME,
            c.IS_NULLABLE, c.DEFAULT_VALUE, c.POSITION,
            ROW_NUMBER() OVER (PARTITION BY c.SCHEMA_NAME, c.TABLE_NAME ORDER BY c.POSITION) AS rn
     FROM SYS.TABLE_COLUMNS c
     INNER JOIN limited_tables lt ON lt.SCHEMA_NAME = c.SCHEMA_NAME AND lt.TABLE_NAME = c.TABLE_NAME
+),
+limited_view_columns AS (
+    SELECT c.SCHEMA_NAME, c.VIEW_NAME AS TABLE_NAME, c.COLUMN_NAME, c.DATA_TYPE_NAME,
+           c.IS_NULLABLE, c.DEFAULT_VALUE, c.POSITION,
+           ROW_NUMBER() OVER (PARTITION BY c.SCHEMA_NAME, c.VIEW_NAME ORDER BY c.POSITION) AS rn
+    FROM SYS.VIEW_COLUMNS c
+    INNER JOIN limited_views lv ON lv.SCHEMA_NAME = c.SCHEMA_NAME AND lv.TABLE_NAME = c.VIEW_NAME
+),
+all_columns AS (
+    SELECT * FROM limited_columns
+    UNION ALL
+    SELECT * FROM limited_view_columns
 )
-SELECT lt.SCHEMA_NAME, lt.TABLE_NAME, lt.TABLE_TYPE, lt.IS_COLUMN_TABLE, lt.SCHEMA_OWNER,
-       lc.COLUMN_NAME, lc.DATA_TYPE_NAME, lc.IS_NULLABLE, lc.DEFAULT_VALUE, lc.POSITION
-FROM limited_tables lt
-LEFT JOIN limited_columns lc
-  ON lc.SCHEMA_NAME = lt.SCHEMA_NAME AND lc.TABLE_NAME = lt.TABLE_NAME
-  AND lc.rn <= {max_columns}
-ORDER BY lt.SCHEMA_NAME, lt.TABLE_NAME, lc.POSITION
+SELECT ao.SCHEMA_NAME, ao.TABLE_NAME, ao.OBJECT_TYPE, ao.IS_COLUMN_TABLE, ao.SCHEMA_OWNER,
+       ao.ROW_COUNT, ao.LAST_UPDATED_ON,
+       ac.COLUMN_NAME, ac.DATA_TYPE_NAME, ac.IS_NULLABLE, ac.DEFAULT_VALUE, ac.POSITION
+FROM all_objects ao
+LEFT JOIN all_columns ac
+  ON ac.SCHEMA_NAME = ao.SCHEMA_NAME AND ac.TABLE_NAME = ao.TABLE_NAME
+  AND ac.rn <= {max_columns}
+ORDER BY ao.SCHEMA_NAME, ao.TABLE_NAME, ac.POSITION
 """
 
 
@@ -73,6 +124,7 @@ class HanaSchemaCollector(SchemaCollector):
     def __init__(self, check: SapHanaCheck, config: CollectSchemas):
         super().__init__(check, HanaSchemaCollectorConfig(config))
         self._pending_row = None
+        self._has_table_statistics: bool | None = None
 
     def _reset(self) -> None:
         super()._reset()
@@ -112,24 +164,51 @@ class HanaSchemaCollector(SchemaCollector):
             self._log.warning("Could not fetch current HANA database info: %s", e)
         return [{'name': self._check._server, 'description': ''}]
 
+    def _probe_stats_permission(self, conn) -> bool:
+        try:
+            with closing(conn.cursor()) as cur:
+                cur.execute(STATS_PERMISSION_PROBE)
+                cur.fetchone()
+            return True
+        except Exception as e:
+            self._log.debug("SYS.M_TABLE_STATISTICS not accessible, skipping stats join: %s", e)
+            return False
+
     def _build_query(self):
-        """Build the schema/tables/columns query with schema filters and the table cap pushed into SQL."""
+        """Build the objects query with schema filters, optional stats join, and table cap in SQL."""
+        include_params: list = []
+        exclude_params: list = []
         include_clause = ''
         exclude_clause = ''
-        params = []
+        include_clause_v = ''
+        exclude_clause_v = ''
         if self._config.include_schemas:
             include = sorted(self._config.include_schemas)
             placeholders = ', '.join('?' for _ in include)
             include_clause = 'AND t.SCHEMA_NAME IN ({})'.format(placeholders)
-            params.extend(include)
+            include_clause_v = 'AND v.SCHEMA_NAME IN ({})'.format(placeholders)
+            include_params.extend(include)
         if self._config.exclude_schemas:
             exclude = sorted(self._config.exclude_schemas)
             placeholders = ', '.join('?' for _ in exclude)
             exclude_clause = 'AND t.SCHEMA_NAME NOT IN ({})'.format(placeholders)
-            params.extend(exclude)
-        query = SCHEMA_TABLES_QUERY.format(
+            exclude_clause_v = 'AND v.SCHEMA_NAME NOT IN ({})'.format(placeholders)
+            exclude_params.extend(exclude)
+        # Both limited_tables and limited_views CTEs have their own ?-placeholders, so params repeat.
+        params = include_params + exclude_params + include_params + exclude_params
+        if self._has_table_statistics:
+            stats_join = STATS_JOIN_FRAGMENT
+            stats_column = 'ts.LAST_MODIFY_TIME AS LAST_UPDATED_ON'
+        else:
+            stats_join = ''
+            stats_column = 'NULL AS LAST_UPDATED_ON'
+        query = SCHEMA_OBJECTS_QUERY.format(
             include_clause=include_clause,
             exclude_clause=exclude_clause,
+            include_clause_v=include_clause_v,
+            exclude_clause_v=exclude_clause_v,
+            stats_join=stats_join,
+            stats_column=stats_column,
             max_tables=int(self._config.max_tables),
             max_columns=int(self._config.max_columns),
         )
@@ -138,6 +217,8 @@ class HanaSchemaCollector(SchemaCollector):
     @contextlib.contextmanager
     def _get_cursor(self, _database_name):
         conn = self._check._conn
+        if self._has_table_statistics is None:
+            self._has_table_statistics = self._probe_stats_permission(conn)
         query, params = self._build_query()
         with closing(conn.cursor()) as cursor:
             cursor.execute(query, params)
@@ -148,23 +229,24 @@ class HanaSchemaCollector(SchemaCollector):
                 self._pending_row = None
 
     def _get_next(self, cursor):
-        """Assemble one table from consecutive cursor rows sharing the same (schema, table) key."""
+        """Assemble one table/view from consecutive cursor rows sharing the same (schema, table) key."""
         row = self._pending_row
         if row is None:
             return None
         schema_name, table_name = row[0], row[1]
         table_type, is_column_table, schema_owner = row[2], row[3], row[4]
+        row_count, last_updated_on = row[5], row[6]
         columns = []
         while row is not None and row[0] == schema_name and row[1] == table_name:
-            column_name = row[5]
+            column_name = row[7]
             if column_name is not None and len(columns) < self._config.max_columns:
                 columns.append(
                     {
                         'name': column_name,
-                        'data_type': row[6] or '',
-                        'nullable': row[7] == 'TRUE',
-                        'default': row[8],
-                        'position': row[9],
+                        'data_type': row[8] or '',
+                        'nullable': row[9] == 'TRUE',
+                        'default': row[10],
+                        'position': row[11],
                     }
                 )
             row = cursor.fetchone()
@@ -175,11 +257,14 @@ class HanaSchemaCollector(SchemaCollector):
             'table_name': table_name,
             'table_type': table_type or '',
             'is_column_table': is_column_table == 'TRUE',
+            'row_count': row_count,
+            'last_updated_on': last_updated_on,
             'columns': columns,
         }
 
     def _map_row(self, database: DatabaseInfo, table_row) -> dict:
         self._queued_column_count += len(table_row['columns'])
+        last_updated_on = table_row['last_updated_on']
         return {
             **database,
             'schemas': [
@@ -191,6 +276,8 @@ class HanaSchemaCollector(SchemaCollector):
                             'name': table_row['table_name'],
                             'type': table_row['table_type'],
                             'is_column_table': table_row['is_column_table'],
+                            'row_count': table_row['row_count'],
+                            'last_updated_on': str(last_updated_on) if last_updated_on is not None else None,
                             'columns': table_row['columns'],
                         }
                     ],

--- a/sap_hana/datadog_checks/sap_hana/schemas.py
+++ b/sap_hana/datadog_checks/sap_hana/schemas.py
@@ -1,0 +1,174 @@
+# (C) Datadog, Inc. 2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from __future__ import annotations
+
+import contextlib
+from contextlib import closing
+from typing import TYPE_CHECKING
+
+from datadog_checks.base.utils.db.schemas import DatabaseInfo, SchemaCollector, SchemaCollectorConfig
+
+if TYPE_CHECKING:
+    from .config_models.instance import CollectSchemas
+    from .sap_hana import SapHanaCheck
+
+_SYSTEM_SCHEMAS = frozenset(['SYS', 'SYSTEM', 'PUBLIC'])
+_SYSTEM_SCHEMA_PREFIX = '_SYS_'
+
+CURRENT_DATABASE_QUERY = "SELECT DATABASE_NAME, DESCRIPTION FROM SYS.M_DATABASE"
+
+SCHEMAS_QUERY = """
+SELECT SCHEMA_NAME, SCHEMA_OWNER
+FROM SYS.SCHEMAS
+WHERE HAS_PRIVILEGES = 'TRUE'
+"""
+
+TABLES_QUERY = """
+SELECT TABLE_NAME, SCHEMA_NAME, TABLE_TYPE, IS_COLUMN_TABLE
+FROM SYS.TABLES
+WHERE IS_TEMPORARY = 'FALSE'
+  AND IS_SYSTEM_TABLE = 'FALSE'
+"""
+
+COLUMNS_QUERY = """
+SELECT SCHEMA_NAME, TABLE_NAME, COLUMN_NAME, DATA_TYPE_NAME, IS_NULLABLE, DEFAULT_VALUE, POSITION
+FROM SYS.TABLE_COLUMNS
+ORDER BY SCHEMA_NAME, TABLE_NAME, POSITION
+"""
+
+
+def _is_system_schema(name):
+    return name in _SYSTEM_SCHEMAS or name.startswith(_SYSTEM_SCHEMA_PREFIX)
+
+
+class HanaSchemaCollectorConfig(SchemaCollectorConfig):
+    def __init__(self, config: CollectSchemas):
+        super().__init__()
+        self.collection_interval = int(config.collection_interval or 600)
+        self.max_tables = int(config.max_tables or 300)
+        self.max_columns = int(config.max_columns or 50)
+        self.exclude_schemas = set(config.exclude_schemas or ())
+        self.include_schemas = set(config.include_schemas or ())
+
+
+class HanaSchemaCollector(SchemaCollector):
+    _check: SapHanaCheck
+    _config: HanaSchemaCollectorConfig
+
+    def __init__(self, check: SapHanaCheck, config: CollectSchemas):
+        super().__init__(check, HanaSchemaCollectorConfig(config))
+
+    @property
+    def kind(self) -> str:
+        return "hana_databases"
+
+    def _get_databases(self) -> list[DatabaseInfo]:
+        try:
+            with closing(self._check._conn.cursor()) as cursor:
+                cursor.execute(CURRENT_DATABASE_QUERY)
+                row = cursor.fetchone()
+                if row:
+                    return [{'name': row[0], 'description': row[1] or ''}]
+        except Exception as e:
+            self._log.warning("Could not fetch current HANA database info: %s", e)
+        return [{'name': self._check._server, 'description': ''}]
+
+    @contextlib.contextmanager
+    def _get_cursor(self, _database_name):
+        conn = self._check._conn
+        table_rows = []
+        try:
+            schemas = {}
+            with closing(conn.cursor()) as cursor:
+                cursor.execute(SCHEMAS_QUERY)
+                for row in cursor.fetchall():
+                    schema_name = row[0]
+                    schema_owner = row[1] or ''
+                    if _is_system_schema(schema_name):
+                        continue
+                    if self._config.include_schemas and schema_name not in self._config.include_schemas:
+                        continue
+                    if schema_name in self._config.exclude_schemas:
+                        continue
+                    schemas[schema_name] = {'owner': schema_owner, 'tables': {}}
+
+            with closing(conn.cursor()) as cursor:
+                cursor.execute(TABLES_QUERY)
+                for row in cursor.fetchall():
+                    table_name, schema_name, table_type, is_column_table = row[0], row[1], row[2], row[3]
+                    if schema_name not in schemas:
+                        continue
+                    schemas[schema_name]['tables'][table_name] = {
+                        'type': table_type or '',
+                        'is_column_table': is_column_table == 'TRUE',
+                        'columns': [],
+                    }
+
+            with closing(conn.cursor()) as cursor:
+                cursor.execute(COLUMNS_QUERY)
+                for row in cursor.fetchall():
+                    schema_name, table_name = row[0], row[1]
+                    if schema_name not in schemas:
+                        continue
+                    tables = schemas[schema_name]['tables']
+                    if table_name not in tables:
+                        continue
+                    columns = tables[table_name]['columns']
+                    if len(columns) >= self._config.max_columns:
+                        continue
+                    columns.append(
+                        {
+                            'name': row[2],
+                            'data_type': row[3] or '',
+                            'nullable': row[4] == 'TRUE',
+                            'default': row[5],
+                            'position': row[6],
+                        }
+                    )
+
+            total = 0
+            for schema_name, schema_data in schemas.items():
+                if total >= self._config.max_tables:
+                    break
+                for table_name, table_data in schema_data['tables'].items():
+                    if total >= self._config.max_tables:
+                        break
+                    table_rows.append(
+                        {
+                            'schema_name': schema_name,
+                            'schema_owner': schema_data['owner'],
+                            'table_name': table_name,
+                            'table_type': table_data['type'],
+                            'is_column_table': table_data['is_column_table'],
+                            'columns': table_data['columns'],
+                        }
+                    )
+                    total += 1
+        except Exception as e:
+            self._log.error("Error fetching HANA schema data: %s", e)
+
+        yield iter(table_rows)
+
+    def _get_next(self, cursor):
+        return next(cursor, None)
+
+    def _map_row(self, database: DatabaseInfo, table_row) -> dict:
+        return {
+            **database,
+            'schemas': [
+                {
+                    'name': table_row['schema_name'],
+                    'owner': table_row['schema_owner'],
+                    'tables': [
+                        {
+                            'name': table_row['table_name'],
+                            'type': table_row['table_type'],
+                            'is_column_table': table_row['is_column_table'],
+                            'columns': table_row['columns'],
+                        }
+                    ],
+                }
+            ],
+        }

--- a/sap_hana/datadog_checks/sap_hana/schemas.py
+++ b/sap_hana/datadog_checks/sap_hana/schemas.py
@@ -35,13 +35,21 @@ WITH limited_tables AS (
       {exclude_clause}
     ORDER BY t.SCHEMA_NAME, t.TABLE_NAME
     LIMIT {max_tables}
+),
+limited_columns AS (
+    SELECT c.SCHEMA_NAME, c.TABLE_NAME, c.COLUMN_NAME, c.DATA_TYPE_NAME,
+           c.IS_NULLABLE, c.DEFAULT_VALUE, c.POSITION,
+           ROW_NUMBER() OVER (PARTITION BY c.SCHEMA_NAME, c.TABLE_NAME ORDER BY c.POSITION) AS rn
+    FROM SYS.TABLE_COLUMNS c
+    INNER JOIN limited_tables lt ON lt.SCHEMA_NAME = c.SCHEMA_NAME AND lt.TABLE_NAME = c.TABLE_NAME
 )
 SELECT lt.SCHEMA_NAME, lt.TABLE_NAME, lt.TABLE_TYPE, lt.IS_COLUMN_TABLE, lt.SCHEMA_OWNER,
-       c.COLUMN_NAME, c.DATA_TYPE_NAME, c.IS_NULLABLE, c.DEFAULT_VALUE, c.POSITION
+       lc.COLUMN_NAME, lc.DATA_TYPE_NAME, lc.IS_NULLABLE, lc.DEFAULT_VALUE, lc.POSITION
 FROM limited_tables lt
-LEFT JOIN SYS.TABLE_COLUMNS c
-  ON c.SCHEMA_NAME = lt.SCHEMA_NAME AND c.TABLE_NAME = lt.TABLE_NAME
-ORDER BY lt.SCHEMA_NAME, lt.TABLE_NAME, c.POSITION
+LEFT JOIN limited_columns lc
+  ON lc.SCHEMA_NAME = lt.SCHEMA_NAME AND lc.TABLE_NAME = lt.TABLE_NAME
+  AND lc.rn <= {max_columns}
+ORDER BY lt.SCHEMA_NAME, lt.TABLE_NAME, lc.POSITION
 """
 
 
@@ -106,6 +114,7 @@ class HanaSchemaCollector(SchemaCollector):
             include_clause=include_clause,
             exclude_clause=exclude_clause,
             max_tables=int(self._config.max_tables),
+            max_columns=int(self._config.max_columns),
         )
         return query, tuple(params)
 

--- a/sap_hana/datadog_checks/sap_hana/schemas.py
+++ b/sap_hana/datadog_checks/sap_hana/schemas.py
@@ -59,8 +59,8 @@ class HanaSchemaCollectorConfig(SchemaCollectorConfig):
     def __init__(self, config: CollectSchemas):
         super().__init__()
         self.collection_interval = int(config.collection_interval or 600)
-        self.max_tables = int(config.max_tables or 300)
-        self.max_columns = int(config.max_columns or 50)
+        self.max_tables = int(config.max_tables or 2000)
+        self.max_columns = int(config.max_columns or 500)
         self.exclude_schemas = set(config.exclude_schemas or ())
         self.include_schemas = set(config.include_schemas or ())
         self.payload_column_chunk_size = PAYLOAD_COLUMN_CHUNK_SIZE

--- a/sap_hana/datadog_checks/sap_hana/schemas.py
+++ b/sap_hana/datadog_checks/sap_hana/schemas.py
@@ -63,7 +63,7 @@ class HanaSchemaCollector(SchemaCollector):
 
     @property
     def kind(self) -> str:
-        return "hana_databases"
+        return "saphana_databases"
 
     def _get_databases(self) -> list[DatabaseInfo]:
         try:

--- a/sap_hana/datadog_checks/sap_hana/schemas.py
+++ b/sap_hana/datadog_checks/sap_hana/schemas.py
@@ -17,7 +17,8 @@ if TYPE_CHECKING:
 _SYSTEM_SCHEMAS = frozenset(['SYS', 'SYSTEM', 'PUBLIC'])
 _SYSTEM_SCHEMA_PREFIX = '_SYS_'
 
-CURRENT_DATABASE_QUERY = "SELECT DATABASE_NAME, DESCRIPTION FROM SYS.M_DATABASE"
+CURRENT_DATABASE_QUERY = "SELECT DATABASE_NAME FROM SYS.M_DATABASE"
+CURRENT_DATABASE_DESCRIPTION_QUERY = "SELECT DESCRIPTION FROM SYS.M_DATABASE"
 
 SCHEMAS_QUERY = """
 SELECT SCHEMA_NAME, SCHEMA_OWNER
@@ -70,7 +71,16 @@ class HanaSchemaCollector(SchemaCollector):
                 cursor.execute(CURRENT_DATABASE_QUERY)
                 row = cursor.fetchone()
                 if row:
-                    return [{'name': row[0], 'description': row[1] or ''}]
+                    db_name = row[0]
+                    description = ''
+                    try:
+                        cursor.execute(CURRENT_DATABASE_DESCRIPTION_QUERY)
+                        desc_row = cursor.fetchone()
+                        if desc_row:
+                            description = desc_row[0] or ''
+                    except Exception:
+                        pass
+                    return [{'name': db_name, 'description': description}]
         except Exception as e:
             self._log.warning("Could not fetch current HANA database info: %s", e)
         return [{'name': self._check._server, 'description': ''}]

--- a/sap_hana/datadog_checks/sap_hana/schemas.py
+++ b/sap_hana/datadog_checks/sap_hana/schemas.py
@@ -14,34 +14,35 @@ if TYPE_CHECKING:
     from .config_models.instance import CollectSchemas
     from .sap_hana import SapHanaCheck
 
-_SYSTEM_SCHEMAS = frozenset(['SYS', 'SYSTEM', 'PUBLIC'])
-_SYSTEM_SCHEMA_PREFIX = '_SYS_'
-
 CURRENT_DATABASE_QUERY = "SELECT DATABASE_NAME FROM SYS.M_DATABASE"
 CURRENT_DATABASE_DESCRIPTION_QUERY = "SELECT DESCRIPTION FROM SYS.M_DATABASE"
 
-SCHEMAS_QUERY = """
-SELECT SCHEMA_NAME, SCHEMA_OWNER
-FROM SYS.SCHEMAS
+# Single query that filters and caps tables in the database (not in Python) and joins their columns.
+# The limited_tables CTE applies the schema filters and max_tables LIMIT before the column join, so
+# the server never returns more than max_tables tables' worth of rows. Results are ordered so each
+# table's columns arrive contiguously and can be assembled one table at a time while streaming the
+# cursor. System schemas are excluded here; '_' is a LIKE wildcard, so '_SYS_' is escaped.
+SCHEMA_TABLES_QUERY = r"""
+WITH limited_tables AS (
+    SELECT t.SCHEMA_NAME, t.TABLE_NAME, t.TABLE_TYPE, t.IS_COLUMN_TABLE, s.SCHEMA_OWNER
+    FROM SYS.TABLES t
+    LEFT JOIN SYS.SCHEMAS s ON s.SCHEMA_NAME = t.SCHEMA_NAME
+    WHERE t.IS_TEMPORARY = 'FALSE'
+      AND t.IS_SYSTEM_TABLE = 'FALSE'
+      AND t.SCHEMA_NAME NOT IN ('SYS', 'SYSTEM', 'PUBLIC')
+      AND t.SCHEMA_NAME NOT LIKE '\_SYS\_%' ESCAPE '\'
+      {include_clause}
+      {exclude_clause}
+    ORDER BY t.SCHEMA_NAME, t.TABLE_NAME
+    LIMIT {max_tables}
+)
+SELECT lt.SCHEMA_NAME, lt.TABLE_NAME, lt.TABLE_TYPE, lt.IS_COLUMN_TABLE, lt.SCHEMA_OWNER,
+       c.COLUMN_NAME, c.DATA_TYPE_NAME, c.IS_NULLABLE, c.DEFAULT_VALUE, c.POSITION
+FROM limited_tables lt
+LEFT JOIN SYS.TABLE_COLUMNS c
+  ON c.SCHEMA_NAME = lt.SCHEMA_NAME AND c.TABLE_NAME = lt.TABLE_NAME
+ORDER BY lt.SCHEMA_NAME, lt.TABLE_NAME, c.POSITION
 """
-
-TABLES_QUERY = """
-SELECT TABLE_NAME, SCHEMA_NAME, TABLE_TYPE, IS_COLUMN_TABLE
-FROM SYS.TABLES
-WHERE IS_TEMPORARY = 'FALSE'
-  AND IS_SYSTEM_TABLE = 'FALSE'
-"""
-
-COLUMNS_QUERY = """
-SELECT SCHEMA_NAME, TABLE_NAME, COLUMN_NAME, DATA_TYPE_NAME, IS_NULLABLE, DEFAULT_VALUE, POSITION
-FROM SYS.TABLE_COLUMNS
-WHERE (SCHEMA_NAME, TABLE_NAME) IN ({placeholders})
-ORDER BY SCHEMA_NAME, TABLE_NAME, POSITION
-"""
-
-
-def _is_system_schema(name):
-    return name in _SYSTEM_SCHEMAS or name.startswith(_SYSTEM_SCHEMA_PREFIX)
 
 
 class HanaSchemaCollectorConfig(SchemaCollectorConfig):
@@ -60,6 +61,7 @@ class HanaSchemaCollector(SchemaCollector):
 
     def __init__(self, check: SapHanaCheck, config: CollectSchemas):
         super().__init__(check, HanaSchemaCollectorConfig(config))
+        self._pending_row = None
 
     @property
     def kind(self) -> str:
@@ -85,92 +87,70 @@ class HanaSchemaCollector(SchemaCollector):
             self._log.warning("Could not fetch current HANA database info: %s", e)
         return [{'name': self._check._server, 'description': ''}]
 
+    def _build_query(self):
+        """Build the schema/tables/columns query with schema filters and the table cap pushed into SQL."""
+        include_clause = ''
+        exclude_clause = ''
+        params = []
+        if self._config.include_schemas:
+            include = sorted(self._config.include_schemas)
+            placeholders = ', '.join('?' for _ in include)
+            include_clause = 'AND t.SCHEMA_NAME IN ({})'.format(placeholders)
+            params.extend(include)
+        if self._config.exclude_schemas:
+            exclude = sorted(self._config.exclude_schemas)
+            placeholders = ', '.join('?' for _ in exclude)
+            exclude_clause = 'AND t.SCHEMA_NAME NOT IN ({})'.format(placeholders)
+            params.extend(exclude)
+        query = SCHEMA_TABLES_QUERY.format(
+            include_clause=include_clause,
+            exclude_clause=exclude_clause,
+            max_tables=int(self._config.max_tables),
+        )
+        return query, tuple(params)
+
     @contextlib.contextmanager
     def _get_cursor(self, _database_name):
         conn = self._check._conn
-        table_rows = []
-        try:
-            schemas = {}
-            with closing(conn.cursor()) as cursor:
-                cursor.execute(SCHEMAS_QUERY)
-                for row in cursor.fetchall():
-                    schema_name = row[0]
-                    schema_owner = row[1] or ''
-                    if _is_system_schema(schema_name):
-                        continue
-                    if self._config.include_schemas and schema_name not in self._config.include_schemas:
-                        continue
-                    if schema_name in self._config.exclude_schemas:
-                        continue
-                    schemas[schema_name] = {'owner': schema_owner, 'tables': {}}
-
-            with closing(conn.cursor()) as cursor:
-                cursor.execute(TABLES_QUERY)
-                for row in cursor.fetchall():
-                    table_name, schema_name, table_type, is_column_table = row[0], row[1], row[2], row[3]
-                    if schema_name not in schemas:
-                        continue
-                    schemas[schema_name]['tables'][table_name] = {
-                        'type': table_type or '',
-                        'is_column_table': is_column_table == 'TRUE',
-                        'columns': [],
-                    }
-
-            total = 0
-            for schema_name in list(schemas.keys()):
-                tables = schemas[schema_name]['tables']
-                for table_name in list(tables.keys()):
-                    if total >= self._config.max_tables:
-                        del tables[table_name]
-                    else:
-                        total += 1
-                if not tables:
-                    del schemas[schema_name]
-
-            surviving_tables = [
-                (schema_name, table_name)
-                for schema_name, schema_data in schemas.items()
-                for table_name in schema_data['tables']
-            ]
-            if surviving_tables:
-                placeholders = ', '.join('(?, ?)' for _ in surviving_tables)
-                params = tuple(v for pair in surviving_tables for v in pair)
-                with closing(conn.cursor()) as cursor:
-                    cursor.execute(COLUMNS_QUERY.format(placeholders=placeholders), params)
-                    for row in cursor.fetchall():
-                        schema_name, table_name = row[0], row[1]
-                        columns = schemas[schema_name]['tables'][table_name]['columns']
-                        if len(columns) >= self._config.max_columns:
-                            continue
-                        columns.append(
-                            {
-                                'name': row[2],
-                                'data_type': row[3] or '',
-                                'nullable': row[4] == 'TRUE',
-                                'default': row[5],
-                                'position': row[6],
-                            }
-                        )
-
-            for schema_name, schema_data in schemas.items():
-                for table_name, table_data in schema_data['tables'].items():
-                    table_rows.append(
-                        {
-                            'schema_name': schema_name,
-                            'schema_owner': schema_data['owner'],
-                            'table_name': table_name,
-                            'table_type': table_data['type'],
-                            'is_column_table': table_data['is_column_table'],
-                            'columns': table_data['columns'],
-                        }
-                    )
-        except Exception as e:
-            self._log.error("Error fetching HANA schema data: %s", e)
-
-        yield iter(table_rows)
+        query, params = self._build_query()
+        with closing(conn.cursor()) as cursor:
+            cursor.execute(query, params)
+            self._pending_row = cursor.fetchone()
+            try:
+                yield cursor
+            finally:
+                self._pending_row = None
 
     def _get_next(self, cursor):
-        return next(cursor, None)
+        """Assemble one table from consecutive cursor rows sharing the same (schema, table) key."""
+        row = self._pending_row
+        if row is None:
+            return None
+        schema_name, table_name = row[0], row[1]
+        table_type, is_column_table, schema_owner = row[2], row[3], row[4]
+        columns = []
+        while row is not None and row[0] == schema_name and row[1] == table_name:
+            column_name = row[5]
+            if column_name is not None and len(columns) < self._config.max_columns:
+                columns.append(
+                    {
+                        'name': column_name,
+                        'data_type': row[6] or '',
+                        'nullable': row[7] == 'TRUE',
+                        'default': row[8],
+                        'position': row[9],
+                    }
+                )
+            row = cursor.fetchone()
+        self._pending_row = row
+        return {
+            'schema_name': schema_name,
+            'schema_owner': schema_owner or '',
+            'table_name': table_name,
+            'table_type': table_type or '',
+            'is_column_table': is_column_table == 'TRUE',
+            'columns': columns,
+        }
 
     def _map_row(self, database: DatabaseInfo, table_row) -> dict:
         return {

--- a/sap_hana/datadog_checks/sap_hana/schemas.py
+++ b/sap_hana/datadog_checks/sap_hana/schemas.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
     from .config_models.instance import CollectSchemas
     from .sap_hana import SapHanaCheck
 
+PAYLOAD_COLUMN_CHUNK_SIZE = 50_000
+
 CURRENT_DATABASE_QUERY = "SELECT DATABASE_NAME FROM SYS.M_DATABASE"
 CURRENT_DATABASE_DESCRIPTION_QUERY = "SELECT DESCRIPTION FROM SYS.M_DATABASE"
 
@@ -61,6 +63,7 @@ class HanaSchemaCollectorConfig(SchemaCollectorConfig):
         self.max_columns = int(config.max_columns or 50)
         self.exclude_schemas = set(config.exclude_schemas or ())
         self.include_schemas = set(config.include_schemas or ())
+        self.payload_column_chunk_size = PAYLOAD_COLUMN_CHUNK_SIZE
 
 
 class HanaSchemaCollector(SchemaCollector):
@@ -70,6 +73,20 @@ class HanaSchemaCollector(SchemaCollector):
     def __init__(self, check: SapHanaCheck, config: CollectSchemas):
         super().__init__(check, HanaSchemaCollectorConfig(config))
         self._pending_row = None
+
+    def _reset(self) -> None:
+        super()._reset()
+        self._queued_column_count = 0
+
+    def maybe_flush(self, is_last_payload: bool) -> None:
+        if self._queued_column_count >= self._config.payload_column_chunk_size:
+            saved = self._config.payload_chunk_size
+            self._config.payload_chunk_size = 0
+            super().maybe_flush(is_last_payload)
+            self._config.payload_chunk_size = saved
+            self._queued_column_count = 0
+        else:
+            super().maybe_flush(is_last_payload)
 
     @property
     def kind(self) -> str:
@@ -162,6 +179,7 @@ class HanaSchemaCollector(SchemaCollector):
         }
 
     def _map_row(self, database: DatabaseInfo, table_row) -> dict:
+        self._queued_column_count += len(table_row['columns'])
         return {
             **database,
             'schemas': [

--- a/sap_hana/datadog_checks/sap_hana/schemas.py
+++ b/sap_hana/datadog_checks/sap_hana/schemas.py
@@ -14,6 +14,14 @@ if TYPE_CHECKING:
     from .config_models.instance import CollectSchemas
     from .sap_hana import SapHanaCheck
 
+# Flush a schema payload once this many columns have accumulated. The base SchemaCollector
+# chunks payloads by table count (`payload_chunk_size`, default 10,000 tables), but a HANA
+# tenant is a single "database", so that threshold rarely trips: every table for the tenant
+# stays resident and is emitted as one large `json.dumps`. Chunking by accumulated column
+# count instead bounds payload size and peak memory regardless of how wide the tables are.
+# The memory benchmark in `sap_hana/benchmarks/schema_collection_memory/` shows the impact:
+# collecting 1000 tables x 1000 columns with limits disabled produced 21 payloads (~95 MB,
+# ~94 MiB peak RSS), while the limited run emitted 1 payload (~1.8 MB, ~61 MiB peak RSS).
 PAYLOAD_COLUMN_CHUNK_SIZE = 50_000
 
 CURRENT_DATABASE_QUERY = "SELECT DATABASE_NAME FROM SYS.M_DATABASE"
@@ -70,6 +78,8 @@ limited_views AS (
       AND v.SCHEMA_NAME NOT LIKE '\_SYS\_%' ESCAPE '\'
       {include_clause_v}
       {exclude_clause_v}
+    ORDER BY v.SCHEMA_NAME, v.VIEW_NAME
+    LIMIT {max_views}
 ),
 all_objects AS (
     SELECT * FROM limited_tables
@@ -111,10 +121,74 @@ class HanaSchemaCollectorConfig(SchemaCollectorConfig):
         super().__init__()
         self.collection_interval = int(config.collection_interval or 600)
         self.max_tables = int(config.max_tables or 2000)
+        self.max_views = int(config.max_views or 2000)
         self.max_columns = int(config.max_columns or 500)
         self.exclude_schemas = set(config.exclude_schemas or ())
         self.include_schemas = set(config.include_schemas or ())
         self.payload_column_chunk_size = PAYLOAD_COLUMN_CHUNK_SIZE
+
+
+class HanaSchemaQueryBuilder:
+    """Builds the catalog query that collects schema metadata in SQL.
+
+    Owns the query-policy decisions: schema include/exclude filters, the optional table
+    statistics join, and the SQL-level table/view/column caps. The collector delegates here so
+    that runtime concerns (streaming, row grouping, payload flushing) stay separate.
+    """
+
+    def __init__(self, config: HanaSchemaCollectorConfig, log):
+        self._config = config
+        self._log = log
+        self._has_table_statistics: bool | None = None
+
+    def ensure_stats_permission(self, conn) -> None:
+        """Probe SELECT access to SYS.M_TABLE_STATISTICS once and cache the result."""
+        if self._has_table_statistics is not None:
+            return
+        try:
+            with closing(conn.cursor()) as cur:
+                cur.execute(STATS_PERMISSION_PROBE)
+                cur.fetchone()
+            self._has_table_statistics = True
+        except Exception as e:
+            self._log.debug("SYS.M_TABLE_STATISTICS not accessible, skipping stats join: %s", e)
+            self._has_table_statistics = False
+
+    def build(self) -> tuple[str, tuple]:
+        """Return the catalog query and its bind parameters."""
+        include_clause, include_clause_v, include_params = self._schema_clause('IN', self._config.include_schemas)
+        exclude_clause, exclude_clause_v, exclude_params = self._schema_clause('NOT IN', self._config.exclude_schemas)
+        # Both limited_tables and limited_views CTEs carry the same ?-placeholders, so params repeat.
+        params = include_params + exclude_params + include_params + exclude_params
+        if self._has_table_statistics:
+            stats_join = STATS_JOIN_FRAGMENT
+            stats_column = 'ts.LAST_MODIFY_TIME AS LAST_UPDATED_ON'
+        else:
+            stats_join = ''
+            stats_column = 'NULL AS LAST_UPDATED_ON'
+        query = SCHEMA_OBJECTS_QUERY.format(
+            include_clause=include_clause,
+            exclude_clause=exclude_clause,
+            include_clause_v=include_clause_v,
+            exclude_clause_v=exclude_clause_v,
+            stats_join=stats_join,
+            stats_column=stats_column,
+            max_tables=int(self._config.max_tables),
+            max_views=int(self._config.max_views),
+            max_columns=int(self._config.max_columns),
+        )
+        return query, tuple(params)
+
+    @staticmethod
+    def _schema_clause(operator: str, schemas):
+        """Build matching SCHEMA_NAME filters for the tables (t) and views (v) CTEs."""
+        if not schemas:
+            return '', '', []
+        names = sorted(schemas)
+        placeholders = ', '.join('?' for _ in names)
+        table_clause = 'AND t.SCHEMA_NAME {} ({})'.format(operator, placeholders)
+        view_clause = 'AND v.SCHEMA_NAME {} ({})'.format(operator, placeholders)
+        return table_clause, view_clause, names
 
 
 class HanaSchemaCollector(SchemaCollector):
@@ -123,8 +197,8 @@ class HanaSchemaCollector(SchemaCollector):
 
     def __init__(self, check: SapHanaCheck, config: CollectSchemas):
         super().__init__(check, HanaSchemaCollectorConfig(config))
+        self._query_builder = HanaSchemaQueryBuilder(self._config, self._log)
         self._pending_row = None
-        self._has_table_statistics: bool | None = None
 
     def _reset(self) -> None:
         super()._reset()
@@ -149,77 +223,28 @@ class HanaSchemaCollector(SchemaCollector):
             with closing(self._check._conn.cursor()) as cursor:
                 cursor.execute(CURRENT_DATABASE_QUERY)
                 row = cursor.fetchone()
-                if row:
-                    db_name = row[0]
-                    description = ''
-                    try:
-                        cursor.execute(CURRENT_DATABASE_DESCRIPTION_QUERY)
-                        desc_row = cursor.fetchone()
-                        if desc_row:
-                            description = desc_row[0] or ''
-                    except Exception:
-                        pass
-                    return [{'name': db_name, 'description': description}]
+                if not row:
+                    self._log.warning("SYS.M_DATABASE returned no rows; skipping schema collection")
+                    return []
+                db_name = row[0]
+                description = ''
+                try:
+                    cursor.execute(CURRENT_DATABASE_DESCRIPTION_QUERY)
+                    desc_row = cursor.fetchone()
+                    if desc_row:
+                        description = desc_row[0] or ''
+                except Exception:
+                    pass
+                return [{'name': db_name, 'description': description}]
         except Exception as e:
-            self._log.warning("Could not fetch current HANA database info: %s", e)
-        return [{'name': self._check._server, 'description': ''}]
-
-    def _probe_stats_permission(self, conn) -> bool:
-        try:
-            with closing(conn.cursor()) as cur:
-                cur.execute(STATS_PERMISSION_PROBE)
-                cur.fetchone()
-            return True
-        except Exception as e:
-            self._log.debug("SYS.M_TABLE_STATISTICS not accessible, skipping stats join: %s", e)
-            return False
-
-    def _build_query(self):
-        """Build the objects query with schema filters, optional stats join, and table cap in SQL."""
-        include_params: list = []
-        exclude_params: list = []
-        include_clause = ''
-        exclude_clause = ''
-        include_clause_v = ''
-        exclude_clause_v = ''
-        if self._config.include_schemas:
-            include = sorted(self._config.include_schemas)
-            placeholders = ', '.join('?' for _ in include)
-            include_clause = 'AND t.SCHEMA_NAME IN ({})'.format(placeholders)
-            include_clause_v = 'AND v.SCHEMA_NAME IN ({})'.format(placeholders)
-            include_params.extend(include)
-        if self._config.exclude_schemas:
-            exclude = sorted(self._config.exclude_schemas)
-            placeholders = ', '.join('?' for _ in exclude)
-            exclude_clause = 'AND t.SCHEMA_NAME NOT IN ({})'.format(placeholders)
-            exclude_clause_v = 'AND v.SCHEMA_NAME NOT IN ({})'.format(placeholders)
-            exclude_params.extend(exclude)
-        # Both limited_tables and limited_views CTEs have their own ?-placeholders, so params repeat.
-        params = include_params + exclude_params + include_params + exclude_params
-        if self._has_table_statistics:
-            stats_join = STATS_JOIN_FRAGMENT
-            stats_column = 'ts.LAST_MODIFY_TIME AS LAST_UPDATED_ON'
-        else:
-            stats_join = ''
-            stats_column = 'NULL AS LAST_UPDATED_ON'
-        query = SCHEMA_OBJECTS_QUERY.format(
-            include_clause=include_clause,
-            exclude_clause=exclude_clause,
-            include_clause_v=include_clause_v,
-            exclude_clause_v=exclude_clause_v,
-            stats_join=stats_join,
-            stats_column=stats_column,
-            max_tables=int(self._config.max_tables),
-            max_columns=int(self._config.max_columns),
-        )
-        return query, tuple(params)
+            self._log.warning("Could not determine current HANA database; skipping schema collection: %s", e)
+            return []
 
     @contextlib.contextmanager
     def _get_cursor(self, _database_name):
         conn = self._check._conn
-        if self._has_table_statistics is None:
-            self._has_table_statistics = self._probe_stats_permission(conn)
-        query, params = self._build_query()
+        self._query_builder.ensure_stats_permission(conn)
+        query, params = self._query_builder.build()
         with closing(conn.cursor()) as cursor:
             cursor.execute(query, params)
             self._pending_row = cursor.fetchone()

--- a/sap_hana/tests/test_schemas_diagnose.py
+++ b/sap_hana/tests/test_schemas_diagnose.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2025-present
+# (C) Datadog, Inc. 2026-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 

--- a/sap_hana/tests/test_schemas_diagnose.py
+++ b/sap_hana/tests/test_schemas_diagnose.py
@@ -74,8 +74,8 @@ class TestHanaSchemaCollector:
 
         assert len(payloads) == 1
         payload = payloads[0]
-        assert payload['kind'] == 'hana_databases'
-        assert payload['dbms'] == 'hana'
+        assert payload['kind'] == 'saphana_databases'
+        assert payload['dbms'] == 'saphana'
         assert payload['host'] == 'hana-host'
         assert payload['database_instance'] == 'hana-host:39015'
 
@@ -274,6 +274,6 @@ class TestHanaDiagnose:
         check = _make_check()
         assert check.reported_hostname == 'hana-host'
         assert check.database_identifier == 'hana-host:39015'
-        assert check.dbms == 'hana'
+        assert check.dbms == 'saphana'
         assert check.cloud_metadata == {}
         assert 'server:hana-host' in check.tags

--- a/sap_hana/tests/test_schemas_diagnose.py
+++ b/sap_hana/tests/test_schemas_diagnose.py
@@ -1,0 +1,279 @@
+# (C) Datadog, Inc. 2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import json
+
+import mock
+import pytest
+
+from datadog_checks.sap_hana import SapHanaCheck
+from datadog_checks.sap_hana.diagnose import HanaConfigurationError
+
+pytestmark = pytest.mark.unit
+
+_BASE_INSTANCE = {
+    'server': 'hana-host',
+    'port': 39015,
+    'username': 'dd',
+    'password': 'pass',
+}
+
+
+def _make_check(extra=None):
+    instance = dict(_BASE_INSTANCE)
+    if extra:
+        instance.update(extra)
+    return SapHanaCheck('sap_hana', {}, [instance])
+
+
+def _make_cursor_mock(schema_rows, table_rows, column_rows):
+    """Return a (conn, cursor) pair whose fetchall cycles through the three catalog result sets."""
+    conn = mock.MagicMock()
+    cursor = mock.MagicMock()
+    conn.cursor.return_value = cursor
+    # fetchone: first call is _get_databases (CURRENT_DATABASE_QUERY)
+    cursor.fetchone.return_value = ('TEST_DB', 'Test database')
+    # fetchall: cycles through schemas → tables → columns
+    cursor.fetchall.side_effect = [schema_rows, table_rows, column_rows]
+    return conn, cursor
+
+
+def _collect_payloads(check):
+    """Run collect_schemas() and return list of decoded payloads."""
+    payloads = []
+    check.database_monitoring_metadata = lambda raw: payloads.append(json.loads(raw))
+    # suppress internal metrics so tests don't need a live aggregator
+    check.histogram = mock.MagicMock()
+    check.gauge = mock.MagicMock()
+    check._schema_collector.collect_schemas()
+    return payloads
+
+
+# ─── Schema Collection ────────────────────────────────────────────────────────
+
+
+class TestHanaSchemaCollector:
+    def test_disabled_by_default(self):
+        check = _make_check()
+        assert check._schema_collector is None
+
+    def test_enabled_creates_collector(self):
+        check = _make_check({'collect_schemas': {'enabled': True}})
+        assert check._schema_collector is not None
+
+    def test_payload_structure(self):
+        check = _make_check({'collect_schemas': {'enabled': True}})
+        check._conn, _ = _make_cursor_mock(
+            schema_rows=[('MY_SCHEMA', 'MY_OWNER')],
+            table_rows=[('MY_TABLE', 'MY_SCHEMA', 'TABLE', 'TRUE')],
+            column_rows=[('MY_SCHEMA', 'MY_TABLE', 'COL1', 'INTEGER', 'TRUE', None, 1)],
+        )
+
+        payloads = _collect_payloads(check)
+
+        assert len(payloads) == 1
+        payload = payloads[0]
+        assert payload['kind'] == 'hana_databases'
+        assert payload['dbms'] == 'hana'
+        assert payload['host'] == 'hana-host'
+        assert payload['database_instance'] == 'hana-host:39015'
+
+        row = payload['metadata'][0]
+        assert row['name'] == 'TEST_DB'
+        schema = row['schemas'][0]
+        assert schema['name'] == 'MY_SCHEMA'
+        assert schema['owner'] == 'MY_OWNER'
+        table = schema['tables'][0]
+        assert table['name'] == 'MY_TABLE'
+        assert table['columns'][0]['name'] == 'COL1'
+        assert table['columns'][0]['data_type'] == 'INTEGER'
+        assert table['columns'][0]['nullable'] is True
+
+    def test_system_schemas_excluded(self):
+        check = _make_check({'collect_schemas': {'enabled': True}})
+        check._conn, _ = _make_cursor_mock(
+            schema_rows=[
+                ('SYS', 'SYSTEM'),
+                ('SYSTEM', 'SYSTEM'),
+                ('PUBLIC', 'PUBLIC'),
+                ('_SYS_REPO', 'SYSTEM'),
+                ('_SYS_BIC', 'SYSTEM'),
+                ('USER_SCHEMA', 'MY_OWNER'),
+            ],
+            table_rows=[('T', 'USER_SCHEMA', 'TABLE', 'TRUE')],
+            column_rows=[],
+        )
+
+        payloads = _collect_payloads(check)
+        schema_names = [s['name'] for s in payloads[0]['metadata'][0]['schemas']]
+        assert schema_names == ['USER_SCHEMA']
+
+    def test_exclude_schemas_filter(self):
+        check = _make_check({'collect_schemas': {'enabled': True, 'exclude_schemas': ['EXCL']}})
+        check._conn, _ = _make_cursor_mock(
+            schema_rows=[('EXCL', 'O'), ('KEEP', 'O')],
+            table_rows=[('T', 'KEEP', 'TABLE', 'TRUE')],
+            column_rows=[],
+        )
+
+        payloads = _collect_payloads(check)
+        schema_names = [s['name'] for s in payloads[0]['metadata'][0]['schemas']]
+        assert 'EXCL' not in schema_names
+        assert 'KEEP' in schema_names
+
+    def test_include_schemas_filter(self):
+        check = _make_check({'collect_schemas': {'enabled': True, 'include_schemas': ['ONLY']}})
+        check._conn, _ = _make_cursor_mock(
+            schema_rows=[('ONLY', 'O'), ('OTHER', 'O')],
+            table_rows=[('T', 'ONLY', 'TABLE', 'TRUE')],
+            column_rows=[],
+        )
+
+        payloads = _collect_payloads(check)
+        schema_names = [s['name'] for s in payloads[0]['metadata'][0]['schemas']]
+        assert schema_names == ['ONLY']
+
+    def test_max_columns_respected(self):
+        check = _make_check({'collect_schemas': {'enabled': True, 'max_columns': 2}})
+        check._conn, _ = _make_cursor_mock(
+            schema_rows=[('S', 'O')],
+            table_rows=[('T', 'S', 'TABLE', 'TRUE')],
+            column_rows=[
+                ('S', 'T', 'C1', 'INT', 'TRUE', None, 1),
+                ('S', 'T', 'C2', 'INT', 'TRUE', None, 2),
+                ('S', 'T', 'C3', 'INT', 'TRUE', None, 3),
+            ],
+        )
+
+        payloads = _collect_payloads(check)
+        cols = payloads[0]['metadata'][0]['schemas'][0]['tables'][0]['columns']
+        assert len(cols) == 2
+
+    def test_max_tables_respected(self):
+        check = _make_check({'collect_schemas': {'enabled': True, 'max_tables': 3}})
+        check._conn, _ = _make_cursor_mock(
+            schema_rows=[('S', 'O')],
+            table_rows=[('T{}'.format(i), 'S', 'TABLE', 'TRUE') for i in range(10)],
+            column_rows=[],
+        )
+
+        payloads = _collect_payloads(check)
+        # each metadata row is one table
+        assert len(payloads[0]['metadata']) == 3
+
+    def test_maybe_collect_schemas_time_gated(self):
+        check = _make_check({'collect_schemas': {'enabled': True, 'collection_interval': 600}})
+        check._conn, _ = _make_cursor_mock(
+            schema_rows=[('S', 'O')],
+            table_rows=[('T', 'S', 'TABLE', 'TRUE')],
+            column_rows=[],
+        )
+        check.database_monitoring_metadata = mock.MagicMock()
+        check.histogram = mock.MagicMock()
+        check.gauge = mock.MagicMock()
+
+        # First call triggers collection (last time = 0)
+        check._maybe_collect_schemas()
+        assert check.database_monitoring_metadata.call_count == 1
+
+        # Immediate second call is gated
+        check._maybe_collect_schemas()
+        assert check.database_monitoring_metadata.call_count == 1
+
+    def test_maybe_collect_schemas_skips_without_connection(self):
+        check = _make_check({'collect_schemas': {'enabled': True}})
+        check._conn = None
+        check.database_monitoring_metadata = mock.MagicMock()
+        check._maybe_collect_schemas()
+        check.database_monitoring_metadata.assert_not_called()
+
+
+# ─── Diagnostics ─────────────────────────────────────────────────────────────
+
+
+class TestHanaDiagnose:
+    def _run(self, check):
+        check.diagnosis.clear()
+        results = check.diagnosis.run_explicit()
+        return {r.name: r for r in results}
+
+    def _healthy_conn(self):
+        conn = mock.MagicMock()
+        cursor = mock.MagicMock()
+        conn.cursor.return_value = cursor
+        cursor.fetchone.return_value = ('2.00.076.00 (fa/CE2024)',)
+        return conn
+
+    def test_connection_failure(self):
+        check = _make_check()
+        check.get_connection = mock.MagicMock(return_value=None)
+
+        results = self._run(check)
+        r = results[HanaConfigurationError.connection_failure.value]
+        assert r.result == 1  # DIAGNOSIS_FAIL
+
+    def test_healthy_instance_all_pass(self):
+        check = _make_check()
+        check.get_connection = mock.MagicMock(return_value=self._healthy_conn())
+
+        results = self._run(check)
+        assert results[HanaConfigurationError.connection_failure.value].result == 0
+        assert results[HanaConfigurationError.version_unsupported.value].result == 0
+        for view in ('sys_schemas_accessible', 'sys_tables_accessible', 'sys_table_columns_accessible'):
+            assert results[view].result == 0
+
+    def test_unsupported_hana_version(self):
+        check = _make_check()
+        conn = mock.MagicMock()
+        cursor = mock.MagicMock()
+        conn.cursor.return_value = cursor
+        cursor.fetchone.return_value = ('1.00.122.00',)  # HANA 1.x
+        check.get_connection = mock.MagicMock(return_value=conn)
+
+        results = self._run(check)
+        assert results[HanaConfigurationError.version_unsupported.value].result == 1
+
+    def test_privilege_error_on_catalog_view(self):
+        check = _make_check()
+        conn = mock.MagicMock()
+        cursor = mock.MagicMock()
+        conn.cursor.return_value = cursor
+        cursor.fetchone.return_value = ('2.00.076.00',)
+
+        def execute_side_effect(query, *args, **kwargs):
+            if 'COUNT' in query and 'SCHEMAS' in query:
+                raise Exception('insufficient privilege: Not authorized')
+
+        cursor.execute.side_effect = execute_side_effect
+        check.get_connection = mock.MagicMock(return_value=conn)
+
+        results = self._run(check)
+        assert results['sys_schemas_accessible'].result == 1
+        # remediation should mention privilege
+        assert results['sys_schemas_accessible'].remediation
+
+    def test_catalog_inaccessible_generic_error(self):
+        check = _make_check()
+        conn = mock.MagicMock()
+        cursor = mock.MagicMock()
+        conn.cursor.return_value = cursor
+        cursor.fetchone.return_value = ('2.00.076.00',)
+
+        def execute_side_effect(query, *args, **kwargs):
+            if 'COUNT' in query and 'TABLES' in query:
+                raise Exception('connection timeout')
+
+        cursor.execute.side_effect = execute_side_effect
+        check.get_connection = mock.MagicMock(return_value=conn)
+
+        results = self._run(check)
+        assert results['sys_tables_accessible'].result == 1
+
+    def test_properties(self):
+        check = _make_check()
+        assert check.reported_hostname == 'hana-host'
+        assert check.database_identifier == 'hana-host:39015'
+        assert check.dbms == 'hana'
+        assert check.cloud_metadata == {}
+        assert 'server:hana-host' in check.tags

--- a/sap_hana/tests/test_schemas_diagnose.py
+++ b/sap_hana/tests/test_schemas_diagnose.py
@@ -154,7 +154,7 @@ class TestHanaSchemaCollector:
 
     def test_system_schemas_excluded_in_sql(self):
         check = _make_check({'collect_schemas': {'enabled': True}})
-        query, params = check._schema_collector._build_query()
+        query, params = check._schema_collector._query_builder.build()
         assert "NOT IN ('SYS', 'SYSTEM', 'PUBLIC')" in query
         assert r"NOT LIKE '\_SYS\_%' ESCAPE '\'" in query
         assert 'SYS.M_TABLES' in query
@@ -166,14 +166,14 @@ class TestHanaSchemaCollector:
 
     def test_exclude_schemas_filter_in_sql(self):
         check = _make_check({'collect_schemas': {'enabled': True, 'exclude_schemas': ['EXCL']}})
-        query, params = check._schema_collector._build_query()
+        query, params = check._schema_collector._query_builder.build()
         assert 'AND t.SCHEMA_NAME NOT IN (?)' in query
         assert 'AND v.SCHEMA_NAME NOT IN (?)' in query
         assert params == ('EXCL', 'EXCL')
 
     def test_include_schemas_filter_in_sql(self):
         check = _make_check({'collect_schemas': {'enabled': True, 'include_schemas': ['ONLY']}})
-        query, params = check._schema_collector._build_query()
+        query, params = check._schema_collector._query_builder.build()
         assert 'AND t.SCHEMA_NAME IN (?)' in query
         assert 'AND v.SCHEMA_NAME IN (?)' in query
         assert params == ('ONLY', 'ONLY')
@@ -194,8 +194,13 @@ class TestHanaSchemaCollector:
 
     def test_max_tables_limit_in_sql(self):
         check = _make_check({'collect_schemas': {'enabled': True, 'max_tables': 3}})
-        query, _ = check._schema_collector._build_query()
+        query, _ = check._schema_collector._query_builder.build()
         assert 'LIMIT 3' in query
+
+    def test_max_views_limit_in_sql(self):
+        check = _make_check({'collect_schemas': {'enabled': True, 'max_views': 7}})
+        query, _ = check._schema_collector._query_builder.build()
+        assert 'LIMIT 7' in query
 
     def test_maybe_collect_schemas_time_gated(self):
         check = _make_check({'collect_schemas': {'enabled': True, 'collection_interval': 600}})
@@ -211,6 +216,28 @@ class TestHanaSchemaCollector:
         # Immediate second call is gated
         check._maybe_collect_schemas()
         assert check.database_monitoring_metadata.call_count == 1
+
+    def test_maybe_collect_schemas_failure_does_not_advance_timestamp(self):
+        check = _make_check({'collect_schemas': {'enabled': True, 'collection_interval': 600}})
+        check._conn = mock.MagicMock()
+        check._schema_collector.collect_schemas = mock.MagicMock(side_effect=Exception('transient'))
+
+        check._maybe_collect_schemas()
+        # A failed collection must not advance the schedule, so the next run retries promptly.
+        assert check._last_schema_collection_time == 0
+        check._maybe_collect_schemas()
+        assert check._schema_collector.collect_schemas.call_count == 2
+
+    def test_maybe_collect_schemas_success_advances_timestamp(self):
+        check = _make_check({'collect_schemas': {'enabled': True, 'collection_interval': 600}})
+        check._conn = mock.MagicMock()
+        check._schema_collector.collect_schemas = mock.MagicMock(return_value=True)
+
+        check._maybe_collect_schemas()
+        assert check._last_schema_collection_time > 0
+        # Within the interval the next call is gated.
+        check._maybe_collect_schemas()
+        assert check._schema_collector.collect_schemas.call_count == 1
 
     def test_maybe_collect_schemas_skips_without_connection(self):
         check = _make_check({'collect_schemas': {'enabled': True}})
@@ -304,7 +331,7 @@ class TestHanaSchemaCollector:
         result = check._schema_collector._get_databases()
         assert result == [{'name': 'PROD_DB', 'description': ''}]
 
-    def test_get_databases_execute_exception_falls_back_to_server(self):
+    def test_get_databases_execute_exception_skips_collection(self):
         check = _make_check({'collect_schemas': {'enabled': True}})
         conn = mock.MagicMock()
         cursor = mock.MagicMock()
@@ -312,8 +339,20 @@ class TestHanaSchemaCollector:
         cursor.execute.side_effect = Exception('connection error')
         check._conn = conn
 
+        # No hostname fallback: an unreadable current database skips collection entirely.
         result = check._schema_collector._get_databases()
-        assert result == [{'name': check._server, 'description': ''}]
+        assert result == []
+
+    def test_get_databases_no_rows_skips_collection(self):
+        check = _make_check({'collect_schemas': {'enabled': True}})
+        conn = mock.MagicMock()
+        cursor = mock.MagicMock()
+        conn.cursor.return_value = cursor
+        cursor.fetchone.return_value = None
+        check._conn = conn
+
+        result = check._schema_collector._get_databases()
+        assert result == []
 
     def test_is_column_table_false(self):
         check = _make_check({'collect_schemas': {'enabled': True}})
@@ -333,7 +372,7 @@ class TestHanaSchemaCollector:
 
     def test_include_and_exclude_combined(self):
         check = _make_check({'collect_schemas': {'enabled': True, 'include_schemas': ['A'], 'exclude_schemas': ['B']}})
-        query, params = check._schema_collector._build_query()
+        query, params = check._schema_collector._query_builder.build()
         assert 'AND t.SCHEMA_NAME IN (?)' in query
         assert 'AND t.SCHEMA_NAME NOT IN (?)' in query
         assert 'AND v.SCHEMA_NAME IN (?)' in query
@@ -389,15 +428,15 @@ class TestHanaSchemaCollector:
 
     def test_stats_join_when_available(self):
         check = _make_check({'collect_schemas': {'enabled': True}})
-        check._schema_collector._has_table_statistics = True
-        query, _ = check._schema_collector._build_query()
+        check._schema_collector._query_builder._has_table_statistics = True
+        query, _ = check._schema_collector._query_builder.build()
         assert 'SYS.M_TABLE_STATISTICS' in query
         assert 'ts.LAST_MODIFY_TIME' in query
 
     def test_stats_join_omitted_when_unavailable(self):
         check = _make_check({'collect_schemas': {'enabled': True}})
-        check._schema_collector._has_table_statistics = False
-        query, _ = check._schema_collector._build_query()
+        check._schema_collector._query_builder._has_table_statistics = False
+        query, _ = check._schema_collector._query_builder.build()
         assert 'SYS.M_TABLE_STATISTICS' not in query
         assert 'NULL AS LAST_UPDATED_ON' in query
 
@@ -481,6 +520,25 @@ class TestHanaDiagnose:
 
         results = self._run(check)
         assert results[HanaConfigurationError.version_unsupported.value].result == 1
+
+    def test_version_query_privilege_error_not_version_unsupported(self):
+        check = _make_check()
+        conn = mock.MagicMock()
+        cursor = mock.MagicMock()
+        conn.cursor.return_value = cursor
+
+        def execute_side_effect(query, *args, **kwargs):
+            if 'VERSION' in query and 'M_DATABASE' in query:
+                raise Exception('insufficient privilege: Not authorized')
+
+        cursor.execute.side_effect = execute_side_effect
+        check.get_connection = mock.MagicMock(return_value=conn)
+
+        results = self._run(check)
+        # A privilege error reading the version must map to the privilege diagnostic,
+        # not a misleading "version unsupported" result.
+        assert HanaConfigurationError.version_unsupported.value not in results
+        assert results[HanaConfigurationError.missing_catalog_privilege.value].result == 1
 
     def test_privilege_error_on_catalog_view(self):
         check = _make_check()

--- a/sap_hana/tests/test_schemas_diagnose.py
+++ b/sap_hana/tests/test_schemas_diagnose.py
@@ -27,15 +27,29 @@ def _make_check(extra=None):
     return SapHanaCheck('sap_hana', {}, [instance])
 
 
-def _make_cursor_mock(schema_rows, table_rows, column_rows):
-    """Return a (conn, cursor) pair whose fetchall cycles through the three catalog result sets."""
+def _joined_row(
+    schema,
+    table,
+    table_type='TABLE',
+    is_column_table='TRUE',
+    owner='OWNER',
+    column_name=None,
+    data_type='INTEGER',
+    nullable='TRUE',
+    default=None,
+    position=1,
+):
+    """Build one row of the streamed schema/tables/columns join, in SELECT column order."""
+    return (schema, table, table_type, is_column_table, owner, column_name, data_type, nullable, default, position)
+
+
+def _make_cursor_mock(joined_rows, db_name='TEST_DB', description='Test database'):
+    """Return a (conn, cursor) pair that streams the joined result set one row at a time via fetchone."""
     conn = mock.MagicMock()
     cursor = mock.MagicMock()
     conn.cursor.return_value = cursor
-    # fetchone: first call is _get_databases (CURRENT_DATABASE_QUERY)
-    cursor.fetchone.return_value = ('TEST_DB', 'Test database')
-    # fetchall: cycles through schemas → tables → columns
-    cursor.fetchall.side_effect = [schema_rows, table_rows, column_rows]
+    # fetchone order: database name, database description, then the joined rows, then end-of-cursor.
+    cursor.fetchone.side_effect = [(db_name,), (description,)] + list(joined_rows) + [None]
     return conn, cursor
 
 
@@ -65,9 +79,7 @@ class TestHanaSchemaCollector:
     def test_payload_structure(self):
         check = _make_check({'collect_schemas': {'enabled': True}})
         check._conn, _ = _make_cursor_mock(
-            schema_rows=[('MY_SCHEMA', 'MY_OWNER')],
-            table_rows=[('MY_TABLE', 'MY_SCHEMA', 'TABLE', 'TRUE')],
-            column_rows=[('MY_SCHEMA', 'MY_TABLE', 'COL1', 'INTEGER', 'TRUE', None, 1)],
+            [_joined_row('MY_SCHEMA', 'MY_TABLE', owner='MY_OWNER', column_name='COL1')],
         )
 
         payloads = _collect_payloads(check)
@@ -90,59 +102,56 @@ class TestHanaSchemaCollector:
         assert table['columns'][0]['data_type'] == 'INTEGER'
         assert table['columns'][0]['nullable'] is True
 
-    def test_system_schemas_excluded(self):
+    def test_zero_column_table(self):
+        # A table with no visible columns comes back as a single row with NULL column fields.
+        check = _make_check({'collect_schemas': {'enabled': True}})
+        check._conn, _ = _make_cursor_mock([_joined_row('S', 'EMPTY', column_name=None)])
+
+        payloads = _collect_payloads(check)
+        table = payloads[0]['metadata'][0]['schemas'][0]['tables'][0]
+        assert table['name'] == 'EMPTY'
+        assert table['columns'] == []
+
+    def test_multiple_tables_streamed(self):
         check = _make_check({'collect_schemas': {'enabled': True}})
         check._conn, _ = _make_cursor_mock(
-            schema_rows=[
-                ('SYS', 'SYSTEM'),
-                ('SYSTEM', 'SYSTEM'),
-                ('PUBLIC', 'PUBLIC'),
-                ('_SYS_REPO', 'SYSTEM'),
-                ('_SYS_BIC', 'SYSTEM'),
-                ('USER_SCHEMA', 'MY_OWNER'),
+            [
+                _joined_row('S', 'T1', column_name='C1', position=1),
+                _joined_row('S', 'T1', column_name='C2', position=2),
+                _joined_row('S', 'T2', column_name='C1', position=1),
             ],
-            table_rows=[('T', 'USER_SCHEMA', 'TABLE', 'TRUE')],
-            column_rows=[],
         )
 
         payloads = _collect_payloads(check)
-        schema_names = [s['name'] for s in payloads[0]['metadata'][0]['schemas']]
-        assert schema_names == ['USER_SCHEMA']
+        tables = [t['name'] for row in payloads[0]['metadata'] for s in row['schemas'] for t in s['tables']]
+        assert tables == ['T1', 'T2']
 
-    def test_exclude_schemas_filter(self):
+    def test_system_schemas_excluded_in_sql(self):
+        check = _make_check({'collect_schemas': {'enabled': True}})
+        query, params = check._schema_collector._build_query()
+        assert "NOT IN ('SYS', 'SYSTEM', 'PUBLIC')" in query
+        assert r"NOT LIKE '\_SYS\_%' ESCAPE '\'" in query
+        assert params == ()
+
+    def test_exclude_schemas_filter_in_sql(self):
         check = _make_check({'collect_schemas': {'enabled': True, 'exclude_schemas': ['EXCL']}})
-        check._conn, _ = _make_cursor_mock(
-            schema_rows=[('EXCL', 'O'), ('KEEP', 'O')],
-            table_rows=[('T', 'KEEP', 'TABLE', 'TRUE')],
-            column_rows=[],
-        )
+        query, params = check._schema_collector._build_query()
+        assert 'AND t.SCHEMA_NAME NOT IN (?)' in query
+        assert params == ('EXCL',)
 
-        payloads = _collect_payloads(check)
-        schema_names = [s['name'] for s in payloads[0]['metadata'][0]['schemas']]
-        assert 'EXCL' not in schema_names
-        assert 'KEEP' in schema_names
-
-    def test_include_schemas_filter(self):
+    def test_include_schemas_filter_in_sql(self):
         check = _make_check({'collect_schemas': {'enabled': True, 'include_schemas': ['ONLY']}})
-        check._conn, _ = _make_cursor_mock(
-            schema_rows=[('ONLY', 'O'), ('OTHER', 'O')],
-            table_rows=[('T', 'ONLY', 'TABLE', 'TRUE')],
-            column_rows=[],
-        )
-
-        payloads = _collect_payloads(check)
-        schema_names = [s['name'] for s in payloads[0]['metadata'][0]['schemas']]
-        assert schema_names == ['ONLY']
+        query, params = check._schema_collector._build_query()
+        assert 'AND t.SCHEMA_NAME IN (?)' in query
+        assert params == ('ONLY',)
 
     def test_max_columns_respected(self):
         check = _make_check({'collect_schemas': {'enabled': True, 'max_columns': 2}})
         check._conn, _ = _make_cursor_mock(
-            schema_rows=[('S', 'O')],
-            table_rows=[('T', 'S', 'TABLE', 'TRUE')],
-            column_rows=[
-                ('S', 'T', 'C1', 'INT', 'TRUE', None, 1),
-                ('S', 'T', 'C2', 'INT', 'TRUE', None, 2),
-                ('S', 'T', 'C3', 'INT', 'TRUE', None, 3),
+            [
+                _joined_row('S', 'T', column_name='C1', position=1),
+                _joined_row('S', 'T', column_name='C2', position=2),
+                _joined_row('S', 'T', column_name='C3', position=3),
             ],
         )
 
@@ -150,25 +159,14 @@ class TestHanaSchemaCollector:
         cols = payloads[0]['metadata'][0]['schemas'][0]['tables'][0]['columns']
         assert len(cols) == 2
 
-    def test_max_tables_respected(self):
+    def test_max_tables_limit_in_sql(self):
         check = _make_check({'collect_schemas': {'enabled': True, 'max_tables': 3}})
-        check._conn, _ = _make_cursor_mock(
-            schema_rows=[('S', 'O')],
-            table_rows=[('T{}'.format(i), 'S', 'TABLE', 'TRUE') for i in range(10)],
-            column_rows=[],
-        )
-
-        payloads = _collect_payloads(check)
-        # each metadata row is one table
-        assert len(payloads[0]['metadata']) == 3
+        query, _ = check._schema_collector._build_query()
+        assert 'LIMIT 3' in query
 
     def test_maybe_collect_schemas_time_gated(self):
         check = _make_check({'collect_schemas': {'enabled': True, 'collection_interval': 600}})
-        check._conn, _ = _make_cursor_mock(
-            schema_rows=[('S', 'O')],
-            table_rows=[('T', 'S', 'TABLE', 'TRUE')],
-            column_rows=[],
-        )
+        check._conn, _ = _make_cursor_mock([_joined_row('S', 'T', column_name='C1')])
         check.database_monitoring_metadata = mock.MagicMock()
         check.histogram = mock.MagicMock()
         check.gauge = mock.MagicMock()

--- a/sap_hana/tests/test_schemas_diagnose.py
+++ b/sap_hana/tests/test_schemas_diagnose.py
@@ -305,6 +305,35 @@ class TestHanaSchemaCollector:
         assert 'AND t.SCHEMA_NAME NOT IN (?)' in query
         assert params == ('A', 'B')
 
+    def test_column_chunk_flush(self):
+        # 3 tables × 3 columns each; threshold set to 5 so flush fires after T1+T2 (6 cols),
+        # then T3 lands in the final payload. Verifies intermediate flush, correct table
+        # distribution, and that collection_payloads_count only appears on the last payload.
+        rows = [
+            _joined_row('S', 'T1', column_name='C1', position=1),
+            _joined_row('S', 'T1', column_name='C2', position=2),
+            _joined_row('S', 'T1', column_name='C3', position=3),
+            _joined_row('S', 'T2', column_name='C1', position=1),
+            _joined_row('S', 'T2', column_name='C2', position=2),
+            _joined_row('S', 'T2', column_name='C3', position=3),
+            _joined_row('S', 'T3', column_name='C1', position=1),
+            _joined_row('S', 'T3', column_name='C2', position=2),
+            _joined_row('S', 'T3', column_name='C3', position=3),
+        ]
+        check = _make_check({'collect_schemas': {'enabled': True}})
+        check._schema_collector._config.payload_column_chunk_size = 5
+        check._conn, _ = _make_cursor_mock(rows)
+
+        payloads = _collect_payloads(check)
+
+        assert len(payloads) == 2
+        tables_p1 = [t['name'] for row in payloads[0]['metadata'] for s in row['schemas'] for t in s['tables']]
+        tables_p2 = [t['name'] for row in payloads[1]['metadata'] for s in row['schemas'] for t in s['tables']]
+        assert tables_p1 == ['T1', 'T2']
+        assert tables_p2 == ['T3']
+        assert 'collection_payloads_count' not in payloads[0]
+        assert payloads[1]['collection_payloads_count'] == 2
+
 
 # ─── Diagnostics ─────────────────────────────────────────────────────────────
 

--- a/sap_hana/tests/test_schemas_diagnose.py
+++ b/sap_hana/tests/test_schemas_diagnose.py
@@ -186,6 +186,125 @@ class TestHanaSchemaCollector:
         check._maybe_collect_schemas()
         check.database_monitoring_metadata.assert_not_called()
 
+    def test_column_field_mapping(self):
+        COLUMNS = [
+            # (name ~20 chars,         data_type,    nullable,  default,                position)
+            ('EMPLOYEE_IDENTIFIER', 'INTEGER', 'FALSE', None, 1),
+            ('CUSTOMER_FIRST_NAME', 'NVARCHAR', 'TRUE', None, 2),
+            ('RECORD_CREATED_TIME', 'TIMESTAMP', 'TRUE', 'CURRENT_TIMESTAMP', 3),
+            ('ACCOUNT_BALANCE_AMT', 'DECIMAL', 'TRUE', '0', 4),
+            ('CUSTOMER_STATUS_CODE', 'VARCHAR', 'FALSE', 'ACTIVE', 5),
+            ('IS_ACTIVE_FLAG_VALUE', 'BOOLEAN', 'TRUE', 'FALSE', 6),
+            ('TOTAL_AMOUNT_NUMERIC', 'BIGINT', 'FALSE', None, 7),
+            ('PRODUCT_CODE_STRING', 'CHAR', 'TRUE', None, 8),
+            ('CONVERSION_RATIO_VAL', 'DOUBLE', 'FALSE', '1.0', 9),
+            ('LONG_TEXT_NOTES_CLOB', 'CLOB', 'TRUE', None, 10),
+            ('LAST_MODIFIED_DTTM', 'TIMESTAMP', 'TRUE', None, 11),
+            ('RECORD_TYPE_TINYINT', 'TINYINT', 'FALSE', '0', 12),
+            ('BINARY_PAYLOAD_DATA', 'BLOB', 'TRUE', None, 13),
+            ('NULL_TYPED_COLUMN_AA', None, 'TRUE', None, 14),  # None → ''
+            ('LAST_SEQUENCE_NUMBER', 'SMALLINT', 'FALSE', None, 15),
+        ]
+        rows = [
+            _joined_row('S', 'T', column_name=name, data_type=dt, nullable=nl, default=d, position=pos)
+            for name, dt, nl, d, pos in COLUMNS
+        ]
+        check = _make_check({'collect_schemas': {'enabled': True, 'max_columns': 100}})
+        check._conn, _ = _make_cursor_mock(rows)
+
+        payloads = _collect_payloads(check)
+        cols = payloads[0]['metadata'][0]['schemas'][0]['tables'][0]['columns']
+
+        assert len(cols) == len(COLUMNS)
+        for col, (name, data_type, nullable, default, position) in zip(cols, COLUMNS):
+            assert col['name'] == name
+            assert col['data_type'] == (data_type or '')
+            assert col['nullable'] == (nullable == 'TRUE')
+            assert col['default'] == default
+            assert col['position'] == position
+
+    def test_column_multi_table_mapping(self):
+        rows = [
+            _joined_row('S', 'T1', column_name='C1', data_type='INTEGER', nullable='TRUE', position=1),
+            _joined_row('S', 'T1', column_name='C2', data_type='VARCHAR', nullable='TRUE', position=2),
+            _joined_row('S', 'T1', column_name='C3', data_type='TIMESTAMP', nullable='FALSE', position=3),
+            _joined_row('S', 'T2', column_name='X1', data_type='BIGINT', nullable='FALSE', position=1),
+            _joined_row('S', 'T2', column_name='X2', data_type='DECIMAL', nullable='TRUE', default='0', position=2),
+        ]
+        check = _make_check({'collect_schemas': {'enabled': True}})
+        check._conn, _ = _make_cursor_mock(rows)
+
+        payloads = _collect_payloads(check)
+        tables = {t['name']: t for row in payloads[0]['metadata'] for s in row['schemas'] for t in s['tables']}
+
+        assert set(tables.keys()) == {'T1', 'T2'}
+        assert [c['name'] for c in tables['T1']['columns']] == ['C1', 'C2', 'C3']
+        assert tables['T1']['columns'][2]['nullable'] is False
+        assert [c['name'] for c in tables['T2']['columns']] == ['X1', 'X2']
+        assert tables['T2']['columns'][1]['default'] == '0'
+
+    def test_get_databases_name_and_description(self):
+        check = _make_check({'collect_schemas': {'enabled': True}})
+        conn = mock.MagicMock()
+        cursor = mock.MagicMock()
+        conn.cursor.return_value = cursor
+        cursor.fetchone.side_effect = [('PROD_DB',), ('Production instance',)]
+        check._conn = conn
+
+        result = check._schema_collector._get_databases()
+        assert result == [{'name': 'PROD_DB', 'description': 'Production instance'}]
+
+    def test_get_databases_description_query_fails(self):
+        check = _make_check({'collect_schemas': {'enabled': True}})
+        conn = mock.MagicMock()
+        cursor = mock.MagicMock()
+        conn.cursor.return_value = cursor
+        cursor.fetchone.return_value = ('PROD_DB',)
+
+        def raise_on_description(query, *args, **kwargs):
+            if 'DESCRIPTION' in query:
+                raise Exception('access denied')
+
+        cursor.execute.side_effect = raise_on_description
+        check._conn = conn
+
+        result = check._schema_collector._get_databases()
+        assert result == [{'name': 'PROD_DB', 'description': ''}]
+
+    def test_get_databases_execute_exception_falls_back_to_server(self):
+        check = _make_check({'collect_schemas': {'enabled': True}})
+        conn = mock.MagicMock()
+        cursor = mock.MagicMock()
+        conn.cursor.return_value = cursor
+        cursor.execute.side_effect = Exception('connection error')
+        check._conn = conn
+
+        result = check._schema_collector._get_databases()
+        assert result == [{'name': check._server, 'description': ''}]
+
+    def test_is_column_table_false(self):
+        check = _make_check({'collect_schemas': {'enabled': True}})
+        check._conn, _ = _make_cursor_mock([_joined_row('S', 'T', is_column_table='FALSE', column_name='C1')])
+
+        payloads = _collect_payloads(check)
+        table = payloads[0]['metadata'][0]['schemas'][0]['tables'][0]
+        assert table['is_column_table'] is False
+
+    def test_null_schema_owner(self):
+        check = _make_check({'collect_schemas': {'enabled': True}})
+        check._conn, _ = _make_cursor_mock([_joined_row('S', 'T', owner=None, column_name='C1')])
+
+        payloads = _collect_payloads(check)
+        schema = payloads[0]['metadata'][0]['schemas'][0]
+        assert schema['owner'] == ''
+
+    def test_include_and_exclude_combined(self):
+        check = _make_check({'collect_schemas': {'enabled': True, 'include_schemas': ['A'], 'exclude_schemas': ['B']}})
+        query, params = check._schema_collector._build_query()
+        assert 'AND t.SCHEMA_NAME IN (?)' in query
+        assert 'AND t.SCHEMA_NAME NOT IN (?)' in query
+        assert params == ('A', 'B')
+
 
 # ─── Diagnostics ─────────────────────────────────────────────────────────────
 

--- a/sap_hana/tests/test_schemas_diagnose.py
+++ b/sap_hana/tests/test_schemas_diagnose.py
@@ -33,23 +33,47 @@ def _joined_row(
     table_type='TABLE',
     is_column_table='TRUE',
     owner='OWNER',
+    row_count=None,
+    last_updated_on=None,
     column_name=None,
     data_type='INTEGER',
     nullable='TRUE',
     default=None,
     position=1,
 ):
-    """Build one row of the streamed schema/tables/columns join, in SELECT column order."""
-    return (schema, table, table_type, is_column_table, owner, column_name, data_type, nullable, default, position)
+    """Build one row of the streamed schema/tables/columns/stats join, in SELECT column order."""
+    return (
+        schema,
+        table,
+        table_type,
+        is_column_table,
+        owner,
+        row_count,
+        last_updated_on,
+        column_name,
+        data_type,
+        nullable,
+        default,
+        position,
+    )
 
 
 def _make_cursor_mock(joined_rows, db_name='TEST_DB', description='Test database'):
-    """Return a (conn, cursor) pair that streams the joined result set one row at a time via fetchone."""
+    """Return a (conn, cursor) pair that streams the joined result set one row at a time via fetchone.
+
+    The first fetchone call is consumed by the stats permission probe (returns a count row),
+    followed by the database name, database description, joined rows, and end-of-cursor sentinel.
+    """
     conn = mock.MagicMock()
     cursor = mock.MagicMock()
     conn.cursor.return_value = cursor
-    # fetchone order: database name, database description, then the joined rows, then end-of-cursor.
-    cursor.fetchone.side_effect = [(db_name,), (description,)] + list(joined_rows) + [None]
+    # fetchone call order (all cursors share this queue since conn.cursor always returns the same mock):
+    #   1. db_name       — _get_databases() CURRENT_DATABASE_QUERY
+    #   2. description   — _get_databases() CURRENT_DATABASE_DESCRIPTION_QUERY
+    #   3. (1,)          — _probe_stats_permission() COUNT probe
+    #   4+. joined rows  — _get_cursor() pending_row + _get_next() iterations
+    #   last. None       — end-of-cursor sentinel
+    cursor.fetchone.side_effect = [(db_name,), (description,), (1,)] + list(joined_rows) + [None]
     return conn, cursor
 
 
@@ -98,6 +122,8 @@ class TestHanaSchemaCollector:
         assert schema['owner'] == 'MY_OWNER'
         table = schema['tables'][0]
         assert table['name'] == 'MY_TABLE'
+        assert table['row_count'] is None
+        assert table['last_updated_on'] is None
         assert table['columns'][0]['name'] == 'COL1'
         assert table['columns'][0]['data_type'] == 'INTEGER'
         assert table['columns'][0]['nullable'] is True
@@ -131,19 +157,26 @@ class TestHanaSchemaCollector:
         query, params = check._schema_collector._build_query()
         assert "NOT IN ('SYS', 'SYSTEM', 'PUBLIC')" in query
         assert r"NOT LIKE '\_SYS\_%' ESCAPE '\'" in query
+        assert 'SYS.M_TABLES' in query
+        assert 'SYS.VIEWS' in query
+        assert 'SYS.VIEW_COLUMNS' in query
+        # SYS.TABLES (without the M_) must not appear
+        assert 'SYS.TABLES' not in query.replace('SYS.M_TABLES', '').replace('SYS.M_TABLE_STATISTICS', '')
         assert params == ()
 
     def test_exclude_schemas_filter_in_sql(self):
         check = _make_check({'collect_schemas': {'enabled': True, 'exclude_schemas': ['EXCL']}})
         query, params = check._schema_collector._build_query()
         assert 'AND t.SCHEMA_NAME NOT IN (?)' in query
-        assert params == ('EXCL',)
+        assert 'AND v.SCHEMA_NAME NOT IN (?)' in query
+        assert params == ('EXCL', 'EXCL')
 
     def test_include_schemas_filter_in_sql(self):
         check = _make_check({'collect_schemas': {'enabled': True, 'include_schemas': ['ONLY']}})
         query, params = check._schema_collector._build_query()
         assert 'AND t.SCHEMA_NAME IN (?)' in query
-        assert params == ('ONLY',)
+        assert 'AND v.SCHEMA_NAME IN (?)' in query
+        assert params == ('ONLY', 'ONLY')
 
     def test_max_columns_respected(self):
         check = _make_check({'collect_schemas': {'enabled': True, 'max_columns': 2}})
@@ -303,7 +336,70 @@ class TestHanaSchemaCollector:
         query, params = check._schema_collector._build_query()
         assert 'AND t.SCHEMA_NAME IN (?)' in query
         assert 'AND t.SCHEMA_NAME NOT IN (?)' in query
-        assert params == ('A', 'B')
+        assert 'AND v.SCHEMA_NAME IN (?)' in query
+        assert 'AND v.SCHEMA_NAME NOT IN (?)' in query
+        assert params == ('A', 'B', 'A', 'B')
+
+    def test_row_count_in_payload(self):
+        check = _make_check({'collect_schemas': {'enabled': True}})
+        check._conn, _ = _make_cursor_mock([_joined_row('S', 'T', row_count=42, column_name='C1')])
+
+        payloads = _collect_payloads(check)
+        table = payloads[0]['metadata'][0]['schemas'][0]['tables'][0]
+        assert table['row_count'] == 42
+
+    def test_last_updated_on_in_payload(self):
+        check = _make_check({'collect_schemas': {'enabled': True}})
+        check._conn, _ = _make_cursor_mock(
+            [_joined_row('S', 'T', last_updated_on='2024-01-15 12:00:00', column_name='C1')]
+        )
+
+        payloads = _collect_payloads(check)
+        table = payloads[0]['metadata'][0]['schemas'][0]['tables'][0]
+        assert table['last_updated_on'] == '2024-01-15 12:00:00'
+
+    def test_view_in_payload(self):
+        check = _make_check({'collect_schemas': {'enabled': True}})
+        check._conn, _ = _make_cursor_mock(
+            [
+                _joined_row(
+                    'S', 'MY_VIEW', table_type='VIEW', is_column_table=None, column_name='V_COL', data_type='NVARCHAR'
+                ),
+            ]
+        )
+
+        payloads = _collect_payloads(check)
+        table = payloads[0]['metadata'][0]['schemas'][0]['tables'][0]
+        assert table['name'] == 'MY_VIEW'
+        assert table['type'] == 'VIEW'
+        assert table['is_column_table'] is False
+        assert table['row_count'] is None
+        assert table['last_updated_on'] is None
+        assert table['columns'][0]['name'] == 'V_COL'
+        assert table['columns'][0]['data_type'] == 'NVARCHAR'
+
+    def test_view_no_columns(self):
+        check = _make_check({'collect_schemas': {'enabled': True}})
+        check._conn, _ = _make_cursor_mock([_joined_row('S', 'MY_VIEW', table_type='VIEW', is_column_table=None)])
+
+        payloads = _collect_payloads(check)
+        table = payloads[0]['metadata'][0]['schemas'][0]['tables'][0]
+        assert table['name'] == 'MY_VIEW'
+        assert table['columns'] == []
+
+    def test_stats_join_when_available(self):
+        check = _make_check({'collect_schemas': {'enabled': True}})
+        check._schema_collector._has_table_statistics = True
+        query, _ = check._schema_collector._build_query()
+        assert 'SYS.M_TABLE_STATISTICS' in query
+        assert 'ts.LAST_MODIFY_TIME' in query
+
+    def test_stats_join_omitted_when_unavailable(self):
+        check = _make_check({'collect_schemas': {'enabled': True}})
+        check._schema_collector._has_table_statistics = False
+        query, _ = check._schema_collector._build_query()
+        assert 'SYS.M_TABLE_STATISTICS' not in query
+        assert 'NULL AS LAST_UPDATED_ON' in query
 
     def test_column_chunk_flush(self):
         # 3 tables × 3 columns each; threshold set to 5 so flush fires after T1+T2 (6 cols),
@@ -366,7 +462,13 @@ class TestHanaDiagnose:
         results = self._run(check)
         assert results[HanaConfigurationError.connection_failure.value].result == 0
         assert results[HanaConfigurationError.version_unsupported.value].result == 0
-        for view in ('sys_schemas_accessible', 'sys_tables_accessible', 'sys_table_columns_accessible'):
+        for view in (
+            'sys_schemas_accessible',
+            'sys_m_tables_accessible',
+            'sys_views_accessible',
+            'sys_table_columns_accessible',
+            'sys_view_columns_accessible',
+        ):
             assert results[view].result == 0
 
     def test_unsupported_hana_version(self):
@@ -388,16 +490,16 @@ class TestHanaDiagnose:
         cursor.fetchone.return_value = ('2.00.076.00',)
 
         def execute_side_effect(query, *args, **kwargs):
-            if 'COUNT' in query and 'SCHEMAS' in query:
+            if 'COUNT' in query and 'M_TABLES' in query:
                 raise Exception('insufficient privilege: Not authorized')
 
         cursor.execute.side_effect = execute_side_effect
         check.get_connection = mock.MagicMock(return_value=conn)
 
         results = self._run(check)
-        assert results['sys_schemas_accessible'].result == 1
+        assert results['sys_m_tables_accessible'].result == 1
         # remediation should mention privilege
-        assert results['sys_schemas_accessible'].remediation
+        assert results['sys_m_tables_accessible'].remediation
 
     def test_catalog_inaccessible_generic_error(self):
         check = _make_check()
@@ -407,14 +509,14 @@ class TestHanaDiagnose:
         cursor.fetchone.return_value = ('2.00.076.00',)
 
         def execute_side_effect(query, *args, **kwargs):
-            if 'COUNT' in query and 'TABLES' in query:
+            if 'COUNT' in query and 'M_TABLES' in query:
                 raise Exception('connection timeout')
 
         cursor.execute.side_effect = execute_side_effect
         check.get_connection = mock.MagicMock(return_value=conn)
 
         results = self._run(check)
-        assert results['sys_tables_accessible'].result == 1
+        assert results['sys_m_tables_accessible'].result == 1
 
     def test_properties(self):
         check = _make_check()


### PR DESCRIPTION
### What does this PR do?

Adds Database Monitoring schema collection and startup diagnostics to the SAP HANA integration.

- **Schema collection** (`schemas.py`): a `HanaSchemaCollector` built on the shared `datadog_checks.base.utils.db.schemas.SchemaCollector` base class (same as postgres). Queries `SYS.M_TABLES`, `SYS.VIEWS`, `SYS.TABLE_COLUMNS`, and `SYS.VIEW_COLUMNS` and emits `kind=saphana_databases` metadata payloads (schemas → tables/views → columns). System schemas are skipped; `include_schemas`/`exclude_schemas`/`max_tables`/`max_columns` limits are honored.
- **Runtime stats**: `row_count` (from `SYS.M_TABLES.RECORD_COUNT`) and `last_updated_on` (from `SYS.M_TABLE_STATISTICS.LAST_MODIFY_TIME`) are included per table. The collector probes for `SYS.M_TABLE_STATISTICS` access at first run and omits the LEFT JOIN silently when the monitoring user lacks the privilege.
- **Views**: `SYS.VIEWS` is queried separately (not present in `SYS.M_TABLES`) with columns sourced from `SYS.VIEW_COLUMNS` (`SYS.TABLE_COLUMNS` does not cover views in HANA).
- **Memory optimizations**:
  - Table/column limits pushed into SQL via a `ROW_NUMBER() OVER (PARTITION BY schema, table)` CTE so the server only sends capped rows.
  - `HanaSchemaCollector` overrides `maybe_flush` to flush after every 50,000 columns rather than the base class default of 10,000 tables. For wide tables this keeps `_queued_rows` bounded (93.7 MiB peak RSS unlimited vs 61.5 MiB limited on a 1000×1000 schema).
  - Default limits: `max_tables=2000`, `max_columns=500`.
  - Memory benchmark under `benchmarks/schema_collection_memory/` (1000×1000 schema, limited vs unlimited modes, isolated subprocesses for clean RSS measurement).
- **Diagnostics** (`diagnose.py`): checks connectivity, minimum supported version (2.x), and per-view catalog access (`SYS.SCHEMAS`, `SYS.M_TABLES`, `SYS.VIEWS`, `SYS.TABLE_COLUMNS`, `SYS.VIEW_COLUMNS`), distinguishing privilege errors from generic failures with actionable remediation.
- **Configuration**: `collect_schemas` option (`enabled`, `collection_interval`, `max_tables`, `max_columns`, `include_schemas`, `exclude_schemas`) in `spec.yaml`. Marked `hidden: true` and omitted from `conf.yaml.example` until backend quality monitors are ready. Disabled by default.
- **Wiring** (`sap_hana.py`): time-gated `_maybe_collect_schemas()` invoked from `check()`.
- **Docs** (`README.md`): grants for `SYS.SCHEMAS`, `SYS.M_TABLES`, `SYS.VIEWS`, `SYS.TABLE_COLUMNS`, `SYS.VIEW_COLUMNS`, and `SYS.M_TABLE_STATISTICS` (optional), plus a "Schema collection" configuration section.

### Motivation

Bring SAP HANA in line with other Database Monitoring integrations (postgres, mysql, sqlserver, clickhouse) by surfacing catalog metadata for Data Quality features in Data Observability, including live row counts, last modification times, and view definitions.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged