### PR TITLE
[Backport 7.78.x] Release base check 37.33.4

### DIFF
--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 37.33.4 / 2026-06-08
+
+***Fixed***:
+
+* Send each logical database as its own independent schema snapshot, so an error or partial collection for one database does not affect others. ([#23913](https://github.com/DataDog/integrations-core/pull/23913))
+
 ## 37.33.3 / 2026-04-09
 
 ***Fixed***:

--- a/datadog_checks_base/datadog_checks/base/__about__.py
+++ b/datadog_checks_base/datadog_checks/base/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = "37.33.3"
+__version__ = "37.33.4"

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -34,7 +34,7 @@ datadog-ceph==4.5.0; sys_platform != 'win32'
 datadog-cert-manager==6.4.0
 datadog-checkpoint-harmony-endpoint==1.2.0
 datadog-checkpoint-quantum-firewall==1.3.0
-datadog-checks-base==37.33.3
+datadog-checks-base==37.33.4
 datadog-checks-dependency-provider==3.2.0
 datadog-checks-downloader==9.1.0
 datadog-cilium==6.4.0


### PR DESCRIPTION
### What does this PR do?
- **[Release] Bumped datadog_checks_base version to 37.33.4**
- **[Release] Update metadata**

### Motivation

Backport of [#23948](https://github.com/DataDog/integrations-core/pull/23948) (Release base check 37.39.1 on master) to `7.78.x`, following [#23913](https://github.com/DataDog/integrations-core/pull/23913).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged