### PR TITLE
GA Proofpoint TAP integration

### DIFF
--- a/proofpoint_tap/assets/dataflows.yaml
+++ b/proofpoint_tap/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: proofpoint-tap-logs
+    always_on: true
+    granular: true
+    data_type: logs
+    direction: inbound

--- a/proofpoint_tap/manifest.json
+++ b/proofpoint_tap/manifest.json
@@ -3,7 +3,7 @@
   "app_uuid": "16ad3243-233b-4a1e-a523-98a35c29162b",
   "app_id": "proofpoint-tap",
   "owner": "saas-integrations",
-  "display_on_public_website": false,
+  "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?

- Flips `display_on_public_website` to `true` for `proofpoint_tap/manifest.json`.
- Adds `proofpoint_tap/assets/dataflows.yaml` with `granular: true` for Cloud SIEM.

### Motivation
Proofpoint TAP is going GA as a Cloud SIEM log source ([SEC-31363](https://datadoghq.atlassian.net/browse/SEC-31363)). This PR enables the public documentation tile on the Datadog integrations page.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

[SEC-31363]: https://datadoghq.atlassian.net/browse/SEC-31363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ