### PR TITLE
Update ddev create tool

### DIFF
--- a/ddev/src/ddev/ai/tools/shell/ddev/create.py
+++ b/ddev/src/ddev/ai/tools/shell/ddev/create.py
@@ -8,22 +8,28 @@ from pydantic import Field
 from ddev.ai.tools.core.base import BaseToolInput
 from ddev.ai.tools.shell.base import CmdTool
 
-IntegrationType = Literal["check", "check_only", "event", "jmx", "logs", "metrics_crawler", "snmp_tile", "tile"]
+Platform = Literal["linux", "windows", "mac_os"]
 
 
-class CreateInput(BaseToolInput):
+class DdevCreateInput(BaseToolInput):
     integration: Annotated[str, Field(description="Name of the new integration (snake_case)")]
-    integration_type: Annotated[
-        IntegrationType,
+    display_name: Annotated[str, Field(description="Human-readable display name (e.g. 'My Integration')")]
+    metrics_prefix: Annotated[str, Field(description="Metric namespace prefix (e.g. 'my_integration.')")]
+    platforms: Annotated[
+        list[Platform],
         Field(
-            description="Template type: 'check' (standard Agent check), 'check_only' (no hatch env),"
-            " 'event', 'jmx', 'logs', 'metrics_crawler', 'snmp_tile', 'tile'"
+            description=(
+                "Target platforms for the integration. Include all three ('linux', 'windows', 'mac_os') by default;"
+                " remove a platform only if the integration explicitly cannot run on it (e.g. a Windows-only service"
+                " would omit 'linux' and 'mac_os')."
+            ),
+            min_length=1,
         ),
     ]
 
 
-class DdevCreateTool(CmdTool[CreateInput]):
-    """Scaffolds a new Datadog Agent integration with all boilerplate files and
+class DdevCreateTool(CmdTool[DdevCreateInput]):
+    """Scaffolds a new Datadog Agent check integration with all boilerplate files and
     directory structure. Creates a directory named after the integration (snake_case)
     in the current working directory. Use before writing any integration code."""
 
@@ -33,7 +39,17 @@ class DdevCreateTool(CmdTool[CreateInput]):
     def name(self) -> str:
         return "ddev_create"
 
-    def cmd(self, tool_input: CreateInput) -> list[str]:
-        # Capitalize to avoid ddev's islower() interactive prompt; normalize_package_name restores snake_case
-        name = tool_input.integration.capitalize()
-        return ["ddev", "--no-interactive", "create", "--type", tool_input.integration_type, "--skip-manifest", name]
+    def cmd(self, tool_input: DdevCreateInput) -> list[str]:
+        return [
+            "ddev",
+            "--no-interactive",
+            "create",
+            "check",
+            "--display-name",
+            tool_input.display_name,
+            "--metrics-prefix",
+            tool_input.metrics_prefix,
+            "--platforms",
+            ",".join(tool_input.platforms),
+            tool_input.integration,
+        ]

--- a/ddev/tests/ai/tools/shell/ddev/test_ddev_tools.py
+++ b/ddev/tests/ai/tools/shell/ddev/test_ddev_tools.py
@@ -4,7 +4,7 @@
 import pytest
 from pydantic import ValidationError
 
-from ddev.ai.tools.shell.ddev.create import CreateInput, DdevCreateTool
+from ddev.ai.tools.shell.ddev.create import DdevCreateInput, DdevCreateTool
 from ddev.ai.tools.shell.ddev.ddev_test import DdevTestInput, DdevTestTool
 from ddev.ai.tools.shell.ddev.env_show import DdevEnvShowTool, EnvShowInput
 from ddev.ai.tools.shell.ddev.env_start import DdevEnvStartTool, EnvStartInput
@@ -15,31 +15,46 @@ from ddev.ai.tools.shell.ddev.validate import DdevValidateInput, DdevValidateToo
 
 # --- ddev create ---
 
+VALID_CREATE_INPUT = {
+    "integration": "my_check",
+    "display_name": "My Check",
+    "metrics_prefix": "my_check.",
+    "platforms": ["linux", "windows", "mac_os"],
+}
 
-def test_create_cmd_basic():
-    tool = DdevCreateTool()
-    assert tool.cmd(CreateInput(integration="my_check", integration_type="check")) == [
+
+def test_create_cmd():
+    cmd = DdevCreateTool().cmd(DdevCreateInput(**VALID_CREATE_INPUT))
+    assert cmd == [
         "ddev",
         "--no-interactive",
         "create",
-        "--type",
         "check",
-        "--skip-manifest",
-        "My_check",
+        "--display-name",
+        "My Check",
+        "--metrics-prefix",
+        "my_check.",
+        "--platforms",
+        "linux,windows,mac_os",
+        "my_check",
     ]
 
 
+def test_create_cmd_platforms_joined():
+    cmd = DdevCreateTool().cmd(DdevCreateInput(**{**VALID_CREATE_INPUT, "platforms": ["linux", "mac_os"]}))
+    assert cmd[cmd.index("--platforms") + 1] == "linux,mac_os"
+
+
 @pytest.mark.parametrize(
-    "integration_type", ["check", "check_only", "event", "jmx", "logs", "metrics_crawler", "snmp_tile", "tile"]
+    "platforms",
+    [
+        ["linux", "bsd"],
+        [],
+    ],
 )
-def test_create_cmd_all_types(integration_type: str):
-    cmd = DdevCreateTool().cmd(CreateInput(integration="my_check", integration_type=integration_type))
-    assert cmd[cmd.index("--type") + 1] == integration_type
-
-
-def test_create_invalid_type_raises():
+def test_create_invalid_platform_raises(platforms):
     with pytest.raises(ValidationError):
-        CreateInput(integration="my_check", integration_type="custom")
+        DdevCreateInput(**{**VALID_CREATE_INPUT, "platforms": platforms})
 
 
 # --- ddev test ---


### PR DESCRIPTION
### What does this PR do?

Updates the `DdevCreateTool` used by AI agents to match the current `ddev create` CLI.

- Removes `integration_type` — the tool now always scaffolds a `check` integration via `ddev create check`
- Adds three required fields: `display_name`, `metrics_prefix`, and `platforms`
- Drops `--skip-manifest` (deprecated no-op) and the `.capitalize()` workaround (no longer needed)
- Updates tests accordingly

It also renames the tool's input from `CreateInput` to `DdevCreateInput`, to make it less confusing.

### Motivation

The `ddev create` command was refactored into subcommands and now accepts `--display-name`, `--metrics-prefix`, and `--platforms` flags to populate `ddev/config.toml` at scaffold time. The old tool was using a deprecated `--type` shim and missing these fields.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged